### PR TITLE
feat(live-voice): update architecture and operator docs (PR 20)

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -589,7 +589,7 @@ All guardian decisions for voice access requests flow through:
 
 ### Speech-to-Text (STT) Boundaries
 
-Audio-to-text conversion occurs in five distinct runtime boundaries, each with its own provider model and adapter layer. The `services.stt` config block is the single source of truth for STT provider selection across both daemon and telephony boundaries.
+Audio-to-text conversion occurs in six distinct runtime boundaries, each with its own provider model and adapter layer. The `services.stt` config block is the single source of truth for STT provider selection across assistant, client, live voice, and telephony boundaries.
 
 **Provider catalog model:** The daemon's canonical provider catalog (`src/providers/speech-to-text/provider-catalog.ts`) is the single source of truth for all STT provider metadata — credential mappings, supported boundaries, telephony mode, conversation streaming mode, and client-facing display metadata (names, hints, setup mode, credentials guide). Native clients fetch provider metadata at launch via `GET /v1/stt/providers`. To add a new provider, follow the checklist in `docs/stt-provider-onboarding.md`.
 
@@ -600,6 +600,7 @@ Audio-to-text conversion occurs in five distinct runtime boundaries, each with i
 | **Telephony (hybrid)**       | Twilio-native ConversationRelay or daemon media-stream (provider-conditional) | Configured STT provider (via `services.stt`) | `src/calls/telephony-stt-routing.ts`                                                                                                                                                                                                                       | `src/calls/twilio-routes.ts`                                                                         |
 | **Daemon batch**             | Daemon process (REST API to provider)                                         | Configured STT provider (via `services.stt`) | `src/stt/daemon-batch-transcriber.ts`                                                                                                                                                                                                                      | `src/runtime/routes/inbound-stages/transcribe-audio.ts`                                              |
 | **Conversation streaming**   | Daemon process (WebSocket-based)                                              | Configured STT provider (via `services.stt`) | `src/stt/stt-stream-session.ts`, `src/providers/speech-to-text/deepgram-realtime.ts`, `src/providers/speech-to-text/google-gemini-live-stream.ts`, `src/providers/speech-to-text/openai-whisper-stream.ts`, `src/providers/speech-to-text/xai-realtime.ts` | `VoiceInputManager` (macOS conversation), `InputBarView` (iOS conversation) via gateway WS proxy     |
+| **Live voice channel**       | Assistant process (gateway-authenticated WebSocket)                           | Configured STT provider (via `services.stt`) | `src/runtime/http-server.ts`, `src/live-voice/live-voice-session-manager.ts`, `src/live-voice/live-voice-session.ts`, `src/providers/speech-to-text/resolve.ts`, streaming provider adapters                                                               | `LiveVoiceChannelManager` (macOS voice mode) via `/v1/live-voice`                                    |
 | **Client service-first**     | macOS / iOS via gateway → daemon                                              | Configured STT provider (via `services.stt`) | `src/runtime/routes/stt-routes.ts`, `clients/shared/Network/STTClient.swift`                                                                                                                                                                               | `VoiceInputManager` (macOS dictation), `InputBarView` (iOS), `OpenAIVoiceService` (macOS voice mode) |
 | **Client-native (fallback)** | macOS / iOS on-device                                                         | Apple Speech (`SFSpeechRecognizer`)          | `clients/macos/.../SpeechRecognizerAdapter.swift`, `clients/ios/.../SpeechRecognizerAdapter.swift`                                                                                                                                                         | Fallback when STT service is unconfigured or fails                                                   |
 
@@ -707,6 +708,29 @@ The conversation streaming path degrades gracefully to the existing batch STT pa
 | `clients/shared/Utilities/STTProviderRegistry.swift`        | Client-side provider catalog: `isStreamingAvailable`, `conversationStreamingMode` per provider                                                        |
 | `clients/macos/.../VoiceInputManager.swift`                 | macOS integration: `startStreamingSession()`, streaming/batch priority, fallback on failure                                                           |
 | `clients/ios/Views/InputBarView.swift`                      | iOS integration: `handleStreamingEvent()`, auto-stop coordination, batch fallback                                                                     |
