### PR TITLE
Lower default interactive threshold from medium to low

### DIFF
--- a/gateway/src/ipc/threshold-handlers.ts
+++ b/gateway/src/ipc/threshold-handlers.ts
@@ -16,7 +16,7 @@ import {
 import type { IpcRoute } from "./server.js";
 
 const GLOBAL_DEFAULTS = {
-  interactive: "medium",
+  interactive: "low",
   autonomous: "low",
 };
 


### PR DESCRIPTION
## Summary
- Changes the default interactive trust threshold from "medium" to "low", aligning it with the autonomous default
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
