### PR TITLE
fix(macos): silence unused-result warning on createRule call

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift
@@ -377,7 +377,7 @@ final class ToolPermissionTesterModel: ObservableObject {
 
         Task {
             do {
-                try await trustRuleClient.createRule(
+                _ = try await trustRuleClient.createRule(
                     tool: snapshot.snapshotToolName,
                     pattern: pattern,
                     risk: "low",


### PR DESCRIPTION
## Summary
- Discard the `TrustRule` returned from `trustRuleClient.createRule(...)` in `ToolPermissionTesterModel.alwaysAllow` to silence the Swift `#no-usage` warning. The caller only re-runs `simulate()` to refresh the UI; it has no use for the rule itself.
- Matches the existing `_ = try await trustRuleClient.createRule(...)` discard pattern in `ChatViewModel.swift:2015`.

## Original prompt
Fix this warning:

```
clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterModel.swift:380:43: warning: result of call to 'createRule(tool:pattern:risk:description:scope:)' is unused [#no-usage]
378 |         Task {
379 |             do {
380 |                 try await trustRuleClient.createRule(
    |                                           `- warning: result of call to 'createRule(tool:pattern:risk:description:scope:)' is unused [#no-usage]
381 |                     tool: snapshot.snapshotToolName,
382 |                     pattern: pattern,
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
