### PR TITLE
fix(clients): key ACPSessionStore by state.id (daemon UUID), not state.acpSessionId

### DIFF
--- a/clients/ios/Tests/ACPSessionDetailViewIOSTests.swift
+++ b/clients/ios/Tests/ACPSessionDetailViewIOSTests.swift
@@ -426,14 +426,14 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
         let session = makeSession(status: .running)
         // Register the session with the store so the optimistic mutation in
         // the spy override has a view model to update.
-        store.sessions[session.state.acpSessionId] = session
+        store.sessions[session.state.id] = session
 
         let view = ACPSessionDetailViewIOS(session: session, store: store)
         view.handleCancelTap()
 
         await waitForSpyInvocation { !store.cancelInvocations.isEmpty }
 
-        XCTAssertEqual(store.cancelInvocations, [session.state.acpSessionId])
+        XCTAssertEqual(store.cancelInvocations, [session.state.id])
     }
 
     // MARK: - Steer footer
@@ -441,7 +441,7 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
     func test_submitSteer_invokesStoreWithTrimmedInstructionAndAppendsSyntheticEvent() async {
         let store = SpyACPSessionStore()
         let session = makeSession(status: .running)
-        store.sessions[session.state.acpSessionId] = session
+        store.sessions[session.state.id] = session
 
         let view = ACPSessionDetailViewIOS(session: session, store: store)
         // Leading/trailing whitespace exercises the trim path — return-key
@@ -456,7 +456,7 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
         await waitForSpyInvocation { !store.steerInvocations.isEmpty }
 
         XCTAssertEqual(store.steerInvocations.count, 1)
-        XCTAssertEqual(store.steerInvocations.first?.id, session.state.acpSessionId)
+        XCTAssertEqual(store.steerInvocations.first?.id, session.state.id)
         XCTAssertEqual(
             store.steerInvocations.first?.instruction,
             "slow down and explain",
@@ -467,7 +467,7 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
     func test_submitSteer_emptyInputIsNoOp() async {
         let store = SpyACPSessionStore()
         let session = makeSession(status: .running)
-        store.sessions[session.state.acpSessionId] = session
+        store.sessions[session.state.id] = session
 
         let view = ACPSessionDetailViewIOS(session: session, store: store)
         view.submitSteer(rawInstruction: "   ")
@@ -485,8 +485,8 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
     func test_handleDeleteTap_invokesStoreDeleteOnce_andDismisses() async {
         let store = SpyACPSessionStore()
         let session = makeSession(status: .completed)
-        store.sessions[session.state.acpSessionId] = session
-        store.sessionOrder = [session.state.acpSessionId]
+        store.sessions[session.state.id] = session
+        store.sessionOrder = [session.state.id]
 
         let dismissed = expectation(description: "onDismiss fires")
         let view = ACPSessionDetailViewIOS(
@@ -498,10 +498,10 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
 
         await fulfillment(of: [dismissed], timeout: 1.0)
 
-        XCTAssertEqual(store.deleteInvocations, [session.state.acpSessionId])
-        XCTAssertNil(store.sessions[session.state.acpSessionId],
+        XCTAssertEqual(store.deleteInvocations, [session.state.id])
+        XCTAssertNil(store.sessions[session.state.id],
                      "Spy store mirror should drop the row on success")
-        XCTAssertFalse(store.sessionOrder.contains(session.state.acpSessionId))
+        XCTAssertFalse(store.sessionOrder.contains(session.state.id))
     }
 
     func test_handleDeleteTap_doesNotDismiss_whenStoreReportsFailure() async {
@@ -510,8 +510,8 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
         // place and skip the dismissal so the user has a chance to react.
         store.deleteResult = .failure(.httpError(statusCode: 409))
         let session = makeSession(status: .completed)
-        store.sessions[session.state.acpSessionId] = session
-        store.sessionOrder = [session.state.acpSessionId]
+        store.sessions[session.state.id] = session
+        store.sessionOrder = [session.state.id]
 
         var dismissCount = 0
         let view = ACPSessionDetailViewIOS(
@@ -524,9 +524,9 @@ final class ACPSessionDetailViewIOSTests: XCTestCase {
         await waitForSpyInvocation { !store.deleteInvocations.isEmpty }
         await Task.yield()
 
-        XCTAssertEqual(store.deleteInvocations, [session.state.acpSessionId])
+        XCTAssertEqual(store.deleteInvocations, [session.state.id])
         XCTAssertEqual(dismissCount, 0, "onDismiss must not fire on failure")
-        XCTAssertNotNil(store.sessions[session.state.acpSessionId],
+        XCTAssertNotNil(store.sessions[session.state.id],
                         "Failed delete should leave the row in place")
     }
 

--- a/clients/ios/Views/ACPSessionDetailView.swift
+++ b/clients/ios/Views/ACPSessionDetailView.swift
@@ -195,7 +195,11 @@ struct ACPSessionDetailViewIOS: View {
     func handleCancelTap() {
         guard !cancelInFlight else { return }
         cancelInFlight = true
-        let id = session.state.acpSessionId
+        // `state.id` (the daemon UUID) is the canonical identifier the
+        // daemon's `acp/:id/cancel` route looks up — `state.acpSessionId`
+        // is the protocol-level handle and would 404 the route for any
+        // session past initialization.
+        let id = session.state.id
         Task { @MainActor in
             // The store flips `state.status` optimistically on success, which
             // hides this control via `isCancelable`. On failure we reset the
@@ -604,9 +608,11 @@ struct ACPSessionDetailViewIOS: View {
             content: "→ steered: \(instruction)"
         ))
 
-        // `acpSessionId` (not `state.id`) is the daemon-side session handle
-        // the steer route accepts and the store keys its dictionary by.
-        Task { await store.steer(id: session.state.acpSessionId, instruction: instruction) }
+        // `state.id` is the daemon UUID — the value the steer route
+        // (`acp/:id/steer`) accepts and the store keys its dictionary by.
+        // `state.acpSessionId` is the protocol-level handle and would
+        // miss the lookup for any session past initialization.
+        Task { await store.steer(id: session.state.id, instruction: instruction) }
     }
 
     // MARK: - Delete Footer
@@ -643,7 +649,10 @@ struct ACPSessionDetailViewIOS: View {
     func handleDeleteTap() {
         guard !isDeleting else { return }
         isDeleting = true
-        let id = session.state.acpSessionId
+        // `state.id` is the daemon UUID — what
+        // `acp_session_history.id` is keyed by and what the
+        // `DELETE /v1/acp/sessions/:id` route looks up.
+        let id = session.state.id
         Task { @MainActor in
             let result = await store.delete(id: id)
             isDeleting = false

--- a/clients/ios/Views/ACPSessionsView.swift
+++ b/clients/ios/Views/ACPSessionsView.swift
@@ -165,6 +165,9 @@ struct ACPSessionsView: View {
     }
 
     private var sessionList: some View {
+        // `sessionOrder` is keyed by `state.id` (the daemon UUID), so the
+        // swipe-to-cancel and selection bindings below all flow through
+        // the canonical identifier the daemon's mutation routes accept.
         List(selection: horizontalSizeClass == .regular ? $selectedSessionId : nil) {
             ForEach(store.sessionOrder, id: \.self) { sessionId in
                 if let viewModel = store.sessions[sessionId] {
@@ -192,13 +195,17 @@ struct ACPSessionsView: View {
         if horizontalSizeClass == .regular {
             // Regular: rely on `List(selection:)` to drive the detail
             // pane. Wrapping the row in a `NavigationLink` would
-            // double-bind the selection.
+            // double-bind the selection. Tag value is the daemon UUID so
+            // the selection binding flows through the same key the store
+            // uses.
             ACPSessionsViewRow(state: state)
-                .tag(state.acpSessionId)
+                .tag(state.id)
         } else {
             // Compact: NavigationStack push via `value:` keeps the row
-            // tap target large and matches the iOS list idiom.
-            NavigationLink(value: state.acpSessionId) {
+            // tap target large and matches the iOS list idiom. Pushed
+            // value is the daemon UUID — `detailView(for:)` uses it to
+            // look the session up in the store.
+            NavigationLink(value: state.id) {
                 ACPSessionsViewRow(state: state)
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -180,7 +180,11 @@ struct ACPSessionDetailView: View {
     func handleCancelTap() {
         guard !cancelInFlight else { return }
         cancelInFlight = true
-        let id = session.state.acpSessionId
+        // `state.id` (the daemon UUID) is the canonical identifier the
+        // daemon's `acp/:id/cancel` route looks up — `state.acpSessionId`
+        // is the protocol-level handle and would 404 the route for any
+        // session past initialization.
+        let id = session.state.id
         Task { @MainActor in
             // The store flips `state.status` optimistically on success, which
             // hides this control via `isCancelable`. On failure we reset the
@@ -596,9 +600,11 @@ struct ACPSessionDetailView: View {
             content: "→ steered: \(instruction)"
         ))
 
-        // `acpSessionId` (not `state.id`) is the daemon-side session handle
-        // the steer route accepts and the store keys its dictionary by.
-        Task { await store.steer(id: session.state.acpSessionId, instruction: instruction) }
+        // `state.id` is the daemon UUID — the value the steer route
+        // (`acp/:id/steer`) accepts and the store keys its dictionary by.
+        // `state.acpSessionId` is the protocol-level handle and would
+        // miss the lookup for any session past initialization.
+        Task { await store.steer(id: session.state.id, instruction: instruction) }
     }
 
     // MARK: - Delete Footer
@@ -637,7 +643,10 @@ struct ACPSessionDetailView: View {
     func handleDeleteTap() {
         guard !isDeleting else { return }
         isDeleting = true
-        let id = session.state.acpSessionId
+        // `state.id` is the daemon UUID — what
+        // `acp_session_history.id` is keyed by and what the
+        // `DELETE /v1/acp/sessions/:id` route looks up.
+        let id = session.state.id
         Task { @MainActor in
             let result = await store.delete(id: id)
             isDeleting = false

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionDetailViewTests.swift
@@ -503,7 +503,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
         // the spy override has a view model to update — mirrors how the
         // production store is populated via `seed()` / SSE before the user
         // can interact with the detail view.
-        store.sessions[session.state.acpSessionId] = session
+        store.sessions[session.state.id] = session
 
         let view = ACPSessionDetailView(session: session, store: store)
         view.handleCancelTap()
@@ -512,7 +512,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
         // yield until it completes so the assertion sees the recorded call.
         await waitForSpyInvocation { !store.cancelInvocations.isEmpty }
 
-        XCTAssertEqual(store.cancelInvocations, [session.state.acpSessionId])
+        XCTAssertEqual(store.cancelInvocations, [session.state.id])
     }
 
     func test_isCancelable_runningAndInitializing() {
@@ -535,7 +535,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
     func test_submitSteer_invokesStoreWithTrimmedInstructionAndAppendsSyntheticEvent() async {
         let store = SpyACPSessionStore()
         let session = makeSession(status: .running)
-        store.sessions[session.state.acpSessionId] = session
+        store.sessions[session.state.id] = session
 
         let view = ACPSessionDetailView(session: session, store: store)
         // Leading/trailing whitespace exercises the trim path — return-key
@@ -550,7 +550,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
         await waitForSpyInvocation { !store.steerInvocations.isEmpty }
 
         XCTAssertEqual(store.steerInvocations.count, 1)
-        XCTAssertEqual(store.steerInvocations.first?.id, session.state.acpSessionId)
+        XCTAssertEqual(store.steerInvocations.first?.id, session.state.id)
         XCTAssertEqual(
             store.steerInvocations.first?.instruction,
             "slow down and explain",
@@ -561,7 +561,7 @@ final class ACPSessionDetailViewTests: XCTestCase {
     func test_submitSteer_emptyInputIsNoOp() async {
         let store = SpyACPSessionStore()
         let session = makeSession(status: .running)
-        store.sessions[session.state.acpSessionId] = session
+        store.sessions[session.state.id] = session
 
         let view = ACPSessionDetailView(session: session, store: store)
         view.submitSteer(rawInstruction: "   ")
@@ -596,8 +596,8 @@ final class ACPSessionDetailViewTests: XCTestCase {
     func test_handleDeleteTap_invokesStoreDeleteOnce_andDismisses() async {
         let store = SpyACPSessionStore()
         let session = makeSession(status: .completed)
-        store.sessions[session.state.acpSessionId] = session
-        store.sessionOrder = [session.state.acpSessionId]
+        store.sessions[session.state.id] = session
+        store.sessionOrder = [session.state.id]
 
         let dismissed = expectation(description: "onDismiss fires")
         let view = ACPSessionDetailView(
@@ -612,10 +612,10 @@ final class ACPSessionDetailViewTests: XCTestCase {
         // make the wait observable without polling.
         await fulfillment(of: [dismissed], timeout: 1.0)
 
-        XCTAssertEqual(store.deleteInvocations, [session.state.acpSessionId])
-        XCTAssertNil(store.sessions[session.state.acpSessionId],
+        XCTAssertEqual(store.deleteInvocations, [session.state.id])
+        XCTAssertNil(store.sessions[session.state.id],
                      "Spy store mirror should drop the row on success")
-        XCTAssertFalse(store.sessionOrder.contains(session.state.acpSessionId))
+        XCTAssertFalse(store.sessionOrder.contains(session.state.id))
     }
 
     func test_handleDeleteTap_doesNotDismiss_whenStoreReportsFailure() async {
@@ -624,8 +624,8 @@ final class ACPSessionDetailViewTests: XCTestCase {
         // place and skip the dismissal so the user has a chance to react.
         store.deleteResult = .failure(.httpError(statusCode: 409))
         let session = makeSession(status: .completed)
-        store.sessions[session.state.acpSessionId] = session
-        store.sessionOrder = [session.state.acpSessionId]
+        store.sessions[session.state.id] = session
+        store.sessionOrder = [session.state.id]
 
         var dismissCount = 0
         let view = ACPSessionDetailView(
@@ -642,9 +642,9 @@ final class ACPSessionDetailViewTests: XCTestCase {
         // negative assertion below.
         await Task.yield()
 
-        XCTAssertEqual(store.deleteInvocations, [session.state.acpSessionId])
+        XCTAssertEqual(store.deleteInvocations, [session.state.id])
         XCTAssertEqual(dismissCount, 0, "onDismiss must not fire on failure")
-        XCTAssertNotNil(store.sessions[session.state.acpSessionId],
+        XCTAssertNotNil(store.sessions[session.state.id],
                         "Failed delete should leave the row in place")
     }
 

--- a/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
@@ -170,13 +170,20 @@ final class ACPSessionStoreTests: XCTestCase {
     func test_updateBeforeSpawn_isStitchedOnSeed() async {
         let store = ACPSessionStore()
 
+        // The wire's `acpSessionId` field carries the daemon UUID on
+        // every ACP event — same value the daemon puts in
+        // `ACPSessionState.id`. The seed snapshot below has a divergent
+        // protocol-level `acpSessionId`, so the orphan must key off the
+        // daemon UUID to match.
         store.handle(.acpSessionUpdate(ACPSessionUpdateMessage(
-            acpSessionId: "acp-seeded",
+            acpSessionId: "sess-seeded",
             updateType: .agentMessageChunk,
             content: "early"
         )))
 
         // Seed returns a snapshot containing the orphan's parent session.
+        // `id` is the daemon UUID; `acpSessionId` is the protocol-level
+        // handle filled in once the agent's `createSession` resolved.
         MockACPSessionStoreURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -191,7 +198,7 @@ final class ACPSessionStoreTests: XCTestCase {
                     {
                       "id": "sess-seeded",
                       "agentId": "claude-code",
-                      "acpSessionId": "acp-seeded",
+                      "acpSessionId": "acp-protocol-seeded",
                       "parentConversationId": "conv-seeded",
                       "status": "running",
                       "startedAt": 1700000000000
@@ -206,7 +213,12 @@ final class ACPSessionStoreTests: XCTestCase {
         await store.seed()
 
         XCTAssertEqual(store.seedState, .loaded)
-        let viewModel = try! XCTUnwrap(store.sessions["acp-seeded"])
+        // Store is keyed by `state.id` (the daemon UUID) so the seeded
+        // entry lands under "sess-seeded" — even though the protocol id
+        // is different — and the buffered orphan flushes onto it.
+        let viewModel = try! XCTUnwrap(store.sessions["sess-seeded"])
+        XCTAssertEqual(viewModel.state.acpSessionId, "acp-protocol-seeded",
+                       "Seed should preserve the protocol-level id, distinct from the store key")
         XCTAssertEqual(viewModel.events.count, 1)
         XCTAssertEqual(viewModel.events.first?.content, "early")
     }
@@ -244,13 +256,16 @@ final class ACPSessionStoreTests: XCTestCase {
     func test_seed_mergesSnapshotIntoSessions_inMemoryWinsOnCollision() async {
         let store = ACPSessionStore()
 
-        // Existing in-memory session populated via SSE.
+        // Existing in-memory session populated via SSE. The wire's
+        // `acpSessionId` field IS the daemon UUID — same value the seed
+        // snapshot below carries as `id`, so the two collide on
+        // `state.id` (the store's key) and the in-memory entry wins.
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
-            acpSessionId: "acp-existing",
+            acpSessionId: "sess-existing",
             agent: "claude-code",
             parentConversationId: "conv-existing"
         )))
-        let originalViewModel = try! XCTUnwrap(store.sessions["acp-existing"])
+        let originalViewModel = try! XCTUnwrap(store.sessions["sess-existing"])
 
         MockACPSessionStoreURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
@@ -261,22 +276,23 @@ final class ACPSessionStoreTests: XCTestCase {
             )!
             // Snapshot includes both the existing in-memory session AND a
             // brand-new one. The existing entry should be left alone; the
-            // new entry should be inserted.
+            // new entry should be inserted. The two `id` values match the
+            // daemon UUIDs the SSE pipeline already saw / will see.
             let data = Data(
                 #"""
                 {
                   "sessions": [
                     {
-                      "id": "sess-a",
+                      "id": "sess-existing",
                       "agentId": "stale",
-                      "acpSessionId": "acp-existing",
+                      "acpSessionId": "acp-protocol-existing",
                       "status": "completed",
                       "startedAt": 1
                     },
                     {
-                      "id": "sess-b",
+                      "id": "sess-new",
                       "agentId": "agent-x",
-                      "acpSessionId": "acp-new",
+                      "acpSessionId": "acp-protocol-new",
                       "status": "running",
                       "startedAt": 2000000000000
                     }
@@ -292,11 +308,11 @@ final class ACPSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.seedState, .loaded)
         XCTAssertEqual(store.sessions.count, 2)
         // Existing view model should be the SAME instance — not replaced.
-        XCTAssertTrue(store.sessions["acp-existing"] === originalViewModel,
-                      "In-memory entry should win on id collision")
+        XCTAssertTrue(store.sessions["sess-existing"] === originalViewModel,
+                      "In-memory entry should win on id collision (keyed by state.id)")
         XCTAssertEqual(originalViewModel.state.agentId, "claude-code",
                        "In-memory state should not be overwritten by stale snapshot")
-        XCTAssertNotNil(store.sessions["acp-new"])
+        XCTAssertNotNil(store.sessions["sess-new"])
     }
 
     func test_seed_sortsSessionOrderByStartedAtDescending() async {
@@ -312,9 +328,9 @@ final class ACPSessionStoreTests: XCTestCase {
                 #"""
                 {
                   "sessions": [
-                    {"id":"s1","agentId":"a","acpSessionId":"acp-old","status":"running","startedAt":100},
-                    {"id":"s2","agentId":"a","acpSessionId":"acp-newest","status":"running","startedAt":300},
-                    {"id":"s3","agentId":"a","acpSessionId":"acp-mid","status":"running","startedAt":200}
+                    {"id":"sess-old","agentId":"a","acpSessionId":"acp-old","status":"running","startedAt":100},
+                    {"id":"sess-newest","agentId":"a","acpSessionId":"acp-newest","status":"running","startedAt":300},
+                    {"id":"sess-mid","agentId":"a","acpSessionId":"acp-mid","status":"running","startedAt":200}
                   ]
                 }
                 """#.utf8
@@ -324,7 +340,9 @@ final class ACPSessionStoreTests: XCTestCase {
 
         await store.seed()
 
-        XCTAssertEqual(store.sessionOrder, ["acp-newest", "acp-mid", "acp-old"])
+        // `sessionOrder` is keyed by `state.id` (the daemon UUID) — same
+        // identifier the store's `sessions` dictionary uses.
+        XCTAssertEqual(store.sessionOrder, ["sess-newest", "sess-mid", "sess-old"])
     }
 
     func test_seed_recordsErrorOnTransportFailure() async {
@@ -363,6 +381,68 @@ final class ACPSessionStoreTests: XCTestCase {
         // Oldest 100 should have been dropped — first kept event is index 100.
         XCTAssertEqual(viewModel.events.first?.content, "msg-100")
         XCTAssertEqual(viewModel.events.last?.content, "msg-599")
+    }
+
+    // MARK: - SSE → seed dedupe across diverged ids
+
+    /// `state.id` (daemon UUID) and `state.acpSessionId` (protocol-level
+    /// handle) diverge for any session that has progressed past
+    /// initialization. The wire's `acpSessionId` field always carries the
+    /// daemon UUID, so an SSE-spawned entry and the same session arriving
+    /// later via `seed()` must collapse onto a single store entry — not
+    /// stack up as two separate rows keyed by the two different
+    /// identifiers.
+    func test_sseSpawnThenSeed_doesNotDuplicateSession() async {
+        let store = ACPSessionStore()
+
+        // SSE spawn with the daemon UUID (the value the wire actually
+        // sends — see `assistant/src/acp/session-manager.ts` line 215
+        // where `acpSessionId` is set to the manager's randomUUID()).
+        store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
+            acpSessionId: "sess-uuid",
+            agent: "claude-code",
+            parentConversationId: "conv-1"
+        )))
+
+        let spawned = try! XCTUnwrap(store.sessions["sess-uuid"])
+        XCTAssertEqual(store.sessions.count, 1)
+
+        // Now seed returns the same session — `id` matches the daemon
+        // UUID we already saw, but `acpSessionId` is the (different)
+        // protocol-level handle that has since been resolved.
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "sessions": [
+                    {
+                      "id": "sess-uuid",
+                      "agentId": "claude-code",
+                      "acpSessionId": "acp-protocol-handle",
+                      "parentConversationId": "conv-1",
+                      "status": "running",
+                      "startedAt": 1700000000000
+                    }
+                  ]
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        await store.seed()
+
+        XCTAssertEqual(store.sessions.count, 1,
+                       "SSE-spawned + seeded entry for the same daemon UUID must collapse")
+        XCTAssertTrue(store.sessions["sess-uuid"] === spawned,
+                      "In-memory SSE-spawned view model wins on collision (no replacement)")
+        XCTAssertEqual(store.sessionOrder, ["sess-uuid"])
     }
 
     // MARK: - Spawn dedupe
@@ -431,6 +511,72 @@ final class ACPSessionStoreTests: XCTestCase {
         XCTAssertNotNil(store.sessions["acp-2"], "Other sessions should be left alone")
         XCTAssertFalse(store.sessionOrder.contains("acp-1"), "sessionOrder should not include deleted id")
         XCTAssertTrue(store.sessionOrder.contains("acp-2"))
+    }
+
+    /// Sessions loaded via `seed()` carry diverged `state.id` /
+    /// `state.acpSessionId` values. A delete keyed by the daemon UUID
+    /// (`state.id`) must hit the matching row in the store — historically
+    /// the store keyed by `state.acpSessionId` and the optimistic removal
+    /// silently no-op'd because the URL `:id` parameter the daemon
+    /// expects is the `state.id` value. This test pins the contract.
+    func test_delete_seedLoadedSession_dropsRowKeyedByDaemonUUID() async {
+        let store = ACPSessionStore()
+
+        // Seed with a session whose protocol-level handle differs from
+        // its daemon UUID — the realistic shape for any session past
+        // initialization.
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "sessions": [
+                    {
+                      "id": "sess-target",
+                      "agentId": "claude-code",
+                      "acpSessionId": "acp-protocol-target",
+                      "parentConversationId": "conv-1",
+                      "status": "completed",
+                      "startedAt": 1700000000000,
+                      "completedAt": 1700000010000
+                    }
+                  ]
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+        await store.seed()
+        XCTAssertNotNil(store.sessions["sess-target"])
+
+        // Now arrange the DELETE response and exercise the helper.
+        MockACPSessionStoreURLProtocol.requestHandler = { request in
+            // The URL must carry the daemon UUID, not the protocol id.
+            XCTAssertTrue(
+                request.url?.path.hasSuffix("/sess-target") ?? false,
+                "Delete URL must carry the daemon UUID (state.id)"
+            )
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"deleted":true}"#.utf8))
+        }
+
+        let result = await store.delete(id: "sess-target")
+        guard case .success(true) = result else {
+            return XCTFail("Expected .success(true), got \(result)")
+        }
+        XCTAssertNil(store.sessions["sess-target"],
+                     "Delete keyed by daemon UUID must drop the seed-loaded row")
+        XCTAssertFalse(store.sessionOrder.contains("sess-target"))
     }
 
     func test_delete_leavesStoreUntouched_onFailure() async {

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -111,17 +111,22 @@ public struct ToolCallProgressBar: View {
     // MARK: - acp_spawn deep-link helpers
 
     /// Best-effort JSON probe for the `acpSessionId` field in
-    /// `acp_spawn`'s result payload. The tool returns a JSON object on
-    /// the first line and may append a free-form outdated-adapter
-    /// warning after a blank line (see `assistant/src/tools/acp/spawn.ts`),
-    /// so we parse the leading line rather than the full string —
-    /// otherwise the appended diagnostic invalidates the JSON and the
-    /// deep link would silently disappear in that case. On failure or
-    /// any non-JSON shape we return `nil` so the caller falls back to
-    /// the regular progress bar. Shared between iOS and macOS — macOS
-    /// `ToolCallStepDetailRow.acpSessionIdToOpen` calls this helper so
-    /// both platforms accept the same payload shapes from a single
-    /// implementation.
+    /// `acp_spawn`'s result payload — the daemon UUID
+    /// (``ACPSessionState/id``) the manager generated for the new
+    /// session. That same UUID is what ``ACPSessionStore`` keys its
+    /// `sessions` dictionary by, so the value flows straight into
+    /// `store.sessions[id]` lookups without translation.
+    ///
+    /// The tool returns a JSON object on the first line and may append
+    /// a free-form outdated-adapter warning after a blank line (see
+    /// `assistant/src/tools/acp/spawn.ts`), so we parse the leading line
+    /// rather than the full string — otherwise the appended diagnostic
+    /// invalidates the JSON and the deep link would silently disappear
+    /// in that case. On failure or any non-JSON shape we return `nil` so
+    /// the caller falls back to the regular progress bar. Shared between
+    /// iOS and macOS — macOS `ToolCallStepDetailRow.acpSessionIdToOpen`
+    /// calls this helper so both platforms accept the same payload
+    /// shapes from a single implementation.
     public static func extractAcpSessionId(from result: String) -> String? {
         let leading = result.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
             .first.map(String.init) ?? ""

--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -8,10 +8,17 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ACPSe
 
 /// Per-session observable state for ACP (Agent Client Protocol) sessions.
 ///
-/// Stored in `ACPSessionStore.sessions` keyed by `acpSessionId`. Each session
-/// gets its own instance so SwiftUI tracks observation per session: streaming
-/// updates to one session's `events` only invalidate views that read that
-/// specific view model.
+/// Stored in `ACPSessionStore.sessions` keyed by `state.id` — the daemon's
+/// canonical UUID, which is also the value the daemon's `cancel`/`steer`/
+/// `delete` routes accept and the value the wire's `acp_session_*` events
+/// carry as `acpSessionId`. We deliberately do **not** key by
+/// `state.acpSessionId`, because that field gets overwritten with the
+/// protocol-level handle once `createSession` resolves — using it would
+/// break mutation routes for any session loaded via `seed()`.
+///
+/// Each session gets its own instance so SwiftUI tracks observation per
+/// session: streaming updates to one session's `events` only invalidate
+/// views that read that specific view model.
 @MainActor @Observable
 public final class ACPSessionViewModel: Identifiable, Hashable {
     /// Snapshot of the session as last reported by the daemon.
@@ -21,7 +28,7 @@ public final class ACPSessionViewModel: Identifiable, Hashable {
     /// dropped first to bound memory.
     public var events: [ACPSessionUpdateMessage] = []
 
-    public var id: String { state.acpSessionId }
+    public var id: String { state.id }
 
     public init(state: ACPSessionState) {
         self.state = state
@@ -60,9 +67,16 @@ public final class ACPSessionViewModel: Identifiable, Hashable {
 
 /// Observable store for ACP sessions.
 ///
-/// Holds a per-session ``ACPSessionViewModel`` keyed by `acpSessionId` plus
-/// an `[acpSessionId]` order array sorted by `startedAt` descending so list
-/// views render newest-first without re-sorting on every change.
+/// Holds a per-session ``ACPSessionViewModel`` keyed by `state.id` — the
+/// daemon UUID — plus an order array sorted by `startedAt` descending so
+/// list views render newest-first without re-sorting on every change.
+/// `state.id` is the canonical identifier the daemon's mutation routes
+/// (`cancel`/`steer`/`delete`) and persisted history primary key all use,
+/// and is also what the wire's `acp_session_*` events carry as their
+/// `acpSessionId` field. Keying by `state.acpSessionId` instead would
+/// break for sessions whose protocol-level handle has been filled in
+/// (i.e. anything past initialization), since `state.id !=
+/// state.acpSessionId` once `createSession` resolves.
 ///
 /// SSE events from the gateway flow through ``handle(_:)``: a `spawned`
 /// event creates a view model, `update` events append to its `events`,
@@ -99,29 +113,31 @@ open class ACPSessionStore {
         case error(String)
     }
 
-    /// Per-session observable state. Mutating an entry's properties only
+    /// Per-session observable state, keyed by the daemon UUID
+    /// (``ACPSessionState/id``). Mutating an entry's properties only
     /// invalidates views that read that specific view model; mutating the
     /// dictionary itself (insert/remove) invalidates list-level readers.
     public var sessions: [String: ACPSessionViewModel] = [:]
-    /// `acpSessionId` order sorted by `startedAt` descending — list views
+    /// Daemon-UUID order sorted by `startedAt` descending — list views
     /// iterate this to render rows in newest-first order.
     public var sessionOrder: [String] = []
     /// State of the most recent ``seed()`` call. Views show a loading
     /// placeholder while `.loading`, an error banner on `.error`, etc.
     public var seedState: SeedState = .idle
 
-    /// Programmatic deep-link target. When set to a non-nil
-    /// `acpSessionId`, ``ACPSessionsPanel`` reacts by pushing the
-    /// matching ``ACPSessionViewModel`` onto its `NavigationStack`. The
-    /// panel clears this back to `nil` after consuming the value so a
+    /// Programmatic deep-link target. When set to a non-nil daemon UUID
+    /// (``ACPSessionState/id``), ``ACPSessionsPanel`` reacts by pushing
+    /// the matching ``ACPSessionViewModel`` onto its `NavigationStack`.
+    /// The panel clears this back to `nil` after consuming the value so a
     /// later set with the same id still triggers a fresh push. Used by
     /// the inline `acp_spawn` tool block to jump straight from a chat
     /// bubble into the corresponding session detail view.
     public var selectedSessionId: String?
 
     /// Update messages received before their parent `spawned` event,
-    /// keyed by `acpSessionId`. Reapplied during ``seed()`` once the
-    /// parent appears in the polled snapshot.
+    /// keyed by the wire `acpSessionId` field — which the daemon
+    /// populates with the daemon UUID on every ACP event. Reapplied
+    /// during ``seed()`` once the parent appears in the polled snapshot.
     @ObservationIgnored
     private var orphanedUpdates: [String: [ACPSessionUpdateMessage]] = [:]
 
@@ -155,9 +171,13 @@ open class ACPSessionStore {
 
     private func mergeSnapshot(_ snapshot: [ACPSessionState]) {
         // In-memory entries already populated via SSE win on collision —
-        // SSE is strictly newer than the polled snapshot.
-        for state in snapshot where sessions[state.acpSessionId] == nil {
-            sessions[state.acpSessionId] = ACPSessionViewModel(state: state)
+        // SSE is strictly newer than the polled snapshot. Both branches
+        // dedupe by `state.id` (the daemon UUID) so an SSE-spawned entry
+        // and the same session arriving via the seed snapshot collapse
+        // onto a single store entry — the SSE-spawn path also writes
+        // `state.id` as the daemon UUID, so the keys line up.
+        for state in snapshot where sessions[state.id] == nil {
+            sessions[state.id] = ACPSessionViewModel(state: state)
         }
         rebuildSessionOrder()
     }
@@ -178,7 +198,7 @@ open class ACPSessionStore {
     private func rebuildSessionOrder() {
         sessionOrder = sessions.values
             .sorted { $0.state.startedAt > $1.state.startedAt }
-            .map(\.state.acpSessionId)
+            .map(\.state.id)
     }
 
     // MARK: - Filtering
@@ -216,10 +236,15 @@ open class ACPSessionStore {
     }
 
     private func handleSpawned(_ message: ACPSessionSpawnedMessage) {
+        // The wire's `acpSessionId` IS the daemon UUID — the daemon
+        // populates it from the same `state.id` that the cancel/steer/
+        // delete routes accept. Use it as both the dictionary key and the
+        // synthetic `state.id` so a later `seed()` snapshot for the same
+        // session collapses onto this entry instead of duplicating it.
+        // `state.acpSessionId` is set to the wire value as a placeholder;
+        // a subsequent seed will overwrite it with the protocol-level
+        // session id once the agent's `createSession` has resolved.
         if sessions[message.acpSessionId] == nil {
-            // Spawned events carry fewer fields than `ACPSessionState`. Fill
-            // in placeholder timestamps; the daemon will overwrite via the
-            // next status-changing event or a subsequent seed snapshot.
             let state = ACPSessionState(
                 id: message.acpSessionId,
                 agentId: message.agent,


### PR DESCRIPTION
## Summary
Fixes a critical bug where cancel/steer/delete API calls failed for sessions loaded via `ACPSessionStore.seed()` because the Swift store keyed by the protocol-level `state.acpSessionId` while the daemon routes look up by the daemon UUID `state.id`.

- Re-keys the store dictionary by `state.id` (the daemon UUID, canonical identifier).
- Updates all consumers (cancel/steer/delete handlers, deep-link helpers).
- Tests assert correct dedup-on-seed and seed-loaded mutation paths.

Gap caught during plan review for acp-sessions-ui.md.
**Gap:** Swift store keyed by wrong identifier; cancel/delete failed silently for history-loaded sessions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
