### PR TITLE
build(setup): install iOS Simulator runtime via xcodebuild

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,25 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# iOS Simulator runtime: ensure the iOS platform is installed for xcodebuild
+#
+# The pre-push hook runs clients/ios/build.sh, which targets an iOS Simulator
+# destination. Without an installed iOS runtime, xcodebuild fails with:
+#   "iOS X.Y is not installed. Please download and install the platform from
+#    Xcode > Settings > Components."
+#
+# `xcodebuild -downloadPlatform iOS` (Xcode 15+) is idempotent — it's a no-op
+# when the latest runtime is already installed and a download otherwise.
+# ---------------------------------------------------------------------------
+if [ "$(uname)" = "Darwin" ] && command -v xcodebuild >/dev/null 2>&1; then
+  info "Ensuring iOS Simulator runtime is installed (xcodebuild -downloadPlatform iOS)"
+  info "  note: first-time install can be multi-GB and take several minutes"
+  xcodebuild -downloadPlatform iOS
+else
+  info "Skipping iOS Simulator runtime install (xcodebuild not available)"
+fi
+
+# ---------------------------------------------------------------------------
 # Install dependencies and register local packages as linkable
 # ---------------------------------------------------------------------------
 for dir in cli gateway assistant credential-executor; do


### PR DESCRIPTION
## Summary

- `setup.sh` now runs `xcodebuild -downloadPlatform iOS` after the existing iOS xcodegen step so contributors don't hit `iOS <version> is not installed` when the pre-push hook invokes `clients/ios/build.sh`.
- Gated on `uname = Darwin` and `command -v xcodebuild` so Linux contributors and Command Line Tools-only setups skip cleanly.
- The `xcodebuild -downloadPlatform iOS` command is idempotent (no-op when the runtime is current); a one-line warning notes the first-time download can be multi-GB.

## Original prompt

> /do those in parallel — fix iOS simulator runtime gap by adding xcodebuild -downloadPlatform iOS to setup.sh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
