### PR TITLE
fix(memory): enqueue rebuild-edges after v1->v2 migration

### DIFF
--- a/assistant/src/memory/v2/__tests__/migration.test.ts
+++ b/assistant/src/memory/v2/__tests__/migration.test.ts
@@ -664,11 +664,23 @@ describe("runMemoryV2Migration", () => {
     expect(essentials).toContain("User is Alice and works at Vellum");
     expect(result.essentialsLines).toBe(1);
 
-    // -- Embed jobs enqueued (one per page). --
-    expect(enqueuedJobs.length).toBe(3);
-    expect(enqueuedJobs.every((j) => j.type === "embed_concept_page")).toBe(
-      true,
+    // -- Embed jobs enqueued (one per page) plus a single trailing
+    //    rebuild-edges enqueue so page frontmatter picks up edges.json. --
+    expect(enqueuedJobs.length).toBe(4);
+    const embedJobs = enqueuedJobs.filter(
+      (j) => j.type === "embed_concept_page",
     );
+    expect(embedJobs.length).toBe(3);
+    const rebuildJobs = enqueuedJobs.filter(
+      (j) => j.type === "memory_v2_rebuild_edges",
+    );
+    expect(rebuildJobs.length).toBe(1);
+    // Rebuild-edges must come last — the embeds depend only on pages on disk,
+    // but rebuild-edges should observe the final edges.json from this run.
+    expect(enqueuedJobs[enqueuedJobs.length - 1].type).toBe(
+      "memory_v2_rebuild_edges",
+    );
+    expect(result.rebuildEdgesJobId).toBe(`job-${enqueuedJobs.length}`);
 
     // -- Sentinel written. --
     expect(existsSync(join(workspaceDir, MIGRATION_SENTINEL_RELATIVE))).toBe(
@@ -774,6 +786,12 @@ describe("runMemoryV2Migration", () => {
     expect(result.pagesCreated).toBe(0);
     expect(result.embedsEnqueued).toBe(0);
     expect(result.sentinelWritten).toBe(true);
+    // Rebuild-edges still runs even with zero pages — the job is idempotent
+    // and ensures any pre-seeded frontmatter aligns with edges.json.
+    expect(result.rebuildEdgesJobId).toBeTruthy();
+    expect(
+      enqueuedJobs.filter((j) => j.type === "memory_v2_rebuild_edges").length,
+    ).toBe(1);
   });
 });
 

--- a/assistant/src/memory/v2/migration.ts
+++ b/assistant/src/memory/v2/migration.ts
@@ -56,6 +56,7 @@ export interface MigrationResult {
   threadsLines: number;
   archiveLines: number;
   embedsEnqueued: number;
+  rebuildEdgesJobId: string;
   sentinelWritten: boolean;
 }
 
@@ -557,6 +558,16 @@ export async function runMemoryV2Migration(
   await writeEdges(workspaceDir, edgesIdx);
 
   const embedsEnqueued = enqueueEmbeds(pages.map((p) => p.slug));
+
+  // Page bodies are written with empty `edges:` frontmatter (the schema is a
+  // derived view of `edges.json`). Without this enqueue the frontmatter would
+  // stay empty until the next consolidation run, but consolidation bails on an
+  // empty buffer — so a freshly-migrated workspace can sit indefinitely with
+  // out-of-date frontmatter. The rebuild-edges job propagates `edges.json` into
+  // every page's frontmatter and is idempotent, so pairing it with the
+  // migration is safe even when nothing else has run yet.
+  const rebuildEdgesJobId = enqueueMemoryJob("memory_v2_rebuild_edges", {});
+
   await writeSentinel(workspaceDir);
 
   // Re-read after writeEdges so the count reflects post-canonicalization
@@ -571,6 +582,7 @@ export async function runMemoryV2Migration(
     threadsLines: promotions.threads.length,
     archiveLines: promotions.archive.length,
     embedsEnqueued,
+    rebuildEdgesJobId,
     sentinelWritten: true,
   };
 }


### PR DESCRIPTION
## Summary

- v1->v2 migration writes pages with empty edges: frontmatter (the schema is a derived view of edges.json), then writes edges.json. Without an explicit rebuild-edges enqueue, frontmatter stays out of sync until consolidation runs — but consolidation bails on an empty buffer, so a freshly-migrated workspace can sit with stale frontmatter indefinitely.
- runMemoryV2Migration now enqueues memory_v2_rebuild_edges after the embed fan-out, surfacing the new jobId on MigrationResult so callers can observe it.

Follow-up to memory-v2 plan; targets the velissa-ai/memory-v2 feature branch.

## Original prompt

Fix gap in v1->v2 migration: pages get empty edges frontmatter and consolidation can't fix it on an empty buffer. Add an enqueueMemoryJob('memory_v2_rebuild_edges', {}) call after enqueueEmbeds in runMemoryV2Migration, expose the jobId on MigrationResult, and update the migration test to assert the enqueue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
