### PR TITLE
chore: remove residual V3 prefixes from trust rule types

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -309,7 +309,7 @@ struct AssistantProgressView: View {
                 commandText: tc.inputSummary,
                 commandDescription: tc.reasonDescription ?? "",
                 riskLevel: tc.riskLevel ?? "medium",
-                scopeOptions: ToolCallStepDetailRow.v3ScopeOptions(from: tc),
+                scopeOptions: ToolCallStepDetailRow.scopeOptions(from: tc),
                 directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
                 suggestion: suggestRuleSuggestion,
                 onSave: { rule in
@@ -961,7 +961,7 @@ struct ToolCallStepDetailRow: View {
                 commandText: tc.inputSummary,
                 commandDescription: tc.reasonDescription ?? "",
                 riskLevel: tc.riskLevel ?? "medium",
-                scopeOptions: Self.v3ScopeOptions(from: tc),
+                scopeOptions: Self.scopeOptions(from: tc),
                 directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
                 suggestion: ruleEditorSuggestion,
                 onSave: { rule in
@@ -1106,19 +1106,19 @@ struct ToolCallStepDetailRow: View {
 
     // MARK: - Scope Options
 
-    /// Constructs the V3 scope option items from the tool call's risk scope options.
+    /// Constructs scope option items from the tool call's risk scope options.
     /// Falls back to a single exact command option when none are provided.
-    static func v3ScopeOptions(from toolCall: ToolCallData) -> [V3ScopeOptionItem] {
+    static func scopeOptions(from toolCall: ToolCallData) -> [ScopeOptionItem] {
         guard let options = toolCall.riskScopeOptions, !options.isEmpty else {
             return [
-                V3ScopeOptionItem(
+                ScopeOptionItem(
                     label: toolCall.inputSummary,
                     pattern: toolCall.inputSummary
                 )
             ]
         }
         return options.map { option in
-            V3ScopeOptionItem(
+            ScopeOptionItem(
                 label: option.label,
                 pattern: option.pattern
             )

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -461,7 +461,7 @@ struct ChatBubble: View, Equatable {
                 commandText: tc.inputSummary,
                 commandDescription: tc.reasonDescription ?? "",
                 riskLevel: tc.riskLevel ?? "medium",
-                scopeOptions: ToolCallStepDetailRow.v3ScopeOptions(from: tc),
+                scopeOptions: ToolCallStepDetailRow.scopeOptions(from: tc),
                 directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
                 suggestion: suggestRuleSuggestion,
                 onSave: { rule in

--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -3,13 +3,13 @@ import VellumAssistantShared
 
 // MARK: - Helper Types
 
-struct V3ScopeOptionItem: Identifiable, Equatable {
+struct ScopeOptionItem: Identifiable, Equatable {
     let id = UUID()
     let label: String
     let pattern: String
 }
 
-struct V3SavedRule {
+struct SavedRule {
     let toolName: String
     let pattern: String
     let riskLevel: String
@@ -26,11 +26,11 @@ struct RuleEditorModal: View {
     let commandText: String
     let commandDescription: String
     let riskLevel: String
-    let scopeOptions: [V3ScopeOptionItem]
+    let scopeOptions: [ScopeOptionItem]
     let directoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]
     /// Optional LLM-generated suggestion used to pre-populate selections.
     let suggestion: TrustRuleSuggestion?
-    let onSave: (V3SavedRule) -> Void
+    let onSave: (SavedRule) -> Void
     let onDismiss: () -> Void
 
     @State private var selectedPatternIndex: Int = 1 // Start from first generalization (skip exact match at index 0)
@@ -41,7 +41,7 @@ struct RuleEditorModal: View {
     /// Generalized pattern options.
     /// If scopeOptions has multiple elements, skip the exact match at index 0.
     /// If scopeOptions has only 1 element (single wildcard), show it directly.
-    private var generalizedOptions: [V3ScopeOptionItem] {
+    private var generalizedOptions: [ScopeOptionItem] {
         scopeOptions.count > 1 ? Array(scopeOptions.dropFirst()) : scopeOptions
     }
 
@@ -208,7 +208,7 @@ struct RuleEditorModal: View {
     }
 
     @ViewBuilder
-    private func patternRow(option: V3ScopeOptionItem, index: Int) -> some View {
+    private func patternRow(option: ScopeOptionItem, index: Int) -> some View {
         // If single option, map directly to index 0. Otherwise, offset by 1 since we skip index 0.
         let targetIndex = isSingleOption ? index : index + 1
         Button {
@@ -357,7 +357,7 @@ struct RuleEditorModal: View {
                     }
                     return "everywhere"
                 }()
-                let rule = V3SavedRule(
+                let rule = SavedRule(
                     toolName: toolName,
                     pattern: selectedOption.pattern,
                     riskLevel: selectedRiskLevel,


### PR DESCRIPTION
## Summary

- Renames `V3ScopeOptionItem` → `ScopeOptionItem`, `V3SavedRule` → `SavedRule`, and `v3ScopeOptions()` → `scopeOptions()` across `RuleEditorModal.swift`, `AssistantProgressView.swift`, and `ChatBubble.swift`
- Completes the v3 name canonicalization started in #28376 and flagged during review of #28383

## Original prompt
Follow-up from review feedback on #28383 — clean up remaining V3-prefixed identifiers
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
