### PR TITLE
feat(memory): IPC route for v2 backfill operations

### DIFF
--- a/assistant/src/ipc/routes/__tests__/memory-v2-backfill.test.ts
+++ b/assistant/src/ipc/routes/__tests__/memory-v2-backfill.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the `memory_v2/backfill` IPC route.
+ *
+ * The route is mutating — it inserts one `memory_jobs` row per call. We mock
+ * `enqueueMemoryJob` at the module level so the tests can assert the exact
+ * `(type, payload)` tuple the route forwards without standing up a real DB.
+ *
+ * Coverage:
+ *   1. method name is the public verb expected by the CLI.
+ *   2. unknown params are rejected (defensive — the schema is `.strict()`).
+ *   3. each of the four ops dispatches to the correct `MemoryJobType`.
+ *   4. `migrate` with `force: true` propagates the flag in the payload.
+ *   5. `migrate` without `force` (and ops that ignore `force`) sends an
+ *      empty payload — the `false` default never reaches the queue.
+ *   6. invalid `op` values are rejected by the enum schema.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module-level mock — capture every enqueue call so each test can assert the
+// route forwarded the correct (type, payload) tuple. The route file is
+// imported below the mock so it picks up this stub instead of the real one.
+// ---------------------------------------------------------------------------
+
+const enqueueCalls: Array<{
+  type: string;
+  payload: Record<string, unknown>;
+}> = [];
+let nextJobId = 0;
+
+mock.module("../../../memory/jobs-store.js", () => ({
+  enqueueMemoryJob: (type: string, payload: Record<string, unknown>) => {
+    enqueueCalls.push({ type, payload });
+    nextJobId += 1;
+    return `test-job-${nextJobId}`;
+  },
+}));
+
+const { memoryV2BackfillRoute } = await import("../memory-v2-backfill.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type BackfillResult = { jobId: string };
+
+async function runRoute(
+  params: Record<string, unknown>,
+): Promise<BackfillResult> {
+  return (await memoryV2BackfillRoute.handler(params)) as BackfillResult;
+}
+
+beforeEach(() => {
+  enqueueCalls.length = 0;
+  nextJobId = 0;
+});
+
+afterEach(() => {
+  enqueueCalls.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("memoryV2BackfillRoute", () => {
+  test("method is 'memory_v2/backfill'", () => {
+    expect(memoryV2BackfillRoute.method).toBe("memory_v2/backfill");
+  });
+
+  test("rejects unknown op", async () => {
+    await expect(runRoute({ op: "wat" })).rejects.toThrow();
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("rejects unknown params", async () => {
+    await expect(runRoute({ op: "migrate", extra: 1 })).rejects.toThrow();
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("rejects missing op", async () => {
+    await expect(runRoute({})).rejects.toThrow();
+    expect(enqueueCalls).toEqual([]);
+  });
+
+  test("migrate enqueues memory_v2_migrate with empty payload by default", async () => {
+    const result = await runRoute({ op: "migrate" });
+
+    expect(enqueueCalls).toEqual([{ type: "memory_v2_migrate", payload: {} }]);
+    expect(result.jobId).toBe("test-job-1");
+  });
+
+  test("migrate with force: true propagates force in payload", async () => {
+    await runRoute({ op: "migrate", force: true });
+
+    expect(enqueueCalls).toEqual([
+      { type: "memory_v2_migrate", payload: { force: true } },
+    ]);
+  });
+
+  test("migrate with force: false omits force from payload", async () => {
+    // We never write `force: false` because the migration runner already
+    // defaults to false and a queued column should not carry a no-op flag.
+    await runRoute({ op: "migrate", force: false });
+
+    expect(enqueueCalls).toEqual([{ type: "memory_v2_migrate", payload: {} }]);
+  });
+
+  test("rebuild-edges enqueues memory_v2_rebuild_edges with empty payload", async () => {
+    await runRoute({ op: "rebuild-edges" });
+
+    expect(enqueueCalls).toEqual([
+      { type: "memory_v2_rebuild_edges", payload: {} },
+    ]);
+  });
+
+  test("rebuild-edges ignores force flag", async () => {
+    // `force` only has meaning for `migrate`. For other ops we still accept
+    // the field (so a single CLI flag works across all ops without
+    // branching) but never forward it to the queue.
+    await runRoute({ op: "rebuild-edges", force: true });
+
+    expect(enqueueCalls).toEqual([
+      { type: "memory_v2_rebuild_edges", payload: {} },
+    ]);
+  });
+
+  test("reembed enqueues memory_v2_reembed with empty payload", async () => {
+    await runRoute({ op: "reembed" });
+
+    expect(enqueueCalls).toEqual([{ type: "memory_v2_reembed", payload: {} }]);
+  });
+
+  test("activation-recompute enqueues memory_v2_activation_recompute with empty payload", async () => {
+    await runRoute({ op: "activation-recompute" });
+
+    expect(enqueueCalls).toEqual([
+      { type: "memory_v2_activation_recompute", payload: {} },
+    ]);
+  });
+
+  test("returns the jobId emitted by enqueueMemoryJob", async () => {
+    const first = await runRoute({ op: "rebuild-edges" });
+    const second = await runRoute({ op: "reembed" });
+
+    expect(first.jobId).toBe("test-job-1");
+    expect(second.jobId).toBe("test-job-2");
+  });
+});

--- a/assistant/src/ipc/routes/index.ts
+++ b/assistant/src/ipc/routes/index.ts
@@ -8,6 +8,7 @@ import { credentialPromptRoute } from "./credential-prompt.js";
 import { deferRoutes } from "./defer.js";
 import { getContactRoute } from "./get-contact.js";
 import { listClientsRoute } from "./list-clients.js";
+import { memoryV2BackfillRoute } from "./memory-v2-backfill.js";
 import { memoryV2ValidateRoute } from "./memory-v2-validate.js";
 import { mergeContactsRoute } from "./merge-contacts.js";
 import { notificationRoutes } from "./notification.js";
@@ -33,6 +34,7 @@ export const cliIpcRoutes: IpcRoute[] = [
   ...deferRoutes,
   getContactRoute,
   listClientsRoute,
+  memoryV2BackfillRoute,
   memoryV2ValidateRoute,
   mergeContactsRoute,
   renameConversationRoute,

--- a/assistant/src/ipc/routes/memory-v2-backfill.ts
+++ b/assistant/src/ipc/routes/memory-v2-backfill.ts
@@ -1,0 +1,76 @@
+/**
+ * Memory v2 — mutating backfill IPC route.
+ *
+ * Enqueues one of four operator-triggered backfill jobs against the memory
+ * jobs queue, returning the new `jobId` so callers can track progress:
+ *
+ *   - `migrate`              — one-shot v1->v2 synthesis (PR 16). Accepts an
+ *                              optional `force: true` to overwrite an existing
+ *                              v2 state when the sentinel is already present.
+ *   - `rebuild-edges`        — recompute every concept page's `edges:`
+ *                              frontmatter from `memory/edges.json`.
+ *   - `reembed`              — fan out an `embed_concept_page` job per page
+ *                              slug, plus four reserved-slug jobs for the
+ *                              meta files.
+ *   - `activation-recompute` — refresh persisted activation state for every
+ *                              conversation that has a stored row.
+ *
+ * The route is intentionally thin: it validates input, picks the matching
+ * memory-job type, and enqueues. The job worker (`jobs-worker.ts`) dispatches
+ * to the handlers in `memory/v2/backfill-jobs.ts` (PR 21). Splitting enqueue
+ * from execution lets backfills run on the background worker rather than
+ * blocking the IPC connection on a multi-minute migration.
+ *
+ * Unlike `memory_v2/validate`, this route is mutating — every successful call
+ * adds a row to `memory_jobs`. It does not require the `memory-v2-enabled`
+ * feature flag, mirroring the validate route: an operator may need to migrate
+ * a workspace before flipping the flag.
+ */
+import { z } from "zod";
+
+import {
+  enqueueMemoryJob,
+  type MemoryJobType,
+} from "../../memory/jobs-store.js";
+import type { IpcRoute } from "../assistant-server.js";
+
+const MemoryV2BackfillParams = z
+  .object({
+    op: z.enum(["migrate", "rebuild-edges", "reembed", "activation-recompute"]),
+    force: z.boolean().optional(),
+  })
+  .strict();
+
+export type MemoryV2BackfillOp = z.infer<typeof MemoryV2BackfillParams>["op"];
+
+export type MemoryV2BackfillResult = {
+  jobId: string;
+};
+
+/**
+ * Map a public operation name to the internal `MemoryJobType` so callers
+ * (CLI, UI, tests) speak in stable verbs while the queue keeps its own
+ * naming convention.
+ */
+const OP_TO_JOB_TYPE: Record<MemoryV2BackfillOp, MemoryJobType> = {
+  migrate: "memory_v2_migrate",
+  "rebuild-edges": "memory_v2_rebuild_edges",
+  reembed: "memory_v2_reembed",
+  "activation-recompute": "memory_v2_activation_recompute",
+};
+
+export const memoryV2BackfillRoute: IpcRoute = {
+  method: "memory_v2/backfill",
+  handler: async (params): Promise<MemoryV2BackfillResult> => {
+    const { op, force } = MemoryV2BackfillParams.parse(params ?? {});
+
+    // `force` only applies to `migrate` and only when explicitly true — the
+    // migration handler already defaults missing/false to false, so omitting
+    // the field keeps the queued JSON minimal.
+    const payload: Record<string, unknown> =
+      op === "migrate" && force === true ? { force: true } : {};
+
+    const jobId = enqueueMemoryJob(OP_TO_JOB_TYPE[op], payload);
+    return { jobId };
+  },
+};


### PR DESCRIPTION
## Summary
- Adds `memory_v2/backfill` IPC route (mutating) that enqueues one of four backfill jobs and returns the `jobId`.
- Supports `migrate` / `rebuild-edges` / `reembed` / `activation-recompute` ops; only `migrate` reads `force: true` from the payload (the other ops accept the field at the schema level for CLI uniformity but never forward it).
- Tests assert each op routes to the correct `MemoryJobType` with the expected payload via a module-level mock of `enqueueMemoryJob`.

Part of plan: memory-v2.md (PR 23 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
