### PR TITLE
feat(memory): implement embed_concept_page job handler

### DIFF
--- a/assistant/src/memory/job-utils.ts
+++ b/assistant/src/memory/job-utils.ts
@@ -27,13 +27,13 @@ const log = getLogger("memory-jobs-worker");
 // ── Vector BLOB encoding/decoding ───────────────────────────────────
 
 /** Encode a number[] into a compact Float32Array BLOB for SQLite storage. */
-function vectorToBlob(vector: number[]): Buffer {
+export function vectorToBlob(vector: number[]): Buffer {
   const f32 = new Float32Array(vector);
   return Buffer.from(f32.buffer, f32.byteOffset, f32.byteLength);
 }
 
 /** Decode a BLOB (Buffer/Uint8Array) back into a number[]. */
-function blobToVector(buf: Buffer | Uint8Array): number[] {
+export function blobToVector(buf: Buffer | Uint8Array): number[] {
   const f32 = new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
   return Array.from(f32);
 }

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -44,6 +44,7 @@ import {
   RETRY_MAX_ATTEMPTS,
   retryDelayForAttempt,
 } from "./job-utils.js";
+import { embedConceptPageJob } from "./jobs/embed-concept-page.js";
 import { embedPkbFileJob } from "./jobs/embed-pkb-file.js";
 import {
   claimMemoryJobs,
@@ -452,6 +453,8 @@ async function processJob(
       await bootstrapFromHistory();
       return;
     case "embed_concept_page":
+      await embedConceptPageJob(job, config);
+      return;
     case "memory_v2_sweep":
     case "memory_v2_consolidate":
     case "memory_v2_migrate":

--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for `assistant/src/memory/jobs/embed-concept-page.ts`.
+ *
+ * Coverage matrix (from PR 13 acceptance criteria):
+ *   - Enqueue + dispatch round-trip: writing a page → enqueueing the job →
+ *     dispatching it via `embedConceptPageJob` → upserts the embedding.
+ *   - Delete propagation: when the page is missing on disk, the handler
+ *     removes the embedding instead of upserting.
+ *   - Cache hit: a second run with the same content reuses the cached dense
+ *     vector and skips the embedding backend.
+ *   - Skips when slug is missing from the payload (defensive).
+ *
+ * Mocks: the embedding backend, Qdrant client, and v2 qdrant module are
+ * stubbed so the test runs without network/IO. Pages live on a temp
+ * workspace under `os.tmpdir()` per the cross-cutting safety rule.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Embedding backend stub ─────────────────────────────────────────
+// `embedConceptPageJob` calls `getMemoryBackendStatus` first to verify a
+// provider is configured, then `embedWithBackend` for the dense vector and
+// `generateSparseEmbedding` for the sparse one. Stub all three so tests run
+// without an embedding backend.
+
+const embedWithBackendCalls: Array<{
+  inputs: unknown;
+  options: unknown;
+}> = [];
+
+mock.module("../../embedding-backend.js", () => ({
+  getMemoryBackendStatus: async () => ({
+    enabled: true,
+    degraded: false,
+    provider: "local",
+    model: "test-model",
+    reason: null,
+  }),
+  embedWithBackend: async (
+    _config: unknown,
+    inputs: unknown[],
+    options?: unknown,
+  ) => {
+    embedWithBackendCalls.push({ inputs, options });
+    // Return a dense vector matching the test config's vectorSize (4).
+    return {
+      provider: "local" as const,
+      model: "test-model",
+      vectors: inputs.map(() => [0.1, 0.2, 0.3, 0.4]),
+    };
+  },
+  generateSparseEmbedding: (text: string) => ({
+    indices: [text.length % 100],
+    values: [1],
+  }),
+  // Other exports from the real module — stubbed so adjacent imports
+  // (e.g. via transitive `db.ts` → `indexer.ts`) don't crash on missing
+  // names when the mock replaces the module wholesale.
+  selectedBackendSupportsMultimodal: async () => false,
+}));
+
+// ── v2 qdrant stub ─────────────────────────────────────────────────
+// `embedConceptPageJob` upserts via `upsertConceptPageEmbedding` and deletes
+// via `deleteConceptPageEmbedding`. Capture both so we can assert on them.
+
+const upsertCalls: Array<{
+  slug: string;
+  dense: number[];
+  sparse: { indices: number[]; values: number[] };
+  updatedAt: number;
+}> = [];
+
+const deleteCalls: string[] = [];
+
+mock.module("../../v2/qdrant.js", () => ({
+  upsertConceptPageEmbedding: async (params: {
+    slug: string;
+    dense: number[];
+    sparse: { indices: number[]; values: number[] };
+    updatedAt: number;
+  }) => {
+    upsertCalls.push(params);
+  },
+  deleteConceptPageEmbedding: async (slug: string) => {
+    deleteCalls.push(slug);
+  },
+}));
+
+// ── Workspace setup ────────────────────────────────────────────────
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "embed-concept-page-test-"));
+  mkdirSync(join(tmpWorkspace, "memory", "concepts"), { recursive: true });
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+// Imports are deferred to after the env var is set so any internal use of
+// `getWorkspaceDir()` resolves to the tmpdir.
+const { DEFAULT_CONFIG } = await import("../../../config/defaults.js");
+const { getDb, initializeDb, resetDb } = await import("../../db.js");
+const { memoryEmbeddings, memoryJobs } = await import("../../schema.js");
+const { claimMemoryJobs } = await import("../../jobs-store.js");
+type MemoryJobMod = typeof import("../../jobs-store.js");
+type MemoryJob = ReturnType<MemoryJobMod["claimMemoryJobs"]>[number];
+const { embedConceptPageJob, enqueueEmbedConceptPageJob } =
+  await import("../embed-concept-page.js");
+const { writePage } = await import("../../v2/page-store.js");
+
+// Use a tiny vectorSize so the cache-dim check matches our stub vector.
+const TEST_CONFIG = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    qdrant: {
+      ...DEFAULT_CONFIG.memory.qdrant,
+      vectorSize: 4,
+    },
+  },
+};
+
+function makeJob(payload: Record<string, unknown>): MemoryJob {
+  return {
+    id: "job-1",
+    type: "embed_concept_page",
+    payload,
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+beforeEach(() => {
+  resetDb();
+  initializeDb();
+  embedWithBackendCalls.length = 0;
+  upsertCalls.length = 0;
+  deleteCalls.length = 0;
+});
+
+afterEach(() => {
+  // Clean up any pages written between tests so each scenario starts fresh.
+  rmSync(join(tmpWorkspace, "memory", "concepts"), {
+    recursive: true,
+    force: true,
+  });
+  mkdirSync(join(tmpWorkspace, "memory", "concepts"), { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("embedConceptPageJob — happy path", () => {
+  test("reads the page, embeds it, and upserts to the v2 collection", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "alice-prefers-vs-code",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Alice prefers VS Code over Vim.\nShe ships at end of day.\n",
+    });
+
+    await embedConceptPageJob(
+      makeJob({ slug: "alice-prefers-vs-code" }),
+      TEST_CONFIG,
+    );
+
+    // Dense embedding came from the backend stub once (no cache to start).
+    expect(embedWithBackendCalls).toHaveLength(1);
+
+    // Exactly one upsert with both vectors and the slug payload.
+    expect(upsertCalls).toHaveLength(1);
+    const call = upsertCalls[0];
+    expect(call.slug).toBe("alice-prefers-vs-code");
+    expect(call.dense).toEqual([0.1, 0.2, 0.3, 0.4]);
+    expect(call.sparse.indices.length).toBe(1);
+    expect(call.sparse.values).toEqual([1]);
+    expect(typeof call.updatedAt).toBe("number");
+
+    // Delete path was never taken.
+    expect(deleteCalls).toEqual([]);
+  });
+
+  test("populates the SQLite embedding cache row keyed on (concept_page, slug)", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "bob-uses-zsh",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Bob uses zsh.\n",
+    });
+
+    await embedConceptPageJob(makeJob({ slug: "bob-uses-zsh" }), TEST_CONFIG);
+
+    const row = getDb()
+      .select()
+      .from(memoryEmbeddings)
+      .all()
+      .find((r) => r.targetId === "bob-uses-zsh");
+
+    expect(row).toBeDefined();
+    expect(row!.targetType).toBe("concept_page");
+    expect(row!.dimensions).toBe(4);
+    expect(row!.contentHash).toBeTruthy();
+  });
+});
+
+describe("embedConceptPageJob — cache hit", () => {
+  test("reuses the cached dense vector when content hash matches", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "alice-prefers-vs-code",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Stable content.\n",
+    });
+
+    // First run — primes the cache.
+    await embedConceptPageJob(
+      makeJob({ slug: "alice-prefers-vs-code" }),
+      TEST_CONFIG,
+    );
+    expect(embedWithBackendCalls).toHaveLength(1);
+
+    // Second run with identical body — backend should not be hit again.
+    await embedConceptPageJob(
+      makeJob({ slug: "alice-prefers-vs-code" }),
+      TEST_CONFIG,
+    );
+    expect(embedWithBackendCalls).toHaveLength(1);
+
+    // Both runs upserted to Qdrant — caching only saves the embedding step.
+    expect(upsertCalls).toHaveLength(2);
+  });
+
+  test("re-embeds when the body changes (content hash mismatch)", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "alice-prefers-vs-code",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "First content.\n",
+    });
+    await embedConceptPageJob(
+      makeJob({ slug: "alice-prefers-vs-code" }),
+      TEST_CONFIG,
+    );
+
+    // Rewrite with different body.
+    await writePage(tmpWorkspace, {
+      slug: "alice-prefers-vs-code",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Second content (different).\n",
+    });
+    await embedConceptPageJob(
+      makeJob({ slug: "alice-prefers-vs-code" }),
+      TEST_CONFIG,
+    );
+
+    // Both runs hit the backend because the second body produces a new hash.
+    expect(embedWithBackendCalls).toHaveLength(2);
+    expect(upsertCalls).toHaveLength(2);
+  });
+});
+
+describe("embedConceptPageJob — delete propagation", () => {
+  test("removes the embedding when the page is missing on disk", async () => {
+    // No `writePage` → page does not exist. Worker should clean up Qdrant.
+    await embedConceptPageJob(makeJob({ slug: "deleted-slug" }), TEST_CONFIG);
+
+    expect(deleteCalls).toEqual(["deleted-slug"]);
+    expect(upsertCalls).toEqual([]);
+    expect(embedWithBackendCalls).toEqual([]);
+  });
+});
+
+describe("embedConceptPageJob — defensive", () => {
+  test("skips when slug is missing from the payload", async () => {
+    await embedConceptPageJob(makeJob({}), TEST_CONFIG);
+    expect(upsertCalls).toEqual([]);
+    expect(deleteCalls).toEqual([]);
+    expect(embedWithBackendCalls).toEqual([]);
+  });
+
+  test("skips when slug is the empty string", async () => {
+    await embedConceptPageJob(makeJob({ slug: "" }), TEST_CONFIG);
+    expect(upsertCalls).toEqual([]);
+    expect(deleteCalls).toEqual([]);
+  });
+});
+
+describe("enqueueEmbedConceptPageJob", () => {
+  test("enqueues a pending embed_concept_page job with the slug payload", () => {
+    const id = enqueueEmbedConceptPageJob({ slug: "alice-prefers-vs-code" });
+    expect(id).toBeTruthy();
+
+    const claimed = claimMemoryJobs(10);
+    expect(claimed).toHaveLength(1);
+    const [job] = claimed;
+    expect(job.type).toBe("embed_concept_page");
+    expect(job.payload).toEqual({ slug: "alice-prefers-vs-code" });
+  });
+
+  test("round-trip: enqueued job dispatches through embedConceptPageJob", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "round-trip-slug",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Round-trip body.\n",
+    });
+
+    enqueueEmbedConceptPageJob({ slug: "round-trip-slug" });
+
+    const claimed = claimMemoryJobs(10);
+    expect(claimed).toHaveLength(1);
+    const [job] = claimed;
+    expect(job.type).toBe("embed_concept_page");
+
+    await embedConceptPageJob(job, TEST_CONFIG);
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].slug).toBe("round-trip-slug");
+  });
+
+  test("inserted job row carries the right type and slug payload", () => {
+    const id = enqueueEmbedConceptPageJob({ slug: "row-check" });
+
+    const row = getDb()
+      .select()
+      .from(memoryJobs)
+      .all()
+      .find((r) => r.id === id);
+    expect(row).toBeDefined();
+    expect(row!.type).toBe("embed_concept_page");
+    expect(JSON.parse(row!.payload)).toEqual({ slug: "row-check" });
+  });
+});

