### PR TITLE
feat(live-voice): add scoped live voice smoke harness (PR 21)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import type { LiveVoiceAudioArchiveResult } from "../live-voice-archive.js";
+import {
+  createLiveVoiceSession,
+  type LiveVoiceSessionArchiveAudioInput,
+  type LiveVoiceTtsStreamer,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsAudioChunk,
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+} from "../protocol.js";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
+} as const satisfies LiveVoiceClientStartFrame;
+
+class FakeStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  readonly audioChunks: Buffer[] = [];
+  stopped = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(audio: Buffer): void {
+    this.audioChunks.push(Buffer.from(audio));
+    this.emit({ type: "partial", text: "hel" });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.emit({ type: "final", text: "hello from live voice" });
+    this.emit({ type: "closed" });
+  }
+
+  private emit(event: SttStreamServerEvent): void {
+    this.onEvent?.(event);
+  }
+}
+
+function createContext(): {
+  context: LiveVoiceSessionFactoryContext;
+  frames: LiveVoiceServerFrame[];
+} {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+
+  return {
+    frames,
+    context: {
+      sessionId: "session-123",
+      startFrame: START_FRAME,
+      sendFrame: mock(async (payload) => {
+        const frame = sequencer.next(payload);
+        frames.push(frame);
+        return frame;
+      }),
+    },
+  };
+}
+
+function createClock(): () => number {
+  let now = 1_000;
+  return () => {
+    now += 25;
+    return now;
+  };
+}
+
+function makeArchiveResult(
+  input: LiveVoiceSessionArchiveAudioInput,
+): LiveVoiceAudioArchiveResult {
+  const attachmentId = `${input.role}-attachment-123`;
+  return {
+    type: "archived",
+    artifact: {
+      source: "live-voice",
+      archiveKey: `live-voice:${input.sessionId}:${input.turnId}:${input.role}`,
+      attachmentId,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      role: input.role,
+      mimeType: input.mimeType,
+      ...(input.sampleRate !== undefined
+        ? { sampleRate: input.sampleRate }
+        : {}),
+      ...(input.durationMs !== undefined
+        ? { durationMs: input.durationMs }
+        : {}),
+      sizeBytes: Buffer.byteLength(input.audio.dataBase64, "base64"),
+      filename: `${attachmentId}.pcm`,
+      archivedAt: 1_234,
+    },
+    idempotent: false,
+  };
+}
+
+function makeTtsChunk(text: string): LiveVoiceTtsAudioChunk {
+  return {
+    type: "tts_audio",
+    seq: 0,
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    dataBase64: Buffer.from(text).toString("base64"),
+  };
+}
+
+function makeTtsResult(text: string): LiveVoiceTtsResult {
+  return {
+    provider: "fish-audio",
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    chunks: 1,
+    bytes: Buffer.byteLength(text),
+  };
+}
+
+function makeTextDelta(
+  text: string,
+): Parameters<NonNullable<VoiceTurnCallbacks["assistant_text_delta"]>>[0] {
+  return {
+    type: "assistant_text_delta",
+    text,
+    conversationId: "conversation-123",
+  };
+}
+
+function makeMessageComplete(): Parameters<
+  NonNullable<VoiceTurnCallbacks["message_complete"]>
+>[0] {
+  return {
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice integration condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+function frameTypes(frames: LiveVoiceServerFrame[]): string[] {
+  return frames.map((frame) => frame.type);
+}
+
+describe("LiveVoiceSession integration smoke harness", () => {
+  test("runs a full credential-free live voice turn through STT, bridge, TTS, archive, and metrics", async () => {
+    const transcriber = new FakeStreamingTranscriber();
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      options.callbacks?.persisted_user_message_id?.("user-message-123");
+      options.callbacks?.assistant_text_delta?.(
+        makeTextDelta("Hello from the assistant."),
+      );
+      options.callbacks?.message_complete?.(makeMessageComplete());
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+      options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+      return makeTtsResult(options.text);
+    });
+    const { context, frames } = createContext();
+    const session = createLiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+      archiveAudio,
+      metricsClock: createClock(),
+      createTurnId: () => "live-turn-1",
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([1, 2, 3, 4]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    expect(transcriber.audioChunks).toHaveLength(1);
+    expect(transcriber.audioChunks[0]).toEqual(Buffer.from([1, 2, 3, 4]));
+    expect(transcriber.stopped).toBe(true);
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      conversationId: "conversation-123",
+      voiceSessionId: "session-123",
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+      userMessageInterface: "macos",
+      assistantMessageInterface: "macos",
+      content: "hello from live voice",
+      isInbound: true,
+    });
+    expect(streamTtsAudio).toHaveBeenCalledTimes(1);
+    expect(streamTtsAudio.mock.calls[0]?.[0]).toMatchObject({
+      text: "Hello from the assistant.",
+      outputFormat: "pcm",
+      sampleRate: 24_000,
+    });
+    expect(archiveAudio.mock.calls.map((call) => call[0].role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_partial",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_audio",
+      "tts_done",
+      "archived",
+      "archived",
+      "metrics",
+    ]);
+    expect(frames[5]).toMatchObject({
+      type: "tts_audio",
+      dataBase64: Buffer.from("audio:Hello from the assistant.").toString(
+        "base64",
+      ),
+    });
+    expect(frames[7]).toMatchObject({
+      type: "archived",
+      role: "user",
+      attachmentIds: ["user-attachment-123"],
+    });
+    expect(frames[8]).toMatchObject({
+      type: "archived",
+      role: "assistant",
+      attachmentIds: ["assistant-attachment-123"],
+    });
+    expect(frames[9]).toMatchObject({
+      type: "metrics",
+      event: "turn_completed",
+      sessionId: "session-123",
+      conversationId: "conversation-123",
+      turnId: "live-turn-1",
+      metrics: {
+        summary: {
+          completedTurnCount: 1,
+          cancelledTurnCount: 0,
+        },
+      },
+    });
+  });
+
+  test("emits archive and cancelled metrics for an interrupted live voice turn", async () => {
+    const transcriber = new FakeStreamingTranscriber();
+    const abort = mock();
+    const archiveAudio = mock(
+      async (input: LiveVoiceSessionArchiveAudioInput) =>
+        makeArchiveResult(input),
+    );
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        options.callbacks?.persisted_user_message_id?.("user-message-123");
+        return { turnId: "bridge-turn-1", abort };
+      },
+    );
+    const streamTtsAudio: LiveVoiceTtsStreamer = mock(
+      async (options: LiveVoiceTtsOptions) => {
+        options.onAudioChunk(makeTtsChunk("late audio"));
+        return makeTtsResult("late audio");
+      },
+    );
+    const { context, frames } = createContext();
+    const session = createLiveVoiceSession(context, {
+      resolveTranscriber: mock(async () => transcriber),
+      startVoiceTurn,
+      streamTtsAudio,
+      archiveAudio,
+      metricsClock: createClock(),
+      createTurnId: () => "live-turn-1",
+    });
+
+    await session.start();
+    await session.handleBinaryAudio(new Uint8Array([9, 8, 7, 6]));
+    await session.handleClientFrame({ type: "ptt_release" });
+    await waitFor(() => frames.some((frame) => frame.type === "thinking"));
+
+    await session.handleClientFrame({ type: "interrupt" });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    );
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(streamTtsAudio).not.toHaveBeenCalled();
+    expect(archiveAudio).toHaveBeenCalledTimes(1);
+    expect(archiveAudio.mock.calls[0]?.[0]).toMatchObject({
+      role: "user",
+      messageId: "user-message-123",
+      sessionId: "session-123",
+      turnId: "live-turn-1",
+    });
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_partial",
+      "stt_final",
+      "thinking",
+      "archived",
+      "metrics",
+    ]);
+    expect(frames[4]).toMatchObject({
+      type: "archived",
+      role: "user",
+      attachmentIds: ["user-attachment-123"],
+    });
+    expect(frames[5]).toMatchObject({
+      type: "metrics",
+      event: "turn_cancelled",
+      turnId: "live-turn-1",
+      metrics: {
+        summary: {
+          completedTurnCount: 0,
+          cancelledTurnCount: 1,
+        },
+      },
+    });
+  });
+});

