### PR TITLE
fix: rule editor modal closing when assistant message arrives

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -31,15 +31,14 @@ struct AssistantProgressView: View {
     /// expansion, override, and rehydration tracking survive view recycling.
     @Binding var progressUIState: ProgressCardUIState
 
+    @Binding var suggestRuleToolCall: ToolCallData?
+    @Binding var suggestRuleSuggestion: TrustRuleSuggestion?
+
     @State private var isExpanded: Bool
     @State private var startDate: Date
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
     @State private var suppressNextExpand: Bool = false
-    /// Tool call that triggered the suggestion-driven rule editor (from "Allow & Create Rule").
-    @State private var suggestRuleToolCall: ToolCallData?
-    /// LLM-generated suggestion returned from the suggest API.
-    @State private var suggestRuleSuggestion: TrustRuleSuggestion?
     /// When the post-tool-completion thinking phase started (typically the last
     /// tool's `completedAt`). Nil until all tools complete and the card remains active.
     @State private var thinkingAfterToolsStartDate: Date?
@@ -69,7 +68,9 @@ struct AssistantProgressView: View {
         onAlwaysAllow: ((String, String, String, String) -> Void)? = nil,
         onTemporaryAllow: ((String, String) -> Void)? = nil,
         activeConfirmationRequestId: String? = nil,
-        progressUIState: Binding<ProgressCardUIState>
+        progressUIState: Binding<ProgressCardUIState>,
+        suggestRuleToolCall: Binding<ToolCallData?> = .constant(nil),
+        suggestRuleSuggestion: Binding<TrustRuleSuggestion?> = .constant(nil)
     ) {
         self.toolCalls = toolCalls
         self.isStreaming = isStreaming
@@ -86,6 +87,8 @@ struct AssistantProgressView: View {
         self.onTemporaryAllow = onTemporaryAllow
         self.activeConfirmationRequestId = activeConfirmationRequestId
         self._progressUIState = progressUIState
+        self._suggestRuleToolCall = suggestRuleToolCall
+        self._suggestRuleSuggestion = suggestRuleSuggestion
         let model = ProgressCardPresentationModel.build(
             toolCalls: toolCalls,
             decidedConfirmations: decidedConfirmations,
@@ -299,35 +302,6 @@ struct AssistantProgressView: View {
         }
         .onAppear {
             handleOnAppear()
-        }
-        .sheet(item: $suggestRuleToolCall) { tc in
-            V3RuleEditorModal(
-                toolName: tc.toolName,
-                commandText: tc.inputSummary,
-                commandDescription: tc.reasonDescription ?? "",
-                riskLevel: tc.riskLevel ?? "medium",
-                scopeOptions: ToolCallStepDetailRow.v3ScopeOptions(from: tc),
-                directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
-                suggestion: suggestRuleSuggestion,
-                onSave: { rule in
-                    Task {
-                        try? await TrustRuleV3Client().createRule(
-                            tool: rule.toolName,
-                            pattern: rule.pattern,
-                            risk: rule.riskLevel,
-                            description: {
-                                let desc = tc.reasonDescription ?? ""
-                                return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
-                            }(),
-                            scope: rule.scope
-                        )
-                    }
-                },
-                onDismiss: {
-                    suggestRuleToolCall = nil
-                    suggestRuleSuggestion = nil
-                }
-            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -122,6 +122,11 @@ struct ChatBubble: View, Equatable {
     /// path switch that destroys and recreates AssistantProgressView mid-stream.
     @State var progressUIState: ProgressCardUIState = ProgressCardUIState()
 
+    /// Rule editor modal state. Lives here (not in AssistantProgressView)
+    /// so the modal survives the trailing→interleaved rendering path switch.
+    @State var suggestRuleToolCall: ToolCallData?
+    @State var suggestRuleSuggestion: TrustRuleSuggestion?
+
     init(
         message: ChatMessage,
         decidedConfirmation: ToolConfirmationData?,
@@ -450,6 +455,35 @@ struct ChatBubble: View, Equatable {
             if !isUser { Spacer(minLength: 0) }
         }
         .contentShape(Rectangle())
+        .sheet(item: $suggestRuleToolCall) { tc in
+            V3RuleEditorModal(
+                toolName: tc.toolName,
+                commandText: tc.inputSummary,
+                commandDescription: tc.reasonDescription ?? "",
+                riskLevel: tc.riskLevel ?? "medium",
+                scopeOptions: ToolCallStepDetailRow.v3ScopeOptions(from: tc),
+                directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
+                suggestion: suggestRuleSuggestion,
+                onSave: { rule in
+                    Task {
+                        try? await TrustRuleV3Client().createRule(
+                            tool: rule.toolName,
+                            pattern: rule.pattern,
+                            risk: rule.riskLevel,
+                            description: {
+                                let desc = tc.reasonDescription ?? ""
+                                return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
+                            }(),
+                            scope: rule.scope
+                        )
+                    }
+                },
+                onDismiss: {
+                    suggestRuleToolCall = nil
+                    suggestRuleSuggestion = nil
+                }
+            )
+        }
         .onChange(of: message.contentOrder) { _, _ in recomputeInterleavedContentCache() }
         .onChange(of: message.textSegments) { _, _ in recomputeInterleavedContentCache() }
         .onHover { hovering in

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -343,7 +343,9 @@ extension ChatBubble {
                     onAlwaysAllow: onAlwaysAllow,
                     onTemporaryAllow: onTemporaryAllow,
                     activeConfirmationRequestId: activeConfirmationRequestId,
-                    progressUIState: $progressUIState
+                    progressUIState: $progressUIState,
+                    suggestRuleToolCall: $suggestRuleToolCall,
+                    suggestRuleSuggestion: $suggestRuleSuggestion
                 )
                 Spacer(minLength: 0)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -52,7 +52,9 @@ extension ChatBubble {
                     onAlwaysAllow: onAlwaysAllow,
                     onTemporaryAllow: onTemporaryAllow,
                     activeConfirmationRequestId: activeConfirmationRequestId,
-                    progressUIState: $progressUIState
+                    progressUIState: $progressUIState,
+                    suggestRuleToolCall: $suggestRuleToolCall,
+                    suggestRuleSuggestion: $suggestRuleSuggestion
                 )
                 Spacer(minLength: 0)
             }


### PR DESCRIPTION
## Summary
- The "Approve and create rule" modal was closing prematurely when the next assistant message streamed in
- Root cause: the modal's `@State` lived on `AssistantProgressView`, which gets destroyed and recreated mid-stream when `ChatBubble` switches from the trailing to interleaved rendering path (text appears after tool calls)
- Fix: hoist `suggestRuleToolCall` and `suggestRuleSuggestion` to `ChatBubble` as `@State`, pass down as `@Binding`, and attach the `.sheet` at the `ChatBubble` level — the same pattern already used for `progressUIState`

## Original prompt
When I click "Approve and create rule" in macos I'm shown a modal but that modal closes when the next assistant message comes through before I have time to act. Help me find the root cause
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
