### PR TITLE
feat(ios): tap acp_spawn tool block to open ACP detail view + live status

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -196,6 +196,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         self.clientProvider = ClientProvider(connectionManager: cm, client: cm)
         super.init()
 
+        // Register with the shared `ACPSpawnAppDelegateBridge` so the
+        // inline `acp_spawn` tool block in chat (rendered via the shared
+        // `ToolCallProgressBar`) can resolve the live `ACPSessionStore`
+        // without `clients/shared/` statically importing iOS-specific
+        // app-delegate types. Mirrors the macOS `AppDelegate.shared`
+        // singleton path.
+        ACPSpawnAppDelegateBridge.shared = self
+
         // Keep the iOS managed-connection identifiers in sync with the shared
         // `AuthManager` auth state. `AuthManager.logout()` clears
         // `managed_assistant_id` / `managed_platform_base_url` from UserDefaults;
@@ -437,6 +445,19 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
         config.delegateClass = SceneDelegate.self
         return config
+    }
+}
+
+// MARK: - ACPSpawnAppDelegateBridgeProvider
+
+extension AppDelegate: ACPSpawnAppDelegateBridgeProvider {
+    /// Surfaces the singleton `ACPSessionStore` to the shared
+    /// `ACPSpawnDeepLinkCard` in `ToolCallProgressBar.swift`. The chat-side
+    /// tap handler resolves this via `ACPSpawnAppDelegateBridge.shared`,
+    /// keeping `clients/shared/` free of any iOS-specific app-delegate
+    /// import.
+    var acpSessionStore: ACPSessionStore {
+        clientProvider.acpSessionStore
     }
 }
 

