### PR TITLE
fix: make retryOneShot use single atomic UPDATE

### DIFF
--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -512,15 +512,10 @@ export function failOneShot(id: string): void {
 export function retryOneShot(id: string): void {
   const db = getDb();
   const now = Date.now();
-  const row = db
-    .select({ retryCount: scheduleJobs.retryCount })
-    .from(scheduleJobs)
-    .where(eq(scheduleJobs.id, id))
-    .get();
   db.update(scheduleJobs)
     .set({
       status: "active",
-      retryCount: (row?.retryCount ?? 0) + 1,
+      retryCount: sql`${scheduleJobs.retryCount} + 1`,
       updatedAt: now,
     })
     .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-defer-bugs.md.

**Gap:** retryOneShot uses non-atomic SELECT-then-UPDATE pattern
**What was expected:** Single atomic UPDATE matching peer functions
**What was found:** Separate SELECT then UPDATE, inconsistent with failOneShot/completeOneShot/cancelSchedule
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
