### PR TITLE
refactor(clients): consolidate extractAcpSessionId to shared module

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -817,9 +817,9 @@ private final class StepDetailAttributedStringCacheEntry: NSObject {
 /// `ToolCallData`.
 ///
 /// `internal` rather than `private` so unit tests can reach the static
-/// `acp_spawn` deep-link helpers (`extractAcpSessionId`,
-/// `applyACPSessionDeepLink`) without standing up the full SwiftUI view
-/// tree. Production callers stay scoped to this file.
+/// `acp_spawn` deep-link helper (`applyACPSessionDeepLink`) without
+/// standing up the full SwiftUI view tree. Production callers stay scoped
+/// to this file.
 struct ToolCallStepDetailRow: View {
     @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
 
@@ -921,6 +921,10 @@ struct ToolCallStepDetailRow: View {
     /// chat-side behaviour unsurprising — a still-running or failed spawn
     /// has no detail view to jump to, so the row falls back to the regular
     /// expandable shape so the user can read the live output / error.
+    ///
+    /// Delegates payload parsing to ``ToolCallProgressBar/extractAcpSessionId(from:)``
+    /// in `clients/shared/` so iOS and macOS accept identical payload shapes
+    /// from a single implementation.
     var acpSessionIdToOpen: String? {
         guard toolCall.toolName == "acp_spawn",
               toolCall.isComplete,
@@ -929,29 +933,7 @@ struct ToolCallStepDetailRow: View {
               !result.isEmpty else {
             return nil
         }
-        return ToolCallStepDetailRow.extractAcpSessionId(from: result)
-    }
-
-    /// Best-effort JSON probe for the `acpSessionId` field in
-    /// `acp_spawn`'s result payload. The tool returns a JSON object on
-    /// the first line and may append a free-form outdated-adapter
-    /// warning after a blank line (see `assistant/src/tools/acp/spawn.ts`),
-    /// so we parse the leading line rather than the full string —
-    /// otherwise the appended diagnostic invalidates the JSON and the
-    /// deep link would silently disappear in that case. On failure or
-    /// any non-JSON shape we return nil so the caller falls back to the
-    /// regular collapsible row. Static so unit tests can exercise the
-    /// parser without standing up the full view.
-    static func extractAcpSessionId(from result: String) -> String? {
-        let leading = result.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
-            .first.map(String.init) ?? ""
-        guard let data = leading.data(using: .utf8) else { return nil }
-        let parsed = try? JSONSerialization.jsonObject(with: data)
-        guard let dict = parsed as? [String: Any] else { return nil }
-        guard let id = dict["acpSessionId"] as? String, !id.isEmpty else {
-            return nil
-        }
-        return id
+        return ToolCallProgressBar.extractAcpSessionId(from: result)
     }
 
     var body: some View {

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
@@ -52,6 +52,10 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
     }
 
     // MARK: - extractAcpSessionId
+    //
+    // The parser lives in shared code (`ToolCallProgressBar.extractAcpSessionId`)
+    // so iOS and macOS accept identical `acp_spawn` payload shapes. These
+    // tests exercise the shared helper rather than a per-platform copy.
 
     /// Happy path: the tool returns a JSON object with `acpSessionId` set.
     /// We must surface exactly that string so the deep link lands on the
@@ -59,7 +63,7 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
     func test_extractAcpSessionId_returnsIdFromCanonicalPayload() {
         let payload = #"{"acpSessionId":"acp-abc-123","protocolSessionId":"proto-x","agent":"claude","cwd":"/tmp","status":"running","message":"…"}"#
         XCTAssertEqual(
-            ToolCallStepDetailRow.extractAcpSessionId(from: payload),
+            ToolCallProgressBar.extractAcpSessionId(from: payload),
             "acp-abc-123"
         )
     }
@@ -76,7 +80,7 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
         Note: claude-agent-acp is outdated (installed: 1.0.0, latest: 1.1.0).
         """
         XCTAssertEqual(
-            ToolCallStepDetailRow.extractAcpSessionId(from: payload),
+            ToolCallProgressBar.extractAcpSessionId(from: payload),
             "acp-xyz-789"
         )
     }
@@ -86,9 +90,9 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
     /// silently rendering an unparseable row as a tap-to-open card would
     /// strand the user on a broken link.
     func test_extractAcpSessionId_returnsNilForEmptyOrMalformedJson() {
-        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: ""))
-        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: "not-json"))
-        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: "{"))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: ""))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: "not-json"))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: "{"))
     }
 
     /// A JSON object that doesn't carry `acpSessionId` (e.g. an error
@@ -96,7 +100,7 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
     /// malformed JSON.
     func test_extractAcpSessionId_returnsNilWhenFieldMissing() {
         let payload = #"{"error":"binary not found","agent":"claude"}"#
-        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: payload))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: payload))
     }
 
     /// `acpSessionId` exists but is empty — also treated as no link, since
@@ -104,15 +108,15 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
     /// would never resolve.
     func test_extractAcpSessionId_returnsNilForEmptyIdString() {
         let payload = #"{"acpSessionId":"","agent":"claude"}"#
-        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: payload))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: payload))
     }
 
     /// A non-string `acpSessionId` (number, null) must not crash the parse
     /// or coerce to a stringified value — it must surface as nil so the
     /// fallback row renders.
     func test_extractAcpSessionId_returnsNilForNonStringIdValues() {
-        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: #"{"acpSessionId":42}"#))
-        XCTAssertNil(ToolCallStepDetailRow.extractAcpSessionId(from: #"{"acpSessionId":null}"#))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: #"{"acpSessionId":42}"#))
+        XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: #"{"acpSessionId":null}"#))
     }
 
     // MARK: - applyACPSessionDeepLink

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -118,9 +118,10 @@ public struct ToolCallProgressBar: View {
     /// otherwise the appended diagnostic invalidates the JSON and the
     /// deep link would silently disappear in that case. On failure or
     /// any non-JSON shape we return `nil` so the caller falls back to
-    /// the regular progress bar. Mirrors
-    /// `ToolCallStepDetailRow.extractAcpSessionId(from:)` on macOS so
-    /// both platforms accept the same payload shapes.
+    /// the regular progress bar. Shared between iOS and macOS — macOS
+    /// `ToolCallStepDetailRow.acpSessionIdToOpen` calls this helper so
+    /// both platforms accept the same payload shapes from a single
+    /// implementation.
     public static func extractAcpSessionId(from result: String) -> String? {
         let leading = result.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
             .first.map(String.init) ?? ""


### PR DESCRIPTION
## Summary
- Drops the duplicate macOS `extractAcpSessionId` from `AssistantProgressView.swift`; macOS now calls the shared `ToolCallProgressBar.extractAcpSessionId`.
- Tests updated to exercise the shared helper.

Gap caught during plan review for acp-sessions-ui.md.
**Gap:** Same JSON-leading-line probe duplicated byte-for-byte in two files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
