### PR TITLE
refactor: unify threshold picker, serialize writes, fix global→composer sync

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -47,12 +47,14 @@ enum ThresholdPreset: String, CaseIterable, Identifiable, Equatable {
         }
     }
 
-    var iconColor: Color {
+    /// The ``RiskThreshold`` value represented by this preset.
+    /// `.default` maps to `.low` for surfaces that persist explicit globals.
+    var riskThreshold: RiskThreshold {
         switch self {
-        case .strict: return VColor.contentSecondary
-        case .default: return VColor.contentSecondary
-        case .relaxed: return VColor.systemMidStrong
-        case .fullAccess: return VColor.systemNegativeStrong
+        case .strict: return .none
+        case .default: return .low
+        case .relaxed: return .medium
+        case .fullAccess: return .high
         }
     }
 
@@ -67,8 +69,18 @@ enum ThresholdPreset: String, CaseIterable, Identifiable, Equatable {
         }
     }
 
-    /// Determines the preset that best describes a conversation override value
-    /// relative to the global interactive default.
+    /// Converts a concrete risk threshold into the matching preset label.
+    static func from(riskThreshold: RiskThreshold) -> ThresholdPreset {
+        switch riskThreshold {
+        case .none: return .strict
+        case .low: return .default
+        case .medium: return .relaxed
+        case .high: return .fullAccess
+        }
+    }
+
+    /// Determines the preset to display for a conversation threshold override,
+    /// falling back to the global interactive default when no override exists.
     ///
     /// - Parameters:
     ///   - override: The conversation-level threshold string, or `nil` when no
@@ -76,29 +88,78 @@ enum ThresholdPreset: String, CaseIterable, Identifiable, Equatable {
     ///   - globalInteractive: The global interactive threshold raw value.
     /// - Returns: The matching preset.
     static func from(override: String?, globalInteractive: String) -> ThresholdPreset {
-        guard let override else { return .default }
-        if override == globalInteractive { return .default }
+        let globalPreset = presetForGlobalInteractive(globalInteractive)
+        guard let override else { return globalPreset }
+        if override == globalInteractive { return globalPreset }
 
-        // Check for exact matches to named presets first
-        if override == RiskThreshold.high.rawValue { return .fullAccess }
+        // Overrides are absolute threshold values, not relative deltas from
+        // the global default. Map directly to the corresponding preset.
+        guard let overrideThreshold = RiskThreshold(rawValue: override) else {
+            return globalPreset
+        }
+        return from(riskThreshold: overrideThreshold)
+    }
 
-        // Compare by risk level ordering: none < low < medium < high
-        let order: [String] = [
-            RiskThreshold.none.rawValue,
-            RiskThreshold.low.rawValue,
-            RiskThreshold.medium.rawValue,
-            RiskThreshold.high.rawValue,
-        ]
-        let overrideIndex = order.firstIndex(of: override) ?? 0
-        let globalIndex = order.firstIndex(of: globalInteractive) ?? 0
-
-        if overrideIndex < globalIndex {
+    /// Maps a global interactive threshold value to the preset that should be
+    /// displayed when no conversation override is set.
+    private static func presetForGlobalInteractive(
+        _ globalInteractive: String
+    ) -> ThresholdPreset {
+        switch globalInteractive {
+        case RiskThreshold.none.rawValue:
             return .strict
-        } else if overrideIndex > globalIndex {
+        case RiskThreshold.medium.rawValue:
             return .relaxed
-        } else {
+        case RiskThreshold.high.rawValue:
+            return .fullAccess
+        default:
             return .default
         }
+    }
+}
+
+// MARK: - ThresholdPresetDropdown
+
+/// Shared dropdown for selecting one of the four risk-threshold presets.
+/// Uses the same composer pill + `VMenu` treatment across chat and settings.
+@MainActor
+struct ThresholdPresetDropdown: View {
+    let preset: ThresholdPreset
+    let accessibilityLabel: String
+    var onSelect: (ThresholdPreset) -> Void
+
+    var body: some View {
+        #if os(macOS)
+        ComposerPillMenu(
+            accessibilityLabel: accessibilityLabel,
+            accessibilityValue: preset.label,
+            tooltip: preset.description
+        ) {
+            VIconView(preset.icon, size: 14)
+                .foregroundStyle(VColor.contentSecondary)
+            Text(preset.label)
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+        } menu: {
+            ForEach(ThresholdPreset.allCases) { option in
+                VMenuItem(
+                    icon: option.icon.rawValue,
+                    label: option.label,
+                    isActive: preset == option,
+                    size: .regular
+                ) {
+                    onSelect(option)
+                } trailing: {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        if preset == option {
+                            VIconView(.check, size: 12)
+                                .foregroundStyle(VColor.primaryBase)
+                        }
+                    }
+                }
+            }
+        }
+        #endif
     }
 }
 
