### PR TITLE
Fix memory graph event date grounding

### DIFF
--- a/assistant/src/__tests__/db-memory-graph-event-date-repair.test.ts
+++ b/assistant/src/__tests__/db-memory-graph-event-date-repair.test.ts
@@ -1,0 +1,116 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import {
+  migrate231RepairMemoryGraphEventDates,
+  repairMemoryGraphEventDate,
+} from "../memory/migrations/231-repair-memory-graph-event-dates.js";
+import * as schema from "../memory/schema.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapTables(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE memory_graph_nodes (
+      id TEXT PRIMARY KEY,
+      created INTEGER NOT NULL,
+      event_date INTEGER
+    );
+
+    CREATE TABLE memory_graph_triggers (
+      id TEXT PRIMARY KEY,
+      node_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      event_date INTEGER
+    );
+  `);
+}
+
+function eventDateFor(raw: Database, nodeId: string): number | null {
+  const row = raw
+    .query(`SELECT event_date FROM memory_graph_nodes WHERE id = ?`)
+    .get(nodeId) as { event_date: number | null } | null;
+  return row?.event_date ?? null;
+}
+
+function triggerEventDateFor(raw: Database, triggerId: string): number | null {
+  const row = raw
+    .query(`SELECT event_date FROM memory_graph_triggers WHERE id = ?`)
+    .get(triggerId) as { event_date: number | null } | null;
+  return row?.event_date ?? null;
+}
+
+describe("repairMemoryGraphEventDate", () => {
+  test("repairs a nearby prior-year event date created in 2026", () => {
+    const created = Date.UTC(2026, 3, 26, 5, 23, 20);
+    const wrongEventDate = Date.UTC(2025, 3, 19, 2, 32, 0);
+
+    expect(repairMemoryGraphEventDate(created, wrongEventDate)).toBe(
+      Date.UTC(2026, 3, 19, 2, 32, 0),
+    );
+  });
+
+  test("leaves distant historical dates alone", () => {
+    const created = Date.UTC(2026, 3, 26, 5, 23, 20);
+    const historicalEventDate = Date.UTC(2025, 10, 1, 12, 0, 0);
+
+    expect(repairMemoryGraphEventDate(created, historicalEventDate)).toBeNull();
+  });
+});
+
+describe("migrate231RepairMemoryGraphEventDates", () => {
+  test("repairs bad node and trigger event dates idempotently", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapTables(raw);
+
+    const created = Date.UTC(2026, 3, 26, 5, 23, 20);
+    const wrongEventDate = Date.UTC(2025, 3, 19, 2, 32, 0);
+    const correctedEventDate = Date.UTC(2026, 3, 19, 2, 32, 0);
+    const distantHistoricalDate = Date.UTC(2025, 10, 1, 12, 0, 0);
+    const futureDate = Date.UTC(2027, 0, 1, 12, 0, 0);
+
+    raw
+      .prepare(
+        `INSERT INTO memory_graph_nodes (id, created, event_date) VALUES (?, ?, ?)`,
+      )
+      .run("bad-node", created, wrongEventDate);
+    raw
+      .prepare(
+        `INSERT INTO memory_graph_nodes (id, created, event_date) VALUES (?, ?, ?)`,
+      )
+      .run("historical-node", created, distantHistoricalDate);
+    raw
+      .prepare(
+        `INSERT INTO memory_graph_nodes (id, created, event_date) VALUES (?, ?, ?)`,
+      )
+      .run("future-node", created, futureDate);
+    raw
+      .prepare(
+        `INSERT INTO memory_graph_triggers (id, node_id, type, event_date) VALUES (?, ?, ?, ?)`,
+      )
+      .run("bad-trigger", "bad-node", "event", wrongEventDate);
+
+    migrate231RepairMemoryGraphEventDates(db);
+    migrate231RepairMemoryGraphEventDates(db);
+
+    expect(eventDateFor(raw, "bad-node")).toBe(correctedEventDate);
+    expect(triggerEventDateFor(raw, "bad-trigger")).toBe(correctedEventDate);
+    expect(eventDateFor(raw, "historical-node")).toBe(distantHistoricalDate);
+    expect(eventDateFor(raw, "future-node")).toBe(futureDate);
+  });
+});

--- a/assistant/src/__tests__/graph-extraction-event-date.test.ts
+++ b/assistant/src/__tests__/graph-extraction-event-date.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildAuthoritativeConversationTimestampBlock,
+  EVENT_DATE_PROMPT_RULES,
   parseEpochMs,
   parseExtractionResponse,
 } from "../memory/graph/extraction.js";
@@ -40,6 +42,34 @@ describe("parseEpochMs", () => {
 
   test("returns null for empty string", () => {
     expect(parseEpochMs("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// event_date prompt grounding
+// ---------------------------------------------------------------------------
+
+describe("event_date prompt grounding", () => {
+  test("conversation timestamp block includes local and ISO anchors", () => {
+    const timestamp = Date.UTC(2026, 3, 26, 18, 30, 0);
+    const block = buildAuthoritativeConversationTimestampBlock(timestamp);
+
+    expect(block).toContain("## Authoritative Conversation Timestamp");
+    expect(block).toContain("Local:");
+    expect(block).toContain("ISO: 2026-04-26T18:30:00.000Z");
+    expect(block).toContain(
+      "Use this timestamp when resolving relative or partial dates",
+    );
+  });
+
+  test("event date rules prefer the conversation year for partial dates", () => {
+    expect(EVENT_DATE_PROMPT_RULES).toContain(
+      "use the authoritative conversation year",
+    );
+    expect(EVENT_DATE_PROMPT_RULES).toContain(
+      "Never backdate a month/day-only reference into the prior year",
+    );
+    expect(EVENT_DATE_PROMPT_RULES).toContain("April 19 (Sunday night)");
   });
 });
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -36,6 +36,7 @@ import {
   createTasksAndWorkItemsTables,
   createWatchersAndLogsTables,
   migrate230AcpSessionHistory,
+  migrate231RepairMemoryGraphEventDates,
   migrateAddConversationInferenceProfile,
   migrateAddSourceTypeColumns,
   migrateAssistantContactMetadata,
@@ -386,6 +387,7 @@ export function initializeDb(): void {
     migrateRenameInferenceProfileSnakeCase,
     migrateDeletePrivateConversations,
     migrate230AcpSessionHistory,
+    migrate231RepairMemoryGraphEventDates,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -19,7 +19,11 @@ import {
 import { BackendUnavailableError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { getDb } from "../db.js";
-import { parseEpochMs } from "./extraction.js";
+import {
+  EVENT_DATE_PROMPT_RULES,
+  formatAuthoritativeConversationTimestamp,
+  parseEpochMs,
+} from "./extraction.js";
 import {
   createTrigger,
   deduplicateParagraphs,
@@ -77,16 +81,15 @@ function buildConsolidationPrompt(
           .join("\n")
       : "  (none)";
 
-  const today = new Date().toLocaleDateString("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  const currentTimestamp = formatAuthoritativeConversationTimestamp(Date.now());
 
   return `You are consolidating the "${partitionName}" partition of a memory graph. These are memories stored by an AI assistant about its conversations and relationship with a user.
 
