### PR TITLE
refactor(clients): drop ACPSpawnAppDelegateBridgeProvider protocol

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -196,13 +196,13 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         self.clientProvider = ClientProvider(connectionManager: cm, client: cm)
         super.init()
 
-        // Register with the shared `ACPSpawnAppDelegateBridge` so the
-        // inline `acp_spawn` tool block in chat (rendered via the shared
-        // `ToolCallProgressBar`) can resolve the live `ACPSessionStore`
-        // without `clients/shared/` statically importing iOS-specific
-        // app-delegate types. Mirrors the macOS `AppDelegate.shared`
-        // singleton path.
-        ACPSpawnAppDelegateBridge.shared = self
+        // Publish the live `ACPSessionStore` through the shared
+        // `ACPSpawnAppDelegateBridge` so the inline `acp_spawn` tool
+        // block in chat (rendered via the shared `ToolCallProgressBar`)
+        // can resolve it without `clients/shared/` statically importing
+        // iOS-specific app-delegate types. Mirrors the macOS
+        // `AppDelegate.shared` singleton path.
+        ACPSpawnAppDelegateBridge.sharedStore = clientProvider.acpSessionStore
 
         // Keep the iOS managed-connection identifiers in sync with the shared
         // `AuthManager` auth state. `AuthManager.logout()` clears
@@ -445,19 +445,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
         config.delegateClass = SceneDelegate.self
         return config
-    }
-}
-
-// MARK: - ACPSpawnAppDelegateBridgeProvider
-
-extension AppDelegate: ACPSpawnAppDelegateBridgeProvider {
-    /// Surfaces the singleton `ACPSessionStore` to the shared
-    /// `ACPSpawnDeepLinkCard` in `ToolCallProgressBar.swift`. The chat-side
-    /// tap handler resolves this via `ACPSpawnAppDelegateBridge.shared`,
-    /// keeping `clients/shared/` free of any iOS-specific app-delegate
-    /// import.
-    var acpSessionStore: ACPSessionStore {
-        clientProvider.acpSessionStore
     }
 }
 

--- a/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
+++ b/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
@@ -99,8 +99,8 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
     }
 
     /// A nil store must short-circuit the deep link without crashing.
-    /// `ACPSpawnAppDelegateBridge.shared` is nil during early launch and
-    /// inside background helpers, so the guard is a real production
+    /// `ACPSpawnAppDelegateBridge.sharedStore` is nil during early launch
+    /// and inside background helpers, so the guard is a real production
     /// path, not just defensive cosmetics.
     func test_applyACPSessionDeepLink_isNoOpWhenStoreIsNil() {
         // No assertion needed beyond "this didn't crash" — the helper

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -439,15 +439,15 @@ public struct ACPSpawnDeepLinkCard: View {
     /// `ACPSessionStore` and asking `IOSRootNavigationView` to surface
     /// the Coding Agents sheet via the same store-observation hook.
     /// The store is resolved through ``ACPSpawnAppDelegateBridge``,
-    /// which the iOS app delegate registers itself with on launch — that
-    /// indirection keeps `clients/shared/` free of any
-    /// iOS-specific `AppDelegate` import.
+    /// which the iOS app delegate populates on launch — that indirection
+    /// keeps `clients/shared/` free of any iOS-specific `AppDelegate`
+    /// import.
     ///
     /// `static` so unit tests can exercise the side effects against an
     /// injected `ACPSessionStore` via
     /// ``applyACPSessionDeepLink(id:store:)``.
     static func openACPSession(id: String) {
-        applyACPSessionDeepLink(id: id, store: ACPSpawnAppDelegateBridge.shared?.acpSessionStore)
+        applyACPSessionDeepLink(id: id, store: ACPSpawnAppDelegateBridge.sharedStore)
     }
 
     /// Pure side-effect helper for ``openACPSession(id:)``. Setting the
@@ -503,20 +503,13 @@ private struct ACPSpawnStatusIndicator: View {
 /// Indirection so the deep-link card can resolve the live
 /// `ACPSessionStore` without `ToolCallProgressBar.swift` (a `shared/`
 /// file) statically referencing the iOS `AppDelegate` class. The iOS
-/// app delegate registers itself here on launch; tests inject a stand-in.
+/// app delegate populates this slot on launch; tests assign directly.
 @MainActor
 public enum ACPSpawnAppDelegateBridge {
-    /// Provider of the singleton `ACPSessionStore` for the running app.
-    /// The slot is `weak` so the bridge doesn't keep the app delegate
-    /// alive past its natural lifetime — losing the reference during
-    /// teardown surfaces as a soft no-op tap rather than a leak.
-    public static weak var shared: ACPSpawnAppDelegateBridgeProvider?
-}
-
-/// Surface the bridge needs from whatever owns the live
-/// `ACPSessionStore`. iOS satisfies this with an `AppDelegate`
-/// extension; tests satisfy it with an inline class.
-public protocol ACPSpawnAppDelegateBridgeProvider: AnyObject {
-    var acpSessionStore: ACPSessionStore { get }
+    /// Live `ACPSessionStore` for the running app. The slot is `weak`
+    /// so the bridge doesn't keep the store alive past its natural
+    /// lifetime — losing the reference during teardown surfaces as a
+    /// soft no-op tap rather than a leak.
+    public static weak var sharedStore: ACPSessionStore?
 }
 #endif


### PR DESCRIPTION
## Summary
- Single-implementer protocol replaced with a direct `weak var sharedStore: ACPSessionStore?` slot on `ACPSpawnAppDelegateBridge`.
- iOS `AppDelegate` sets the slot directly at init.

Gap caught during plan review for acp-sessions-ui.md.
**Gap:** Protocol with one production conformer and zero test conformers — pure indirection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
