### PR TITLE
feat(macos): auto-release live voice push-to-talk on silence

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -668,7 +668,7 @@ struct ComposerView: View, Equatable {
     private func voiceConversationAmplitude(_ manager: VoiceModeManager) -> Float {
         let raw: Float
         switch manager.state {
-        case .listening: raw = voiceService?.amplitude ?? 0
+        case .listening: raw = max(manager.inputAmplitude, voiceService?.amplitude ?? 0)
         case .speaking: raw = voiceService?.speakingAmplitude ?? 0
         default: raw = 0
         }

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -55,6 +55,7 @@ final class LiveVoiceChannelManager {
     private(set) var partialTranscript: String = ""
     private(set) var finalTranscript: String = ""
     private(set) var assistantTranscript: String = ""
+    private(set) var inputAmplitude: Float = 0
     private(set) var errorMessage: String = ""
 
     var isActive: Bool {
@@ -70,6 +71,9 @@ final class LiveVoiceChannelManager {
     @ObservationIgnored private let capture: any LiveVoiceAudioCapturing
     @ObservationIgnored private let playback: any LiveVoiceAudioPlaying
     @ObservationIgnored private let bargeInAmplitudeThreshold: Float
+    @ObservationIgnored private let speechAmplitudeThreshold: Float
+    @ObservationIgnored private let silenceDurationBeforeRelease: TimeInterval
+    @ObservationIgnored private let minimumSpeechDurationBeforeRelease: TimeInterval
 
     @ObservationIgnored private var client: (any LiveVoiceChannelClientProtocol)?
     @ObservationIgnored private var captureStartTask: Task<Void, Never>?
@@ -78,17 +82,26 @@ final class LiveVoiceChannelManager {
     @ObservationIgnored private var captureStartInFlight = false
     @ObservationIgnored private var responseAudioStarted = false
     @ObservationIgnored private var interruptSentForCurrentResponse = false
+    @ObservationIgnored private var speechDurationInCurrentUtterance: TimeInterval = 0
+    @ObservationIgnored private var silenceDurationAfterSpeech: TimeInterval = 0
+    @ObservationIgnored private var automaticReleaseInFlight = false
 
     init(
         clientFactory: @escaping @MainActor () -> any LiveVoiceChannelClientProtocol = { LiveVoiceChannelClient() },
         capture: any LiveVoiceAudioCapturing = LiveVoiceAudioCapture(),
         playback: (any LiveVoiceAudioPlaying)? = nil,
-        bargeInAmplitudeThreshold: Float = 0.05
+        bargeInAmplitudeThreshold: Float = 0.05,
+        speechAmplitudeThreshold: Float = 0.03,
+        silenceDurationBeforeRelease: TimeInterval = 1.0,
+        minimumSpeechDurationBeforeRelease: TimeInterval = 0.12
     ) {
         self.clientFactory = clientFactory
         self.capture = capture
         self.playback = playback ?? LiveVoiceAudioPlayer()
         self.bargeInAmplitudeThreshold = bargeInAmplitudeThreshold
+        self.speechAmplitudeThreshold = speechAmplitudeThreshold
+        self.silenceDurationBeforeRelease = silenceDurationBeforeRelease
+        self.minimumSpeechDurationBeforeRelease = minimumSpeechDurationBeforeRelease
     }
 
     func start(conversationId: String) async {
@@ -180,13 +193,22 @@ final class LiveVoiceChannelManager {
         partialTranscript = ""
         finalTranscript = ""
         assistantTranscript = ""
+        inputAmplitude = 0
         errorMessage = ""
+        resetVoiceActivityTracking()
     }
 
     private func resetIgnoredSessionState() {
         client = nil
         responseAudioStarted = false
         interruptSentForCurrentResponse = false
+        automaticReleaseInFlight = false
+    }
+
+    private func resetVoiceActivityTracking() {
+        speechDurationInCurrentUtterance = 0
+        silenceDurationAfterSpeech = 0
+        automaticReleaseInFlight = false
     }
 
     private func handle(_ event: LiveVoiceChannelEvent, generation: UInt64) {
@@ -312,6 +334,8 @@ final class LiveVoiceChannelManager {
     private func handleCapturedAudioChunk(_ chunk: LiveVoiceAudioCaptureChunk, generation: UInt64) {
         guard generation == sessionGeneration, captureRunning else { return }
 
+        update(&inputAmplitude, to: chunk.amplitude)
+
         let audioData = chunk.pcm16LittleEndian
         if !audioData.isEmpty, let client {
             Task {
@@ -319,8 +343,48 @@ final class LiveVoiceChannelManager {
             }
         }
 
+        updateAutomaticPushToTalkRelease(with: chunk, generation: generation)
+
         guard chunk.amplitude >= bargeInAmplitudeThreshold else { return }
         interruptIfAssistantAudioIsPlaying(generation: generation)
+    }
+
+    private func updateAutomaticPushToTalkRelease(
+        with chunk: LiveVoiceAudioCaptureChunk,
+        generation: UInt64
+    ) {
+        guard state == .listening, captureRunning, client != nil else { return }
+
+        let chunkDuration: TimeInterval
+        if chunk.sampleRate > 0, chunk.frameCount > 0 {
+            chunkDuration = TimeInterval(chunk.frameCount) / TimeInterval(chunk.sampleRate)
+        } else {
+            chunkDuration = 0
+        }
+
+        guard chunkDuration > 0 else { return }
+
+        if chunk.amplitude >= speechAmplitudeThreshold {
+            speechDurationInCurrentUtterance += chunkDuration
+            silenceDurationAfterSpeech = 0
+            return
+        }
+
+        guard speechDurationInCurrentUtterance >= minimumSpeechDurationBeforeRelease else { return }
+        silenceDurationAfterSpeech += chunkDuration
+
+        guard silenceDurationAfterSpeech >= silenceDurationBeforeRelease else { return }
+        automaticallyReleasePushToTalk(generation: generation)
+    }
+
+    private func automaticallyReleasePushToTalk(generation: UInt64) {
+        guard !automaticReleaseInFlight else { return }
+        automaticReleaseInFlight = true
+
+        Task { @MainActor [weak self] in
+            guard let self, generation == self.sessionGeneration else { return }
+            await self.stopListening()
+        }
     }
 
     private func interruptIfAssistantAudioIsPlaying(generation: UInt64) {
@@ -377,6 +441,8 @@ final class LiveVoiceChannelManager {
         }
         captureRunning = false
         captureStartInFlight = false
+        inputAmplitude = 0
+        resetVoiceActivityTracking()
     }
 
     private func update<T: Equatable>(_ value: inout T, to newValue: T) {

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -9,6 +9,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Voice
 @MainActor
 protocol LiveVoiceChannelManaging: AnyObject {
     var state: LiveVoiceChannelManager.State { get }
+    var inputAmplitude: Float { get }
     var partialTranscript: String { get }
     var finalTranscript: String { get }
     var errorMessage: String { get }
@@ -48,6 +49,7 @@ final class VoiceModeManager {
     }
     var partialTranscription: String = ""
     var liveTranscription: String = ""
+    var inputAmplitude: Float = 0
     var errorMessage: String = ""
     /// Set to true when deactivation was triggered by the conversation timeout
     /// (as opposed to manual deactivation).
@@ -290,6 +292,7 @@ final class VoiceModeManager {
         state = .off
         partialTranscription = ""
         liveTranscription = ""
+        inputAmplitude = 0
         log.info("Voice mode deactivated")
     }
 
@@ -416,6 +419,7 @@ final class VoiceModeManager {
         liveVoicePausedForPermission = false
         partialTranscription = ""
         liveTranscription = ""
+        inputAmplitude = 0
         errorMessage = ""
         state = .listening
         startLiveVoiceObservation()
@@ -446,6 +450,7 @@ final class VoiceModeManager {
 
         withObservationTracking {
             _ = liveVoiceChannelManager.state
+            _ = liveVoiceChannelManager.inputAmplitude
             _ = liveVoiceChannelManager.partialTranscript
             _ = liveVoiceChannelManager.finalTranscript
             _ = liveVoiceChannelManager.errorMessage
@@ -471,6 +476,9 @@ final class VoiceModeManager {
         }
         if partialTranscription != liveVoiceChannelManager.finalTranscript {
             partialTranscription = liveVoiceChannelManager.finalTranscript
+        }
+        if inputAmplitude != liveVoiceChannelManager.inputAmplitude {
+            inputAmplitude = liveVoiceChannelManager.inputAmplitude
         }
 
         switch liveVoiceChannelManager.state {

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -217,6 +217,47 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .listening)
     }
 
+    func testInputAmplitudeTracksCaptureAndResetsWhenStopped() async {
+        await startReadySession()
+
+        capture.emitChunk(data: Data([1, 2]), frameCount: 1_600, amplitude: 0.4)
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.inputAmplitude, 0.4)
+
+        await manager.stopListening()
+
+        XCTAssertEqual(manager.inputAmplitude, 0)
+    }
+
+    func testInitialSilenceDoesNotAutomaticallyReleasePushToTalk() async {
+        await startReadySession()
+
+        for _ in 0..<20 {
+            capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        }
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.releasePushToTalkCallCount, 0)
+        XCTAssertEqual(capture.stopCallCount, 0)
+        XCTAssertEqual(manager.state, .listening)
+    }
+
+    func testSpeechThenSilenceAutomaticallyReleasesPushToTalk() async {
+        await startReadySession()
+
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        capture.emitChunk(frameCount: 1_600, amplitude: 0.05)
+        for _ in 0..<10 {
+            capture.emitChunk(frameCount: 1_600, amplitude: 0.0)
+        }
+        await flushAsyncTasks()
+
+        XCTAssertEqual(client.releasePushToTalkCallCount, 1)
+        XCTAssertEqual(capture.stopCallCount, 1)
+        XCTAssertEqual(manager.state, .transcribing)
+    }
+
     func testStopListeningSendsPushToTalkRelease() async {
         await startReadySession()
 

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -35,6 +35,7 @@ private final class MockSpeechRecognizerAdapter: SpeechRecognizerAdapter {
 @Observable
 private final class FakeLiveVoiceChannelManager: LiveVoiceChannelManaging {
     var state: LiveVoiceChannelManager.State = .idle
+    var inputAmplitude: Float = 0
     var partialTranscript: String = ""
     var finalTranscript: String = ""
     var errorMessage: String = ""
@@ -899,6 +900,27 @@ final class VoiceModeManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .listening)
         XCTAssertFalse(mockVoiceService.stopSpeakingCalled)
         XCTAssertFalse(mockVoiceService.startRecordingCalled)
+    }
+
+    func testLiveChannelAmplitudeIsExposedForComposerWaveform() async {
+        let liveManager = FakeLiveVoiceChannelManager()
+        chatViewModel.conversationId = "conv-123"
+        manager = VoiceModeManager(
+            voiceService: mockVoiceService,
+            liveVoiceChannelManager: liveManager,
+            liveVoiceAvailability: { true }
+        )
+        forceActivate()
+
+        manager.startListening()
+        await flushAsyncTasks()
+        liveManager.becomeReady()
+        await flushAsyncTasks()
+
+        liveManager.inputAmplitude = 0.42
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.inputAmplitude, 0.42)
     }
 
     func testLiveChannelBargeInInterruptsAndRestartsLiveListening() async {


### PR DESCRIPTION
## Summary
- Auto-release live voice push-to-talk after ~1s of silence following >=120ms of detected speech, so users don't have to tap to stop.
- Expose `LiveVoiceChannelManager.inputAmplitude` through `VoiceModeManager` and feed it into the composer waveform so the bars react to the user's mic input during listening.
- Adds unit tests for amplitude propagation, initial-silence suppression, and the speech-then-silence auto-release path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
