### PR TITLE
Fix live voice unmute recovery

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -641,7 +641,7 @@ struct ComposerView: View, Equatable {
                         iconSize: composerActionButtonSize,
                         action: { manager.toggleListening() }
                     )
-                    .disabled(manager.state == .processing)
+                    .disabled(!manager.canToggleListening)
                     .vTooltip(manager.state == .listening ? "Mute" : "Unmute")
 
                     VButton(

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -125,7 +125,7 @@ final class LiveVoiceChannelManager {
             failWithoutActiveClient(message: "A conversation is required to start live voice.")
             return
         }
-        guard state == .speaking, client != nil else {
+        guard client != nil, state != .idle, state != .failed else {
             await start(conversationId: trimmedConversationId)
             return
         }

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -201,7 +201,9 @@ final class LiveVoiceChannelManager {
 
         case .sttPartial(let text, _):
             update(&partialTranscript, to: text)
-            if state == .listening || state == .transcribing {
+            if captureRunning {
+                state = .listening
+            } else if state == .listening || state == .transcribing {
                 state = .transcribing
             }
 
@@ -209,7 +211,7 @@ final class LiveVoiceChannelManager {
             update(&finalTranscript, to: text)
             update(&partialTranscript, to: "")
             if state != .ending {
-                state = .thinking
+                state = captureRunning ? .listening : .thinking
             }
 
         case .thinking:

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -128,6 +128,17 @@ final class VoiceModeManager {
         }
     }
 
+    var canToggleListening: Bool {
+        switch state {
+        case .idle, .listening, .speaking:
+            return true
+        case .processing:
+            return activeVoicePath == .liveChannel
+        case .off:
+            return false
+        }
+    }
+
     func activate(chatViewModel: ChatViewModel, settingsStore: SettingsStore? = nil) {
         guard state == .off else { return }
         wasAutoDeactivated = false
@@ -290,9 +301,13 @@ final class VoiceModeManager {
             stopListening()
         case .speaking:
             if activeVoicePath == .liveChannel {
-                handleLiveBargeIn()
+                interruptLiveVoiceAndStartListening()
             } else {
                 handleBargeIn()
+            }
+        case .processing:
+            if activeVoicePath == .liveChannel {
+                interruptLiveVoiceAndStartListening()
             }
         default:
             break
@@ -339,10 +354,11 @@ final class VoiceModeManager {
         guard state == .listening else { return }
 
         if activeVoicePath == .liveChannel {
-            state = .processing
             let liveVoiceChannelManager = liveVoiceChannelManager
             Task { @MainActor in
-                await liveVoiceChannelManager?.stopListening()
+                guard let liveVoiceChannelManager else { return }
+                await liveVoiceChannelManager.stopListening()
+                self.syncLiveVoiceState(from: liveVoiceChannelManager)
             }
             log.info("Voice mode: released live voice push-to-talk")
             return
@@ -1048,12 +1064,12 @@ final class VoiceModeManager {
 
     // MARK: - Barge-in (interrupt TTS)
 
-    private func handleLiveBargeIn() {
-        guard state == .speaking,
+    private func interruptLiveVoiceAndStartListening() {
+        guard activeVoicePath == .liveChannel,
               let liveVoiceChannelManager,
               let conversationId = liveVoiceConversationId(for: chatViewModel) else { return }
 
-        log.info("Voice mode: live barge-in — interrupting TTS")
+        log.info("Voice mode: live voice resume — interrupting current turn")
 
         ttsTimeoutTask?.cancel()
         ttsTimeoutTask = nil

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -475,7 +475,11 @@ final class VoiceModeManager {
 
         switch liveVoiceChannelManager.state {
         case .idle:
+            let wasListening = state == .listening
             state = .idle
+            if !wasListening, let conversationId = liveVoiceConversationId(for: chatViewModel) {
+                startLiveVoiceListening(conversationId: conversationId)
+            }
         case .connecting, .listening:
             state = .listening
         case .transcribing, .thinking, .ending:

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -477,7 +477,9 @@ final class VoiceModeManager {
         case .idle:
             let wasListening = state == .listening
             state = .idle
-            if !wasListening, let conversationId = liveVoiceConversationId(for: chatViewModel) {
+            if !wasListening,
+               canStartLiveVoiceSession(for: chatViewModel),
+               let conversationId = liveVoiceConversationId(for: chatViewModel) {
                 startLiveVoiceListening(conversationId: conversationId)
             }
         case .connecting, .listening:

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -320,6 +320,43 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertEqual(capture.startCallCount, 2)
     }
 
+    func testManualResumeWhileThinkingInterruptsAndStartsFreshSession() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.thinking(turnId: "turn-1"))
+
+        XCTAssertEqual(manager.state, .thinking)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+        XCTAssertEqual(secondClient.startCalls[0].conversationId, "conv-123")
+        XCTAssertEqual(manager.state, .connecting)
+
+        secondClient.emit(.ready(sessionId: "session-2", conversationId: "conv-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(capture.startCallCount, 2)
+    }
+
     func testEndCleansUpResourcesAndReturnsToIdle() async {
         await startReadySession()
         client.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -227,8 +227,23 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .transcribing)
     }
 
-    func testSttEventsUpdateTranscriptState() async {
+    func testSttEventsKeepListeningWhileCaptureRuns() async {
         await startReadySession()
+
+        client.emit(.sttPartial(text: "hel", seq: 1))
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.partialTranscript, "hel")
+        XCTAssertEqual(manager.finalTranscript, "")
+
+        client.emit(.sttFinal(text: "hello", seq: 2))
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertEqual(manager.partialTranscript, "")
+        XCTAssertEqual(manager.finalTranscript, "hello")
+    }
+
+    func testSttEventsUpdateProcessingStateAfterPushToTalkRelease() async {
+        await startReadySession()
+        await manager.stopListening()
 
         client.emit(.sttPartial(text: "hel", seq: 1))
         XCTAssertEqual(manager.state, .transcribing)

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -43,6 +43,7 @@ private final class FakeLiveVoiceChannelManager: LiveVoiceChannelManaging {
     private(set) var interruptSpeakingAndStartListeningCalls: [String] = []
     private(set) var stopListeningCallCount = 0
     private(set) var endCallCount = 0
+    var stopListeningUpdatesState = true
 
     func start(conversationId: String) async {
         startCalls.append(conversationId)
@@ -56,7 +57,9 @@ private final class FakeLiveVoiceChannelManager: LiveVoiceChannelManaging {
 
     func stopListening() async {
         stopListeningCallCount += 1
-        state = .transcribing
+        if stopListeningUpdatesState {
+            state = .transcribing
+        }
     }
 
     func end() async {
@@ -571,6 +574,21 @@ final class VoiceModeManagerTests: XCTestCase {
         XCTAssertFalse(mockVoiceService.startRecordingCalled)
     }
 
+    func testCanToggleListeningAllowsLiveChannelProcessingOnly() {
+        forceActivate()
+        manager.state = .idle
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.state = .listening
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.state = .speaking
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.state = .processing
+        XCTAssertFalse(manager.canToggleListening)
+    }
+
     // MARK: - Service-First STT: State Transitions
 
     /// Verify voice mode cycles through listening -> processing -> speaking -> idle -> listening
@@ -830,6 +848,57 @@ final class VoiceModeManagerTests: XCTestCase {
         XCTAssertEqual(liveManager.stopListeningCallCount, 1)
         XCTAssertEqual(manager.state, .processing)
         XCTAssertFalse(mockVoiceService.cancelRecordingCalled)
+    }
+
+    func testLiveChannelStopListeningDoesNotTrapProcessingWhenReleaseIsNoOp() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        liveManager.stopListeningUpdatesState = false
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        manager.toggleListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.stopListeningCallCount, 1)
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertTrue(manager.canToggleListening)
+    }
+
+    func testLiveChannelProcessingToggleInterruptsAndRestartsListening() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.state = .thinking
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .processing)
+        XCTAssertTrue(manager.canToggleListening)
+
+        manager.toggleListening()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.interruptSpeakingAndStartListeningCalls, ["conv-123"])
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertFalse(mockVoiceService.stopSpeakingCalled)
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
     }
 
     func testLiveChannelBargeInInterruptsAndRestartsLiveListening() async {

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -929,6 +929,33 @@ final class VoiceModeManagerTests: XCTestCase {
         XCTAssertFalse(mockVoiceService.startRecordingCalled)
     }
 
+    func testLiveChannelCompletionRestartsListening() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+        liveManager.state = .speaking
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+
+        liveManager.state = .idle
+        await flushAsyncTasks()
+
+        XCTAssertEqual(liveManager.startCalls, ["conv-123", "conv-123"])
+        XCTAssertEqual(manager.state, .listening)
+        XCTAssertFalse(mockVoiceService.startRecordingCalled)
+    }
+
     func testDeactivateEndsLiveChannelAndClearsVoiceMode() async {
         let liveManager = FakeLiveVoiceChannelManager()
         chatViewModel.conversationId = "conv-123"


### PR DESCRIPTION
## Summary
- Keep the live voice composer toggle enabled for resumable live-channel processing states.
- Restart the live voice channel when users unmute during thinking or transcription instead of trapping the UI muted.
- Add regression tests for no-op release, STT state handling, and manual resume from live processing.

## Original prompt
it keeps getting muted with the option to unmute disabled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