--- a/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
+++ b/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
@@ -1,0 +1,325 @@
+#if canImport(UIKit)
+import SwiftUI
+import XCTest
+
+@testable import VellumAssistantShared
+@testable import vellum_assistant_ios
+
+/// Unit tests for the inline `acp_spawn` tap-to-open shortcut wired up in
+/// `ToolCallProgressBar` on iOS. The view itself is exercised only through
+/// pure helpers (no SwiftUI view tree spun up) — pixel-level rendering is
+/// covered indirectly by the existing ``ACPSessionsViewIOSTests`` end-to-end
+/// coverage.
+@MainActor
+final class ChatBubbleACPSpawnIOSTests: XCTestCase {
+
+    // MARK: - extractAcpSessionId
+
+    /// Happy path: the tool returns a JSON object with `acpSessionId` set.
+    /// We must surface exactly that string so the deep link lands on the
+    /// matching session row.
+    func test_extractAcpSessionId_returnsIdFromCanonicalPayload() {
+        let payload = #"{"acpSessionId":"acp-abc-123","protocolSessionId":"proto-x","agent":"claude","cwd":"/tmp","status":"running","message":"…"}"#
+        XCTAssertEqual(
+            ToolCallProgressBar.extractAcpSessionId(from: payload),
+            "acp-abc-123"
+        )
+    }
+
+    /// The daemon appends an outdated-adapter warning after a blank line
+    /// in some payloads (see `assistant/src/tools/acp/spawn.ts`). The
+    /// parser scans only the leading line so the deep link still lights
+    /// up in that case — losing the affordance just because the user has
+    /// an out-of-date adapter installed would be a frustrating regression.
+    func test_extractAcpSessionId_returnsIdEvenWithTrailingWarningLines() {
+        let payload = """
+        {"acpSessionId":"acp-xyz-789","protocolSessionId":"proto","agent":"claude","cwd":"/tmp","status":"running","message":"…"}
+
+        Note: claude-agent-acp is outdated (installed: 1.0.0, latest: 1.1.0).
+        """
+        XCTAssertEqual(
+            ToolCallProgressBar.extractAcpSessionId(from: payload),
+            "acp-xyz-789"
+        )
+    }
+
+    /// Empty / malformed payloads must return nil so the row falls back to
+    /// the standard step bar (with technical details visible) — silently
+    /// rendering an unparseable row as a tap-to-open card would strand the
+    /// user on a broken link.
+    func test_extractAcpSessionId_returnsNilForEmptyOrMalformedJson() {
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: ""))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: "not-json"))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: "{"))
+    }
+
+    /// A JSON object that doesn't carry `acpSessionId` (e.g. an error
+    /// payload) must be treated as "no deep link" — same fallback as
+    /// malformed JSON.
+    func test_extractAcpSessionId_returnsNilWhenFieldMissing() {
+        let payload = #"{"error":"binary not found","agent":"claude"}"#
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: payload))
+    }
+
+    /// `acpSessionId` exists but is empty — also treated as no link, since
+    /// the panel keys its `sessions` dictionary by id and an empty string
+    /// would never resolve.
+    func test_extractAcpSessionId_returnsNilForEmptyIdString() {
+        let payload = #"{"acpSessionId":"","agent":"claude"}"#
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: payload))
+    }
+
+    /// A non-string `acpSessionId` (number, null) must not crash the parse
+    /// or coerce to a stringified value — it must surface as nil so the
+    /// fallback row renders.
+    func test_extractAcpSessionId_returnsNilForNonStringIdValues() {
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: #"{"acpSessionId":42}"#))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: #"{"acpSessionId":null}"#))
+    }
+
+    // MARK: - applyACPSessionDeepLink
+
+    /// End-to-end of the deep-link side effect: the store's
+    /// `selectedSessionId` carries the requested id (the sheet consumes
+    /// it on its next observation tick).
+    func test_applyACPSessionDeepLink_setsStoreSelectedSessionId() {
+        let store = ACPSessionStore()
+        XCTAssertNil(store.selectedSessionId)
+
+        ACPSpawnDeepLinkCard.applyACPSessionDeepLink(
+            id: "acp-target-id",
+            store: store
+        )
+
+        XCTAssertEqual(
+            store.selectedSessionId,
+            "acp-target-id",
+            "Store must carry the requested session id so the sheet can push the matching detail view"
+        )
+    }
+
+    /// A nil store must short-circuit the deep link without crashing.
+    /// `ACPSpawnAppDelegateBridge.shared` is nil during early launch and
+    /// inside background helpers, so the guard is a real production
+    /// path, not just defensive cosmetics.
+    func test_applyACPSessionDeepLink_isNoOpWhenStoreIsNil() {
+        // No assertion needed beyond "this didn't crash" — the helper
+        // returns void and a nil store has no observable side effect.
+        ACPSpawnDeepLinkCard.applyACPSessionDeepLink(id: "acp-id", store: nil)
+    }
+
+    // MARK: - statusLabel
+
+    /// Running spawns map to "Running" so the secondary text under the
+    /// tool name communicates live state. Mirrors macOS's "Running"
+    /// label inside `AssistantProgressView`.
+    func test_statusLabel_runningWhenIncomplete() {
+        let toolCall = makeAcpSpawnToolCall(isComplete: false, isError: false)
+        XCTAssertEqual(ACPSpawnDeepLinkCard.statusLabel(for: toolCall), "Running")
+    }
+
+    /// Completed and successful spawns map to "Completed".
+    func test_statusLabel_completedWhenSuccessful() {
+        let toolCall = makeAcpSpawnToolCall(isComplete: true, isError: false)
+        XCTAssertEqual(ACPSpawnDeepLinkCard.statusLabel(for: toolCall), "Completed")
+    }
+
+    /// Error spawns map to "Failed" regardless of completion state.
+    /// We allow the deep-link card to render for errors so the user can
+    /// jump in to see the failure mode — the indicator turns red.
+    func test_statusLabel_failedWhenErrored() {
+        let toolCall = makeAcpSpawnToolCall(isComplete: true, isError: true)
+        XCTAssertEqual(ACPSpawnDeepLinkCard.statusLabel(for: toolCall), "Failed")
+    }
+
+    // MARK: - ACPSessionsView deep-link consumption (compact)
+
+    /// When `selectedSessionId` matches a session already in the store,
+    /// invoking the consume helper pushes that id onto the panel's
+    /// navigation path on compact (iPhone). The store's field is cleared
+    /// on consume so a repeated set-with-same-id still triggers a fresh
+    /// push.
+    func test_acpSessionsView_consumesSelectedSessionIdAndPushesDetail_compact() {
+        let store = ACPSessionStore()
+        injectFixture(into: store, acpSessionId: "acp-deep-link", agentId: "claude-code")
+
+        var path: [String] = []
+        var selected: String?
+        store.selectedSessionId = "acp-deep-link"
+
+        ACPSessionsView.consumeSelectedSessionIdIfPresent(
+            store: store,
+            isCompact: true,
+            selected: &selected,
+            path: &path
+        )
+
+        XCTAssertEqual(path, ["acp-deep-link"], "Detail view must be pushed onto compact NavigationStack")
+        XCTAssertNil(
+            store.selectedSessionId,
+            "selectedSessionId must be cleared after consume so a later set still fires a push"
+        )
+    }
+
+    /// Regular (iPad) consumes the deep link by setting the split-view
+    /// selection, not by pushing onto the path. Mirrors the
+    /// `List(selection:)` binding the regular-size-class layout uses.
+    func test_acpSessionsView_consumesSelectedSessionIdAndSelectsDetail_regular() {
+        let store = ACPSessionStore()
+        injectFixture(into: store, acpSessionId: "acp-deep-link", agentId: "codex")
+
+        var path: [String] = []
+        var selected: String?
+        store.selectedSessionId = "acp-deep-link"
+
+        ACPSessionsView.consumeSelectedSessionIdIfPresent(
+            store: store,
+            isCompact: false,
+            selected: &selected,
+            path: &path
+        )
+
+        XCTAssertEqual(selected, "acp-deep-link", "Selection binding must carry the deep-link id on regular")
+        XCTAssertEqual(path, [], "Path must remain empty on regular — selection drives the detail pane")
+        XCTAssertNil(store.selectedSessionId)
+    }
+
+    /// If the requested id has no matching row yet (e.g. the deep link
+    /// landed before the SSE `acp_session_spawned` event), consume must
+    /// be a no-op so the user lands on the list and the field stays set
+    /// for a later arrival to flush.
+    func test_acpSessionsView_consumeIsNoOpWhenSessionMissing() {
+        let store = ACPSessionStore()
+        var path: [String] = []
+        var selected: String?
+        store.selectedSessionId = "acp-not-yet-spawned"
+
+        ACPSessionsView.consumeSelectedSessionIdIfPresent(
+            store: store,
+            isCompact: true,
+            selected: &selected,
+            path: &path
+        )
+
+        XCTAssertEqual(path, [], "No push when the session row doesn't exist yet")
+        XCTAssertNil(selected)
+        XCTAssertEqual(
+            store.selectedSessionId,
+            "acp-not-yet-spawned",
+            "Field must stay set so a later spawn + re-trigger can still flush the deep link"
+        )
+    }
+
+    /// Pushing the same id twice in a row must collapse to one push so
+    /// a re-tap on the same `acp_spawn` block doesn't stack duplicate
+    /// detail views on top of each other.
+    func test_acpSessionsView_consumeIsIdempotentForSameTopOfStack_compact() {
+        let store = ACPSessionStore()
+        injectFixture(into: store, acpSessionId: "acp-same", agentId: "codex")
+
+        var path: [String] = []
+        var selected: String?
+
+        store.selectedSessionId = "acp-same"
+        ACPSessionsView.consumeSelectedSessionIdIfPresent(
+            store: store,
+            isCompact: true,
+            selected: &selected,
+            path: &path
+        )
+        XCTAssertEqual(path, ["acp-same"])
+
+        // Re-triggering with the same id must not stack a duplicate row.
+        store.selectedSessionId = "acp-same"
+        ACPSessionsView.consumeSelectedSessionIdIfPresent(
+            store: store,
+            isCompact: true,
+            selected: &selected,
+            path: &path
+        )
+        XCTAssertEqual(
+            path,
+            ["acp-same"],
+            "Re-tapping the same session must not stack duplicate detail views"
+        )
+    }
+
+    /// Same idempotence guarantee on regular (iPad): re-selecting the
+    /// already-selected detail must not flicker the selection binding.
+    func test_acpSessionsView_consumeIsIdempotentForSameSelection_regular() {
+        let store = ACPSessionStore()
+        injectFixture(into: store, acpSessionId: "acp-same", agentId: "claude-code")
+
+        var path: [String] = []
+        var selected: String? = "acp-same"
+
+        store.selectedSessionId = "acp-same"
+        ACPSessionsView.consumeSelectedSessionIdIfPresent(
+            store: store,
+            isCompact: false,
+            selected: &selected,
+            path: &path
+        )
+
+        XCTAssertEqual(selected, "acp-same")
+        XCTAssertNil(
+            store.selectedSessionId,
+            "Field must still be cleared so a later set with a different id will fire"
+        )
+    }
+
+    // MARK: - Status transitions update indicator state
+
+    /// The indicator's pulse-vs-check behavior is driven entirely by
+    /// `toolCall.isComplete` / `toolCall.isError`, so verifying the
+    /// status label flips alongside the underlying state is enough to
+    /// pin the contract — view-level rendering is out of scope.
+    func test_statusTransitions_updateLabelAcrossLifecycle() {
+        var toolCall = makeAcpSpawnToolCall(isComplete: false, isError: false)
+        XCTAssertEqual(ACPSpawnDeepLinkCard.statusLabel(for: toolCall), "Running")
+
+        toolCall.isComplete = true
+        XCTAssertEqual(ACPSpawnDeepLinkCard.statusLabel(for: toolCall), "Completed")
+
+        toolCall.isError = true
+        XCTAssertEqual(ACPSpawnDeepLinkCard.statusLabel(for: toolCall), "Failed")
+    }
+
+    // MARK: - Helpers
+
+    /// Synthetic `acp_spawn` tool call sized for the deep-link helpers.
+    /// The result payload carries a parseable `acpSessionId` so the
+    /// card-vs-bar split in `ToolCallProgressBar.body` resolves to the
+    /// card path.
+    private func makeAcpSpawnToolCall(
+        isComplete: Bool,
+        isError: Bool,
+        sessionId: String = "acp-test"
+    ) -> ToolCallData {
+        let result = #"{"acpSessionId":"\#(sessionId)","agent":"claude","status":"running"}"#
+        return ToolCallData(
+            toolName: "acp_spawn",
+            inputSummary: "claude",
+            result: result,
+            isError: isError,
+            isComplete: isComplete
+        )
+    }
+
+    /// Inserts a synthetic ACP session into the store via the same
+    /// ``ServerMessage`` path the SSE pipeline uses. Matches the helper
+    /// used in ``ACPSessionsViewIOSTests`` so fixtures behave the same
+    /// across the two suites.
+    private func injectFixture(
+        into store: ACPSessionStore,
+        acpSessionId: String,
+        agentId: String
+    ) {
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: acpSessionId,
+            agent: agentId,
+            parentConversationId: "conv-\(acpSessionId)"
+        )))
+    }
+}
+#endif

