### PR TITLE
fix(live-voice): align macOS live voice lifecycle and audio

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -73,7 +73,7 @@ sequenceDiagram
     LVM-->>VM: state + transcript updates
 ```
 
-**Transport:** `clients/shared/Network/LiveVoiceChannelClient.swift` is the shared WebSocket client. It builds the authenticated request with `GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params:)`, sends the initial `start` JSON frame, sends mic audio as binary WebSocket frames, sends `ptt_release`, `interrupt`, and `end` control frames, and decodes `ready`, `busy`, `stt_*`, `assistant_text_delta`, `tts_*`, `metrics`, `archived`, and `error` server frames.
+**Transport:** `clients/shared/Network/LiveVoiceChannelClient.swift` is the shared WebSocket client. It builds the authenticated request with `GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params: nil)`, sends the conversation ID in the initial `start` JSON frame, sends mic audio as binary WebSocket frames, sends `ptt_release`, `interrupt`, and `end` control frames, and decodes `ready`, `busy`, `stt_*`, `assistant_text_delta`, `tts_*`, `metrics`, `archived`, and `error` server frames.
 
 **macOS session state:** `clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift` owns the live session state machine (`idle`, `connecting`, `listening`, `transcribing`, `thinking`, `speaking`, `ending`, `failed`). It wires `LiveVoiceAudioCapture` for push-to-talk PCM capture and `LiveVoiceAudioPlayer` for streamed assistant audio. `VoiceModeManager` observes the manager with `withObservationTracking()` and maps live-channel states onto the existing voice-mode UI states (`listening`, `processing`, `speaking`, `idle`).
 

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioCapture.swift
@@ -61,6 +61,7 @@ final class LiveVoiceAudioCapture {
     private var generation: UInt64 = 0
     private var chunkHandler: ChunkHandler?
     private var amplitudeHandler: AmplitudeHandler?
+    private var pcmConverter = LiveVoicePCM16kMonoConverter()
 
     init(
         engineController: any LiveVoiceAudioEngineControlling = AudioEngineController(label: "com.vellum.audioEngine.liveVoiceCapture"),
@@ -128,6 +129,7 @@ final class LiveVoiceAudioCapture {
             chunkHandler = nil
             handlerToReset = amplitudeHandler
             amplitudeHandler = nil
+            pcmConverter.reset()
             shouldRemoveTap = false
         case .running:
             generation &+= 1
@@ -135,6 +137,7 @@ final class LiveVoiceAudioCapture {
             chunkHandler = nil
             handlerToReset = amplitudeHandler
             amplitudeHandler = nil
+            pcmConverter.reset()
             shouldRemoveTap = true
         case .idle, .shutDown:
             handlerToReset = nil
@@ -167,6 +170,7 @@ final class LiveVoiceAudioCapture {
             chunkHandler = nil
             handlerToReset = amplitudeHandler
             amplitudeHandler = nil
+            pcmConverter.reset()
         }
         lock.unlock()
 
@@ -202,27 +206,30 @@ final class LiveVoiceAudioCapture {
             state = .starting
             chunkHandler = onChunk
             amplitudeHandler = onAmplitude
+            pcmConverter.reset()
             return .starting(generation)
         }
     }
 
     private func handle(buffer: AVAudioPCMBuffer, generation captureGeneration: UInt64) {
-        guard let chunk = Self.makeChunk(from: buffer) else { return }
-
         let chunkHandler: ChunkHandler?
         let amplitudeHandler: AmplitudeHandler?
+        let chunk: LiveVoiceAudioCaptureChunk?
 
         lock.lock()
         let acceptsBuffer = generation == captureGeneration && (state == .starting || state == .running)
         if acceptsBuffer {
+            chunk = pcmConverter.makeChunk(from: buffer)
             chunkHandler = self.chunkHandler
             amplitudeHandler = self.amplitudeHandler
         } else {
+            chunk = nil
             chunkHandler = nil
             amplitudeHandler = nil
         }
         lock.unlock()
 
+        guard let chunk else { return }
         chunkHandler?(chunk)
         amplitudeHandler?(chunk.amplitude)
     }
@@ -254,6 +261,7 @@ final class LiveVoiceAudioCapture {
             chunkHandler = nil
             handlerToReset = amplitudeHandler
             amplitudeHandler = nil
+            pcmConverter.reset()
         } else {
             handlerToReset = nil
         }
@@ -263,35 +271,8 @@ final class LiveVoiceAudioCapture {
     }
 
     static func makeChunk(from buffer: AVAudioPCMBuffer) -> LiveVoiceAudioCaptureChunk? {
-        guard let channelData = buffer.floatChannelData else { return nil }
-
-        let frameCount = Int(buffer.frameLength)
-        let inputChannelCount = Int(buffer.format.channelCount)
-        let sampleRate = Int(buffer.format.sampleRate.rounded())
-        guard frameCount > 0, inputChannelCount > 0, sampleRate > 0 else { return nil }
-
-        var pcmData = Data(capacity: frameCount * MemoryLayout<Int16>.size)
-        var squareSum: Float = 0
-        let channelZero = channelData[0]
-
-        for frame in 0..<frameCount {
-            let sourceIndex = buffer.format.isInterleaved ? frame * inputChannelCount : frame
-            let clamped = max(-1, min(1, channelZero[sourceIndex]))
-            let sample = pcmInt16Sample(from: clamped)
-            squareSum += clamped * clamped
-            withUnsafeBytes(of: sample.littleEndian) { pcmData.append(contentsOf: $0) }
-        }
-
-        let rms = sqrt(squareSum / Float(frameCount))
-        let amplitude = min(rms * 5, 1)
-
-        return LiveVoiceAudioCaptureChunk(
-            pcm16LittleEndian: pcmData,
-            sampleRate: sampleRate,
-            channelCount: 1,
-            frameCount: frameCount,
-            amplitude: amplitude
-        )
+        var converter = LiveVoicePCM16kMonoConverter()
+        return converter.makeChunk(from: buffer)
     }
 
     static func pcmInt16Sample(from sample: Float) -> Int16 {
@@ -305,5 +286,120 @@ final class LiveVoiceAudioCapture {
 
         let scale: Float = clamped < 0 ? 32768 : 32767
         return Int16((clamped * scale).rounded(.towardZero))
+    }
+}
+
+private struct LiveVoicePCM16kMonoConverter {
+    private static let targetSampleRate = 16_000
+    private static let targetSampleRateDouble = Double(targetSampleRate)
+
+    private var sourceSampleRate: Double?
+    private var nextSourceFramePosition: Double = 0
+
+    mutating func reset() {
+        sourceSampleRate = nil
+        nextSourceFramePosition = 0
+    }
+
+    mutating func makeChunk(from buffer: AVAudioPCMBuffer) -> LiveVoiceAudioCaptureChunk? {
+        guard let channelData = buffer.floatChannelData else { return nil }
+
+        let frameCount = Int(buffer.frameLength)
+        let inputChannelCount = Int(buffer.format.channelCount)
+        let inputSampleRate = buffer.format.sampleRate
+        guard frameCount > 0, inputChannelCount > 0, inputSampleRate > 0 else { return nil }
+
+        if sourceSampleRate != inputSampleRate {
+            sourceSampleRate = inputSampleRate
+            nextSourceFramePosition = 0
+        }
+
+        let samples = makeResampledMonoSamples(
+            channelData: channelData,
+            frameCount: frameCount,
+            channelCount: inputChannelCount,
+            isInterleaved: buffer.format.isInterleaved,
+            inputSampleRate: inputSampleRate
+        )
+        guard !samples.isEmpty else { return nil }
+
+        var pcmData = Data(capacity: samples.count * MemoryLayout<Int16>.size)
+        var squareSum: Float = 0
+
+        for sample in samples {
+            let clamped = max(-1, min(1, sample))
+            let pcmSample = LiveVoiceAudioCapture.pcmInt16Sample(from: clamped)
+            squareSum += clamped * clamped
+            withUnsafeBytes(of: pcmSample.littleEndian) { pcmData.append(contentsOf: $0) }
+        }
+
+        let rms = sqrt(squareSum / Float(samples.count))
+        let amplitude = min(rms * 5, 1)
+
+        return LiveVoiceAudioCaptureChunk(
+            pcm16LittleEndian: pcmData,
+            sampleRate: Self.targetSampleRate,
+            channelCount: 1,
+            frameCount: samples.count,
+            amplitude: amplitude
+        )
+    }
+
+    private mutating func makeResampledMonoSamples(
+        channelData: UnsafePointer<UnsafeMutablePointer<Float>>,
+        frameCount: Int,
+        channelCount: Int,
+        isInterleaved: Bool,
+        inputSampleRate: Double
+    ) -> [Float] {
+        let sourceFramesPerOutputFrame = inputSampleRate / Self.targetSampleRateDouble
+        var samples: [Float] = []
+        samples.reserveCapacity(max(1, Int((Double(frameCount) / sourceFramesPerOutputFrame).rounded(.up))))
+
+        while nextSourceFramePosition < Double(frameCount) {
+            let lowerFrame = min(Int(nextSourceFramePosition.rounded(.down)), frameCount - 1)
+            let upperFrame = min(lowerFrame + 1, frameCount - 1)
+            let fraction = Float(nextSourceFramePosition - Double(lowerFrame))
+            let lowerSample = monoSample(
+                channelData: channelData,
+                frame: lowerFrame,
+                channelCount: channelCount,
+                isInterleaved: isInterleaved
+            )
+            let upperSample = monoSample(
+                channelData: channelData,
+                frame: upperFrame,
+                channelCount: channelCount,
+                isInterleaved: isInterleaved
+            )
+            samples.append(lowerSample + (upperSample - lowerSample) * fraction)
+            nextSourceFramePosition += sourceFramesPerOutputFrame
+        }
+
+        nextSourceFramePosition -= Double(frameCount)
+        if nextSourceFramePosition < 0 {
+            nextSourceFramePosition = 0
+        }
+        return samples
+    }
+
+    private func monoSample(
+        channelData: UnsafePointer<UnsafeMutablePointer<Float>>,
+        frame: Int,
+        channelCount: Int,
+        isInterleaved: Bool
+    ) -> Float {
+        var sum: Float = 0
+        if isInterleaved {
+            let baseIndex = frame * channelCount
+            for channel in 0..<channelCount {
+                sum += channelData[0][baseIndex + channel]
+            }
+        } else {
+            for channel in 0..<channelCount {
+                sum += channelData[channel][frame]
+            }
+        }
+        return sum / Float(channelCount)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -225,10 +225,7 @@ final class LiveVoiceChannelManager {
             state = .speaking
 
         case .ttsDone:
-            responseAudioStarted = false
-            if state == .speaking || state == .thinking {
-                state = captureRunning ? .listening : .idle
-            }
+            closeCompletedUtteranceSession()
 
         case .metrics, .archived:
             break
@@ -341,6 +338,21 @@ final class LiveVoiceChannelManager {
         responseAudioStarted = true
         interruptSentForCurrentResponse = false
         playback.resetForNextResponse()
+    }
+
+    private func closeCompletedUtteranceSession() {
+        responseAudioStarted = false
+        sessionGeneration &+= 1
+        stopCapture()
+
+        let completedClient = client
+        resetIgnoredSessionState()
+        sessionId = nil
+        state = .idle
+
+        Task {
+            await completedClient?.close()
+        }
     }
 
     private func stopCapture() {

--- a/clients/macos/vellum-assistantTests/LiveVoiceAudioCaptureTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceAudioCaptureTests.swift
@@ -59,6 +59,19 @@ final class LiveVoiceAudioCaptureTests: XCTestCase {
         XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 12), Int16.max)
     }
 
+    func testHardwareRateFloatPCMResamplesTo16kMonoChunk() {
+        let buffer = makeBuffer(samples: [0.25, 0, 0, -0.25, 0, 0], sampleRate: 48_000)
+
+        let chunk = LiveVoiceAudioCapture.makeChunk(from: buffer)
+
+        XCTAssertEqual(chunk?.sampleRate, 16_000)
+        XCTAssertEqual(chunk?.channelCount, 1)
+        XCTAssertEqual(chunk?.frameCount, 2)
+        XCTAssertEqual(chunk?.pcm16LittleEndian.count, 4)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 0), 8_191)
+        XCTAssertEqual(readInt16LE(chunk!.pcm16LittleEndian, offset: 2), -8_192)
+    }
+
     func testCapturedBufferReportsChunkAndScaledAmplitude() async {
         let engine = MockLiveVoiceAudioEngineController()
         let permission = MockLiveVoiceMicrophonePermission()
@@ -78,12 +91,12 @@ final class LiveVoiceAudioCaptureTests: XCTestCase {
         XCTAssertTrue(started)
         XCTAssertEqual(engine.lastBufferSize, 256)
 
-        let buffer = makeBuffer(samples: [0.1, -0.1, 0.1, -0.1], sampleRate: 24_000)
-        engine.tapBlock?(buffer, AVAudioTime(sampleTime: 0, atRate: 24_000))
+        let buffer = makeBuffer(samples: [0.1, 0, 0, -0.1, 0, 0], sampleRate: 48_000)
+        engine.tapBlock?(buffer, AVAudioTime(sampleTime: 0, atRate: 48_000))
 
         XCTAssertEqual(chunks.count, 1)
-        XCTAssertEqual(chunks[0].sampleRate, 24_000)
-        XCTAssertEqual(chunks[0].frameCount, 4)
+        XCTAssertEqual(chunks[0].sampleRate, 16_000)
+        XCTAssertEqual(chunks[0].frameCount, 2)
         XCTAssertEqual(readInt16LE(chunks[0].pcm16LittleEndian, offset: 0), 3_276)
         XCTAssertEqual(readInt16LE(chunks[0].pcm16LittleEndian, offset: 2), -3_276)
         XCTAssertEqual(amplitudes.count, 1)

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -243,8 +243,9 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertEqual(manager.finalTranscript, "hello")
     }
 
-    func testAssistantSpeechStreamsToPlaybackAndReturnsToListening() async {
+    func testAssistantSpeechStreamsToPlaybackAndClosesSessionAfterTtsDone() async {
         await startReadySession()
+        await manager.stopListening()
 
         client.emit(.thinking(turnId: "turn-123"))
         client.emit(.assistantTextDelta(text: "Hi", seq: 3))
@@ -260,8 +261,11 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertEqual(playback.enqueuedChunks[0].sequence, 4)
 
         client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
 
-        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 1)
     }
 
     func testSpeakingOverAssistantAudioSendsInterruptOnce() async {
@@ -295,36 +299,36 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertNil(manager.sessionId)
     }
 
-    func testStartListeningResumesCaptureOnIdleOpenSession() async {
-        await startReadySession()
+    func testNextStartCreatesFreshClientAfterTtsDone() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
 
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
         await manager.stopListening()
-        client.emit(.sttFinal(text: "hello", seq: 1))
-        client.emit(.ttsDone(turnId: "turn-123"))
-        XCTAssertEqual(manager.state, .idle)
-
-        await manager.startListening()
+        firstClient.emit(.ttsDone(turnId: "turn-1"))
         await flushAsyncTasks()
 
-        XCTAssertEqual(capture.startCallCount, 2)
-        XCTAssertEqual(manager.state, .listening)
-        XCTAssertEqual(client.startCalls.count, 1)
-    }
-
-    func testEndClosesIdleOpenSession() async {
-        await startReadySession()
-
-        await manager.stopListening()
-        client.emit(.sttFinal(text: "hello", seq: 1))
-        client.emit(.ttsDone(turnId: "turn-123"))
         XCTAssertEqual(manager.state, .idle)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
 
-        await manager.end()
+        await manager.start(conversationId: "conv-123")
 
-        XCTAssertEqual(client.endCallCount, 1)
-        XCTAssertEqual(playback.endCallCount, 1)
-        XCTAssertEqual(manager.state, .idle)
-        XCTAssertNil(manager.activeConversationId)
+        XCTAssertEqual(factoryCalls, 2)
+        XCTAssertEqual(firstClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
     }
 
     func testFailureCleansUpResourcesAndStoresError() async {

--- a/clients/shared/Network/LiveVoiceChannelClient.swift
+++ b/clients/shared/Network/LiveVoiceChannelClient.swift
@@ -171,7 +171,7 @@ public final class LiveVoiceChannelClient: LiveVoiceChannelClientProtocol {
 
     static let connectionTimeout: TimeInterval = 10
 
-    private let requestBuilder: ([String: String]?) throws -> URLRequest
+    private let requestBuilder: () throws -> URLRequest
     private let webSocketFactory: (URLRequest) -> any LiveVoiceChannelWebSocketTask
 
     private var state: LiveVoiceChannelSessionState = .idle
@@ -183,8 +183,8 @@ public final class LiveVoiceChannelClient: LiveVoiceChannelClientProtocol {
 
     public convenience init() {
         self.init(
-            requestBuilder: { params in
-                try GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params: params)
+            requestBuilder: {
+                try GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params: nil)
             },
             webSocketFactory: { request in
                 URLSession.shared.webSocketTask(with: request)
@@ -193,7 +193,7 @@ public final class LiveVoiceChannelClient: LiveVoiceChannelClientProtocol {
     }
 
     init(
-        requestBuilder: @escaping ([String: String]?) throws -> URLRequest,
+        requestBuilder: @escaping () throws -> URLRequest,
         webSocketFactory: @escaping (URLRequest) -> any LiveVoiceChannelWebSocketTask
     ) {
         self.requestBuilder = requestBuilder
@@ -222,8 +222,7 @@ public final class LiveVoiceChannelClient: LiveVoiceChannelClientProtocol {
         state = .connecting
 
         do {
-            let params = Self.requestParams(conversationId: conversationId)
-            let request = try requestBuilder(params)
+            let request = try requestBuilder()
             log.info("Opening live voice WebSocket")
 
             let task = webSocketFactory(request)
@@ -273,11 +272,6 @@ public final class LiveVoiceChannelClient: LiveVoiceChannelClientProtocol {
     }
 
     // MARK: - Request and Frame Encoding
-
-    static func requestParams(conversationId: String?) -> [String: String]? {
-        guard let conversationId, !conversationId.isEmpty else { return nil }
-        return ["conversationId": conversationId]
-    }
 
     static func encodeStartFrame(conversationId: String?, audioFormat: LiveVoiceChannelAudioFormat) throws -> String {
         struct StartFrame: Encodable {

--- a/clients/shared/Tests/LiveVoiceChannelClientIntegrationTests.swift
+++ b/clients/shared/Tests/LiveVoiceChannelClientIntegrationTests.swift
@@ -7,9 +7,9 @@ import XCTest
 final class LiveVoiceChannelClientIntegrationTests: XCTestCase {
 
     func testScriptedSessionSendsTextAndBinaryFramesAndDecodesServerEvents() async throws {
-        var capturedParams: [String: String]?
+        var capturedRequest: URLRequest?
         let task = ScriptedLiveVoiceWebSocketTask()
-        let client = makeClient(task: task, capturedParams: &capturedParams)
+        let client = makeClient(task: task, capturedRequest: &capturedRequest)
         var events: [LiveVoiceChannelEvent] = []
         var failures: [LiveVoiceChannelFailure] = []
         let audio = Data([0, 1, 2, 255])
@@ -38,7 +38,7 @@ final class LiveVoiceChannelClientIntegrationTests: XCTestCase {
 
         await client.end()
 
-        XCTAssertEqual(capturedParams, ["conversationId": "conv-123"])
+        XCTAssertNil(capturedRequest?.url?.query)
         XCTAssertTrue(task.didResume)
         XCTAssertEqual(task.stringMessages.map { try? frameType($0) }, ["start", "ptt_release", "end"])
         XCTAssertEqual(task.dataMessages, [audio])
@@ -111,14 +111,16 @@ final class LiveVoiceChannelClientIntegrationTests: XCTestCase {
 
     private func makeClient(
         task: ScriptedLiveVoiceWebSocketTask,
-        capturedParams: UnsafeMutablePointer<[String: String]?>? = nil
+        capturedRequest: UnsafeMutablePointer<URLRequest?>? = nil
     ) -> LiveVoiceChannelClient {
         LiveVoiceChannelClient(
-            requestBuilder: { params in
-                capturedParams?.pointee = params
+            requestBuilder: {
                 return URLRequest(url: URL(string: "wss://example.com/v1/live-voice")!)
             },
-            webSocketFactory: { _ in task }
+            webSocketFactory: { request in
+                capturedRequest?.pointee = request
+                return task
+            }
         )
     }
 

--- a/clients/shared/Tests/LiveVoiceChannelClientTests.swift
+++ b/clients/shared/Tests/LiveVoiceChannelClientTests.swift
@@ -8,15 +8,6 @@ final class LiveVoiceChannelClientTests: XCTestCase {
 
     // MARK: - Request and Client Frames
 
-    func testRequestParamsOnlyIncludeConversationId() {
-        XCTAssertNil(LiveVoiceChannelClient.requestParams(conversationId: nil))
-        XCTAssertNil(LiveVoiceChannelClient.requestParams(conversationId: ""))
-        XCTAssertEqual(
-            LiveVoiceChannelClient.requestParams(conversationId: "conv-123"),
-            ["conversationId": "conv-123"]
-        )
-    }
-
     func testStartFrameOmitsProviderCredentialsAndProviderIds() throws {
         let frame = try LiveVoiceChannelClient.encodeStartFrame(
             conversationId: "conv-123",
@@ -123,9 +114,9 @@ final class LiveVoiceChannelClientTests: XCTestCase {
     // MARK: - WebSocket Lifecycle
 
     func testStartSendsProviderAgnosticStartFrameAndBinaryAudioOnlyAfterReady() async throws {
-        var capturedParams: [String: String]?
+        var capturedRequest: URLRequest?
         let task = MockLiveVoiceWebSocketTask()
-        let client = makeClient(task: task, capturedParams: &capturedParams)
+        let client = makeClient(task: task, capturedRequest: &capturedRequest)
         var events: [LiveVoiceChannelEvent] = []
         var failures: [LiveVoiceChannelFailure] = []
 
@@ -137,7 +128,7 @@ final class LiveVoiceChannelClientTests: XCTestCase {
         )
 
         XCTAssertTrue(task.didResume)
-        XCTAssertEqual(capturedParams, ["conversationId": "conv-123"])
+        XCTAssertNil(capturedRequest?.url?.query)
         XCTAssertEqual(task.stringMessages.count, 1)
         XCTAssertEqual(try frameType(task.stringMessages[0]), "start")
 
@@ -288,14 +279,16 @@ final class LiveVoiceChannelClientTests: XCTestCase {
 
     private func makeClient(
         task: MockLiveVoiceWebSocketTask,
-        capturedParams: UnsafeMutablePointer<[String: String]?>? = nil
+        capturedRequest: UnsafeMutablePointer<URLRequest?>? = nil
     ) -> LiveVoiceChannelClient {
         LiveVoiceChannelClient(
-            requestBuilder: { params in
-                capturedParams?.pointee = params
+            requestBuilder: {
                 return URLRequest(url: URL(string: "wss://example.com/v1/live-voice")!)
             },
-            webSocketFactory: { _ in task }
+            webSocketFactory: { request in
+                capturedRequest?.pointee = request
+                return task
+            }
         )
     }
 


### PR DESCRIPTION
## Summary
Fixes self-review gaps from live-voice-channel.md.

Gaps: macOS declared 16 kHz PCM while sending hardware-rate PCM, the client reused a one-utterance server session, and conversation id was duplicated in query params and start frame.

Apple refs checked (2026-04-25): AVAudioNode installTap and AVAudioConverter sample-rate conversion docs.

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
