### PR TITLE
feat(memory): add memory.v2 config schema with tunable activation params

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+
+import { MemoryConfigSchema } from "../memory.js";
+import { MemoryV2ConfigSchema } from "../memory-v2.js";
+
+describe("MemoryV2ConfigSchema", () => {
+  test("parses an empty object to documented defaults", () => {
+    const parsed = MemoryV2ConfigSchema.parse({});
+    expect(parsed).toEqual({
+      enabled: false,
+      d: 0.3,
+      c_user: 0.3,
+      c_assistant: 0.2,
+      c_now: 0.2,
+      k: 0.5,
+      hops: 2,
+      top_k: 20,
+      epsilon: 0.01,
+      dense_weight: 0.7,
+      sparse_weight: 0.3,
+      consolidation_interval_hours: 1,
+      max_page_chars: 5000,
+    });
+  });
+
+  test("defaults satisfy both weight-sum constraints", () => {
+    const parsed = MemoryV2ConfigSchema.parse({});
+    expect(parsed.d + parsed.c_user + parsed.c_assistant + parsed.c_now).toBe(
+      1,
+    );
+    expect(parsed.dense_weight + parsed.sparse_weight).toBe(1);
+  });
+
+  test("accepts an explicit override that still sums to 1.0", () => {
+    const parsed = MemoryV2ConfigSchema.parse({
+      d: 0.4,
+      c_user: 0.3,
+      c_assistant: 0.2,
+      c_now: 0.1,
+    });
+    expect(parsed.d).toBe(0.4);
+    expect(parsed.c_user).toBe(0.3);
+    expect(parsed.c_assistant).toBe(0.2);
+    expect(parsed.c_now).toBe(0.1);
+  });
+
+  test("accepts hybrid weights that still sum to 1.0", () => {
+    const parsed = MemoryV2ConfigSchema.parse({
+      dense_weight: 0.5,
+      sparse_weight: 0.5,
+    });
+    expect(parsed.dense_weight).toBe(0.5);
+    expect(parsed.sparse_weight).toBe(0.5);
+  });
+
+  test("rejects activation weights that do not sum to 1.0", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({
+        d: 0.5,
+        c_user: 0.5,
+        c_assistant: 0.5,
+        c_now: 0.5,
+      }),
+    ).toThrow(/activation weights/);
+  });
+
+  test("rejects activation weights that sum to less than 1.0", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({
+        d: 0.1,
+        c_user: 0.1,
+        c_assistant: 0.1,
+        c_now: 0.1,
+      }),
+    ).toThrow(/activation weights/);
+  });
+
+  test("rejects hybrid weights that do not sum to 1.0", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({
+        dense_weight: 0.8,
+        sparse_weight: 0.5,
+      }),
+    ).toThrow(/hybrid weights/);
+  });
+
+  test("allows weight sums within the 0.001 tolerance and rejects beyond it", () => {
+    // Just inside the tolerance (gap ~0.0005) — accepted.
+    const ok = MemoryV2ConfigSchema.parse({
+      d: 0.3005,
+      c_user: 0.3,
+      c_assistant: 0.2,
+      c_now: 0.2,
+    });
+    expect(ok.d).toBe(0.3005);
+
+    // Beyond the tolerance (gap = 0.005) — rejected.
+    expect(() =>
+      MemoryV2ConfigSchema.parse({
+        d: 0.305,
+        c_user: 0.3,
+        c_assistant: 0.2,
+        c_now: 0.2,
+      }),
+    ).toThrow(/activation weights/);
+  });
+
+  test("rejects negative weight values", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({
+        d: -0.1,
+        c_user: 0.4,
+        c_assistant: 0.4,
+        c_now: 0.3,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer hops", () => {
+    expect(() => MemoryV2ConfigSchema.parse({ hops: 1.5 })).toThrow();
+  });
+
+  test("rejects zero or negative top_k", () => {
+    expect(() => MemoryV2ConfigSchema.parse({ top_k: 0 })).toThrow();
+    expect(() => MemoryV2ConfigSchema.parse({ top_k: -5 })).toThrow();
+  });
+
+  test("rejects zero or negative consolidation_interval_hours", () => {
+    expect(() =>
+      MemoryV2ConfigSchema.parse({ consolidation_interval_hours: 0 }),
+    ).toThrow();
+  });
+
+  test("rejects zero or negative max_page_chars", () => {
+    expect(() => MemoryV2ConfigSchema.parse({ max_page_chars: 0 })).toThrow();
+  });
+
+  test("rejects non-boolean enabled", () => {
+    expect(() => MemoryV2ConfigSchema.parse({ enabled: "yes" })).toThrow();
+  });
+
+  test("rejects epsilon outside [0, 1]", () => {
+    expect(() => MemoryV2ConfigSchema.parse({ epsilon: -0.01 })).toThrow();
+    expect(() => MemoryV2ConfigSchema.parse({ epsilon: 1.5 })).toThrow();
+  });
+});
+
+describe("MemoryConfigSchema integration with v2 block", () => {
+  test("parses an empty memory config and includes a v2 block with defaults", () => {
+    const parsed = MemoryConfigSchema.parse({});
+    expect(parsed.v2).toBeDefined();
+    expect(parsed.v2.enabled).toBe(false);
+    expect(parsed.v2.d).toBe(0.3);
+    expect(parsed.v2.dense_weight).toBe(0.7);
+    expect(parsed.v2.sparse_weight).toBe(0.3);
+    expect(parsed.v2.consolidation_interval_hours).toBe(1);
+    expect(parsed.v2.max_page_chars).toBe(5000);
+  });
+
+  test("propagates v2 overrides through MemoryConfigSchema", () => {
+    const parsed = MemoryConfigSchema.parse({
+      v2: { enabled: true, top_k: 50 },
+    });
+    expect(parsed.v2.enabled).toBe(true);
+    expect(parsed.v2.top_k).toBe(50);
+    // Non-overridden v2 fields keep their defaults.
+    expect(parsed.v2.d).toBe(0.3);
+  });
+
+  test("rejects invalid v2 weights when nested in MemoryConfigSchema", () => {
+    expect(() =>
+      MemoryConfigSchema.parse({
+        v2: {
+          d: 0.5,
+          c_user: 0.5,
+          c_assistant: 0.5,
+          c_now: 0.5,
+        },
+      }),
+    ).toThrow(/activation weights/);
+  });
+});

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+
+/**
+ * Tolerance for floating-point comparisons of weight sums. Using 0.001 lets
+ * users specify weights to three decimal places without spurious rejections,
+ * while still catching obvious mis-sums.
+ */
+const WEIGHT_SUM_TOLERANCE = 0.001;
+
+/**
+ * Memory v2 (concept-page activation model) configuration.
+ *
+ * Activation weights (`d`, `c_user`, `c_assistant`, `c_now`) must sum to 1.0
+ * because they form a convex combination in the per-turn activation formula:
+ *   A_o = d·prev + c_user·sim_u + c_assistant·sim_a + c_now·sim_n
+ *
+ * Hybrid retrieval weights (`dense_weight`, `sparse_weight`) must likewise
+ * sum to 1.0 since they fuse normalized dense and sparse similarity scores.
+ */
+export const MemoryV2ConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "memory.v2.enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether the v2 memory subsystem (concept-page activation model) is enabled. Independent of the memory-v2-enabled feature flag — both must be true for v2 to run.",
+      ),
+    d: z
+      .number({ error: "memory.v2.d must be a number" })
+      .min(0, "memory.v2.d must be >= 0")
+      .max(1, "memory.v2.d must be <= 1")
+      .default(0.3)
+      .describe(
+        "Decay weight on prior activation in the per-turn activation formula",
+      ),
+    c_user: z
+      .number({ error: "memory.v2.c_user must be a number" })
+      .min(0, "memory.v2.c_user must be >= 0")
+      .max(1, "memory.v2.c_user must be <= 1")
+      .default(0.3)
+      .describe(
+        "Weight on similarity to the latest user message in the per-turn activation formula",
+      ),
+    c_assistant: z
+      .number({ error: "memory.v2.c_assistant must be a number" })
+      .min(0, "memory.v2.c_assistant must be >= 0")
+      .max(1, "memory.v2.c_assistant must be <= 1")
+      .default(0.2)
+      .describe(
+        "Weight on similarity to the latest assistant message in the per-turn activation formula",
+      ),
+    c_now: z
+      .number({ error: "memory.v2.c_now must be a number" })
+      .min(0, "memory.v2.c_now must be >= 0")
+      .max(1, "memory.v2.c_now must be <= 1")
+      .default(0.2)
+      .describe(
+        "Weight on similarity to NOW context (essentials/threads/recent) in the per-turn activation formula",
+      ),
+    k: z
+      .number({ error: "memory.v2.k must be a number" })
+      .min(0, "memory.v2.k must be >= 0")
+      .max(1, "memory.v2.k must be <= 1")
+      .default(0.5)
+      .describe(
+        "Spreading-activation propagation coefficient — fraction of own activation that flows to neighbors per hop",
+      ),
+    hops: z
+      .number({ error: "memory.v2.hops must be a number" })
+      .int("memory.v2.hops must be an integer")
+      .nonnegative("memory.v2.hops must be non-negative")
+      .default(2)
+      .describe(
+        "Maximum BFS distance for spreading activation across the concept graph",
+      ),
+    top_k: z
+      .number({ error: "memory.v2.top_k must be a number" })
+      .int("memory.v2.top_k must be an integer")
+      .positive("memory.v2.top_k must be a positive integer")
+      .default(20)
+      .describe(
+        "Number of top-activation concept pages considered for injection per turn",
+      ),
+    epsilon: z
+      .number({ error: "memory.v2.epsilon must be a number" })
+      .min(0, "memory.v2.epsilon must be >= 0")
+      .max(1, "memory.v2.epsilon must be <= 1")
+      .default(0.01)
+      .describe(
+        "Activation cutoff — slugs with activation <= epsilon are dropped from the persisted state",
+      ),
+    dense_weight: z
+      .number({ error: "memory.v2.dense_weight must be a number" })
+      .min(0, "memory.v2.dense_weight must be >= 0")
+      .max(1, "memory.v2.dense_weight must be <= 1")
+      .default(0.7)
+      .describe(
+        "Weight on dense (cosine) similarity in the hybrid retrieval score",
+      ),
+    sparse_weight: z
+      .number({ error: "memory.v2.sparse_weight must be a number" })
+      .min(0, "memory.v2.sparse_weight must be >= 0")
+      .max(1, "memory.v2.sparse_weight must be <= 1")
+      .default(0.3)
+      .describe(
+        "Weight on sparse (BM25-style) similarity in the hybrid retrieval score",
+      ),
+    consolidation_interval_hours: z
+      .number({
+        error: "memory.v2.consolidation_interval_hours must be a number",
+      })
+      .int("memory.v2.consolidation_interval_hours must be an integer")
+      .positive(
+        "memory.v2.consolidation_interval_hours must be a positive integer",
+      )
+      .default(1)
+      .describe(
+        "Hours between scheduled consolidation runs that synthesize buffered memories into concept pages",
+      ),
+    max_page_chars: z
+      .number({ error: "memory.v2.max_page_chars must be a number" })
+      .int("memory.v2.max_page_chars must be an integer")
+      .positive("memory.v2.max_page_chars must be a positive integer")
+      .default(5000)
+      .describe(
+        "Soft upper bound on concept-page body length — pages exceeding this are flagged for split during consolidation",
+      ),
+  })
+  .describe(
+    "Memory v2 — concept-page activation model with hourly LLM-driven consolidation",
+  )
+  .superRefine((config, ctx) => {
+    const activationSum =
+      config.d + config.c_user + config.c_assistant + config.c_now;
+    if (Math.abs(activationSum - 1.0) >= WEIGHT_SUM_TOLERANCE) {
+      const message = `memory.v2 activation weights (d + c_user + c_assistant + c_now) must sum to 1.0 (got ${activationSum.toFixed(4)})`;
+      // Emit on every contributing field so validateWithSchema's
+      // delete-and-retry repair can strip the offending values and fall
+      // back to the documented defaults rather than wiping the whole v2
+      // block.
+      for (const path of ["d", "c_user", "c_assistant", "c_now"] as const) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [path],
+          message,
+        });
+      }
+    }
+    const hybridSum = config.dense_weight + config.sparse_weight;
+    if (Math.abs(hybridSum - 1.0) >= WEIGHT_SUM_TOLERANCE) {
+      const message = `memory.v2 hybrid weights (dense_weight + sparse_weight) must sum to 1.0 (got ${hybridSum.toFixed(4)})`;
+      for (const path of ["dense_weight", "sparse_weight"] as const) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [path],
+          message,
+        });
+      }
+    }
+  });
+
+export type MemoryV2Config = z.infer<typeof MemoryV2ConfigSchema>;