+
+**Live voice channel boundary:**
+
+The local live voice channel uses a single gateway-authenticated WebSocket at `/v1/live-voice`. Native clients connect to the gateway route, the gateway validates an actor token, mints a gateway service token, and opens an upstream WebSocket to the assistant runtime route. Both text control frames and binary audio frames are proxied opaquely by `gateway/src/http/routes/live-voice-websocket.ts`; `gateway/src/index.ts` dispatches `open`, `message`, and `close` callbacks to that handler before the generic runtime proxy fallback.
+
+The assistant runtime route lives in `src/runtime/http-server.ts`. It mirrors the STT streaming security posture: direct access must come from private-network peers/origins, and authenticated deployments require the gateway service token. The runtime parses JSON frames with `parseLiveVoiceClientTextFrame()`, parses binary frames with `parseLiveVoiceBinaryAudioFrame()`, and routes accepted sessions through `LiveVoiceSessionManager`. The V1 manager owns a single-active-session lock and returns a `busy` frame for concurrent sessions.
+
+The assistant-side live voice module is intentionally bounded under `src/live-voice/`:
+
+| File                            | Boundary                                                                                                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `protocol.ts`                   | Provider-agnostic client/server frame types, validation, binary audio parsing, and monotonic server-frame sequencing                                        |
+| `live-voice-session-manager.ts` | Single-active-session lock, session factory context, and dispatch/release lifecycle                                                                         |
+| `live-voice-session.ts`         | Session orchestration: streaming STT, push-to-talk release, voice turn bridge callbacks, assistant text deltas, TTS, archive, metrics, interrupt, and close |
+| `live-voice-tts.ts`             | Streaming TTS helper that resolves `services.tts`, requires `TtsProvider.synthesizeStream()`, and forwards audio chunks as `tts_audio` frames               |
+| `live-voice-archive.ts`         | Audio artifact creation/linking for user utterance and assistant response message IDs                                                                       |
+| `live-voice-metrics.ts`         | Per-session and per-turn latency snapshots emitted as `metrics` frames                                                                                      |
+
+Live voice STT uses the same `resolveStreamingTranscriber()` path as conversation streaming. For V1 latency-sensitive behavior, the selected `services.stt.provider` must resolve to a `daemon-streaming` transcriber whose catalog entry has `conversationStreamingMode: "realtime-ws"` and usable credentials. Providers that only support batch or incremental-batch transcription remain valid for other voice surfaces, but do not satisfy live voice's streaming STT requirement.
+
+Live voice TTS uses `streamLiveVoiceTtsAudio()` and the configured `services.tts.provider`. The selected provider must be registered, catalog-compatible, and expose `capabilities.supportsStreaming` plus `synthesizeStream()`. Fish Audio is the current catalog provider with streaming synthesis support; non-streaming providers remain available for buffered message playback or other supported surfaces, but live voice reports a TTS error instead of silently falling back to buffered playback.
+
+V1 is local/gateway-scoped. Managed/cloud WebSocket proxy support, cross-region routing, and p50/p95 latency guarantees are out of scope for this version. Metrics frames expose timing data for measurement, but the architecture does not promise a hard latency SLO.
 
 **Client service-first boundary:**
 

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -43,6 +43,46 @@ Low-risk types use Swift's `@Observable` macro (Observation framework) instead o
 
 Types that use Combine `$`-prefixed publishers (e.g., `VoiceTranscriptionViewModel`) remain as `ObservableObject`.
 
+### macOS Voice Mode Live Channel
+
+Voice mode can use a local live channel when the current conversation has an ID, the gateway connection is healthy, and no tool permission prompt is pending. `MainWindow` creates one `LiveVoiceChannelManager` and injects it into `VoiceModeManager` with `liveVoiceAvailability: { connectionManager.isConnected }`. `VoiceModeManager.startListening()` then selects the live channel path before the standard turn-based voice path.
+
+```mermaid
+sequenceDiagram
+    participant VM as VoiceModeManager
+    participant LVM as LiveVoiceChannelManager
+    participant LVC as LiveVoiceChannelClient
+    participant CAP as LiveVoiceAudioCapture
+    participant PLAY as LiveVoiceAudioPlayer
+    participant GW as Gateway /v1/live-voice
+    participant AS as Assistant runtime
+
+    VM->>LVM: start(conversationId)
+    LVM->>LVC: start(conversationId, audioFormat: pcm16kMono)
+    LVC->>GW: WebSocket live-voice + token query param
+    GW->>AS: upstream WebSocket with gateway service token
+    AS-->>LVC: ready(sessionId, conversationId)
+    LVM->>CAP: start mic capture
+    CAP-->>LVC: binary PCM chunks
+    VM->>LVM: stopListening()
+    LVM->>LVC: ptt_release
+    AS-->>LVC: stt_partial / stt_final / thinking / assistant_text_delta
+    AS-->>LVC: tts_audio chunks / tts_done / metrics / archived
+    LVC-->>LVM: LiveVoiceChannelEvent
+    LVM->>PLAY: enqueueTTSAudio(...)
+    LVM-->>VM: state + transcript updates
+```
+
+**Transport:** `clients/shared/Network/LiveVoiceChannelClient.swift` is the shared WebSocket client. It builds the authenticated request with `GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params:)`, sends the initial `start` JSON frame, sends mic audio as binary WebSocket frames, sends `ptt_release`, `interrupt`, and `end` control frames, and decodes `ready`, `busy`, `stt_*`, `assistant_text_delta`, `tts_*`, `metrics`, `archived`, and `error` server frames.
+
+**macOS session state:** `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift` owns the live session state machine (`idle`, `connecting`, `listening`, `transcribing`, `thinking`, `speaking`, `ending`, `failed`). It wires `LiveVoiceAudioCapture` for push-to-talk PCM capture and `LiveVoiceAudioPlayer` for streamed assistant audio. `VoiceModeManager` observes the manager with `withObservationTracking()` and maps live-channel states onto the existing voice-mode UI states (`listening`, `processing`, `speaking`, `idle`).
+
+**Fallback behavior:** When live voice is unavailable at listen start, `VoiceModeManager` uses the standard turn-based voice path. If a live session fails after selection, `VoiceModeManager` attempts one fallback to turn-based voice for that session and then relies on the existing STT/service and Apple Speech permission checks. Pending tool permissions also move voice mode back to the turn-based path so the existing approval prompt behavior stays unchanged.
+
+**Provider requirements:** The assistant side requires a configured streaming STT provider for live partial/final transcripts and a streaming-capable TTS provider for `tts_audio` frames. Missing or non-streaming providers surface as live-channel failures; the macOS fallback path can still use standard voice mode if its own STT or speech-recognition requirements are satisfied.
+
+**V1 scope:** The live channel is local/gateway-scoped. Managed/cloud WebSocket proxy support and latency guarantees are not part of this version. `metrics` events expose timing data for measurement, but the client must not assume a hard p50/p95 latency SLO.
+
 ---
 
 ## Data Persistence — Where Everything Lives

