### PR TITLE
fix: make `--hint` optional on parent `defer` command to unblock subcommands

### DIFF
--- a/assistant/src/__tests__/conversations-defer-cli.test.ts
+++ b/assistant/src/__tests__/conversations-defer-cli.test.ts
@@ -1,6 +1,31 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { parseDuration } from "../cli/commands/conversations-defer.js";
+
+// ---------------------------------------------------------------------------
+// Mocks for CLI command tests — declared before importing registerCommand
+// ---------------------------------------------------------------------------
+
+const logMessages: { level: string; msg: string }[] = [];
+
+mock.module("../cli/logger.js", () => ({
+  log: {
+    info: (msg: string) => logMessages.push({ level: "info", msg }),
+    warn: (msg: string) => logMessages.push({ level: "warn", msg }),
+    error: (msg: string) => logMessages.push({ level: "error", msg }),
+    debug: () => {},
+  },
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../ipc/cli-client.js", () => ({
+  cliIpcCall: async () => ({ ok: true, result: { defers: [] } }),
+}));
 
 describe("parseDuration", () => {
   test("bare number treated as seconds", () => {
@@ -35,5 +60,91 @@ describe("parseDuration", () => {
 
   test("throws on empty string", () => {
     expect(() => parseDuration("")).toThrow('Invalid duration: ""');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defer CLI option inheritance
+// ---------------------------------------------------------------------------
+
+import { Command } from "commander";
+
+import { registerConversationsDeferCommand } from "../cli/commands/conversations-defer.js";
+
+describe("defer CLI option inheritance", () => {
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    logMessages.length = 0;
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+  });
+
+  function makeProgram(): Command {
+    const program = new Command();
+    program.exitOverride(); // throw instead of calling process.exit
+    const conversations = program.command("conversations");
+    registerConversationsDeferCommand(conversations);
+    return program;
+  }
+
+  test("list subcommand can be parsed without --hint", async () => {
+    const program = makeProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "conversations",
+      "defer",
+      "list",
+    ]);
+    // Should not set a failure exit code — the command parsed successfully
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test("cancel subcommand can be parsed without --hint", async () => {
+    const program = makeProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "conversations",
+      "defer",
+      "cancel",
+      "--all",
+    ]);
+    // Should not set a failure exit code — the command parsed successfully
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test("create action errors when --hint is omitted", async () => {
+    const program = makeProgram();
+    // Provide --in so we get past the --in/--at check, but omit --hint
+    // Also set a conversation ID env var so we get past that check
+    const origConvId = process.env.__CONVERSATION_ID;
+    process.env.__CONVERSATION_ID = "conv-test-123";
+    try {
+      await program.parseAsync([
+        "node",
+        "test",
+        "conversations",
+        "defer",
+        "--in",
+        "30s",
+      ]);
+      expect(process.exitCode).toBe(1);
+      const errorMsg = logMessages.find((m) => m.level === "error");
+      expect(errorMsg?.msg).toContain(
+        "--hint is required when creating a deferred wake",
+      );
+    } finally {
+      if (origConvId === undefined) {
+        delete process.env.__CONVERSATION_ID;
+      } else {
+        process.env.__CONVERSATION_ID = origConvId;
+      }
+    }
   });
 });

--- a/assistant/src/cli/commands/conversations-defer.ts
+++ b/assistant/src/cli/commands/conversations-defer.ts
@@ -79,7 +79,7 @@ export function registerConversationsDeferCommand(parent: Command): void {
     .description("Create a deferred wake for a conversation")
     .option("--in <duration>", "Delay before firing (e.g. 60, 60s, 5m, 1h)")
     .option("--at <iso8601>", "Absolute ISO 8601 fire time")
-    .requiredOption("--hint <text>", "Hint message for the wake")
+    .option("--hint <text>", "Hint message for the wake")
     .option("--name <text>", "Name for the deferred wake", "Deferred wake")
     .option("--json", "Output result as JSON")
     .addHelpText(
@@ -103,7 +103,7 @@ Examples:
         opts: {
           in?: string;
           at?: string;
-          hint: string;
+          hint?: string;
           name: string;
           json?: boolean;
         },
@@ -124,6 +124,17 @@ Examples:
 
         if (!opts.in && !opts.at) {
           const msg = "Either --in or --at must be provided";
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!opts.hint) {
+          const msg = "--hint is required when creating a deferred wake";
           if (opts.json) {
             log.info(JSON.stringify({ ok: false, error: msg }));
           } else {
@@ -328,10 +339,9 @@ Examples:
           }
         }
 
-        const result = await cliIpcCall<{ cancelled: number }>(
-          "defer_cancel",
-          { body: ipcParams },
-        );
+        const result = await cliIpcCall<{ cancelled: number }>("defer_cancel", {
+          body: ipcParams,
+        });
 
         if (!result.ok) {
           if (opts.json) {


### PR DESCRIPTION
## Summary
- Change `--hint` from `.requiredOption()` to `.option()` on the parent `defer` command so it does not leak into subcommands
- Add explicit validation in the create action handler to require `--hint` when creating a deferred wake
- Add tests verifying subcommands work without `--hint` and create action still requires it

Part of plan: fix-defer-bugs.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
