### PR TITLE
feat(memory): add activation_state table for v2 retrieval persistence

### DIFF
--- a/assistant/src/__tests__/db-activation-state.test.ts
+++ b/assistant/src/__tests__/db-activation-state.test.ts
@@ -1,0 +1,240 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import {
+  downActivationState,
+  migrateActivationState,
+} from "../memory/migrations/232-activation-state.js";
+import * as schema from "../memory/schema.js";
+
+interface TableRow {
+  name: string;
+}
+
+interface ColumnRow {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapCheckpointsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+describe("activation_state migration", () => {
+  test("creates table with expected columns", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateActivationState(db);
+
+    const tableRow = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='activation_state'`,
+      )
+      .get() as TableRow | null;
+    expect(tableRow?.name).toBe("activation_state");
+
+    const columns = raw
+      .query(`PRAGMA table_info(activation_state)`)
+      .all() as ColumnRow[];
+
+    const byName = new Map(columns.map((c) => [c.name, c]));
+    expect(byName.get("conversation_id")?.pk).toBe(1);
+    expect(byName.get("conversation_id")?.type).toBe("TEXT");
+    expect(byName.get("message_id")?.notnull).toBe(1);
+    expect(byName.get("message_id")?.type).toBe("TEXT");
+    expect(byName.get("state_json")?.notnull).toBe(1);
+    expect(byName.get("state_json")?.type).toBe("TEXT");
+    expect(byName.get("ever_injected_json")?.notnull).toBe(1);
+    expect(byName.get("ever_injected_json")?.dflt_value).toBe("'[]'");
+    expect(byName.get("current_turn")?.notnull).toBe(1);
+    expect(byName.get("current_turn")?.type).toBe("INTEGER");
+    expect(byName.get("current_turn")?.dflt_value).toBe("0");
+    expect(byName.get("updated_at")?.notnull).toBe(1);
+    expect(byName.get("updated_at")?.type).toBe("INTEGER");
+  });
+
+  test("supports insert and select round-trip", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateActivationState(db);
+
+    const stateJson = JSON.stringify({ "alice-prefers-vscode": 0.42 });
+    const everInjectedJson = JSON.stringify([
+      { slug: "alice-prefers-vscode", turn: 3 },
+    ]);
+
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO activation_state (
+          conversation_id,
+          message_id,
+          state_json,
+          ever_injected_json,
+          current_turn,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run("conv-abc", "msg-xyz", stateJson, everInjectedJson, 5, 1000);
+
+    const row = raw
+      .query(
+        /*sql*/ `
+        SELECT
+          conversation_id,
+          message_id,
+          state_json,
+          ever_injected_json,
+          current_turn,
+          updated_at
+        FROM activation_state
+        WHERE conversation_id = ?
+      `,
+      )
+      .get("conv-abc") as {
+      conversation_id: string;
+      message_id: string;
+      state_json: string;
+      ever_injected_json: string;
+      current_turn: number;
+      updated_at: number;
+    } | null;
+
+    expect(row).toEqual({
+      conversation_id: "conv-abc",
+      message_id: "msg-xyz",
+      state_json: stateJson,
+      ever_injected_json: everInjectedJson,
+      current_turn: 5,
+      updated_at: 1000,
+    });
+  });
+
+  test("ever_injected_json defaults to '[]' and current_turn to 0 when omitted", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateActivationState(db);
+
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO activation_state (
+          conversation_id,
+          message_id,
+          state_json,
+          updated_at
+        ) VALUES (?, ?, ?, ?)
+      `,
+      )
+      .run("conv-defaults", "msg-1", "{}", 2000);
+
+    const row = raw
+      .query(
+        /*sql*/ `
+        SELECT ever_injected_json, current_turn
+        FROM activation_state
+        WHERE conversation_id = ?
+      `,
+      )
+      .get("conv-defaults") as {
+      ever_injected_json: string;
+      current_turn: number;
+    } | null;
+
+    expect(row).toEqual({
+      ever_injected_json: "[]",
+      current_turn: 0,
+    });
+  });
+
+  test("re-running the migration is idempotent", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateActivationState(db);
+
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO activation_state (
+          conversation_id,
+          message_id,
+          state_json,
+          updated_at
+        ) VALUES (?, ?, ?, ?)
+      `,
+      )
+      .run("conv-rerun", "msg-1", "{}", 1234);
+
+    expect(() => migrateActivationState(db)).not.toThrow();
+
+    const row = raw
+      .query(
+        `SELECT conversation_id FROM activation_state WHERE conversation_id = 'conv-rerun'`,
+      )
+      .get() as { conversation_id: string } | null;
+    expect(row?.conversation_id).toBe("conv-rerun");
+  });
+
+  test("down() drops the table", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateActivationState(db);
+
+    expect(
+      raw
+        .query(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='activation_state'`,
+        )
+        .get(),
+    ).toBeTruthy();
+
+    downActivationState(db);
+
+    expect(
+      raw
+        .query(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='activation_state'`,
+        )
+        .get(),
+    ).toBeNull();
+  });
+
+  test("down() is idempotent when run on an empty schema", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    expect(() => downActivationState(db)).not.toThrow();
+    expect(() => downActivationState(db)).not.toThrow();
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   createWatchersAndLogsTables,
   migrate230AcpSessionHistory,
   migrate231RepairMemoryGraphEventDates,
+  migrateActivationState,
   migrateAddConversationInferenceProfile,
   migrateAddSourceTypeColumns,
   migrateAssistantContactMetadata,
@@ -388,6 +389,7 @@ export function initializeDb(): void {
     migrateDeletePrivateConversations,
     migrate230AcpSessionHistory,
     migrate231RepairMemoryGraphEventDates,
+    migrateActivationState,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/232-activation-state.ts
+++ b/assistant/src/memory/migrations/232-activation-state.ts
@@ -1,0 +1,38 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_activation_state_v1";
+
+/**
+ * Create the activation_state table for memory v2 retrieval persistence.
+ *
+ * One row per conversation captures the latest activation snapshot:
+ * - state_json holds a sparse `{slug: activation}` map.
+ * - ever_injected_json is an append-only `[{slug, turn}]` list used to keep
+ *   injections strictly delta-only across turns.
+ * - current_turn tracks the latest turn index the activation reflects.
+ *
+ * Mirrors the existing `conversation_graph_memory_state` (migration 207)
+ * pattern: single-row-per-conversation snapshot rehydrated on resume.
+ */
+export function migrateActivationState(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS activation_state (
+        conversation_id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        state_json TEXT NOT NULL,
+        ever_injected_json TEXT NOT NULL DEFAULT '[]',
+        current_turn INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+  });
+}
+
+export function downActivationState(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS activation_state`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -178,6 +178,10 @@ export { migrateDeletePrivateConversations } from "./229-delete-private-conversa
 export { migrate230AcpSessionHistory } from "./230-acp-session-history.js";
 export { migrate231RepairMemoryGraphEventDates } from "./231-repair-memory-graph-event-dates.js";
 export {
+  downActivationState,
+  migrateActivationState,
+} from "./232-activation-state.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -43,6 +43,7 @@ import { migrateRenameMemoryGraphTypeValuesDown } from "./204-rename-memory-grap
 import { migrateScrubCorruptedImageAttachmentsDown } from "./206-scrub-corrupted-image-attachments.js";
 import { downConversationHostAccess } from "./217-conversation-host-access.js";
 import { downNormalizeUserFileByPrincipal } from "./220-normalize-user-file-by-principal.js";
+import { downActivationState } from "./232-activation-state.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -372,6 +373,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Normalize contacts.user_file across rows sharing the same principal_id so every channel for one principal loads the same users/<slug>.md persona and journal directory",
     down: downNormalizeUserFileByPrincipal,
+  },
+  {
+    key: "migration_activation_state_v1",
+    version: 43,
+    description: "Create activation_state table for memory v2",
+    down: downActivationState,
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adds migration 232 creating the `activation_state` table (`conversation_id` PK, `message_id`, `state_json`, `ever_injected_json`, `current_turn`, `updated_at`).
- Registers `migration_activation_state_v1` (version 43) in `MIGRATION_REGISTRY` with a `down` that drops the table, and wires `migrateActivationState` into `db-init.ts`.
- Adds `assistant/src/__tests__/db-activation-state.test.ts` covering schema, insert/select round-trip, default values, idempotent re-run, and `down()` behavior.

Part of plan: memory-v2.md (PR 4 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