--- a/docs/proposals/live-voice-channel.md
+++ b/docs/proposals/live-voice-channel.md
@@ -1,5 +1,9 @@
 # Live Voice Channel Integration Plan
 
+> **Implementation status:** V1 now uses `/v1/live-voice` as a gateway-authenticated WebSocket route. The gateway handler is `gateway/src/http/routes/live-voice-websocket.ts`; the assistant runtime upgrade and protocol shell live in `assistant/src/runtime/http-server.ts`; the assistant-side module boundaries are under `assistant/src/live-voice/`; and macOS voice mode is wired through `clients/shared/Network/LiveVoiceChannelClient.swift`, `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift`, `LiveVoiceAudioCapture.swift`, `LiveVoiceAudioPlayer.swift`, and `VoiceModeManager.swift`. Treat the proposal below as historical design context; the durable architecture references are `assistant/ARCHITECTURE.md` and `clients/ARCHITECTURE.md`.
+>
+> V1 requires a configured streaming STT provider for live partial/final transcripts and a streaming-capable TTS provider for streamed assistant audio. Managed/cloud WebSocket proxy support, cross-region routing, and hard p50/p95 latency guarantees are explicitly out of scope for this version.
+
 ## 1. Existing Infrastructure Map
 
 This repository already has most of the production primitives needed for a local, push-to-talk live voice channel. The standalone proof of concept should be treated as a behavioral reference, not as code to copy: its FastAPI/WebSocket, prompt loader, direct provider clients, and global lock duplicate in-repo abstractions.


### PR DESCRIPTION
## PR 20: update architecture and operator docs

### Depends on

PR 10, PR 19.

### Branch

`live-voice-channel/pr-20-docs`

### Files

- `assistant/ARCHITECTURE.md`
- `clients/ARCHITECTURE.md`
- `docs/proposals/live-voice-channel.md`

### Scope

Update durable docs after the implementation shape is real:

- document `/v1/live-voice` as a gateway-authenticated WebSocket route
- describe assistant-side live voice module boundaries
- document macOS voice mode live-channel flow and fallback behavior
- note provider requirements for streaming STT and streaming TTS
- explicitly state that managed/cloud WebSocket proxy support and latency guarantees are out of scope for this V1
- mark the original proposal with an implementation status note rather than rewriting it

### Acceptance Criteria

- Docs use user-facing "assistant" terminology where appropriate.
- No secrets, personal data, or private workspace paths are added.
- Architecture docs reflect the actual files and route names shipped in prior PRs.

### Verification

Run:

```bash
rg -n "live-voice|LiveVoice|/v1/live-voice" assistant/ARCHITECTURE.md clients/ARCHITECTURE.md docs/proposals/live-voice-channel.md

Orchestrated by velissa-ai via run-plan; implemented by Codex.

Apple refs checked (2026-04-26): URLSessionWebSocketTask, AVAudioEngine, AVAudioPlayer.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
