### PR TITLE
feat(memory): activation_state read/write/fork

### DIFF
--- a/assistant/src/memory/schema/memory-graph.ts
+++ b/assistant/src/memory/schema/memory-graph.ts
@@ -138,17 +138,39 @@ export const memoryGraphTriggers = sqliteTable(
   ],
 );
 
-export const memoryGraphNodeEdits = sqliteTable(
-  "memory_graph_node_edits",
-  {
-    id: text("id").primaryKey(),
-    nodeId: text("node_id")
-      .notNull()
-      .references(() => memoryGraphNodes.id, { onDelete: "cascade" }),
-    previousContent: text("previous_content").notNull(),
-    newContent: text("new_content").notNull(),
-    source: text("source").notNull(),
-    conversationId: text("conversation_id"),
-    created: integer("created").notNull(),
-  },
-);
+export const memoryGraphNodeEdits = sqliteTable("memory_graph_node_edits", {
+  id: text("id").primaryKey(),
+  nodeId: text("node_id")
+    .notNull()
+    .references(() => memoryGraphNodes.id, { onDelete: "cascade" }),
+  previousContent: text("previous_content").notNull(),
+  newContent: text("new_content").notNull(),
+  source: text("source").notNull(),
+  conversationId: text("conversation_id"),
+  created: integer("created").notNull(),
+});
+
+// ---------------------------------------------------------------------------
+// Memory v2 — activation_state
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-conversation snapshot of the v2 retrieval state. One row per
+ * conversation; created lazily on first injection.
+ *
+ * - `stateJson`: sparse `{slug: activation}` map (only slugs > epsilon).
+ * - `everInjectedJson`: append-only `[{slug, turn}]` list used to keep
+ *   per-turn injections strictly delta-only. Pruned when compaction evicts
+ *   the turns whose attached slugs lived on.
+ *
+ * No FK to conversations.id — fork() may copy state for a child
+ * conversation that hasn't been persisted yet, and stale rows are cheap.
+ */
+export const activationState = sqliteTable("activation_state", {
+  conversationId: text("conversation_id").primaryKey(),
+  messageId: text("message_id").notNull(),
+  stateJson: text("state_json").notNull(),
+  everInjectedJson: text("ever_injected_json").notNull().default("[]"),
+  currentTurn: integer("current_turn").notNull().default(0),
+  updatedAt: integer("updated_at").notNull(),
+});

