### PR TITLE
fix(macos): inject AssistantFeatureFlagStore into pop-out thread window

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -634,7 +634,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if threadWindowManager == nil {
-            threadWindowManager = ThreadWindowManager(services: services)
+            threadWindowManager = ThreadWindowManager(services: services, assistantFeatureFlagStore: featureFlagStore)
         }
         setupGatewayConnectionManager()
         setupMenuBar()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -31,7 +31,8 @@ final class ThreadWindow: NSObject, NSWindowDelegate {
         ambientAgent: AmbientAgent,
         connectionManager: GatewayConnectionManager,
         eventStreamClient: EventStreamClient,
-        zoomManager: ZoomManager
+        zoomManager: ZoomManager,
+        assistantFeatureFlagStore: AssistantFeatureFlagStore
     ) {
         if let existing = window {
             existing.makeKeyAndOrderFront(nil)
@@ -46,6 +47,7 @@ final class ThreadWindow: NSObject, NSWindowDelegate {
             settingsStore: settingsStore,
             ambientAgent: ambientAgent,
             zoomManager: zoomManager,
+            assistantFeatureFlagStore: assistantFeatureFlagStore,
             onFork: { [weak conversationManager] daemonMessageId in
                 guard let conversationManager else { return }
                 Task { @MainActor in
@@ -178,6 +180,7 @@ private struct ThreadWindowContentView: View {
     @ObservedObject var settingsStore: SettingsStore
     var ambientAgent: AmbientAgent
     let zoomManager: ZoomManager
+    let assistantFeatureFlagStore: AssistantFeatureFlagStore
     let onFork: (String) -> Void
 
     @State private var anchorMessageId: UUID?
@@ -233,6 +236,9 @@ private struct ThreadWindowContentView: View {
                     conversationManager: conversationManager
                 )
                 .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
+                // Required: AssistantProgressView reads this via @Environment
+                // and triggers a SwiftUI assertion crash if it's missing.
+                .environment(assistantFeatureFlagStore)
                 .padding(.bottom, VSpacing.md)
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindowManager.swift
@@ -10,6 +10,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Threa
 @MainActor
 final class ThreadWindowManager {
     private let services: AppServices
+    private let assistantFeatureFlagStore: AssistantFeatureFlagStore
     private var threadWindows: [UUID: ThreadWindow] = [:]
 
     /// Returns the set of conversation local IDs that have open pop-out windows.
@@ -17,8 +18,9 @@ final class ThreadWindowManager {
         Set(threadWindows.keys)
     }
 
-    init(services: AppServices) {
+    init(services: AppServices, assistantFeatureFlagStore: AssistantFeatureFlagStore) {
         self.services = services
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
     }
 
     /// Open (or focus) a pop-out window for the given conversation.
@@ -37,7 +39,8 @@ final class ThreadWindowManager {
                 ambientAgent: services.ambientAgent,
                 connectionManager: services.connectionManager,
                 eventStreamClient: services.connectionManager.eventStreamClient,
-                zoomManager: services.zoomManager
+                zoomManager: services.zoomManager,
+                assistantFeatureFlagStore: assistantFeatureFlagStore
             )
             return false
         }
@@ -66,7 +69,8 @@ final class ThreadWindowManager {
             ambientAgent: services.ambientAgent,
             connectionManager: services.connectionManager,
             eventStreamClient: services.connectionManager.eventStreamClient,
-            zoomManager: services.zoomManager
+            zoomManager: services.zoomManager,
+            assistantFeatureFlagStore: assistantFeatureFlagStore
         )
 
         threadWindows[conversationLocalId] = threadWindow


### PR DESCRIPTION
## Summary
- Pop-out thread windows (Cmd+P) crashed immediately on open with `EXC_BREAKPOINT` inside SwiftUI's `EnvironmentValues.subscript.getter`.
- Root cause: `AssistantProgressView` (rendered inside `ChatView`) reads `@Environment(AssistantFeatureFlagStore.self)`, but `ThreadWindowContentView` never injected the store. `MainWindowView` already does (`MainWindowView.swift:316`), which is why the same `ChatView` worked from the main window.
- Fix: thread `AssistantFeatureFlagStore` from `AppDelegate` → `ThreadWindowManager` → `ThreadWindow.show()` → `ThreadWindowContentView`, and inject via `.environment(assistantFeatureFlagStore)`.

## Test plan
- [ ] Open the app, focus a conversation, hit Cmd+P (or the configured pop-out shortcut). Window opens without crashing and chat renders.
- [ ] Reopen the same conversation while it's already popped out — existing window comes to front (no crash).
- [ ] Close pop-out, then send a message that triggers a tool call. Confirm `AssistantProgressView` renders inside the pop-out.

## Original prompt
Fix this crash: SwiftUI EnvironmentValues assertion failure in `popOutActiveConversation()` → `ThreadWindowManager.openThread` → `ThreadWindow.show` → `NSWindow.setContentViewController:`, recursing through `AG::Graph::update_attribute` and `EnvironmentBox.update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
