### PR TITLE
fix: resolve macOS build warnings/errors from v3 trust rule rename

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -456,7 +456,7 @@ struct ChatBubble: View, Equatable {
         }
         .contentShape(Rectangle())
         .sheet(item: $suggestRuleToolCall) { tc in
-            V3RuleEditorModal(
+            RuleEditorModal(
                 toolName: tc.toolName,
                 commandText: tc.inputSummary,
                 commandDescription: tc.reasonDescription ?? "",
@@ -466,13 +466,16 @@ struct ChatBubble: View, Equatable {
                 suggestion: suggestRuleSuggestion,
                 onSave: { rule in
                     Task {
-                        try? await TrustRuleV3Client().createRule(
+                        try? await TrustRuleClient().createRule(
                             tool: rule.toolName,
                             pattern: rule.pattern,
                             risk: rule.riskLevel,
                             description: {
                                 let desc = tc.reasonDescription ?? ""
-                                return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
+                                if desc.isEmpty {
+                                    return rule.toolName + " — " + rule.pattern
+                                }
+                                return desc
                             }(),
                             scope: rule.scope
                         )

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2054,7 +2054,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         let risk = decision == "deny" ? "high" : "low"
         Task {
             do {
-                try await trustRuleClient.createRule(
+                _ = try await trustRuleClient.createRule(
                     tool: toolName,
                     pattern: pattern,
                     risk: risk,


### PR DESCRIPTION
## Summary

- Fixes build errors in `ChatBubble.swift` where `V3RuleEditorModal` and `TrustRuleV3Client` were referenced but no longer exist after the v3 canonicalization rename (#28376) — updated to `RuleEditorModal` and `TrustRuleClient`
- Fixes compiler type-check timeout by replacing ternary string interpolation with explicit `if`/`else`
- Suppresses unused-result warning on `createRule()` in `ChatViewModel.swift` with `_ =`

## Original prompt
help me fix these macos build warnings/errors from the v3 trust rule rename
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