--- a/assistant/src/memory/v2/__tests__/activation-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation-store.test.ts
@@ -1,0 +1,202 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { type DrizzleDb, getSqliteFrom } from "../../db-connection.js";
+import { migrateActivationState } from "../../migrations/232-activation-state.js";
+import * as schema from "../../schema.js";
+import {
+  evictCompactedTurns,
+  fork,
+  hydrate,
+  save,
+} from "../activation-store.js";
+import type { ActivationState } from "../types.js";
+
+function createTestDb(): DrizzleDb {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  const db = drizzle(sqlite, { schema });
+
+  // Migration uses the checkpoints table for crash recovery — bootstrap it.
+  getSqliteFrom(db).exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  migrateActivationState(db);
+  return db;
+}
+
+function buildState(overrides: Partial<ActivationState> = {}): ActivationState {
+  return {
+    messageId: "msg-1",
+    state: { "alice-prefers-vscode": 0.42, "bob-coffee-order": 0.18 },
+    everInjected: [
+      { slug: "alice-prefers-vscode", turn: 1 },
+      { slug: "bob-coffee-order", turn: 2 },
+    ],
+    currentTurn: 3,
+    updatedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+let db: DrizzleDb;
+beforeEach(() => {
+  db = createTestDb();
+});
+
+describe("activation-store", () => {
+  describe("hydrate", () => {
+    test("returns null when no row exists", async () => {
+      expect(await hydrate(db, "conv-missing")).toBeNull();
+    });
+
+    test("round-trips state through save + hydrate", async () => {
+      const state = buildState();
+      await save(db, "conv-1", state);
+
+      const loaded = await hydrate(db, "conv-1");
+      expect(loaded).toEqual(state);
+    });
+
+    test("rejects rows whose state_json values are not numbers", async () => {
+      const raw = getSqliteFrom(db);
+      raw
+        .query(
+          /*sql*/ `INSERT INTO activation_state
+            (conversation_id, message_id, state_json, ever_injected_json, current_turn, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("conv-bad", "msg-x", '{"slug-a": "not-a-number"}', "[]", 0, 1);
+
+      await expect(hydrate(db, "conv-bad")).rejects.toThrow();
+    });
+  });
+
+  describe("save", () => {
+    test("upserts on conflict (second save replaces first)", async () => {
+      await save(db, "conv-1", buildState({ currentTurn: 1 }));
+      await save(
+        db,
+        "conv-1",
+        buildState({
+          messageId: "msg-2",
+          state: { "carla-likes-vim": 0.9 },
+          everInjected: [{ slug: "carla-likes-vim", turn: 5 }],
+          currentTurn: 5,
+          updatedAt: 1_700_000_001_000,
+        }),
+      );
+
+      const loaded = await hydrate(db, "conv-1");
+      expect(loaded).toEqual({
+        messageId: "msg-2",
+        state: { "carla-likes-vim": 0.9 },
+        everInjected: [{ slug: "carla-likes-vim", turn: 5 }],
+        currentTurn: 5,
+        updatedAt: 1_700_000_001_000,
+      });
+    });
+
+    test("persists empty state map and ever-injected list", async () => {
+      const state = buildState({ state: {}, everInjected: [] });
+      await save(db, "conv-empty", state);
+
+      const loaded = await hydrate(db, "conv-empty");
+      expect(loaded).toEqual(state);
+    });
+  });
+
+  describe("fork", () => {
+    test("copies parent state to a new conversation id", async () => {
+      const parentState = buildState();
+      await save(db, "conv-parent", parentState);
+
+      await fork(db, "conv-parent", "conv-child");
+
+      const child = await hydrate(db, "conv-child");
+      expect(child).toEqual(parentState);
+
+      // Parent is untouched.
+      const parentAfter = await hydrate(db, "conv-parent");
+      expect(parentAfter).toEqual(parentState);
+    });
+
+    test("is a no-op when the parent has no state", async () => {
+      await fork(db, "conv-parent-missing", "conv-child");
+
+      expect(await hydrate(db, "conv-child")).toBeNull();
+    });
+
+    test("forking onto an existing child overwrites it", async () => {
+      const parentState = buildState({ currentTurn: 7 });
+      await save(db, "conv-parent", parentState);
+      await save(db, "conv-child", buildState({ currentTurn: 99 }));
+
+      await fork(db, "conv-parent", "conv-child");
+
+      const child = await hydrate(db, "conv-child");
+      expect(child?.currentTurn).toBe(7);
+    });
+  });
+
+  describe("evictCompactedTurns", () => {
+    test("drops entries with turn <= upToTurn and preserves the rest", () => {
+      const state = buildState({
+        everInjected: [
+          { slug: "slug-a", turn: 1 },
+          { slug: "slug-b", turn: 2 },
+          { slug: "slug-c", turn: 3 },
+          { slug: "slug-d", turn: 5 },
+        ],
+      });
+
+      const result = evictCompactedTurns(state, 2);
+
+      expect(result.everInjected).toEqual([
+        { slug: "slug-c", turn: 3 },
+        { slug: "slug-d", turn: 5 },
+      ]);
+    });
+
+    test("returns a new object — does not mutate the input", () => {
+      const state = buildState({
+        everInjected: [{ slug: "slug-a", turn: 1 }],
+      });
+
+      const result = evictCompactedTurns(state, 1);
+
+      expect(result.everInjected).toEqual([]);
+      expect(state.everInjected).toEqual([{ slug: "slug-a", turn: 1 }]);
+      expect(result).not.toBe(state);
+    });
+
+    test("preserves every other field on the state", () => {
+      const state = buildState();
+      const result = evictCompactedTurns(state, 0);
+
+      expect(result.messageId).toBe(state.messageId);
+      expect(result.state).toEqual(state.state);
+      expect(result.currentTurn).toBe(state.currentTurn);
+      expect(result.updatedAt).toBe(state.updatedAt);
+    });
+
+    test("evicts everything when upToTurn covers the entire list", () => {
+      const state = buildState({
+        everInjected: [
+          { slug: "slug-a", turn: 1 },
+          { slug: "slug-b", turn: 2 },
+        ],
+      });
+
+      const result = evictCompactedTurns(state, 5);
+      expect(result.everInjected).toEqual([]);
+    });
+  });
+});

--- a/assistant/src/memory/v2/activation-store.ts
+++ b/assistant/src/memory/v2/activation-store.ts
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — Activation state SQLite persistence
+// ---------------------------------------------------------------------------
+//
+// One row per conversation. The row is hydrated on resume, mutated in-memory
+// across the turn, and written back at the end of the turn. Forking a
+// conversation copies the parent row so the child starts with the same
+// activation/everInjected snapshot.
+
+import { eq } from "drizzle-orm";
+
+import type { DrizzleDb } from "../db-connection.js";
+import { activationState } from "../schema.js";
+import {
+  type ActivationState,
+  ActivationStateSchema,
+  type EverInjectedEntry,
+} from "./types.js";
+
+/**
+ * Load the activation state for a conversation, or `null` if no row exists.
+ * Validates the on-disk JSON columns through `ActivationStateSchema`.
+ */
+export async function hydrate(
+  database: DrizzleDb,
+  conversationId: string,
+): Promise<ActivationState | null> {
+  const row = database
+    .select()
+    .from(activationState)
+    .where(eq(activationState.conversationId, conversationId))
+    .get();
+  if (!row) return null;
+
+  return ActivationStateSchema.parse({
+    messageId: row.messageId,
+    state: JSON.parse(row.stateJson),
+    everInjected: JSON.parse(row.everInjectedJson),
+    currentTurn: row.currentTurn,
+    updatedAt: row.updatedAt,
+  });
+}
+
+/**
+ * Upsert the activation state for a conversation. The `updatedAt` field of
+ * `state` is persisted as-is — callers control the timestamp.
+ */
+export async function save(
+  database: DrizzleDb,
+  conversationId: string,
+  state: ActivationState,
+): Promise<void> {
+  const stateJson = JSON.stringify(state.state);
+  const everInjectedJson = JSON.stringify(state.everInjected);
+  database
+    .insert(activationState)
+    .values({
+      conversationId,
+      messageId: state.messageId,
+      stateJson,
+      everInjectedJson,
+      currentTurn: state.currentTurn,
+      updatedAt: state.updatedAt,
+    })
+    .onConflictDoUpdate({
+      target: activationState.conversationId,
+      set: {
+        messageId: state.messageId,
+        stateJson,
+        everInjectedJson,
+        currentTurn: state.currentTurn,
+        updatedAt: state.updatedAt,
+      },
+    })
+    .run();
+}
+
+/**
+ * Copy the parent conversation's activation row to a new conversation id.
+ * No-op if the parent has no state (e.g. fork happened before any injection).
+ *
+ * The child row inherits everInjected as-is so previously-attached slugs are
+ * not re-injected on the child's first turn — matching the v1 semantics where
+ * a fork carries over all in-context memories.
+ */
+export async function fork(
+  database: DrizzleDb,
+  parentConversationId: string,
+  newConversationId: string,
+): Promise<void> {
+  const parent = await hydrate(database, parentConversationId);
+  if (!parent) return;
+  await save(database, newConversationId, parent);
+}
+
+/**
+ * Drop `everInjected` entries whose `turn` is at or below `upToTurn`.
+ * Used after compaction evicts older turns — slugs that lived only on those
+ * turns become eligible for re-injection on the next turn.
+ */
+export function evictCompactedTurns(
+  state: ActivationState,
+  upToTurn: number,
+): ActivationState {
+  const everInjected: EverInjectedEntry[] = state.everInjected.filter(
+    (entry) => entry.turn > upToTurn,
+  );
+  return { ...state, everInjected };
+}


### PR DESCRIPTION
## Summary
- Add the `activationState` Drizzle schema entry (table created in PR 4) and a v2 `activation-store.ts` exposing `hydrate`, `save`, `fork`, and the pure `evictCompactedTurns` helper.
- Round-trip data through `ActivationStateSchema` on hydrate so corrupt rows surface as parse errors instead of NaN activations downstream.
- Cover the four entry points with in-memory SQLite tests (hydrate-empty, save+hydrate round-trip, fork preserves parent and overwrites existing child, eviction).

Part of plan: memory-v2.md (PR 10 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
