### PR TITLE
test(clients): diverge state.id and state.acpSessionId in ACP test fixtures

### DIFF
--- a/clients/ios/Tests/ACPSessionsViewIOSTests.swift
+++ b/clients/ios/Tests/ACPSessionsViewIOSTests.swift
@@ -21,8 +21,8 @@ final class ACPSessionsViewIOSTests: XCTestCase {
 
     func test_populatedStore_listsBothFixturesNewestFirst() {
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-old", agentId: "claude-code", startedAt: 100)
-        injectFixture(into: store, acpSessionId: "acp-new", agentId: "codex", startedAt: 300)
+        injectFixture(into: store, id: "acp-old", agentId: "claude-code", startedAt: 100)
+        injectFixture(into: store, id: "acp-new", agentId: "codex", startedAt: 300)
 
         XCTAssertEqual(store.sessions.count, 2)
         // ``ACPSessionStore.sessionOrder`` sorts by startedAt descending.
@@ -118,7 +118,7 @@ final class ACPSessionsViewIOSTests: XCTestCase {
         // wiring would land the session in `.cancelled` once the daemon
         // emits its terminal event.
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-1", agentId: "claude-code", startedAt: 100)
+        injectFixture(into: store, id: "acp-1", agentId: "claude-code", startedAt: 100)
         XCTAssertEqual(store.sessions["acp-1"]?.state.status, .running)
 
         store.handle(.acpSessionCompleted(ACPSessionCompletedMessage(
@@ -132,26 +132,30 @@ final class ACPSessionsViewIOSTests: XCTestCase {
     // MARK: - Helpers
 
     /// Inserts a synthetic ACP session into the store via the same
-    /// ``ServerMessage`` path the SSE pipeline uses, then pins
-    /// `startedAt` to a deterministic value so assertions don't drift
-    /// with wall-clock skew.
+    /// ``ServerMessage`` path the SSE pipeline uses. Pins `startedAt` and
+    /// sets `state.acpSessionId` to a value distinct from `state.id` —
+    /// matching what the daemon emits after `createSession` resolves on the
+    /// agent process. This ensures the iOS list's store-keyed-by-`state.id`
+    /// contract is exercised: a regression that re-keyed by
+    /// `state.acpSessionId` would break lookups on these fixtures rather
+    /// than silently pass.
     private func injectFixture(
         into store: ACPSessionStore,
-        acpSessionId: String,
+        id: String,
         agentId: String,
         startedAt: Int
     ) {
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
-            acpSessionId: acpSessionId,
+            acpSessionId: id,
             agent: agentId,
-            parentConversationId: "conv-\(acpSessionId)"
+            parentConversationId: "conv-\(id)"
         )))
-        if let viewModel = store.sessions[acpSessionId] {
+        if let viewModel = store.sessions[id] {
             viewModel.state = ACPSessionState(
-                id: viewModel.state.id,
+                id: id,
                 agentId: agentId,
-                acpSessionId: acpSessionId,
-                parentConversationId: "conv-\(acpSessionId)",
+                acpSessionId: "protocol-\(id)",
+                parentConversationId: "conv-\(id)",
                 status: .running,
                 startedAt: startedAt
             )

--- a/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
+++ b/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
@@ -141,7 +141,7 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
     /// push.
     func test_acpSessionsView_consumesSelectedSessionIdAndPushesDetail_compact() {
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-deep-link", agentId: "claude-code")
+        injectFixture(into: store, id: "acp-deep-link", agentId: "claude-code")
 
         var path: [String] = []
         var selected: String?
@@ -166,7 +166,7 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
     /// `List(selection:)` binding the regular-size-class layout uses.
     func test_acpSessionsView_consumesSelectedSessionIdAndSelectsDetail_regular() {
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-deep-link", agentId: "codex")
+        injectFixture(into: store, id: "acp-deep-link", agentId: "codex")
 
         var path: [String] = []
         var selected: String?
@@ -215,7 +215,7 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
     /// detail views on top of each other.
     func test_acpSessionsView_consumeIsIdempotentForSameTopOfStack_compact() {
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-same", agentId: "codex")
+        injectFixture(into: store, id: "acp-same", agentId: "codex")
 
         var path: [String] = []
         var selected: String?
@@ -248,7 +248,7 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
     /// already-selected detail must not flicker the selection binding.
     func test_acpSessionsView_consumeIsIdempotentForSameSelection_regular() {
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-same", agentId: "claude-code")
+        injectFixture(into: store, id: "acp-same", agentId: "claude-code")
 
         var path: [String] = []
         var selected: String? = "acp-same"
@@ -450,19 +450,33 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
     }
 
     /// Inserts a synthetic ACP session into the store via the same
-    /// ``ServerMessage`` path the SSE pipeline uses. Matches the helper
-    /// used in ``ACPSessionsViewIOSTests`` so fixtures behave the same
-    /// across the two suites.
+    /// ``ServerMessage`` path the SSE pipeline uses. Sets
+    /// `state.acpSessionId` to a value distinct from `state.id` —
+    /// matching what the daemon emits after `createSession` resolves on the
+    /// agent process. This ensures the deep-link consume helper exercises
+    /// the store-keyed-by-`state.id` contract: a regression that re-keyed
+    /// by `state.acpSessionId` would break consume on these fixtures
+    /// rather than silently pass.
     private func injectFixture(
         into store: ACPSessionStore,
-        acpSessionId: String,
+        id: String,
         agentId: String
     ) {
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
-            acpSessionId: acpSessionId,
+            acpSessionId: id,
             agent: agentId,
-            parentConversationId: "conv-\(acpSessionId)"
+            parentConversationId: "conv-\(id)"
         )))
+        if let viewModel = store.sessions[id] {
+            viewModel.state = ACPSessionState(
+                id: id,
+                agentId: agentId,
+                acpSessionId: "protocol-\(id)",
+                parentConversationId: "conv-\(id)",
+                status: .running,
+                startedAt: viewModel.state.startedAt
+            )
+        }
     }
 }
 #endif

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
@@ -218,11 +218,26 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
     /// repeated set-with-same-id still triggers a fresh push.
     func test_acpSessionsPanel_consumesSelectedSessionIdAndPushesDetail() {
         let store = ACPSessionStore()
+        // Spawn synthesizes state.id == state.acpSessionId. Diverge them
+        // afterward so the assertion below pins the
+        // store-keyed-by-`state.id` contract — a regression that re-keyed
+        // by `state.acpSessionId` would fail this test instead of silently
+        // passing.
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
             acpSessionId: "acp-deep-link",
             agent: "claude-code",
             parentConversationId: "conv-deep"
         )))
+        if let viewModel = store.sessions["acp-deep-link"] {
+            viewModel.state = ACPSessionState(
+                id: "acp-deep-link",
+                agentId: "claude-code",
+                acpSessionId: "protocol-acp-deep-link",
+                parentConversationId: "conv-deep",
+                status: .running,
+                startedAt: viewModel.state.startedAt
+            )
+        }
 
         var path: [ACPSessionViewModel] = []
         store.selectedSessionId = "acp-deep-link"
@@ -230,9 +245,9 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
 
         XCTAssertEqual(path.count, 1, "Detail view must be pushed onto the panel's NavigationStack")
         XCTAssertEqual(
-            path.last?.state.acpSessionId,
+            path.last?.state.id,
             "acp-deep-link",
-            "Pushed view model must match the requested session"
+            "Pushed view model must match the requested session by daemon UUID (state.id)"
         )
         XCTAssertNil(
             store.selectedSessionId,
@@ -264,11 +279,23 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
     /// duplicate detail views on top of each other.
     func test_acpSessionsPanel_consumeIsIdempotentForSameTopOfStack() {
         let store = ACPSessionStore()
+        // Diverge state.id and state.acpSessionId so the consume path is
+        // exercised under the realistic post-`createSession` shape.
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
             acpSessionId: "acp-same",
             agent: "codex",
             parentConversationId: "conv-x"
         )))
+        if let viewModel = store.sessions["acp-same"] {
+            viewModel.state = ACPSessionState(
+                id: "acp-same",
+                agentId: "codex",
+                acpSessionId: "protocol-acp-same",
+                parentConversationId: "conv-x",
+                status: .running,
+                startedAt: viewModel.state.startedAt
+            )
+        }
 
         var path: [ACPSessionViewModel] = []
 

--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -70,8 +70,8 @@ final class ACPSessionsPanelTests: XCTestCase {
 
     func test_populatedStore_listsBothFixturesNewestFirst() {
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-old", agentId: "claude-code", startedAt: 100)
-        injectFixture(into: store, acpSessionId: "acp-new", agentId: "codex", startedAt: 300)
+        injectFixture(into: store, id: "acp-old", agentId: "claude-code", startedAt: 100)
+        injectFixture(into: store, id: "acp-new", agentId: "codex", startedAt: 300)
 
         XCTAssertEqual(store.sessions.count, 2)
         // ``ACPSessionStore.sessionOrder`` sorts by startedAt descending.
@@ -179,11 +179,11 @@ final class ACPSessionsPanelTests: XCTestCase {
         try installLockfileFixture()
 
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-running", agentId: "claude-code", startedAt: 100, status: .running)
-        injectFixture(into: store, acpSessionId: "acp-completed", agentId: "codex", startedAt: 200, status: .completed)
-        injectFixture(into: store, acpSessionId: "acp-failed", agentId: "claude-code", startedAt: 300, status: .failed)
-        injectFixture(into: store, acpSessionId: "acp-cancelled", agentId: "codex", startedAt: 400, status: .cancelled)
-        injectFixture(into: store, acpSessionId: "acp-init", agentId: "claude-code", startedAt: 500, status: .initializing)
+        injectFixture(into: store, id: "acp-running", agentId: "claude-code", startedAt: 100, status: .running)
+        injectFixture(into: store, id: "acp-completed", agentId: "codex", startedAt: 200, status: .completed)
+        injectFixture(into: store, id: "acp-failed", agentId: "claude-code", startedAt: 300, status: .failed)
+        injectFixture(into: store, id: "acp-cancelled", agentId: "codex", startedAt: 400, status: .cancelled)
+        injectFixture(into: store, id: "acp-init", agentId: "claude-code", startedAt: 500, status: .initializing)
 
         let requestExpectation = expectation(description: "clear completed request")
         MockACPSessionsPanelURLProtocol.requestHandler = { request in
@@ -218,8 +218,8 @@ final class ACPSessionsPanelTests: XCTestCase {
         try installLockfileFixture()
 
         let store = ACPSessionStore()
-        injectFixture(into: store, acpSessionId: "acp-running", agentId: "claude-code", startedAt: 100, status: .running)
-        injectFixture(into: store, acpSessionId: "acp-completed", agentId: "codex", startedAt: 200, status: .completed)
+        injectFixture(into: store, id: "acp-running", agentId: "claude-code", startedAt: 100, status: .running)
+        injectFixture(into: store, id: "acp-completed", agentId: "codex", startedAt: 200, status: .completed)
 
         MockACPSessionsPanelURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
@@ -349,33 +349,36 @@ final class ACPSessionsPanelTests: XCTestCase {
     // MARK: - Helpers
 
     /// Inserts a synthetic ACP session into the store via the same
-    /// ``ServerMessage`` path the SSE pipeline uses. The spawn handler stamps
-    /// `startedAt` with the wall-clock time at insertion — newer fixtures
-    /// therefore sort ahead of older ones automatically, so callers should
-    /// inject in oldest-first order to get a deterministic newest-first
-    /// ``sessionOrder``.
+    /// ``ServerMessage`` path the SSE pipeline uses. Pins `startedAt` to a
+    /// deterministic value and sets `state.acpSessionId` to a value that
+    /// differs from `state.id` — this matches what the daemon emits after
+    /// `createSession` resolves on the agent process and ensures the panel's
+    /// store-keyed-by-`state.id` contract is exercised: a regression that
+    /// re-keyed by `state.acpSessionId` would break lookups on these
+    /// fixtures rather than silently pass.
+    ///
+    /// Callers should inject in oldest-first order to get a deterministic
+    /// newest-first ``sessionOrder``.
     private func injectFixture(
         into store: ACPSessionStore,
-        acpSessionId: String,
+        id: String,
         agentId: String,
         parentConversationId: String? = nil,
         startedAt: Int,
-        status: ACPSessionState.Status = .running
+        status: ACPSessionState.Status = .running,
+        protocolSessionId: String? = nil
     ) {
-        let parent = parentConversationId ?? "conv-\(acpSessionId)"
+        let parent = parentConversationId ?? "conv-\(id)"
         store.handle(.acpSessionSpawned(ACPSessionSpawnedMessage(
-            acpSessionId: acpSessionId,
+            acpSessionId: id,
             agent: agentId,
             parentConversationId: parent
         )))
-        // Pin `startedAt` to a deterministic value so assertions don't drift
-        // with wall-clock skew. ``sessionOrder`` was already computed by the
-        // spawn handler using insertion order, which matches our intent.
-        if let viewModel = store.sessions[acpSessionId] {
+        if let viewModel = store.sessions[id] {
             viewModel.state = ACPSessionState(
-                id: viewModel.state.id,
+                id: id,
                 agentId: agentId,
-                acpSessionId: acpSessionId,
+                acpSessionId: protocolSessionId ?? "protocol-\(id)",
                 parentConversationId: parent,
                 status: status,
                 startedAt: startedAt


### PR DESCRIPTION
## Summary
- Updates the panel/view test injectFixture helpers and macOS deep-link tests to set `state.acpSessionId` to a value distinct from `state.id`, matching what the daemon emits after `createSession` resolves on the agent process.
- Pins the store-keyed-by-`state.id` contract (Round 1 fix #28334) at the panel/view layer too — a regression that re-keyed by `state.acpSessionId` would now fail these fixtures rather than silently pass.
- Updated assertion in macOS `consumesSelectedSessionIdAndPushesDetail` to verify by `state.id`, not `state.acpSessionId`.

## Original prompt
the followup