### PR TITLE
feat(memory): route injection to v2 when flag enabled

### DIFF
--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for the v2 routing wired into `ConversationGraphMemory.prepareMemory`.
+ *
+ * The wiring layer at `conversation-graph-memory.ts` reads two signals to
+ * decide whether to swap v1's injection step for the v2 activation pipeline:
+ *
+ *   1. The `memory-v2-enabled` feature flag (`isAssistantFeatureFlagEnabled`).
+ *   2. The workspace config value `memory.v2.enabled`.
+ *
+ * Both must be true for v2 to take over. This file uses the *real*
+ * `injectMemoryV2Block` and stubs only the lower-level deps (Qdrant client,
+ * embedding backend) the way `memory/v2/__tests__/injection.test.ts` does —
+ * mocking `injection.js` itself would clobber that sibling test when both
+ * files run in the same `bun test` invocation, since `mock.module` is
+ * process-global. Avoiding the mock keeps the suite hermetic in either order.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import type { AssistantConfig } from "../../../config/types.js";
+import type { Message } from "../../../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the dynamic imports below)
+// ---------------------------------------------------------------------------
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+// Stub the v1 retriever so we don't reach Qdrant. Both modes return zero
+// nodes — the v1 injection branch becomes a no-op, isolating the assertion
+// to "did the v2 routing fire?".
+mock.module("../retriever.js", () => ({
+  loadContextMemory: async () => ({
+    nodes: [],
+    serendipityNodes: [],
+    latencyMs: 1,
+    metrics: null,
+    queryVector: undefined,
+    sparseVector: undefined,
+    userQueryVector: undefined,
+    userQuerySparseVector: undefined,
+  }),
+  retrieveForTurn: async () => ({
+    nodes: [],
+    latencyMs: 1,
+    metrics: null,
+    queryVector: undefined,
+    sparseVector: undefined,
+  }),
+}));
+
+// Programmable embedding + Qdrant state. Mirrors the pattern in
+// `memory/v2/__tests__/injection.test.ts` so we drive the real
+// `injectMemoryV2Block` end-to-end without a live backend.
+const qdrantState = {
+  queryResponses: {
+    dense: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+    sparse: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+  },
+};
+
+class MockQdrantClient {
+  constructor(_opts: unknown) {}
+  async collectionExists(_name: string) {
+    return { exists: true };
+  }
+  async createCollection() {
+    return {};
+  }
+  async createPayloadIndex() {
+    return {};
+  }
+  async query(
+    _name: string,
+    params: { using: string; limit: number; filter?: unknown },
+  ) {
+    const queue =
+      qdrantState.queryResponses[params.using as "dense" | "sparse"];
+    return queue.shift() ?? { points: [] };
+  }
+}
+
+mock.module("@qdrant/js-client-rest", () => ({
+  QdrantClient: MockQdrantClient,
+}));
+
+const realEmbeddingBackend = await import("../../embedding-backend.js");
+mock.module("../../embedding-backend.js", () => ({
+  ...realEmbeddingBackend,
+  embedWithBackend: async () => ({
+    provider: "local",
+    model: "test-model",
+    vectors: [[0.1, 0.2, 0.3]] as number[][],
+  }),
+  generateSparseEmbedding: () => ({
+    indices: [1, 2, 3],
+    values: [0.5, 0.5, 0.5] as number[],
+  }),
+}));
+
+const realQdrantClient = await import("../../qdrant-client.js");
+mock.module("../../qdrant-client.js", () => ({
+  ...realQdrantClient,
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+// ---------------------------------------------------------------------------
+// Workspace + DB fixtures
+// ---------------------------------------------------------------------------
+
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "conv-graph-v2-routing-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+
+  // Seed v2 layout with a single concept page so the real injection module
+  // has something concrete to render. Generic placeholders only.
+  mkdirSync(join(tmpWorkspace, "memory", "concepts"), { recursive: true });
+  writeFileSync(
+    join(tmpWorkspace, "memory", "edges.json"),
+    JSON.stringify({ version: 1, edges: [] }),
+  );
+  writeFileSync(
+    join(tmpWorkspace, "memory", "concepts", "alice-vscode.md"),
+    `---\nedges: []\nref_files: []\n---\nAlice prefers VS Code as her editor.`,
+  );
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+  // Restore mocks so a sibling test loaded in the same `bun test` run sees
+  // unmocked module bindings.
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+// Dynamic imports — must come AFTER the mock.module() calls above so the
+// bindings resolve through the stubs.
+// ---------------------------------------------------------------------------
+
+import type { DrizzleDb } from "../../db-connection.js";
+
+const { ConversationGraphMemory } =
+  await import("../conversation-graph-memory.js");
+const { _setOverridesForTesting } =
+  await import("../../../config/assistant-feature-flags.js");
+const { applyNestedDefaults } = await import("../../../config/loader.js");
+const { getSqliteFrom } = await import("../../db-connection.js");
+const { migrateActivationState } =
+  await import("../../migrations/232-activation-state.js");
+const schema = await import("../../schema.js");
+const { _resetMemoryV2QdrantForTests } = await import("../../v2/qdrant.js");
+
+// The wiring layer calls `getDb()` to fetch the SQLite handle. We mock
+// only that one export and spread the real module so unrelated callers
+// (`raw*` helpers, etc.) keep working when this test runs alongside
+// others. A live mutable holder lets each `beforeEach` swap the handle
+// without re-registering the mock.
+let testDbHandle: DrizzleDb | null = null;
+const realDbModule = await import("../../db.js");
+mock.module("../../db.js", () => ({
+  ...realDbModule,
+  getDb: () => {
+    if (!testDbHandle) throw new Error("test db not initialized");
+    return testDbHandle;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestDb(): DrizzleDb {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  const db = drizzle(sqlite, { schema });
+  getSqliteFrom(db).exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  migrateActivationState(db);
+  return db;
+}
+
+function makeConfig(v2Enabled: boolean): AssistantConfig {
+  return applyNestedDefaults({
+    memory: { v2: { enabled: v2Enabled } },
+  }) as AssistantConfig;
+}
+
+function makeMessages(
+  text = "hello there, this is a long enough question",
+): Message[] {
+  return [
+    {
+      role: "user",
+      content: [{ type: "text" as const, text }],
+    },
+  ];
+}
+
+function makeMemory(): InstanceType<typeof ConversationGraphMemory> {
+  // `initialized = true` skips the context-load branch and the
+  // `fetchRecentSummaries` DB read it depends on, isolating the per-turn path
+  // for these unit tests. Context-load is covered by its own block below.
+  const m = new ConversationGraphMemory("scope-1", "conv-test-1");
+  (m as unknown as { initialized: boolean }).initialized = true;
+  return m;
+}
+
+/** Stage one set of dense/sparse hits for each channel of the activation
+ *  pipeline (1 candidate query + 3 simBatch channels). */
+function stageTurn(
+  hits: Array<{ slug: string; denseScore?: number; sparseScore?: number }>,
+): void {
+  for (let i = 0; i < 4; i++) {
+    qdrantState.queryResponses.dense.push({
+      points: hits
+        .filter((h) => h.denseScore !== undefined)
+        .map((h) => ({ score: h.denseScore, payload: { slug: h.slug } })),
+    });
+    qdrantState.queryResponses.sparse.push({
+      points: hits
+        .filter((h) => h.sparseScore !== undefined)
+        .map((h) => ({ score: h.sparseScore, payload: { slug: h.slug } })),
+    });
+  }
+}
+
+const noopEvent = () => {};
+
+beforeEach(() => {
+  testDbHandle = createTestDb();
+  qdrantState.queryResponses.dense.length = 0;
+  qdrantState.queryResponses.sparse.length = 0;
+  _resetMemoryV2QdrantForTests();
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ConversationGraphMemory.prepareMemory — v2 routing (per-turn path)", () => {
+  test("flag off → v2 not run, messages unchanged", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const messages = makeMessages();
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("per-turn");
+    expect(result.injectedBlockText).toBeNull();
+    // No v2 block prepended — the v1 retriever returned zero nodes so the
+    // user message is exactly the input.
+    expect(result.runMessages).toEqual(messages);
+  });
+
+  test("flag on + config off → v2 not run, messages unchanged", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = makeMemory();
+    const config = makeConfig(false);
+    const messages = makeMessages();
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("per-turn");
+    expect(result.injectedBlockText).toBeNull();
+    expect(result.runMessages).toEqual(messages);
+  });
+
+  test("flag on + config on → v2 block prepended, mode is per-turn", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const messages = makeMessages("Tell me about Alice's editor preferences");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("per-turn");
+    expect(result.injectedBlockText).not.toBeNull();
+    expect(result.injectedBlockText).toContain("<memory __injected>");
+    expect(result.injectedBlockText).toContain("### alice-vscode");
+
+    // The leading content block on the user message is the v2 block.
+    const lastMsg = result.runMessages[result.runMessages.length - 1];
+    expect(lastMsg?.role).toBe("user");
+    const firstBlock = lastMsg?.content[0];
+    expect(firstBlock?.type).toBe("text");
+    if (firstBlock?.type !== "text") throw new Error("unexpected block type");
+    expect(firstBlock.text).toContain("<memory __injected>");
+  });
+
+  test("flag on + config on with empty Qdrant hits → no v2 block, v1 fallback skipped", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    // No `stageTurn` call — every channel returns `{ points: [] }` so the
+    // candidate set is empty and `injectMemoryV2Block` returns block=null.
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const messages = makeMessages();
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.injectedBlockText).toBeNull();
+    expect(result.runMessages).toEqual(messages);
+  });
+});
+
+describe("ConversationGraphMemory.prepareMemory — v2 routing (context-load path)", () => {
+  test("flag on + config on → v2 fires with mode=context-load", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    // Fresh memory → initialized=false → runContextLoad branch.
+    const memory = new ConversationGraphMemory("scope-1", "conv-test-cl");
+    const config = makeConfig(true);
+    const messages = makeMessages("first message of the conversation here");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("context-load");
+    expect(result.injectedBlockText).not.toBeNull();
+    expect(result.injectedBlockText).toContain("<memory __injected>");
+  });
+
+  test("flag off → v2 not run on first turn either", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = new ConversationGraphMemory("scope-1", "conv-test-cl-off");
+    const config = makeConfig(true);
+    const messages = makeMessages("first message of the conversation here");
+
+    const result = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+
+    expect(result.mode).toBe("context-load");
+    expect(result.injectedBlockText).toBeNull();
+  });
+});

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -8,6 +8,7 @@
 
 import { and, desc, eq, inArray, ne, notInArray } from "drizzle-orm";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { estimateTextTokens } from "../../context/token-estimator.js";
 import type { ServerMessage } from "../../daemon/message-protocol.js";
