### PR TITLE
refactor(clients): consolidate ACP row formatters to shared module

### DIFF
--- a/clients/ios/Tests/ACPSessionsViewIOSTests.swift
+++ b/clients/ios/Tests/ACPSessionsViewIOSTests.swift
@@ -34,48 +34,48 @@ final class ACPSessionsViewIOSTests: XCTestCase {
     // MARK: - Agent / status label mapping
 
     func test_agentLabel_mapsKnownAgentIds() {
-        XCTAssertEqual(ACPSessionsViewRow.agentLabel(for: "claude-code"), "Claude")
-        XCTAssertEqual(ACPSessionsViewRow.agentLabel(for: "codex"), "Codex")
+        XCTAssertEqual(ACPSessionStateFormatter.agentLabel(for: "claude-code"), "Claude")
+        XCTAssertEqual(ACPSessionStateFormatter.agentLabel(for: "codex"), "Codex")
     }
 
     func test_agentLabel_fallsBackToRawIdForUnknownAgents() {
         XCTAssertEqual(
-            ACPSessionsViewRow.agentLabel(for: "future-agent"),
+            ACPSessionStateFormatter.agentLabel(for: "future-agent"),
             "future-agent",
             "Unknown agent ids must fall through so a new agent type still renders"
         )
     }
 
     func test_statusLabel_capitalisesEveryCase() {
-        XCTAssertEqual(ACPSessionsViewRow.statusLabel(.initializing), "Starting")
-        XCTAssertEqual(ACPSessionsViewRow.statusLabel(.running), "Running")
-        XCTAssertEqual(ACPSessionsViewRow.statusLabel(.completed), "Completed")
-        XCTAssertEqual(ACPSessionsViewRow.statusLabel(.failed), "Failed")
-        XCTAssertEqual(ACPSessionsViewRow.statusLabel(.cancelled), "Cancelled")
-        XCTAssertEqual(ACPSessionsViewRow.statusLabel(.unknown), "Unknown")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.initializing), "Starting")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.running), "Running")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.completed), "Completed")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.failed), "Failed")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.cancelled), "Cancelled")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.unknown), "Unknown")
     }
 
     // MARK: - Parent conversation truncation
 
     func test_parentConversationLabel_truncatesLongIds() {
-        let label = ACPSessionsViewRow.parentConversationLabel("conv-abcdef-1234567890")
+        let label = ACPSessionStateFormatter.parentConversationLabel("conv-abcdef-1234567890")
         XCTAssertEqual(label, "conv-abc…")
     }
 
     func test_parentConversationLabel_returnsShortIdsUntouched() {
-        XCTAssertEqual(ACPSessionsViewRow.parentConversationLabel("short"), "short")
+        XCTAssertEqual(ACPSessionStateFormatter.parentConversationLabel("short"), "short")
     }
 
     func test_parentConversationLabel_isNilForMissingOrEmptyIds() {
-        XCTAssertNil(ACPSessionsViewRow.parentConversationLabel(nil))
-        XCTAssertNil(ACPSessionsViewRow.parentConversationLabel(""))
+        XCTAssertNil(ACPSessionStateFormatter.parentConversationLabel(nil))
+        XCTAssertNil(ACPSessionStateFormatter.parentConversationLabel(""))
     }
 
     // MARK: - Elapsed-time formatting
 
     func test_elapsedLabel_completedSessionReportsDuration() {
         // 1700000000000 ms → +90s == 1m 30s.
-        let label = ACPSessionsViewRow.elapsedLabel(
+        let label = ACPSessionStateFormatter.elapsedLabel(
             startedAt: 1_700_000_000_000,
             completedAt: 1_700_000_000_000 + 90_000
         )
@@ -83,7 +83,7 @@ final class ACPSessionsViewIOSTests: XCTestCase {
     }
 
     func test_elapsedLabel_subMinuteCompletedSessionReportsSeconds() {
-        let label = ACPSessionsViewRow.elapsedLabel(
+        let label = ACPSessionStateFormatter.elapsedLabel(
             startedAt: 1_700_000_000_000,
             completedAt: 1_700_000_000_000 + 5_000
         )
@@ -93,7 +93,7 @@ final class ACPSessionsViewIOSTests: XCTestCase {
     func test_elapsedLabel_runningSessionFallsBackToRelativeFormatter() {
         // No `completedAt` → relative-time formatter takes over. We can't
         // pin its exact string (locale-dependent) but it must not be empty.
-        let label = ACPSessionsViewRow.elapsedLabel(
+        let label = ACPSessionStateFormatter.elapsedLabel(
             startedAt: Int(Date().addingTimeInterval(-120).timeIntervalSince1970 * 1000),
             completedAt: nil
         )

--- a/clients/ios/Views/ACPSessionDetailView.swift
+++ b/clients/ios/Views/ACPSessionDetailView.swift
@@ -109,7 +109,7 @@ struct ACPSessionDetailViewIOS: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                Text(ACPSessionsViewRow.agentLabel(for: session.state.agentId))
+                Text(ACPSessionStateFormatter.agentLabel(for: session.state.agentId))
                     .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)

--- a/clients/ios/Views/ACPSessionsView.swift
+++ b/clients/ios/Views/ACPSessionsView.swift
@@ -294,7 +294,7 @@ struct ACPSessionsViewRow: View {
 
     @ViewBuilder
     private var agentBadge: some View {
-        Text(Self.agentLabel(for: state.agentId))
+        Text(ACPSessionStateFormatter.agentLabel(for: state.agentId))
             .font(VFont.labelDefault)
             .foregroundStyle(VColor.contentDefault)
             .padding(.horizontal, VSpacing.sm)
@@ -306,12 +306,12 @@ struct ACPSessionsViewRow: View {
     }
 
     private var statusPill: some View {
-        let tint = Self.statusColor(state.status)
+        let tint = ACPSessionStateFormatter.statusColor(state.status)
         return HStack(spacing: VSpacing.xs) {
             Circle()
                 .fill(tint)
                 .frame(width: 6, height: 6)
-            Text(Self.statusLabel(state.status))
+            Text(ACPSessionStateFormatter.statusLabel(state.status))
                 .font(VFont.labelDefault)
                 .foregroundStyle(tint)
         }
@@ -326,11 +326,11 @@ struct ACPSessionsViewRow: View {
     @ViewBuilder
     private var metadataLine: some View {
         HStack(spacing: VSpacing.xs) {
-            Text(Self.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt))
+            Text(ACPSessionStateFormatter.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt))
                 .font(VFont.labelSmall)
                 .foregroundStyle(VColor.contentTertiary)
                 .monospacedDigit()
-            if let parentLabel = Self.parentConversationLabel(state.parentConversationId) {
+            if let parentLabel = ACPSessionStateFormatter.parentConversationLabel(state.parentConversationId) {
                 Text("·")
                     .font(VFont.labelSmall)
                     .foregroundStyle(VColor.contentTertiary)
@@ -346,70 +346,14 @@ struct ACPSessionsViewRow: View {
 
     private var accessibilityLabel: String {
         var parts: [String] = [
-            Self.agentLabel(for: state.agentId),
-            Self.statusLabel(state.status),
-            Self.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt)
+            ACPSessionStateFormatter.agentLabel(for: state.agentId),
+            ACPSessionStateFormatter.statusLabel(state.status),
+            ACPSessionStateFormatter.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt)
         ]
-        if let parentLabel = Self.parentConversationLabel(state.parentConversationId) {
+        if let parentLabel = ACPSessionStateFormatter.parentConversationLabel(state.parentConversationId) {
             parts.append("conversation \(parentLabel)")
         }
         return parts.joined(separator: ", ")
-    }
-
-    // MARK: - Formatting (static for testability)
-
-    /// Unknown ids fall through to the raw value so a new agent type still
-    /// renders without a code change.
-    static func agentLabel(for agentId: String) -> String {
-        switch agentId {
-        case "claude-code": return "Claude"
-        case "codex": return "Codex"
-        default: return agentId
-        }
-    }
-
-    static func statusLabel(_ status: ACPSessionState.Status) -> String {
-        switch status {
-        case .initializing: return "Starting"
-        case .running: return "Running"
-        case .completed: return "Completed"
-        case .failed: return "Failed"
-        case .cancelled: return "Cancelled"
-        case .unknown: return "Unknown"
-        }
-    }
-
-    static func statusColor(_ status: ACPSessionState.Status) -> Color {
-        switch status {
-        case .running, .initializing: return VColor.primaryActive
-        case .completed: return VColor.systemPositiveStrong
-        case .failed, .cancelled: return VColor.systemNegativeStrong
-        case .unknown: return VColor.contentTertiary
-        }
-    }
-
-    /// Locale-aware "5m ago" for live sessions; wall-clock duration for
-    /// terminated sessions so a finished row doesn't keep ticking.
-    static func elapsedLabel(startedAt: Int, completedAt: Int?) -> String {
-        let started = Date(timeIntervalSince1970: TimeInterval(startedAt) / 1000)
-        if let completedAt {
-            let completed = Date(timeIntervalSince1970: TimeInterval(completedAt) / 1000)
-            return VCollapsibleStepRowDurationFormatter.format(
-                max(0, completed.timeIntervalSince(started))
-            )
-        }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: started, relativeTo: Date())
-    }
-
-    /// Returns `nil` for empty/missing ids so the metadata line degrades
-    /// gracefully instead of rendering a stray separator.
-    static func parentConversationLabel(_ parentId: String?) -> String? {
-        guard let parentId, !parentId.isEmpty else { return nil }
-        let prefixLength = 8
-        if parentId.count <= prefixLength { return parentId }
-        return String(parentId.prefix(prefixLength)) + "…"
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -357,7 +357,7 @@ struct ACPSessionsPanelRow: View {
 
     @ViewBuilder
     private var agentBadge: some View {
-        Text(Self.agentLabel(for: state.agentId))
+        Text(ACPSessionStateFormatter.agentLabel(for: state.agentId))
             .font(VFont.labelDefault)
             .foregroundStyle(VColor.contentDefault)
             .padding(.horizontal, VSpacing.sm)
@@ -369,12 +369,12 @@ struct ACPSessionsPanelRow: View {
     }
 
     private var statusPill: some View {
-        let tint = Self.statusColor(state.status)
+        let tint = ACPSessionStateFormatter.statusColor(state.status)
         return HStack(spacing: VSpacing.xs) {
             Circle()
                 .fill(tint)
                 .frame(width: 6, height: 6)
-            Text(Self.statusLabel(state.status))
+            Text(ACPSessionStateFormatter.statusLabel(state.status))
                 .font(VFont.labelDefault)
                 .foregroundStyle(tint)
         }
@@ -389,11 +389,11 @@ struct ACPSessionsPanelRow: View {
     @ViewBuilder
     private var metadataLine: some View {
         HStack(spacing: VSpacing.xs) {
-            Text(Self.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt))
+            Text(ACPSessionStateFormatter.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt))
                 .font(VFont.labelSmall)
                 .foregroundStyle(VColor.contentTertiary)
                 .monospacedDigit()
-            if let parentLabel = Self.parentConversationLabel(state.parentConversationId) {
+            if let parentLabel = ACPSessionStateFormatter.parentConversationLabel(state.parentConversationId) {
                 Text("·")
                     .font(VFont.labelSmall)
                     .foregroundStyle(VColor.contentTertiary)
@@ -409,69 +409,13 @@ struct ACPSessionsPanelRow: View {
 
     private var accessibilityLabel: String {
         var parts: [String] = [
-            Self.agentLabel(for: state.agentId),
-            Self.statusLabel(state.status),
-            Self.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt)
+            ACPSessionStateFormatter.agentLabel(for: state.agentId),
+            ACPSessionStateFormatter.statusLabel(state.status),
+            ACPSessionStateFormatter.elapsedLabel(startedAt: state.startedAt, completedAt: state.completedAt)
         ]
-        if let parentLabel = Self.parentConversationLabel(state.parentConversationId) {
+        if let parentLabel = ACPSessionStateFormatter.parentConversationLabel(state.parentConversationId) {
             parts.append("conversation \(parentLabel)")
         }
         return parts.joined(separator: ", ")
-    }
-
-    // MARK: - Formatting (static for testability)
-
-    /// Unknown ids fall through to the raw value so a new agent type still
-    /// renders without a code change.
-    static func agentLabel(for agentId: String) -> String {
-        switch agentId {
-        case "claude-code": return "Claude"
-        case "codex": return "Codex"
-        default: return agentId
-        }
-    }
-
-    static func statusLabel(_ status: ACPSessionState.Status) -> String {
-        switch status {
-        case .initializing: return "Starting"
-        case .running: return "Running"
-        case .completed: return "Completed"
-        case .failed: return "Failed"
-        case .cancelled: return "Cancelled"
-        case .unknown: return "Unknown"
-        }
-    }
-
-    static func statusColor(_ status: ACPSessionState.Status) -> Color {
-        switch status {
-        case .running, .initializing: return VColor.primaryActive
-        case .completed: return VColor.systemPositiveStrong
-        case .failed, .cancelled: return VColor.systemNegativeStrong
-        case .unknown: return VColor.contentTertiary
-        }
-    }
-
-    /// Locale-aware "5m ago" for live sessions; wall-clock duration for
-    /// terminated sessions so a finished row doesn't keep ticking.
-    static func elapsedLabel(startedAt: Int, completedAt: Int?) -> String {
-        let started = Date(timeIntervalSince1970: TimeInterval(startedAt) / 1000)
-        if let completedAt {
-            let completed = Date(timeIntervalSince1970: TimeInterval(completedAt) / 1000)
-            return VCollapsibleStepRowDurationFormatter.format(
-                max(0, completed.timeIntervalSince(started))
-            )
-        }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: started, relativeTo: Date())
-    }
-
-    /// Returns `nil` for empty/missing ids so the metadata line degrades
-    /// gracefully instead of rendering a stray separator.
-    static func parentConversationLabel(_ parentId: String?) -> String? {
-        guard let parentId, !parentId.isEmpty else { return nil }
-        let prefixLength = 8
-        if parentId.count <= prefixLength { return parentId }
-        return String(parentId.prefix(prefixLength)) + "…"
     }
 }

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -83,13 +83,13 @@ final class ACPSessionsPanelTests: XCTestCase {
     // MARK: - Agent label mapping
 
     func test_agentLabel_mapsKnownAgentIds() {
-        XCTAssertEqual(ACPSessionsPanelRow.agentLabel(for: "claude-code"), "Claude")
-        XCTAssertEqual(ACPSessionsPanelRow.agentLabel(for: "codex"), "Codex")
+        XCTAssertEqual(ACPSessionStateFormatter.agentLabel(for: "claude-code"), "Claude")
+        XCTAssertEqual(ACPSessionStateFormatter.agentLabel(for: "codex"), "Codex")
     }
 
     func test_agentLabel_fallsBackToRawIdForUnknownAgents() {
         XCTAssertEqual(
-            ACPSessionsPanelRow.agentLabel(for: "future-agent"),
+            ACPSessionStateFormatter.agentLabel(for: "future-agent"),
             "future-agent",
             "Unknown agent ids must fall through so a new agent type still renders"
         )
@@ -98,35 +98,35 @@ final class ACPSessionsPanelTests: XCTestCase {
     // MARK: - Status label / colour mapping
 
     func test_statusLabel_capitalisesEveryCase() {
-        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.initializing), "Starting")
-        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.running), "Running")
-        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.completed), "Completed")
-        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.failed), "Failed")
-        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.cancelled), "Cancelled")
-        XCTAssertEqual(ACPSessionsPanelRow.statusLabel(.unknown), "Unknown")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.initializing), "Starting")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.running), "Running")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.completed), "Completed")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.failed), "Failed")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.cancelled), "Cancelled")
+        XCTAssertEqual(ACPSessionStateFormatter.statusLabel(.unknown), "Unknown")
     }
 
     // MARK: - Parent conversation truncation
 
     func test_parentConversationLabel_truncatesLongIds() {
-        let label = ACPSessionsPanelRow.parentConversationLabel("conv-abcdef-1234567890")
+        let label = ACPSessionStateFormatter.parentConversationLabel("conv-abcdef-1234567890")
         XCTAssertEqual(label, "conv-abc…")
     }
 
     func test_parentConversationLabel_returnsShortIdsUntouched() {
-        XCTAssertEqual(ACPSessionsPanelRow.parentConversationLabel("short"), "short")
+        XCTAssertEqual(ACPSessionStateFormatter.parentConversationLabel("short"), "short")
     }
 
     func test_parentConversationLabel_isNilForMissingOrEmptyIds() {
-        XCTAssertNil(ACPSessionsPanelRow.parentConversationLabel(nil))
-        XCTAssertNil(ACPSessionsPanelRow.parentConversationLabel(""))
+        XCTAssertNil(ACPSessionStateFormatter.parentConversationLabel(nil))
+        XCTAssertNil(ACPSessionStateFormatter.parentConversationLabel(""))
     }
 
     // MARK: - Elapsed-time formatting
 
     func test_elapsedLabel_completedSessionReportsDuration() {
         // 1700000000000 ms → +90s == 1m 30s.
-        let label = ACPSessionsPanelRow.elapsedLabel(
+        let label = ACPSessionStateFormatter.elapsedLabel(
             startedAt: 1_700_000_000_000,
             completedAt: 1_700_000_000_000 + 90_000
         )
@@ -134,7 +134,7 @@ final class ACPSessionsPanelTests: XCTestCase {
     }
 
     func test_elapsedLabel_subMinuteCompletedSessionReportsSeconds() {
-        let label = ACPSessionsPanelRow.elapsedLabel(
+        let label = ACPSessionStateFormatter.elapsedLabel(
             startedAt: 1_700_000_000_000,
             completedAt: 1_700_000_000_000 + 5_000
         )
@@ -147,7 +147,7 @@ final class ACPSessionsPanelTests: XCTestCase {
         // No `completedAt` → relative-time formatter takes over. We can't
         // pin its exact string (locale-dependent) but it must not be empty
         // and must not look like the duration formatter's output.
-        let label = ACPSessionsPanelRow.elapsedLabel(
+        let label = ACPSessionStateFormatter.elapsedLabel(
             startedAt: Int(Date().addingTimeInterval(-120).timeIntervalSince1970 * 1000),
             completedAt: nil
         )

--- a/clients/shared/Network/ACPSessionStateFormatter.swift
+++ b/clients/shared/Network/ACPSessionStateFormatter.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftUI
+
+/// Pure-function formatters for ACP session row content.
+///
+/// Shared by ``ACPSessionsPanelRow`` (macOS) and ``ACPSessionsViewRow``
+/// (iOS) so the two surfaces present coding-agent rows identically without
+/// duplicating the label/colour/elapsed mapping. Keep this enum free of
+/// platform-specific types — both row implementations import the shared
+/// module, so anything that compiles here must work for both.
+public enum ACPSessionStateFormatter {
+
+    /// Human label for the agent that owns a session. Unknown ids fall
+    /// through to the raw value so a new agent type still renders without
+    /// a code change.
+    public static func agentLabel(for agentId: String) -> String {
+        switch agentId {
+        case "claude-code": return "Claude"
+        case "codex": return "Codex"
+        default: return agentId
+        }
+    }
+
+    /// Capitalised label for a status enum case.
+    public static func statusLabel(_ status: ACPSessionState.Status) -> String {
+        switch status {
+        case .initializing: return "Starting"
+        case .running: return "Running"
+        case .completed: return "Completed"
+        case .failed: return "Failed"
+        case .cancelled: return "Cancelled"
+        case .unknown: return "Unknown"
+        }
+    }
+
+    /// Tint colour for a status enum case. Live sessions use the primary
+    /// accent so they stand out from completed/terminal rows.
+    public static func statusColor(_ status: ACPSessionState.Status) -> Color {
+        switch status {
+        case .running, .initializing: return VColor.primaryActive
+        case .completed: return VColor.systemPositiveStrong
+        case .failed, .cancelled: return VColor.systemNegativeStrong
+        case .unknown: return VColor.contentTertiary
+        }
+    }
+
+    /// Locale-aware "5m ago" for live sessions; wall-clock duration for
+    /// terminated sessions so a finished row doesn't keep ticking.
+    public static func elapsedLabel(startedAt: Int, completedAt: Int?) -> String {
+        let started = Date(timeIntervalSince1970: TimeInterval(startedAt) / 1000)
+        if let completedAt {
+            let completed = Date(timeIntervalSince1970: TimeInterval(completedAt) / 1000)
+            return VCollapsibleStepRowDurationFormatter.format(
+                max(0, completed.timeIntervalSince(started))
+            )
+        }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: started, relativeTo: Date())
+    }
+
+    /// Returns `nil` for empty/missing ids so the metadata line degrades
+    /// gracefully instead of rendering a stray separator.
+    public static func parentConversationLabel(_ parentId: String?) -> String? {
+        guard let parentId, !parentId.isEmpty else { return nil }
+        let prefixLength = 8
+        if parentId.count <= prefixLength { return parentId }
+        return String(parentId.prefix(prefixLength)) + "…"
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts five row formatter helpers (agent label, status label, status color, elapsed label, parent-conversation label) to `ACPSessionStateFormatter` in shared.
- macOS `ACPSessionsPanelRow` and iOS `ACPSessionsViewRow` both call into it.

Gap caught during plan review for acp-sessions-ui.md.
**Gap:** Five row-formatting helpers duplicated byte-for-byte across macOS panel and iOS list view.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
