### PR TITLE
feat(memory): v1->v2 migration synthesis logic

### DIFF
--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -45,6 +45,7 @@ export const LLMCallSiteEnum = z.enum([
   "memoryExtraction",
   "memoryConsolidation",
   "memoryRetrieval",
+  "memoryV2Migration",
   "recall",
   "narrativeRefinement",
   "patternScan",

--- a/assistant/src/memory/v2/__tests__/migration.test.ts
+++ b/assistant/src/memory/v2/__tests__/migration.test.ts
@@ -1,0 +1,794 @@
+/**
+ * Tests for `assistant/src/memory/v2/migration.ts`.
+ *
+ * The migration is heavily LLM-dependent at runtime, but every stage is
+ * structured so it can be unit-tested without a live provider:
+ *
+ *   - `gatherV1State`        — uses an in-memory SQLite DB seeded by the
+ *     test (no real workspace DB, no `initializeDb`).
+ *   - `clusterByTopic`       — pure function over `V1Item[]`.
+ *   - `synthesizeConceptPage`— accepts a stub `Provider` so the test never
+ *     reaches a real provider.
+ *   - `derivePromotions`     — pure function.
+ *   - `collapseEdges`        — pure function.
+ *   - `enqueueEmbeds`        — exercised end-to-end via `runMemoryV2Migration`,
+ *     which inserts rows into the test memory_jobs table.
+ *
+ * The end-to-end `runMemoryV2Migration` test stitches all stages together
+ * with a stub provider, runs against an isolated mkdtemp workspace + an
+ * in-memory DB, and asserts the on-disk side-effects (concept pages,
+ * edges.json, promotions, sentinel) plus the enqueued embed jobs.
+ *
+ * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`.
+ * Sample content uses generic placeholders (Alice, Bob, user@example.com).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+import type { Provider, ProviderResponse } from "../../../providers/types.js";
+
+// -- Mocks that must be installed before importing the module under test ---
+//
+// Order matters: every `mock.module` here runs before the migration module is
+// imported below, so its top-level `getLogger`/`getConfiguredProvider`/
+// `enqueueMemoryJob` references resolve to our stubs. Reversing the order
+// lets the real implementations leak through.
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// `runMemoryV2Migration` calls `enqueueMemoryJob` which in turn calls
+// `getDb()`. We intercept the enqueue call so the test doesn't need to wire
+// up the full migration runner / data-dir scaffolding just to count
+// enqueues. The stub records every (type, payload) pair for assertion.
+const enqueuedJobs: Array<{ type: string; payload: Record<string, unknown> }> =
+  [];
+mock.module("../../jobs-store.js", () => ({
+  enqueueMemoryJob: (type: string, payload: Record<string, unknown>) => {
+    enqueuedJobs.push({ type, payload });
+    return `job-${enqueuedJobs.length}`;
+  },
+}));
+
+// `getConfiguredProvider` is invoked when the runner is called without an
+// explicit `provider` arg. Our top-level runner test always passes a stub
+// provider, but the safety net mock keeps any accidental real-call from
+// reaching the network — and lets us add a "no provider configured" test.
+let providerStub: Provider | null = null;
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  userMessage: (text: string) => ({
+    role: "user" as const,
+    content: [{ type: "text" as const, text }],
+  }),
+  extractText: (response: ProviderResponse) => {
+    const block = response.content.find(
+      (b): b is { type: "text"; text: string } => b.type === "text",
+    );
+    return block?.text?.trim() ?? "";
+  },
+}));
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import type { DrizzleDb } from "../../db-connection.js";
+import { getSqliteFrom } from "../../db-connection.js";
+import * as schema from "../../schema.js";
+// Type-only imports are erased at runtime so they don't evaluate the module —
+// safe to declare alongside the dynamic value import below.
+import type { Cluster, V1Edge, V1Item } from "../migration.js";
+
+// Dynamic import — runs *after* the mock.module calls above so the migration
+// module's transitive references to logger / jobs-store / provider-send-message
+// resolve to our stubs (matches the pattern used in `qdrant.test.ts`).
+const {
+  clusterByTopic,
+  collapseEdges,
+  derivePromotions,
+  enqueueEmbeds,
+  gatherV1State,
+  MIGRATION_SENTINEL_RELATIVE,
+  MigrationAlreadyAppliedError,
+  runMemoryV2Migration,
+  synthesizeConceptPage,
+} = await import("../migration.js");
+
+// ---------------------------------------------------------------------------
+// Test fixtures + helpers
+// ---------------------------------------------------------------------------
+
+let workspaceDir: string;
+let database: DrizzleDb;
+let sqlite: Database;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(
+    join(tmpdir(), "vellum-memory-v2-migration-test-"),
+  );
+  mkdirSync(join(workspaceDir, "memory", "concepts"), { recursive: true });
+  mkdirSync(join(workspaceDir, "memory", "archive"), { recursive: true });
+  mkdirSync(join(workspaceDir, "memory", ".v2-state"), { recursive: true });
+  mkdirSync(join(workspaceDir, "pkb"), { recursive: true });
+
+  sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  database = drizzle(sqlite, { schema });
+
+  // Minimal schema — only the v1 tables the migration reads from. We don't
+  // need the full memory schema; reading is unaffected by indexes / FKs we
+  // don't seed.
+  getSqliteFrom(database).exec(/*sql*/ `
+    CREATE TABLE memory_graph_nodes (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL,
+      created INTEGER NOT NULL,
+      last_accessed INTEGER NOT NULL,
+      last_consolidated INTEGER NOT NULL,
+      event_date INTEGER,
+      emotional_charge TEXT NOT NULL,
+      fidelity TEXT NOT NULL DEFAULT 'vivid',
+      confidence REAL NOT NULL,
+      significance REAL NOT NULL,
+      stability REAL NOT NULL DEFAULT 14,
+      reinforcement_count INTEGER NOT NULL DEFAULT 0,
+      last_reinforced INTEGER NOT NULL,
+      source_conversations TEXT NOT NULL DEFAULT '[]',
+      source_type TEXT NOT NULL DEFAULT 'inferred',
+      narrative_role TEXT,
+      part_of_story TEXT,
+      scope_id TEXT NOT NULL DEFAULT 'default',
+      image_refs TEXT
+    );
+    CREATE TABLE memory_graph_edges (
+      id TEXT PRIMARY KEY,
+      source_node_id TEXT NOT NULL,
+      target_node_id TEXT NOT NULL,
+      relationship TEXT NOT NULL,
+      weight REAL NOT NULL DEFAULT 1.0,
+      created INTEGER NOT NULL
+    );
+  `);
+
+  enqueuedJobs.length = 0;
+  providerStub = null;
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+  sqlite.close();
+});
+
+/** Insert one v1 graph node row. Defaults match a "remember-this fact" shape. */
+function insertNode(
+  database: DrizzleDb,
+  overrides: Partial<{
+    id: string;
+    content: string;
+    type: string;
+    significance: number;
+    eventDate: number | null;
+  }> = {},
+): string {
+  const id = overrides.id ?? `node-${Math.random().toString(36).slice(2, 10)}`;
+  getSqliteFrom(database)
+    .query(
+      /*sql*/ `INSERT INTO memory_graph_nodes (
+        id, content, type, created, last_accessed, last_consolidated,
+        event_date, emotional_charge, confidence, significance, last_reinforced
+      ) VALUES (?, ?, ?, 0, 0, 0, ?, '{}', 0.9, ?, 0)`,
+    )
+    .run(
+      id,
+      overrides.content ?? "Alice prefers VS Code over Vim.",
+      overrides.type ?? "semantic",
+      overrides.eventDate ?? null,
+      overrides.significance ?? 0.5,
+    );
+  return id;
+}
+
+function insertEdge(
+  database: DrizzleDb,
+  sourceId: string,
+  targetId: string,
+): void {
+  getSqliteFrom(database)
+    .query(
+      /*sql*/ `INSERT INTO memory_graph_edges (
+        id, source_node_id, target_node_id, relationship, weight, created
+      ) VALUES (?, ?, ?, 'reminds-of', 0.7, 0)`,
+    )
+    .run(`edge-${Math.random().toString(36).slice(2, 10)}`, sourceId, targetId);
+}
+
+/** Build a `Provider` that returns canned text per call. */
+function buildStubProvider(textPerCall: string[] | string): Provider {
+  const queue = Array.isArray(textPerCall) ? [...textPerCall] : null;
+  return {
+    name: "stub",
+    sendMessage: async () => {
+      const text = queue ? (queue.shift() ?? "") : (textPerCall as string);
+      return {
+        content: [{ type: "text", text }],
+        model: "stub-model",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// gatherV1State
+// ---------------------------------------------------------------------------
+
+describe("gatherV1State", () => {
+  test("returns empty state for an empty workspace + empty DB", () => {
+    const { items, edges } = gatherV1State(database, workspaceDir);
+    expect(items).toEqual([]);
+    expect(edges).toEqual([]);
+  });
+
+  test("reads graph nodes from the v1 store", () => {
+    const id = insertNode(database, {
+      content: "Alice ships to Vellum at end of day.",
+      type: "semantic",
+      significance: 0.8,
+    });
+    const { items } = gatherV1State(database, workspaceDir);
+    expect(items.length).toBe(1);
+    expect(items[0]).toMatchObject({
+      id,
+      text: "Alice ships to Vellum at end of day.",
+      source: "graph_node",
+      significance: 0.8,
+      type: "semantic",
+    });
+  });
+
+  test("reads graph edges from the v1 store", () => {
+    const a = insertNode(database, { id: "node-a" });
+    const b = insertNode(database, { id: "node-b" });
+    insertEdge(database, a, b);
+    const { edges } = gatherV1State(database, workspaceDir);
+    expect(edges.length).toBe(1);
+    expect(edges[0]).toEqual({
+      sourceNodeId: "node-a",
+      targetNodeId: "node-b",
+    });
+  });
+
+  test("reads pkb/buffer.md", () => {
+    writeFileSync(
+      join(workspaceDir, "pkb", "buffer.md"),
+      "- Alice's preferred IDE is VS Code\n",
+      "utf-8",
+    );
+    const { items } = gatherV1State(database, workspaceDir);
+    const buffer = items.find((i) => i.source === "pkb_buffer");
+    expect(buffer).toBeDefined();
+    expect(buffer?.text).toBe("- Alice's preferred IDE is VS Code\n");
+  });
+
+  test("reads pkb/archive/*.md and pkb/<topic>.md files", () => {
+    mkdirSync(join(workspaceDir, "pkb", "archive"), { recursive: true });
+    writeFileSync(
+      join(workspaceDir, "pkb", "archive", "2026-01-01.md"),
+      "Archive content for Bob.\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(workspaceDir, "pkb", "ides.md"),
+      "VS Code is preferred.\n",
+      "utf-8",
+    );
+    const { items } = gatherV1State(database, workspaceDir);
+    expect(items.find((i) => i.source === "pkb_archive")).toMatchObject({
+      sourcePath: "pkb/archive/2026-01-01.md",
+    });
+    expect(items.find((i) => i.source === "pkb_topic")).toMatchObject({
+      sourcePath: "pkb/ides.md",
+    });
+  });
+
+  test("ignores non-.md files in pkb/ and pkb/archive/", () => {
+    mkdirSync(join(workspaceDir, "pkb", "archive"), { recursive: true });
+    writeFileSync(join(workspaceDir, "pkb", "ignored.txt"), "skip me", "utf-8");
+    writeFileSync(
+      join(workspaceDir, "pkb", "archive", "junk.bin"),
+      "skip me",
+      "utf-8",
+    );
+    const { items } = gatherV1State(database, workspaceDir);
+    expect(items.filter((i) => i.source !== "graph_node")).toEqual([]);
+  });
+
+  test("gracefully handles a missing pkb/ directory", () => {
+    rmSync(join(workspaceDir, "pkb"), { recursive: true, force: true });
+    expect(() => gatherV1State(database, workspaceDir)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clusterByTopic
+// ---------------------------------------------------------------------------
+
+describe("clusterByTopic", () => {
+  test("emits one cluster per item in input order", () => {
+    const items: V1Item[] = [
+      buildItem({ id: "n1", text: "Alice IDE preference is VS Code" }),
+      buildItem({ id: "n2", text: "Bob coffee order is double espresso" }),
+    ];
+    const clusters = clusterByTopic(items);
+    expect(clusters.length).toBe(2);
+    expect(clusters[0].items[0].id).toBe("n1");
+    expect(clusters[1].items[0].id).toBe("n2");
+  });
+
+  test("topic file → slug-hint matches filename", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "pkb:topic:ides.md",
+        text: "VS Code preferred",
+        source: "pkb_topic",
+        sourcePath: "pkb/ides.md",
+      }),
+    ];
+    const [cluster] = clusterByTopic(items);
+    expect(cluster.slugHint).toBe("ides");
+  });
+
+  test("archive entry → slug hint includes the date stamp", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "pkb:archive:2026-01-01.md",
+        text: "x",
+        source: "pkb_archive",
+        sourcePath: "pkb/archive/2026-01-01.md",
+      }),
+    ];
+    const [cluster] = clusterByTopic(items);
+    expect(cluster.slugHint).toBe("archive-2026-01-01");
+  });
+
+  test("graph node → slug hint is first few words of content", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "node-1",
+        text: "Alice prefers VS Code over Vim and ships at end of day.",
+      }),
+    ];
+    const [cluster] = clusterByTopic(items);
+    // Punctuation survives the hint stage; slugify in stage 3 strips it.
+    expect(cluster.slugHint).toBe("Alice-prefers-VS-Code-over-Vim");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// synthesizeConceptPage
+// ---------------------------------------------------------------------------
+
+describe("synthesizeConceptPage", () => {
+  test("returns a ConceptPage built from the provider's text response", async () => {
+    const cluster: Cluster = {
+      slugHint: "alice-ides",
+      items: [
+        buildItem({
+          id: "node-1",
+          text: "Alice prefers VS Code over Vim.",
+        }),
+      ],
+    };
+    const provider = buildStubProvider(
+      "Alice prefers VS Code. She ships at end of day.",
+    );
+    const page = await synthesizeConceptPage(cluster, null, provider);
+    expect(page.slug).toBe("alice-ides");
+    expect(page.frontmatter).toEqual({ edges: [], ref_files: [] });
+    expect(page.body).toContain("VS Code");
+    expect(page.body.endsWith("\n")).toBe(true);
+  });
+
+  test("appends identity context to the system prompt when provided", async () => {
+    let capturedSystem: string | undefined;
+    const provider: Provider = {
+      name: "stub",
+      sendMessage: async (_messages, _tools, system) => {
+        capturedSystem = system;
+        return {
+          content: [{ type: "text", text: "synthesized" }],
+          model: "stub-model",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          stopReason: "end_turn",
+        };
+      },
+    };
+    await synthesizeConceptPage(
+      {
+        slugHint: "x",
+        items: [buildItem({ id: "node-1", text: "fact" })],
+      },
+      "I am the example assistant. Be precise.",
+      provider,
+    );
+    expect(capturedSystem).toContain("I am the example assistant.");
+  });
+
+  test("normalizes the slug via slugify", async () => {
+    const provider = buildStubProvider("body");
+    const page = await synthesizeConceptPage(
+      {
+        slugHint: "ALICE!! Preferences!!",
+        items: [buildItem({ id: "node-1", text: "x" })],
+      },
+      null,
+      provider,
+    );
+    expect(page.slug).toBe("alice-preferences");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// derivePromotions
+// ---------------------------------------------------------------------------
+
+describe("derivePromotions", () => {
+  test("high significance → essentials", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "n1",
+        text: "User's name is Alice",
+        significance: 0.95,
+      }),
+    ];
+    const result = derivePromotions(items);
+    expect(result.essentials).toEqual(["- User's name is Alice"]);
+    expect(result.threads).toEqual([]);
+    expect(result.archive).toEqual([]);
+  });
+
+  test("prospective type → threads (regardless of significance)", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "n1",
+        text: "Follow up with Bob next Tuesday",
+        significance: 0.5,
+        type: "prospective",
+      }),
+    ];
+    const result = derivePromotions(items);
+    expect(result.threads).toEqual(["- Follow up with Bob next Tuesday"]);
+    expect(result.essentials).toEqual([]);
+    expect(result.archive).toEqual([]);
+  });
+
+  test("low significance → archive", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "n1",
+        text: "Random small detail",
+        significance: 0.1,
+      }),
+    ];
+    const result = derivePromotions(items);
+    expect(result.archive).toEqual(["- Random small detail"]);
+    expect(result.essentials).toEqual([]);
+    expect(result.threads).toEqual([]);
+  });
+
+  test("middle significance → no promotion (concept page only)", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "n1",
+        text: "Mid-significance fact",
+        significance: 0.5,
+      }),
+    ];
+    const result = derivePromotions(items);
+    expect(result.essentials).toEqual([]);
+    expect(result.threads).toEqual([]);
+    expect(result.archive).toEqual([]);
+  });
+
+  test("PKB items are never promoted (concept page only)", () => {
+    const items: V1Item[] = [
+      buildItem({
+        id: "pkb:buffer",
+        text: "Alice's preferred IDE is VS Code",
+        source: "pkb_buffer",
+        significance: 0,
+      }),
+    ];
+    const result = derivePromotions(items);
+    expect(result.essentials).toEqual([]);
+    expect(result.threads).toEqual([]);
+    expect(result.archive).toEqual([]);
+  });
+
+  test("essentials threshold takes precedence over prospective", () => {
+    // High-significance prospective node is essential first; threads is the
+    // bucket for *active* follow-ups, not core identity.
+    const items: V1Item[] = [
+      buildItem({
+        id: "n1",
+        text: "User is undergoing therapy and remembers everything",
+        significance: 0.95,
+        type: "prospective",
+      }),
+    ];
+    const result = derivePromotions(items);
+    expect(result.essentials.length).toBe(1);
+    expect(result.threads).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collapseEdges
+// ---------------------------------------------------------------------------
+
+describe("collapseEdges", () => {
+  test("maps v1 ids to v2 slugs and emits canonical tuples after writeEdges", () => {
+    const v1: V1Edge[] = [
+      { sourceNodeId: "node-a", targetNodeId: "node-b" },
+      { sourceNodeId: "node-b", targetNodeId: "node-c" },
+    ];
+    const slugMap = new Map([
+      ["node-a", "alice"],
+      ["node-b", "bob"],
+      ["node-c", "carol"],
+    ]);
+    const idx = collapseEdges(v1, slugMap);
+    expect(idx.version).toBe(1);
+    expect(idx.edges.length).toBe(2);
+  });
+
+  test("drops edges whose endpoints aren't in the slug map", () => {
+    const v1: V1Edge[] = [
+      { sourceNodeId: "node-a", targetNodeId: "ghost" },
+      { sourceNodeId: "ghost", targetNodeId: "node-b" },
+    ];
+    const slugMap = new Map([
+      ["node-a", "alice"],
+      ["node-b", "bob"],
+    ]);
+    const idx = collapseEdges(v1, slugMap);
+    expect(idx.edges).toEqual([]);
+  });
+
+  test("drops self-loops introduced by the slug mapping", () => {
+    // Two distinct v1 nodes mapped to the same v2 slug (e.g. clustered
+    // together) cannot produce an edge — `addEdge`/writeEdges reject self
+    // loops, so we must filter at collapse time.
+    const v1: V1Edge[] = [{ sourceNodeId: "node-a", targetNodeId: "node-b" }];
+    const slugMap = new Map([
+      ["node-a", "merged"],
+      ["node-b", "merged"],
+    ]);
+    const idx = collapseEdges(v1, slugMap);
+    expect(idx.edges).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enqueueEmbeds
+// ---------------------------------------------------------------------------
+
+describe("enqueueEmbeds", () => {
+  test("enqueues one embed_concept_page job per slug", () => {
+    expect(enqueueEmbeds(["alice", "bob", "carol"])).toBe(3);
+    expect(enqueuedJobs).toEqual([
+      { type: "embed_concept_page", payload: { slug: "alice" } },
+      { type: "embed_concept_page", payload: { slug: "bob" } },
+      { type: "embed_concept_page", payload: { slug: "carol" } },
+    ]);
+  });
+
+  test("empty list is a no-op", () => {
+    expect(enqueueEmbeds([])).toBe(0);
+    expect(enqueuedJobs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runMemoryV2Migration (end-to-end)
+// ---------------------------------------------------------------------------
+
+describe("runMemoryV2Migration", () => {
+  test("end-to-end: gathers, synthesizes, promotes, collapses, embeds, sentinel", async () => {
+    const a = insertNode(database, {
+      id: "node-a",
+      content: "User is Alice and works at Vellum",
+      significance: 0.95,
+    });
+    const b = insertNode(database, {
+      id: "node-b",
+      content: "Alice prefers VS Code over Vim",
+      significance: 0.5,
+    });
+    insertEdge(database, a, b);
+    writeFileSync(
+      join(workspaceDir, "pkb", "ides.md"),
+      "VS Code is preferred at Vellum.\n",
+      "utf-8",
+    );
+
+    const provider = buildStubProvider([
+      "Alice works at Vellum.\n",
+      "Alice prefers VS Code over Vim.\n",
+      "VS Code is preferred at Vellum.\n",
+    ]);
+    const result = await runMemoryV2Migration({
+      workspaceDir,
+      database,
+      provider,
+    });
+
+    // -- Pages were written. --
+    const conceptDir = join(workspaceDir, "memory", "concepts");
+    const pages = readdirSync(conceptDir);
+    expect(pages.length).toBe(3);
+    expect(result.pagesCreated).toBe(3);
+
+    // -- edges.json reflects the v1 edge collapse. --
+    const edgesRaw = readFileSync(
+      join(workspaceDir, "memory", "edges.json"),
+      "utf-8",
+    );
+    const edges = JSON.parse(edgesRaw) as { edges: [string, string][] };
+    expect(edges.edges.length).toBe(1);
+
+    // -- Promotions appended to the right files. --
+    const essentials = readFileSync(
+      join(workspaceDir, "memory", "essentials.md"),
+      "utf-8",
+    );
+    expect(essentials).toContain("User is Alice and works at Vellum");
+    expect(result.essentialsLines).toBe(1);
+
+    // -- Embed jobs enqueued (one per page). --
+    expect(enqueuedJobs.length).toBe(3);
+    expect(enqueuedJobs.every((j) => j.type === "embed_concept_page")).toBe(
+      true,
+    );
+
+    // -- Sentinel written. --
+    expect(existsSync(join(workspaceDir, MIGRATION_SENTINEL_RELATIVE))).toBe(
+      true,
+    );
+    expect(result.sentinelWritten).toBe(true);
+  });
+
+  test("rejects re-run when sentinel exists and force is not set", async () => {
+    const provider = buildStubProvider("body");
+    insertNode(database, { content: "fact" });
+    await runMemoryV2Migration({ workspaceDir, database, provider });
+
+    await expect(
+      runMemoryV2Migration({ workspaceDir, database, provider }),
+    ).rejects.toThrow(MigrationAlreadyAppliedError);
+  });
+
+  test("force=true overwrites and re-writes the sentinel", async () => {
+    insertNode(database, { content: "fact" });
+    const provider1 = buildStubProvider("first body");
+    await runMemoryV2Migration({ workspaceDir, database, provider: provider1 });
+
+    const provider2 = buildStubProvider("second body");
+    const result = await runMemoryV2Migration({
+      workspaceDir,
+      database,
+      provider: provider2,
+      force: true,
+    });
+    expect(result.sentinelWritten).toBe(true);
+
+    const conceptDir = join(workspaceDir, "memory", "concepts");
+    const pages = readdirSync(conceptDir);
+    expect(pages.length).toBe(1);
+    const body = readFileSync(join(conceptDir, pages[0]), "utf-8");
+    expect(body).toContain("second body");
+  });
+
+  test("clearing the sentinel allows a non-force re-run", async () => {
+    insertNode(database, { content: "fact" });
+    const provider = buildStubProvider("body");
+    await runMemoryV2Migration({ workspaceDir, database, provider });
+    unlinkSync(join(workspaceDir, MIGRATION_SENTINEL_RELATIVE));
+    // No throw.
+    await runMemoryV2Migration({
+      workspaceDir,
+      database,
+      provider: buildStubProvider("rerun"),
+    });
+  });
+
+  test("throws when no provider is available and none is configured", async () => {
+    insertNode(database, { content: "fact" });
+    providerStub = null;
+    await expect(
+      runMemoryV2Migration({ workspaceDir, database }),
+    ).rejects.toThrow(/memoryV2Migration provider unavailable/);
+  });
+
+  test("uses getConfiguredProvider when no provider is passed", async () => {
+    insertNode(database, { content: "fact" });
+    providerStub = buildStubProvider("body from configured provider");
+    const result = await runMemoryV2Migration({ workspaceDir, database });
+    expect(result.pagesCreated).toBe(1);
+    const conceptDir = join(workspaceDir, "memory", "concepts");
+    const body = readFileSync(
+      join(conceptDir, readdirSync(conceptDir)[0]),
+      "utf-8",
+    );
+    expect(body).toContain("body from configured provider");
+  });
+
+  test("disambiguates colliding slugs with -2/-3 suffixes", async () => {
+    insertNode(database, {
+      id: "n1",
+      content: "Alice IDE preferences",
+      significance: 0.5,
+    });
+    insertNode(database, {
+      id: "n2",
+      content: "Alice IDE preferences",
+      significance: 0.5,
+    });
+    const provider = buildStubProvider(["body 1", "body 2"]);
+    await runMemoryV2Migration({ workspaceDir, database, provider });
+
+    const conceptDir = join(workspaceDir, "memory", "concepts");
+    const pages = new Set(readdirSync(conceptDir));
+    expect(pages.size).toBe(2);
+    // First page wins the bare slug; second gets the `-2` suffix.
+    expect(pages.has("alice-ide-preferences.md")).toBe(true);
+    expect(pages.has("alice-ide-preferences-2.md")).toBe(true);
+  });
+
+  test("dry workspace + empty DB still writes sentinel and produces zero pages", async () => {
+    const provider = buildStubProvider("");
+    const result = await runMemoryV2Migration({
+      workspaceDir,
+      database,
+      provider,
+    });
+    expect(result.pagesCreated).toBe(0);
+    expect(result.embedsEnqueued).toBe(0);
+    expect(result.sentinelWritten).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildItem(overrides: Partial<V1Item> = {}): V1Item {
+  return {
+    id: overrides.id ?? "node-default",
+    text: overrides.text ?? "default content",
+    source: overrides.source ?? "graph_node",
+    significance: overrides.significance ?? 0.5,
+    type: overrides.type ?? "semantic",
+    eventDate: overrides.eventDate ?? null,
+    sourcePath: overrides.sourcePath ?? null,
+  };
+}

--- a/assistant/src/memory/v2/migration.ts
+++ b/assistant/src/memory/v2/migration.ts
@@ -1,0 +1,642 @@
+/**
+ * Memory v2 — One-shot v1→v2 migration.
+ *
+ * Gathers v1 graph nodes plus PKB markdown content, clusters them by topic,
+ * synthesizes a concept page per cluster via the configured LLM, promotes
+ * high-significance nodes to `essentials.md` / active follow-ups to
+ * `threads.md` / low-significance episodes to `archive/migrated-<date>.md`,
+ * collapses v1 weighted directional edges into the v2 unweighted-undirected
+ * `memory/edges.json`, and enqueues `embed_concept_page` jobs for each new
+ * page. A sentinel file at `memory/.v2-state/.migration-complete-v1-to-v2`
+ * gates re-runs — `force: true` is required to overwrite.
+ *
+ * The migration is structured as a sequence of small helpers — `gatherV1State`,
+ * `clusterByTopic`, `synthesizeConceptPage`, `derivePromotions`,
+ * `collapseEdges`, `enqueueEmbeds` — each individually testable so the live
+ * LLM never has to be invoked from the unit suite. `runMemoryV2Migration`
+ * threads them together and writes the sentinel on success.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { AssistantConfig } from "../../config/types.js";
+import {
+  extractText,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import type { Provider } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { enqueueMemoryJob } from "../jobs-store.js";
+import { writeEdges } from "./edges.js";
+import { slugify, writePage } from "./page-store.js";
+import type { ConceptPage, EdgesIndex } from "./types.js";
+
+const log = getLogger("memory-v2-migration");
+
+/** Sentinel file written when the v1→v2 migration completes successfully. */
+export const MIGRATION_SENTINEL_RELATIVE = join(
+  "memory",
+  ".v2-state",
+  ".migration-complete-v1-to-v2",
+);
+
+/**
+ * Result returned by `runMemoryV2Migration`. Counts every meaningful
+ * side-effect so the caller (CLI, IPC route, tests) can surface a useful
+ * summary without having to re-walk the workspace.
+ */
+export interface MigrationResult {
+  pagesCreated: number;
+  edgesWritten: number;
+  essentialsLines: number;
+  threadsLines: number;
+  archiveLines: number;
+  embedsEnqueued: number;
+  sentinelWritten: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 1 — Gather v1 state
+// ---------------------------------------------------------------------------
+
+/**
+ * v1 source item — either a graph node or a PKB markdown chunk. The shape is
+ * intentionally narrow: each stage only needs `id` (for stable identity),
+ * `text` (for clustering + synthesis), and the structural fields that drive
+ * promotion decisions (`significance`, `type`, `eventDate`).
+ */
+export interface V1Item {
+  id: string;
+  text: string;
+  /** v1 source bucket — drives clustering fallback and promotion decisions. */
+  source: "graph_node" | "pkb_buffer" | "pkb_archive" | "pkb_topic";
+  /** Significance in [0, 1] for graph nodes; 0 for PKB items. */
+  significance: number;
+  /** Memory type for graph nodes; null for PKB items. */
+  type: string | null;
+  /** Epoch ms; null when unknown. */
+  eventDate: number | null;
+  /** Source filename (relative to workspace root) for PKB items; null for graph nodes. */
+  sourcePath: string | null;
+}
+
+/**
+ * v1 weighted directional edge — collapsed in stage 5 into v2's unweighted
+ * undirected canonical pairs.
+ */
+export interface V1Edge {
+  sourceNodeId: string;
+  targetNodeId: string;
+}
+
+/**
+ * Read every `memory_graph_nodes` row, every `memory_graph_edges` row, and
+ * every `pkb/` markdown file inside `workspaceDir`. PKB files that don't
+ * exist on disk are silently skipped — a fresh workspace with no PKB content
+ * still migrates cleanly (it just produces no concept pages).
+ */
+export function gatherV1State(
+  database: DrizzleDb,
+  workspaceDir: string,
+): { items: V1Item[]; edges: V1Edge[] } {
+  const items: V1Item[] = [];
+  const raw = getSqliteFrom(database);
+
+  // -- Graph nodes --
+  // Use a raw SELECT so this module stays decoupled from the v1 graph-store
+  // domain layer (which v2 will eventually replace). We only need id /
+  // content / type / significance / event_date — everything else is unused
+  // by the migration.
+  const nodeRows = raw
+    .query<
+      {
+        id: string;
+        content: string;
+        type: string;
+        significance: number;
+        event_date: number | null;
+      },
+      []
+    >(
+      /*sql*/ `SELECT id, content, type, significance, event_date FROM memory_graph_nodes`,
+    )
+    .all();
+  for (const row of nodeRows) {
+    items.push({
+      id: row.id,
+      text: row.content,
+      source: "graph_node",
+      significance: row.significance,
+      type: row.type,
+      eventDate: row.event_date,
+      sourcePath: null,
+    });
+  }
+
+  // -- Graph edges --
+  const edgeRows = raw
+    .query<
+      { source_node_id: string; target_node_id: string },
+      []
+    >(/*sql*/ `SELECT source_node_id, target_node_id FROM memory_graph_edges`)
+    .all();
+  const edges: V1Edge[] = edgeRows.map((row) => ({
+    sourceNodeId: row.source_node_id,
+    targetNodeId: row.target_node_id,
+  }));
+
+  // -- PKB content --
+  const pkbDir = join(workspaceDir, "pkb");
+  if (existsSync(pkbDir)) {
+    items.push(...readPkbItems(pkbDir));
+  }
+
+  return { items, edges };
+}
+
+/**
+ * Walk `pkbDir` once and emit a `V1Item` per markdown file. Sub-buckets:
+ *
+ *   - `buffer.md` (top-level) → `pkb_buffer`
+ *   - `archive/*.md`          → `pkb_archive`
+ *   - everything else `*.md`  → `pkb_topic`
+ *
+ * We deliberately read the full file rather than chunking — the LLM in stage
+ * 3 will summarize, and the upstream PKB chunker is overkill here.
+ */
+function readPkbItems(pkbDir: string): V1Item[] {
+  const items: V1Item[] = [];
+
+  const bufferPath = join(pkbDir, "buffer.md");
+  if (existsSync(bufferPath)) {
+    items.push({
+      id: "pkb:buffer",
+      text: readFileSync(bufferPath, "utf-8"),
+      source: "pkb_buffer",
+      significance: 0,
+      type: null,
+      eventDate: null,
+      sourcePath: "pkb/buffer.md",
+    });
+  }
+
+  const archiveDir = join(pkbDir, "archive");
+  if (existsSync(archiveDir)) {
+    for (const name of readdirSync(archiveDir).sort()) {
+      if (!name.endsWith(".md")) continue;
+      items.push({
+        id: `pkb:archive:${name}`,
+        text: readFileSync(join(archiveDir, name), "utf-8"),
+        source: "pkb_archive",
+        significance: 0,
+        type: null,
+        eventDate: null,
+        sourcePath: join("pkb", "archive", name),
+      });
+    }
+  }
+
+  // Topic files — anything else at the top level besides buffer.md.
+  for (const name of readdirSync(pkbDir).sort()) {
+    if (!name.endsWith(".md")) continue;
+    if (name === "buffer.md") continue;
+    items.push({
+      id: `pkb:topic:${name}`,
+      text: readFileSync(join(pkbDir, name), "utf-8"),
+      source: "pkb_topic",
+      significance: 0,
+      type: null,
+      eventDate: null,
+      sourcePath: join("pkb", name),
+    });
+  }
+
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 2 — Cluster by topic
+// ---------------------------------------------------------------------------
+
+/**
+ * One proposed concept page. `slugHint` seeds `slugify` in stage 3 — the
+ * synthesizer is free to refine it but always produces *some* slug.
+ */
+export interface Cluster {
+  slugHint: string;
+  items: V1Item[];
+}
+
+/**
+ * Group v1 items into proposed concept pages.
+ *
+ * The heuristic is intentionally simple — embedding-cluster is on the
+ * "follow-up improvements" list (see plan §11), but for the v1-of-v2 cutover
+ * file-based grouping for PKB plus per-graph-node singletons gives a
+ * reasonable starting set that the LLM can refine in stage 3:
+ *
+ *   - Each `pkb_topic` file becomes its own cluster (slug derived from
+ *     filename — that's literally what topic files were already keyed on).
+ *   - `pkb_buffer` and every `pkb_archive` entry becomes its own cluster
+ *     (these are timeline-style; no obvious topic to merge on).
+ *   - Each graph node is its own cluster (the LLM call in stage 3 already
+ *     synthesizes prose; merging duplicates is consolidation's job).
+ *
+ * The output is deterministic: clusters are emitted in iteration order of
+ * the input items, which matches the SELECT order from `gatherV1State`.
+ */
+export function clusterByTopic(items: V1Item[]): Cluster[] {
+  return items.map((item) => ({
+    slugHint: deriveSlugHint(item),
+    items: [item],
+  }));
+}
+
+/**
+ * Pick a slug seed for a single v1 item. PKB topic files use their filename
+ * (sans `.md`); archive entries use the date stamp; graph nodes use the
+ * first ~6 words of the content. `slugify` enforces ASCII / kebab-case /
+ * length cap downstream so we don't have to.
+ */
+function deriveSlugHint(item: V1Item): string {
+  if (item.source === "pkb_topic" && item.sourcePath) {
+    const base = item.sourcePath.split("/").pop() ?? "";
+    return base.replace(/\.md$/, "");
+  }
+  if (item.source === "pkb_archive" && item.sourcePath) {
+    return `archive-${item.sourcePath.split("/").pop()?.replace(/\.md$/, "")}`;
+  }
+  if (item.source === "pkb_buffer") {
+    return "pkb-buffer";
+  }
+  // graph_node — first few words of the content.
+  return item.text.split(/\s+/).slice(0, 6).join("-");
+}
+
+// ---------------------------------------------------------------------------
+// Stage 3 — Synthesize a concept page per cluster
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesis prompt — kept here (rather than under `prompts/`) because it's
+ * only used by the migration. The model is asked to emit prose only; the
+ * frontmatter is filled in deterministically by the caller.
+ */
+const SYNTHESIS_SYSTEM_PROMPT = `You are migrating an assistant's memory from a legacy graph + PKB store to a v2 concept-page store. For each cluster of v1 source items, write a single concept page in first-person prose, in the assistant's voice. Do NOT include YAML frontmatter — the caller will add it. Do NOT include a title heading — the slug filename is the title. Keep the body under 5000 characters. Stay grounded in the source items; do not invent facts.`;
+
+/**
+ * Synthesize a single concept page from a `Cluster`. Calls the configured
+ * provider via `memoryV2Migration` LLMCallSite. The body is the model's
+ * response text; the slug is derived from the cluster's `slugHint`.
+ *
+ * `provider` is injected so unit tests can pass a stub. Production callers
+ * pass the result of `getConfiguredProvider("memoryV2Migration")`.
+ *
+ * `identityContext` (typically the assistant's SOUL.md / IDENTITY.md
+ * concatenation) is appended to the system prompt so the synthesized prose
+ * sounds like the assistant rather than a generic narrator.
+ */
+export async function synthesizeConceptPage(
+  cluster: Cluster,
+  identityContext: string | null,
+  provider: Provider,
+): Promise<ConceptPage> {
+  const sourceListing = cluster.items
+    .map((item, i) => {
+      const tag =
+        item.source === "graph_node"
+          ? `node ${item.id} (type=${item.type ?? "?"}, sig=${item.significance.toFixed(2)})`
+          : (item.sourcePath ?? item.source);
+      return `### Source ${i + 1} [${tag}]\n${item.text.trim()}`;
+    })
+    .join("\n\n");
+
+  const systemPrompt = identityContext
+    ? `${SYNTHESIS_SYSTEM_PROMPT}\n\n## Assistant identity\n${identityContext}`
+    : SYNTHESIS_SYSTEM_PROMPT;
+
+  const response = await provider.sendMessage(
+    [
+      userMessage(
+        `Synthesize a single concept page from these v1 sources. Slug hint: \`${cluster.slugHint}\`.\n\n${sourceListing}`,
+      ),
+    ],
+    [],
+    systemPrompt,
+    { config: { callSite: "memoryV2Migration" as const } },
+  );
+  const body = extractText(response);
+
+  return {
+    slug: slugify(cluster.slugHint),
+    frontmatter: { edges: [], ref_files: [] },
+    body: body.endsWith("\n") ? body : `${body}\n`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stage 4 — Derive essentials / threads / archive promotions
+// ---------------------------------------------------------------------------
+
+/**
+ * Bucketed promotions written to the prose files in `memory/`. The runner
+ * appends each bucket to its target file (rather than overwriting) so an
+ * operator running `--force` keeps any hand-edits the assistant has made
+ * since the last migration.
+ */
+export interface Promotions {
+  /** Lines for `memory/essentials.md`. */
+  essentials: string[];
+  /** Lines for `memory/threads.md`. */
+  threads: string[];
+  /** Lines for `memory/archive/migrated-<date>.md`. */
+  archive: string[];
+}
+
+/** Cutoff above which a graph node is treated as essential. */
+const ESSENTIALS_SIGNIFICANCE_THRESHOLD = 0.85;
+/** Cutoff below which a graph node is bucketed as low-significance episodic. */
+const ARCHIVE_SIGNIFICANCE_THRESHOLD = 0.3;
+
+/**
+ * Decide which v1 graph nodes get promoted to which prose file. PKB items
+ * are always synthesized into concept pages — they don't get a separate
+ * prose-file promotion.
+ *
+ *   - significance >= 0.85         → `essentials.md`
+ *   - type == "prospective"        → `threads.md`
+ *   - significance <= 0.3          → archive
+ *   - everything else              → no promotion (only the synthesized page)
+ *
+ * The thresholds are intentionally chunky — fine-tuning happens during
+ * consolidation, not here.
+ */
+export function derivePromotions(items: V1Item[]): Promotions {
+  const essentials: string[] = [];
+  const threads: string[] = [];
+  const archive: string[] = [];
+
+  for (const item of items) {
+    if (item.source !== "graph_node") continue;
+
+    const summary = formatPromotionLine(item);
+    if (item.significance >= ESSENTIALS_SIGNIFICANCE_THRESHOLD) {
+      essentials.push(summary);
+      continue;
+    }
+    if (item.type === "prospective") {
+      threads.push(summary);
+      continue;
+    }
+    if (item.significance <= ARCHIVE_SIGNIFICANCE_THRESHOLD) {
+      archive.push(summary);
+    }
+  }
+
+  return { essentials, threads, archive };
+}
+
+/** Format a single graph node as a one-line bullet for the prose files. */
+function formatPromotionLine(item: V1Item): string {
+  // Strip newlines so each item becomes a single bullet.
+  const text = item.text.replace(/\s+/g, " ").trim();
+  return `- ${text}`;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 5 — Collapse v1 edges into v2 edges.json
+// ---------------------------------------------------------------------------
+
+/**
+ * Map every v1 graph-node id to a v2 concept-page slug, then rewrite v1
+ * edges as canonical v2 tuples. Edges with either endpoint missing from
+ * `slugMap` are dropped silently — those endpoints didn't survive
+ * synthesis (e.g. their cluster produced no usable page).
+ *
+ * The returned `EdgesIndex` is canonicalized + deduped by `writeEdges`'s
+ * own write-time normalization, so callers can pass it straight through.
+ */
+export function collapseEdges(
+  v1Edges: V1Edge[],
+  slugMap: Map<string, string>,
+): EdgesIndex {
+  const tuples: [string, string][] = [];
+  for (const edge of v1Edges) {
+    const a = slugMap.get(edge.sourceNodeId);
+    const b = slugMap.get(edge.targetNodeId);
+    if (!a || !b) continue;
+    if (a === b) continue;
+    tuples.push([a, b]);
+  }
+  return { version: 1, edges: tuples };
+}
+
+// ---------------------------------------------------------------------------
+// Stage 6 — Fan out embed jobs
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueue an `embed_concept_page` job for each newly-written slug. The job
+ * itself lands in PR 13 — we just stage the queue here, so the embeddings
+ * are ready by the time activation needs them.
+ */
+export function enqueueEmbeds(slugs: string[]): number {
+  for (const slug of slugs) {
+    enqueueMemoryJob("embed_concept_page", { slug });
+  }
+  return slugs.length;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level migration runner
+// ---------------------------------------------------------------------------
+
+export interface RunMemoryV2MigrationParams {
+  workspaceDir: string;
+  database: DrizzleDb;
+  /** Overwrite existing v2 state when the sentinel is already present. */
+  force?: boolean;
+  /** Identity context appended to the synthesis system prompt. */
+  identityContext?: string | null;
+  /** Caller-supplied LLM provider for synthesis. Defaults to the configured provider. */
+  provider?: Provider;
+  /** Caller-supplied config; reserved for future tunables (e.g. cluster knobs). */
+  config?: AssistantConfig;
+}
+
+/**
+ * Run the full v1→v2 migration. Returns a `MigrationResult` summarizing
+ * every side-effect for the CLI / IPC caller.
+ *
+ * Re-runs are gated by the sentinel file
+ * `memory/.v2-state/.migration-complete-v1-to-v2`. Without `force: true`, a
+ * second invocation throws `MigrationAlreadyAppliedError` without mutating
+ * anything; with `force: true`, the migration overwrites pages and
+ * `edges.json` and re-appends to the prose files.
+ */
+export class MigrationAlreadyAppliedError extends Error {
+  constructor() {
+    super(
+      "Memory v2 migration sentinel exists; pass force: true to re-run. Running without --force preserves the existing v2 state.",
+    );
+    this.name = "MigrationAlreadyAppliedError";
+  }
+}
+
+export async function runMemoryV2Migration(
+  params: RunMemoryV2MigrationParams,
+): Promise<MigrationResult> {
+  const {
+    workspaceDir,
+    database,
+    force = false,
+    identityContext = null,
+  } = params;
+
+  const sentinelPath = join(workspaceDir, MIGRATION_SENTINEL_RELATIVE);
+  if (existsSync(sentinelPath) && !force) {
+    throw new MigrationAlreadyAppliedError();
+  }
+
+  const { items, edges: v1Edges } = gatherV1State(database, workspaceDir);
+  log.info(
+    { itemCount: items.length, edgeCount: v1Edges.length },
+    "Gathered v1 state for memory v2 migration",
+  );
+
+  const clusters = clusterByTopic(items);
+
+  const provider =
+    params.provider ?? (await getConfiguredProvider("memoryV2Migration"));
+  if (!provider) {
+    throw new Error(
+      "memoryV2Migration provider unavailable — configure llm.callSites.memoryV2Migration or llm.default before re-running.",
+    );
+  }
+
+  // PKB items never become edge endpoints, so the slug map only needs the
+  // graph-node side of the cluster.
+  const slugMap = new Map<string, string>();
+  const pages: ConceptPage[] = [];
+  const usedSlugs = new Set<string>();
+
+  for (const cluster of clusters) {
+    const page = await synthesizeConceptPage(
+      cluster,
+      identityContext,
+      provider,
+    );
+    // Disambiguate slug collisions deterministically: append `-2`, `-3`, …
+    // until we find an unused slug. Keeps synthesizeConceptPage stateless
+    // while still tolerating two clusters that hash to the same hint.
+    let finalSlug = page.slug;
+    let suffix = 2;
+    while (usedSlugs.has(finalSlug)) {
+      finalSlug = `${page.slug}-${suffix++}`;
+    }
+    usedSlugs.add(finalSlug);
+    const finalized: ConceptPage = { ...page, slug: finalSlug };
+    pages.push(finalized);
+
+    for (const item of cluster.items) {
+      if (item.source === "graph_node") slugMap.set(item.id, finalSlug);
+    }
+  }
+
+  // Page writes hit different filenames so they're safe to fan out.
+  await Promise.all(pages.map((page) => writePage(workspaceDir, page)));
+
+  const promotions = derivePromotions(items);
+  await appendPromotions(workspaceDir, promotions);
+
+  const edgesIdx = collapseEdges(v1Edges, slugMap);
+  await writeEdges(workspaceDir, edgesIdx);
+
+  const embedsEnqueued = enqueueEmbeds(pages.map((p) => p.slug));
+  await writeSentinel(workspaceDir);
+
+  // Re-read after writeEdges so the count reflects post-canonicalization
+  // dedup (collapseEdges can produce duplicate tuples when v1 had multiple
+  // weighted edges between the same pair).
+  const finalEdges = await readPersistedEdgeCount(workspaceDir);
+
+  return {
+    pagesCreated: pages.length,
+    edgesWritten: finalEdges,
+    essentialsLines: promotions.essentials.length,
+    threadsLines: promotions.threads.length,
+    archiveLines: promotions.archive.length,
+    embedsEnqueued,
+    sentinelWritten: true,
+  };
+}
+
+/**
+ * Append each promotion bucket to its target file. Files are created if
+ * absent — the workspace migration in PR 3 (`060-memory-v2-init`) seeds
+ * empty placeholders, so this is mostly belt-and-suspenders.
+ */
+async function appendPromotions(
+  workspaceDir: string,
+  promotions: Promotions,
+): Promise<void> {
+  const memoryDir = join(workspaceDir, "memory");
+  await mkdir(memoryDir, { recursive: true });
+  await mkdir(join(memoryDir, "archive"), { recursive: true });
+
+  if (promotions.essentials.length > 0) {
+    await appendLines(join(memoryDir, "essentials.md"), promotions.essentials);
+  }
+  if (promotions.threads.length > 0) {
+    await appendLines(join(memoryDir, "threads.md"), promotions.threads);
+  }
+  if (promotions.archive.length > 0) {
+    const today = new Date().toISOString().slice(0, 10);
+    await appendLines(
+      join(memoryDir, "archive", `migrated-${today}.md`),
+      promotions.archive,
+    );
+  }
+}
+
+/** Append `lines` to `path`, creating it (with a trailing newline) if absent. */
+async function appendLines(path: string, lines: string[]): Promise<void> {
+  let existing = "";
+  try {
+    existing = await readFile(path, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  const trailing = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  const next = `${existing}${trailing}${lines.join("\n")}\n`;
+  await writeFile(path, next, "utf-8");
+}
+
+/** Write the migration sentinel. The body is metadata for human inspection. */
+async function writeSentinel(workspaceDir: string): Promise<void> {
+  const sentinelPath = join(workspaceDir, MIGRATION_SENTINEL_RELATIVE);
+  await mkdir(join(workspaceDir, "memory", ".v2-state"), { recursive: true });
+  await writeFile(sentinelPath, `${new Date().toISOString()}\n`, "utf-8");
+}
+
+/**
+ * Read `memory/edges.json` after writing and return the edge count. Used
+ * only to populate the result summary — the file has already been
+ * canonicalized by `writeEdges`, so this is just a count, not validation.
+ */
+async function readPersistedEdgeCount(workspaceDir: string): Promise<number> {
+  try {
+    const raw = await readFile(
+      join(workspaceDir, "memory", "edges.json"),
+      "utf-8",
+    );
+    const parsed = JSON.parse(raw) as { edges?: unknown[] };
+    return Array.isArray(parsed.edges) ? parsed.edges.length : 0;
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `memory/v2/migration.ts` — `gatherV1State`, `clusterByTopic`, `synthesizeConceptPage`, `derivePromotions`, `collapseEdges`, `enqueueEmbeds`, plus the `runMemoryV2Migration` runner that threads them together with sentinel-gated re-runs (`force: true` to overwrite).
- Adds `memoryV2Migration` to `LLMCallSiteEnum` so the resolver can route the synthesis call.
- 33 unit tests cover every stage individually plus end-to-end with a stub provider — no live LLM hit from CI.

Part of plan: memory-v2.md (PR 16 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
