### PR TITLE
fix(live-voice): order STT and TTS turn finalization

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-agent-turn.test.ts
@@ -89,6 +89,7 @@ function createSessionHarness(
     transcriber?: MockStreamingTranscriber;
     startVoiceTurn?: LiveVoiceTurnStarter;
     createTurnId?: () => string;
+    emitMetrics?: boolean;
   } = {},
 ) {
   const transcriber =
@@ -106,6 +107,7 @@ function createSessionHarness(
     resolveTranscriber: mock(async () => transcriber),
     startVoiceTurn,
     createTurnId: options.createTurnId ?? (() => "live-turn-1"),
+    emitMetrics: options.emitMetrics ?? false,
   });
 
   return { frames, session, startVoiceTurn, transcriber };
@@ -122,6 +124,17 @@ async function waitForFrameCount(
 
 async function flushAsyncCallbacks(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "Timed out waiting for live voice assistant turn condition",
+): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
 }
 
 describe("LiveVoiceSession assistant turn", () => {
@@ -191,6 +204,88 @@ describe("LiveVoiceSession assistant turn", () => {
       type: "tts_done",
       turnId: "live-turn-1",
     });
+  });
+
+  test("waits for transcriber closed before starting an assistant turn after release", async () => {
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => ({
+      turnId: "bridge-turn-1",
+      abort: mock(),
+    }));
+    const { frames, session } = createSessionHarness({
+      transcriber,
+      startVoiceTurn,
+    });
+
+    await session.start();
+    transcriber.emit({ type: "final", text: "hello" });
+    await waitForFrameCount(frames, 2);
+
+    await session.handleClientFrame({ type: "ptt_release" });
+    expect(transcriber.stopped).toBe(true);
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+
+    transcriber.emit({ type: "final", text: "after release" });
+    await waitForFrameCount(frames, 3);
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+
+    transcriber.emit({ type: "closed" });
+    await waitForFrameCount(frames, 4);
+
+    expect(startVoiceTurn).toHaveBeenCalledTimes(1);
+    expect(startVoiceTurn.mock.calls[0]?.[0]).toMatchObject({
+      content: "hello after release",
+    });
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "stt_final",
+      "thinking",
+    ]);
+  });
+
+  test("empty transcripts finalize only after the transcriber closes", async () => {
+    const transcriber = new MockStreamingTranscriber();
+    const startVoiceTurn = mock(async (_options: VoiceTurnOptions) => ({
+      turnId: "bridge-turn-1",
+      abort: mock(),
+    }));
+    const { frames, session } = createSessionHarness({
+      transcriber,
+      startVoiceTurn,
+      emitMetrics: true,
+    });
+
+    await session.start();
+    await session.handleClientFrame({
+      type: "audio",
+      dataBase64: Buffer.from("user audio").toString("base64"),
+    });
+    await session.handleClientFrame({ type: "ptt_release" });
+
+    transcriber.emit({ type: "final", text: "   \n\t  " });
+    await waitForFrameCount(frames, 2);
+
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    ).toBe(false);
+
+    transcriber.emit({ type: "closed" });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_cancelled",
+      ),
+    );
+
+    expect(startVoiceTurn).not.toHaveBeenCalled();
+    expect(frames.map((frame) => frame.type)).toEqual([
+      "ready",
+      "stt_final",
+      "metrics",
+    ]);
   });
 
   test("does not start an assistant turn for whitespace-only final transcripts", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-events.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-events.test.ts
@@ -240,14 +240,21 @@ describe("LiveVoiceSession archive and metrics events", () => {
     });
     callbacks?.assistant_text_delta?.(makeTextDelta("Hello there."));
     callbacks?.message_complete?.(makeMessageComplete());
-    await waitFor(() =>
-      frames.some(
-        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
-      ),
-    );
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     await session.close("client_end");
 
-    expect(frameTypes(frames)).toContain("tts_done");
+    expect(frameTypes(frames)).toEqual([
+      "ready",
+      "stt_final",
+      "thinking",
+      "assistant_text_delta",
+      "tts_audio",
+      "archived",
+      "archived",
+      "metrics",
+      "tts_done",
+      "metrics",
+    ]);
     expect(archiveAudio).toHaveBeenCalledTimes(2);
     expect(archiveAudio.mock.calls.map((call) => call[0].role)).toEqual([
       "user",

--- a/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-integration.test.ts
@@ -207,11 +207,7 @@ describe("LiveVoiceSession integration smoke harness", () => {
     await session.start();
     await session.handleBinaryAudio(new Uint8Array([1, 2, 3, 4]));
     await session.handleClientFrame({ type: "ptt_release" });
-    await waitFor(() =>
-      frames.some(
-        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
-      ),
-    );
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
 
     expect(transcriber.audioChunks).toHaveLength(1);
     expect(transcriber.audioChunks[0]).toEqual(Buffer.from([1, 2, 3, 4]));
@@ -245,10 +241,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
       "thinking",
       "assistant_text_delta",
       "tts_audio",
-      "tts_done",
       "archived",
       "archived",
       "metrics",
+      "tts_done",
     ]);
     expect(frames[5]).toMatchObject({
       type: "tts_audio",
@@ -256,17 +252,17 @@ describe("LiveVoiceSession integration smoke harness", () => {
         "base64",
       ),
     });
-    expect(frames[7]).toMatchObject({
+    expect(frames[6]).toMatchObject({
       type: "archived",
       role: "user",
       attachmentIds: ["user-attachment-123"],
     });
-    expect(frames[8]).toMatchObject({
+    expect(frames[7]).toMatchObject({
       type: "archived",
       role: "assistant",
       attachmentIds: ["assistant-attachment-123"],
     });
-    expect(frames[9]).toMatchObject({
+    expect(frames[8]).toMatchObject({
       type: "metrics",
       event: "turn_completed",
       sessionId: "session-123",
@@ -278,6 +274,10 @@ describe("LiveVoiceSession integration smoke harness", () => {
           cancelledTurnCount: 0,
         },
       },
+    });
+    expect(frames[9]).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
     });
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
@@ -187,6 +187,7 @@ describe("LiveVoiceSessionManager", () => {
 
     expect(result).toEqual({ status: "handled", sessionId: "session-1" });
     expect(sessions[0]?.clientFrames).toEqual([{ type: "end" }]);
+    expect(sessions[0]?.close).toHaveBeenCalledTimes(1);
     expect(sessions[0]?.closeReasons).toEqual(["client_end"]);
     expect(next).toEqual({ status: "accepted", sessionId: "session-2" });
     expect(sessions).toHaveLength(2);

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -224,7 +224,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         await this.interrupt();
         return;
       case "end":
-        await this.close("client_end");
         return;
       case "start":
         return;
@@ -307,6 +306,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           err,
         )}`,
       });
+      this.state = "transcriber_closed";
+      this.transcriber = null;
     }
     await this.startAssistantTurnIfReady();
     await this.drainOutboundFrames();
@@ -375,10 +376,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     ) {
       return;
     }
-    if (
-      this.state !== "utterance_released" &&
-      this.state !== "transcriber_closed"
-    ) {
+    if (this.state !== "transcriber_closed") {
       return;
     }
     if (!this.startVoiceTurn) return;
@@ -575,11 +573,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         if (currentTurn?.token !== token || currentTurn.ttsDone) return;
 
         currentTurn.ttsDone = true;
+        await this.finalizeAssistantTurn(
+          currentTurn,
+          "completed",
+          "completed",
+          {
+            clearActive: false,
+          },
+        );
         await this.sendFrame(
           { type: "tts_done", turnId: currentTurn.turnId },
-          () => this.isActiveAssistantTurn(token),
+          () =>
+            this.activeAssistantTurn?.token === token &&
+            currentTurn.finalized &&
+            !this.isClosed,
         );
-        await this.finalizeAssistantTurn(currentTurn, "completed");
 
         if (this.activeAssistantTurn?.token === token) {
           if (currentTurn.handle && currentTurn.finalized) {
@@ -732,6 +740,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn: ActiveAssistantTurn,
     status: "completed" | "cancelled",
     reason = "completed",
+    options: { clearActive?: boolean } = {},
   ): Promise<void> {
     if (turn.finalized) return;
 
@@ -749,7 +758,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     });
     await this.finishMetricsTurn(status, reason, turn.turnId);
 
-    if (this.activeAssistantTurn?.token === turn.token && turn.handle) {
+    if (
+      (options.clearActive ?? true) &&
+      this.activeAssistantTurn?.token === turn.token &&
+      turn.handle
+    ) {
       this.activeAssistantTurn = null;
     }
   }


### PR DESCRIPTION
## Summary
Fixes third-round self-review gaps from live-voice-channel.md.

Gaps: assistant turns could start before post-stop STT finals, tts_done could precede archive/metrics finalization, and end-frame close ownership was split between session and manager.

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
