### PR TITLE
feat(memory): edges.json read/write + neighbor resolution

### DIFF
--- a/assistant/src/memory/v2/__tests__/edges.test.ts
+++ b/assistant/src/memory/v2/__tests__/edges.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for `memory/v2/edges.ts` — the read/write/neighbor primitives over
+ * `memory/edges.json`.
+ *
+ * Tests live in temp workspaces (mkdtemp) and never touch `~/.vellum/`.
+ * Slug names use generic placeholders (`alice`, `bob`, `topic-x`, ...).
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  addEdge,
+  getNeighbors,
+  readEdges,
+  removeEdge,
+  validateEdges,
+  writeEdges,
+} from "../edges.js";
+import type { EdgesIndex } from "../types.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-memory-v2-edges-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function edgesFile(): string {
+  return join(workspaceDir, "memory", "edges.json");
+}
+
+function readEdgesFileRaw(): unknown {
+  return JSON.parse(readFileSync(edgesFile(), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// readEdges
+// ---------------------------------------------------------------------------
+
+describe("readEdges", () => {
+  test("returns empty index when memory/edges.json is missing", async () => {
+    const idx = await readEdges(workspaceDir);
+    expect(idx).toEqual({ version: 1, edges: [] });
+  });
+
+  test("reads and validates an existing edges.json", async () => {
+    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+    const fixture: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["bob", "carol"],
+      ],
+    };
+    writeFileSync(edgesFile(), JSON.stringify(fixture), "utf-8");
+    const idx = await readEdges(workspaceDir);
+    expect(idx).toEqual(fixture);
+  });
+
+  test("throws on schema violation (e.g. wrong version)", async () => {
+    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+    writeFileSync(
+      edgesFile(),
+      JSON.stringify({ version: 2, edges: [] }),
+      "utf-8",
+    );
+    await expect(readEdges(workspaceDir)).rejects.toThrow();
+  });
+
+  test("throws on malformed JSON", async () => {
+    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+    writeFileSync(edgesFile(), "not-json", "utf-8");
+    await expect(readEdges(workspaceDir)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeEdges
+// ---------------------------------------------------------------------------
+
+describe("writeEdges", () => {
+  test("creates memory/ if missing and writes the canonical empty index", async () => {
+    await writeEdges(workspaceDir, { version: 1, edges: [] });
+    expect(readEdgesFileRaw()).toEqual({ version: 1, edges: [] });
+  });
+
+  test("canonicalizes each tuple to [min, max] alphabetical-first ordering", async () => {
+    await writeEdges(workspaceDir, {
+      version: 1,
+      edges: [
+        ["bob", "alice"],
+        ["delta", "carol"],
+      ],
+    });
+    expect(readEdgesFileRaw()).toEqual({
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["carol", "delta"],
+      ],
+    });
+  });
+
+  test("dedupes tuples that collapse to the same canonical form", async () => {
+    await writeEdges(workspaceDir, {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["bob", "alice"],
+        ["alice", "bob"],
+      ],
+    });
+    expect(readEdgesFileRaw()).toEqual({
+      version: 1,
+      edges: [["alice", "bob"]],
+    });
+  });
+
+  test("drops self-loops on write", async () => {
+    await writeEdges(workspaceDir, {
+      version: 1,
+      edges: [
+        ["alice", "alice"],
+        ["alice", "bob"],
+      ],
+    });
+    expect(readEdgesFileRaw()).toEqual({
+      version: 1,
+      edges: [["alice", "bob"]],
+    });
+  });
+
+  test("emits deterministically-sorted output regardless of input order", async () => {
+    await writeEdges(workspaceDir, {
+      version: 1,
+      edges: [
+        ["zeta", "yankee"],
+        ["alice", "bob"],
+        ["mike", "lima"],
+      ],
+    });
+    const reread = readEdgesFileRaw() as EdgesIndex;
+    expect(reread.edges).toEqual([
+      ["alice", "bob"],
+      ["lima", "mike"],
+      ["yankee", "zeta"],
+    ]);
+  });
+
+  test("write-then-read round-trip preserves a non-trivial graph", async () => {
+    const original: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["bob", "carol"],
+        ["carol", "delta"],
+        ["alice", "delta"],
+      ],
+    };
+    await writeEdges(workspaceDir, original);
+    const reread = await readEdges(workspaceDir);
+    // Edges may be reordered by canonicalization, but content is identical.
+    expect(new Set(reread.edges.map((e) => e.join("\u0000")))).toEqual(
+      new Set(original.edges.map((e) => e.join("\u0000"))),
+    );
+  });
+
+  test("atomic: leaves no .tmp file behind on success", async () => {
+    await writeEdges(workspaceDir, {
+      version: 1,
+      edges: [["alice", "bob"]],
+    });
+    const stragglers = readdirSync(join(workspaceDir, "memory")).filter((n) =>
+      n.startsWith("edges.json.tmp-"),
+    );
+    expect(stragglers).toEqual([]);
+  });
+
+  test("atomic: a concurrent reader observes the prior file until rename completes", async () => {
+    // Seed with a known-good prior file.
+    const prior: EdgesIndex = {
+      version: 1,
+      edges: [["alice", "bob"]],
+    };
+    await writeEdges(workspaceDir, prior);
+
+    // Race a write against many reads. Each read must observe a fully-formed
+    // index — never a partial JSON document.
+    const next: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["carol", "delta"],
+      ],
+    };
+    const writePromise = writeEdges(workspaceDir, next);
+    const reads = Array.from({ length: 20 }, () => readEdges(workspaceDir));
+    const results = await Promise.all([writePromise, ...reads]);
+
+    // Skip the write result (undefined); every read returns one of the two
+    // valid indices.
+    const possibilities = [
+      JSON.stringify(prior),
+      JSON.stringify({
+        version: 1,
+        edges: [
+          ["alice", "bob"],
+          ["carol", "delta"],
+        ],
+      }),
+    ];
+    for (const r of results.slice(1) as EdgesIndex[]) {
+      expect(possibilities).toContain(JSON.stringify(r));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addEdge / removeEdge
+// ---------------------------------------------------------------------------
+
+describe("addEdge", () => {
+  const empty: EdgesIndex = { version: 1, edges: [] };
+
+  test("adds a new edge in canonical form", () => {
+    const next = addEdge(empty, "bob", "alice");
+    expect(next.edges).toEqual([["alice", "bob"]]);
+  });
+
+  test("does not duplicate an existing edge regardless of argument order", () => {
+    const once = addEdge(empty, "alice", "bob");
+    const twice = addEdge(once, "bob", "alice");
+    expect(twice).toBe(once);
+  });
+
+  test("rejects self-loops", () => {
+    expect(() => addEdge(empty, "alice", "alice")).toThrow();
+  });
+
+  test("does not mutate the input index", () => {
+    const idx: EdgesIndex = { version: 1, edges: [["alice", "bob"]] };
+    const next = addEdge(idx, "carol", "delta");
+    expect(idx.edges).toEqual([["alice", "bob"]]);
+    expect(next.edges).toEqual([
+      ["alice", "bob"],
+      ["carol", "delta"],
+    ]);
+  });
+});
+
+describe("removeEdge", () => {
+  test("removes an edge regardless of argument order", () => {
+    const idx: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["bob", "carol"],
+      ],
+    };
+    const next = removeEdge(idx, "bob", "alice");
+    expect(next.edges).toEqual([["bob", "carol"]]);
+  });
+
+  test("returns the same index when the edge is not present", () => {
+    const idx: EdgesIndex = { version: 1, edges: [["alice", "bob"]] };
+    const next = removeEdge(idx, "carol", "delta");
+    expect(next).toBe(idx);
+  });
+
+  test("does not mutate the input index", () => {
+    const idx: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["bob", "carol"],
+      ],
+    };
+    removeEdge(idx, "alice", "bob");
+    expect(idx.edges).toEqual([
+      ["alice", "bob"],
+      ["bob", "carol"],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNeighbors
+// ---------------------------------------------------------------------------
+
+describe("getNeighbors", () => {
+  // Graph used across BFS tests:
+  //
+  //   alice -- bob -- carol -- delta
+  //              \
+  //               echo
+  //
+  // (orphan: foxtrot)
+  const graph: EdgesIndex = {
+    version: 1,
+    edges: [
+      ["alice", "bob"],
+      ["bob", "carol"],
+      ["bob", "echo"],
+      ["carol", "delta"],
+    ],
+  };
+
+  test("hops=1 returns immediate neighbors only", () => {
+    expect(getNeighbors(graph, "bob", 1)).toEqual(
+      new Set(["alice", "carol", "echo"]),
+    );
+  });
+
+  test("hops=2 includes second-degree neighbors", () => {
+    // From alice: bob (1), then carol+echo (2).
+    expect(getNeighbors(graph, "alice", 2)).toEqual(
+      new Set(["bob", "carol", "echo"]),
+    );
+  });
+
+  test("hops=3 reaches the third-degree node", () => {
+    // From alice: bob (1), carol+echo (2), delta (3).
+    expect(getNeighbors(graph, "alice", 3)).toEqual(
+      new Set(["bob", "carol", "echo", "delta"]),
+    );
+  });
+
+  test("never includes the start slug", () => {
+    expect(getNeighbors(graph, "bob", 5).has("bob")).toBe(false);
+  });
+
+  test("orphan node returns the empty set", () => {
+    expect(getNeighbors(graph, "foxtrot", 5)).toEqual(new Set());
+  });
+
+  test("unknown slug returns the empty set", () => {
+    expect(getNeighbors(graph, "ghost", 3)).toEqual(new Set());
+  });
+
+  test("hops=0 returns the empty set", () => {
+    expect(getNeighbors(graph, "alice", 0)).toEqual(new Set());
+  });
+
+  test("negative hops returns the empty set without throwing", () => {
+    expect(getNeighbors(graph, "alice", -1)).toEqual(new Set());
+  });
+
+  test("a cycle is traversed without infinite-looping", () => {
+    // Triangle: alice--bob, bob--carol, carol--alice.
+    const triangle: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["bob", "carol"],
+        ["alice", "carol"],
+      ],
+    };
+    expect(getNeighbors(triangle, "alice", 5)).toEqual(
+      new Set(["bob", "carol"]),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateEdges
+// ---------------------------------------------------------------------------
+
+describe("validateEdges", () => {
+  test("ok=true with empty missing list when every endpoint is known", () => {
+    const idx: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["bob", "carol"],
+      ],
+    };
+    expect(validateEdges(idx, new Set(["alice", "bob", "carol"]))).toEqual({
+      ok: true,
+      missing: [],
+    });
+  });
+
+  test("reports endpoints that are not in knownSlugs", () => {
+    const idx: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "bob"],
+        ["carol", "delta"],
+      ],
+    };
+    const result = validateEdges(idx, new Set(["alice", "bob"]));
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual(["carol", "delta"]);
+  });
+
+  test("dedupes a missing slug that appears in multiple edges", () => {
+    const idx: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["alice", "ghost"],
+        ["bob", "ghost"],
+      ],
+    };
+    const result = validateEdges(idx, new Set(["alice", "bob"]));
+    expect(result.missing).toEqual(["ghost"]);
+  });
+
+  test("returns a sorted missing list for stable output", () => {
+    const idx: EdgesIndex = {
+      version: 1,
+      edges: [
+        ["zeta", "alpha"],
+        ["mike", "kilo"],
+      ],
+    };
+    const result = validateEdges(idx, new Set());
+    expect(result.missing).toEqual(["alpha", "kilo", "mike", "zeta"]);
+  });
+});

--- a/assistant/src/memory/v2/edges.ts
+++ b/assistant/src/memory/v2/edges.ts
@@ -1,0 +1,217 @@
+/**
+ * Memory v2 — `memory/edges.json` read/write and neighbor resolution.
+ *
+ * This module is the sole owner of the `memory/edges.json` file. The edges
+ * index is the source of truth for v2 graph topology — concept-page
+ * frontmatter only mirrors a derived view of it.
+ *
+ * Edges are unweighted, undirected, and stored as canonicalized 2-tuples
+ * (alphabetically-first slug first). Self-loops are rejected at write time.
+ *
+ * Writes are atomic (write to `<file>.tmp-<uuid>`, then `rename(2)` onto the
+ * destination) so a crashed writer never leaves a torn JSON file behind —
+ * readers always see either the previous or the new index.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import type { EdgesIndex } from "./types.js";
+import { EdgesIndexSchema } from "./types.js";
+
+const EDGES_FILENAME = "edges.json";
+
+/** Path to `memory/edges.json` inside `workspaceDir`. */
+function edgesPath(workspaceDir: string): string {
+  return join(workspaceDir, "memory", EDGES_FILENAME);
+}
+
+/**
+ * Canonicalize a single tuple so `[a, b]` and `[b, a]` collapse to the same
+ * representation. Keeps writes deterministic regardless of caller order.
+ */
+function canonicalTuple(a: string, b: string): [string, string] {
+  return a <= b ? [a, b] : [b, a];
+}
+
+/** Stable string key for a canonical tuple, used for de-duplication. */
+function tupleKey(t: readonly [string, string]): string {
+  return `${t[0]}\u0000${t[1]}`;
+}
+
+/**
+ * Read `memory/edges.json` and validate it against `EdgesIndexSchema`.
+ * Returns the canonical empty index when the file is missing.
+ *
+ * Any JSON parse error or schema-validation failure throws — the file should
+ * never be silently quarantined, since a broken edges.json signals a bug in
+ * a writer or external tampering.
+ */
+export async function readEdges(workspaceDir: string): Promise<EdgesIndex> {
+  let raw: string;
+  try {
+    raw = await readFile(edgesPath(workspaceDir), "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { version: 1, edges: [] };
+    }
+    throw err;
+  }
+  const parsed = JSON.parse(raw);
+  return EdgesIndexSchema.parse(parsed);
+}
+
+/**
+ * Write `memory/edges.json` atomically. The on-disk tuples are canonicalized
+ * and de-duplicated before serialization, so the output is independent of
+ * insertion order and free of redundant pairs.
+ *
+ * Atomicity: bytes are written to a sibling temp file then renamed onto the
+ * destination. `rename(2)` on the same filesystem is atomic, so a reader
+ * concurrent with the writer sees either the prior file or the new one in
+ * full — never a partial write.
+ */
+export async function writeEdges(
+  workspaceDir: string,
+  idx: EdgesIndex,
+): Promise<void> {
+  const canonical = canonicalizeIndex(idx);
+  const finalPath = edgesPath(workspaceDir);
+  await mkdir(dirname(finalPath), { recursive: true });
+  const tmpPath = `${finalPath}.tmp-${randomUUID()}`;
+  const body = `${JSON.stringify(canonical, null, 2)}\n`;
+  await writeFile(tmpPath, body, "utf-8");
+  await rename(tmpPath, finalPath);
+}
+
+/**
+ * Pure helper: return a new index with `(a, b)` added (canonicalized). If the
+ * edge already exists the index is returned unchanged. Self-loops are
+ * rejected — concept-page graphs are simple graphs.
+ */
+export function addEdge(idx: EdgesIndex, a: string, b: string): EdgesIndex {
+  if (a === b) {
+    throw new Error(`addEdge: refusing to add self-loop on slug "${a}"`);
+  }
+  const tuple = canonicalTuple(a, b);
+  const key = tupleKey(tuple);
+  for (const existing of idx.edges) {
+    if (tupleKey(canonicalTuple(existing[0], existing[1])) === key) {
+      return idx;
+    }
+  }
+  return { version: idx.version, edges: [...idx.edges, tuple] };
+}
+
+/**
+ * Pure helper: return a new index with `(a, b)` removed (matched on its
+ * canonical form). No-op if the edge is not present.
+ */
+export function removeEdge(idx: EdgesIndex, a: string, b: string): EdgesIndex {
+  const target = tupleKey(canonicalTuple(a, b));
+  const filtered = idx.edges.filter(
+    ([x, y]) => tupleKey(canonicalTuple(x, y)) !== target,
+  );
+  if (filtered.length === idx.edges.length) return idx;
+  return { version: idx.version, edges: filtered };
+}
+
+/**
+ * Iterative BFS over the undirected edge graph starting at `slug`. Returns
+ * every slug reachable within `hops` edges, *excluding* the start slug. An
+ * orphan node (or unknown slug) yields the empty set.
+ *
+ * `hops` is clamped at 0 — a non-positive value collapses to an immediate
+ * empty result so callers never need to special-case it.
+ */
+export function getNeighbors(
+  idx: EdgesIndex,
+  slug: string,
+  hops: number,
+): Set<string> {
+  const result = new Set<string>();
+  if (hops <= 0) return result;
+
+  const adjacency = buildAdjacency(idx);
+  const visited = new Set<string>([slug]);
+  let frontier: string[] = [slug];
+
+  for (let depth = 0; depth < hops && frontier.length > 0; depth++) {
+    const next: string[] = [];
+    for (const node of frontier) {
+      const neighbors = adjacency.get(node);
+      if (!neighbors) continue;
+      for (const neighbor of neighbors) {
+        if (visited.has(neighbor)) continue;
+        visited.add(neighbor);
+        result.add(neighbor);
+        next.push(neighbor);
+      }
+    }
+    frontier = next;
+  }
+
+  return result;
+}
+
+/**
+ * Validate an edges index against a known set of concept-page slugs. Returns
+ * the unique list of endpoints that are referenced by an edge but missing
+ * from `knownSlugs`. `ok` mirrors `missing.length === 0` for caller
+ * convenience.
+ */
+export function validateEdges(
+  idx: EdgesIndex,
+  knownSlugs: Set<string>,
+): { ok: boolean; missing: string[] } {
+  const missing = new Set<string>();
+  for (const [a, b] of idx.edges) {
+    if (!knownSlugs.has(a)) missing.add(a);
+    if (!knownSlugs.has(b)) missing.add(b);
+  }
+  const list = [...missing].sort();
+  return { ok: list.length === 0, missing: list };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonicalize tuples + dedup, returning a deterministically-sorted index.
+ * Self-loops are dropped silently here (writer-side) so a malformed in-memory
+ * value can still be persisted as a clean file.
+ */
+function canonicalizeIndex(idx: EdgesIndex): EdgesIndex {
+  const seen = new Map<string, [string, string]>();
+  for (const [a, b] of idx.edges) {
+    if (a === b) continue;
+    const tuple = canonicalTuple(a, b);
+    seen.set(tupleKey(tuple), tuple);
+  }
+  // Sort by canonical key (NUL-separated) — gives a lexicographic order on
+  // the (left, right) pair without a multi-clause comparator.
+  const tuples = [...seen.entries()]
+    .sort(([keyX], [keyY]) => (keyX < keyY ? -1 : keyX > keyY ? 1 : 0))
+    .map(([, tuple]) => tuple);
+  return { version: idx.version, edges: tuples };
+}
+
+/** Build slug → neighbors map from canonicalized tuples (undirected). */
+function buildAdjacency(idx: EdgesIndex): Map<string, Set<string>> {
+  const adjacency = new Map<string, Set<string>>();
+  const ensure = (slug: string): Set<string> => {
+    let set = adjacency.get(slug);
+    if (!set) {
+      set = new Set<string>();
+      adjacency.set(slug, set);
+    }
+    return set;
+  };
+  for (const [a, b] of idx.edges) {
+    if (a === b) continue;
+    ensure(a).add(b);
+    ensure(b).add(a);
+  }
+  return adjacency;
+}


### PR DESCRIPTION
## Summary
- Adds `assistant/src/memory/v2/edges.ts` — sole owner of `memory/edges.json` with atomic temp+rename writes, schema-validated reads, canonicalized + dedup tuples, undirected BFS for neighbor resolution, and a validateEdges helper for orphan-endpoint detection.
- Tests cover canonical ordering, dedup, BFS at hops=1/2/3, orphan/unknown nodes, cycles, and the atomic-write invariant (concurrent readers always see a fully-formed index).

Part of plan: memory-v2.md (PR 7 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
