### PR TITLE
feat(memory): concept page read/write with frontmatter parse

### DIFF
--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Tests for `assistant/src/memory/v2/page-store.ts`.
+ *
+ * Coverage matrix (from PR 8 acceptance criteria):
+ *   - slugify: lowercase / kebab-case / ascii / 80-char cap / empty fallback.
+ *   - readPage / writePage round-trip: frontmatter survives, body preserved.
+ *   - readPage on missing file: returns null.
+ *   - writePage atomicity: a fault between temp-write and rename leaves the
+ *     prior file intact (or the new one) — never a half-written page.
+ *   - listPages: excludes non-.md entries, returns slugs only, missing dir → [].
+ *   - deletePage: idempotent on missing file.
+ *
+ * Tests use temp workspaces under `os.tmpdir()` per the cross-cutting safety
+ * rule in the v2 plan; they never touch `~/.vellum/`.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  deletePage,
+  listPages,
+  pageExists,
+  readPage,
+  slugify,
+  writePage,
+} from "../page-store.js";
+import type { ConceptPage } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-page-store-test-"));
+  // Mirror the workspace migration so readPage / writePage have a target dir.
+  mkdirSync(join(workspaceDir, "memory", "concepts"), { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function makePage(overrides: Partial<ConceptPage> = {}): ConceptPage {
+  return {
+    slug: "alice-preferences",
+    frontmatter: { edges: ["bob-handoff"], ref_files: [] },
+    body: "Alice prefers VS Code over Vim.\nShe ships at end of day.\n",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// slugify
+// ---------------------------------------------------------------------------
+
+describe("slugify", () => {
+  test("lowercases ASCII letters", () => {
+    expect(slugify("AliceBob")).toBe("alicebob");
+  });
+
+  test("converts spaces and punctuation to single hyphens", () => {
+    expect(slugify("Alice's Preferred IDE!")).toBe("alice-s-preferred-ide");
+  });
+
+  test("collapses runs of separators to one hyphen", () => {
+    expect(slugify("foo   ___ bar")).toBe("foo-bar");
+  });
+
+  test("trims leading and trailing hyphens", () => {
+    expect(slugify("---hello world---")).toBe("hello-world");
+  });
+
+  test("strips non-ASCII characters via NFKD normalization", () => {
+    // Non-ASCII reduces to hyphens; we want a stable ascii-only slug.
+    expect(slugify("café résumé")).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  test("caps slug length at 80 chars and re-trims trailing hyphen", () => {
+    const long = "a".repeat(120);
+    const slug = slugify(long);
+    expect(slug.length).toBe(80);
+    expect(slug.endsWith("-")).toBe(false);
+  });
+
+  test("falls back to a unique placeholder for empty inputs", () => {
+    const a = slugify("");
+    const b = slugify("!!!");
+    const c = slugify("###");
+    expect(a).toMatch(/^concept-[a-f0-9]{8}$/);
+    expect(b).toMatch(/^concept-[a-f0-9]{8}$/);
+    // Each call generates a fresh UUID, so distinct empty inputs do not collide.
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readPage / writePage round-trip
+// ---------------------------------------------------------------------------
+
+describe("writePage + readPage round-trip", () => {
+  test("round-trips frontmatter and body verbatim", async () => {
+    const page = makePage();
+    await writePage(workspaceDir, page);
+
+    const read = await readPage(workspaceDir, page.slug);
+    expect(read).not.toBeNull();
+    expect(read!.slug).toBe(page.slug);
+    expect(read!.frontmatter.edges).toEqual(page.frontmatter.edges);
+    expect(read!.frontmatter.ref_files).toEqual(page.frontmatter.ref_files);
+    expect(read!.body).toBe(page.body);
+  });
+
+  test("renders frontmatter at the top with --- delimiters", async () => {
+    const page = makePage();
+    await writePage(workspaceDir, page);
+
+    const raw = readFileSync(
+      join(workspaceDir, "memory", "concepts", `${page.slug}.md`),
+      "utf-8",
+    );
+    expect(raw.startsWith("---\n")).toBe(true);
+    // Body follows the closing delimiter exactly once.
+    expect(raw.split("---").length).toBeGreaterThanOrEqual(3);
+    expect(raw).toContain("Alice prefers VS Code");
+  });
+
+  test("preserves an empty body", async () => {
+    const page = makePage({ body: "" });
+    await writePage(workspaceDir, page);
+
+    const read = await readPage(workspaceDir, page.slug);
+    expect(read!.body).toBe("");
+  });
+
+  test("preserves multiline body with embedded YAML-looking lines", async () => {
+    const tricky = "key: value\n---\nnot-frontmatter\n";
+    const page = makePage({ slug: "tricky", body: tricky });
+    await writePage(workspaceDir, page);
+
+    const read = await readPage(workspaceDir, page.slug);
+    expect(read!.body).toBe(tricky);
+  });
+
+  test("readPage returns null for a slug that does not exist", async () => {
+    const result = await readPage(workspaceDir, "nonexistent-slug");
+    expect(result).toBeNull();
+  });
+
+  test("readPage parses a hand-written page with no frontmatter as empty frontmatter + full body", async () => {
+    const slug = "no-frontmatter";
+    const body = "Just some prose, no YAML.\n";
+    writeFileSync(
+      join(workspaceDir, "memory", "concepts", `${slug}.md`),
+      body,
+      "utf-8",
+    );
+
+    const read = await readPage(workspaceDir, slug);
+    expect(read).not.toBeNull();
+    expect(read!.frontmatter.edges).toEqual([]);
+    expect(read!.frontmatter.ref_files).toEqual([]);
+    expect(read!.body).toBe(body);
+  });
+
+  test("writePage overwrites an existing page", async () => {
+    const page1 = makePage({ body: "first version\n" });
+    await writePage(workspaceDir, page1);
+
+    const page2 = makePage({ body: "second version\n" });
+    await writePage(workspaceDir, page2);
+
+    const read = await readPage(workspaceDir, page1.slug);
+    expect(read!.body).toBe("second version\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Atomic write — fault injection
+// ---------------------------------------------------------------------------
+
+describe("writePage atomicity", () => {
+  test("write that fails partway leaves prior file intact and no orphan tmp", async () => {
+    // Seed the page with a known prior version.
+    const original = makePage({ body: "original body\n" });
+    await writePage(workspaceDir, original);
+    const originalRaw = readFileSync(
+      join(workspaceDir, "memory", "concepts", `${original.slug}.md`),
+      "utf-8",
+    );
+
+    // Inject a fault: replace the destination with a directory of the same
+    // name so `rename` cannot overwrite it (POSIX rejects renaming a regular
+    // file onto a non-empty directory). This forces writePage's temp-then-
+    // rename path to fail at the rename step — exactly the window where a
+    // real process crash would leave a stranded `.tmp.*` file behind. The
+    // assertions below verify (a) the prior page is untouched and (b) the
+    // catch block cleaned up the temp file before re-throwing.
+    const targetPath = join(
+      workspaceDir,
+      "memory",
+      "concepts",
+      `${original.slug}.md`,
+    );
+    rmSync(targetPath);
+    mkdirSync(targetPath);
+    writeFileSync(join(targetPath, "blocker"), "x", "utf-8");
+
+    await expect(
+      writePage(workspaceDir, makePage({ body: "interrupted body\n" })),
+    ).rejects.toThrow();
+
+    // Restore the directory shape so cleanup helpers don't trip.
+    rmSync(targetPath, { recursive: true, force: true });
+    writeFileSync(targetPath, originalRaw, "utf-8");
+
+    // Prior content is recoverable from what we just rewrote — i.e. the failed
+    // writePage never replaced it.
+    expect(readFileSync(targetPath, "utf-8")).toBe(originalRaw);
+
+    // No orphan .tmp.* files in concepts/ (cleanup ran in the catch block).
+    const remaining = readdirSync(join(workspaceDir, "memory", "concepts"));
+    const orphanTmps = remaining.filter((name) => name.includes(".tmp."));
+    expect(orphanTmps).toEqual([]);
+  });
+
+  test("successful write produces no orphan tmp files", async () => {
+    await writePage(workspaceDir, makePage());
+
+    const remaining = readdirSync(join(workspaceDir, "memory", "concepts"));
+    const orphanTmps = remaining.filter((name) => name.includes(".tmp."));
+    expect(orphanTmps).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listPages
+// ---------------------------------------------------------------------------
+
+describe("listPages", () => {
+  test("returns slugs (filename minus .md) for every page on disk", async () => {
+    await writePage(workspaceDir, makePage({ slug: "alice" }));
+    await writePage(workspaceDir, makePage({ slug: "bob" }));
+    await writePage(workspaceDir, makePage({ slug: "carol" }));
+
+    const slugs = await listPages(workspaceDir);
+    expect(slugs).toEqual(["alice", "bob", "carol"]);
+  });
+
+  test("excludes non-.md files in the concepts directory", async () => {
+    await writePage(workspaceDir, makePage({ slug: "alice" }));
+
+    const conceptsDir = join(workspaceDir, "memory", "concepts");
+    writeFileSync(join(conceptsDir, "README.txt"), "ignore me", "utf-8");
+    writeFileSync(join(conceptsDir, "image.png"), "fake", "utf-8");
+    writeFileSync(join(conceptsDir, ".hidden"), "fake", "utf-8");
+
+    const slugs = await listPages(workspaceDir);
+    expect(slugs).toEqual(["alice"]);
+  });
+
+  test("excludes subdirectories (only files count)", async () => {
+    await writePage(workspaceDir, makePage({ slug: "alice" }));
+
+    mkdirSync(join(workspaceDir, "memory", "concepts", "subdir"), {
+      recursive: true,
+    });
+
+    const slugs = await listPages(workspaceDir);
+    expect(slugs).toEqual(["alice"]);
+  });
+
+  test("returns [] when the concepts directory does not exist", async () => {
+    rmSync(join(workspaceDir, "memory", "concepts"), {
+      recursive: true,
+      force: true,
+    });
+
+    const slugs = await listPages(workspaceDir);
+    expect(slugs).toEqual([]);
+  });
+
+  test("returns [] when the concepts directory is empty", async () => {
+    const slugs = await listPages(workspaceDir);
+    expect(slugs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deletePage
+// ---------------------------------------------------------------------------
+
+describe("deletePage", () => {
+  test("removes the page from disk", async () => {
+    const page = makePage();
+    await writePage(workspaceDir, page);
+    expect(await pageExists(workspaceDir, page.slug)).toBe(true);
+
+    await deletePage(workspaceDir, page.slug);
+    expect(await pageExists(workspaceDir, page.slug)).toBe(false);
+    expect(await readPage(workspaceDir, page.slug)).toBeNull();
+  });
+
+  test("is idempotent — deleting a missing page does not throw", async () => {
+    await deletePage(workspaceDir, "never-existed");
+    // Second call still does not throw.
+    await deletePage(workspaceDir, "never-existed");
+  });
+
+  test("does not affect other pages", async () => {
+    await writePage(workspaceDir, makePage({ slug: "alice" }));
+    await writePage(workspaceDir, makePage({ slug: "bob" }));
+
+    await deletePage(workspaceDir, "alice");
+
+    expect(await pageExists(workspaceDir, "alice")).toBe(false);
+    expect(await pageExists(workspaceDir, "bob")).toBe(true);
+  });
+});

--- a/assistant/src/memory/v2/page-store.ts
+++ b/assistant/src/memory/v2/page-store.ts
@@ -1,0 +1,245 @@
+/**
+ * Memory v2 — Concept page store.
+ *
+ * Owns the on-disk read/write contract for `memory/concepts/<slug>.md`.
+ * Each page is a YAML-frontmatter Markdown file: a `---`-delimited block
+ * (`edges`, `ref_files`) followed by prose body. This module is the only
+ * v2 component that knows how to parse or render that format — every other
+ * v2 module routes through `readPage` / `writePage` so the on-disk shape
+ * can evolve without touching downstream callers.
+ *
+ * Writes are atomic (temp + rename) so a crash mid-write leaves either the
+ * old file or the new file in place — never a half-written page.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { join } from "node:path";
+
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+import { FRONTMATTER_REGEX } from "../../skills/frontmatter.js";
+import { type ConceptPage, ConceptPageFrontmatterSchema } from "./types.js";
+
+/** Filename suffix for concept pages. */
+const PAGE_EXTENSION = ".md";
+
+/** Cap slug length so we stay well under filesystem name limits. */
+const MAX_SLUG_LENGTH = 80;
+
+/**
+ * Convert an arbitrary input string into a filesystem-safe slug.
+ *
+ * Rules:
+ *   - Lowercase ASCII letters, digits, and hyphens only.
+ *   - Non-ASCII / non-alphanumeric characters collapse to hyphens.
+ *   - Consecutive hyphens collapse to one; leading/trailing hyphens trimmed.
+ *   - Truncated to {@link MAX_SLUG_LENGTH} characters (with trailing hyphen
+ *     re-trimmed after truncation).
+ *   - Empty inputs (e.g. emoji-only) fall back to `concept-<random>` so the
+ *     caller always gets a non-empty, write-safe slug.
+ */
+export function slugify(input: string): string {
+  let slug = input
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (slug.length > MAX_SLUG_LENGTH) {
+    slug = slug.slice(0, MAX_SLUG_LENGTH).replace(/-+$/, "");
+  }
+
+  if (!slug) {
+    slug = `concept-${randomUUID().slice(0, 8)}`;
+  }
+
+  return slug;
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+function getConceptsDir(workspaceDir: string): string {
+  return join(workspaceDir, "memory", "concepts");
+}
+
+function getPagePath(workspaceDir: string, slug: string): string {
+  return join(getConceptsDir(workspaceDir), `${slug}${PAGE_EXTENSION}`);
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parse / render
+// ---------------------------------------------------------------------------
+
+/**
+ * Split raw file contents into (frontmatter, body). If no frontmatter block
+ * is present the entire input is treated as body and an empty frontmatter
+ * block is returned (validated by `ConceptPageFrontmatterSchema` so any
+ * unexpected shape — bad types, extra junk — surfaces as a parse error to
+ * the caller, not silent dropped data).
+ *
+ * The schema's defaults guarantee `edges` and `ref_files` are always arrays
+ * even on freshly created pages with empty frontmatter.
+ */
+function parsePageContent(raw: string): {
+  frontmatter: ConceptPage["frontmatter"];
+  body: string;
+} {
+  const match = raw.match(FRONTMATTER_REGEX);
+  if (!match) {
+    return {
+      frontmatter: ConceptPageFrontmatterSchema.parse({}),
+      body: raw,
+    };
+  }
+  const yamlBlock = match[1];
+  const body = raw.slice(match[0].length);
+  const parsed = parseYaml(yamlBlock) ?? {};
+  return {
+    frontmatter: ConceptPageFrontmatterSchema.parse(parsed),
+    body,
+  };
+}
+
+/**
+ * Render a concept page back into the on-disk Markdown form. The output is
+ * always frontmatter + body; even pages with empty `edges` and `ref_files`
+ * keep the explicit YAML keys so callers see the canonical shape on round-trip.
+ */
+function renderPageContent(page: ConceptPage): string {
+  const frontmatter = ConceptPageFrontmatterSchema.parse(page.frontmatter);
+  const yamlBlock = stringifyYaml(frontmatter, { indent: 2 }).trimEnd();
+  return `---\n${yamlBlock}\n---\n${page.body}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a single concept page. Returns `null` if the file does not exist.
+ *
+ * Any other read or parse failure (permission denied, malformed YAML,
+ * frontmatter that fails schema validation) throws — unlike "missing", these
+ * are programmer / data-corruption errors the caller needs to see.
+ */
+export async function readPage(
+  workspaceDir: string,
+  slug: string,
+): Promise<ConceptPage | null> {
+  const path = getPagePath(workspaceDir, slug);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+  const { frontmatter, body } = parsePageContent(raw);
+  return { slug, frontmatter, body };
+}
+
+/**
+ * Write a concept page atomically (temp file + rename). A crash between the
+ * temp write and the rename leaves the prior file intact; a crash after the
+ * rename leaves the new file. Readers therefore never observe a partial page.
+ */
+export async function writePage(
+  workspaceDir: string,
+  page: ConceptPage,
+): Promise<void> {
+  const path = getPagePath(workspaceDir, page.slug);
+  const tmpPath = `${path}.tmp.${process.pid}.${randomUUID()}`;
+  const content = renderPageContent(page);
+  try {
+    await writeFile(tmpPath, content, "utf-8");
+    await rename(tmpPath, path);
+  } catch (err) {
+    // Best-effort cleanup: if the rename failed (or the write succeeded but
+    // the rename did not), remove the orphan tmp file so we don't leak it
+    // into the concepts/ directory where listPages would then surface it.
+    await rm(tmpPath, { force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * List every concept-page slug present on disk. Slugs are returned without
+ * the `.md` suffix so callers can pass them straight back to `readPage`.
+ *
+ * Non-`.md` files (e.g. editor swap files, attached media) are filtered out.
+ * If the concepts/ directory does not yet exist (fresh workspace pre-migration),
+ * returns `[]`.
+ */
+export async function listPages(workspaceDir: string): Promise<string[]> {
+  const dir = getConceptsDir(workspaceDir);
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  const slugs: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(PAGE_EXTENSION)) continue;
+    slugs.push(entry.name.slice(0, -PAGE_EXTENSION.length));
+  }
+  slugs.sort();
+  return slugs;
+}
+
+/**
+ * Delete a concept page. Idempotent — missing files are not an error.
+ *
+ * Any other failure (permission denied, etc.) throws so the caller can react.
+ */
+export async function deletePage(
+  workspaceDir: string,
+  slug: string,
+): Promise<void> {
+  const path = getPagePath(workspaceDir, slug);
+  try {
+    await rm(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Check whether a concept page exists on disk. Useful for callers that want
+ * to gate work on presence without paying for a full read.
+ */
+export async function pageExists(
+  workspaceDir: string,
+  slug: string,
+): Promise<boolean> {
+  const path = getPagePath(workspaceDir, slug);
+  try {
+    await stat(path);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- New `assistant/src/memory/v2/page-store.ts`: `slugify`, `readPage`, `writePage` (atomic temp+rename), `listPages`, `deletePage`, plus a small `pageExists` helper. Uses the existing `yaml` dependency and the shared `FRONTMATTER_REGEX` from `skills/frontmatter.ts` instead of adding gray-matter.
- Frontmatter is validated via `ConceptPageFrontmatterSchema` (PR 5) so corrupted edges/ref_files surface as a parse error rather than silent dropped data.
- Tests cover: slugify rules (lowercase, NFKD, 80-char cap, empty fallback), round-trip read/write, atomic write fault-injection (no orphan tmp files), list excludes non-`.md`, delete idempotent.

Part of plan: memory-v2.md (PR 8 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
