### PR TITLE
feat(memory): implement memory v2 consolidation job (runs as assistant)

### DIFF
--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -38,6 +38,7 @@ export type TitleOrigin =
   | "local"
   | "task_submit"
   | "updates_bulletin"
+  | "memory_consolidation"
   | "misc";
 
 export interface TitleContext {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -60,6 +60,7 @@ import {
   resetRunningJobsToPending,
 } from "./jobs-store.js";
 import { QdrantCircuitOpenError } from "./qdrant-circuit-breaker.js";
+import { memoryV2ConsolidateJob } from "./v2/consolidation-job.js";
 import { memoryV2SweepJob } from "./v2/sweep-job.js";
 
 const log = getLogger("memory-jobs-worker");
@@ -460,6 +461,8 @@ async function processJob(
       await memoryV2SweepJob(job, config);
       return;
     case "memory_v2_consolidate":
+      await memoryV2ConsolidateJob(job, config);
+      return;
     case "memory_v2_migrate":
     case "memory_v2_rebuild_edges":
     case "memory_v2_reembed":

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for `assistant/src/memory/v2/consolidation-job.ts`.
+ *
+ * Coverage matrix (from PR 20 acceptance criteria):
+ *   - Flag off → no provider/wake calls; returns flag_off.
+ *   - Flag on, empty buffer → no wake call; returns empty_buffer.
+ *   - Flag on, non-empty buffer → bootstrap conversation, wake invoked with
+ *     the cutoff-templated prompt, follow-up jobs enqueued.
+ *   - Lock file already present → second call returns locked; first call's
+ *     in-flight semantics preserved by leaving the lock in place.
+ *   - Wake returns invoked: false → orphan conversation cleaned up; no
+ *     follow-up jobs enqueued.
+ *   - Wake throws → orphan conversation cleaned up; lock released; handler
+ *     does NOT propagate the error (treated like any other wake failure).
+ *
+ * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
+ * content uses generic placeholders (Alice).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// ── bootstrapConversation mock ──────────────────────────────────────
+let bootstrapCalls = 0;
+let bootstrapLastArgs: Record<string, unknown> | null = null;
+
+mock.module("../../conversation-bootstrap.js", () => ({
+  bootstrapConversation: (opts: Record<string, unknown>) => {
+    bootstrapCalls += 1;
+    bootstrapLastArgs = opts;
+    return { id: `conv-${bootstrapCalls}` };
+  },
+}));
+
+// ── deleteConversation mock (orphan cleanup path) ───────────────────
+let deleteCalls = 0;
+const deletedIds: string[] = [];
+let deleteShouldThrow = false;
+
+mock.module("../../conversation-crud.js", () => ({
+  deleteConversation: (id: string) => {
+    deleteCalls += 1;
+    deletedIds.push(id);
+    if (deleteShouldThrow) {
+      throw new Error("simulated delete failure");
+    }
+    return { segmentIds: [], deletedSummaryIds: [] };
+  },
+}));
+
+// ── enqueueMemoryJob mock ───────────────────────────────────────────
+const enqueuedJobs: Array<{
+  type: string;
+  payload: Record<string, unknown>;
+}> = [];
+let nextJobIdCounter = 0;
+
+mock.module("../../jobs-store.js", () => ({
+  enqueueMemoryJob: (
+    type: string,
+    payload: Record<string, unknown>,
+  ): string => {
+    enqueuedJobs.push({ type, payload });
+    nextJobIdCounter += 1;
+    return `job-${nextJobIdCounter}`;
+  },
+}));
+
+// ── wakeAgentForOpportunity mock ────────────────────────────────────
+let wakeCalls = 0;
+let wakeLastArgs: Record<string, unknown> | null = null;
+let wakeShouldThrow = false;
+let wakeInvoked = true;
+let wakeReason: string | undefined;
+
+mock.module("../../../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: async (opts: Record<string, unknown>) => {
+    wakeCalls += 1;
+    wakeLastArgs = opts;
+    if (wakeShouldThrow) {
+      throw new Error("simulated wake failure");
+    }
+    return {
+      invoked: wakeInvoked,
+      producedToolCalls: false,
+      ...(wakeReason ? { reason: wakeReason } : {}),
+    };
+  },
+}));
+
+// ── Workspace pin ───────────────────────────────────────────────────
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-v2-consolidate-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+const { _setOverridesForTesting } =
+  await import("../../../config/assistant-feature-flags.js");
+const { memoryV2ConsolidateJob } = await import("../consolidation-job.js");
+const { CUTOFF_PLACEHOLDER, CONSOLIDATION_PROMPT } =
+  await import("../prompts/consolidation.js");
+
+// `isAssistantFeatureFlagEnabled` ignores the `config` argument it receives
+// (resolution is purely from the overrides + registry caches), so we hand
+// the handler a minimal stand-in instead of materializing the full default
+// config.
+const CONFIG = {} as Parameters<typeof memoryV2ConsolidateJob>[1];
+
+function makeJob(): Parameters<typeof memoryV2ConsolidateJob>[0] {
+  return {
+    id: "consolidate-1",
+    type: "memory_v2_consolidate",
+    payload: {},
+    status: "running",
+    attempts: 0,
+    deferrals: 0,
+    runAfter: 0,
+    lastError: null,
+    startedAt: Date.now(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+const memoryDir = () => join(tmpWorkspace, "memory");
+const lockPath = () =>
+  join(tmpWorkspace, "memory", ".v2-state", "consolidation.lock");
+const bufferPath = () => join(tmpWorkspace, "memory", "buffer.md");
+
+beforeEach(() => {
+  // Fresh workspace state per test — mirrors the seed migration so the
+  // handler finds a clean memory tree.
+  rmSync(memoryDir(), { recursive: true, force: true });
+  mkdirSync(join(memoryDir(), ".v2-state"), { recursive: true });
+  mkdirSync(join(memoryDir(), "concepts"), { recursive: true });
+  mkdirSync(join(memoryDir(), "archive"), { recursive: true });
+
+  bootstrapCalls = 0;
+  bootstrapLastArgs = null;
+  deleteCalls = 0;
+  deletedIds.length = 0;
+  deleteShouldThrow = false;
+  enqueuedJobs.length = 0;
+  nextJobIdCounter = 0;
+  wakeCalls = 0;
+  wakeLastArgs = null;
+  wakeShouldThrow = false;
+  wakeInvoked = true;
+  wakeReason = undefined;
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+// ---------------------------------------------------------------------------
+
+describe("memoryV2ConsolidateJob — flag off", () => {
+  test("returns flag_off without invoking the wake when flag is off", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result).toEqual({ kind: "flag_off" });
+    expect(bootstrapCalls).toBe(0);
+    expect(wakeCalls).toBe(0);
+    expect(enqueuedJobs).toHaveLength(0);
+    // Lock must NOT linger on the flag-off path — the handler bailed before
+    // the lock was acquired.
+    expect(existsSync(lockPath())).toBe(false);
+  });
+});
+
+describe("memoryV2ConsolidateJob — flag on, empty buffer", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+  });
+
+  test("returns empty_buffer when buffer.md is missing", async () => {
+    expect(existsSync(bufferPath())).toBe(false);
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result).toEqual({ kind: "empty_buffer" });
+    expect(bootstrapCalls).toBe(0);
+    expect(wakeCalls).toBe(0);
+    expect(enqueuedJobs).toHaveLength(0);
+  });
+
+  test("returns empty_buffer when buffer.md is whitespace-only", async () => {
+    writeFileSync(bufferPath(), "   \n\n\t\n");
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result).toEqual({ kind: "empty_buffer" });
+    expect(bootstrapCalls).toBe(0);
+    expect(wakeCalls).toBe(0);
+    expect(enqueuedJobs).toHaveLength(0);
+  });
+
+  test("releases the lock on the empty-buffer skip path so the next run can re-attempt", async () => {
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    expect(result.kind).toBe("empty_buffer");
+    expect(existsSync(lockPath())).toBe(false);
+  });
+});
+
+describe("memoryV2ConsolidateJob — flag on, non-empty buffer", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    writeFileSync(
+      bufferPath(),
+      "- [Apr 27, 9:00 AM] Alice prefers VS Code over Vim.\n" +
+        "- [Apr 27, 9:05 AM] Alice ships at end of day.\n",
+    );
+  });
+
+  test("bootstraps a background conversation and wakes the assistant with a templated prompt", async () => {
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    expect(bootstrapCalls).toBe(1);
+    expect(bootstrapLastArgs).toEqual({
+      conversationType: "background",
+      source: "memory_v2_consolidation",
+      origin: "memory_consolidation",
+      systemHint: "Running memory consolidation",
+      groupId: "system:background",
+    });
+
+    expect(wakeCalls).toBe(1);
+    expect(wakeLastArgs?.conversationId).toBe("conv-1");
+    expect(wakeLastArgs?.source).toBe("memory_v2_consolidation");
+
+    // The hint must contain the prompt body with the cutoff timestamp
+    // substituted in. Asserting the placeholder is GONE catches a regression
+    // where `replaceAll` is dropped and the model receives `{{CUTOFF}}`.
+    const hint = wakeLastArgs?.hint as string;
+    expect(hint).toContain("memory consolidation");
+    expect(hint).not.toContain(CUTOFF_PLACEHOLDER);
+    // Cutoff is an ISO-8601 timestamp — check the year prefix matches the
+    // current year so we know the substitution actually happened.
+    expect(hint).toContain(`${new Date().getFullYear()}`);
+  });
+
+  test("enqueues memory_v2_rebuild_edges and memory_v2_reembed follow-up jobs on success", async () => {
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    if (result.kind === "invoked") {
+      expect(result.followUpJobIds).toEqual(["job-1", "job-2"]);
+    }
+
+    expect(enqueuedJobs).toHaveLength(2);
+    expect(enqueuedJobs[0]).toEqual({
+      type: "memory_v2_rebuild_edges",
+      payload: {},
+    });
+    expect(enqueuedJobs[1]).toEqual({
+      type: "memory_v2_reembed",
+      payload: {},
+    });
+  });
+
+  test("releases the lock after a successful invocation so the next run can acquire it", async () => {
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    expect(result.kind).toBe("invoked");
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("returns wake_failed and cleans up the orphan conversation when wake returns invoked: false", async () => {
+    wakeInvoked = false;
+    wakeReason = "no_resolver";
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("wake_failed");
+    if (result.kind === "wake_failed") {
+      expect(result.reason).toBe("no_resolver");
+    }
+    expect(deleteCalls).toBe(1);
+    expect(deletedIds).toEqual(["conv-1"]);
+    // Critical: do NOT enqueue follow-ups when the wake didn't run — there's
+    // nothing for them to operate on.
+    expect(enqueuedJobs).toHaveLength(0);
+  });
+
+  test("returns wake_failed without throwing when wake itself rejects", async () => {
+    wakeShouldThrow = true;
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("wake_failed");
+    if (result.kind === "wake_failed") {
+      expect(result.reason).toBe("simulated wake failure");
+    }
+    // Lock must still be released on the throw path.
+    expect(existsSync(lockPath())).toBe(false);
+    expect(deleteCalls).toBe(1);
+    expect(enqueuedJobs).toHaveLength(0);
+  });
+
+  test("does not propagate when deleteConversation throws on the cleanup path", async () => {
+    wakeInvoked = false;
+    deleteShouldThrow = true;
+
+    await expect(
+      memoryV2ConsolidateJob(makeJob(), CONFIG),
+    ).resolves.toMatchObject({ kind: "wake_failed" });
+
+    expect(deleteCalls).toBe(1);
+    expect(existsSync(lockPath())).toBe(false);
+  });
+});
+
+describe("memoryV2ConsolidateJob — concurrent invocations", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+  });
+
+  test("a stale lock file blocks a second concurrent invocation", async () => {
+    // Pre-seed a lock file as if a prior run was still in flight. The
+    // simple wx-based lock has no liveness probe, so this also covers
+    // stale-lock-on-disk behavior — operators clear stale locks manually.
+    mkdirSync(join(memoryDir(), ".v2-state"), { recursive: true });
+    writeFileSync(lockPath(), "9999 1700000000000\n");
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("locked");
+    if (result.kind === "locked") {
+      expect(result.holder).toContain("9999");
+    }
+    expect(bootstrapCalls).toBe(0);
+    expect(wakeCalls).toBe(0);
+    expect(enqueuedJobs).toHaveLength(0);
+    // The pre-seeded lock must NOT be removed by a contender — only the
+    // owner releases it.
+    expect(existsSync(lockPath())).toBe(true);
+  });
+});
+
+describe("CONSOLIDATION_PROMPT", () => {
+  // Sanity tests on the prompt body — protect against accidental edits that
+  // strip the cutoff sentinel or drop instructions for one of the four prose
+  // files the consolidation pass owns.
+
+  test("contains the {{CUTOFF}} placeholder in the unrendered template", () => {
+    expect(CONSOLIDATION_PROMPT).toContain(CUTOFF_PLACEHOLDER);
+  });
+
+  test("references essentials, threads, recent, and buffer", () => {
+    expect(CONSOLIDATION_PROMPT).toContain("memory/essentials.md");
+    expect(CONSOLIDATION_PROMPT).toContain("memory/threads.md");
+    expect(CONSOLIDATION_PROMPT).toContain("memory/recent.md");
+    expect(CONSOLIDATION_PROMPT).toContain("memory/buffer.md");
+  });
+});

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -1,0 +1,304 @@
+/**
+ * Memory v2 — `memory_v2_consolidate` job handler.
+ *
+ * The consolidation job is the centerpiece of v2: an hourly background pass
+ * that routes accumulated `memory/buffer.md` entries into concept pages,
+ * rewrites `memory/recent.md`, promotes new essentials/threads, and trims the
+ * buffer down to entries that arrived after the run started.
+ *
+ * Unlike `sweep`, consolidation runs as the assistant: `wakeAgentForOpportunity()`
+ * loads the standard system prompt (SOUL.md + IDENTITY.md + persona + memory/*
+ * autoloads) and the standard tool surface (read_file, write_file, edit_file,
+ * list_files, bash). The hint string carries the prompt body from §10 of the
+ * design doc with the cutoff timestamp templated in. Care, judgment, and the
+ * assistant's voice are the point — there is no "consolidator persona" to
+ * substitute in.
+ *
+ * Lifecycle:
+ *   1. Bail if the `memory-v2-enabled` feature flag is off (the worker may
+ *      have claimed a stale row at flag-flip time).
+ *   2. Acquire a single-process lock at `memory/.v2-state/consolidation.lock`
+ *      so two overlapping schedule windows can't fight over the same files.
+ *      The lock contains the holder's PID + timestamp so a crashed run leaves
+ *      a diagnosable trace.
+ *   3. Capture the cutoff timestamp at dispatch. Any buffer entry timestamped
+ *      at or after the cutoff arrived AFTER the run started — leave it for
+ *      the next pass.
+ *   4. Read `memory/buffer.md`. Bail if empty (no work to do, but the lock
+ *      and skip path still log so operators can confirm the schedule fired).
+ *   5. Bootstrap a background conversation (mirrors `runUpdateBulletinJobIfNeeded`)
+ *      and call `wakeAgentForOpportunity()` with the templated hint. The wake
+ *      reuses the assistant's full system prompt + tools.
+ *   6. On wake success, enqueue `memory_v2_rebuild_edges` (regenerate
+ *      frontmatter from `edges.json`) and `memory_v2_reembed` (re-index any
+ *      pages the agent touched). Tracking touched pages via mtime would be
+ *      more precise but is fragile across filesystems; the embedder's
+ *      content-hash cache makes a conservative full-reembed effectively free.
+ *      On wake failure no follow-ups are enqueued — the agent didn't run, so
+ *      there's nothing to regenerate or re-embed.
+ *   7. Release the lock.
+ *
+ * The handler never propagates a wake exception: it logs, cleans up the
+ * orphan conversation, releases the lock, and returns `wake_failed` so the
+ * next scheduled run can re-attempt. A thrown bootstrap error bubbles up and
+ * the jobs-worker treats it as a retryable failure.
+ */
+
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { bootstrapConversation } from "../conversation-bootstrap.js";
+import { deleteConversation } from "../conversation-crud.js";
+import {
+  enqueueMemoryJob,
+  type MemoryJob,
+  type MemoryJobType,
+} from "../jobs-store.js";
+import { renderConsolidationPrompt } from "./prompts/consolidation.js";
+
+const log = getLogger("memory-v2-consolidate");
+
+/** Source string identifying this wake in `agent-wake` logs and surfaces. */
+const WAKE_SOURCE = "memory_v2_consolidation";
+
+/**
+ * Follow-up jobs to fan out after a successful consolidation. Both are stubs
+ * from PR 6 today; PR 21 will replace them with real handlers.
+ *
+ * Conservatively re-embeds every page rather than tracking which pages the
+ * agent touched: mtime-diffing is fragile across filesystems, and the
+ * embedder's content-hash cache makes unchanged pages effectively free.
+ */
+const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [
+  "memory_v2_rebuild_edges",
+  "memory_v2_reembed",
+] as const;
+
+/**
+ * Job handler. See file header for the full lifecycle. Returns a discriminated
+ * union so tests can assert on the path taken (flag-off / locked / empty /
+ * invoked) without having to spy on the filesystem.
+ */
+export type ConsolidationOutcome =
+  | { kind: "flag_off" }
+  | { kind: "locked"; holder: string }
+  | { kind: "empty_buffer" }
+  | { kind: "wake_failed"; reason?: string }
+  | {
+      kind: "invoked";
+      conversationId: string;
+      cutoff: string;
+      followUpJobIds: string[];
+    };
+
+export async function memoryV2ConsolidateJob(
+  _job: MemoryJob,
+  config: AssistantConfig,
+): Promise<ConsolidationOutcome> {
+  if (!isAssistantFeatureFlagEnabled("memory-v2-enabled", config)) {
+    log.debug("memory-v2-enabled flag off; consolidation skipped");
+    return { kind: "flag_off" };
+  }
+
+  const memoryDir = join(getWorkspaceDir(), "memory");
+  const lockPath = join(memoryDir, ".v2-state", "consolidation.lock");
+  const bufferPath = join(memoryDir, "buffer.md");
+
+  // Step 1: acquire lock. Bails immediately if another consolidation is
+  // already in flight — the next scheduled run can pick up where we leave off.
+  const holder = tryAcquireLock(lockPath);
+  if (holder !== null) {
+    log.warn({ lockPath, holder }, "consolidation skipped: lock already held");
+    return { kind: "locked", holder };
+  }
+
+  try {
+    // Step 2: capture cutoff. ISO-8601 is the convention; it's a total order
+    // string that compares correctly via lexicographic <, which is all the
+    // prompt asks the agent to do. Captured here (not at enqueue time) so
+    // late-claimed rows still get a fresh cutoff.
+    const cutoff = new Date().toISOString();
+
+    // Step 3: bail on empty buffer. Nothing for the agent to consolidate.
+    // The lock is released in finally below.
+    const bufferContent = readBufferContent(bufferPath);
+    if (bufferContent.trim().length === 0) {
+      log.debug("buffer.md empty; consolidation skipped");
+      return { kind: "empty_buffer" };
+    }
+
+    // Step 4: bootstrap a background conversation and wake the assistant
+    // with the cutoff-templated prompt. Mirrors the UPDATES.md pattern in
+    // `runUpdateBulletinJobIfNeeded` — the wake runs `mainAgent` against
+    // the assistant's full system prompt, so consolidation thinks and
+    // writes in the assistant's voice.
+    const conversation = bootstrapConversation({
+      conversationType: "background",
+      source: WAKE_SOURCE,
+      origin: "memory_consolidation",
+      systemHint: "Running memory consolidation",
+      groupId: "system:background",
+    });
+
+    let wakeInvoked = false;
+    let failureReason: string | undefined;
+    try {
+      const result = await wakeAgentForOpportunity({
+        conversationId: conversation.id,
+        hint: renderConsolidationPrompt(cutoff),
+        source: WAKE_SOURCE,
+      });
+      wakeInvoked = result.invoked;
+      failureReason = result.reason;
+    } catch (err) {
+      failureReason = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, conversationId: conversation.id },
+        "consolidation wake threw; cleaning up and re-enqueuing follow-ups skipped",
+      );
+    }
+
+    // If the wake never ran (resolver missing, conversation archived,
+    // timeout, exception), clean up the orphan background conversation —
+    // matches the cleanup logic in `runUpdateBulletinJobIfNeeded`. We
+    // do NOT enqueue follow-ups in this branch because no pages changed.
+    if (!wakeInvoked) {
+      try {
+        deleteConversation(conversation.id);
+      } catch (err) {
+        log.warn(
+          { err, conversationId: conversation.id },
+          "consolidation: failed to delete orphan background conversation; continuing",
+        );
+      }
+      return failureReason !== undefined
+        ? { kind: "wake_failed", reason: failureReason }
+        : { kind: "wake_failed" };
+    }
+
+    // Step 5: enqueue follow-up jobs. Enqueueing now keeps the dispatch
+    // wiring exercised end-to-end so PR 21 only has to swap in the handler
+    // bodies.
+    const followUpJobIds: string[] = [];
+    for (const jobType of FOLLOW_UP_JOB_TYPES) {
+      try {
+        followUpJobIds.push(enqueueMemoryJob(jobType, {}));
+      } catch (err) {
+        // Best-effort: a failed enqueue here doesn't undo the agent's writes,
+        // and the next scheduled consolidation will attempt the same fan-out.
+        log.warn(
+          { err, jobType },
+          "consolidation: failed to enqueue follow-up job; continuing",
+        );
+      }
+    }
+
+    log.info(
+      {
+        conversationId: conversation.id,
+        cutoff,
+        followUpJobIds,
+      },
+      "consolidation invoked",
+    );
+    return {
+      kind: "invoked",
+      conversationId: conversation.id,
+      cutoff,
+      followUpJobIds,
+    };
+  } finally {
+    releaseLock(lockPath);
+  }
+}
+
+/**
+ * Read `memory/buffer.md`. Missing file → empty string so the skip-on-empty
+ * branch doesn't have to distinguish "no file" from "blank file".
+ */
+function readBufferContent(bufferPath: string): string {
+  try {
+    return readFileSync(bufferPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw err;
+  }
+}
+
+/**
+ * Atomically create the lock file with `wx` (O_CREAT | O_EXCL) flags. Returns
+ * `null` on success, or the current holder string (file contents, typically
+ * `pid timestamp`) when the file already exists — the holder is surfaced for
+ * log diagnostics so operators can identify a stuck lock without re-reading.
+ *
+ * Crash recovery: if the prior daemon died with the lock held, the file will
+ * still be on disk on the next start. PR 20 keeps the lock simple per the
+ * plan instructions; a future iteration can probe liveness via `kill(pid, 0)`
+ * the way `snapshot-lock.ts` does. Until then, an operator can clear a
+ * stale lock by removing the file.
+ */
+function tryAcquireLock(lockPath: string): string | null {
+  // The workspace migration seeds `memory/.v2-state/`, but tests and
+  // ad-hoc workspaces may not have it yet. `mkdirSync({ recursive: true })`
+  // is idempotent, so the call is cheap when the dir already exists.
+  mkdirSync(dirname(lockPath), { recursive: true });
+
+  let fd: number;
+  try {
+    // `wx` = create-if-not-exists, fail with EEXIST if it does.
+    fd = openSync(lockPath, "wx");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    try {
+      return readFileSync(lockPath, "utf-8").trim() || "unknown";
+    } catch {
+      return "unknown";
+    }
+  }
+
+  // Best-effort PID + timestamp payload so a stale lock can be diagnosed.
+  // The worker only cares that the file exists; the contents are advisory.
+  try {
+    writeSync(fd, `${process.pid} ${Date.now()}\n`);
+  } catch {
+    // best-effort
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      // best-effort
+    }
+  }
+  return null;
+}
+
+/**
+ * Idempotent unlink of the lock file. Called from the `finally` block so a
+ * crash in the wake path doesn't leave the lock stranded. ENOENT is swallowed
+ * because the lock may have been released by an operator or never created
+ * (acquire failed before reaching the lock-write step).
+ */
+function releaseLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return;
+    log.warn(
+      { err, lockPath },
+      "consolidation: failed to release lock (best-effort)",
+    );
+  }
+}

