### PR TITLE
fix(tests): create lockfile parent dir in ACP test fixtures

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -414,6 +414,10 @@ final class ACPSessionsPanelTests: XCTestCase {
             ],
         ]
         let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try FileManager.default.createDirectory(
+            at: primaryLockfileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try data.write(to: primaryLockfileURL, options: .atomic)
         lockfileInstalled = true
     }

--- a/clients/macos/vellum-assistantTests/Network/ACPClientTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPClientTests.swift
@@ -488,7 +488,12 @@ final class ACPClientTests: XCTestCase {
             ],
         ]
         let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
-        try data.write(to: LockfilePaths.primary, options: .atomic)
+        let primaryLockfileURL = LockfilePaths.primary
+        try FileManager.default.createDirectory(
+            at: primaryLockfileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: primaryLockfileURL, options: .atomic)
     }
 
     private func requestJSONBody(from request: URLRequest) throws -> [String: Any] {

--- a/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/ACPSessionStoreTests.swift
@@ -626,6 +626,11 @@ final class ACPSessionStoreTests: XCTestCase {
             ],
         ]
         let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
-        try data.write(to: LockfilePaths.primary, options: .atomic)
+        let primaryLockfileURL = LockfilePaths.primary
+        try FileManager.default.createDirectory(
+            at: primaryLockfileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: primaryLockfileURL, options: .atomic)
     }
 }


### PR DESCRIPTION
## Summary
- Three ACP test classes (`ACPClientTests`, `ACPSessionStoreTests`, `ACPSessionsPanelTests`) were failing on the macOS Tests CI job because `installLockfileFixture()` writes to `~/.config/vellum-test/lockfile.json` (the test-environment `LockfilePaths.primary`) but never created the parent `~/.config/vellum-test/` directory. Fresh CI runners have no such directory, so `Data.write(...)` threw `NSCocoaErrorDomain Code=4` ("No such file or directory") and the entire `setUpWithError`/fixture path crashed before any assertions ran.
- Add an idempotent `FileManager.createDirectory(withIntermediateDirectories: true)` call in each fixture immediately before the atomic write.

Failing job: https://github.com/vellum-ai/vellum-assistant/actions/runs/24952083860/job/73063844074

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24952083860/job/73063844074
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
