### PR TITLE
fix(live-voice): remove stale client playback plumbing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
@@ -7,20 +7,17 @@ struct LiveVoiceAudioChunk: Equatable {
     let mimeType: String
     let sampleRate: Int
     let channels: Int
-    let sequence: Int?
 
     init(
         data: Data,
         mimeType: String,
         sampleRate: Int,
-        channels: Int = 1,
-        sequence: Int? = nil
+        channels: Int = 1
     ) {
         self.data = data
         self.mimeType = mimeType
         self.sampleRate = sampleRate
         self.channels = channels
-        self.sequence = sequence
     }
 }
 
@@ -100,16 +97,14 @@ final class LiveVoiceAudioPlayer {
         data: Data,
         mimeType: String,
         sampleRate: Int,
-        channels: Int = 1,
-        sequence: Int? = nil
+        channels: Int = 1
     ) {
         enqueueTTSAudio(
             LiveVoiceAudioChunk(
                 data: data,
                 mimeType: mimeType,
                 sampleRate: sampleRate,
-                channels: channels,
-                sequence: sequence
+                channels: channels
             )
         )
     }

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -25,8 +25,7 @@ protocol LiveVoiceAudioPlaying: AnyObject {
         data: Data,
         mimeType: String,
         sampleRate: Int,
-        channels: Int,
-        sequence: Int?
+        channels: Int
     )
     func handleInterrupt()
     func handleEnd()
@@ -98,13 +97,6 @@ final class LiveVoiceChannelManager {
             failWithoutActiveClient(message: "A conversation is required to start live voice.")
             return
         }
-        if state == .idle, client != nil {
-            if activeConversationId == trimmedConversationId {
-                await startListening()
-                return
-            }
-            await end()
-        }
         guard state == .idle || state == .failed else { return }
 
         sessionGeneration &+= 1
@@ -125,11 +117,6 @@ final class LiveVoiceChannelManager {
                 self?.handle(failure, generation: generation)
             }
         )