-Today is ${today}.
+## Authoritative Current Timestamp
+
+${currentTimestamp}
+
+${EVENT_DATE_PROMPT_RULES}
 
 ## Your Tasks
 
@@ -150,7 +153,7 @@ const CONSOLIDATE_TOOL_SCHEMA = {
             event_date: {
               type: ["number", "null"] as const,
               description:
-                "Epoch ms of the event this memory describes. Preserve from merged duplicates when the survivor lacks one. Set to null to clear a stale event date.",
+                "Epoch ms of the event this memory describes. Resolve partial dates from the authoritative current timestamp and do not infer a prior year unless stated. Preserve from merged duplicates when the survivor lacks one. Set to null to clear a stale event date.",
             },
           },
           required: ["id"] as const,

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -57,6 +57,47 @@ const log = getLogger("graph-extraction");
 
 const EXTRACTION_SYSTEM_PROMPT_CHAR_BUDGET = 24_000;
 
+export const EVENT_DATE_PROMPT_RULES = `Event date grounding:
+- Treat the authoritative conversation timestamp as the only current date/time source. Do not use the model's built-in current date.
+- Resolve relative dates from that timestamp ("today", "tomorrow", "next Tuesday", "last week").
+- If the transcript gives a month/day or weekday/month/day without a year, use the authoritative conversation year unless the transcript explicitly says another year ("2025", "last year", "next year").
+- Never backdate a month/day-only reference into the prior year just because the event is in the past.
+- Sanity-check weekdays against the resolved year. For example, with an authoritative timestamp in 2026, "April 19 (Sunday night)" resolves to 2026-04-19, not 2025-04-19.
+- If the year is ambiguous after those checks, leave event_date null rather than guessing.`;
+
+export function formatAuthoritativeConversationTimestamp(
+  conversationTimestamp: number,
+): string {
+  const convDate = new Date(conversationTimestamp);
+  const timeZone =
+    Intl.DateTimeFormat().resolvedOptions().timeZone || "local time";
+  const localDate = convDate.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  const localTime = convDate.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+    timeZoneName: "short",
+  });
+
+  return `Local: ${localDate} at ${localTime} (${timeZone})\nISO: ${convDate.toISOString()}`;
+}
+
+export function buildAuthoritativeConversationTimestampBlock(
+  conversationTimestamp: number,
+): string {
+  return `## Authoritative Conversation Timestamp
+
+${formatAuthoritativeConversationTimestamp(conversationTimestamp)}
+
+Use this timestamp when resolving relative or partial dates in the transcript.`;
+}
+
 function buildGraphExtractionSystemPrompt(
   candidateNodes: Array<{ id: string; type: string; content: string }>,
   identityContext: string | null,
@@ -108,7 +149,10 @@ Do not: set the scene, describe surrounding context, preserve dialogue verbatim,
   - 0.9: Transformative moments, identity-defining events ("User said 'I love you' for the first time")
   - 1.0: RARE — reserve for the single most important memories. A graph of 1000 nodes should have fewer than 20 at 1.0.
 - **confidence**: 0-1. How sure are you this is accurate? Direct statements: 0.9+. Inferences: 0.4-0.7.
-- **event_date**: If this memory is anchored to a specific future date/time (flight, appointment, birthday, deadline, trip), provide the epoch ms. Use the conversation date above to resolve relative references ("next Tuesday", "tomorrow"). ALSO create a matching event trigger with the same date. Leave null for open-ended plans or recurring patterns.
+- **event_date**: If this memory is anchored to a specific calendar date/time, past or future (flight, appointment, birthday, deadline, trip, dated milestone), provide the epoch ms. For future dates, ALSO create a matching event trigger with the same date. Leave null for open-ended plans or recurring patterns.
+
+${EVENT_DATE_PROMPT_RULES}
+
 - **sourceType**: "direct" (user stated it), "inferred" (you derived it), "observed" (you noticed a pattern), "told-by-other".
 
 Also notice patterns in the ASSISTANT's own behavior — meta-memory. "I tend to skip verification when I'm confident." "I write more when I'm processing something big."
@@ -286,7 +330,7 @@ const EXTRACT_TOOL_SCHEMA = {
             event_date: {
               type: ["number", "null"],
               description:
-                "Epoch ms of the event date for calendar-anchored events (flights, appointments, birthdays, deadlines). Null for non-event memories.",
+                "Epoch ms for a calendar-anchored event. Resolve partial dates from the authoritative conversation timestamp and do not infer a prior year unless stated. Null for non-event memories.",
             },
             triggers: {
               type: "array",
@@ -384,7 +428,7 @@ const EXTRACT_TOOL_SCHEMA = {
             event_date: {
               type: ["number", "null"],
               description:
-                "Epoch ms of the event date. Use to update when an event is rescheduled. Set to null to clear.",
+                "Epoch ms of the event date. Resolve partial dates from the authoritative conversation timestamp. Use to update when an event is rescheduled. Set to null to clear.",
             },
           },
           required: ["id"],
@@ -1002,20 +1046,8 @@ export async function runGraphExtraction(
     imageResult?.lastTimestamp ??
     Date.now();
 
-  const convDate = new Date(conversationTimestamp);
-  const conversationDate =
-    convDate.toLocaleDateString("en-US", {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    }) +
-    " at " +
-    convDate.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
+  const conversationTimestampBlock =
+    buildAuthoritativeConversationTimestampBlock(conversationTimestamp);
 
   // 6. LLM call — use multimodal message when images are present
   const useMultimodal = imageResult?.hasImages === true;
@@ -1027,7 +1059,7 @@ export async function runGraphExtraction(
           content: [
             {
               type: "text" as const,
-              text: `## Conversation Date\n\n${conversationDate}\n\n## Conversation Transcript\n\n`,
+              text: `${conversationTimestampBlock}\n\n## Conversation Transcript\n\n`,
             },
             ...imageResult.message.content,
           ],
@@ -1035,7 +1067,7 @@ export async function runGraphExtraction(
       ]
     : [
         userMessage(
-          `## Conversation Date\n\n${conversationDate}\n\n## Conversation Transcript\n\n${transcript}`,
+          `${conversationTimestampBlock}\n\n## Conversation Transcript\n\n${transcript}`,
         ),
       ];
 

--- a/assistant/src/memory/migrations/231-repair-memory-graph-event-dates.ts
+++ b/assistant/src/memory/migrations/231-repair-memory-graph-event-dates.ts
@@ -1,0 +1,128 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_repair_memory_graph_event_dates_v1";
+const REPAIR_CREATED_YEAR = 2026;
+const CORRUPT_EVENT_YEARS = [2024, 2025] as const;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_CORRECTED_DISTANCE_MS = 120 * DAY_MS;
+
+interface GraphNodeEventDateRow {
+  id: string;
+  created: number;
+  event_date: number;
+}
+
+interface EventDateRepair {
+  id: string;
+  oldEventDate: number;
+  newEventDate: number;
+}
+
+function utcYear(epochMs: number): number {
+  return new Date(epochMs).getUTCFullYear();
+}
+
+function replaceUtcYear(epochMs: number, year: number): number {
+  const date = new Date(epochMs);
+  return Date.UTC(
+    year,
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+    date.getUTCMilliseconds(),
+  );
+}
+
+export function repairMemoryGraphEventDate(
+  createdMs: number,
+  eventDateMs: number,
+): number | null {
+  if (!Number.isFinite(createdMs) || !Number.isFinite(eventDateMs)) {
+    return null;
+  }
+
+  const createdYear = utcYear(createdMs);
+  const eventYear = utcYear(eventDateMs);
+  if (createdYear !== REPAIR_CREATED_YEAR) return null;
+  if (!CORRUPT_EVENT_YEARS.includes(eventYear as 2024 | 2025)) return null;
+
+  const corrected = replaceUtcYear(eventDateMs, createdYear);
+  if (corrected === eventDateMs) return null;
+
+  // This targets the observed extractor failure: a recent or near-future
+  // month/day was anchored to a prior year. Leave distant historical dates
+  // alone even if they are in 2024/2025.
+  if (Math.abs(corrected - createdMs) > MAX_CORRECTED_DISTANCE_MS) {
+    return null;
+  }
+
+  return corrected;
+}
+
+export function migrate231RepairMemoryGraphEventDates(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    const rows = raw
+      .query(
+        /*sql*/ `
+          SELECT id, created, event_date
+          FROM memory_graph_nodes
+          WHERE event_date IS NOT NULL
+            AND CAST(strftime('%Y', created / 1000, 'unixepoch') AS INTEGER) = ?
+            AND CAST(strftime('%Y', event_date / 1000, 'unixepoch') AS INTEGER) IN (?, ?)
+        `,
+      )
+      .all(
+        REPAIR_CREATED_YEAR,
+        ...CORRUPT_EVENT_YEARS,
+      ) as GraphNodeEventDateRow[];
+
+    const repairs: EventDateRepair[] = [];
+    for (const row of rows) {
+      const corrected = repairMemoryGraphEventDate(row.created, row.event_date);
+      if (corrected == null) continue;
+      repairs.push({
+        id: row.id,
+        oldEventDate: row.event_date,
+        newEventDate: corrected,
+      });
+    }
+
+    if (repairs.length === 0) return;
+
+    const updateNode = raw.prepare(/*sql*/ `
+        UPDATE memory_graph_nodes
+        SET event_date = ?
+        WHERE id = ?
+          AND event_date = ?
+      `);
+    const updateTrigger = raw.prepare(/*sql*/ `
+        UPDATE memory_graph_triggers
+        SET event_date = ?
+        WHERE node_id = ?
+          AND event_date = ?
+      `);
+
+    raw.exec("BEGIN");
+    try {
+      for (const repair of repairs) {
+        updateNode.run(repair.newEventDate, repair.id, repair.oldEventDate);
+        updateTrigger.run(repair.newEventDate, repair.id, repair.oldEventDate);
+      }
+      raw.exec("COMMIT");
+    } catch (error) {
+      try {
+        raw.exec("ROLLBACK");
+      } catch {
+        // No active transaction.
+      }
+      throw error;
+    }
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -176,6 +176,7 @@ export { migrateAddConversationInferenceProfile } from "./227-add-conversation-i
 export { migrateRenameInferenceProfileSnakeCase } from "./228-rename-inference-profile-snake-case.js";
 export { migrateDeletePrivateConversations } from "./229-delete-private-conversations.js";
 export { migrate230AcpSessionHistory } from "./230-acp-session-history.js";
+export { migrate231RepairMemoryGraphEventDates } from "./231-repair-memory-graph-event-dates.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Add authoritative timestamp and conversation-year guardrails to memory extraction and consolidation event_date prompts.
- Add a one-time graph-memory migration that repairs the 2026 prior-year event_date drift and matching event triggers.
- Cover the prompt grounding and repair migration with focused tests.

## Original prompt
this. also fix the bad memory items in the db
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
