### PR TITLE
feat(memory): register memory-v2-enabled feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -368,6 +368,14 @@
       "label": "Compaction Playground",
       "description": "Expose the developer-only Compaction Playground tab in macOS Settings and enable the /playground/* HTTP endpoints for exercising compaction conditions. Dev-only; default off.",
       "defaultEnabled": false
+    },
+    {
+      "id": "memory-v2-enabled",
+      "scope": "assistant",
+      "key": "memory-v2-enabled",
+      "label": "Memory v2 (concept-page activation model)",
+      "description": "Enables the v2 memory subsystem: prose concept pages with bidirectional edges, activation-based retrieval, and hourly LLM-driven consolidation. v1 graph + PKB stays write-active until cutover.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the assistant-scope feature flag \`memory-v2-enabled\` (default \`false\`) to \`meta/feature-flags/feature-flag-registry.json\`.
- The flag will gate every v2 memory subsystem code path landed by subsequent PRs. No behavior changes ship in this PR.
- Companion Terraform PR in \`vellum-assistant-platform\` is tracked separately per \`meta/feature-flags/AGENTS.md\`.

Part of plan: memory-v2.md (PR 1 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
