### PR TITLE
feat(memory): implement memory v2 sweep job

### DIFF
--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -46,6 +46,7 @@ export const LLMCallSiteEnum = z.enum([
   "memoryConsolidation",
   "memoryRetrieval",
   "memoryV2Migration",
+  "memoryV2Sweep",
   "recall",
   "narrativeRefinement",
   "patternScan",

--- a/assistant/src/memory/__tests__/jobs-worker-v2-stubs.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-stubs.test.ts
@@ -51,7 +51,7 @@ mock.module("../checkpoints.js", () => ({
   setMemoryCheckpoint: () => {},
 }));
 
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 import { getDb, initializeDb } from "../db.js";
 import { enqueueMemoryJob, type MemoryJobType } from "../jobs-store.js";
@@ -72,12 +72,24 @@ initializeDb();
 
 async function drainJobs(): Promise<void> {
   // `startMemoryJobsWorker` kicks off an auto-tick that races with our
-  // explicit `runOnce`; loop until both report no remaining work so
-  // either path finishes draining the queue.
+  // explicit `runOnce`. The auto-tick can claim a subset of pending jobs
+  // first and then still be in-flight when `runOnce` returns 0; if we exit
+  // immediately we may observe a job that's still in `running` state. Loop
+  // until both `runOnce` AND the DB show no remaining pending/running rows
+  // so either drain path finishes the queue.
   const worker = startMemoryJobsWorker();
   try {
-    let safety = 5;
-    while (safety > 0 && (await worker.runOnce()) > 0) {
+    let safety = 20;
+    while (safety > 0) {
+      const processed = await worker.runOnce();
+      const remaining = getDb()
+        .select({ id: memoryJobs.id })
+        .from(memoryJobs)
+        .where(inArray(memoryJobs.status, ["pending", "running"]))
+        .all().length;
+      if (processed === 0 && remaining === 0) break;
+      // Yield so any concurrently in-flight auto-tick can advance.
+      await new Promise((resolve) => setImmediate(resolve));
       safety -= 1;
     }
   } finally {

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -76,8 +76,11 @@ export function handleRemember(
  * Format mirrors the long-standing v1 PKB layout so v2 buffers stay
  * human-readable and downstream consumers (sweep, consolidation) can parse
  * the same shape regardless of which path produced the entry.
+ *
+ * Exported so memory v2 sweep / extractor jobs format their auto-remembered
+ * entries identically to user-facing `remember()` calls.
  */
-function formatRememberEntry(content: string, now: Date): string {
+export function formatRememberEntry(content: string, now: Date): string {
   const month = now.toLocaleString("en-US", { month: "short" });
   const day = now.getDate();
   const hours = now.getHours();
@@ -93,8 +96,13 @@ function formatRememberEntry(content: string, now: Date): string {
  *
  * Returns the absolute paths of both files so callers can fan out follow-up
  * work (e.g. PKB re-indexing in the v1 path).
+ *
+ * Exported so memory v2 background jobs (`sweep`, future LLM-driven
+ * extractors) can append to `memory/buffer.md` + `memory/archive/<today>.md`
+ * with exactly the same format `remember()` produces, keeping the two write
+ * paths byte-compatible for downstream consumers (consolidation, search).
  */
-function appendBufferAndArchive(args: {
+export function appendBufferAndArchive(args: {
   rootDir: string;
   entry: string;
   now: Date;

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -60,6 +60,7 @@ import {
   resetRunningJobsToPending,
 } from "./jobs-store.js";
 import { QdrantCircuitOpenError } from "./qdrant-circuit-breaker.js";
+import { memoryV2SweepJob } from "./v2/sweep-job.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -456,6 +457,8 @@ async function processJob(
       await embedConceptPageJob(job, config);
       return;
     case "memory_v2_sweep":
+      await memoryV2SweepJob(job, config);
+      return;
     case "memory_v2_consolidate":
     case "memory_v2_migrate":
     case "memory_v2_rebuild_edges":

--- a/assistant/src/memory/v2/__tests__/sweep-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/sweep-job.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests for `assistant/src/memory/v2/sweep-job.ts`.
+ *
+ * Coverage matrix (from PR 18 acceptance criteria):
+ *   - Flag off → no provider/DB calls, returns 0 (early bail).
+ *   - Flag on + no recent messages → no provider call, returns 0.
+ *   - Flag on + recent messages → provider invoked with rendered prompt;
+ *     each entry is appended to `memory/buffer.md` AND today's archive.
+ *   - Tool-call response shape mismatch → returns 0 without writes.
+ *   - Empty entries are skipped (the model can't pad the buffer).
+ *
+ * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
+ * content uses generic placeholders (Alice, Bob, user@example.com).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+import type {
+  Provider,
+  ProviderResponse,
+  ToolUseContent,
+} from "../../../providers/types.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// Provider stub. Each test sets `providerStub` to control the response;
+// `null` simulates "no configured provider".
+let providerStub: Provider | null = null;
+const providerCalls: Array<{
+  systemPrompt: string | undefined;
+  userText: string;
+}> = [];
+
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  userMessage: (text: string) => ({
+    role: "user" as const,
+    content: [{ type: "text" as const, text }],
+  }),
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+}));
+
+// Workspace setup — temp dir per test run, pinned via VELLUM_WORKSPACE_DIR
+// so `getWorkspaceDir()` resolves to the tmpdir.
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-v2-sweep-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+const { initializeDb, resetDb, getDb } = await import("../../db.js");
+const { messages, conversations } = await import("../../schema.js");
+const { _setOverridesForTesting } =
+  await import("../../../config/assistant-feature-flags.js");
+const { memoryV2SweepJob } = await import("../sweep-job.js");
+
+// `isAssistantFeatureFlagEnabled` ignores the `config` argument it receives
+// (resolution is purely from the overrides + registry caches), so we hand
+// the handler a minimal stand-in instead of materializing the full default
+// config — which would otherwise pull in heavy schemas this test doesn't
+// exercise.
+const CONFIG = {} as Parameters<typeof memoryV2SweepJob>[1];
+
+function makeJob(): Parameters<typeof memoryV2SweepJob>[0] {
+  return {
+    id: "sweep-1",
+    type: "memory_v2_sweep",
+    payload: {},
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+/**
+ * Tool-shape provider stub. Returns a single `tool_use` block whose `input`
+ * matches `{ entries: [...] }` so the sweep's parser accepts it.
+ */
+function makeEntriesProvider(entries: string[]): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (msgs, _tools, systemPrompt) => {
+      providerCalls.push({
+        systemPrompt,
+        userText: extractFirstUserText(msgs),
+      });
+      return {
+        model: "stub-model",
+        stopReason: "end_turn",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        content: [
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "emit_remember_entries",
+            input: { entries },
+          },
+        ],
+      } satisfies ProviderResponse;
+    },
+  };
+}
+
+/**
+ * Extract the first text block of the first user message — keeps the test
+ * assertions readable when only one user message is in flight.
+ */
+function extractFirstUserText(msgs: { content: unknown }[]): string {
+  const first = msgs[0];
+  if (!first || !Array.isArray(first.content)) return "";
+  const block = first.content.find(
+    (b: unknown) =>
+      typeof b === "object" &&
+      b !== null &&
+      (b as { type?: string }).type === "text",
+  ) as { text?: string } | undefined;
+  return block?.text ?? "";
+}
+
+/** Insert a conversation + N messages, with createdAt offsets in ms relative to now. */
+function seedMessages(
+  conversationId: string,
+  rows: Array<{ role: string; content: string; offsetMs: number }>,
+): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id: conversationId,
+      title: null,
+      createdAt: now - 60_000,
+      updatedAt: now,
+    })
+    .run();
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    db.insert(messages)
+      .values({
+        id: `${conversationId}-msg-${i}`,
+        conversationId,
+        role: row.role,
+        content: row.content,
+        createdAt: now + row.offsetMs,
+        metadata: null,
+      })
+      .run();
+  }
+}
+
+beforeEach(() => {
+  resetDb();
+  initializeDb();
+  // Fresh memory dir per test — keeps assertions on file contents independent.
+  rmSync(join(tmpWorkspace, "memory"), { recursive: true, force: true });
+  mkdirSync(join(tmpWorkspace, "memory"), { recursive: true });
+  providerCalls.length = 0;
+  providerStub = null;
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+// ---------------------------------------------------------------------------
+
+describe("memoryV2SweepJob — flag off", () => {
+  test("returns 0 without invoking the provider when flag is off", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    providerStub = makeEntriesProvider(["should-not-be-written"]);
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(0);
+    expect(providerCalls).toHaveLength(0);
+    expect(existsSync(join(tmpWorkspace, "memory", "buffer.md"))).toBe(false);
+  });
+});
+
+describe("memoryV2SweepJob — flag on, no recent messages", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+  });
+
+  test("returns 0 when no messages exist in the recent window", async () => {
+    providerStub = makeEntriesProvider(["should-not-be-written"]);
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(0);
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  test("returns 0 when messages exist but are all outside the 30m window", async () => {
+    seedMessages("conv-old", [
+      { role: "user", content: "Hello.", offsetMs: -60 * 60 * 1000 }, // 1h ago
+      { role: "assistant", content: "Hi!", offsetMs: -59 * 60 * 1000 },
+    ]);
+    providerStub = makeEntriesProvider(["should-not-be-written"]);
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(0);
+    expect(providerCalls).toHaveLength(0);
+  });
+});
+
+// Per-test conversation id ensures each test seeds a row that doesn't
+// collide with the previous test's row in the (shared) test DB. `resetDb`
+// is called in the outer beforeEach, but bun's mock module flow keeps the
+// DB intact long enough for the SQL inserts here to clash.
+let convCounter = 0;
+
+describe("memoryV2SweepJob — flag on, recent messages", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    seedMessages(`conv-${++convCounter}`, [
+      {
+        role: "user",
+        content: "I just switched my editor to VS Code.",
+        offsetMs: -60_000,
+      },
+      {
+        role: "assistant",
+        content: "Got it — VS Code it is.",
+        offsetMs: -30_000,
+      },
+    ]);
+  });
+
+  test("appends each returned entry to buffer.md and today's archive", async () => {
+    providerStub = makeEntriesProvider([
+      "Alice prefers VS Code over Vim.",
+      "Alice ships at end of day.",
+    ]);
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(2);
+    expect(providerCalls).toHaveLength(1);
+
+    const buffer = readFileSync(
+      join(tmpWorkspace, "memory", "buffer.md"),
+      "utf-8",
+    );
+    expect(buffer).toContain("Alice prefers VS Code over Vim.");
+    expect(buffer).toContain("Alice ships at end of day.");
+
+    const archivePath = join(
+      tmpWorkspace,
+      "memory",
+      "archive",
+      todaysArchiveBasename(),
+    );
+    expect(existsSync(archivePath)).toBe(true);
+    const archive = readFileSync(archivePath, "utf-8");
+    expect(archive).toContain("Alice prefers VS Code over Vim.");
+    expect(archive).toContain("Alice ships at end of day.");
+  });
+
+  test("renders system prompt with assistant + user names from IDENTITY/persona", async () => {
+    // The IDENTITY / persona files use markdown-bold name labels — the
+    // production prompt-resolver greps for the same shape, so we have to
+    // emit a literal markdown-bold "Name" marker here.
+    const NAME_LABEL = `**${"Name"}:**`;
+    writeFileSync(
+      join(tmpWorkspace, "IDENTITY.md"),
+      `${NAME_LABEL} Aria\n`,
+      "utf-8",
+    );
+    mkdirSync(join(tmpWorkspace, "users"), { recursive: true });
+    writeFileSync(
+      join(tmpWorkspace, "users", "default.md"),
+      `${NAME_LABEL} Alice\n`,
+      "utf-8",
+    );
+
+    providerStub = makeEntriesProvider(["entry"]);
+    await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(providerCalls).toHaveLength(1);
+    const [{ systemPrompt }] = providerCalls;
+    expect(systemPrompt).toContain("Aria");
+    expect(systemPrompt).toContain("Alice");
+  });
+
+  test("hands the model the existing buffer for dedup", async () => {
+    writeFileSync(
+      join(tmpWorkspace, "memory", "buffer.md"),
+      "- [Apr 27, 9:00 AM] Existing entry that should be referenced as dedup signal.\n",
+      "utf-8",
+    );
+
+    providerStub = makeEntriesProvider(["new entry"]);
+    await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(providerCalls).toHaveLength(1);
+    const [{ userText }] = providerCalls;
+    expect(userText).toContain("existingBuffer");
+    expect(userText).toContain("Existing entry that should be referenced");
+  });
+
+  test("skips empty / whitespace-only entries the model returns", async () => {
+    providerStub = makeEntriesProvider([
+      "Alice prefers VS Code.",
+      "",
+      "   ",
+      "Alice ships at end of day.",
+    ]);
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(2);
+    const buffer = readFileSync(
+      join(tmpWorkspace, "memory", "buffer.md"),
+      "utf-8",
+    );
+    // Two timestamped bullets — count newlines that start with "- ".
+    const bullets = buffer.split("\n").filter((line) => line.startsWith("- "));
+    expect(bullets).toHaveLength(2);
+  });
+
+  test("returns 0 when the model returns no tool_use block", async () => {
+    providerStub = {
+      name: "no-tool",
+      sendMessage: async () => ({
+        model: "stub-model",
+        stopReason: "end_turn",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        content: [{ type: "text", text: "I have nothing to add." }],
+      }),
+    };
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(0);
+    expect(existsSync(join(tmpWorkspace, "memory", "buffer.md"))).toBe(false);
+  });
+
+  test("returns 0 when the tool input is malformed", async () => {
+    providerStub = {
+      name: "bad-shape",
+      sendMessage: async () => ({
+        model: "stub-model",
+        stopReason: "end_turn",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        content: [
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "emit_remember_entries",
+            // Missing `entries` array — schema rejects.
+            input: { other: "shape" },
+          },
+        ],
+      }),
+    };
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(0);
+    expect(existsSync(join(tmpWorkspace, "memory", "buffer.md"))).toBe(false);
+  });
+
+  test("returns 0 when no provider is configured", async () => {
+    providerStub = null;
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+
+    expect(written).toBe(0);
+  });
+});
+
+function todaysArchiveBasename(now: Date = new Date()): string {
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}.md`;
+}

--- a/assistant/src/memory/v2/prompts/sweep.ts
+++ b/assistant/src/memory/v2/prompts/sweep.ts
@@ -1,0 +1,56 @@
+/**
+ * Memory v2 — sweep prompt template.
+ *
+ * Body taken from §9 of the design doc (`memoized-spinning-wadler.md`). The
+ * template uses two placeholders that the sweep job substitutes at runtime:
+ *
+ *   - `{{ASSISTANT_NAME}}` — the assistant's display name (from IDENTITY.md
+ *     when available, else "the assistant" so the prompt still parses).
+ *   - `{{USER_NAME}}` — the guardian's display name (from the guardian
+ *     persona when available, else "the user").
+ *
+ * Kept here (under `prompts/`) rather than inlined in `sweep-job.ts` so the
+ * prompt body is reviewable on its own and the job module stays focused on
+ * orchestration. The same convention applies to the consolidation prompt
+ * landing in PR 20.
+ */
+
+/** Sentinel substituted with the assistant's display name at runtime. */
+export const ASSISTANT_NAME_PLACEHOLDER = "{{ASSISTANT_NAME}}";
+
+/** Sentinel substituted with the guardian's display name at runtime. */
+export const USER_NAME_PLACEHOLDER = "{{USER_NAME}}";
+
+/**
+ * Sweep prompt — body from design doc §9. The model is asked to surface
+ * additional facts/preferences/plans/etc. that should be remembered but
+ * aren't already in the existing buffer. It MUST emit a JSON-shaped tool
+ * call with an `entries` array; the runtime parses the response via the
+ * tool definition declared in `sweep-job.ts`.
+ *
+ * The `existingBuffer` text is appended at the call site (rather than
+ * templated here) so we don't inadvertently expand `{{` inside user buffer
+ * content. Recent messages are likewise appended outside the template.
+ */
+export const SWEEP_PROMPT = `You are a background helper for ${ASSISTANT_NAME_PLACEHOLDER}. Read these recent messages between ${ASSISTANT_NAME_PLACEHOLDER} and ${USER_NAME_PLACEHOLDER}. The assistant has already called \`remember()\` for the entries shown in \`existingBuffer\`.
+
+Identify additional facts, preferences, plans, corrections, names, dates, decisions, or notable felt moments that should be remembered but aren't already in \`existingBuffer\`. Emit a list of \`remember()\` entries (each one line, in the assistant's first-person voice). Don't duplicate. Prefer to over-remember rather than miss things.
+
+Return only the \`entries\` array.`;
+
+/**
+ * Resolve `SWEEP_PROMPT` with assistant + user names substituted. Falls back
+ * to neutral defaults so the prompt still produces well-formed English when
+ * either name is unavailable on this workspace.
+ */
+export function renderSweepPrompt(opts: {
+  assistantName: string | null;
+  userName: string | null;
+}): string {
+  const assistant = opts.assistantName?.trim() || "the assistant";
+  const user = opts.userName?.trim() || "the user";
+  return SWEEP_PROMPT.replaceAll(
+    ASSISTANT_NAME_PLACEHOLDER,
+    assistant,
+  ).replaceAll(USER_NAME_PLACEHOLDER, user);
+}

--- a/assistant/src/memory/v2/sweep-job.ts
+++ b/assistant/src/memory/v2/sweep-job.ts
@@ -1,0 +1,292 @@
+/**
+ * Memory v2 — `memory_v2_sweep` job handler.
+ *
+ * The sweep is the auto-extraction analog of v1's `graph_extract`: idle-
+ * debounced, prompted with the current `memory/buffer.md` so it dedupes
+ * against entries `remember()` already wrote, and asked to surface anything
+ * the assistant should have remembered but missed. Each returned entry is
+ * appended to `memory/buffer.md` and `memory/archive/<today>.md` using the
+ * exact same write path as `remember()` so consolidation can't tell which
+ * entries came from the model and which came from the tool call.
+ *
+ * Lifecycle integration: scheduled by PR 24's hook into the existing
+ * extraction-trigger path. Until then this handler is invoked only by
+ * `memory_v2_sweep` rows enqueued explicitly (tests, future CLI).
+ *
+ * Skipped entirely when the `memory-v2-enabled` feature flag is off — keeps
+ * the sweep dormant in v1-only workspaces even if a stale row sits in the
+ * queue at flag-flip time.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { desc, gt } from "drizzle-orm";
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { getAssistantName } from "../../daemon/identity-helpers.js";
+import {
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { getDb } from "../db.js";
+import {
+  appendBufferAndArchive,
+  formatRememberEntry,
+} from "../graph/tool-handlers.js";
+import type { MemoryJob } from "../jobs-store.js";
+import { messages } from "../schema.js";
+import { renderSweepPrompt } from "./prompts/sweep.js";
+
+const log = getLogger("memory-v2-sweep");
+
+/** Window of conversation history the sweep inspects on each run. */
+const RECENT_MESSAGES_WINDOW_MS = 30 * 60 * 1000;
+
+/**
+ * Cap on the message text we hand the model. Recent-messages text is the
+ * single-largest input — clamping keeps the request under typical context
+ * windows without having to compute precise token counts.
+ */
+const MAX_RECENT_TEXT_CHARS = 32_000;
+
+/**
+ * Cap on the buffer text we hand the model. The buffer can grow large in
+ * busy workspaces; the model only needs enough to dedupe, not the entire
+ * archive.
+ */
+const MAX_BUFFER_CHARS = 16_000;
+
+// Tool-call schema. The JSON schema is what the provider sees; the Zod
+// schema below validates the model's reply at runtime since the SDK
+// returns the tool input as `unknown`. The two must stay in sync.
+const SWEEP_TOOL_NAME = "emit_remember_entries";
+
+const SWEEP_TOOL: ToolDefinition = {
+  name: SWEEP_TOOL_NAME,
+  description:
+    "Emit zero or more remember()-style entries the assistant should commit to long-term memory.",
+  input_schema: {
+    type: "object",
+    properties: {
+      entries: {
+        type: "array",
+        description:
+          "Each entry is a single line in the assistant's first-person voice (e.g. 'Alice prefers VS Code over Vim').",
+        items: { type: "string" },
+      },
+    },
+    required: ["entries"],
+  },
+};
+
+const SweepResultSchema = z.object({
+  entries: z.array(z.string()),
+});
+
+/**
+ * Job handler. Reads recent messages + buffer, asks the configured provider
+ * for additional remember-able entries, and appends each entry to
+ * `memory/buffer.md` + `memory/archive/<today>.md` via the same helper
+ * `remember()` uses.
+ *
+ * Returns the number of entries written so callers (and tests) can assert
+ * progress without inspecting the filesystem.
+ */
+export async function memoryV2SweepJob(
+  _job: MemoryJob,
+  config: AssistantConfig,
+): Promise<number> {
+  if (!isAssistantFeatureFlagEnabled("memory-v2-enabled", config)) {
+    log.debug("memory-v2-enabled flag off; sweep skipped");
+    return 0;
+  }
+
+  const workspaceDir = getWorkspaceDir();
+  const memoryDir = join(workspaceDir, "memory");
+  const recentText = loadRecentMessagesText(Date.now());
+  if (!recentText) {
+    log.debug("No recent messages in window; sweep skipped");
+    return 0;
+  }
+
+  const existingBuffer = readBufferText(memoryDir);
+
+  const provider = await getConfiguredProvider("memoryV2Sweep");
+  if (!provider) {
+    log.warn("memoryV2Sweep provider unavailable; sweep skipped");
+    return 0;
+  }
+
+  const systemPrompt = renderSweepPrompt({
+    assistantName: getAssistantName(),
+    userName: resolveUserName(workspaceDir),
+  });
+  const userText =
+    `## existingBuffer\n\n${existingBuffer || "(empty)"}\n\n` +
+    `## recentMessages\n\n${recentText}`;
+
+  const response = await provider.sendMessage(
+    [userMessage(userText)],
+    [SWEEP_TOOL],
+    systemPrompt,
+    {
+      config: {
+        callSite: "memoryV2Sweep" as const,
+        tool_choice: { type: "tool" as const, name: SWEEP_TOOL_NAME },
+      },
+    },
+  );
+
+  const toolBlock = extractToolUse(response);
+  if (!toolBlock || toolBlock.name !== SWEEP_TOOL_NAME) {
+    log.debug("Sweep model returned no tool_use block");
+    return 0;
+  }
+  const parsed = SweepResultSchema.safeParse(toolBlock.input);
+  if (!parsed.success) {
+    log.warn(
+      { error: parsed.error.message },
+      "Sweep tool input did not match schema",
+    );
+    return 0;
+  }
+
+  const written = appendEntries(memoryDir, parsed.data.entries);
+  if (written > 0) {
+    log.info({ written }, "Memory v2 sweep wrote new buffer entries");
+  }
+  return written;
+}
+
+/**
+ * Append each non-empty entry to `memory/buffer.md` + today's archive,
+ * using the same format `remember()` produces. Returns the count of entries
+ * actually written (empties and whitespace-only strings are skipped so the
+ * model can't pad the response).
+ */
+function appendEntries(memoryDir: string, entries: string[]): number {
+  let written = 0;
+  for (const raw of entries) {
+    const content = typeof raw === "string" ? raw.trim() : "";
+    if (!content) continue;
+    const now = new Date();
+    const entry = formatRememberEntry(content, now);
+    appendBufferAndArchive({ rootDir: memoryDir, entry, now });
+    written += 1;
+  }
+  return written;
+}
+
+/**
+ * Read `memory/buffer.md` and return its contents, capped at
+ * `MAX_BUFFER_CHARS`. Missing file → empty string. The cap keeps the dedup
+ * signal manageable; we slice from the *end* of the file so the most recent
+ * entries always survive.
+ */
+function readBufferText(memoryDir: string): string {
+  let text: string;
+  try {
+    text = readFileSync(join(memoryDir, "buffer.md"), "utf-8");
+  } catch {
+    return "";
+  }
+  if (text.length <= MAX_BUFFER_CHARS) return text;
+  return text.slice(text.length - MAX_BUFFER_CHARS);
+}
+
+/**
+ * Pull recent messages from every conversation in the window, formatted
+ * as `[role]: content` lines so the model can follow the back-and-forth.
+ *
+ * Bounded by `MAX_RECENT_TEXT_CHARS` — when the window is busier than the
+ * cap, the *oldest* messages are dropped (truncate-from-front) so the model
+ * always sees the latest context.
+ */
+function loadRecentMessagesText(nowMs: number): string {
+  const cutoff = nowMs - RECENT_MESSAGES_WINDOW_MS;
+  const db = getDb();
+  // Pull newest-first then reverse for chronological output. Bounding the
+  // initial limit (1000) defends against pathological busy windows where a
+  // naive scan would touch every recent message.
+  const rows = db
+    .select({
+      role: messages.role,
+      content: messages.content,
+    })
+    .from(messages)
+    .where(gt(messages.createdAt, cutoff))
+    .orderBy(desc(messages.createdAt))
+    .limit(1000)
+    .all();
+  if (rows.length === 0) return "";
+
+  const lines: string[] = [];
+  for (const row of rows) {
+    const text = stringifyMessageContent(row.content);
+    if (!text) continue;
+    lines.push(`[${row.role}]: ${text}`);
+  }
+  if (lines.length === 0) return "";
+
+  // Reverse so the oldest message lands first — natural reading order.
+  lines.reverse();
+  let joined = lines.join("\n\n");
+  if (joined.length > MAX_RECENT_TEXT_CHARS) {
+    joined = joined.slice(joined.length - MAX_RECENT_TEXT_CHARS);
+  }
+  return joined;
+}
+
+/**
+ * Coerce stored message content (JSON-serialized `ContentBlock[]` *or* plain
+ * string in legacy rows) into a single text string. Image / tool blocks are
+ * dropped — the sweep model only needs the spoken context.
+ */
+function stringifyMessageContent(stored: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return stored.trim();
+  }
+  if (typeof parsed === "string") return parsed.trim();
+  if (!Array.isArray(parsed)) return "";
+  const parts: string[] = [];
+  for (const block of parsed) {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: string }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      parts.push((block as { text: string }).text);
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+/**
+ * Read the guardian's display name from `users/default.md`. We look for the
+ * markdown-bold "Name" label (matching the IDENTITY.md convention) and fall
+ * back to `null` on any miss; the prompt template substitutes a generic
+ * label.
+ */
+function resolveUserName(workspaceDir: string): string | null {
+  try {
+    const content = readFileSync(
+      join(workspaceDir, "users", "default.md"),
+      "utf-8",
+    );
+    const match = content.match(/\*\*Name:\*\*\s*(.+)/);
+    return match?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the memory_v2_sweep stub with a real handler: reads the last 30 minutes of messages and memory/buffer.md for dedup, asks an LLM via getConfiguredProvider('memoryV2Sweep') to surface additional remember-able entries, and appends each one through the shared appendBufferAndArchive helper so the writes are byte-compatible with remember().
- Adds memoryV2Sweep LLM call site and a sweep prompt template under memory/v2/prompts/sweep.ts lifted from design doc with assistant/user name placeholders.
- Handler short-circuits when the memory-v2-enabled flag is off, no recent messages exist, or no provider is configured — sweep stays dormant on v1-only workspaces.

Part of plan: memory-v2.md (PR 18 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
