### PR TITLE
fix(tests): unbreak live-voice startup contract and 057 migration registry assertion

### DIFF
--- a/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
+++ b/assistant/src/__tests__/workspace-migration-057-repair-stale-gemini-model-ids.test.ts
@@ -52,7 +52,7 @@ describe("057-repair-stale-gemini-model-ids migration", () => {
     expect(repairStaleGeminiModelIdsMigration.id).toBe(
       "057-repair-stale-gemini-model-ids",
     );
-    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
       "057-repair-stale-gemini-model-ids",
     );
   });

--- a/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-stt.test.ts
@@ -9,7 +9,10 @@ import {
   LiveVoiceSession,
   type LiveVoiceStreamingTranscriberResolver,
 } from "../live-voice-session.js";
-import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import {
+  type LiveVoiceSessionFactoryContext,
+  LiveVoiceSessionStartupError,
+} from "../live-voice-session-manager.js";
 import {
   createLiveVoiceServerFrameSequencer,
   type LiveVoiceClientStartFrame,
@@ -183,7 +186,9 @@ describe("LiveVoiceSession STT", () => {
       resolveTranscriber: resolver,
     });
 
-    await session.start();
+    await expect(session.start()).rejects.toBeInstanceOf(
+      LiveVoiceSessionStartupError,
+    );
 
     expect(frames).toHaveLength(1);
     expect(frames[0]).toMatchObject({
@@ -209,7 +214,9 @@ describe("LiveVoiceSession STT", () => {
       resolveTranscriber: resolver,
     });
 
-    await expect(session.start()).resolves.toBeUndefined();
+    await expect(session.start()).rejects.toBeInstanceOf(
+      LiveVoiceSessionStartupError,
+    );
 
     expect(frames).toEqual([
       {


### PR DESCRIPTION
## Summary
- Update two failing tests in \`live-voice-stt.test.ts\` to expect \`LiveVoiceSessionStartupError\` to be thrown by \`session.start()\` (and still verify the error frame is sent). PR #28336 changed \`failStartup()\` to throw after sending the error frame, but the original tests still expected resolution.
- Replace the brittle \`WORKSPACE_MIGRATIONS.at(-1)?.id\` assertion in the 057 migration test with a membership check (\`.toContain()\`). The original assertion failed as soon as 058 was appended; the new check stays valid as more migrations land.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24949177655/job/73056118184
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