@@ -121,58 +182,41 @@ struct ComposerThresholdPicker: View {
     /// The global interactive threshold raw value, fetched on load.
     @State private var globalInteractive: String = RiskThreshold.low.rawValue
 
-    /// In-flight write task, cancelled on rapid re-selection.
+    /// In-flight write task. Writes are serialized so the final selection wins
+    /// even when the user changes options rapidly.
     @State private var writeTask: Task<Void, Never>?
+    /// Monotonic selection version used to drop superseded queued writes.
+    @State private var writeVersion: UInt64 = 0
 
     /// In-flight load task, cancelled on re-appearance.
     @State private var loadTask: Task<Void, Never>?
 
-    /// Tracks whether the user has actively picked since last load so stale
-    /// GET responses don't overwrite an optimistic selection.
-    @State private var hasUserInteracted: Bool = false
-
-    private var pillLabelColor: Color {
-        switch currentPreset {
-        case .fullAccess: return VColor.systemNegativeStrong
-        case .relaxed: return VColor.systemMidStrong
-        default: return VColor.contentSecondary
-        }
-    }
+    /// Monotonic selection version used by load reconciliation. A load only
+    /// applies if the user has not changed selection since that load started.
+    @State private var selectionVersion: UInt64 = 0
 
     var body: some View {
         #if os(macOS)
-        ComposerPillMenu(
-            accessibilityLabel: "Risk tolerance",
-            accessibilityValue: currentPreset.label,
-            tooltip: currentPreset.description
-        ) {
-            VIconView(currentPreset.icon, size: 14)
-                .foregroundStyle(currentPreset.iconColor)
-            Text(currentPreset.label)
-                .font(VFont.labelDefault)
-                .foregroundStyle(pillLabelColor)
-        } menu: {
-            ForEach(ThresholdPreset.allCases) { preset in
-                VMenuItem(
-                    icon: preset.icon.rawValue,
-                    label: preset.label,
-                    isActive: currentPreset == preset,
-                    size: .regular
-                ) {
-                    selectPreset(preset)
-                } trailing: {
-                    VStack(alignment: .trailing, spacing: 2) {
-                        if currentPreset == preset {
-                            VIconView(.check, size: 12)
-                                .foregroundStyle(VColor.primaryBase)
-                        }
-                    }
-                }
-            }
+        ThresholdPresetDropdown(
+            preset: currentPreset,
+            accessibilityLabel: "Risk tolerance"
+        ) { preset in
+            selectPreset(preset)
         }
-        .task(id: assistantConversationId ?? "draft:\(draftInteractiveOverride ?? "nil")") {
-            hasUserInteracted = false
+        .task(id: assistantConversationId ?? "draft") {
             await loadState()
+        }
+        .onChange(of: draftInteractiveOverride) { _, newValue in
+            guard assistantConversationId == nil else { return }
+            currentPreset = ThresholdPreset.from(
+                override: newValue,
+                globalInteractive: globalInteractive
+            )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .globalRiskThresholdsDidChange)) { _ in
+            Task { @MainActor in
+                await loadState()
+            }
         }
         #endif
     }
@@ -180,20 +224,30 @@ struct ComposerThresholdPicker: View {
     // MARK: - Selection
 
     private func selectPreset(_ preset: ThresholdPreset) {
-        hasUserInteracted = true
+        selectionVersion &+= 1
         withAnimation(VAnimation.fast) {
             currentPreset = preset
         }
 
-        writeTask?.cancel()
+        // Keep draft state in sync immediately so first-send bootstrap carries
+        // the current selection even before any network write completes.
+        onDraftInteractiveOverrideChange?(
+            Self.stagedDraftOverride(
+                for: preset,
+                globalInteractive: globalInteractive
+            )
+        )
+
+        // Serialize writes instead of canceling in-flight network calls.
+        // Cancellation doesn't guarantee the underlying HTTP request stops,
+        // which can produce out-of-order "higher than selected" outcomes.
+        writeVersion &+= 1
+        let selectionVersion = writeVersion
+        let previousWrite = writeTask
         writeTask = Task { @MainActor in
+            await previousWrite?.value
+            guard selectionVersion == writeVersion else { return }
             do {
-                onDraftInteractiveOverrideChange?(
-                    Self.stagedDraftOverride(
-                        for: preset,
-                        globalInteractive: globalInteractive
-                    )
-                )
                 if assistantConversationId == nil {
                     return
                 } else {
@@ -217,6 +271,7 @@ struct ComposerThresholdPicker: View {
     /// override, then reconciles `currentPreset`.
     private func loadState() async {
         loadTask?.cancel()
+        let selectionVersionAtLoadStart = selectionVersion
         let task = Task { @MainActor in
             do {
                 let globals = try await thresholdClient.getGlobalThresholds()
@@ -237,7 +292,8 @@ struct ComposerThresholdPicker: View {
                     override = draftInteractiveOverride
                 }
 
-                guard !Task.isCancelled, !hasUserInteracted else { return }
+                guard !Task.isCancelled else { return }
+                guard selectionVersionAtLoadStart == selectionVersion else { return }
                 currentPreset = ThresholdPreset.from(
                     override: override,
                     globalInteractive: globals.interactive

--- a/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/RiskToleranceSection.swift
@@ -26,9 +26,11 @@ struct RiskToleranceSection: View {
     /// Defaults to `.none` to match the gateway schema default.
     @State private var headlessSelection: RiskThreshold = .none
 
-    /// In-flight sync task so rapid picker changes cancel the previous
-    /// write and only the latest selection reaches the gateway.
+    /// In-flight sync task. Writes are serialized so rapid picker changes
+    /// resolve in order and the latest selection wins deterministically.
     @State private var syncTask: Task<Void, Never>?
+    /// Monotonic sync version used to drop superseded queued writes.
+    @State private var syncVersion: UInt64 = 0
 
     /// In-flight load task so repeated view appearances don't stack
     /// concurrent GETs against the gateway.
@@ -59,21 +61,14 @@ struct RiskToleranceSection: View {
                 Text("When chatting")
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentDefault)
-                VDropdown(
-                    options: RiskThreshold.allCases.map {
-                        VDropdownOption(label: $0.label, value: $0, icon: $0.icon)
-                    },
-                    selection: Binding(
-                        get: { interactiveSelection },
-                        set: { newValue in
-                            hasUserInteracted = true
-                            interactiveSelection = newValue
-                            syncThresholds()
-                        }
-                    ),
-                    maxWidth: 280
-                )
-                .accessibilityLabel("When chatting risk threshold")
+                ThresholdPresetDropdown(
+                    preset: ThresholdPreset.from(riskThreshold: interactiveSelection),
+                    accessibilityLabel: "When chatting risk threshold"
+                ) { preset in
+                    hasUserInteracted = true
+                    interactiveSelection = preset.riskThreshold
+                    syncThresholds()
+                }
                 Text(interactiveSelection.settingsDescription)
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
@@ -88,21 +83,14 @@ struct RiskToleranceSection: View {
                         Text("Scheduled tasks")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentDefault)
-                        VDropdown(
-                            options: RiskThreshold.allCases.map {
-                                VDropdownOption(label: $0.label, value: $0, icon: $0.icon)
-                            },
-                            selection: Binding(
-                                get: { backgroundSelection },
-                                set: { newValue in
-                                    hasUserInteracted = true
-                                    backgroundSelection = newValue
-                                    syncThresholds()
-                                }
-                            ),
-                            maxWidth: 280
-                        )
-                        .accessibilityLabel("Scheduled tasks risk threshold")
+                        ThresholdPresetDropdown(
+                            preset: ThresholdPreset.from(riskThreshold: backgroundSelection),
+                            accessibilityLabel: "Scheduled tasks risk threshold"
+                        ) { preset in
+                            hasUserInteracted = true
+                            backgroundSelection = preset.riskThreshold
+                            syncThresholds()
+                        }
                         Text("When your assistant runs background tasks like heartbeats and scheduled jobs.")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
@@ -118,21 +106,14 @@ struct RiskToleranceSection: View {
                         Text("Automation / API")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.contentDefault)
-                        VDropdown(
-                            options: RiskThreshold.allCases.map {
-                                VDropdownOption(label: $0.label, value: $0, icon: $0.icon)
-                            },
-                            selection: Binding(
-                                get: { headlessSelection },
-                                set: { newValue in
-                                    hasUserInteracted = true
-                                    headlessSelection = newValue
-                                    syncThresholds()
-                                }
-                            ),
-                            maxWidth: 280
-                        )
-                        .accessibilityLabel("Automation / API risk threshold")
+                        ThresholdPresetDropdown(
+                            preset: ThresholdPreset.from(riskThreshold: headlessSelection),
+                            accessibilityLabel: "Automation / API risk threshold"
+                        ) { preset in
+                            hasUserInteracted = true
+                            headlessSelection = preset.riskThreshold
+                            syncThresholds()
+                        }
                         Text("When triggered externally via API or webhooks.")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
@@ -178,9 +159,9 @@ struct RiskToleranceSection: View {
 
     // MARK: - Sync Thresholds
 
-    /// Syncs the current threshold selections to the gateway, cancelling
-    /// any in-flight sync so that only the latest state wins when the user
-    /// changes rapidly.
+    /// Syncs the current threshold selections to the gateway. Writes are
+    /// serialized rather than cancelled because cancellation does not
+    /// guarantee an in-flight HTTP request stops server-side.
     ///
     /// If the PUT fails, clears `hasUserInteracted` so a subsequent
     /// `loadThresholds()` call can reconcile the picker against the
@@ -189,22 +170,30 @@ struct RiskToleranceSection: View {
         // Don't sync until we've loaded at least once — otherwise we'd
         // persist stale local defaults over the real server state.
         guard hasLoadedInitial else { return }
-        syncTask?.cancel()
+
+        let payload = GlobalThresholds(
+            interactive: interactiveSelection.rawValue,
+            background: backgroundSelection.rawValue,
+            headless: headlessSelection.rawValue
+        )
+        syncVersion &+= 1
+        let requestVersion = syncVersion
+        let previousSync = syncTask
+
         syncTask = Task {
+            await previousSync?.value
+            guard requestVersion == syncVersion else { return }
             do {
-                try await thresholdClient.setGlobalThresholds(
-                    GlobalThresholds(
-                        interactive: interactiveSelection.rawValue,
-                        background: backgroundSelection.rawValue,
-                        headless: headlessSelection.rawValue
-                    )
-                )
+                try await thresholdClient.setGlobalThresholds(payload)
+                guard requestVersion == syncVersion else { return }
+                NotificationCenter.default.post(name: .globalRiskThresholdsDidChange, object: nil)
             } catch {
-                guard !Task.isCancelled else { return }
                 riskToleranceLog.error(
                     "setGlobalThresholds failed: \(error.localizedDescription, privacy: .public)"
                 )
-                hasUserInteracted = false
+                if requestVersion == syncVersion {
+                    hasUserInteracted = false
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistantTests/Features/Chat/ComposerThresholdPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ComposerThresholdPickerTests.swift
@@ -74,6 +74,83 @@ final class ComposerThresholdPickerTests: XCTestCase {
         )
         XCTAssertNil(`default`)
     }
+
+    func testPresetFromNoOverrideReflectsGlobalInteractiveThreshold() {
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: nil,
+                globalInteractive: RiskThreshold.none.rawValue
+            ),
+            .strict
+        )
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: nil,
+                globalInteractive: RiskThreshold.low.rawValue
+            ),
+            .default
+        )
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: nil,
+                globalInteractive: RiskThreshold.medium.rawValue
+            ),
+            .relaxed
+        )
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: nil,
+                globalInteractive: RiskThreshold.high.rawValue
+            ),
+            .fullAccess
+        )
+    }
+
+    func testPresetFromOverrideMatchingGlobalReflectsGlobalPreset() {
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: RiskThreshold.high.rawValue,
+                globalInteractive: RiskThreshold.high.rawValue
+            ),
+            .fullAccess
+        )
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: RiskThreshold.medium.rawValue,
+                globalInteractive: RiskThreshold.medium.rawValue
+            ),
+            .relaxed
+        )
+    }
+
+    func testPresetFromOverrideUsesAbsoluteThresholdValue() {
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: RiskThreshold.medium.rawValue,
+                globalInteractive: RiskThreshold.high.rawValue
+            ),
+            .relaxed
+        )
+        XCTAssertEqual(
+            ThresholdPreset.from(
+                override: RiskThreshold.low.rawValue,
+                globalInteractive: RiskThreshold.none.rawValue
+            ),
+            .default
+        )
+    }
+
+    func testPresetRiskThresholdMappingRoundTrips() {
+        XCTAssertEqual(ThresholdPreset.strict.riskThreshold, .none)
+        XCTAssertEqual(ThresholdPreset.default.riskThreshold, .low)
+        XCTAssertEqual(ThresholdPreset.relaxed.riskThreshold, .medium)
+        XCTAssertEqual(ThresholdPreset.fullAccess.riskThreshold, .high)
+
+        XCTAssertEqual(ThresholdPreset.from(riskThreshold: .none), .strict)
+        XCTAssertEqual(ThresholdPreset.from(riskThreshold: .low), .default)
+        XCTAssertEqual(ThresholdPreset.from(riskThreshold: .medium), .relaxed)
+        XCTAssertEqual(ThresholdPreset.from(riskThreshold: .high), .fullAccess)
+    }
 }
 
 private final class MockThresholdClient: ThresholdClientProtocol {

--- a/clients/shared/Network/DaemonNotifications.swift
+++ b/clients/shared/Network/DaemonNotifications.swift
@@ -19,4 +19,8 @@ extension Notification.Name {
     /// state for the missing assistant and switch to a replacement or show
     /// onboarding.
     public static let managedAssistantRetiredRemotely = Notification.Name("managedAssistantRetiredRemotely")
+
+    /// Posted after the user updates global risk thresholds in Settings.
+    /// Composer threshold pickers listen for this to refresh inherited state.
+    public static let globalRiskThresholdsDidChange = Notification.Name("globalRiskThresholdsDidChange")
 }


### PR DESCRIPTION
## Summary
- Extracts a shared `ThresholdPresetDropdown` component replacing duplicated dropdown logic in the composer and settings views
- Serializes threshold write tasks instead of cancelling in-flight requests, preventing race conditions where a cancelled HTTP request still completes server-side and applies an outdated value
- Maps conversation overrides to absolute threshold values rather than relative deltas, fixing preset display when the global default changes
- Adds a `globalRiskThresholdsDidChange` notification so the composer picker refreshes immediately after settings are updated
- Adds comprehensive tests for preset↔threshold round-tripping and absolute override resolution
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
