### PR TITLE
fix: retry deferred wakes that fire during active tool calls instead of dropping them

### DIFF
--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -16,8 +16,12 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (value: string) => value,
 }));
 
-const mockWakeAgentForOpportunity = mock(() =>
-  Promise.resolve({ invoked: true, producedToolCalls: false }),
+const mockWakeAgentForOpportunity = mock(
+  (): Promise<{
+    invoked: boolean;
+    producedToolCalls: boolean;
+    reason?: string;
+  }> => Promise.resolve({ invoked: true, producedToolCalls: false }),
 );
 mock.module("../runtime/agent-wake.js", () => ({
   wakeAgentForOpportunity: mockWakeAgentForOpportunity,

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -260,4 +260,93 @@ describe("scheduler wake mode", () => {
       }),
     );
   });
+
+  test("retries wake when wakeAgentForOpportunity returns timeout", async () => {
+    // GIVEN wakeAgentForOpportunity returns timeout on first call, then succeeds
+    mockWakeAgentForOpportunity
+      .mockResolvedValueOnce({
+        invoked: false,
+        producedToolCalls: false,
+        reason: "timeout",
+      })
+      .mockResolvedValueOnce({
+        invoked: true,
+        producedToolCalls: false,
+      });
+
+    const schedule = createSchedule({
+      name: "Wake Retry",
+      message: "Retry after timeout",
+      mode: "wake",
+      wakeConversationId: "conv-retry",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+
+    // WHEN the first tick runs (fires immediately from startScheduler)
+    await new Promise((resolve) => origSetTimeout(resolve, 600));
+
+    // THEN the job is NOT completed — it's reverted to 'active' for retry
+    const rowAfterFirst = getRawDb()
+      .query("SELECT status, retry_count FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string; retry_count: number } | null;
+    expect(rowAfterFirst?.status).toBe("active");
+    expect(rowAfterFirst?.retry_count).toBe(1);
+
+    // WHEN the second tick fires (call runOnce directly to avoid waiting for setInterval)
+    await scheduler.runOnce();
+    scheduler.stop();
+
+    // THEN the job IS completed (status = 'fired')
+    const rowAfterSecond = getRawDb()
+      .query("SELECT status FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string } | null;
+    expect(rowAfterSecond?.status).toBe("fired");
+
+    // AND wakeAgentForOpportunity was called twice total
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(2);
+  });
+
+  test("fails wake after max retries on persistent timeout", async () => {
+    // GIVEN wakeAgentForOpportunity always returns timeout
+    mockWakeAgentForOpportunity.mockResolvedValue({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "timeout",
+    });
+
+    const schedule = createSchedule({
+      name: "Wake Max Retry",
+      message: "Always busy",
+      mode: "wake",
+      wakeConversationId: "conv-busy",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    // Simulate having already retried up to the max (set retry_count = 20)
+    getRawDb().run("UPDATE cron_jobs SET retry_count = 20 WHERE id = ?", [
+      schedule.id,
+    ]);
+
+    // WHEN the scheduler fires (first tick runs immediately from startScheduler)
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+    await new Promise((resolve) => origSetTimeout(resolve, 600));
+    scheduler.stop();
+
+    // THEN the job is permanently failed (status = 'cancelled', enabled = false)
+    const row = getRawDb()
+      .query("SELECT status, enabled FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string; enabled: number } | null;
+    expect(row?.status).toBe("cancelled");
+    expect(row?.enabled).toBe(0);
+  });
 });

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -505,6 +505,51 @@ export function failOneShot(id: string): void {
 }
 
 /**
+ * Revert a one-shot from 'firing' back to 'active' and increment its
+ * retry count. Used when a wake times out waiting for an idle conversation
+ * — the job should be retried on the next scheduler tick.
+ */
+export function retryOneShot(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  const row = db
+    .select({ retryCount: scheduleJobs.retryCount })
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.id, id))
+    .get();
+  db.update(scheduleJobs)
+    .set({
+      status: "active",
+      retryCount: (row?.retryCount ?? 0) + 1,
+      updatedAt: now,
+    })
+    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+    .run();
+}
+
+/**
+ * Permanently fail a one-shot schedule by marking it as cancelled and
+ * disabled. Used when a wake has exceeded its retry cap and should not
+ * be retried further.
+ */
+export function failOneShotPermanently(id: string, error?: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(scheduleJobs)
+    .set({
+      status: "cancelled",
+      enabled: false,
+      lastStatus: "error",
+      updatedAt: now,
+    })
+    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+    .run();
+  if (error) {
+    logger.warn({ scheduleId: id, error }, "One-shot permanently failed");
+  }
+}
+
+/**
  * Cancel a one-shot schedule. Sets status to 'cancelled' and disables it.
  * Returns true if a row was actually updated (i.e., it was in 'active' status).
  */

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -19,7 +19,9 @@ import {
   completeScheduleRun,
   createScheduleRun,
   failOneShot,
+  failOneShotPermanently,
   getLastScheduleConversationId,
+  retryOneShot,
   type RoutingIntent,
 } from "./schedule-store.js";
 
@@ -63,6 +65,13 @@ export interface SchedulerHandle {
 }
 
 const TICK_INTERVAL_MS = 15_000;
+
+/**
+ * Maximum number of times a wake can be retried after a timeout before
+ * being permanently failed. At 15-second scheduler intervals, 20 retries
+ * ≈ 5 minutes of total retry window.
+ */
+const WAKE_MAX_RETRIES = 20;
 
 export function startScheduler(
   processMessage: ScheduleMessageProcessor,
@@ -246,11 +255,45 @@ async function runScheduleOnce(
           { jobId: job.id, name: job.name, wakeConversationId, isOneShot },
           "Executing wake schedule",
         );
-        await wakeAgentForOpportunity({
+        const result = await wakeAgentForOpportunity({
           conversationId: wakeConversationId,
           hint: job.message,
           source: "defer",
         });
+
+        if (result.reason === "timeout" && isOneShot) {
+          // The conversation is busy processing a tool call. Retry on
+          // the next scheduler tick unless we've exceeded the retry cap.
+          if (job.retryCount >= WAKE_MAX_RETRIES) {
+            log.warn(
+              {
+                jobId: job.id,
+                name: job.name,
+                wakeConversationId,
+                retryCount: job.retryCount,
+              },
+              "Wake timed out and exceeded max retries — permanently failing",
+            );
+            failOneShotPermanently(
+              job.id,
+              `Conversation remained busy for ${job.retryCount} retries (~${Math.round((job.retryCount * TICK_INTERVAL_MS) / 60_000)} minutes)`,
+            );
+          } else {
+            log.warn(
+              {
+                jobId: job.id,
+                name: job.name,
+                wakeConversationId,
+                retryCount: job.retryCount,
+              },
+              "Wake timed out waiting for idle conversation — will retry on next tick",
+            );
+            retryOneShot(job.id);
+          }
+          processed += 1;
+          continue;
+        }
+
         if (isOneShot) completeOneShot(job.id);
         if (!job.quiet) {
           emitScheduleFeedEvent({


### PR DESCRIPTION
## Summary
- Inspect the return value of `wakeAgentForOpportunity()` in the scheduler's wake handler
- When a wake returns `reason: "timeout"`, leave the one-shot job active so the next scheduler tick retries it
- Add a retry cap (~20 retries / ~5 minutes) to prevent infinite retry loops on persistently busy conversations
- Add tests for timeout retry and max-retry failure behavior

Part of plan: fix-defer-bugs.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
