### PR TITLE
fix(live-voice): wire runtime route to real session

### DIFF
--- a/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
+++ b/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
@@ -40,6 +45,44 @@ mock.module("../../config/loader.js", () => {
     invalidateConfigCache: () => {},
   };
 });
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  readonly audioChunks: number[][] = [];
+  readonly mimeTypes: string[] = [];
+  started = false;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.started = true;
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(audio: Buffer, mimeType: string): void {
+    this.audioChunks.push([...audio]);
+    this.mimeTypes.push(mimeType);
+    this.onEvent?.({
+      type: "partial",
+      text: `partial-${this.audioChunks.length}`,
+    });
+  }
+
+  stop(): void {
+    this.onEvent?.({ type: "closed" });
+  }
+}
+
+const resolvedTranscribers: MockStreamingTranscriber[] = [];
+const resolveStreamingTranscriberMock = mock(async () => {
+  const transcriber = new MockStreamingTranscriber();
+  resolvedTranscribers.push(transcriber);
+  return transcriber;
+});
+
+mock.module("../../providers/speech-to-text/resolve.js", () => ({
+  resolveStreamingTranscriber: resolveStreamingTranscriberMock,
+}));
 
 import { CURRENT_POLICY_EPOCH } from "../../runtime/auth/policy.js";
 import { mintToken } from "../../runtime/auth/token-service.js";
@@ -191,6 +234,8 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
   beforeEach(async () => {
     delete process.env.DISABLE_HTTP_AUTH;
     delete process.env.VELLUM_UNSAFE_AUTH_BYPASS;
+    resolveStreamingTranscriberMock.mockClear();
+    resolvedTranscribers.length = 0;
     clients = [];
     const port = 21100 + Math.floor(Math.random() * 300);
     server = new RuntimeHttpServer({ port, hostname: "127.0.0.1" });
@@ -256,7 +301,7 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
     expect(externalOrigin.status).toBe(403);
   });
 
-  test("sends ready for a well-formed start frame", async () => {
+  test("routes start and audio frames through the real live voice session", async () => {
     const ws = openLiveVoiceClient();
     await waitForOpen(ws);
 
@@ -269,6 +314,21 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
       conversationId: "conversation-ready",
     });
     expect(typeof ready.sessionId).toBe("string");
+    expect(resolveStreamingTranscriberMock).toHaveBeenCalledWith({
+      sampleRate: 24_000,
+    });
+    expect(resolvedTranscribers).toHaveLength(1);
+    expect(resolvedTranscribers[0]?.started).toBe(true);
+
+    ws.send(new Uint8Array([1, 2, 3]));
+    const partial = await waitForJsonFrame(ws);
+    expect(partial).toMatchObject({
+      type: "stt_partial",
+      seq: 2,
+      text: "partial-1",
+    });
+    expect(resolvedTranscribers[0]?.audioChunks).toEqual([[1, 2, 3]]);
+    expect(resolvedTranscribers[0]?.mimeTypes).toEqual(["audio/pcm"]);
   });
 
   test("sends an error for malformed frames and can still start", async () => {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -43,11 +43,8 @@ import {
 } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
 import { normalizeConversationType } from "../daemon/message-types/shared.js";
-import {
-  type LiveVoiceSession,
-  type LiveVoiceSessionFactoryContext,
-  LiveVoiceSessionManager,
-} from "../live-voice/live-voice-session-manager.js";
+import { createLiveVoiceSession } from "../live-voice/live-voice-session.js";
+import { LiveVoiceSessionManager } from "../live-voice/live-voice-session-manager.js";
 import {
   type LiveVoiceClientFrame,
   type LiveVoiceProtocolError,
@@ -350,25 +347,6 @@ interface LiveVoiceWebSocketData {
   lastSeq: number;
 }
 
-class RuntimeLiveVoiceStubSession implements LiveVoiceSession {
-  constructor(private readonly context: LiveVoiceSessionFactoryContext) {}
-
-  async start(): Promise<void> {
-    await this.context.sendFrame({
-      type: "ready",
-      sessionId: this.context.sessionId,
-      conversationId:
-        this.context.startFrame.conversationId ?? this.context.sessionId,
-    });
-  }
-
-  handleClientFrame(_frame: LiveVoiceClientFrame): void {}
-
-  handleBinaryAudio(_chunk: Uint8Array): void {}
-
-  close(): void {}
-}
-
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -421,7 +399,7 @@ export class RuntimeHttpServer {
     this.getHeartbeatService = options.getHeartbeatService;
     this.getFilingService = options.getFilingService;
     this.liveVoiceSessionManager = new LiveVoiceSessionManager({
-      createSession: (context) => new RuntimeLiveVoiceStubSession(context),
+      createSession: (context) => createLiveVoiceSession(context),
     });
     this.router = new HttpRouter(this.buildRouteTable());
   }


### PR DESCRIPTION
## Summary
Fixes self-review gap from live-voice-channel.md.

Gap: Runtime WebSocket still used the PR 3 stub session, so the shipped route did not reach STT/assistant/TTS/archive/metrics.

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
