### PR TITLE
Keep conversation starters in user voice

### DIFF
--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -9,6 +9,11 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../prompts/user-reference.js", () => ({
+  DEFAULT_USER_REFERENCE: "my human",
+  resolveUserReference: () => "Alice",
+}));
+
 import { getSqlite, initializeDb } from "../memory/db.js";
 import type { RouteParams } from "../runtime/http-router.js";
 import {
@@ -253,6 +258,74 @@ describe("GET /v1/conversation-starters", () => {
     expect(res.status).toBe(200);
     expect(body.status).toBe("refreshing");
     expect(body.starters).toHaveLength(1);
+    expect(countStarterJobs()).toBe(1);
+  });
+
+  test("filters assistant-voice starters and refreshes the batch", async () => {
+    const now = Date.now();
+    insertStarter({
+      label: "Let me check calendar",
+      prompt: "Let me check what Alice has today.",
+      category: "productivity",
+      createdAt: now,
+    });
+    insertStarter({
+      label: "Plan my morning",
+      prompt: "Can you help me plan my morning?",
+      category: "productivity",
+      createdAt: now - 1,
+    });
+    setCheckpoint("conversation_starters:last_gen_at:default", String(now));
+    setCheckpoint("conversation_starters:item_count_at_last_gen:default", "1");
+    insertMemoryItem();
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: Array<{ label: string }>;
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("refreshing");
+    expect(body.total).toBe(1);
+    expect(body.starters.map((starter) => starter.label)).toEqual([
+      "Plan my morning",
+    ]);
+    expect(countStarterJobs()).toBe(1);
+  });
+
+  test("filters current-user third-person starters", async () => {
+    const now = Date.now();
+    insertStarter({
+      label: "Catch up with Alice",
+      prompt: "What has Alice been thinking about today?",
+      category: "communication",
+      createdAt: now,
+    });
+    insertStarter({
+      label: "Catch me up",
+      prompt: "Can you catch me up on what you've been thinking about today?",
+      category: "communication",
+      createdAt: now - 1,
+    });
+    setCheckpoint("conversation_starters:last_gen_at:default", String(now));
+    setCheckpoint("conversation_starters:item_count_at_last_gen:default", "1");
+    insertMemoryItem();
+
+    const res = await dispatch("conversation-starters");
+    const body = (await res.json()) as {
+      starters: Array<{ label: string }>;
+      total: number;
+      status: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("refreshing");
+    expect(body.total).toBe(1);
+    expect(body.starters.map((starter) => starter.label)).toEqual([
+      "Catch me up",
+    ]);
     expect(countStarterJobs()).toBe(1);
   });
 

--- a/assistant/src/memory/conversation-starter-validation.ts
+++ b/assistant/src/memory/conversation-starter-validation.ts
@@ -1,0 +1,88 @@
+import {
+  DEFAULT_USER_REFERENCE,
+  resolveUserReference,
+} from "../prompts/user-reference.js";
+
+export interface ConversationStarterText {
+  label: string;
+  prompt: string;
+}
+
+export interface ConversationStarterValidationContext {
+  userReferences: string[];
+}
+
+const ASSISTANT_VOICE_PREFIXES = [
+  "let me",
+  "i['’]?ll",
+  "i will",
+  "i should",
+  "i can help",
+  "i can check",
+  "i can draft",
+  "i can organize",
+  "i can plan",
+  "i can summarize",
+  "you['’]?ve got",
+  "you have",
+  "your",
+].join("|");
+const ASSISTANT_VOICE_PATTERN = new RegExp(
+  `^(?:${ASSISTANT_VOICE_PREFIXES})\\b`,
+  "i",
+);
+
+export function buildConversationStarterValidationContext(): ConversationStarterValidationContext {
+  const reference = resolveUserReference();
+  const references = new Set<string>();
+
+  if (reference !== DEFAULT_USER_REFERENCE) {
+    references.add(reference);
+    const firstWord = reference.match(/[A-Za-z0-9][A-Za-z0-9'-]*/)?.[0];
+    if (firstWord && firstWord.length >= 2) {
+      references.add(firstWord);
+    }
+  }
+
+  return { userReferences: [...references] };
+}
+
+export function isValidConversationStarterText(
+  starter: ConversationStarterText,
+  context = buildConversationStarterValidationContext(),
+): boolean {
+  const label = starter.label.trim();
+  const prompt = starter.prompt.trim();
+
+  if (label.length === 0 || label.length > 40 || prompt.length === 0) {
+    return false;
+  }
+  if (isAssistantVoice(label) || isAssistantVoice(prompt)) {
+    return false;
+  }
+  if (
+    mentionsCurrentUser(label, context) ||
+    mentionsCurrentUser(prompt, context)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function isAssistantVoice(text: string): boolean {
+  return ASSISTANT_VOICE_PATTERN.test(text.trim());
+}
+
+function mentionsCurrentUser(
+  text: string,
+  context: ConversationStarterValidationContext,
+): boolean {
+  return context.userReferences.some((reference) =>
+    new RegExp(`\\b${escapeRegExp(reference)}\\b`, "i").test(text),
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/assistant/src/memory/job-handlers/conversation-starters.ts
+++ b/assistant/src/memory/job-handlers/conversation-starters.ts
@@ -19,6 +19,10 @@ import {
 } from "../../providers/provider-send-message.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
+import {
+  buildConversationStarterValidationContext,
+  isValidConversationStarterText,
+} from "../conversation-starter-validation.js";
 import { getDb } from "../db.js";
 import { asString } from "../job-utils.js";
 import type { MemoryJob } from "../jobs-store.js";
@@ -280,10 +284,10 @@ Bad → Good (ticket-speak → natural):
 Bad → Good (assistant voice → user voice):
 - "You've got a busy week ahead" → "Plan my week ahead"
 - "Let me check your calendar" → "Check my Thursday schedule"
-- "Catch up with <user's own name> today" → "Catch up with you today" (only the user's own name becomes "you" — third-party names like a colleague or friend stay as written)
+- "Catch up with <user's own name> today" → "Catch me up today" (the user's own name becomes me/my/I, never "you"; third-party names like a colleague or friend stay as written)
 
 Bad → Good (prompt in assistant's voice → prompt in user's voice):
-- "It's Saturday morning and I haven't connected with <user's own name> yet. Let me see what they've been up to." → "What have you been up to today? Let's catch up." (assistant narrating about the user → user speaking to assistant; only the user's own name becomes "you/I", names of other people are preserved)
+- "It's Saturday morning and I haven't connected with <user's own name> yet. Let me see what they've been up to." → "Let's catch up this morning; can you help me sort through what matters today?" (assistant narrating about the user → user speaking to assistant; only the user's own name becomes me/my/I, names of other people are preserved)
 - "<User's own name> has had a busy week — I should check in on how they're feeling." → "I've had a busy week — can we talk through how it went?"
 
 Bad → Good (incomplete phrase → complete):
@@ -364,14 +368,13 @@ Bad → Good (incomplete phrase → complete):
       return [];
     }
 
+    const validationContext = buildConversationStarterValidationContext();
     return input.starters
       .filter(
         (s) =>
           typeof s.label === "string" &&
-          s.label.length > 0 &&
-          s.label.length <= 40 &&
           typeof s.prompt === "string" &&
-          s.prompt.length > 0,
+          isValidConversationStarterText(s, validationContext),
       )
       .slice(0, 4)
       .map((s) => ({

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -8,6 +8,10 @@
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
+import {
+  buildConversationStarterValidationContext,
+  isValidConversationStarterText,
+} from "../../memory/conversation-starter-validation.js";
 import { getDb } from "../../memory/db.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import { rawGet } from "../../memory/raw-query.js";
@@ -187,12 +191,17 @@ function handleListConversationStarters(url: URL): Response {
     )
     .all();
 
-  const total = allItems.length;
+  const validationContext = buildConversationStarterValidationContext();
+  const validItems = allItems.filter((item) =>
+    isValidConversationStarterText(item, validationContext),
+  );
+  const invalidItemCount = allItems.length - validItems.length;
+  const total = validItems.length;
 
   // If starters exist, return them immediately. If the batch is stale or
   // the generation checkpoint is ahead of the current active memory count,
   // kick off a background refresh but keep the existing chips visible.
-  if (total > 0) {
+  if (allItems.length > 0) {
     const totalActive =
       rawGet<{ c: number }>(
         `SELECT COUNT(*) AS c FROM memory_graph_nodes WHERE fidelity != 'gone' AND scope_id = ?`,
@@ -219,14 +228,17 @@ function handleListConversationStarters(url: URL): Response {
       Date.now() - lastGenAt >= CONVERSATION_STARTERS_STALE_TTL_MS;
     const checkpointAhead = lastCount != null && totalActive < lastCount;
     let hasActiveJob = hasActiveConversationStarterJob(db, scopeId);
-    const shouldRefresh = staleByAge || checkpointAhead;
+    const shouldRefresh =
+      staleByAge ||
+      checkpointAhead ||
+      (invalidItemCount > 0 && totalActive > 0);
 
     if (shouldRefresh && !hasActiveJob) {
       enqueueMemoryJob("generate_conversation_starters", { scopeId });
       hasActiveJob = true;
     }
 
-    const ordered = orderStrongestFirst(allItems);
+    const ordered = orderStrongestFirst(validItems);
     const page = ordered.slice(offsetParam, offsetParam + limitParam);
     return Response.json({
       starters: page,


### PR DESCRIPTION
## Summary
- Keep generated conversation starter labels and prompts in the user's voice before storing them.
- Filter legacy assistant-voice starter rows out of list responses and refresh affected batches.
- Add route coverage for assistant-voice and current-user third-person starter bugs.

## Original prompt
--skip-ci --yolo it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