--- a/clients/ios/Views/ACPSessionsView.swift
+++ b/clients/ios/Views/ACPSessionsView.swift
@@ -29,6 +29,13 @@ struct ACPSessionsView: View {
 
     @State private var selectedSessionId: String?
 
+    /// Mutable navigation path so the inline `acp_spawn` chat tap can
+    /// push a detail view programmatically on compact iPhone. Mirrors
+    /// the `navigationPath` on macOS's `ACPSessionsPanel` and lets
+    /// ``consumeSelectedSessionIdIfPresent`` flush a pending deep link
+    /// without rebuilding the navigation hierarchy from scratch.
+    @State private var navigationPath: [String] = []
+
     var body: some View {
         Group {
             if horizontalSizeClass == .regular {
@@ -38,7 +45,7 @@ struct ACPSessionsView: View {
                     detailContent
                 }
             } else {
-                NavigationStack {
+                NavigationStack(path: $navigationPath) {
                     listContent
                         .navigationDestination(for: String.self) { sessionId in
                             detailView(for: sessionId)
@@ -54,6 +61,59 @@ struct ACPSessionsView: View {
             if store.seedState == .idle {
                 await store.seed()
             }
+            // If a deep-link landed before this sheet mounted (e.g.
+            // tapping an inline `acp_spawn` chat block opens the sheet
+            // and sets the id in the same tick), consume it now so the
+            // user lands directly on the detail view instead of the
+            // list.
+            consumeSelectedSessionIdIfPresent()
+        }
+        .onChange(of: store.selectedSessionId) { _, _ in
+            consumeSelectedSessionIdIfPresent()
+        }
+    }
+
+    /// Consume a pending `store.selectedSessionId`, routing it to the
+    /// size-class-appropriate selection mechanism. Defers to the pure
+    /// helper ``consumeSelectedSessionIdIfPresent(store:isCompact:selected:path:)``
+    /// so unit tests can exercise the consumption logic without standing
+    /// up a SwiftUI view tree.
+    func consumeSelectedSessionIdIfPresent() {
+        Self.consumeSelectedSessionIdIfPresent(
+            store: store,
+            isCompact: horizontalSizeClass != .regular,
+            selected: &selectedSessionId,
+            path: &navigationPath
+        )
+    }
+
+    /// Pure helper that drives the deep-link consumption against an
+    /// arbitrary store + path / selection pair. `static` so tests can
+    /// call it directly with their own storage. Idempotent: if the
+    /// requested session is already at the top of the stack (compact)
+    /// or already selected (regular), the field is still cleared but
+    /// the push is skipped to avoid stacking duplicate detail views.
+    static func consumeSelectedSessionIdIfPresent(
+        store: ACPSessionStore,
+        isCompact: Bool,
+        selected: inout String?,
+        path: inout [String]
+    ) {
+        guard let id = store.selectedSessionId,
+              store.sessions[id] != nil else {
+            // Either no deep link, or the row hasn't streamed in yet.
+            // Leaving the field set lets a later spawn + re-trigger
+            // flush the deep link when the SSE event finally arrives.
+            return
+        }
+        // Clear first so reentrant `onChange` invocations don't loop.
+        store.selectedSessionId = nil
+        if isCompact {
+            if path.last == id { return }
+            path.append(id)
+        } else {
+            if selected == id { return }
+            selected = id
         }
     }
 

--- a/clients/ios/Views/IOSRootNavigationView.swift
+++ b/clients/ios/Views/IOSRootNavigationView.swift
@@ -103,9 +103,31 @@ struct IOSRootNavigationView: View {
             if navigateToConnect && !isSettingsPresented {
                 isSettingsPresented = true
             }
+            // Mirror the same coverage for ACP deep links: an
+            // `acp_spawn` tap that lands while the sheet is mounted
+            // re-presents naturally via `.onChange` below, but a deep
+            // link that was already set before this view appeared (e.g.
+            // a launch path that wakes the app via the inline card)
+            // would be missed by `.onChange` alone.
+            if clientProvider.acpSessionStore.selectedSessionId != nil
+                && !isACPSessionsPresented {
+                isACPSessionsPresented = true
+            }
         }
         .onChange(of: store.selectionRequest?.id) { _, _ in
             applyPendingSelectionRequestIfNeeded()
+        }
+        .onChange(of: clientProvider.acpSessionStore.selectedSessionId) { _, newValue in
+            // Inline `acp_spawn` taps (rendered by `ToolCallProgressBar`
+            // on iOS) land here by setting the store's
+            // `selectedSessionId`. We surface the Coding Agents sheet
+            // and let `ACPSessionsView` consume the field on its own
+            // observation tick — that's where the actual detail-view
+            // push happens. Clearing the field here would race the
+            // panel's consume helper, so we leave it alone.
+            if newValue != nil && !isACPSessionsPresented {
+                isACPSessionsPresented = true
+            }
         }
         .onChange(of: store.conversations.map(\.id)) { _, _ in
             // Seeds when no conversation is active AND reselects when the

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -19,7 +19,46 @@ public struct ToolCallProgressBar: View {
         toolCalls.first(where: { !$0.isComplete }) ?? toolCalls.last
     }
 
+    /// When this progress bar contains exactly one `acp_spawn` tool call
+    /// whose result carries a parseable `acpSessionId`, render the inline
+    /// tap-to-open card instead of the standard step bar. The card opens
+    /// the Coding Agents detail view for that session — mirrors the macOS
+    /// `acp_spawn` row in `AssistantProgressView.swift`. We restrict to
+    /// the single-call case so a streaming progress bar that happens to
+    /// include `acp_spawn` alongside other tools doesn't lose its
+    /// step-by-step affordance.
+    ///
+    /// The card stays available for spawns in any state (running,
+    /// completed, errored) so users can navigate into the detail view as
+    /// soon as the session id is known — the live status indicator
+    /// communicates state instead of forcing a fallback to the standard
+    /// row. Returns `nil` when no `acpSessionId` can be extracted.
+    private var acpSpawnDeepLink: (toolCall: ToolCallData, sessionId: String)? {
+        guard toolCalls.count == 1,
+              let toolCall = toolCalls.first,
+              toolCall.toolName == "acp_spawn",
+              let result = toolCall.result,
+              !result.isEmpty,
+              let sessionId = ToolCallProgressBar.extractAcpSessionId(from: result) else {
+            return nil
+        }
+        return (toolCall, sessionId)
+    }
+
     public var body: some View {
+        #if os(iOS)
+        if let deepLink = acpSpawnDeepLink {
+            ACPSpawnDeepLinkCard(toolCall: deepLink.toolCall, acpSessionId: deepLink.sessionId)
+        } else {
+            standardBody
+        }
+        #else
+        standardBody
+        #endif
+    }
+
+    @ViewBuilder
+    private var standardBody: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
             // Progress bar with steps
             VStack(spacing: VSpacing.xs) {
@@ -67,6 +106,31 @@ public struct ToolCallProgressBar: View {
                     ))
             }
         }
+    }
+
+    // MARK: - acp_spawn deep-link helpers
+
+    /// Best-effort JSON probe for the `acpSessionId` field in
+    /// `acp_spawn`'s result payload. The tool returns a JSON object on
+    /// the first line and may append a free-form outdated-adapter
+    /// warning after a blank line (see `assistant/src/tools/acp/spawn.ts`),
+    /// so we parse the leading line rather than the full string —
+    /// otherwise the appended diagnostic invalidates the JSON and the
+    /// deep link would silently disappear in that case. On failure or
+    /// any non-JSON shape we return `nil` so the caller falls back to
+    /// the regular progress bar. Mirrors
+    /// `ToolCallStepDetailRow.extractAcpSessionId(from:)` on macOS so
+    /// both platforms accept the same payload shapes.
+    public static func extractAcpSessionId(from result: String) -> String? {
+        let leading = result.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+            .first.map(String.init) ?? ""
+        guard let data = leading.data(using: .utf8) else { return nil }
+        let parsed = try? JSONSerialization.jsonObject(with: data)
+        guard let dict = parsed as? [String: Any] else { return nil }
+        guard let id = dict["acpSessionId"] as? String, !id.isEmpty else {
+            return nil
+        }
+        return id
     }
 
     // MARK: - Step Circle
@@ -302,3 +366,157 @@ public struct ToolCallProgressBar: View {
         }
     }
 }
+
+#if os(iOS)
+
+/// Compact tap-to-open card replacing the standard step bar for
+/// `acp_spawn` tool calls on iOS. Visually mirrors the macOS row in
+/// `ToolCallStepDetailRow.acpSpawnDeepLinkRow` — a status-driven leading
+/// glyph, the friendly tool name, and a chevron-right hint pointing at
+/// "tap to navigate". Status updates live: if a spawn lands on the chat
+/// before its session row finishes initializing, the indicator pulses
+/// until the daemon reports a terminal state via SSE.
+public struct ACPSpawnDeepLinkCard: View {
+    public let toolCall: ToolCallData
+    public let acpSessionId: String
+
+    public init(toolCall: ToolCallData, acpSessionId: String) {
+        self.toolCall = toolCall
+        self.acpSessionId = acpSessionId
+    }
+
+    public var body: some View {
+        Button {
+            Self.openACPSession(id: acpSessionId)
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                ACPSpawnStatusIndicator(toolCall: toolCall)
+                    .frame(width: 16, height: 16)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(ToolCallData.displaySafe(toolCall.friendlyName))
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text(ACPSpawnDeepLinkCard.statusLabel(for: toolCall))
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+                }
+                Spacer(minLength: 0)
+                VIconView(.chevronRight, size: 12)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .contentShape(Rectangle())
+            .padding(VSpacing.md)
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .fill(VColor.surfaceOverlay)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+        .accessibilityLabel("\(ToolCallData.displaySafe(toolCall.friendlyName)). \(Self.statusLabel(for: toolCall)). Tap to open coding agent session.")
+    }
+
+    /// Short human-readable phase label used for both the secondary
+    /// text under the title and the accessibility announcement.
+    /// `static` so unit tests can exercise the mapping without
+    /// spinning up a SwiftUI view tree.
+    static func statusLabel(for toolCall: ToolCallData) -> String {
+        if toolCall.isError {
+            return "Failed"
+        }
+        if toolCall.isComplete {
+            return "Completed"
+        }
+        return "Running"
+    }
+
+    /// Drive the deep link by stashing the requested id on the shared
+    /// `ACPSessionStore` and asking `IOSRootNavigationView` to surface
+    /// the Coding Agents sheet via the same store-observation hook.
+    /// The store is resolved through ``ACPSpawnAppDelegateBridge``,
+    /// which the iOS app delegate registers itself with on launch — that
+    /// indirection keeps `clients/shared/` free of any
+    /// iOS-specific `AppDelegate` import.
+    ///
+    /// `static` so unit tests can exercise the side effects against an
+    /// injected `ACPSessionStore` via
+    /// ``applyACPSessionDeepLink(id:store:)``.
+    static func openACPSession(id: String) {
+        applyACPSessionDeepLink(id: id, store: ACPSpawnAppDelegateBridge.shared?.acpSessionStore)
+    }
+
+    /// Pure side-effect helper for ``openACPSession(id:)``. Setting the
+    /// id triggers `IOSRootNavigationView`'s observer to flip
+    /// `isACPSessionsPresented = true`; the sheet's `ACPSessionsView`
+    /// then consumes the same field to push the matching detail view
+    /// onto its `NavigationStack`. A nil store is a no-op so callers
+    /// can pass through the bridge result without a guard of their own.
+    @MainActor
+    static func applyACPSessionDeepLink(id: String, store: ACPSessionStore?) {
+        guard let store else { return }
+        store.selectedSessionId = id
+    }
+}
+
+/// Animated leading glyph for ``ACPSpawnDeepLinkCard``. Pulses while the
+/// underlying spawn is still running, flips to a solid check on success,
+/// and to an alert on error. Driven by `Timer.publish` for the same
+/// reason `ElapsedTimeLabel` in `AssistantProgressView.swift` uses it on
+/// macOS — `TimelineView(.periodic)` can stop firing on long-idle
+/// hierarchies and freeze the dot.
+private struct ACPSpawnStatusIndicator: View {
+    let toolCall: ToolCallData
+    @State private var pulsePhase: Double = 0
+
+    private let timer = Timer.publish(every: 0.35, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        Group {
+            if toolCall.isError {
+                VIconView(.circleAlert, size: 14)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            } else if toolCall.isComplete {
+                VIconView(.circleCheck, size: 14)
+                    .foregroundStyle(VColor.primaryBase)
+            } else {
+                Circle()
+                    .fill(VColor.primaryBase)
+                    .frame(width: 10, height: 10)
+                    .opacity(0.4 + 0.6 * pulsePhase)
+                    .scaleEffect(0.9 + 0.15 * pulsePhase)
+            }
+        }
+        .onReceive(timer) { _ in
+            guard !toolCall.isComplete else { return }
+            withAnimation(.easeInOut(duration: 0.35)) {
+                pulsePhase = pulsePhase < 0.5 ? 1 : 0
+            }
+        }
+    }
+}
+
+/// Indirection so the deep-link card can resolve the live
+/// `ACPSessionStore` without `ToolCallProgressBar.swift` (a `shared/`
+/// file) statically referencing the iOS `AppDelegate` class. The iOS
+/// app delegate registers itself here on launch; tests inject a stand-in.
+@MainActor
+public enum ACPSpawnAppDelegateBridge {
+    /// Provider of the singleton `ACPSessionStore` for the running app.
+    /// The slot is `weak` so the bridge doesn't keep the app delegate
+    /// alive past its natural lifetime — losing the reference during
+    /// teardown surfaces as a soft no-op tap rather than a leak.
+    public static weak var shared: ACPSpawnAppDelegateBridgeProvider?
+}
+
+/// Surface the bridge needs from whatever owns the live
+/// `ACPSessionStore`. iOS satisfies this with an `AppDelegate`
+/// extension; tests satisfy it with an inline class.
+public protocol ACPSpawnAppDelegateBridgeProvider: AnyObject {
+    var acpSessionStore: ACPSessionStore { get }
+}
+#endif


### PR DESCRIPTION
## Summary
- iOS `acp_spawn` tool blocks are tap-to-open; pushes/selects `ACPSessionDetailViewIOS`.
- Live status indicator (pulsing dot / check / red x / dash) driven by `ACPSessionStore`.

Part of plan: acp-sessions-ui.md (PR 35 of 36)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
