### PR TITLE
fix(macos): wait for live voice playback before closing session

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceAudioPlayer.swift
@@ -88,6 +88,7 @@ final class LiveVoiceAudioPlayer {
     @ObservationIgnored private var activeChunk: LiveVoiceAudioChunk?
     @ObservationIgnored private var playbackGeneration: UInt64 = 0
     @ObservationIgnored private var acceptsAudio = true
+    @ObservationIgnored private var playbackWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(output: (any LiveVoiceAudioOutput)? = nil) {
         self.output = output ?? AVFoundationLiveVoiceAudioOutput()
@@ -136,6 +137,7 @@ final class LiveVoiceAudioPlayer {
         activeChunk = nil
         output.stop()
         state = .stopped(reason)
+        notifyPlaybackWaiters()
     }
 
     func resetForNextResponse() {
@@ -145,6 +147,15 @@ final class LiveVoiceAudioPlayer {
         activeChunk = nil
         acceptsAudio = true
         state = .idle
+        notifyPlaybackWaiters()
+    }
+
+    func waitUntilPlaybackFinishes() async {
+        guard state == .playing || activeChunk != nil || !queuedChunks.isEmpty else { return }
+
+        await withCheckedContinuation { continuation in
+            playbackWaiters.append(continuation)
+        }
     }
 
     private func playNextChunkIfNeeded() {
@@ -169,6 +180,7 @@ final class LiveVoiceAudioPlayer {
         case .success:
             if queuedChunks.isEmpty {
                 state = .idle
+                notifyPlaybackWaiters()
             } else {
                 playNextChunkIfNeeded()
             }
@@ -179,6 +191,17 @@ final class LiveVoiceAudioPlayer {
             queuedChunks.removeAll()
             output.stop()
             state = .failed(error.localizedDescription)
+            notifyPlaybackWaiters()
+        }
+    }
+
+    private func notifyPlaybackWaiters() {
+        guard state != .playing, activeChunk == nil, queuedChunks.isEmpty else { return }
+
+        let waiters = playbackWaiters
+        playbackWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/LiveVoiceChannelManager.swift
@@ -31,6 +31,7 @@ protocol LiveVoiceAudioPlaying: AnyObject {
     func handleEnd()
     func handleSessionError()
     func resetForNextResponse()
+    func waitUntilPlaybackFinishes() async
 }
 
 extension LiveVoiceAudioPlayer: LiveVoiceAudioPlaying {}
@@ -260,7 +261,7 @@ final class LiveVoiceChannelManager {
             state = .speaking
 
         case .ttsDone:
-            closeCompletedUtteranceSession()
+            closeCompletedUtteranceSessionAfterPlayback(generation: generation)
 
         case .metrics, .archived:
             break
@@ -417,17 +418,20 @@ final class LiveVoiceChannelManager {
         playback.resetForNextResponse()
     }
 
-    private func closeCompletedUtteranceSession() {
+    private func closeCompletedUtteranceSessionAfterPlayback(generation: UInt64) {
         responseAudioStarted = false
-        sessionGeneration &+= 1
-        stopCapture()
-
         let completedClient = client
-        resetIgnoredSessionState()
-        sessionId = nil
-        state = .idle
 
-        Task {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.playback.waitUntilPlaybackFinishes()
+            guard generation == self.sessionGeneration else { return }
+
+            self.sessionGeneration &+= 1
+            self.stopCapture()
+            self.resetIgnoredSessionState()
+            self.sessionId = nil
+            self.state = .idle
             await completedClient?.close()
         }
     }

--- a/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/LiveVoiceChannelManagerTests.swift
@@ -108,6 +108,7 @@ private final class FakeLiveVoiceAudioPlayback: LiveVoiceAudioPlaying {
     private(set) var resetCallCount = 0
 
     var isPlaying = false
+    private var playbackWaiters: [CheckedContinuation<Void, Never>] = []
 
     func enqueueTTSAudio(
         data: Data,
@@ -129,22 +130,49 @@ private final class FakeLiveVoiceAudioPlayback: LiveVoiceAudioPlaying {
     func handleInterrupt() {
         interruptCallCount += 1
         isPlaying = false
+        notifyPlaybackWaiters()
     }
 
     func handleEnd() {
         endCallCount += 1
         isPlaying = false
+        notifyPlaybackWaiters()
     }
 
     func handleSessionError() {
         sessionErrorCallCount += 1
         isPlaying = false
+        notifyPlaybackWaiters()
     }
 
     func resetForNextResponse() {
         resetCallCount += 1
         enqueuedChunks.removeAll()
         isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    func waitUntilPlaybackFinishes() async {
+        guard isPlaying else { return }
+
+        await withCheckedContinuation { continuation in
+            playbackWaiters.append(continuation)
+        }
+    }
+
+    func finishPlayback() {
+        isPlaying = false
+        notifyPlaybackWaiters()
+    }
+
+    private func notifyPlaybackWaiters() {
+        guard !isPlaying else { return }
+
+        let waiters = playbackWaiters
+        playbackWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }
 
@@ -316,9 +344,67 @@ final class LiveVoiceChannelManagerTests: XCTestCase {
         client.emit(.ttsDone(turnId: "turn-123"))
         await flushAsyncTasks()
 
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertNotNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 0)
+
+        playback.finishPlayback()
+        await flushAsyncTasks()
+
         XCTAssertEqual(manager.state, .idle)
         XCTAssertNil(manager.sessionId)
         XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testTtsDoneWithoutQueuedPlaybackClosesSessionImmediately() async {
+        await startReadySession()
+        await manager.stopListening()
+
+        client.emit(.thinking(turnId: "turn-123"))
+        client.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertNil(manager.sessionId)
+        XCTAssertEqual(client.closeCallCount, 1)
+    }
+
+    func testManualBargeInBeforePlaybackFinishesInterruptsInsteadOfAutoClosing() async {
+        let firstClient = FakeLiveVoiceChannelClient()
+        let secondClient = FakeLiveVoiceChannelClient()
+        var factoryCalls = 0
+        manager = LiveVoiceChannelManager(
+            clientFactory: {
+                factoryCalls += 1
+                return factoryCalls == 1 ? firstClient : secondClient
+            },
+            capture: capture,
+            playback: playback,
+            bargeInAmplitudeThreshold: 0.2
+        )
+
+        await manager.start(conversationId: "conv-123")
+        firstClient.emit(.ready(sessionId: "session-1", conversationId: "conv-123"))
+        await flushAsyncTasks()
+        await manager.stopListening()
+        firstClient.emit(.ttsAudio(data: Data([9, 8]), mimeType: "audio/pcm", sampleRate: 16_000, seq: 4))
+        firstClient.emit(.ttsDone(turnId: "turn-123"))
+        await flushAsyncTasks()
+
+        XCTAssertEqual(manager.state, .speaking)
+        XCTAssertEqual(firstClient.closeCallCount, 0)
+
+        await manager.interruptSpeakingAndStartListening(conversationId: "conv-123")
+
+        XCTAssertEqual(firstClient.interruptCallCount, 1)
+        XCTAssertEqual(firstClient.closeCallCount, 1)
+        XCTAssertEqual(playback.interruptCallCount, 1)
+        XCTAssertEqual(secondClient.startCalls.count, 1)
+
+        playback.finishPlayback()
+        await flushAsyncTasks()
+
+        XCTAssertEqual(firstClient.closeCallCount, 1)
     }
 
     func testSpeakingOverAssistantAudioSendsInterruptOnce() async {


### PR DESCRIPTION
## Summary
- Add `waitUntilPlaybackFinishes()` to `LiveVoiceAudioPlayer` so callers can await the queued chunks draining.
- On `ttsDone`, keep the session open until playback finishes (guarded by session generation) so audio isn't truncated when the server signals done before the speaker has caught up.
- Cover the new behavior with tests for the deferred close, the immediate close when nothing is queued, and a manual barge-in arriving mid-playback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