--- a/assistant/src/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/memory/jobs/embed-concept-page.ts
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — `embed_concept_page` job handler
+// ---------------------------------------------------------------------------
+//
+// Reads a concept page from `memory/concepts/<slug>.md`, computes its dense +
+// sparse embeddings via the shared embedding backend, and upserts the pair
+// into the dedicated v2 Qdrant collection. When the page has been deleted out
+// from under us, the prior embedding is removed instead so the retrieval
+// surface stays in sync with disk.
+//
+// Modeled on `embed-pkb-file.ts` for the embedding flow + cache key handling:
+// dense vectors are looked up in the existing `memory_embeddings` SQLite cache
+// keyed on `(targetType="concept_page", targetId=<slug>, provider, model,
+// contentHash)` so unchanged pages skip the backend call. Unlike the PKB
+// handler, the v2 path bypasses `embedAndUpsert` because that helper is hard-
+// coupled to the v1 Qdrant collection — v2 uses its own collection via
+// `upsertConceptPageEmbedding`.
+
+import { randomUUID } from "node:crypto";
+
+import { and, eq } from "drizzle-orm";
+
+import type { AssistantConfig } from "../../config/types.js";
+import { BackendUnavailableError } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { getDb } from "../db.js";
+import {
+  embedWithBackend,
+  generateSparseEmbedding,
+  getMemoryBackendStatus,
+} from "../embedding-backend.js";
+import { embeddingInputContentHash } from "../embedding-types.js";
+import { asString, blobToVector, vectorToBlob } from "../job-utils.js";
+import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
+import { memoryEmbeddings } from "../schema.js";
+import { readPage } from "../v2/page-store.js";
+import {
+  deleteConceptPageEmbedding,
+  upsertConceptPageEmbedding,
+} from "../v2/qdrant.js";
+
+const log = getLogger("memory-v2-embed-concept-page");
+
+/** target_type marker stored on rows of `memory_embeddings` for v2 pages. */
+const CONCEPT_PAGE_TARGET_TYPE = "concept_page";
+
+/**
+ * Input shape for the `embed_concept_page` background job.
+ */
+export interface EmbedConceptPageJobInput {
+  /** Slug of the concept page to (re)embed (filename minus `.md`). */
+  slug: string;
+}
+
+/**
+ * Job handler: read the concept page at `memory/concepts/<slug>.md`, embed
+ * (dense + sparse), and upsert into the v2 Qdrant collection.
+ *
+ * Delete semantics: when the page no longer exists on disk (consolidation
+ * removed it, or the user deleted it manually), the handler removes the
+ * matching embedding instead of leaving a stale point behind. This makes the
+ * job a one-stop "sync this slug from disk to Qdrant" call and lets callers
+ * enqueue the same job type for both updates and deletions without branching.
+ */
+export async function embedConceptPageJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): Promise<void> {
+  const slug = asString(job.payload.slug);
+  if (!slug) return;
+
+  const workspaceDir = getWorkspaceDir();
+  const page = await readPage(workspaceDir, slug);
+
+  if (!page) {
+    // Page was deleted out from under us — clean up the prior embedding so
+    // retrieval no longer surfaces a slug whose disk-side prose is gone.
+    await deleteConceptPageEmbedding(slug);
+    return;
+  }
+
+  // Embed the prose body. Frontmatter is metadata the model never produces —
+  // leaving it out keeps the embedding stable across pure edges-rebuild
+  // backfills (which only rewrite frontmatter, not body) and matches the
+  // design doc decision that "body is prose, embedded for sim()".
+  const text = page.body;
+
+  const status = await getMemoryBackendStatus(config);
+  if (!status.provider) {
+    throw new BackendUnavailableError(
+      `Embedding backend unavailable (${status.reason ?? "no provider"})`,
+    );
+  }
+
+  const contentHash = embeddingInputContentHash({ type: "text", text });
+  const expectedDim = config.memory.qdrant.vectorSize;
+  let provider = status.provider;
+  let model = status.model!;
+
+  // Cache lookup: same (targetType, targetId, provider, model) row gets
+  // reused across runs as long as `contentHash` matches. The dim mismatch
+  // check guards against a config change (vectorSize bumped) since the last
+  // write — in that case we treat the row as stale and re-embed.
+  const db = getDb();
+  let cachedRow = db
+    .select({
+      vectorBlob: memoryEmbeddings.vectorBlob,
+      vectorJson: memoryEmbeddings.vectorJson,
+      dimensions: memoryEmbeddings.dimensions,
+      contentHash: memoryEmbeddings.contentHash,
+    })
+    .from(memoryEmbeddings)
+    .where(
+      and(
+        eq(memoryEmbeddings.targetType, CONCEPT_PAGE_TARGET_TYPE),
+        eq(memoryEmbeddings.targetId, slug),
+        eq(memoryEmbeddings.provider, provider),
+        eq(memoryEmbeddings.model, model),
+      ),
+    )
+    .get();
+  if (cachedRow && cachedRow.dimensions !== expectedDim) cachedRow = undefined;
+  if (cachedRow && cachedRow.contentHash !== contentHash) cachedRow = undefined;
+
+  let dense: number[];
+  let cacheHit = false;
+  if (cachedRow) {
+    dense = cachedRow.vectorBlob
+      ? blobToVector(cachedRow.vectorBlob as Buffer)
+      : (JSON.parse(cachedRow.vectorJson!) as number[]);
+    cacheHit = true;
+  } else {
+    const embedded = await embedWithBackend(config, [{ type: "text", text }]);
+    const vector = embedded.vectors[0];
+    if (!vector) return;
+    dense = vector;
+    provider = embedded.provider;
+    model = embedded.model;
+  }
+
+  // Sparse is cheap (in-process tokenization) and changes any time the body
+  // changes, so we always recompute it rather than caching alongside dense.
+  const sparse = generateSparseEmbedding(text);
+
+  const now = Date.now();
+  // Persist freshly embedded vectors for cross-restart reuse. On cache hit
+  // the existing row already has identical content + hash, so the write
+  // would be a no-op — skip it. Best-effort: write failure is not fatal,
+  // we still want the Qdrant upsert below to fire.
+  if (!cacheHit) {
+    try {
+      const blobValue = vectorToBlob(dense);
+      db.insert(memoryEmbeddings)
+        .values({
+          id: randomUUID(),
+          targetType: CONCEPT_PAGE_TARGET_TYPE,
+          targetId: slug,
+          provider,
+          model,
+          dimensions: dense.length,
+          vectorBlob: blobValue,
+          vectorJson: null,
+          contentHash,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [
+            memoryEmbeddings.targetType,
+            memoryEmbeddings.targetId,
+            memoryEmbeddings.provider,
+            memoryEmbeddings.model,
+          ],
+          set: {
+            vectorBlob: blobValue,
+            vectorJson: null,
+            dimensions: dense.length,
+            contentHash,
+            updatedAt: now,
+          },
+        })
+        .run();
+    } catch (err) {
+      log.warn(
+        { err, slug },
+        "Failed to write concept-page embedding cache row",
+      );
+    }
+  }
+
+  await upsertConceptPageEmbedding({
+    slug,
+    dense,
+    sparse,
+    updatedAt: now,
+  });
+}
+
+/**
+ * Enqueue an `embed_concept_page` job (async, fire-and-forget). Modeled on
+ * `enqueuePkbIndexJob` — callers that want a slug re-embedded after a write
+ * (or evicted after a delete) hand off to this helper instead of running the
+ * embedding inline.
+ */
+export function enqueueEmbedConceptPageJob(
+  input: EmbedConceptPageJobInput,
+): string {
+  return enqueueMemoryJob("embed_concept_page", { slug: input.slug });
+}


### PR DESCRIPTION
## Summary
- Real handler for the `embed_concept_page` v2 job: reads the concept page from `memory/concepts/<slug>.md`, computes dense + sparse embeddings (cache-aware via the existing `memory_embeddings` SQLite table), and upserts to the dedicated v2 Qdrant collection.
- Missing pages now trigger `deleteConceptPageEmbedding(slug)` so retrieval no longer surfaces a deleted slug.
- Promotes `vectorToBlob` / `blobToVector` in `job-utils.ts` from private to exported so the v2 handler shares the SQLite Float32Array encoding with the v1 pipeline.

Part of plan: memory-v2.md (PR 13 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
