### PR TITLE
fix(clients): unbreak iOS build + finish formatter consolidation in detail views

### DIFF
--- a/clients/ios/Views/ACPSessionDetailView.swift
+++ b/clients/ios/Views/ACPSessionDetailView.swift
@@ -212,22 +212,11 @@ struct ACPSessionDetailViewIOS: View {
     @ViewBuilder
     private var statusPill: some View {
         VBadge(
-            label: statusLabel(session.state.status),
+            label: ACPSessionStateFormatter.statusLabel(session.state.status),
             tone: statusTone(session.state.status),
             emphasis: .subtle
         )
-        .accessibilityLabel("Status: \(statusLabel(session.state.status))")
-    }
-
-    private func statusLabel(_ status: ACPSessionState.Status) -> String {
-        switch status {
-        case .initializing: return "Starting"
-        case .running:      return "Running"
-        case .completed:    return "Completed"
-        case .failed:       return "Failed"
-        case .cancelled:    return "Cancelled"
-        case .unknown:      return "Unknown"
-        }
+        .accessibilityLabel("Status: \(ACPSessionStateFormatter.statusLabel(session.state.status))")
     }
 
     private func statusTone(_ status: ACPSessionState.Status) -> VBadge.Tone {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionDetailView.swift
@@ -98,7 +98,7 @@ struct ACPSessionDetailView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(alignment: .center, spacing: VSpacing.sm) {
-                Text(session.state.agentId)
+                Text(ACPSessionStateFormatter.agentLabel(for: session.state.agentId))
                     .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentDefault)
                     .lineLimit(1)
@@ -197,22 +197,11 @@ struct ACPSessionDetailView: View {
     @ViewBuilder
     private var statusPill: some View {
         VBadge(
-            label: statusLabel(session.state.status),
+            label: ACPSessionStateFormatter.statusLabel(session.state.status),
             tone: statusTone(session.state.status),
             emphasis: .subtle
         )
-        .accessibilityLabel("Status: \(statusLabel(session.state.status))")
-    }
-
-    private func statusLabel(_ status: ACPSessionState.Status) -> String {
-        switch status {
-        case .initializing: return "Starting"
-        case .running:      return "Running"
-        case .completed:    return "Completed"
-        case .failed:       return "Failed"
-        case .cancelled:    return "Cancelled"
-        case .unknown:      return "Unknown"
-        }
+        .accessibilityLabel("Status: \(ACPSessionStateFormatter.statusLabel(session.state.status))")
     }
 
     private func statusTone(_ status: ACPSessionState.Status) -> VBadge.Tone {

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -399,7 +399,7 @@ public struct ACPSpawnDeepLinkCard: View {
                 ACPSpawnStatusIndicatorView(
                     toolCall: toolCall,
                     acpSessionId: acpSessionId,
-                    store: ACPSpawnAppDelegateBridge.shared?.acpSessionStore
+                    store: ACPSpawnAppDelegateBridge.sharedStore
                 )
                 .frame(width: 16, height: 16)
                 VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
## Summary
- **Critical**: fix `ACPSpawnAppDelegateBridge.shared?.acpSessionStore` -> `.sharedStore` (iOS main has been failing to compile since #28331).
- Drop private `statusLabel` from macOS + iOS detail views; both now call shared `ACPSessionStateFormatter.statusLabel`.
- macOS detail header now renders friendly agent label via `ACPSessionStateFormatter.agentLabel(for:)` (was raw daemon id).

Gaps caught during Round 2 plan review for acp-sessions-ui.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
