### PR TITLE
refactor: unify threshold tooltip and settings description text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -30,12 +30,7 @@ enum ThresholdPreset: String, CaseIterable, Identifiable, Equatable {
     }
 
     var description: String {
-        switch self {
-        case .strict: return "Prompt for everything"
-        case .default: return "Auto-approve low-risk tools"
-        case .relaxed: return "Auto-approve most tools"
-        case .fullAccess: return "Auto-approve all actions"
-        }
+        riskThreshold.settingsDescription
     }
 
     var icon: VIcon {

--- a/clients/shared/Network/ThresholdClient.swift
+++ b/clients/shared/Network/ThresholdClient.swift
@@ -25,7 +25,7 @@ public enum RiskThreshold: String, CaseIterable, Identifiable, Hashable {
 
     public var icon: VIcon {
         switch self {
-        case .none: return .lock
+        case .none: return .shieldAlert
         case .low: return .shieldCheck
         case .medium: return .shield
         case .high: return .shieldOff


### PR DESCRIPTION
## Summary
- `ThresholdPreset.description` now delegates to `RiskThreshold.settingsDescription` so the composer tooltip and the settings help text share the same constants
- Fixed `RiskThreshold.icon` for `.none` from `.lock` to `.shieldAlert` to match the previous PR's change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