-    }
-
-    func startListening() async {
-        guard state == .idle, client != nil else { return }
-        startCapture(generation: sessionGeneration)
     }
 
     func interruptSpeakingAndStartListening(conversationId: String) async {
@@ -238,14 +225,13 @@ final class LiveVoiceChannelManager {
                 state = .thinking
             }
 
-        case .ttsAudio(let data, let mimeType, let sampleRate, let seq):
+        case .ttsAudio(let data, let mimeType, let sampleRate, _):
             beginAssistantAudioIfNeeded()
             playback.enqueueTTSAudio(
                 data: data,
                 mimeType: mimeType,
                 sampleRate: sampleRate,
-                channels: 1,
-                sequence: seq
+                channels: 1
             )
             state = .speaking
 

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -14,7 +14,6 @@ protocol LiveVoiceChannelManaging: AnyObject {
     var errorMessage: String { get }
 
     func start(conversationId: String) async
-    func startListening() async
     func interruptSpeakingAndStartListening(conversationId: String) async
     func stopListening() async
     func end() async

--- a/clients/macos/vellum-assistantTests/LiveVoiceAudioPlayerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceAudioPlayerTests.swift
@@ -68,42 +68,42 @@ final class LiveVoiceAudioPlayerTests: XCTestCase {
         XCTAssertFalse(player.isPlaying)
         XCTAssertTrue(output.playedChunks.isEmpty)
 
-        player.enqueueTTSAudio(chunk(sequence: 1))
+        player.enqueueTTSAudio(chunk(id: 1))
 
-        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(output.playedChunks.map(\.data), [chunkData(id: 1)])
         XCTAssertEqual(player.state, .playing)
         XCTAssertTrue(player.isPlaying)
     }
 
     func testRapidEnqueuePreservesDeterministicChunkOrder() {
-        let expectedSequences = Array(0..<100)
+        let expectedIds = Array(0..<100)
 
-        for sequence in expectedSequences {
-            player.enqueueTTSAudio(chunk(sequence: sequence))
+        for id in expectedIds {
+            player.enqueueTTSAudio(chunk(id: id))
         }
 
-        XCTAssertEqual(output.playedChunks.map(\.sequence), [0])
+        XCTAssertEqual(output.playedChunks.map(\.data), [chunkData(id: 0)])
         XCTAssertEqual(player.queuedChunkCount, 99)
 
-        for expectedSequence in expectedSequences.dropFirst() {
+        for expectedId in expectedIds.dropFirst() {
             output.completeNextSuccessfully()
-            XCTAssertEqual(output.playedChunks.last?.sequence, expectedSequence)
+            XCTAssertEqual(output.playedChunks.last?.data, chunkData(id: expectedId))
         }
 
         output.completeNextSuccessfully()
 
-        XCTAssertEqual(output.playedChunks.map(\.sequence), expectedSequences)
+        XCTAssertEqual(output.playedChunks.map(\.data), expectedIds.map { chunkData(id: $0) })
         XCTAssertEqual(player.queuedChunkCount, 0)
         XCTAssertEqual(player.state, .idle)
         XCTAssertFalse(player.isPlaying)
     }
 
     func testStopDrainsQueuedChunksAndIgnoresLateCompletion() {
-        player.enqueueTTSAudio(chunk(sequence: 1))
-        player.enqueueTTSAudio(chunk(sequence: 2))
-        player.enqueueTTSAudio(chunk(sequence: 3))
+        player.enqueueTTSAudio(chunk(id: 1))
+        player.enqueueTTSAudio(chunk(id: 2))
+        player.enqueueTTSAudio(chunk(id: 3))
 
-        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(output.playedChunks.map(\.data), [chunkData(id: 1)])
         XCTAssertEqual(player.queuedChunkCount, 2)
 
         player.stop(reason: .interrupt)
@@ -115,48 +115,48 @@ final class LiveVoiceAudioPlayerTests: XCTestCase {
 
         output.completeNextSuccessfully()
 
-        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(output.playedChunks.map(\.data), [chunkData(id: 1)])
         XCTAssertEqual(player.state, .stopped(.interrupt))
     }
 
     func testStopPreventsLatePlaybackUntilReset() {
-        player.enqueueTTSAudio(chunk(sequence: 1))
+        player.enqueueTTSAudio(chunk(id: 1))
         player.stop(reason: .end)
 
-        player.enqueueTTSAudio(chunk(sequence: 2))
+        player.enqueueTTSAudio(chunk(id: 2))
 
-        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        XCTAssertEqual(output.playedChunks.map(\.data), [chunkData(id: 1)])
         XCTAssertEqual(player.state, .stopped(.end))
 
         player.resetForNextResponse()
-        player.enqueueTTSAudio(chunk(sequence: 3))
+        player.enqueueTTSAudio(chunk(id: 3))
 
-        XCTAssertEqual(output.playedChunks.map(\.sequence), [1, 3])
+        XCTAssertEqual(output.playedChunks.map(\.data), [chunkData(id: 1), chunkData(id: 3)])
         XCTAssertEqual(player.state, .playing)
     }
 
     func testInterruptEndAndSessionErrorStopImmediately() {
-        player.enqueueTTSAudio(chunk(sequence: 1))
+        player.enqueueTTSAudio(chunk(id: 1))
         player.handleInterrupt()
         XCTAssertEqual(output.stopCallCount, 1)
         XCTAssertEqual(player.state, .stopped(.interrupt))
 
         player.resetForNextResponse()
-        player.enqueueTTSAudio(chunk(sequence: 2))
+        player.enqueueTTSAudio(chunk(id: 2))
         player.handleEnd()
         XCTAssertEqual(output.stopCallCount, 3)
         XCTAssertEqual(player.state, .stopped(.end))
 
         player.resetForNextResponse()
-        player.enqueueTTSAudio(chunk(sequence: 3))
+        player.enqueueTTSAudio(chunk(id: 3))
         player.handleSessionError()
         XCTAssertEqual(output.stopCallCount, 5)
         XCTAssertEqual(player.state, .stopped(.sessionError))
     }
 
     func testPlaybackFailureStopsQueueAndPreventsLatePlayback() {
-        player.enqueueTTSAudio(chunk(sequence: 1))
-        player.enqueueTTSAudio(chunk(sequence: 2))
+        player.enqueueTTSAudio(chunk(id: 1))
+        player.enqueueTTSAudio(chunk(id: 2))
 
         output.failNext()
 
@@ -164,28 +164,30 @@ final class LiveVoiceAudioPlayerTests: XCTestCase {
         XCTAssertEqual(player.queuedChunkCount, 0)
         XCTAssertEqual(output.stopCallCount, 1)
 
-        player.enqueueTTSAudio(chunk(sequence: 3))
-        XCTAssertEqual(output.playedChunks.map(\.sequence), [1])
+        player.enqueueTTSAudio(chunk(id: 3))
+        XCTAssertEqual(output.playedChunks.map(\.data), [chunkData(id: 1)])
     }
 
     func testEmptyChunksAreIgnored() {
         player.enqueueTTSAudio(
             data: Data(),
             mimeType: "audio/pcm",
-            sampleRate: 24_000,
-            sequence: 1
+            sampleRate: 24_000
         )
 
         XCTAssertTrue(output.playedChunks.isEmpty)
         XCTAssertEqual(player.state, .idle)
     }
 
-    private func chunk(sequence: Int) -> LiveVoiceAudioChunk {
+    private func chunk(id: Int) -> LiveVoiceAudioChunk {
         LiveVoiceAudioChunk(
-            data: Data([UInt8(sequence % 256), UInt8((sequence + 1) % 256)]),
+            data: chunkData(id: id),
             mimeType: "audio/pcm",
-            sampleRate: 24_000,
-            sequence: sequence
+            sampleRate: 24_000
         )
+    }
+
+    private func chunkData(id: Int) -> Data {
+        Data([UInt8(id % 256), UInt8((id + 1) % 256)])
     }
 }

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -113,16 +113,14 @@ private final class FakeLiveVoiceAudioPlayback: LiveVoiceAudioPlaying {
         data: Data,
         mimeType: String,
         sampleRate: Int,
-        channels: Int,
-        sequence: Int?
+        channels: Int
     ) {
         enqueuedChunks.append(
             LiveVoiceAudioChunk(
                 data: data,
                 mimeType: mimeType,
                 sampleRate: sampleRate,
-                channels: channels,
-                sequence: sequence
+                channels: channels
             )
         )
         isPlaying = true
@@ -258,7 +256,6 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertEqual(playback.enqueuedChunks[0].data, Data([9, 8]))
         XCTAssertEqual(playback.enqueuedChunks[0].mimeType, "audio/pcm")
         XCTAssertEqual(playback.enqueuedChunks[0].sampleRate, 16_000)
-        XCTAssertEqual(playback.enqueuedChunks[0].sequence, 4)
 
         client.emit(.ttsDone(turnId: "turn-123"))
         await flushAsyncTasks()

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -40,7 +40,6 @@ private final class FakeLiveVoiceChannelManager: LiveVoiceChannelManaging {
     var errorMessage: String = ""
 
     private(set) var startCalls: [String] = []
-    private(set) var startListeningCallCount = 0
     private(set) var interruptSpeakingAndStartListeningCalls: [String] = []
     private(set) var stopListeningCallCount = 0
     private(set) var endCallCount = 0
@@ -48,11 +47,6 @@ private final class FakeLiveVoiceChannelManager: LiveVoiceChannelManaging {
     func start(conversationId: String) async {
         startCalls.append(conversationId)
         state = .connecting
-    }
-
-    func startListening() async {
-        startListeningCallCount += 1
-        state = .listening
     }
 
     func interruptSpeakingAndStartListening(conversationId: String) async {


### PR DESCRIPTION
## Summary
Fixes third-round cleanup from live-voice-channel.md.

Gaps: unused TTS playback sequence plumbing and stale reusable-session live voice code remained after the one-shot lifecycle fix.

Orchestrated by velissa-ai via run-plan; implemented by Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
