### PR TITLE
Make Advanced accordion label clickable in Risk Tolerance settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -143,12 +143,14 @@ struct RiskToleranceSection: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             } label: {
-                Text("Advanced")
-                    .onTapGesture {
-                        withAnimation {
-                            isAdvancedExpanded.toggle()
-                        }
+                Button {
+                    withAnimation {
+                        isAdvancedExpanded.toggle()
                     }
+                } label: {
+                    Text("Advanced")
+                }
+                .buttonStyle(.plain)
             }
         }
         .task { await loadThresholds() }

--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -46,6 +46,8 @@ struct RiskToleranceSection: View {
     /// server data.
     @State private var hasUserInteracted: Bool = false
 
+    @State private var isAdvancedExpanded: Bool = false
+
     var body: some View {
         SettingsCard(title: "Risk Tolerance") {
             Text("Control which actions your assistant can take without asking first. Each action is classified by risk level — your tolerance determines which levels auto-approve.")
@@ -78,7 +80,7 @@ struct RiskToleranceSection: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            DisclosureGroup("Advanced") {
+            DisclosureGroup(isExpanded: $isAdvancedExpanded) {
                 VStack(alignment: .leading, spacing: VSpacing.lg) {
                     SettingsDivider()
 
@@ -140,6 +142,13 @@ struct RiskToleranceSection: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+            } label: {
+                Text("Advanced")
+                    .onTapGesture {
+                        withAnimation {
+                            isAdvancedExpanded.toggle()
+                        }
+                    }
             }
         }
         .task { await loadThresholds() }

--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -80,7 +80,7 @@ struct RiskToleranceSection: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            DisclosureGroup(isExpanded: $isAdvancedExpanded) {
+            VDisclosureSection(title: "Advanced", isExpanded: $isAdvancedExpanded) {
                 VStack(alignment: .leading, spacing: VSpacing.lg) {
                     SettingsDivider()
 
@@ -142,15 +142,6 @@ struct RiskToleranceSection: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
-            } label: {
-                Button {
-                    withAnimation {
-                        isAdvancedExpanded.toggle()
-                    }
-                } label: {
-                    Text("Advanced")
-                }
-                .buttonStyle(.plain)
             }
         }
         .task { await loadThresholds() }


### PR DESCRIPTION
## Summary
- The "Advanced" `DisclosureGroup` in Risk Tolerance settings only had a clickable caret, not the label text
- Switched from the string-label initializer to `DisclosureGroup(isExpanded:content:label:)` with a custom label that toggles expansion on tap

## Original prompt
the fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
