### PR TITLE
fix(tests): assert state.id in ACPSessionsPanel filter tests

### DIFF
--- a/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Panels/ACPSessionsPanelTests.swift
@@ -268,12 +268,12 @@ final class ACPSessionsPanelTests: XCTestCase {
 
         let convA = store.sessions(forConversation: "conv-a")
         XCTAssertEqual(
-            convA.map(\.state.acpSessionId),
+            convA.map(\.state.id),
             ["acp-conv-a-new", "acp-conv-a-old"],
             "Filter must preserve newest-first ordering from sessionOrder"
         )
 
-        let convB = store.sessions(forConversation: "conv-b").map(\.state.acpSessionId)
+        let convB = store.sessions(forConversation: "conv-b").map(\.state.id)
         XCTAssertEqual(convB, ["acp-conv-b"])
 
         XCTAssertTrue(
@@ -315,7 +315,7 @@ final class ACPSessionsPanelTests: XCTestCase {
         // "This conversation" filter renders only the active conversation's
         // sessions.
         let scoped = store.sessions(forConversation: "conv-active")
-        XCTAssertEqual(scoped.map(\.state.acpSessionId), ["acp-active"])
+        XCTAssertEqual(scoped.map(\.state.id), ["acp-active"])
 
         // Toggling to `.all` persists across lookups.
         storage.setFilter(.all, for: "conv-active")
@@ -324,7 +324,7 @@ final class ACPSessionsPanelTests: XCTestCase {
 
         // With the filter switched off, the panel iterates `sessionOrder`
         // and shows every session newest-first.
-        let allSessions = store.sessionOrder.compactMap { store.sessions[$0]?.state.acpSessionId }
+        let allSessions = store.sessionOrder.compactMap { store.sessions[$0]?.state.id }
         XCTAssertEqual(allSessions, ["acp-active", "acp-other"])
 
         // A different conversation has its own preference and is unaffected.


### PR DESCRIPTION
## Summary
- Switch the four `test_sessionsForConversation_*` assertions from `\.state.acpSessionId` to `\.state.id`. The fixture helper sets `state.acpSessionId = "protocol-\(id)"` (matching the daemon's post-createSession diverged shape from #28346), so the filter tests were comparing the protocol-prefixed value against the unprefixed expected list and failing.
- Unblocks the macOS Tests job on main; the prior PR (#28353) only fixed the parameter-name compile error and missed the assertion sites.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/24953052580/job/73066470689
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
