### PR TITLE
feat(memory): schedule v2 consolidation hourly + sweep idle-debounced

### DIFF
--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for the v2 consolidation entry in `maybeEnqueueGraphMaintenanceJobs`.
+ *
+ * Coverage matrix (from PR 24 acceptance criteria):
+ *   - Flag off → no `memory_v2_consolidate` row enqueued, even after the
+ *     interval has elapsed.
+ *   - Flag on + config off → still no row enqueued (both gates required).
+ *   - Flag on + config on, no prior checkpoint → row enqueued, checkpoint
+ *     stamped to `nowMs`.
+ *   - Flag on + config on, recent checkpoint → no row enqueued (interval
+ *     not yet elapsed).
+ *   - Flag on + config on, stale checkpoint → row enqueued, checkpoint
+ *     refreshed.
+ *   - The v1 maintenance entries (decay, consolidate, pattern_scan,
+ *     narrative) still fire under the v2 path — adding the v2 entry must
+ *     not regress v1 scheduling.
+ *
+ * The sweep job is intentionally NOT scheduled here: PR 24 wires it into
+ * the `graph_extract` debounce in `indexer.ts`. Those triggers are covered
+ * by the separate trigger-path tests; this file owns only the cron entries.
+ *
+ * Tests use a temp workspace pinned via `VELLUM_WORKSPACE_DIR` so the DB
+ * lives under `tmpdir()` and `~/.vellum/` is never touched.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// Workspace pin must precede the `db` import below — the DB singleton
+// resolves its path at first call, so we need the env var set before
+// anything touches sqlite.
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-v2-schedule-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+const { initializeDb, getDb } = await import("../db.js");
+const { resetTestTables } = await import("../raw-query.js");
+const { memoryJobs } = await import("../schema.js");
+const { _setOverridesForTesting } =
+  await import("../../config/assistant-feature-flags.js");
+const { applyNestedDefaults } = await import("../../config/loader.js");
+const { setMemoryCheckpoint, deleteMemoryCheckpoint } =
+  await import("../checkpoints.js");
+const { maybeEnqueueGraphMaintenanceJobs } = await import("../jobs-worker.js");
+
+const CONSOLIDATE_CHECKPOINT_KEY = "memory_v2_consolidate_last_run";
+
+function buildConfig(overrides: {
+  v2Enabled?: boolean;
+  intervalHours?: number;
+}) {
+  const partial = applyNestedDefaults({});
+  if (overrides.v2Enabled !== undefined) {
+    partial.memory.v2.enabled = overrides.v2Enabled;
+  }
+  if (overrides.intervalHours !== undefined) {
+    partial.memory.v2.consolidation_interval_hours = overrides.intervalHours;
+  }
+  return partial;
+}
+
+function countPendingJobs(type: string): number {
+  return getDb()
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, type))
+    .all().length;
+}
+
+// Initialize the DB once for the file; clear per-test tables in beforeEach
+// rather than tearing down the singleton, which is slow because it re-runs
+// every migration on the next access.
+initializeDb();
+
+beforeEach(() => {
+  // Clear job + checkpoint state so each test starts from zero rows. Other
+  // tables stay intact — the worker only inspects these two.
+  resetTestTables("memory_jobs", "memory_checkpoints");
+});
+
+afterEach(() => {
+  _setOverridesForTesting({});
+});
+
+// ---------------------------------------------------------------------------
+
+describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
+  test("does not enqueue consolidate when memory-v2-enabled flag is off", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
+    // Force the interval to look elapsed. If the gate failed open, this
+    // would be enough to enqueue a job.
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+
+  test("does not enqueue consolidate when config.memory.v2.enabled is off", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    const config = buildConfig({ v2Enabled: false, intervalHours: 1 });
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+
+  test("enqueues consolidate when both gates are on and no checkpoint exists", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("does not enqueue consolidate before the interval has elapsed", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
+    const now = Date.now();
+    // Stamp checkpoint to "1 minute ago"; interval is 1h, so elapsed << interval.
+    setMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY, String(now - 60_000));
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+
+  test("enqueues consolidate again once the interval elapses", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
+    const now = Date.now();
+    // Stamp checkpoint to >1h ago.
+    setMemoryCheckpoint(
+      CONSOLIDATE_CHECKPOINT_KEY,
+      String(now - 2 * 60 * 60 * 1000),
+    );
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("respects a custom consolidation_interval_hours value", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 6 });
+
+    const now = Date.now();
+    // 4h elapsed — under the configured 6h interval.
+    setMemoryCheckpoint(
+      CONSOLIDATE_CHECKPOINT_KEY,
+      String(now - 4 * 60 * 60 * 1000),
+    );
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+
+    // 7h elapsed — over the configured 6h interval.
+    setMemoryCheckpoint(
+      CONSOLIDATE_CHECKPOINT_KEY,
+      String(now - 7 * 60 * 60 * 1000),
+    );
+
+    maybeEnqueueGraphMaintenanceJobs(config, now);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("v1 graph maintenance entries still fire alongside the v2 entry", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
+    // No checkpoints set — every entry should be due.
+    deleteMemoryCheckpoint("graph_maintenance:decay:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:consolidate:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:pattern_scan:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:narrative:last_run");
+    deleteMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY);
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("graph_decay")).toBe(1);
+    expect(countPendingJobs("graph_consolidate")).toBe(1);
+    expect(countPendingJobs("graph_pattern_scan")).toBe(1);
+    expect(countPendingJobs("graph_narrative_refine")).toBe(1);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("flag-off path does not enqueue v2 but still fires the v1 entries", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
+    deleteMemoryCheckpoint("graph_maintenance:decay:last_run");
+    deleteMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY);
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("graph_decay")).toBe(1);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
+});

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -193,14 +193,48 @@ export async function indexMessageNow(
       // Routing both paths through `upsertDebouncedJob` ensures the
       // row's `runAfter` reflects whichever trigger ran last, so a
       // batch crossing always takes effect immediately.
+      const extractRunAfter = graphBatchFired
+        ? Date.now()
+        : Date.now() + idleTimeoutMs;
       upsertDebouncedJob(
         "graph_extract",
         {
           conversationId: input.conversationId,
           scopeId: input.scopeId ?? "default",
         },
-        graphBatchFired ? Date.now() : Date.now() + idleTimeoutMs,
+        extractRunAfter,
       );
+
+      // Reading config here is best-effort: feature-gated triggers below
+      // (memory v2 sweep, auto-analyze batch) skip when it fails — the
+      // idle-debounced enqueues above are unaffected.
+      let triggerConfig: ReturnType<typeof getConfig> | null = null;
+      try {
+        triggerConfig = getConfig();
+      } catch (err) {
+        log.debug(
+          { err, conversationId: input.conversationId },
+          "Skipping feature-gated extraction triggers: failed to load config",
+        );
+      }
+
+      // Memory v2 sweep mirrors graph_extract's debounce: when the v2
+      // flag + config are on, every extraction trigger also enqueues a
+      // sweep. The sweep itself reads recent messages globally, so the
+      // `conversationId` here is just the dedup key — one pending row
+      // per active conversation. Both gates ensure the job remains a
+      // no-op when v2 is off.
+      if (
+        triggerConfig != null &&
+        isAssistantFeatureFlagEnabled("memory-v2-enabled", triggerConfig) &&
+        triggerConfig.memory.v2.enabled
+      ) {
+        upsertDebouncedJob(
+          "memory_v2_sweep",
+          { conversationId: input.conversationId },
+          extractRunAfter,
+        );
+      }
 
       // ── Auto-analysis triggers ─────────────────────────────────────
       // Immediate triggers (batch, compaction) and debounced triggers
@@ -218,23 +252,12 @@ export async function indexMessageNow(
       // Gated behind the `auto-analyze` feature flag so the counter
       // does not accumulate stale counts while the flag is off — if it
       // did, flipping the flag on would trigger an immediate batch from
-      // messages buffered during the disabled period. Reading config
-      // here is best-effort: if it fails we skip the batch trigger
-      // (the idle-debounced enqueue above still runs).
-      let analysisConfig: ReturnType<typeof getConfig> | null = null;
-      try {
-        analysisConfig = getConfig();
-      } catch (err) {
-        log.debug(
-          { err, conversationId: input.conversationId },
-          "Skipping auto-analysis batch trigger: failed to load config",
-        );
-      }
+      // messages buffered during the disabled period.
       if (
-        analysisConfig != null &&
-        isAssistantFeatureFlagEnabled("auto-analyze", analysisConfig)
+        triggerConfig != null &&
+        isAssistantFeatureFlagEnabled("auto-analyze", triggerConfig)
       ) {
-        const analysisBatchSize = analysisConfig.analysis.batchSize;
+        const analysisBatchSize = triggerConfig.analysis.batchSize;
         const analysisPendingKey = `conversation_analyze:${input.conversationId}:pending_count`;
         const analysisCurrentVal = getMemoryCheckpoint(analysisPendingKey);
         const analysisPendingCount =

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,3 +1,4 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
@@ -176,7 +177,7 @@ async function runMemoryJobsOnce(
     if (enableScheduledCleanup) {
       maybeEnqueueScheduledCleanupJobs(config);
     }
-    maybeEnqueueGraphMaintenanceJobs();
+    maybeEnqueueGraphMaintenanceJobs(config);
     maybeRunDbMaintenance();
     return 0;
   }
@@ -273,7 +274,7 @@ async function runMemoryJobsOnce(
   if (enableScheduledCleanup) {
     maybeEnqueueScheduledCleanupJobs(config);
   }
-  maybeEnqueueGraphMaintenanceJobs();
+  maybeEnqueueGraphMaintenanceJobs(config);
   maybeRunDbMaintenance();
   return processed;
 }
@@ -550,14 +551,24 @@ const GRAPH_MAINTENANCE_CHECKPOINTS = {
   consolidate: "graph_maintenance:consolidate:last_run",
   patternScan: "graph_maintenance:pattern_scan:last_run",
   narrative: "graph_maintenance:narrative:last_run",
+  memoryV2Consolidate: "memory_v2_consolidate_last_run",
 } as const;
 
 /**
  * Enqueue periodic graph maintenance jobs (decay, consolidation, pattern scan, narrative).
  * Uses durable checkpoints so intervals survive daemon restarts — jobs only fire
  * when the actual elapsed time since last run exceeds the interval.
+ *
+ * The v2 consolidation entry is gated on both the `memory-v2-enabled` feature
+ * flag and the `memory.v2.enabled` config — both must be true for the cron
+ * to fire. Sweep is intentionally not on this schedule: it is debounced from
+ * the live `graph_extract` trigger path (see `indexMessageNow` in
+ * `indexer.ts`) so it runs on the same idle/message-count cadence.
  */
-function maybeEnqueueGraphMaintenanceJobs(nowMs = Date.now()): void {
+export function maybeEnqueueGraphMaintenanceJobs(
+  config: AssistantConfig,
+  nowMs = Date.now(),
+): void {
   const schedule: Array<{
     key: string;
     intervalMs: number;
@@ -584,6 +595,18 @@ function maybeEnqueueGraphMaintenanceJobs(nowMs = Date.now()): void {
       jobType: "graph_narrative_refine",
     },
   ];
+
+  if (
+    isAssistantFeatureFlagEnabled("memory-v2-enabled", config) &&
+    config.memory.v2.enabled
+  ) {
+    schedule.push({
+      key: GRAPH_MAINTENANCE_CHECKPOINTS.memoryV2Consolidate,
+      intervalMs:
+        config.memory.v2.consolidation_interval_hours * 60 * 60 * 1000,
+      jobType: "memory_v2_consolidate",
+    });
+  }
 
   for (const { key, intervalMs, jobType } of schedule) {
     const lastRun = parseInt(getMemoryCheckpoint(key) ?? "0", 10);


### PR DESCRIPTION
## Summary

- Adds a gated entry to `maybeEnqueueGraphMaintenanceJobs` that enqueues `memory_v2_consolidate` once per `config.memory.v2.consolidation_interval_hours` (default 1h), keyed by a new `memory_v2_consolidate_last_run` checkpoint. Both the `memory-v2-enabled` feature flag and `config.memory.v2.enabled` must be true for the cron to fire.
- Hooks `memory_v2_sweep` into the existing `graph_extract` debounce in `indexer.ts`: every extraction trigger also enqueues a sweep (via `upsertDebouncedJob`, sharing the same `runAfter` as `graph_extract`), so the sweep runs on the same idle/message-count cadence v1 already uses.
- Refactors the existing `analysisConfig` block in `indexer.ts` to a shared `triggerConfig` so both the v2-sweep gate and the auto-analyze gate read `getConfig()` exactly once per call.

Part of plan: memory-v2.md (PR 24 of 25)

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/memory/__tests__/jobs-worker-v2-schedule.test.ts` passes (8 tests covering flag-off, config-off, fresh checkpoint, recent checkpoint, stale checkpoint, custom interval, and v1 entries still firing alongside the v2 entry)
- [x] Existing v2 sweep / consolidation tests continue to pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
