### PR TITLE
fix(perms): Thread correct conversation id through to threshold picker

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -479,6 +479,7 @@ struct ChatView: View {
                 onDictateToggle: onDictateToggle,
                 onVoiceModeToggle: onVoiceModeToggle,
                 conversationId: conversationId,
+                assistantConversationId: currentConversation?.conversationId,
                 isInteractionEnabled: isInteractionEnabled,
                 contextWindowFillRatio: viewModel.contextWindowFillRatio,
                 contextWindowTokens: viewModel.contextWindowTokens,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -30,6 +30,7 @@ struct ComposerSection: View, Equatable {
             && lhs.isLoadingAttachment == rhs.isLoadingAttachment
             && lhs.recordingAmplitude == rhs.recordingAmplitude
             && lhs.conversationId == rhs.conversationId
+            && lhs.assistantConversationId == rhs.assistantConversationId
             && lhs.isInteractionEnabled == rhs.isInteractionEnabled
             && lhs.contextWindowFillRatio == rhs.contextWindowFillRatio
             && lhs.contextWindowTokens == rhs.contextWindowTokens
@@ -75,6 +76,7 @@ struct ComposerSection: View, Equatable {
     var onDictateToggle: (() -> Void)? = nil
     var onVoiceModeToggle: (() -> Void)? = nil
     var conversationId: UUID?
+    var assistantConversationId: String? = nil
     var isInteractionEnabled: Bool = true
     var contextWindowFillRatio: Double? = nil
     var contextWindowTokens: Int? = nil
@@ -118,6 +120,7 @@ struct ComposerSection: View, Equatable {
                 onVoiceModeToggle: onVoiceModeToggle,
                 placeholderText: isAssistantBusy ? "Working on it..." : "What would you like to do?",
                 conversationId: conversationId,
+                assistantConversationId: assistantConversationId,
                 isInteractionEnabled: isInteractionEnabled,
                 contextWindowFillRatio: contextWindowFillRatio,
                 contextWindowTokens: contextWindowTokens,

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -109,7 +109,7 @@ enum ThresholdPreset: String, CaseIterable, Identifiable, Equatable {
 /// with four presets: Strict, Default, Relaxed, and Full access.
 @MainActor
 struct ComposerThresholdPicker: View {
-    let conversationId: UUID?
+    let assistantConversationId: String?
     var thresholdClient: ThresholdClientProtocol = ThresholdClient()
 
     /// The currently displayed preset. Updated optimistically on selection and
@@ -168,7 +168,7 @@ struct ComposerThresholdPicker: View {
                 }
             }
         }
-        .task(id: conversationId) {
+        .task(id: assistantConversationId) {
             hasUserInteracted = false
             await loadState()
         }
@@ -184,23 +184,14 @@ struct ComposerThresholdPicker: View {
         }
 
         writeTask?.cancel()
-        writeTask = Task {
-            guard let conversationId else { return }
-            let conversationIdString = conversationId.uuidString.lowercased()
-
+        writeTask = Task { @MainActor in
             do {
-                if let value = preset.thresholdValue,
-                   value != globalInteractive {
-                    try await thresholdClient.setConversationOverride(
-                        conversationId: conversationIdString,
-                        threshold: value
-                    )
-                } else {
-                    // Default or matching global — remove the override row.
-                    try await thresholdClient.deleteConversationOverride(
-                        conversationId: conversationIdString
-                    )
-                }
+                try await Self.applyPresetSelection(
+                    preset: preset,
+                    globalInteractive: globalInteractive,
+                    assistantConversationId: assistantConversationId,
+                    thresholdClient: thresholdClient
+                )
             } catch {
                 guard !Task.isCancelled else { return }
                 log.error("Failed to write conversation threshold override: \(error.localizedDescription, privacy: .public)")
@@ -221,8 +212,7 @@ struct ComposerThresholdPicker: View {
                 globalInteractive = globals.interactive
 
                 var override: String? = nil
-                if let conversationId {
-                    let conversationIdString = conversationId.uuidString.lowercased()
+                if let conversationIdString = Self.canonicalConversationId(assistantConversationId) {
                     override = try await thresholdClient.getConversationOverride(
                         conversationId: conversationIdString
                     )
@@ -240,5 +230,50 @@ struct ComposerThresholdPicker: View {
         }
         loadTask = task
         await task.value
+    }
+
+    // MARK: - Helpers (testable)
+
+    enum OverrideAction: Equatable {
+        case set(String)
+        case clear
+    }
+
+    static func canonicalConversationId(_ conversationId: String?) -> String? {
+        let trimmed = conversationId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else { return nil }
+        return trimmed.lowercased()
+    }
+
+    static func overrideAction(
+        for preset: ThresholdPreset,
+        globalInteractive: String
+    ) -> OverrideAction {
+        if let value = preset.thresholdValue,
+           value != globalInteractive {
+            return .set(value)
+        }
+        // Default or matching global — remove the override row.
+        return .clear
+    }
+
+    static func applyPresetSelection(
+        preset: ThresholdPreset,
+        globalInteractive: String,
+        assistantConversationId: String?,
+        thresholdClient: any ThresholdClientProtocol
+    ) async throws {
+        guard let canonicalConversationId = canonicalConversationId(assistantConversationId) else { return }
+        switch overrideAction(for: preset, globalInteractive: globalInteractive) {
+        case .set(let threshold):
+            try await thresholdClient.setConversationOverride(
+                conversationId: canonicalConversationId,
+                threshold: threshold
+            )
+        case .clear:
+            try await thresholdClient.deleteConversationOverride(
+                conversationId: canonicalConversationId
+            )
+        }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -32,6 +32,7 @@ struct ComposerView: View, Equatable {
             && lhs.placeholderText == rhs.placeholderText
             && lhs.composerCompactHeight == rhs.composerCompactHeight
             && lhs.conversationId == rhs.conversationId
+            && lhs.assistantConversationId == rhs.assistantConversationId
             && lhs.isInteractionEnabled == rhs.isInteractionEnabled
             && lhs.contextWindowFillRatio == rhs.contextWindowFillRatio
             && lhs.contextWindowTokens == rhs.contextWindowTokens
@@ -98,6 +99,7 @@ struct ComposerView: View, Equatable {
     var placeholderText: String = "What would you like to do?"
     var composerCompactHeight: CGFloat = 38
     var conversationId: UUID?
+    var assistantConversationId: String? = nil
     var isInteractionEnabled: Bool = true
     var contextWindowFillRatio: Double? = nil
     var contextWindowTokens: Int? = nil
@@ -450,7 +452,7 @@ struct ComposerView: View, Equatable {
             }
 
             if showThresholdPicker {
-                ComposerThresholdPicker(conversationId: conversationId)
+                ComposerThresholdPicker(assistantConversationId: assistantConversationId)
             }
 
             if let inferenceProfilePicker, !inferenceProfilePicker.profiles.isEmpty {

--- a/clients/macos/vellum-assistantTests/Features/Chat/ComposerThresholdPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ComposerThresholdPickerTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ComposerThresholdPickerTests: XCTestCase {
+
+    func testCanonicalConversationIdNormalizesWhitespaceAndCasing() {
+        let canonical = ComposerThresholdPicker.canonicalConversationId(
+            "  FACB62CB-1A24-4002-B835-9D2FF83606DE "
+        )
+        XCTAssertEqual(canonical, "facb62cb-1a24-4002-b835-9d2ff83606de")
+    }
+
+    func testApplyPresetSelectionUsesDaemonConversationId() async throws {
+        let mock = MockThresholdClient()
+        let daemonConversationId = "facb62cb-1a24-4002-b835-9d2ff83606de"
+
+        try await ComposerThresholdPicker.applyPresetSelection(
+            preset: .strict,
+            globalInteractive: RiskThreshold.low.rawValue,
+            assistantConversationId: daemonConversationId,
+            thresholdClient: mock
+        )
+
+        XCTAssertEqual(
+            mock.setCalls,
+            [MockThresholdClient.SetCall(
+                conversationId: daemonConversationId,
+                threshold: RiskThreshold.none.rawValue
+            )]
+        )
+        XCTAssertTrue(mock.deleteCalls.isEmpty)
+    }
+
+    func testApplyPresetSelectionClearsOverrideWhenPresetMatchesGlobal() async throws {
+        let mock = MockThresholdClient()
+        let daemonConversationId = "facb62cb-1a24-4002-b835-9d2ff83606de"
+
+        try await ComposerThresholdPicker.applyPresetSelection(
+            preset: .relaxed,
+            globalInteractive: RiskThreshold.medium.rawValue,
+            assistantConversationId: daemonConversationId,
+            thresholdClient: mock
+        )
+
+        XCTAssertTrue(mock.setCalls.isEmpty)
+        XCTAssertEqual(mock.deleteCalls, [daemonConversationId])
+    }
+
+    func testApplyPresetSelectionSkipsWhenConversationIdMissing() async throws {
+        let mock = MockThresholdClient()
+        try await ComposerThresholdPicker.applyPresetSelection(
+            preset: .strict,
+            globalInteractive: RiskThreshold.low.rawValue,
+            assistantConversationId: nil,
+            thresholdClient: mock
+        )
+
+        XCTAssertTrue(mock.setCalls.isEmpty)
+        XCTAssertTrue(mock.deleteCalls.isEmpty)
+    }
+}
+
+private final class MockThresholdClient: ThresholdClientProtocol {
+    struct SetCall: Equatable {
+        let conversationId: String
+        let threshold: String
+    }
+
+    private(set) var setCalls: [SetCall] = []
+    private(set) var deleteCalls: [String] = []
+
+    func getGlobalThresholds() async throws -> GlobalThresholds {
+        GlobalThresholds(
+            interactive: RiskThreshold.low.rawValue,
+            background: RiskThreshold.medium.rawValue,
+            headless: RiskThreshold.none.rawValue
+        )
+    }
+
+    func setGlobalThresholds(_ thresholds: GlobalThresholds) async throws {}
+
+    func getConversationOverride(conversationId: String) async throws -> String? {
+        nil
+    }
+
+    func setConversationOverride(conversationId: String, threshold: String) async throws {
+        setCalls.append(SetCall(conversationId: conversationId, threshold: threshold))
+    }
+
+    func deleteConversationOverride(conversationId: String) async throws {
+        deleteCalls.append(conversationId)
+    }
+}


### PR DESCRIPTION
Uses the proper conversation id in permission picker.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
