### PR TITLE
feat: add tooltip support to VMenuItem and VNavItem

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -140,6 +140,7 @@ struct ThresholdPresetDropdown: View {
                 VMenuItem(
                     icon: option.icon.rawValue,
                     label: option.label,
+                    tooltip: option.description,
                     isActive: preset == option,
                     size: .regular
                 ) {

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -351,6 +351,7 @@ public enum VMenuItemSize {
 public struct VMenuItem<Trailing: View>: View {
     public let icon: String?
     public let label: String
+    public let tooltipText: String?
     public let isActive: Bool
     public let variant: VMenuItemVariant
     public let size: VMenuItemSize
@@ -378,6 +379,7 @@ public struct VMenuItem<Trailing: View>: View {
     public init(
         icon: String? = nil,
         label: String,
+        tooltip: String? = nil,
         isActive: Bool = false,
         variant: VMenuItemVariant = .default,
         size: VMenuItemSize = .compact,
@@ -387,6 +389,7 @@ public struct VMenuItem<Trailing: View>: View {
     ) {
         self.icon = icon
         self.label = label
+        self.tooltipText = tooltip
         self.isActive = isActive
         self.variant = variant
         self.size = size
@@ -425,6 +428,7 @@ public struct VMenuItem<Trailing: View>: View {
             VNavItem(
                 icon: icon,
                 label: label,
+                tooltip: tooltipText,
                 isActive: isActive,
                 isExpanded: true,
                 isKeyboardFocused: {

--- a/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VNavItem.swift
@@ -20,6 +20,7 @@ public struct VNavItem<Trailing: View>: View {
     public let icon: String?
     public let label: String
     public var subtitle: String?
+    public var tooltip: String?
     public var isActive: Bool
     public var isExpanded: Bool
     /// When `true`, applies the keyboard-focus highlight background (same as hover).
@@ -38,6 +39,7 @@ public struct VNavItem<Trailing: View>: View {
         icon: String? = nil,
         label: String,
         subtitle: String? = nil,
+        tooltip: String? = nil,
         isActive: Bool = false,
         isExpanded: Bool = true,
         isKeyboardFocused: Bool = false,
@@ -47,6 +49,7 @@ public struct VNavItem<Trailing: View>: View {
         self.icon = icon
         self.label = label
         self.subtitle = subtitle
+        self.tooltip = tooltip
         self.isActive = isActive
         self.isExpanded = isExpanded
         self.isKeyboardFocused = isKeyboardFocused
@@ -103,7 +106,7 @@ public struct VNavItem<Trailing: View>: View {
         .contentShape(Rectangle())
         .onTapGesture { action() }
         .padding(.horizontal, 0)
-        .vTooltip(label)
+        .vTooltip(tooltip ?? label)
         .pointerCursor(onHover: { isHovered = $0 })
         .accessibilityElement(children: .combine)
         .accessibilityLabel(label)


### PR DESCRIPTION
## Summary
- Added an optional `tooltip` parameter to `VNavItem` and `VMenuItem`, falling back to the label when unset
- Threshold preset dropdown items now show the full settings description on hover (e.g. "Auto-approve low and medium-risk actions like writing files in your workspace.") instead of just the preset name
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
