### PR TITLE
fix(tests): rename acpSessionId to id in ACPSessionsPanel per-conv tests

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -246,21 +246,21 @@ final class ACPSessionsPanelTests: XCTestCase {
         let store = ACPSessionStore()
         injectFixture(
             into: store,
-            acpSessionId: "acp-conv-a-old",
+            id: "acp-conv-a-old",
             agentId: "claude-code",
             parentConversationId: "conv-a",
             startedAt: 100
         )
         injectFixture(
             into: store,
-            acpSessionId: "acp-conv-b",
+            id: "acp-conv-b",
             agentId: "codex",
             parentConversationId: "conv-b",
             startedAt: 200
         )
         injectFixture(
             into: store,
-            acpSessionId: "acp-conv-a-new",
+            id: "acp-conv-a-new",
             agentId: "claude-code",
             parentConversationId: "conv-a",
             startedAt: 300
@@ -286,14 +286,14 @@ final class ACPSessionsPanelTests: XCTestCase {
         let store = ACPSessionStore()
         injectFixture(
             into: store,
-            acpSessionId: "acp-other",
+            id: "acp-other",
             agentId: "codex",
             parentConversationId: "conv-other",
             startedAt: 100
         )
         injectFixture(
             into: store,
-            acpSessionId: "acp-active",
+            id: "acp-active",
             agentId: "claude-code",
             parentConversationId: "conv-active",
             startedAt: 200


### PR DESCRIPTION
## Summary
- Fixes the macOS Tests CI job failure on main: `extra argument 'acpSessionId' in call` / `missing argument for parameter 'id' in call` at `ACPSessionsPanelTests.swift:248-296`.
- PR #28346 renamed `injectFixture`'s parameter from `acpSessionId:` to `id:` and updated existing call sites, but five call sites inside the per-conversation tests added in #28307 were missed. This PR renames those five.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24952533782/job/73065079272
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
