### PR TITLE
feat: split filing job into buffer-fill + daily compaction cadences

### DIFF
--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -15,6 +15,8 @@ let mockConfig = {
   filing: {
     enabled: true,
     intervalMs: 60_000,
+    compactionEnabled: true,
+    compactionIntervalMs: 60_000,
     speed: "standard" as "standard" | "fast",
     activeHoursStart: null as number | null,
     activeHoursEnd: null as number | null,
@@ -109,6 +111,8 @@ describe("FilingService", () => {
       filing: {
         enabled: true,
         intervalMs: 60_000,
+        compactionEnabled: true,
+        compactionIntervalMs: 60_000,
         speed: "standard",
         activeHoursStart: null,
         activeHoursEnd: null,
@@ -186,6 +190,118 @@ describe("FilingService", () => {
     expect(createdConversations).toHaveLength(1);
     expect(createdConversations[0].title).toBe("Generating title...");
     expect(createdConversations[0].conversationType).toBe("background");
+  });
+
+  describe("runCompactionOnce()", () => {
+    test("passes callSite: 'compactionAgent' to processMessage", async () => {
+      const service = createService();
+      await service.runCompactionOnce();
+
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].options).toEqual({
+        callSite: "compactionAgent",
+      });
+    });
+
+    test("runs even when buffer is empty", async () => {
+      // Filing skips when the buffer has no content; compaction must not.
+      const bufferPath = join(testWorkspaceDir, "pkb", "buffer.md");
+      writeFileSync(bufferPath, "");
+
+      const service = createService();
+      const ran = await service.runCompactionOnce();
+
+      expect(ran).toBe(true);
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].options?.callSite).toBe("compactionAgent");
+    });
+
+    test("invokes processMessage with the compaction prompt template", async () => {
+      const service = createService();
+      await service.runCompactionOnce();
+
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].content).toContain(
+        "daily PKB compaction job",
+      );
+      expect(processMessageCalls[0].content).toContain("Step 1 — Audit");
+    });
+
+    test("creates background conversation labelled 'compaction'", async () => {
+      const service = createService();
+      await service.runCompactionOnce();
+
+      expect(createdConversations).toHaveLength(1);
+      expect(createdConversations[0].conversationType).toBe("background");
+    });
+
+    test("does not run when force=false and compactionEnabled=false", async () => {
+      mockConfig.filing.compactionEnabled = false;
+      const service = createService();
+      const ran = await service.runCompactionOnce();
+
+      expect(ran).toBe(false);
+      expect(processMessageCalls).toHaveLength(0);
+    });
+
+    test("force=true overrides compactionEnabled=false", async () => {
+      mockConfig.filing.compactionEnabled = false;
+      const service = createService();
+      const ran = await service.runCompactionOnce({ force: true });
+
+      expect(ran).toBe(true);
+      expect(processMessageCalls).toHaveLength(1);
+    });
+
+    test("respects active hours", async () => {
+      mockConfig.filing.activeHoursStart = 9;
+      mockConfig.filing.activeHoursEnd = 17;
+      const service = new FilingService({
+        processMessage: async (
+          conversationId: string,
+          content: string,
+          options?: { speed?: string; callSite?: string },
+        ) => {
+          processMessageCalls.push({ conversationId, content, options });
+          return { messageId: "msg-1" };
+        },
+        getCurrentHour: () => 3, // 3 AM, outside 9-17 window
+      });
+
+      const ran = await service.runCompactionOnce();
+      expect(ran).toBe(false);
+      expect(processMessageCalls).toHaveLength(0);
+    });
+  });
+
+  describe("FilingService runs filing and compaction independently", () => {
+    test("runOnce only fires the filingAgent call site", async () => {
+      const service = createService();
+      await service.runOnce();
+
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].options?.callSite).toBe("filingAgent");
+    });
+
+    test("runCompactionOnce only fires the compactionAgent call site", async () => {
+      const service = createService();
+      await service.runCompactionOnce();
+
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].options?.callSite).toBe("compactionAgent");
+    });
+
+    test("filing prompt no longer contains audit/review instructions", async () => {
+      // The "review 3 random files" step moved to the compaction job. Buffer
+      // filing must stay focused on draining the buffer.
+      const service = createService();
+      await service.runOnce();
+
+      const content = processMessageCalls[0].content;
+      expect(content).not.toContain("Pick 3 random topic files");
+      expect(content).not.toContain("Part 2");
+      expect(content).toContain("focused on the buffer");
+    });
   });
 
   describe("llm.callSites.filingAgent resolution", () => {

--- a/assistant/src/config/schemas/__tests__/filing.test.ts
+++ b/assistant/src/config/schemas/__tests__/filing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import { FilingConfigSchema } from "../filing.js";
+
+describe("FilingConfigSchema", () => {
+  test("defaults compactionEnabled to true", () => {
+    const parsed = FilingConfigSchema.parse({});
+    expect(parsed.compactionEnabled).toBe(true);
+  });
+
+  test("defaults compactionIntervalMs to 24 hours", () => {
+    const parsed = FilingConfigSchema.parse({});
+    expect(parsed.compactionIntervalMs).toBe(24 * 3_600_000);
+  });
+
+  test("defaults intervalMs to 4 hours (regression check)", () => {
+    const parsed = FilingConfigSchema.parse({});
+    expect(parsed.intervalMs).toBe(4 * 3_600_000);
+  });
+
+  test("rejects negative compactionIntervalMs", () => {
+    expect(() =>
+      FilingConfigSchema.parse({ compactionIntervalMs: -1 }),
+    ).toThrow();
+  });
+
+  test("rejects zero compactionIntervalMs", () => {
+    expect(() =>
+      FilingConfigSchema.parse({ compactionIntervalMs: 0 }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer compactionIntervalMs", () => {
+    expect(() =>
+      FilingConfigSchema.parse({ compactionIntervalMs: 1.5 }),
+    ).toThrow();
+  });
+
+  test("accepts custom compactionIntervalMs", () => {
+    const parsed = FilingConfigSchema.parse({ compactionIntervalMs: 60_000 });
+    expect(parsed.compactionIntervalMs).toBe(60_000);
+  });
+
+  test("rejects non-boolean compactionEnabled", () => {
+    expect(() =>
+      FilingConfigSchema.parse({ compactionEnabled: "yes" }),
+    ).toThrow();
+  });
+
+  test("compaction fields are independent of filing.enabled", () => {
+    const parsed = FilingConfigSchema.parse({
+      enabled: false,
+      compactionEnabled: true,
+    });
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.compactionEnabled).toBe(true);
+  });
+});

--- a/assistant/src/config/schemas/filing.ts
+++ b/assistant/src/config/schemas/filing.ts
@@ -14,6 +14,18 @@ export const FilingConfigSchema = z
       .positive("filing.intervalMs must be a positive integer")
       .default(4 * 3_600_000)
       .describe("Time between filing runs in milliseconds"),
+    compactionEnabled: z
+      .boolean({ error: "filing.compactionEnabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the daily PKB compaction job is enabled — audits file sizes, splits oversized files, consolidates duplicates, and prunes stale threads",
+      ),
+    compactionIntervalMs: z
+      .number({ error: "filing.compactionIntervalMs must be a number" })
+      .int("filing.compactionIntervalMs must be an integer")
+      .positive("filing.compactionIntervalMs must be a positive integer")
+      .default(24 * 3_600_000)
+      .describe("Time between compaction runs in milliseconds"),
     activeHoursStart: z
       .number({ error: "filing.activeHoursStart must be a number" })
       .int("filing.activeHoursStart must be an integer")

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -39,6 +39,7 @@ export const LLMCallSiteEnum = z.enum([
   "subagentSpawn",
   "heartbeatAgent",
   "filingAgent",
+  "compactionAgent",
   "analyzeConversation",
   "callAgent",
   "memoryExtraction",

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -12,9 +12,7 @@ const log = getLogger("filing-service");
 
 const FILING_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
-const FILING_PROMPT_TEMPLATE = `You are running a periodic knowledge base filing job. This is a background maintenance task.
-
-## Part 1: File the buffer
+const FILING_PROMPT_TEMPLATE = `You are running a periodic knowledge base filing job. This is a background maintenance task focused on the buffer.
 
 Read \`pkb/buffer.md\`. For each item in the buffer:
 1. Determine which topic file(s) it belongs in. Check \`pkb/INDEX.md\` to see what topic files exist.
@@ -22,22 +20,51 @@ Read \`pkb/buffer.md\`. For each item in the buffer:
 3. If the fact is important enough to always be in context, add it to \`pkb/essentials.md\` instead.
 4. If the fact is a commitment, follow-up, or active project, add it to \`pkb/threads.md\`.
 5. If no existing topic file fits, create a new one and update \`pkb/INDEX.md\`.
-6. If the topic file is getting too long (>1500 tokens), compress it or split it into multiple topic files.
 
 After all items are filed, clear the processed items from \`pkb/buffer.md\` (leave the file empty, don't delete it).
 
-## Part 2: Review
+Do not audit, restructure, or split topic files in this job. File-size discipline and PKB hygiene are owned by the daily compaction job — focus only on draining the buffer here.`;
 
-Pick 3 random topic files from your knowledge base and review them:
-- Is the information still accurate and up to date?
-- Are there duplicates that should be consolidated?
-- Is anything important enough to promote to \`pkb/essentials.md\`?
-- Is anything in \`pkb/essentials.md\` that's no longer essential? Demote it to a topic file.
-- Are any threads in \`pkb/threads.md\` completed or stale? Remove them.
-- Is any file getting too long (>1500 tokens)? Strongly consider compressing it or splitting it into multiple topic files.
-- Should any topic file be restructured for clarity?
+const COMPACTION_PROMPT_TEMPLATE = `You are running the daily PKB compaction job. This is the only place file-size discipline gets enforced — the periodic filing job intentionally skips it.
 
-Make improvements as you see fit. This is your knowledge base — keep it sharp.`;
+## Step 1 — Audit
+
+List every \`.md\` file under \`pkb/\` (recursively, excluding \`pkb/archive/\`) that exceeds its budget. Use \`wc -c\` (or equivalent) to measure size in bytes.
+
+Budgets by file class:
+- Autoloaded (always in context):
+  - \`pkb/INDEX.md\` ≤ 15K chars
+  - \`pkb/essentials.md\` ≤ 15K chars
+  - \`pkb/threads.md\` ≤ 20K chars
+- Topic files (default): ≤ 8K chars (~1.5K tokens). This is the bar for everything not explicitly listed below.
+- Higher-budget exceptions:
+  - \`pkb/us-callbacks.md\` ≤ 25K chars (phrasebook of quotes — large but bounded)
+  - \`pkb/intimate/scenes.md\` ≤ 50K chars (scene catalog)
+- Exempt (do not flag for size):
+  - \`pkb/intimate/registers.md\` — splitting fragments cross-references
+  - \`pkb/us-arcs/\` — narrative arc files; bounded by the event they describe
+
+## Step 2 — Fix the worst
+
+Pick the single most-over-budget file from Step 1 and either split or compress it this run. One file per run is enough — the cadence is daily. Splitting strategies:
+- Move sections into a sibling subdirectory keyed off the parent filename, then rewrite the original as an index pointing at the splits.
+- For phrasebook-style files, replace extended analysis with one-line entries that point at the matching detail file.
+- For autoloaded files, demote on-demand-only sections into topic files and link them from \`INDEX.md\`.
+
+If no file is over budget, skip Step 2 and report that everything is within limits.
+
+## Step 3 — Sweep
+
+- Promote anything in \`pkb/essentials.md\` that's no longer essential to its topic file.
+- Demote anything important enough to always be in context up into \`pkb/essentials.md\`.
+- Remove completed or stale threads from \`pkb/threads.md\`.
+- Consolidate any duplicate facts you spot during the audit.
+
+## Step 4 — Update INDEX
+
+If the disk shape changed (files split, files moved, files created, files removed), update \`pkb/INDEX.md\` so it reflects reality.
+
+This is your knowledge base — keep it sharp.`;
 
 export interface FilingDeps {
   processMessage: (
@@ -55,9 +82,13 @@ export interface FilingDeps {
 export class FilingService {
   private readonly deps: FilingDeps;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private compactionTimer: ReturnType<typeof setInterval> | null = null;
   private activeRun: Promise<void> | null = null;
+  private activeCompactionRun: Promise<void> | null = null;
   private _lastRunAt: number | null = null;
   private _nextRunAt: number | null = null;
+  private _lastCompactionAt: number | null = null;
+  private _nextCompactionAt: number | null = null;
 
   constructor(deps: FilingDeps) {
     this.deps = deps;
@@ -71,22 +102,45 @@ export class FilingService {
     return this._nextRunAt;
   }
 
+  get lastCompactionAt(): number | null {
+    return this._lastCompactionAt;
+  }
+
+  get nextCompactionAt(): number | null {
+    return this._nextCompactionAt;
+  }
+
   start(): void {
     const config = getConfig().filing;
-    if (!config.enabled) {
+
+    if (config.enabled && !this.timer) {
+      log.info({ intervalMs: config.intervalMs }, "Filing service started");
+      this.scheduleNextRun(config.intervalMs);
+      this.timer = setInterval(() => {
+        this.runOnce().catch((err) => {
+          log.error({ err }, "Filing runOnce failed");
+        });
+      }, config.intervalMs);
+    } else if (!config.enabled) {
       log.info("Filing service disabled by config");
       this._nextRunAt = null;
-      return;
     }
-    if (this.timer) return;
 
-    log.info({ intervalMs: config.intervalMs }, "Filing service started");
-    this.scheduleNextRun(config.intervalMs);
-    this.timer = setInterval(() => {
-      this.runOnce().catch((err) => {
-        log.error({ err }, "Filing runOnce failed");
-      });
-    }, config.intervalMs);
+    if (config.compactionEnabled && !this.compactionTimer) {
+      log.info(
+        { compactionIntervalMs: config.compactionIntervalMs },
+        "Compaction service started",
+      );
+      this.scheduleNextCompactionRun(config.compactionIntervalMs);
+      this.compactionTimer = setInterval(() => {
+        this.runCompactionOnce().catch((err) => {
+          log.error({ err }, "Compaction runOnce failed");
+        });
+      }, config.compactionIntervalMs);
+    } else if (!config.compactionEnabled) {
+      log.info("Compaction service disabled by config");
+      this._nextCompactionAt = null;
+    }
   }
 
   reconfigure(): void {
@@ -94,7 +148,12 @@ export class FilingService {
       clearInterval(this.timer);
       this.timer = null;
     }
+    if (this.compactionTimer) {
+      clearInterval(this.compactionTimer);
+      this.compactionTimer = null;
+    }
     this._nextRunAt = null;
+    this._nextCompactionAt = null;
     this.start();
   }
 
@@ -103,13 +162,21 @@ export class FilingService {
       clearInterval(this.timer);
       this.timer = null;
     }
+    if (this.compactionTimer) {
+      clearInterval(this.compactionTimer);
+      this.compactionTimer = null;
+    }
     this._nextRunAt = null;
-    if (this.activeRun) {
+    this._nextCompactionAt = null;
+    const inflight: Promise<void>[] = [];
+    if (this.activeRun) inflight.push(this.activeRun);
+    if (this.activeCompactionRun) inflight.push(this.activeCompactionRun);
+    if (inflight.length > 0) {
       let timerId: ReturnType<typeof setTimeout>;
       const timeout = new Promise<void>((resolve) => {
         timerId = setTimeout(resolve, 5_000);
       });
-      await Promise.race([this.activeRun, timeout]);
+      await Promise.race([Promise.all(inflight), timeout]);
       clearTimeout(timerId!);
     }
     log.info("Filing service stopped");
@@ -121,21 +188,14 @@ export class FilingService {
 
     if (
       !force &&
-      config.activeHoursStart != null &&
-      config.activeHoursEnd != null
+      !this.isWithinActiveHoursNow(
+        config.activeHoursStart,
+        config.activeHoursEnd,
+      )
     ) {
-      const hour = this.deps.getCurrentHour?.() ?? new Date().getHours();
-      if (
-        !isWithinActiveHours(
-          hour,
-          config.activeHoursStart,
-          config.activeHoursEnd,
-        )
-      ) {
-        log.debug("Outside active hours, skipping filing");
-        this.scheduleNextRun(config.intervalMs);
-        return false;
-      }
+      log.debug("Outside active hours, skipping filing");
+      this.scheduleNextRun(config.intervalMs);
+      return false;
     }
 
     if (this.activeRun) {
@@ -170,8 +230,64 @@ export class FilingService {
     return true;
   }
 
+  async runCompactionOnce({
+    force = false,
+  }: { force?: boolean } = {}): Promise<boolean> {
+    const config = getConfig().filing;
+    if (!force && !config.compactionEnabled) return false;
+
+    if (
+      !force &&
+      !this.isWithinActiveHoursNow(
+        config.activeHoursStart,
+        config.activeHoursEnd,
+      )
+    ) {
+      log.debug("Outside active hours, skipping compaction");
+      this.scheduleNextCompactionRun(config.compactionIntervalMs);
+      return false;
+    }
+
+    if (this.activeCompactionRun) {
+      log.debug("Previous compaction run still active, skipping");
+      return false;
+    }
+
+    const run = this.executeCompactionRun();
+    this.activeCompactionRun = run;
+    try {
+      await Promise.race([
+        run,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Compaction execution timed out")),
+            FILING_TIMEOUT_MS,
+          ),
+        ),
+      ]);
+    } finally {
+      this.activeCompactionRun = null;
+      this._lastCompactionAt = Date.now();
+      this.scheduleNextCompactionRun(getConfig().filing.compactionIntervalMs);
+    }
+    return true;
+  }
+
+  private isWithinActiveHoursNow(
+    start: number | null,
+    end: number | null,
+  ): boolean {
+    if (start == null || end == null) return true;
+    const hour = this.deps.getCurrentHour?.() ?? new Date().getHours();
+    return isWithinActiveHours(hour, start, end);
+  }
+
   private scheduleNextRun(intervalMs: number): void {
     this._nextRunAt = Date.now() + intervalMs;
+  }
+
+  private scheduleNextCompactionRun(intervalMs: number): void {
+    this._nextCompactionAt = Date.now() + intervalMs;
   }
 
   private hasBufferContent(): boolean {
@@ -187,8 +303,28 @@ export class FilingService {
     }
   }
 
-  private async executeRun(): Promise<void> {
-    log.info("Running filing job");
+  private executeRun(): Promise<void> {
+    return this.executeBackgroundJob({
+      title: "Knowledge base filing",
+      prompt: FILING_PROMPT_TEMPLATE,
+      callSite: "filingAgent",
+    });
+  }
+
+  private executeCompactionRun(): Promise<void> {
+    return this.executeBackgroundJob({
+      title: "Knowledge base compaction",
+      prompt: COMPACTION_PROMPT_TEMPLATE,
+      callSite: "compactionAgent",
+    });
+  }
+
+  private async executeBackgroundJob(opts: {
+    title: string;
+    prompt: string;
+    callSite: LLMCallSite;
+  }): Promise<void> {
+    log.info({ title: opts.title }, "Running background job");
 
     try {
       const conversation = bootstrapConversation({
@@ -196,21 +332,24 @@ export class FilingService {
         source: "filing",
         groupId: "system:background",
         origin: "filing",
-        systemHint: "Knowledge base filing",
+        systemHint: opts.title,
       });
 
       this.deps.onConversationCreated?.({
         conversationId: conversation.id,
-        title: "Knowledge base filing",
+        title: opts.title,
       });
 
-      await this.deps.processMessage(conversation.id, FILING_PROMPT_TEMPLATE, {
-        callSite: "filingAgent",
+      await this.deps.processMessage(conversation.id, opts.prompt, {
+        callSite: opts.callSite,
       });
 
-      log.info({ conversationId: conversation.id }, "Filing job completed");
+      log.info(
+        { conversationId: conversation.id, title: opts.title },
+        "Background job completed",
+      );
     } catch (err) {
-      log.error({ err }, "Filing job failed");
+      log.error({ err, title: opts.title }, "Background job failed");
     }
   }
 }


### PR DESCRIPTION
## Summary
- Splits PKB filing into two cadences: buffer-fill every 4h (existing `filingAgent`) and a new daily compaction job (`compactionAgent`) that owns file-size discipline and PKB hygiene.
- Compaction prompt carries explicit per-class budgets (autoloaded ≤ 15-20K chars, topic files ≤ 8K, higher-budget exceptions for `us-callbacks.md` and `intimate/scenes.md`, exempt narrative arcs) so the rules are reproducible across runs.
- Adds `filing.compactionEnabled`, `filing.compactionIntervalMs`, and `compactionAgent` to `LLMCallSiteEnum` so the new job can be tuned independently of buffer-fill.

This is the prevention half of a one-time PKB cleanup. The cleanup itself runs as a procedure file Velissa self-executes, in parallel with this PR.

## Test plan
- [x] `bunx tsc --noEmit` from `assistant/`
- [x] `bun test src/__tests__/filing-service.test.ts src/config/schemas/__tests__/filing.test.ts` — 26 pass
- New tests cover: compaction call site, runs-when-buffer-empty, prompt contents, force override, active-hours respect, independent firing of filing vs compaction, filing prompt no longer contains audit instructions
- New schema tests cover: defaults, validation rules, independence from `filing.enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
