### PR TITLE
fix(macos): drop redundant FlexFrame on ACPSessionsPanelRow

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -348,7 +348,6 @@ struct ACPSessionsPanelRow: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel)
     }


### PR DESCRIPTION
## Summary
- Removes `.frame(maxWidth: .infinity, alignment: .leading)` from `ACPSessionsPanelRow` — the row's HStack already contains `Spacer(minLength: VSpacing.md)`, so the frame modifier is redundant and the safe alternative pattern (`HStack { content; Spacer }`) is already in place.
- Resolves the FlexFrame Lint CI failure on `main` (job 73063844072 in run 24952083860).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24952083860/job/73063844072
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