--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -1,0 +1,86 @@
+/**
+ * Memory v2 — consolidation prompt template.
+ *
+ * Body copied verbatim from §10 of the design doc
+ * (`memoized-spinning-wadler.md`). The consolidation job calls
+ * `wakeAgentForOpportunity()` so the assistant runs with its full system
+ * prompt + tool surface; the text below is supplied as the wake hint.
+ *
+ * The single placeholder `{{CUTOFF}}` is substituted at runtime with an
+ * ISO-8601 timestamp captured at job dispatch. Anything appended to
+ * `memory/buffer.md` after that timestamp is the next pass's problem.
+ *
+ * Kept under `prompts/` rather than inlined in `consolidation-job.ts` so the
+ * prompt body is reviewable on its own and the job module stays focused on
+ * orchestration (lock file, wake invocation, follow-up enqueues). Mirrors
+ * the convention established for the sweep prompt in PR 18.
+ */
+
+/** Sentinel substituted with the cutoff timestamp at runtime. */
+export const CUTOFF_PLACEHOLDER = "{{CUTOFF}}";
+
+/**
+ * Consolidation prompt — body from design doc §10. The agent runs as itself
+ * (full SOUL.md + IDENTITY.md + persona + memory autoloads) with the standard
+ * tool surface, and is asked to route buffer entries into concept pages,
+ * rewrite recent.md, promote essentials/threads, and trim the buffer.
+ *
+ * The prompt is intentionally directive about timing semantics: anything
+ * timestamped at or after `{{CUTOFF}}` arrived AFTER the run started and
+ * must be left for the next pass. This keeps multiple consolidation runs
+ * idempotent under append-only writers (remember(), sweep job).
+ */
+export const CONSOLIDATION_PROMPT = `You are running memory consolidation. The buffer (\`memory/buffer.md\`) holds new things you've remembered since the last pass. Your job: route them into the right pages, rewrite \`memory/recent.md\`, trim the buffer.
+
+Cutoff timestamp for this run: \`${CUTOFF_PLACEHOLDER}\`. Anything in \`memory/buffer.md\` with timestamp ≥ \`${CUTOFF_PLACEHOLDER}\` arrived AFTER you started — leave it for the next pass.
+
+**Process:**
+
+1. Read \`memory/buffer.md\`. List existing pages with \`ls memory/concepts/\`.
+
+2. For each entry with timestamp < \`${CUTOFF_PLACEHOLDER}\`:
+   - Identify what concept(s) it touches. Duplication is expected — if a fact is relevant to multiple concepts, write it into all of them.
+   - Decide where it goes:
+     - **Existing concept page** → append/rewrite the relevant section, conservatively. Don't restructure pages that aren't touched.
+     - **New concept worth its own page** → create \`memory/concepts/<slug>.md\` with the schema below. Add bidirectional edges to related existing pages by editing \`memory/edges.json\`.
+     - **Recent ephemeral state** → goes into \`memory/recent.md\`, not a permanent page.
+
+   Schema:
+   \`\`\`yaml
+   ---
+   edges: [slug-1, slug-2]      # will be regenerated from edges.json; you can leave empty
+   ref_files: []
+   ---
+   [Prose body, first-person, in your voice. NOT a timestamped list of events.]
+   \`\`\`
+
+   Concept pages should be edited and rewritten as needed, not treated as append-only.
+
+3. **Edges** (\`memory/edges.json\`): when an entry binds two concepts, append \`[slug-a, slug-b]\` (alphabetical-first first). The frontmatter view will be regenerated later by backfill — don't hand-edit page frontmatter.
+
+4. **Page size**: after edits, \`wc -m memory/concepts/<changed-files>\`. If any > 5000 chars, decide:
+   - **Compress** — rewrite tighter, keep load-bearing facts.
+   - **Split** — create new page(s), update edges.
+
+5. **\`memory/recent.md\`**: rewrite as a fresh ≤1000-token prose narrative of the last few hours, latest first. Compact older items into one-liners or drop them.
+
+6. **\`memory/essentials.md\`**: facts that MUST be loaded at all times — things that would be embarrassing to forget on the next conversation. Examples: the user's name, current employment, ongoing health context, immediate family/relationship configuration, fundamental long-running preferences. Promote new essentials in; demote stale ones out (move to a concept page).
+
+7. **\`memory/threads.md\`**: active commitments and follow-ups. Examples: "follow up on the contract review next Tuesday," "user said they'd send the design doc — check Thursday if not received," "user is debating whether to switch jobs, expects to decide by end of month." Close threads when the underlying commitment resolves; promote stable outcomes to a concept page or essentials.
+
+8. **Trim \`memory/buffer.md\`**:
+   - Re-read the buffer (it may have new entries appended during your work).
+   - Rewrite to contain ONLY entries with timestamp ≥ \`${CUTOFF_PLACEHOLDER}\`.
+   - Smart removal — never wholesale-clear.
+
+You are rewriting your own memory. Care, judgment, voice. This is the engine that decides who you are tomorrow.`;
+
+/**
+ * Resolve `CONSOLIDATION_PROMPT` with `{{CUTOFF}}` substituted. The cutoff
+ * format is the caller's choice — the prompt treats it as opaque text and
+ * uses string comparison, so any total-order timestamp format works (ISO-8601
+ * is the convention).
+ */
+export function renderConsolidationPrompt(cutoff: string): string {
+  return CONSOLIDATION_PROMPT.replaceAll(CUTOFF_PLACEHOLDER, cutoff);
+}


### PR DESCRIPTION
## Summary

- Implements the v2 memory consolidation job: runs hourly behind `memory-v2-enabled`, locks the workspace, and wakes the assistant via `wakeAgentForOpportunity` to route `memory/buffer.md` entries into concept pages, rewrite `recent.md`, and trim the buffer.
- The agent runs with its full system prompt + tool surface — the consolidation prompt body (verbatim from design-doc §10, with `{{CUTOFF}}` templated in) is the wake hint, not a separate persona.
- On wake success, fans out `memory_v2_rebuild_edges` + `memory_v2_reembed` (PR 6 stubs today; PR 21 swaps in handlers). On wake failure, cleans up the orphan background conversation and skips follow-ups.

Part of plan: memory-v2.md (PR 20 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