--- a/clients/shared/Tests/LiveVoiceChannelClientIntegrationTests.swift
+++ b/clients/shared/Tests/LiveVoiceChannelClientIntegrationTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+@MainActor
+final class LiveVoiceChannelClientIntegrationTests: XCTestCase {
+
+    func testScriptedSessionSendsTextAndBinaryFramesAndDecodesServerEvents() async throws {
+        var capturedParams: [String: String]?
+        let task = ScriptedLiveVoiceWebSocketTask()
+        let client = makeClient(task: task, capturedParams: &capturedParams)
+        var events: [LiveVoiceChannelEvent] = []
+        var failures: [LiveVoiceChannelFailure] = []
+        let audio = Data([0, 1, 2, 255])
+
+        await client.start(
+            conversationId: "conv-123",
+            audioFormat: .pcm16kMono,
+            onEvent: { events.append($0) },
+            onFailure: { failures.append($0) }
+        )
+        task.enqueueString(#"{"type":"ready","sessionId":"session-123","conversationId":"conv-123","seq":1}"#)
+        try await waitUntil { events == [.ready(sessionId: "session-123", conversationId: "conv-123")] }
+
+        await client.sendAudio(audio)
+        await client.releasePushToTalk()
+        task.enqueueString(#"{"type":"stt_final","text":"hello","seq":2}"#)
+        task.enqueueString(#"{"type":"thinking","turnId":"turn-123","seq":3}"#)
+        task.enqueueString(#"{"type":"assistant_text_delta","text":"Hi there.","seq":4}"#)
+        task.enqueueString("""
+        {"type":"tts_audio","mimeType":"audio/pcm","sampleRate":16000,"dataBase64":"\(audio.base64EncodedString())","seq":5}
+        """)
+        task.enqueueString(#"{"type":"tts_done","turnId":"turn-123","seq":6}"#)
+        task.enqueueString(#"{"type":"metrics","turnId":"turn-123","sttMs":25,"llmFirstDeltaMs":50,"ttsFirstAudioMs":75,"totalMs":100,"seq":7}"#)
+        task.enqueueString(#"{"type":"archived","conversationId":"conv-123","sessionId":"session-123","seq":8}"#)
+        try await waitUntil { events.count == 8 }
+
+        await client.end()
+
+        XCTAssertEqual(capturedParams, ["conversationId": "conv-123"])
+        XCTAssertTrue(task.didResume)
+        XCTAssertEqual(task.stringMessages.map { try? frameType($0) }, ["start", "ptt_release", "end"])
+        XCTAssertEqual(task.dataMessages, [audio])
+        XCTAssertEqual(events, [
+            .ready(sessionId: "session-123", conversationId: "conv-123"),
+            .sttFinal(text: "hello", seq: 2),
+            .thinking(turnId: "turn-123"),
+            .assistantTextDelta(text: "Hi there.", seq: 4),
+            .ttsAudio(data: audio, mimeType: "audio/pcm", sampleRate: 16_000, seq: 5),
+            .ttsDone(turnId: "turn-123"),
+            .metrics(LiveVoiceChannelMetrics(
+                turnId: "turn-123",
+                sttMs: 25,
+                llmFirstDeltaMs: 50,
+                ttsFirstAudioMs: 75,
+                totalMs: 100
+            )),
+            .archived(conversationId: "conv-123", sessionId: "session-123"),
+        ])
+        XCTAssertEqual(task.cancelCodes, [.normalClosure])
+        XCTAssertTrue(failures.isEmpty)
+    }
+
+    func testBusyFrameReportsTypedFailureAndClosesWithoutSendingAudio() async throws {
+        let task = ScriptedLiveVoiceWebSocketTask()
+        let client = makeClient(task: task)
+        var failures: [LiveVoiceChannelFailure] = []
+
+        await client.start(
+            conversationId: nil,
+            audioFormat: .pcm16kMono,
+            onEvent: { _ in },
+            onFailure: { failures.append($0) }
+        )
+        task.enqueueString(#"{"type":"busy","activeSessionId":"session-active","seq":1}"#)
+        try await waitUntil { failures == [.busy(activeSessionId: "session-active")] }
+
+        await client.sendAudio(Data([1, 2, 3]))
+
+        XCTAssertEqual(task.stringMessages.map { try? frameType($0) }, ["start"])
+        XCTAssertTrue(task.dataMessages.isEmpty)
+        XCTAssertEqual(task.cancelCodes, [.normalClosure])
+    }
+
+    func testAbnormalCloseMapsToTypedFailure() async throws {
+        let task = ScriptedLiveVoiceWebSocketTask()
+        task.closeCode = .internalServerError
+        task.closeReason = Data("upstream failed".utf8)
+        let client = makeClient(task: task)
+        var failures: [LiveVoiceChannelFailure] = []
+
+        await client.start(
+            conversationId: nil,
+            audioFormat: .pcm16kMono,
+            onEvent: { _ in },
+            onFailure: { failures.append($0) }
+        )
+        task.failNextReceive(URLError(.networkConnectionLost))
+
+        try await waitUntil {
+            failures == [
+                .abnormalClosure(
+                    code: URLSessionWebSocketTask.CloseCode.internalServerError.rawValue,
+                    reason: "upstream failed"
+                ),
+            ]
+        }
+        XCTAssertEqual(task.cancelCodes, [.normalClosure])
+    }
+
+    private func makeClient(
+        task: ScriptedLiveVoiceWebSocketTask,
+        capturedParams: UnsafeMutablePointer<[String: String]?>? = nil
+    ) -> LiveVoiceChannelClient {
+        LiveVoiceChannelClient(
+            requestBuilder: { params in
+                capturedParams?.pointee = params
+                return URLRequest(url: URL(string: "wss://example.com/v1/live-voice")!)
+            },
+            webSocketFactory: { _ in task }
+        )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1.0,
+        _ predicate: @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("Timed out waiting for live voice client integration condition")
+    }
+
+    private func frameType(_ text: String) throws -> String {
+        let data = try XCTUnwrap(text.data(using: .utf8))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return try XCTUnwrap(json["type"] as? String)
+    }
+}
+
+private final class ScriptedLiveVoiceWebSocketTask: LiveVoiceChannelWebSocketTask {
+    var closeCode: URLSessionWebSocketTask.CloseCode = .invalid
+    var closeReason: Data?
+    var response: URLResponse?
+
+    private(set) var didResume = false
+    private(set) var sentMessages: [URLSessionWebSocketTask.Message] = []
+    private(set) var cancelCodes: [URLSessionWebSocketTask.CloseCode] = []
+    private var queuedMessages: [URLSessionWebSocketTask.Message] = []
+    private var receiveError: Error?
+
+    var stringMessages: [String] {
+        sentMessages.compactMap { message in
+            if case .string(let text) = message { return text }
+            return nil
+        }
+    }
+
+    var dataMessages: [Data] {
+        sentMessages.compactMap { message in
+            if case .data(let data) = message { return data }
+            return nil
+        }
+    }
+
+    func enqueueString(_ text: String) {
+        queuedMessages.append(.string(text))
+    }
+
+    func failNextReceive(_ error: Error) {
+        receiveError = error
+    }
+
+    func resume() {
+        didResume = true
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        sentMessages.append(message)
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        while !Task.isCancelled {
+            if let receiveError {
+                self.receiveError = nil
+                throw receiveError
+            }
+            if !queuedMessages.isEmpty {
+                return queuedMessages.removeFirst()
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        throw URLError(.cancelled)
+    }
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        cancelCodes.append(closeCode)
+        self.closeCode = closeCode
+        closeReason = reason
+    }
+}


### PR DESCRIPTION
## PR 21: add scoped live voice smoke harness

### Depends on

PR 10, PR 19.

### Branch

`live-voice-channel/pr-21-smoke-harness`

### Files

- `assistant/src/live-voice/__tests__/live-voice-integration.test.ts`
- `clients/shared/Tests/LiveVoiceChannelClientIntegrationTests.swift`

### Scope

Add scoped integration coverage that exercises the shipped path with fake STT, fake conversation turn output, and fake streaming TTS. Keep this credential-free and deterministic.

Assistant test:

- instantiate the live voice session with fake STT, bridge, TTS, archive, and clock dependencies
- send `start`, binary audio, and `ptt_release`
- assert ordered `ready`, STT, thinking, assistant text, TTS, archive, and metrics frames

Swift test:

- run the shared live voice client against a local test WebSocket server or URLProtocol-backed test double, matching the pattern used by existing client networking tests
- verify text frame sends, binary audio sends, event decoding, busy handling, and close behavior

### Acceptance Criteria

- Tests do not require real provider credentials or a running assistant instance.
- The assistant test covers at least one full successful turn and one interrupted turn.
- The Swift test covers `tts_audio` decoding and abnormal close handling.

### Verification

Run:

```bash
export PATH="$HOME/.bun/bin:$PATH"
cd assistant && bun test src/live-voice/__tests__/live-voice-integration.test.ts
cd assistant && bunx tsc --noEmit
cd ../clients
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LiveVoiceChannelClientIntegrationTests
```

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
