### PR TITLE
fix(live-voice): harden assistant TTS and startup failure handling

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -169,7 +169,6 @@ function makeTtsChunk(
 ): LiveVoiceTtsAudioChunk {
   return {
     type: "tts_audio",
-    seq: 0,
     contentType,
     sampleRate: 24_000,
     dataBase64: Buffer.from(text).toString("base64"),

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -124,7 +124,6 @@ function makeArchiveResult(
 function makeTtsChunk(text: string): LiveVoiceTtsAudioChunk {
   return {
     type: "tts_audio",
-    seq: 0,
     contentType: "audio/pcm",
     sampleRate: 24_000,
     dataBase64: Buffer.from(text).toString("base64"),

--- a/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
@@ -5,6 +5,7 @@ import {
   type LiveVoiceSessionCloseReason,
   type LiveVoiceSessionFactoryContext,
   LiveVoiceSessionManager,
+  LiveVoiceSessionStartupError,
 } from "../live-voice-session-manager.js";
 import type {
   LiveVoiceClientFrame,
@@ -215,6 +216,50 @@ describe("LiveVoiceSessionManager", () => {
     ).rejects.toThrow("session start failed");
     const retry = await manager.startSession(START_FRAME, createSink().sink);
 
+    expect(sessions[0]?.closeReasons).toEqual(["error"]);
+    expect(retry).toEqual({ status: "accepted", sessionId: "session-2" });
+    expect(manager.activeSessionId).toBe("session-2");
+  });
+
+  test("releases the lock without rethrowing terminal startup failures", async () => {
+    const sessions: TestSession[] = [];
+    const first = createSink();
+    const second = createSink();
+    const startupErrorMessage = "Live voice transcription could not be started";
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      createSession: (context) => {
+        const session = createTestSession(
+          context.sessionId === "session-1"
+            ? {
+                start: mock(async () => {
+                  await context.sendFrame({
+                    type: "error",
+                    code: "invalid_field",
+                    message: startupErrorMessage,
+                  });
+                  throw new LiveVoiceSessionStartupError(startupErrorMessage);
+                }),
+              }
+            : {},
+        );
+        sessions.push(session);
+        return session;
+      },
+    });
+
+    const failed = await manager.startSession(START_FRAME, first.sink);
+    const retry = await manager.startSession(START_FRAME, second.sink);
+
+    expect(failed).toEqual({ status: "failed", sessionId: "session-1" });
+    expect(first.frames).toEqual([
+      {
+        type: "error",
+        seq: 1,
+        code: "invalid_field",
+        message: startupErrorMessage,
+      },
+    ]);
     expect(sessions[0]?.closeReasons).toEqual(["error"]);
     expect(retry).toEqual({ status: "accepted", sessionId: "session-2" });
     expect(manager.activeSessionId).toBe("session-2");

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -125,7 +125,6 @@ function makeTtsChunk(
 ): LiveVoiceTtsAudioChunk {
   return {
     type: "tts_audio",
-    seq: 0,
     contentType,
     sampleRate: 24_000,
     dataBase64: Buffer.from(text).toString("base64"),

--- a/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 });
 
 describe("streamLiveVoiceTtsAudio", () => {
-  test("streams Fish Audio chunks through the configured TTS registry", async () => {
+  test("buffers non-PCM Fish Audio chunks into one playable frame", async () => {
     const requests: TtsSynthesisRequest[] = [];
     const provider: TtsProvider = {
       id: "fish-audio",
@@ -72,29 +72,21 @@ describe("streamLiveVoiceTtsAudio", () => {
     expect(frames).toEqual([
       {
         type: "tts_audio",
-        seq: 0,
         contentType: "audio/mpeg",
         sampleRate: 24_000,
-        dataBase64: Buffer.from("chunk-one").toString("base64"),
-      },
-      {
-        type: "tts_audio",
-        seq: 1,
-        contentType: "audio/mpeg",
-        sampleRate: 24_000,
-        dataBase64: Buffer.from("chunk-two").toString("base64"),
+        dataBase64: Buffer.from("chunk-onechunk-two").toString("base64"),
       },
     ]);
     expect(result).toEqual({
       provider: "fish-audio",
       contentType: "audio/mpeg",
       sampleRate: 24_000,
-      chunks: 2,
+      chunks: 1,
       bytes: Buffer.byteLength("chunk-onechunk-two"),
     });
   });
 
-  test("labels Fish Audio live voice PCM requests as WAV chunks", async () => {
+  test("emits split Fish Audio WAV chunks as one complete WAV frame", async () => {
     const requests: TtsSynthesisRequest[] = [];
     registerTtsProvider({
       id: "fish-audio",
@@ -110,7 +102,8 @@ describe("streamLiveVoiceTtsAudio", () => {
         onChunk: (chunk: Uint8Array) => void,
       ): Promise<TtsSynthesisResult> {
         requests.push(request);
-        onChunk(Buffer.from("wav-chunk"));
+        onChunk(Buffer.from("wav-"));
+        onChunk(Buffer.from("chunk"));
         return {
           audio: Buffer.from("wav-chunk"),
           contentType: "audio/wav",
@@ -130,13 +123,74 @@ describe("streamLiveVoiceTtsAudio", () => {
     expect(frames).toEqual([
       {
         type: "tts_audio",
-        seq: 0,
         contentType: "audio/wav",
         sampleRate: 24_000,
         dataBase64: Buffer.from("wav-chunk").toString("base64"),
       },
     ]);
-    expect(result.contentType).toBe("audio/wav");
+    expect(result).toMatchObject({
+      contentType: "audio/wav",
+      chunks: 1,
+      bytes: Buffer.byteLength("wav-chunk"),
+    });
+  });
+
+  test("streams raw PCM provider chunks incrementally", async () => {
+    config = makeConfig({ provider: "elevenlabs" });
+    const requests: TtsSynthesisRequest[] = [];
+    registerTtsProvider({
+      id: "elevenlabs",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "pcm"],
+      },
+      async synthesize(): Promise<TtsSynthesisResult> {
+        throw new Error("buffered synthesis should not be used");
+      },
+      async synthesizeStream(
+        request: TtsSynthesisRequest,
+        onChunk: (chunk: Uint8Array) => void,
+      ): Promise<TtsSynthesisResult> {
+        requests.push(request);
+        onChunk(Buffer.from("pcm-one"));
+        onChunk(Buffer.from("pcm-two"));
+        return {
+          audio: Buffer.from("pcm-onepcm-two"),
+          contentType: "audio/pcm",
+        };
+      },
+    });
+
+    const frames: LiveVoiceTtsAudioChunk[] = [];
+    const result = await streamLiveVoiceTtsAudio({
+      config,
+      text: "hello from live voice",
+      outputFormat: "pcm",
+      onAudioChunk: (chunk) => frames.push(chunk),
+    });
+
+    expect(requests[0]?.outputFormat).toBe("pcm");
+    expect(frames).toEqual([
+      {
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: 24_000,
+        dataBase64: Buffer.from("pcm-one").toString("base64"),
+      },
+      {
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: 24_000,
+        dataBase64: Buffer.from("pcm-two").toString("base64"),
+      },
+    ]);
+    expect(result).toEqual({
+      provider: "elevenlabs",
+      contentType: "audio/pcm",
+      sampleRate: 24_000,
+      chunks: 2,
+      bytes: Buffer.byteLength("pcm-onepcm-two"),
+    });
   });
 
   test("returns a typed configuration error for a non-streaming provider", async () => {

--- a/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
+++ b/assistant/src/live-voice/__tests__/runtime-websocket-shell.test.ts
@@ -74,11 +74,16 @@ class MockStreamingTranscriber implements StreamingTranscriber {
 }
 
 const resolvedTranscribers: MockStreamingTranscriber[] = [];
-const resolveStreamingTranscriberMock = mock(async () => {
+function createResolvedTranscriber(): MockStreamingTranscriber {
   const transcriber = new MockStreamingTranscriber();
   resolvedTranscribers.push(transcriber);
   return transcriber;
-});
+}
+
+let resolveStreamingTranscriberImpl = async () => createResolvedTranscriber();
+const resolveStreamingTranscriberMock = mock(() =>
+  resolveStreamingTranscriberImpl(),
+);
 
 mock.module("../../providers/speech-to-text/resolve.js", () => ({
   resolveStreamingTranscriber: resolveStreamingTranscriberMock,
@@ -234,6 +239,7 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
   beforeEach(async () => {
     delete process.env.DISABLE_HTTP_AUTH;
     delete process.env.VELLUM_UNSAFE_AUTH_BYPASS;
+    resolveStreamingTranscriberImpl = async () => createResolvedTranscriber();
     resolveStreamingTranscriberMock.mockClear();
     resolvedTranscribers.length = 0;
     clients = [];
@@ -378,5 +384,38 @@ describe("RuntimeHttpServer live voice WebSocket shell", () => {
       conversationId: "conversation-second",
     });
     expect(secondReady.sessionId).not.toBe(firstReady.sessionId);
+  });
+
+  test("releases the session lock after startup STT failure without WebSocket close", async () => {
+    let attempts = 0;
+    resolveStreamingTranscriberImpl = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("Deepgram credentials missing");
+      }
+      return createResolvedTranscriber();
+    };
+    const ws = openLiveVoiceClient();
+    await waitForOpen(ws);
+
+    ws.send(startFrame("conversation-failed"));
+    const error = await waitForJsonFrame(ws);
+    expect(error).toMatchObject({
+      type: "error",
+      code: "invalid_field",
+      message: expect.stringContaining("Deepgram credentials missing"),
+    });
+
+    ws.send(startFrame("conversation-retry"));
+    const ready = await waitForJsonFrame(ws);
+
+    expect(ready).toMatchObject({
+      type: "ready",
+      conversationId: "conversation-retry",
+    });
+    expect(typeof ready.sessionId).toBe("string");
+    expect(resolveStreamingTranscriberMock).toHaveBeenCalledTimes(2);
+    expect(resolvedTranscribers).toHaveLength(1);
+    expect(resolvedTranscribers[0]?.started).toBe(true);
   });
 });

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -11,7 +11,8 @@ export type LiveVoiceMetricsEvent =
   | "first_assistant_delta"
   | "first_tts_audio"
   | "turn_completed"
-  | "turn_cancelled";
+  | "turn_cancelled"
+  | "session_ended";
 
 export type LiveVoiceTurnStatus = "active" | "completed" | "cancelled";
 

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -42,9 +42,20 @@ export interface LiveVoiceSessionManagerOptions {
   createSessionId?: () => string;
 }
 
+export class LiveVoiceSessionStartupError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LiveVoiceSessionStartupError";
+  }
+}
+
 export type LiveVoiceStartSessionResult =
   | {
       status: "accepted";
+      sessionId: string;
+    }
+  | {
+      status: "failed";
       sessionId: string;
     }
   | {
@@ -127,6 +138,9 @@ export class LiveVoiceSessionManager {
       await session.start();
     } catch (err) {
       await this.releaseAfterSessionError(sessionId);
+      if (err instanceof LiveVoiceSessionStartupError) {
+        return { status: "failed", sessionId };
+      }
       throw err;
     }
 
@@ -205,10 +219,4 @@ export class LiveVoiceSessionManager {
       // The original session error is more useful to callers than a cleanup error.
     }
   }
-}
-
-export function createLiveVoiceSessionManager(
-  options: LiveVoiceSessionManagerOptions,
-): LiveVoiceSessionManager {
-  return new LiveVoiceSessionManager(options);
 }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -22,11 +22,13 @@ import {
   getLiveVoiceMetricsAggregateFields,
   type LiveVoiceMetricsClock,
   LiveVoiceMetricsCollector,
+  type LiveVoiceMetricsEvent,
 } from "./live-voice-metrics.js";
-import type {
-  LiveVoiceSession as LiveVoiceSessionContract,
-  LiveVoiceSessionCloseReason,
-  LiveVoiceSessionFactoryContext,
+import {
+  type LiveVoiceSession as LiveVoiceSessionContract,
+  type LiveVoiceSessionCloseReason,
+  type LiveVoiceSessionFactoryContext,
+  LiveVoiceSessionStartupError,
 } from "./live-voice-session-manager.js";
 import type {
   LiveVoiceTtsOptions,
@@ -172,13 +174,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
 
       if (!transcriber) {
-        this.state = "failed";
-        await this.sendFrame({
-          type: "error",
-          code: LiveVoiceProtocolErrorCode.InvalidField,
-          message: unavailableTranscriberMessage(),
-        });
-        return;
+        return await this.failStartup(unavailableTranscriberMessage());
       }
 
       this.transcriber = transcriber;
@@ -200,18 +196,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         conversationId: this.conversationId,
       });
     } catch (err) {
+      if (err instanceof LiveVoiceSessionStartupError) {
+        throw err;
+      }
+
       stopTranscriberBestEffort(this.transcriber);
       this.transcriber = null;
       if (this.isClosed) return;
 
-      this.state = "failed";
-      await this.sendFrame({
-        type: "error",
-        code: LiveVoiceProtocolErrorCode.InvalidField,
-        message: `Live voice transcription could not be started: ${errorMessage(
-          err,
-        )}`,
-      });
+      await this.failStartup(
+        `Live voice transcription could not be started: ${errorMessage(err)}`,
+      );
     }
   }
 
@@ -243,11 +238,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   async close(_reason: LiveVoiceSessionCloseReason): Promise<void> {
     if (this.isClosed) return;
 
+    const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
     stopTranscriberBestEffort(this.transcriber);
     this.transcriber = null;
     await this.cancelAssistantTurn("session_closed");
-    await this.emitSessionEndMetrics();
+    if (shouldEmitSessionEndMetrics) {
+      await this.emitSessionEndMetrics();
+    }
     await this.drainOutboundFrames();
   }
 
@@ -894,7 +892,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async emitMetricsFrame(
-    event: string,
+    event: LiveVoiceMetricsEvent,
     turnId = this.currentTurnId ?? this.context.sessionId,
   ): Promise<void> {
     const metrics = this.metrics.getSnapshot();
@@ -907,6 +905,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       metrics,
       ...getLiveVoiceMetricsAggregateFields(metrics, turnId),
     });
+  }
+
+  private async failStartup(message: string): Promise<never> {
+    this.state = "failed";
+    await this.sendFrame({
+      type: "error",
+      code: LiveVoiceProtocolErrorCode.InvalidField,
+      message,
+    });
+    throw new LiveVoiceSessionStartupError(message);
   }
 
   private async sendAudioAfterReleaseError(): Promise<void> {

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -13,7 +13,6 @@ export type LiveVoiceTtsConfig = Parameters<typeof resolveTtsConfig>[0];
 
 export interface LiveVoiceTtsAudioChunk {
   type: "tts_audio";
-  seq: number;
   contentType: string;
   sampleRate: number;
   dataBase64: string;
@@ -79,9 +78,22 @@ export async function streamLiveVoiceTtsAudio(
     providerConfig,
     options.outputFormat,
   );
-  let seq = 0;
+  const canStreamChunks = isRawPcmContentType(chunkContentType);
   let chunks = 0;
   let bytes = 0;
+
+  const emitAudioFrame = (contentType: string, audio: Uint8Array): void => {
+    if (audio.byteLength === 0) return;
+
+    chunks += 1;
+    bytes += audio.byteLength;
+    options.onAudioChunk({
+      type: "tts_audio",
+      contentType,
+      sampleRate,
+      dataBase64: Buffer.from(audio).toString("base64"),
+    });
+  };
 
   try {
     const result = await provider.synthesizeStream!(
@@ -93,23 +105,20 @@ export async function streamLiveVoiceTtsAudio(
         outputFormat: options.outputFormat,
       },
       (audioChunk) => {
-        if (audioChunk.byteLength === 0) return;
-
-        chunks += 1;
-        bytes += audioChunk.byteLength;
-        options.onAudioChunk({
-          type: "tts_audio",
-          seq: seq++,
-          contentType: chunkContentType,
-          sampleRate,
-          dataBase64: Buffer.from(audioChunk).toString("base64"),
-        });
+        if (canStreamChunks) {
+          emitAudioFrame(chunkContentType, audioChunk);
+        }
       },
     );
+    const contentType = result.contentType || chunkContentType;
+
+    if (!canStreamChunks) {
+      emitAudioFrame(contentType, result.audio);
+    }
 
     return {
       provider: providerId,
-      contentType: result.contentType || chunkContentType,
+      contentType,
       sampleRate,
       chunks,
       bytes,
@@ -244,4 +253,8 @@ function resolveSampleRate(
 
 function isPositiveFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function isRawPcmContentType(contentType: string): boolean {
+  return contentType.split(";", 1)[0]?.trim().toLowerCase() === "audio/pcm";
 }


### PR DESCRIPTION
## Summary
Fixes second-round self-review gaps from live-voice-channel.md.

Gaps: container TTS chunks were not independently playable, startup STT errors could hold the live voice lock, and remaining metrics/TTS/session-manager slop needed cleanup.

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
