### PR TITLE
fix: update trust-rules suggest test default threshold expectation

### DIFF
--- a/gateway/src/http/routes/trust-rules.suggest.test.ts
+++ b/gateway/src/http/routes/trust-rules.suggest.test.ts
@@ -12,14 +12,13 @@ import "../../__tests__/test-preload.js";
 // Mocks — must be registered before importing the handler under test
 // ---------------------------------------------------------------------------
 
-const ipcSuggestTrustRuleMock = mock(
-  (_params: unknown) =>
-    Promise.resolve({
-      pattern: "git push",
-      risk: "medium",
-      description: "Allow git push",
-      scopeOptions: [{ pattern: "git push", label: "This exact command" }],
-    }),
+const ipcSuggestTrustRuleMock = mock((_params: unknown) =>
+  Promise.resolve({
+    pattern: "git push",
+    risk: "medium",
+    description: "Allow git push",
+    scopeOptions: [{ pattern: "git push", label: "This exact command" }],
+  }),
 );
 
 mock.module("../../ipc/assistant-client.js", () => ({
@@ -27,9 +26,7 @@ mock.module("../../ipc/assistant-client.js", () => ({
 }));
 
 // Import after mocks are registered
-const { createTrustRulesSuggestHandler } = await import(
-  "./trust-rules.js"
-);
+const { createTrustRulesSuggestHandler } = await import("./trust-rules.js");
 
 import { initGatewayDb, resetGatewayDb } from "../../db/connection.js";
 import { clearFeatureFlagStoreCache } from "../../feature-flag-store.js";
@@ -137,9 +134,7 @@ describe("POST /v1/trust-rules/suggest", () => {
     const handler = createTrustRulesSuggestHandler();
 
     // Missing tool
-    const res1 = await handler(
-      jsonRequest({ ...VALID_BODY, tool: undefined }),
-    );
+    const res1 = await handler(jsonRequest({ ...VALID_BODY, tool: undefined }));
     expect(res1.status).toBe(400);
 
     // Missing command
@@ -205,7 +200,7 @@ describe("POST /v1/trust-rules/suggest", () => {
     expect(callArgs.currentThreshold).toBe("medium");
   });
 
-  test("currentThreshold defaults to 'low' when no threshold row in DB", async () => {
+  test("currentThreshold defaults to 'medium' when no threshold row in DB", async () => {
     // No row inserted — DB is fresh from beforeEach
     const handler = createTrustRulesSuggestHandler();
     await handler(jsonRequest(VALID_BODY));
@@ -214,7 +209,7 @@ describe("POST /v1/trust-rules/suggest", () => {
     const callArgs = ipcSuggestTrustRuleMock.mock.calls[0][0] as {
       currentThreshold: string;
     };
-    expect(callArgs.currentThreshold).toBe("low");
+    expect(callArgs.currentThreshold).toBe("medium");
   });
 
   test("passes directoryScopeOptions when provided", async () => {


### PR DESCRIPTION
## Summary
- Update `trust-rules.suggest.test.ts` to expect `"medium"` instead of `"low"` as the default `currentThreshold` when no DB row exists
- The default was changed in a7ce4254ab (collapse background+headless thresholds into autonomous) but this test was missed

## Original prompt
--yolo fix CI failures https://github.com/vellum-ai/vellum-assistant/actions/runs/25006866605
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
