### PR TITLE
feat(memory): route remember() to memory/buffer.md under flag

### DIFF
--- a/assistant/src/memory/graph/__tests__/handle-remember-v2.test.ts
+++ b/assistant/src/memory/graph/__tests__/handle-remember-v2.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for `handleRemember` flag-routing between v1 (PKB) and v2 (memory/).
+ *
+ * Verifies:
+ *   - Flag on  → writes go to `memory/buffer.md` + `memory/archive/<today>.md`
+ *                and NO PKB re-index job is enqueued.
+ *   - Flag off → existing PKB path is unchanged (writes to `pkb/buffer.md`
+ *                + `pkb/archive/<today>.md`, both files are re-indexed).
+ *   - Archive filename uses today's local date.
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+// Shared mock state for the PKB enqueue helper. Module-scoped so the
+// hoisted mock.module factory can close over it.
+const enqueueCalls: Array<{
+  pkbRoot: string;
+  absPath: string;
+  memoryScopeId: string;
+}> = [];
+
+mock.module("../../jobs/embed-pkb-file.js", () => ({
+  enqueuePkbIndexJob: (input: {
+    pkbRoot: string;
+    absPath: string;
+    memoryScopeId: string;
+  }) => {
+    enqueueCalls.push(input);
+    return "job-mock-id";
+  },
+}));
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "handle-remember-v2-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+// Imports are deferred to after the env var is set so any internal use of
+// `getWorkspaceDir()` resolves to the tmpdir.
+const { handleRemember } = await import("../tool-handlers.js");
+const { _setOverridesForTesting } =
+  await import("../../../config/assistant-feature-flags.js");
+const { applyNestedDefaults } = await import("../../../config/loader.js");
+
+const CONFIG = applyNestedDefaults({});
+
+beforeEach(() => {
+  enqueueCalls.length = 0;
+  // Reset to a clean workspace for each test so file existence assertions
+  // don't depend on prior-test side effects.
+  rmSync(join(tmpWorkspace, "pkb"), { recursive: true, force: true });
+  rmSync(join(tmpWorkspace, "memory"), { recursive: true, force: true });
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+function todaysArchiveBasename(now: Date = new Date()): string {
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}.md`;
+}
+
+describe("handleRemember — memory-v2 flag on", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+  });
+
+  test("writes to memory/buffer.md and memory/archive/<today>.md", () => {
+    const result = handleRemember(
+      { content: "Alice prefers VS Code over Vim" },
+      "conv-test-1",
+      "default",
+      CONFIG,
+    );
+
+    expect(result.success).toBe(true);
+
+    const memoryDir = join(tmpWorkspace, "memory");
+    const bufferPath = join(memoryDir, "buffer.md");
+    const archivePath = join(memoryDir, "archive", todaysArchiveBasename());
+
+    const buffer = readFileSync(bufferPath, "utf-8");
+    expect(buffer).toContain("Alice prefers VS Code over Vim");
+
+    const archive = readFileSync(archivePath, "utf-8");
+    expect(archive).toContain("Alice prefers VS Code over Vim");
+
+    // v2 must NOT touch the PKB tree.
+    expect(existsSync(join(tmpWorkspace, "pkb"))).toBe(false);
+  });
+
+  test("does not enqueue any PKB re-index jobs", () => {
+    const result = handleRemember(
+      { content: "Bob lives in Austin" },
+      "conv-test-2",
+      "default",
+      CONFIG,
+    );
+
+    expect(result.success).toBe(true);
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("seeds the daily archive header on first write", () => {
+    handleRemember(
+      { content: "First entry of the day" },
+      "conv-test-3",
+      "default",
+      CONFIG,
+    );
+
+    const archivePath = join(
+      tmpWorkspace,
+      "memory",
+      "archive",
+      todaysArchiveBasename(),
+    );
+    const archive = readFileSync(archivePath, "utf-8");
+    // Header is "# <Mon> <D>, <YYYY>" — assert just the prefix to avoid
+    // hard-coding the locale-formatted month name in the test.
+    expect(archive.startsWith("# ")).toBe(true);
+    expect(archive).toContain("First entry of the day");
+  });
+
+  test("appends multiple entries to the same buffer", () => {
+    handleRemember({ content: "first" }, "c", "default", CONFIG);
+    handleRemember({ content: "second" }, "c", "default", CONFIG);
+
+    const buffer = readFileSync(
+      join(tmpWorkspace, "memory", "buffer.md"),
+      "utf-8",
+    );
+    expect(buffer).toContain("first");
+    expect(buffer).toContain("second");
+  });
+
+  test("rejects empty content without writing", () => {
+    const result = handleRemember(
+      { content: "   " },
+      "conv-test-4",
+      "default",
+      CONFIG,
+    );
+
+    expect(result.success).toBe(false);
+    expect(existsSync(join(tmpWorkspace, "memory", "buffer.md"))).toBe(false);
+    expect(enqueueCalls).toEqual([]);
+  });
+});
+
+describe("handleRemember — memory-v2 flag off (v1 PKB path)", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+  });
+
+  test("writes to pkb/buffer.md and pkb/archive/<today>.md", () => {
+    const result = handleRemember(
+      { content: "v1 path still works" },
+      "conv-v1-1",
+      "default",
+      CONFIG,
+    );
+
+    expect(result.success).toBe(true);
+
+    const pkbDir = join(tmpWorkspace, "pkb");
+    const bufferPath = join(pkbDir, "buffer.md");
+    const archivePath = join(pkbDir, "archive", todaysArchiveBasename());
+
+    expect(readFileSync(bufferPath, "utf-8")).toContain("v1 path still works");
+    expect(readFileSync(archivePath, "utf-8")).toContain("v1 path still works");
+
+    // v1 must NOT touch the v2 memory/ tree.
+    expect(existsSync(join(tmpWorkspace, "memory"))).toBe(false);
+  });
+
+  test("enqueues PKB re-index jobs for both buffer and archive", () => {
+    const result = handleRemember(
+      { content: "index me" },
+      "conv-v1-2",
+      "default",
+      CONFIG,
+    );
+
+    expect(result.success).toBe(true);
+
+    const pkbDir = join(tmpWorkspace, "pkb");
+    const bufferPath = join(pkbDir, "buffer.md");
+    const archivePath = join(pkbDir, "archive", todaysArchiveBasename());
+
+    expect(enqueueCalls).toHaveLength(2);
+    expect(enqueueCalls[0]?.absPath).toBe(bufferPath);
+    expect(enqueueCalls[1]?.absPath).toBe(archivePath);
+    for (const call of enqueueCalls) {
+      expect(call.pkbRoot).toBe(pkbDir);
+    }
+  });
+});

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -1,12 +1,16 @@
 // ---------------------------------------------------------------------------
 // Memory Tool handlers
 //
-// remember: save facts to the PKB (buffer.md + daily archive)
+// remember: save facts to the PKB (buffer.md + daily archive) under the v1
+// path, or to memory/buffer.md + memory/archive/<today>.md when the
+// `memory-v2-enabled` feature flag is on.
 // ---------------------------------------------------------------------------
 
 import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { enqueuePkbIndexJob } from "../jobs/embed-pkb-file.js";
@@ -15,7 +19,7 @@ import { PKB_WORKSPACE_SCOPE } from "../pkb/types.js";
 const log = getLogger("graph-tool-handlers");
 
 // ---------------------------------------------------------------------------
-// remember handler — writes to PKB buffer + daily archive
+// remember handler — writes to PKB (v1) or memory/ (v2) buffer + daily archive
 // ---------------------------------------------------------------------------
 
 export interface RememberInput {
@@ -32,46 +36,91 @@ export function handleRemember(
   input: RememberInput,
   _conversationId: string,
   _scopeId: string,
+  config: AssistantConfig,
 ): RememberResult {
   if (!input.content || input.content.trim().length === 0) {
     return { success: false, message: "content is required" };
   }
 
   const workspaceDir = getWorkspaceDir();
-  const pkbDir = join(workspaceDir, "pkb");
-  const archiveDir = join(pkbDir, "archive");
-
-  // Ensure directories exist
-  mkdirSync(pkbDir, { recursive: true });
-  mkdirSync(archiveDir, { recursive: true });
-
-  // Build timestamped entry
   const now = new Date();
+  const entry = formatRememberEntry(input.content.trim(), now);
+
+  if (isAssistantFeatureFlagEnabled("memory-v2-enabled", config)) {
+    appendBufferAndArchive({
+      rootDir: join(workspaceDir, "memory"),
+      entry,
+      now,
+    });
+    // v2 path skips the PKB re-index queue — embedding for memory v2 happens
+    // via the dedicated `embed_concept_page` job after consolidation, not on
+    // every remember() write.
+    return { success: true, message: "Saved to knowledge base." };
+  }
+
+  const pkbDir = join(workspaceDir, "pkb");
+  const { bufferPath, archivePath } = appendBufferAndArchive({
+    rootDir: pkbDir,
+    entry,
+    now,
+  });
+  enqueuePkbReindex(pkbDir, bufferPath);
+  enqueuePkbReindex(pkbDir, archivePath);
+
+  return { success: true, message: "Saved to knowledge base." };
+}
+
+/**
+ * Build a timestamped bullet entry for `buffer.md` / `archive/<date>.md`.
+ *
+ * Format mirrors the long-standing v1 PKB layout so v2 buffers stay
+ * human-readable and downstream consumers (sweep, consolidation) can parse
+ * the same shape regardless of which path produced the entry.
+ */
+function formatRememberEntry(content: string, now: Date): string {
   const month = now.toLocaleString("en-US", { month: "short" });
   const day = now.getDate();
   const hours = now.getHours();
   const minutes = String(now.getMinutes()).padStart(2, "0");
   const ampm = hours >= 12 ? "PM" : "AM";
   const displayHour = hours % 12 || 12;
-  const entry = `- [${month} ${day}, ${displayHour}:${minutes} ${ampm}] ${input.content.trim()}\n`;
+  return `- [${month} ${day}, ${displayHour}:${minutes} ${ampm}] ${content}\n`;
+}
 
-  // Append to buffer.md
-  const bufferPath = join(pkbDir, "buffer.md");
+/**
+ * Append `entry` to `<rootDir>/buffer.md` and `<rootDir>/archive/<today>.md`,
+ * creating the archive directory and seeding the archive header if missing.
+ *
+ * Returns the absolute paths of both files so callers can fan out follow-up
+ * work (e.g. PKB re-indexing in the v1 path).
+ */
+function appendBufferAndArchive(args: {
+  rootDir: string;
+  entry: string;
+  now: Date;
+}): { bufferPath: string; archivePath: string } {
+  const { rootDir, entry, now } = args;
+  const archiveDir = join(rootDir, "archive");
+  mkdirSync(archiveDir, { recursive: true });
+
+  const bufferPath = join(rootDir, "buffer.md");
   appendFileSync(bufferPath, entry, "utf-8");
-  enqueuePkbReindex(pkbDir, bufferPath);
 
-  // Append to daily archive
   const yyyy = now.getFullYear();
   const mm = String(now.getMonth() + 1).padStart(2, "0");
   const dd = String(now.getDate()).padStart(2, "0");
   const archivePath = join(archiveDir, `${yyyy}-${mm}-${dd}.md`);
   if (!existsSync(archivePath)) {
-    appendFileSync(archivePath, `# ${month} ${day}, ${yyyy}\n\n`, "utf-8");
+    const month = now.toLocaleString("en-US", { month: "short" });
+    appendFileSync(
+      archivePath,
+      `# ${month} ${now.getDate()}, ${yyyy}\n\n`,
+      "utf-8",
+    );
   }
   appendFileSync(archivePath, entry, "utf-8");
-  enqueuePkbReindex(pkbDir, archivePath);
 
-  return { success: true, message: "Saved to knowledge base." };
+  return { bufferPath, archivePath };
 }
 
 /**

--- a/assistant/src/memory/graph/tools.ts
+++ b/assistant/src/memory/graph/tools.ts
@@ -54,15 +54,17 @@ export const graphRecallDefinition: ToolDefinition = {
 };
 
 /**
- * Save a fact to the personal knowledge base. The fact is appended to
- * buffer.md (immediately available in the next conversation) and the
- * daily archive (permanent date-indexed record). Filing into topic
- * files happens during the periodic filing job.
+ * Save a fact to the assistant's knowledge base. The fact is appended to
+ * `buffer.md` (immediately available in the next conversation) and the daily
+ * archive (permanent date-indexed record). With the `memory-v2-enabled`
+ * feature flag on, writes go under `memory/`; otherwise they go under
+ * `pkb/`. Consolidation of the buffer into longer-form storage runs as a
+ * separate periodic job in both modes.
  */
 export const graphRememberDefinition: ToolDefinition = {
   name: "remember",
   description:
-    "Save a fact to your knowledge base. Call this AGGRESSIVELY — capture anything concrete about their life: preferences, locations, names, dates, habits, opinions, health details, plans, relationship facts, routines, commitments. Default to remembering; only skip obvious noise (small talk, hypotheticals, things they're just musing about). Don't judge importance — filing decides that later. Examples: 'Prefers UberEats over DoorDash', 'Lives in NYC, from Texas', 'Takes daily medication, tapering dose', 'Partner Alex lives in Austin', 'Watches a weekly show on Saturday nights', 'Conference in May'. Call this multiple times per conversation — it's cheap (one line appended to a file). Don't wait until the end. Don't batch. Every new fact, immediately. Remembering too much is infinitely better than forgetting something that mattered. CORRECTIONS are the highest priority — when the user corrects a fact you had wrong, `remember` the correction immediately. The wrong version is already propagated in your prior turns and memory graph; skipping a correction means future-you keeps operating on the old value. Never skip a correction even if you'd skip the equivalent fresh fact.",
+    "Remember anything concrete: facts, preferences, corrections, plans, felt moments, names, dates, decisions. Default to remembering. Skip only obvious noise. Never wait until end of conversation. Corrections are highest priority — call remember the same turn the correction lands. Almost every turn is correct.",
   input_schema: {
     type: "object",
     properties: {

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -35,6 +35,7 @@ class RememberTool implements Tool {
       typedInput,
       context.conversationId,
       context.memoryScopeId ?? "default",
+      getConfig(),
     );
     return {
       content: result.message,


### PR DESCRIPTION
## Summary
- Branch handleRemember on isAssistantFeatureFlagEnabled("memory-v2-enabled", config): when on, write to memory/buffer.md + memory/archive/<today>.md and skip the PKB re-index job; when off, existing PKB path is unchanged.
- Replace graphRememberDefinition.description with the more aggressive copy from the v2 design doc and update the doc comment to mention the flag.
- Add handle-remember-v2.test.ts covering both flag states, archive seeding, multi-entry append, and empty-content rejection.

Part of plan: memory-v2.md (PR 12 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