--- a/assistant/src/config/schemas/memory.ts
+++ b/assistant/src/config/schemas/memory.ts
@@ -15,6 +15,7 @@ import {
   MemorySegmentationConfigSchema,
   QdrantConfigSchema,
 } from "./memory-storage.js";
+import { MemoryV2ConfigSchema } from "./memory-v2.js";
 
 export const MemoryConfigSchema = z
   .object({
@@ -45,6 +46,7 @@ export const MemoryConfigSchema = z
     summarization: MemorySummarizationConfigSchema.default(
       MemorySummarizationConfigSchema.parse({}),
     ),
+    v2: MemoryV2ConfigSchema.default(MemoryV2ConfigSchema.parse({})),
   })
   .describe(
     "Long-term memory system — stores, retrieves, and manages persistent knowledge across conversations",


### PR DESCRIPTION
## Summary
- Adds `MemoryV2ConfigSchema` with all activation/retrieval/consolidation knobs and a `superRefine` enforcing both weight-sum invariants (within a 0.001 tolerance).
- Wires the new schema into `MemoryConfigSchema` as a defaulted `v2` block — existing configs round-trip unchanged.
- Tests cover defaults, both weight-sum violations, the tolerance boundary, type-level rejections, and integration with the parent schema.

Part of plan: memory-v2.md (PR 2 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
