### PR TITLE
Explicitly disable Anthropic thinking

### DIFF
--- a/assistant/src/__tests__/agent-loop-callsite-precedence.test.ts
+++ b/assistant/src/__tests__/agent-loop-callsite-precedence.test.ts
@@ -210,12 +210,8 @@ describe("AgentLoop — call-site precedence", () => {
     );
 
     // Call-site override resolves `thinking.enabled: false`, so the
-    // RetryProvider normalizer must omit `thinking` entirely (matching the
-    // legacy non-callSite path which only sets `providerConfig.thinking`
-    // when enabled). Without the fix at agent/loop.ts, the conversation
-    // default's `thinking: { type: "adaptive" }` would be pre-set and mask
-    // the call-site override.
-    expect(lastConfig()!.thinking).toBeUndefined();
+    // RetryProvider normalizer must send Anthropic's explicit disabled shape.
+    expect(lastConfig()!.thinking).toEqual({ type: "disabled" });
   });
 
   test("call-site thinking is converted to Anthropic wire-format when enabled", async () => {

--- a/assistant/src/__tests__/agent-loop-thinking.test.ts
+++ b/assistant/src/__tests__/agent-loop-thinking.test.ts
@@ -55,7 +55,7 @@ describe("AgentLoop thinking and effort", () => {
     expect(thinking.type).toBe("adaptive");
   });
 
-  test("does not include thinking config when thinking is disabled", async () => {
+  test("sends disabled thinking when thinking is disabled", async () => {
     const { provider, lastConfig } = createMockProvider();
     const loop = new AgentLoop(provider, "test", {
       maxTokens: 64000,
@@ -68,7 +68,7 @@ describe("AgentLoop thinking and effort", () => {
     );
 
     const config = lastConfig()!;
-    expect(config.thinking).toBeUndefined();
+    expect(config.thinking).toEqual({ type: "disabled" });
   });
 
   test("sends effort in provider config", async () => {
@@ -87,7 +87,7 @@ describe("AgentLoop thinking and effort", () => {
     expect(config.effort).toBe("high");
   });
 
-  test("sends effort without thinking when thinking is disabled", async () => {
+  test("sends effort with disabled thinking when thinking is disabled", async () => {
     const { provider, lastConfig } = createMockProvider();
     const loop = new AgentLoop(provider, "test", {
       maxTokens: 64000,
@@ -102,6 +102,6 @@ describe("AgentLoop thinking and effort", () => {
 
     const config = lastConfig()!;
     expect(config.effort).toBe("medium");
-    expect(config.thinking).toBeUndefined();
+    expect(config.thinking).toEqual({ type: "disabled" });
   });
 });

--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -196,6 +196,14 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(lastStreamParams!.system).toBeUndefined();
   });
 
+  test("sends disabled thinking config natively", async () => {
+    await provider.sendMessage([userMsg("Hi")], undefined, undefined, {
+      config: { thinking: { type: "disabled" } },
+    });
+
+    expect(lastStreamParams!.thinking).toEqual({ type: "disabled" });
+  });
+
   test("splits system prompt into two cache blocks on boundary marker", async () => {
     const staticBlock = "You are a helpful assistant.";
     const dynamicBlock = "User workspace files here.";
@@ -2187,6 +2195,21 @@ describe("OpenRouterProvider — Anthropic dispatch", () => {
     expect(lastStreamParams!.thinking).toEqual({ type: "adaptive" });
     // The OpenAI-compat `reasoning` parameter must NOT be sent on the
     // native Messages API path.
+    expect(lastStreamParams!.reasoning).toBeUndefined();
+  });
+
+  test("disabled thinking config flows through to Anthropic Messages API natively", async () => {
+    const { OpenRouterProvider } =
+      await import("../providers/openrouter/client.js");
+    const provider = new OpenRouterProvider(
+      "or-key",
+      "anthropic/claude-sonnet-4.6",
+    );
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { type: "disabled" } },
+    });
+
+    expect(lastStreamParams!.thinking).toEqual({ type: "disabled" });
     expect(lastStreamParams!.reasoning).toBeUndefined();
   });
 

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1316,6 +1316,16 @@ describe("OpenRouterProvider reasoning", () => {
     expect(lastCreateParams!.reasoning).toEqual({ enabled: true });
   });
 
+  test("sends reasoning.enabled=false when thinking is explicitly disabled", async () => {
+    const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
+    await provider.sendMessage([userMsg("hi")], undefined, undefined, {
+      config: { thinking: { type: "disabled" } },
+    });
+
+    expect(lastCreateParams).toBeTruthy();
+    expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
+  });
+
   test("sends reasoning.enabled=false when thinking config is absent", async () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     await provider.sendMessage([userMsg("hi")], undefined, undefined, {
@@ -1349,9 +1359,9 @@ describe("OpenRouterProvider reasoning", () => {
     const provider = new OpenRouterProvider("or-key", "x-ai/grok-4");
     const retry = new RetryProvider(provider);
 
-    // thinking disabled at loop-level → config.thinking omitted
+    // thinking disabled at loop-level can arrive as an explicit disabled config.
     await retry.sendMessage([userMsg("hi")], undefined, undefined, {
-      config: {},
+      config: { thinking: { type: "disabled" } },
     });
     expect(lastCreateParams!.reasoning).toEqual({ enabled: false });
   });

--- a/assistant/src/__tests__/openrouter-provider-only.test.ts
+++ b/assistant/src/__tests__/openrouter-provider-only.test.ts
@@ -9,9 +9,7 @@ import type { SendMessageOptions } from "../providers/types.js";
 
 /** Expose the protected `buildExtraCreateParams` hook for assertion. */
 class ProbeOpenRouterProvider extends OpenRouterProvider {
-  public probeExtras(
-    options?: SendMessageOptions,
-  ): Record<string, unknown> {
+  public probeExtras(options?: SendMessageOptions): Record<string, unknown> {
     return this.buildExtraCreateParams(options);
   }
 }
@@ -61,7 +59,10 @@ describe("OpenRouter provider.only plumbing", () => {
 
     test("returns options unchanged when only list is empty", () => {
       const options = {
-        config: { model: "anthropic/claude-opus-4.7", openrouter: { only: [] } },
+        config: {
+          model: "anthropic/claude-opus-4.7",
+          openrouter: { only: [] },
+        },
       };
       expect(withOpenRouterBodyExtras(options)).toBe(options);
     });
@@ -128,6 +129,23 @@ describe("OpenRouter provider.only plumbing", () => {
       });
       expect(extras).toEqual({
         reasoning: { enabled: true },
+        provider: { only: ["xAI"] },
+      });
+    });
+
+    test("disabled thinking keeps reasoning disabled alongside provider.only", () => {
+      const provider = new ProbeOpenRouterProvider(
+        "fake-key",
+        "x-ai/grok-4.20-beta",
+      );
+      const extras = provider.probeExtras({
+        config: {
+          thinking: { type: "disabled" },
+          openrouter: { only: ["xAI"] },
+        },
+      });
+      expect(extras).toEqual({
+        reasoning: { enabled: false },
         provider: { only: ["xAI"] },
       });
     });

--- a/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
+++ b/assistant/src/__tests__/retry-thinking-tool-choice.test.ts
@@ -161,13 +161,25 @@ describe("retry normalization: thinking + forced tool_choice", () => {
         tool_choice: { type: "tool", name: "select_memories" },
       },
     });
-    // thinking: { type: "disabled" } should be stripped because the strip
-    // logic doesn't distinguish disabled from adaptive — the Anthropic API
-    // actually accepts disabled + forced tool_choice, but since thinking is
-    // explicitly set by the caller, the callSite resolution path doesn't
-    // overwrite it. The strip is harmless: Anthropic treats absent thinking
-    // the same as disabled.
-    expect(lastConfig()?.thinking).toBeUndefined();
+    expect(lastConfig()?.thinking).toEqual({ type: "disabled" });
+  });
+
+  test("preserves resolved thinking: disabled with forced tool_choice", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        thinking: { enabled: false },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("anthropic");
+    await provider.sendMessage([userMessage], undefined, undefined, {
+      config: {
+        callSite: "memoryExtraction",
+        tool_choice: { type: "tool", name: "extract_graph_diff" },
+      },
+    });
+    expect(lastConfig()?.thinking).toEqual({ type: "disabled" });
   });
 
   test("strips thinking for openrouter with anthropic model and forced tool_choice", async () => {

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -23,13 +23,14 @@ import type {
   ToolResultTruncateResult,
   TurnContext,
 } from "../plugins/types.js";
+import { normalizeThinkingConfigForWire } from "../providers/thinking-config.js";
 import type {
   ContentBlock,
   Message,
   Provider,
   ToolDefinition,
+  ToolResultContent,
 } from "../providers/types.js";
-import type { ToolResultContent } from "../providers/types.js";
 import type { SensitiveOutputBinding } from "../tools/sensitive-output-placeholders.js";
 import {
   applyStreamingSubstitution,
@@ -432,8 +433,9 @@ export class AgentLoop {
         }
 
         if (!callSite) {
-          if (this.config.thinking?.enabled) {
-            providerConfig.thinking = { type: "adaptive" };
+          const thinking = normalizeThinkingConfigForWire(this.config.thinking);
+          if (thinking !== undefined) {
+            providerConfig.thinking = thinking;
           }
           if (this.config.effort) {
             providerConfig.effort = this.config.effort;

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -179,10 +179,7 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.effort).toBe("high");
     expect(config.speed).toBe("fast");
     expect(config.temperature).toBe(0.7);
-    // Disabled thinking is omitted entirely so providers fall back to their
-    // default behavior — matches the legacy non-callSite path which only sets
-    // `providerConfig.thinking` when `enabled === true`.
-    expect(config.thinking).toBeUndefined();
+    expect(config.thinking).toEqual({ type: "disabled" });
     // `contextWindow` and `provider` are server-side concerns and must NOT
     // leak into the per-call provider config — Anthropic rejects unknown
     // fields with `{type:"invalid_request_error", message:"contextWindow:
@@ -225,7 +222,7 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.thinking).toEqual({ type: "adaptive" });
   });
 
-  test("omits thinking when resolved config has thinking.enabled: false", async () => {
+  test("converts disabled thinking to Anthropic wire-format `{ type: 'disabled' }`", async () => {
     setLlmConfig({
       default: {
         provider: "anthropic",
@@ -249,7 +246,7 @@ describe("RetryProvider — callSite resolution", () => {
     });
 
     const config = seen?.config as Record<string, unknown>;
-    expect(config.thinking).toBeUndefined();
+    expect(config.thinking).toEqual({ type: "disabled" });
   });
 
   test("does NOT propagate temperature when resolved value is null (schema default)", async () => {

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,5 +1,6 @@
 import { AnthropicProvider } from "../anthropic/client.js";
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
+import { isThinkingConfigEnabled } from "../thinking-config.js";
 import type {
   Message,
   ProviderResponse,
@@ -143,15 +144,13 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
   }
 
   // OpenRouter's unified `reasoning` parameter controls extended thinking on
-  // its OpenAI-compatible endpoint. Mirror the assistant's `thinking.enabled`
-  // config — loop.ts only sets `config.thinking` when enabled — so non-
-  // Anthropic reasoning models (e.g. xAI Grok) can be toggled the same way.
-  // Anthropic models skip this path entirely and go through AnthropicProvider.
+  // its OpenAI-compatible endpoint. Anthropic models skip this path entirely and
+  // go through AnthropicProvider, which receives the native `thinking` object.
   protected override buildExtraCreateParams(
     options?: SendMessageOptions,
   ): Record<string, unknown> {
     const config = options?.config as Record<string, unknown> | undefined;
-    const thinkingEnabled = config?.thinking !== undefined;
+    const thinkingEnabled = isThinkingConfigEnabled(config?.thinking);
     const extras: Record<string, unknown> = {
       reasoning: { enabled: thinkingEnabled },
     };

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -10,6 +10,10 @@ import {
   sleep,
 } from "../util/retry.js";
 import {
+  isThinkingConfigDisabled,
+  normalizeThinkingConfigForWire,
+} from "./thinking-config.js";
+import {
   isContextOverflowError,
   type Message,
   type Provider,
@@ -30,8 +34,8 @@ const EFFORT_SUPPORTED_PROVIDERS = new Set([
 
 /**
  * Providers that consume the `thinking` config. Anthropic uses it directly on
- * the wire; OpenRouter translates it into its unified `reasoning` parameter so
- * users can control extended thinking on Anthropic models served via OpenRouter.
+ * the wire; OpenRouter either forwards it to its Anthropic-compatible path or
+ * translates it into the unified `reasoning` parameter on OpenAI-compat calls.
  */
 const THINKING_AWARE_PROVIDERS = new Set(["anthropic", "openrouter"]);
 
@@ -168,16 +172,14 @@ function normalizeSendMessageOptions(
       nextConfig.temperature = resolved.temperature;
     }
     if (nextConfig.thinking === undefined) {
-      // Convert the schema-shape `{ enabled, streamThinking }` into the
-      // Anthropic wire-format `{ type: "adaptive" }` (or omit when disabled).
-      // Mirrors the non-callSite path in `agent/loop.ts` which sets
-      // `providerConfig.thinking = { type: "adaptive" }` only when enabled.
+      // Convert the schema-shape `{ enabled, streamThinking }` into Anthropic's
+      // discriminated wire-format (`{ type: "adaptive" | "disabled" }`).
       // Without this conversion, `thinking` arrives at `AnthropicProvider`
       // with a shape the SDK doesn't accept (`ThinkingConfigParam` requires
-      // a `type` discriminator), and OpenRouter's truthy check would treat
-      // a disabled config as enabled.
-      if (resolved.thinking?.enabled === true) {
-        nextConfig.thinking = { type: "adaptive" };
+      // a `type` discriminator).
+      const thinking = normalizeThinkingConfigForWire(resolved.thinking);
+      if (thinking !== undefined) {
+        nextConfig.thinking = thinking;
       }
     }
     // Forward OpenRouter-only routing preferences so `OpenRouterProvider` can
@@ -223,6 +225,7 @@ function normalizeSendMessageOptions(
   // and may support reasoning with forced tool_choice.
   const isThinkingForcedToolConflict = (() => {
     if (nextConfig.thinking == null) return false;
+    if (isThinkingConfigDisabled(nextConfig.thinking)) return false;
     const tc = nextConfig.tool_choice as Record<string, unknown> | undefined;
     if (tc == null || (tc.type !== "tool" && tc.type !== "any")) return false;
     if (providerName === "anthropic") return true;

--- a/assistant/src/providers/thinking-config.ts
+++ b/assistant/src/providers/thinking-config.ts
@@ -1,0 +1,34 @@
+type ThinkingConfigRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is ThinkingConfigRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeThinkingConfigForWire(
+  thinking: unknown,
+): ThinkingConfigRecord | undefined {
+  if (!isRecord(thinking)) return undefined;
+
+  if (typeof thinking.type === "string") {
+    return thinking;
+  }
+
+  if (thinking.enabled === true) {
+    return { type: "adaptive" };
+  }
+
+  if (thinking.enabled === false) {
+    return { type: "disabled" };
+  }
+
+  return undefined;
+}
+
+export function isThinkingConfigDisabled(thinking: unknown): boolean {
+  return normalizeThinkingConfigForWire(thinking)?.type === "disabled";
+}
+
+export function isThinkingConfigEnabled(thinking: unknown): boolean {
+  const normalized = normalizeThinkingConfigForWire(thinking);
+  return normalized !== undefined && normalized.type !== "disabled";
+}


### PR DESCRIPTION
## Summary
- Convert resolved `thinking.enabled: false` into Anthropic's explicit `{ type: "disabled" }` wire config.
- Preserve disabled thinking through forced tool-choice normalization while still stripping enabled thinking conflicts.
- Treat disabled thinking as `reasoning.enabled=false` for non-Anthropic OpenRouter models and pass it natively for Anthropic models on OpenRouter.

## Original prompt
When the config has thinking.enabled = false, we should pass thinking disabled for anthropic api calls. This should apply to the Anthropic provider, and to Anthropic models on OpenRouter
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