@@ -17,10 +18,16 @@ import type {
   Message,
 } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
 import { getDb } from "../db.js";
 import type { QdrantSparseVector } from "../qdrant-client.js";
 import { memorySummaries } from "../schema.js";
 import { conversations } from "../schema/conversations.js";
+import {
+  injectMemoryV2Block,
+  type InjectMemoryV2Mode,
+} from "../v2/injection.js";
+import { loadNowText } from "../v2/now-text.js";
 import {
   loadGraphMemoryState,
   saveGraphMemoryState,
@@ -389,6 +396,40 @@ export class ConversationGraphMemory {
     this.initialized = true;
     this.needsReload = false;
 
+    // v2 routing: when the feature flag and workspace config are both on,
+    // replace v1's injection with the activation-pipeline output. v1
+    // retrieval still runs above so its tracker stays warm — keeps the
+    // off→on→off flag flip cheap and avoids invalidating cached metrics.
+    // assistantMessage is empty: context-load fires on turn 1 / post-
+    // compaction, so there is no immediately-prior assistant turn to
+    // weight the activation against.
+    const v2 = await this.maybeRouteV2Injection(
+      messages,
+      config,
+      "context-load",
+      userQuery ?? "",
+      "",
+    );
+    if (v2.routed) {
+      this.lastInjectedBlock = v2.injectedBlockText;
+      this.lastInjectedNodeIds = [];
+      this.lastInjectedImages = new Map();
+      return {
+        runMessages: v2.runMessages,
+        injectedTokens: v2.injectedBlockText
+          ? estimateTextTokens(v2.injectedBlockText)
+          : 0,
+        latencyMs: result.latencyMs,
+        mode: "context-load" as const,
+        injectedBlockText: v2.injectedBlockText,
+        metrics: result.metrics,
+        queryVector: result.queryVector,
+        sparseVector: result.sparseVector,
+        userQueryVector: result.userQueryVector,
+        userQuerySparseVector: result.userQuerySparseVector,
+      };
+    }
+
     if (result.nodes.length === 0) {
       this.lastInjectedBlock = null;
       this.lastInjectedNodeIds = [];
@@ -506,6 +547,36 @@ export class ConversationGraphMemory {
       signal,
     });
 
+    // v2 routing: same gating as `runContextLoad` — when the flag and config
+    // are both on, the v2 activation pipeline produces the injection block
+    // (or `null` for the cache-stable empty path). v1 retrieval above runs
+    // unconditionally so the tracker stays in sync with the v1 nodes —
+    // cheap insurance for an off→on→off flag flip mid-conversation.
+    const v2 = await this.maybeRouteV2Injection(
+      messages,
+      config,
+      "per-turn",
+      userLast,
+      assistantLast,
+    );
+    if (v2.routed) {
+      this.lastInjectedBlock = v2.injectedBlockText;
+      this.lastInjectedNodeIds = [];
+      this.lastInjectedImages = new Map();
+      return {
+        runMessages: v2.runMessages,
+        injectedTokens: v2.injectedBlockText
+          ? estimateTextTokens(v2.injectedBlockText)
+          : 0,
+        latencyMs: result.latencyMs,
+        mode: "per-turn" as const,
+        injectedBlockText: v2.injectedBlockText,
+        metrics: result.metrics,
+        queryVector: result.queryVector,
+        sparseVector: result.sparseVector,
+      };
+    }
+
     if (result.nodes.length === 0) {
       this.lastInjectedBlock = null;
       this.lastInjectedNodeIds = [];
@@ -560,6 +631,62 @@ export class ConversationGraphMemory {
       metrics: result.metrics,
       queryVector: result.queryVector,
       sparseVector: result.sparseVector,
+    };
+  }
+
+  /**
+   * Route the v1 retrieval's injection step through the v2 activation
+   * pipeline when the `memory-v2-enabled` feature flag *and* the workspace
+   * config (`memory.v2.enabled`) are both on.
+   *
+   * The two outcomes the caller distinguishes via `routed`:
+   *   - `routed: false` — v2 disabled; caller runs the existing v1 injection.
+   *   - `routed: true`  — v2 ran. `runMessages` is either the v2-prepended
+   *                        message list (block was non-null) or the input
+   *                        messages unchanged (cache-stable empty path).
+   *                        Caller does NOT fall through to v1 in either case.
+   */
+  private async maybeRouteV2Injection(
+    messages: Message[],
+    config: AssistantConfig,
+    mode: InjectMemoryV2Mode,
+    userMessage: string,
+    assistantMessage: string,
+  ): Promise<{
+    routed: boolean;
+    runMessages: Message[];
+    injectedBlockText: string | null;
+  }> {
+    if (
+      !isAssistantFeatureFlagEnabled("memory-v2-enabled", config) ||
+      !config.memory.v2.enabled
+    ) {
+      return { routed: false, runMessages: messages, injectedBlockText: null };
+    }
+
+    const nowText = await loadNowText(getWorkspaceDir());
+    const currentTurn = this.tracker.getTurn();
+
+    const result = await injectMemoryV2Block({
+      database: getDb(),
+      conversationId: this.conversationId,
+      currentTurn,
+      userMessage,
+      assistantMessage,
+      nowText,
+      messageId: `${this.conversationId}:turn:${currentTurn}`,
+      mode,
+      config,
+    });
+
+    if (!result.block) {
+      return { routed: true, runMessages: messages, injectedBlockText: null };
+    }
+
+    return {
+      routed: true,
+      runMessages: prependMemoryV2Block(messages, result.block),
+      injectedBlockText: result.block,
     };
   }
 }
@@ -731,4 +858,27 @@ function extractUserText(message: Message): string | null {
   const joined = texts.join(" ");
   // Skip very short messages ("hi", "yes") — they produce vague embeddings
   return joined.length > 10 ? joined : null;
+}
+
+/**
+ * Prepend a pre-rendered `<memory __injected>` block (produced by
+ * `injectMemoryV2Block`) to the last user message. Unlike v1's
+ * {@link injectMemoryBlock}, the input here is already wrapped — we
+ * just need to attach it as a leading text block. We still strip any
+ * pre-existing memory injections first so the layer is idempotent
+ * across compaction-driven re-injection.
+ */
+function prependMemoryV2Block(messages: Message[], block: string): Message[] {
+  if (block.trim().length === 0) return messages;
+  if (messages.length === 0) return messages;
+  const cleaned = stripExistingMemoryInjections(messages);
+  const userTail = cleaned[cleaned.length - 1];
+  if (!userTail || userTail.role !== "user") return messages;
+  return [
+    ...cleaned.slice(0, -1),
+    {
+      ...userTail,
+      content: [{ type: "text" as const, text: block }, ...userTail.content],
+    },
+  ];
 }

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -41,6 +41,15 @@ import type { ActivationState, EverInjectedEntry } from "./types.js";
 // Public types
 // ---------------------------------------------------------------------------
 
+/**
+ * Discriminator the wiring layer (`conversation-graph-memory.ts`) sets to
+ * tell the v2 injector which call site is asking. Both modes currently share
+ * the same block layout (mirroring v1 which also wraps both flows in
+ * `<memory __injected>...</memory>`); the parameter exists so future tuning
+ * can shape the conversation-start block without touching the call site.
+ */
+export type InjectMemoryV2Mode = "context-load" | "per-turn";
+
 export interface InjectMemoryV2BlockParams {
   /** SQLite database handle for activation_state hydrate/save. */
   database: DrizzleDb;
@@ -56,6 +65,13 @@ export interface InjectMemoryV2BlockParams {
   nowText: string;
   /** Resolved messageId to persist on the activation_state row. */
   messageId: string;
+  /**
+   * Whether the caller is doing a fresh context-load (turn 1 / post-compaction)
+   * or a per-turn append injection. Currently informational — both modes
+   * produce the same block layout — but accepted so callers don't have to
+   * change when the layouts diverge.
+   */
+  mode?: InjectMemoryV2Mode;
   config: AssistantConfig;
 }
 

--- a/assistant/src/memory/v2/now-text.ts
+++ b/assistant/src/memory/v2/now-text.ts
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — Shared "NOW" context loader
+// ---------------------------------------------------------------------------
+//
+// The activation formula's `c_now` term needs a snapshot of the prose meta
+// files (`essentials.md`, `threads.md`, `recent.md`) that the system prompt
+// also autoloads (see `prompts/system-prompt.ts buildMemoryV2Section`).
+// Missing or unreadable files are treated as empty so a fresh workspace
+// (no consolidation has run yet) still reaches the v2 injector with a
+// well-defined `nowText`.
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const NOW_FILES = ["essentials.md", "threads.md", "recent.md"] as const;
+
+/**
+ * Read `memory/{essentials,threads,recent}.md` and concatenate the trimmed
+ * non-empty contents (in the same order the system prompt autoloads them).
+ *
+ * Returns an empty string when none of the files exist or all are empty.
+ */
+export async function loadNowText(workspaceDir: string): Promise<string> {
+  const reads = await Promise.all(
+    NOW_FILES.map(async (filename) => {
+      try {
+        const text = await readFile(
+          join(workspaceDir, "memory", filename),
+          "utf-8",
+        );
+        return text.trim();
+      } catch {
+        return "";
+      }
+    }),
+  );
+  return reads.filter((part) => part.length > 0).join("\n\n");
+}


### PR DESCRIPTION
## Summary
- Wires v2 injection into ConversationGraphMemory's context-load and per-turn paths behind the memory-v2-enabled flag + memory.v2.enabled config (both must be true).
- v1 injection remains the default and is unchanged when v2 is off; v1 retrieval still runs when v2 is on so the tracker stays warm for off-on-off flag flips.
- Adds memory/v2/now-text.ts (shared NOW-context concatenator) and an InjectMemoryV2Mode discriminator on injectMemoryV2Block.

Part of plan: memory-v2.md (PR 22 of 25)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
