### PR TITLE
fix(macos): isolate ACPSessionViewModel Identifiable conformance to MainActor

### DIFF
--- a/clients/shared/Network/ACPSessionStore.swift
+++ b/clients/shared/Network/ACPSessionStore.swift
@@ -20,7 +20,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ACPSe
 /// session: streaming updates to one session's `events` only invalidate
 /// views that read that specific view model.
 @MainActor @Observable
-public final class ACPSessionViewModel: Identifiable, Hashable {
+public final class ACPSessionViewModel: @MainActor Identifiable, Hashable {
     /// Snapshot of the session as last reported by the daemon.
     public var state: ACPSessionState
     /// Stream of update messages received for this session, capped at


### PR DESCRIPTION
## Summary
- Add `@MainActor` to `ACPSessionViewModel`'s `Identifiable` conformance so the protocol's nonisolated `id` requirement no longer crosses the main actor — this resolves the Swift 6 `#ConformanceIsolation` warning that fires when building `./build.sh run`.
- `Hashable` is left unisolated; its `==` and `hash(into:)` are already explicitly `nonisolated` and use `ObjectIdentifier`, which doesn't touch main-actor state.
- All call sites (`NavigationStack` paths, `ForEach`, tests) execute on the main actor, so the tighter conformance is a no-op at runtime.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/shared/Network/ACPSessionStore.swift:23:41: warning: conformance of 'ACPSessionViewModel' to protocol 'Identifiable' crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode [#ConformanceIsolation]
 21 | /// views that read that specific view model.
 22 | @MainActor @Observable
 23 | public final class ACPSessionViewModel: Identifiable, Hashable {
    |                                         |- warning: conformance of 'ACPSessionViewModel' to protocol 'Identifiable' crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode [#ConformanceIsolation]
    |                                         |- note: isolate this conformance to the main actor with '@MainActor'
    |                                         `- note: turn data races into runtime errors with '@preconcurrency'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
