### PR TITLE
refactor(clients): unify ACPSpawnStatusIndicator across macOS and iOS

### DIFF
--- a/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
+++ b/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
@@ -285,6 +285,149 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
         XCTAssertEqual(ACPSpawnDeepLinkCard.statusLabel(for: toolCall), "Failed")
     }
 
+    // MARK: - Shared resolver wiring (live store)
+
+    /// `.running` and `.initializing` are both "still working" from the
+    /// user's perspective — neither is a terminal state they can act on,
+    /// so the inline block must show the same pulsing dot for both.
+    /// Mirrors the macOS test of the same name; both platforms now drive
+    /// off the same shared resolver.
+    func test_acpSpawnStatusIndicator_pulsesWhileRunningOrInitializing() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .running),
+            .pulsing
+        )
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .initializing),
+            .pulsing
+        )
+    }
+
+    /// Successful terminal — green check.
+    func test_acpSpawnStatusIndicator_completedRendersPositiveCheck() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .completed),
+            .icon(glyph: .check, role: .positive)
+        )
+    }
+
+    /// Errored terminal — red x.
+    func test_acpSpawnStatusIndicator_failedRendersNegativeXmark() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .failed),
+            .icon(glyph: .xmark, role: .negative)
+        )
+    }
+
+    /// Cancelled terminal — muted dash.
+    func test_acpSpawnStatusIndicator_cancelledRendersMutedDash() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .cancelled),
+            .icon(glyph: .dash, role: .muted)
+        )
+    }
+
+    /// `.unknown` arrives only via daemon version skew — treat as
+    /// completed since the row only renders when the spawn already
+    /// returned a session id.
+    func test_acpSpawnStatusIndicator_unknownStatusFallsBackToCompleted() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: .unknown),
+            .icon(glyph: .check, role: .positive)
+        )
+    }
+
+    /// Nil status (history cleared, daemon restarted) falls through to
+    /// the static "completed" check — same fallback as `.unknown`.
+    func test_acpSpawnStatusIndicator_missingStoreEntryFallsBackToCompleted() {
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forStatus: nil),
+            .icon(glyph: .check, role: .positive)
+        )
+    }
+
+    /// Live transition: a running session flips to completed and the
+    /// indicator switches from pulsing to the positive check without any
+    /// view-side input. This is the gap fix-r1-5 closes — before this
+    /// PR, iOS read `toolCall.isComplete` directly and missed live
+    /// running → completed transitions emitted via `ACPSessionStore`.
+    func test_acpSpawnStatusIndicator_transitionsFromRunningToCompletedViaStore() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-live",
+            agent: "claude-code",
+            parentConversationId: "conv-live"
+        )))
+
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(
+                forStatus: store.sessions["acp-live"]?.state.status
+            ),
+            .pulsing,
+            "Newly spawned session must render pulsing while running"
+        )
+
+        store.handle(.acpSessionCompleted(ACPSessionCompletedMessage(
+            acpSessionId: "acp-live",
+            stopReason: .endTurn
+        )))
+
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(
+                forStatus: store.sessions["acp-live"]?.state.status
+            ),
+            .icon(glyph: .check, role: .positive),
+            "Completed session must render the positive check"
+        )
+    }
+
+    /// Mirror of the above for the failure path — `.failed` flowing
+    /// through `acpSessionError` must surface as the negative red x.
+    func test_acpSpawnStatusIndicator_transitionsFromRunningToFailedViaStore() {
+        let store = ACPSessionStore()
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "acp-fail",
+            agent: "codex",
+            parentConversationId: "conv-fail"
+        )))
+
+        store.handle(.acpSessionError(ACPSessionErrorMessage(
+            acpSessionId: "acp-fail",
+            error: "agent crashed"
+        )))
+
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(
+                forStatus: store.sessions["acp-fail"]?.state.status
+            ),
+            .icon(glyph: .xmark, role: .negative)
+        )
+    }
+
+    /// Tool-call fallback used when the store has no entry for the
+    /// requested session id — kicks in for early launch, test harnesses,
+    /// or when the bridge isn't yet registered. Ensures iOS still
+    /// renders a sensible terminal glyph even without a live store.
+    func test_acpSpawnStatusIndicator_toolCallFallbackMapsToTerminalState() {
+        let running = makeAcpSpawnToolCall(isComplete: false, isError: false)
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forToolCall: running),
+            .pulsing
+        )
+
+        let completed = makeAcpSpawnToolCall(isComplete: true, isError: false)
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forToolCall: completed),
+            .icon(glyph: .check, role: .positive)
+        )
+
+        let failed = makeAcpSpawnToolCall(isComplete: true, isError: true)
+        XCTAssertEqual(
+            ACPSpawnStatusIndicator.resolve(forToolCall: failed),
+            .icon(glyph: .xmark, role: .negative)
+        )
+    }
+
     // MARK: - Helpers
 
     /// Synthetic `acp_spawn` tool call sized for the deep-link helpers.

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1401,68 +1401,6 @@ struct ToolCallStepDetailRow: View {
 
 // MARK: - ACP Spawn Status Dot
 
-/// Render decision for the leading status indicator on the inline
-/// `acp_spawn` deep-link row. Resolved as a pure function from the live
-/// store status (when present) so unit tests can pin-point each visual
-/// state without standing up the SwiftUI view tree.
-///
-/// `internal` so unit tests can read the resolved value; production
-/// callers go through ``ACPSpawnStatusDot``.
-enum ACPSpawnStatusIndicator: Equatable {
-    /// The session is still working — render a pulsing dot. Both
-    /// `.running` and `.initializing` map to this state since neither is a
-    /// terminal stop condition the user can act on.
-    case pulsing
-    /// The session reached a terminal state — render a static glyph in
-    /// the supplied semantic role. Color is derived from the role at
-    /// render time so the resolver can stay UI-framework-agnostic.
-    case icon(glyph: Glyph, role: Role)
-
-    enum Glyph: Equatable {
-        case check
-        case xmark
-        case dash
-    }
-
-    enum Role: Equatable {
-        /// Successful terminal — green check.
-        case positive
-        /// Errored terminal — red x.
-        case negative
-        /// Cancelled / unknown / muted terminal — gray dash.
-        case muted
-    }
-
-    /// Map a live ``ACPSessionState/Status`` into a render decision.
-    /// Falls back to a static "completed" check when the store has no
-    /// entry for the session id (`status` is nil) — for an `acp_spawn`
-    /// row to render at all the tool call already succeeded, so a
-    /// missing-from-store entry is almost always "history was cleared
-    /// after a successful run" rather than "something unobservable went
-    /// wrong". Treating it as completed keeps the inline block honest
-    /// instead of perpetually pulsing on a stale id.
-    static func resolve(forStatus status: ACPSessionState.Status?) -> ACPSpawnStatusIndicator {
-        guard let status else {
-            return .icon(glyph: .check, role: .positive)
-        }
-        switch status {
-        case .running, .initializing:
-            return .pulsing
-        case .completed:
-            return .icon(glyph: .check, role: .positive)
-        case .failed:
-            return .icon(glyph: .xmark, role: .negative)
-        case .cancelled:
-            return .icon(glyph: .dash, role: .muted)
-        case .unknown:
-            // Daemon version skew — treat as completed so the inline
-            // block matches the spawn tool's own "we got back a session
-            // id" semantics rather than stalling on a ghost pulse.
-            return .icon(glyph: .check, role: .positive)
-        }
-    }
-}
-
 /// Live status indicator for the inline `acp_spawn` deep-link row.
 ///
 /// Reads the matching ``ACPSessionViewModel`` off the supplied store —
@@ -1473,6 +1411,12 @@ enum ACPSpawnStatusIndicator: Equatable {
 /// because the chat transcript renders inside test harnesses and
 /// pre-launch contexts where ``AppDelegate/shared`` is nil; a missing
 /// store falls through to the static-completed indicator.
+///
+/// The render decision is owned by the shared ``ACPSpawnStatusIndicator``
+/// enum in `clients/shared/Features/Chat/ACPSpawnStatusIndicator.swift`;
+/// iOS renders the same enum through `ACPSpawnStatusIndicatorView` in
+/// `ToolCallProgressBar.swift`, so both platforms agree on the lifecycle
+/// they show for any given session status.
 private struct ACPSpawnStatusDot: View {
     let acpSessionId: String
     let store: ACPSessionStore?
@@ -1483,24 +1427,8 @@ private struct ACPSpawnStatusDot: View {
         case .pulsing:
             VBusyIndicator(size: 8)
         case .icon(let glyph, let role):
-            VIconView(Self.icon(for: glyph), size: 12)
-                .foregroundStyle(Self.color(for: role))
-        }
-    }
-
-    private static func icon(for glyph: ACPSpawnStatusIndicator.Glyph) -> VIcon {
-        switch glyph {
-        case .check: return .circleCheck
-        case .xmark: return .circleX
-        case .dash: return .circleDashed
-        }
-    }
-
-    private static func color(for role: ACPSpawnStatusIndicator.Role) -> Color {
-        switch role {
-        case .positive: return VColor.primaryBase
-        case .negative: return VColor.systemNegativeStrong
-        case .muted: return VColor.contentTertiary
+            VIconView(glyph.icon, size: 12)
+                .foregroundStyle(role.color)
         }
     }
 }

--- a/clients/shared/Features/Chat/ACPSpawnStatusIndicator.swift
+++ b/clients/shared/Features/Chat/ACPSpawnStatusIndicator.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+// MARK: - ACPSpawnStatusIndicator
+
+/// Render decision for the leading status indicator on the inline
+/// `acp_spawn` deep-link row used by both macOS (`ACPSpawnStatusDot`
+/// inside `AssistantProgressView.swift`) and iOS
+/// (`ACPSpawnStatusIndicatorView` inside `ToolCallProgressBar.swift`).
+/// Resolved as a pure function from the live store status (when present)
+/// so unit tests can pin-point each visual state without standing up the
+/// SwiftUI view tree, and so both platforms render the same lifecycle
+/// from the same input.
+///
+/// Lives in `clients/shared/` so the macOS dot view and the iOS indicator
+/// view consume one canonical resolver — previously each platform had its
+/// own subtly different contract (iOS read `ToolCallData.isComplete` /
+/// `isError` directly, ignoring the live `ACPSessionStore`, so it missed
+/// running → completed transitions and the "history cleared while running"
+/// edge case the macOS resolver covers).
+public enum ACPSpawnStatusIndicator: Equatable {
+    /// The session is still working — render a pulsing dot. Both
+    /// `.running` and `.initializing` map to this state since neither is a
+    /// terminal stop condition the user can act on.
+    case pulsing
+    /// The session reached a terminal state — render a static glyph in
+    /// the supplied semantic role. Color is derived from the role at
+    /// render time so the resolver can stay UI-framework-agnostic.
+    case icon(glyph: Glyph, role: Role)
+
+    public enum Glyph: Equatable {
+        case check
+        case xmark
+        case dash
+
+        /// Lucide glyph backing this case. Lives on the enum so both
+        /// platforms render the same icon for the same state.
+        public var icon: VIcon {
+            switch self {
+            case .check: return .circleCheck
+            case .xmark: return .circleX
+            case .dash: return .circleDashed
+            }
+        }
+    }
+
+    public enum Role: Equatable {
+        /// Successful terminal — green check.
+        case positive
+        /// Errored terminal — red x.
+        case negative
+        /// Cancelled / unknown / muted terminal — gray dash.
+        case muted
+
+        /// Semantic color for this role. Lives on the enum so both
+        /// platforms apply the same tone to the same state.
+        public var color: Color {
+            switch self {
+            case .positive: return VColor.primaryBase
+            case .negative: return VColor.systemNegativeStrong
+            case .muted: return VColor.contentTertiary
+            }
+        }
+    }
+
+    /// Map a live ``ACPSessionState/Status`` into a render decision.
+    /// Falls back to a static "completed" check when the store has no
+    /// entry for the session id (`status` is nil) — for an `acp_spawn`
+    /// row to render at all the tool call already succeeded, so a
+    /// missing-from-store entry is almost always "history was cleared
+    /// after a successful run" rather than "something unobservable went
+    /// wrong". Treating it as completed keeps the inline block honest
+    /// instead of perpetually pulsing on a stale id.
+    public static func resolve(forStatus status: ACPSessionState.Status?) -> ACPSpawnStatusIndicator {
+        guard let status else {
+            return .icon(glyph: .check, role: .positive)
+        }
+        switch status {
+        case .running, .initializing:
+            return .pulsing
+        case .completed:
+            return .icon(glyph: .check, role: .positive)
+        case .failed:
+            return .icon(glyph: .xmark, role: .negative)
+        case .cancelled:
+            return .icon(glyph: .dash, role: .muted)
+        case .unknown:
+            // Daemon version skew — treat as completed so the inline
+            // block matches the spawn tool's own "we got back a session
+            // id" semantics rather than stalling on a ghost pulse.
+            return .icon(glyph: .check, role: .positive)
+        }
+    }
+
+    /// Tool-call-only fallback used when no live store entry exists yet
+    /// (early launch, test harness, missing bridge). Mirrors the
+    /// pre-shared iOS behavior so a row that lands before the store is
+    /// wired still renders a sensible terminal glyph the moment the tool
+    /// call itself finishes. Callers should prefer ``resolve(forStatus:)``
+    /// against the live store and fall back to this only when the store
+    /// lookup yields no entry.
+    public static func resolve(forToolCall toolCall: ToolCallData) -> ACPSpawnStatusIndicator {
+        if toolCall.isError {
+            return .icon(glyph: .xmark, role: .negative)
+        }
+        if toolCall.isComplete {
+            return .icon(glyph: .check, role: .positive)
+        }
+        return .pulsing
+    }
+}

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -390,8 +390,12 @@ public struct ACPSpawnDeepLinkCard: View {
             Self.openACPSession(id: acpSessionId)
         } label: {
             HStack(spacing: VSpacing.sm) {
-                ACPSpawnStatusIndicator(toolCall: toolCall)
-                    .frame(width: 16, height: 16)
+                ACPSpawnStatusIndicatorView(
+                    toolCall: toolCall,
+                    acpSessionId: acpSessionId,
+                    store: ACPSpawnAppDelegateBridge.shared?.acpSessionStore
+                )
+                .frame(width: 16, height: 16)
                 VStack(alignment: .leading, spacing: 0) {
                     Text(ToolCallData.displaySafe(toolCall.friendlyName))
                         .font(VFont.bodyMediumDefault)
@@ -463,40 +467,48 @@ public struct ACPSpawnDeepLinkCard: View {
     }
 }
 
-/// Animated leading glyph for ``ACPSpawnDeepLinkCard``. Pulses while the
-/// underlying spawn is still running, flips to a solid check on success,
-/// and to an alert on error. Driven by `Timer.publish` for the same
-/// reason `ElapsedTimeLabel` in `AssistantProgressView.swift` uses it on
-/// macOS — `TimelineView(.periodic)` can stop firing on long-idle
-/// hierarchies and freeze the dot.
-private struct ACPSpawnStatusIndicator: View {
+/// Live status glyph for ``ACPSpawnDeepLinkCard``. Pulses while the
+/// underlying spawn is still running, flips to a positive check on
+/// success, a negative x on error, or a muted dash on cancellation.
+///
+/// Reads the matching ``ACPSessionViewModel`` off the supplied store —
+/// because `ACPSessionStore` is `@Observable`, simply touching
+/// `store.sessions[id]?.state.status` inside `body` enrolls this view
+/// in SwiftUI's per-property observation graph, so a daemon SSE update
+/// flips the glyph without a manual refresh. Mirrors the macOS
+/// ``ACPSpawnStatusDot`` in `AssistantProgressView.swift` so both
+/// platforms catch running → completed/failed transitions and the
+/// "history cleared while running" edge case.
+///
+/// When the store has no entry for the session id (early launch, test
+/// harness, missing bridge) the view falls through to the tool-call
+/// result via ``ACPSpawnStatusIndicator/resolve(forToolCall:)`` so a
+/// row that lands before the store is wired still renders sensibly.
+private struct ACPSpawnStatusIndicatorView: View {
     let toolCall: ToolCallData
-    @State private var pulsePhase: Double = 0
-
-    private let timer = Timer.publish(every: 0.35, on: .main, in: .common).autoconnect()
+    let acpSessionId: String
+    let store: ACPSessionStore?
 
     var body: some View {
-        Group {
-            if toolCall.isError {
-                VIconView(.circleAlert, size: 14)
-                    .foregroundStyle(VColor.systemNegativeStrong)
-            } else if toolCall.isComplete {
-                VIconView(.circleCheck, size: 14)
-                    .foregroundStyle(VColor.primaryBase)
-            } else {
-                Circle()
-                    .fill(VColor.primaryBase)
-                    .frame(width: 10, height: 10)
-                    .opacity(0.4 + 0.6 * pulsePhase)
-                    .scaleEffect(0.9 + 0.15 * pulsePhase)
-            }
+        switch resolveIndicator() {
+        case .pulsing:
+            VBusyIndicator(size: 10)
+        case .icon(let glyph, let role):
+            VIconView(glyph.icon, size: 14)
+                .foregroundStyle(role.color)
         }
-        .onReceive(timer) { _ in
-            guard !toolCall.isComplete else { return }
-            withAnimation(.easeInOut(duration: 0.35)) {
-                pulsePhase = pulsePhase < 0.5 ? 1 : 0
-            }
+    }
+
+    /// Prefer the live store status — it picks up running → completed
+    /// and the cleared-history fallback baked into the shared resolver.
+    /// When the store has no entry at all (no `ACPSpawnAppDelegateBridge`
+    /// in tests / preview harnesses), fall back to the tool call so the
+    /// glyph still reflects whatever terminal state the spawn returned.
+    private func resolveIndicator() -> ACPSpawnStatusIndicator {
+        if let session = store?.sessions[acpSessionId] {
+            return ACPSpawnStatusIndicator.resolve(forStatus: session.state.status)
         }
+        return ACPSpawnStatusIndicator.resolve(forToolCall: toolCall)
     }
 }
 


### PR DESCRIPTION
## Summary
- Lifts `ACPSpawnStatusIndicator` resolver to shared; both macOS and iOS use the same enum + resolve(forStatus:) static.
- iOS now reads live `ACPSessionStore` status (was tool-call-only); falls back to tool-call result when no store entry exists.

Gap caught during plan review for acp-sessions-ui.md.
**Gap:** Divergent contracts — iOS missed live status updates and 'history cleared while running' edge case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
