### PR TITLE
feat(acp): release notes for Coding Agents UI

### DIFF
--- a/assistant/src/__tests__/workspace-migration-acp-sessions-ui.test.ts
+++ b/assistant/src/__tests__/workspace-migration-acp-sessions-ui.test.ts
@@ -1,0 +1,144 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { releaseNotesAcpSessionsUiMigration } from "../workspace/migrations/058-release-notes-acp-sessions-ui.js";
+
+const MIGRATION_ID = "058-release-notes-acp-sessions-ui";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+let testRoot: string;
+let workspaceDir: string;
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "migration-058-test-"));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(testRoot, "ws-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function updatesPath(): string {
+  return join(workspaceDir, "UPDATES.md");
+}
+
+describe("workspace migration 058-release-notes-acp-sessions-ui", () => {
+  test("has the correct id and description", () => {
+    expect(releaseNotesAcpSessionsUiMigration.id).toBe(MIGRATION_ID);
+    expect(releaseNotesAcpSessionsUiMigration.description).toContain(
+      "Coding Agents",
+    );
+  });
+
+  test("creates UPDATES.md with marker and key copy when file is absent", () => {
+    expect(existsSync(updatesPath())).toBe(false);
+
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(MARKER)).toBe(true);
+    expect(content).toContain("Coding Agents");
+    expect(content).toContain("Codex");
+    expect(content).toContain("Claude");
+    expect(content).toContain("Acp Spawn");
+    expect(content).toContain("per-conversation filter");
+    expect(content).toContain("persist across assistant and app restarts");
+    expect(content).toContain("agent_thought_chunk");
+    expect(content).toContain("italic secondary text");
+  });
+
+  test("appends to existing UPDATES.md when marker is absent and preserves existing content", () => {
+    const prior = "## Earlier note\n\nSomething already queued.\n";
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(prior)).toBe(true);
+    expect(content.slice(prior.length).startsWith(`\n${MARKER}`)).toBe(true);
+    expect(content.split(MARKER).length - 1).toBe(1);
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  test("is a no-op when marker is already present", () => {
+    const seeded = `## Prior\n\n${MARKER}\n## Coding Agents\n\nAlready appended.\n`;
+    writeFileSync(updatesPath(), seeded, "utf-8");
+
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+    const afterFirst = readFileSync(updatesPath(), "utf-8");
+    expect(afterFirst).toBe(seeded);
+
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+    const afterSecond = readFileSync(updatesPath(), "utf-8");
+    expect(afterSecond).toBe(seeded);
+    expect(afterSecond.split(MARKER).length - 1).toBe(1);
+  });
+
+  test("running twice on a fresh workspace appends only once (idempotent)", () => {
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+    const afterFirst = readFileSync(updatesPath(), "utf-8");
+
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+    const afterSecond = readFileSync(updatesPath(), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(afterSecond.split(MARKER).length - 1).toBe(1);
+  });
+
+  test("re-creates UPDATES.md when it was deleted between runs", () => {
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+    expect(existsSync(updatesPath())).toBe(true);
+
+    rmSync(updatesPath());
+
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(MARKER)).toBe(true);
+    expect(content).toContain("Coding Agents");
+  });
+
+  test("existing UPDATES.md with no trailing newline gets one blank line separator", () => {
+    const prior = "## Prior\n\nBody.";
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesAcpSessionsUiMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(prior)).toBe(true);
+    expect(content.slice(prior.length).startsWith(`\n\n${MARKER}`)).toBe(true);
+    expect(content).not.toContain("\n\n\n");
+  });
+
+  test("down() is a no-op", () => {
+    writeFileSync(updatesPath(), `${MARKER}\nBody.\n`, "utf-8");
+    const before = readFileSync(updatesPath(), "utf-8");
+
+    releaseNotesAcpSessionsUiMigration.down(workspaceDir);
+
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/workspace/migrations/058-release-notes-acp-sessions-ui.ts
+++ b/assistant/src/workspace/migrations/058-release-notes-acp-sessions-ui.ts
@@ -1,0 +1,71 @@
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-058-release-notes-acp-sessions-ui");
+
+const MIGRATION_ID = "058-release-notes-acp-sessions-ui";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+const RELEASE_NOTE = `${MARKER}
+## Coding Agents panel for Codex and Claude sessions
+
+A new "Coding Agents" panel in the macOS app and a matching iOS surface show
+running and historical Codex and Claude Code sessions with live progress.
+
+- Inline \`Acp Spawn\` step blocks in chat are now tap-to-open and show live
+  status as the agent runs.
+- A per-conversation filter narrows the panel to just the agents spawned by
+  the current conversation.
+- Sessions persist across assistant and app restarts: completed sessions
+  appear in history, and any sessions that were running when the assistant
+  stopped are clearly marked as ended with the assistant.
+- \`agent_thought_chunk\` reasoning is now rendered as italic secondary text
+  and can be toggled on or off.
+`;
+
+export const releaseNotesAcpSessionsUiMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description:
+    "Append release notes for the Coding Agents panel and ACP session UI to UPDATES.md",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+
+    try {
+      if (existsSync(updatesPath)) {
+        const existing = readFileSync(updatesPath, "utf-8");
+        if (existing.includes(MARKER)) {
+          return;
+        }
+        const needsLeadingNewline = !existing.endsWith("\n\n");
+        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+        appendFileSync(
+          updatesPath,
+          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
+          "utf-8",
+        );
+      } else {
+        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
+      }
+      log.info({ path: updatesPath }, "Appended ACP sessions UI release note");
+    } catch (err) {
+      log.warn(
+        { err, path: updatesPath },
+        "Failed to append ACP sessions UI release note to UPDATES.md",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
+    // processes and deletes on its own.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -55,6 +55,7 @@ import { seedRecallCallsiteMigration } from "./054-seed-recall-callsite.js";
 import { releaseNotesAgenticRecallMigration } from "./055-release-notes-agentic-recall.js";
 import { releaseNotesInferenceProfileReorderingMigration } from "./056-release-notes-inference-profile-reordering.js";
 import { repairStaleGeminiModelIdsMigration } from "./057-repair-stale-gemini-model-ids.js";
+import { releaseNotesAcpSessionsUiMigration } from "./058-release-notes-acp-sessions-ui.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -121,4 +122,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesAgenticRecallMigration,
   releaseNotesInferenceProfileReorderingMigration,
   repairStaleGeminiModelIdsMigration,
+  releaseNotesAcpSessionsUiMigration,
 ];


### PR DESCRIPTION
## Summary
- Workspace migration 058 appends release notes for the new Coding Agents panel/view (macOS + iOS), inline tool-block tap-to-open with live status, per-conversation filter, persistence across restarts, and agent thought rendering.

Note: plan said to use 057, but 057-repair-stale-gemini-model-ids was added in the meantime, so this uses the next available sequence number (058) — append-only, no reordering.

Part of plan: acp-sessions-ui.md (PR 36 of 36 — final)