### PR TITLE
fix: skip feed event when wake is not invoked

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -294,6 +294,23 @@ async function runScheduleOnce(
           continue;
         }
 
+        // Guard: if the wake was not invoked for any reason (timeout on
+        // a recurring schedule, not_found, archived, no_resolver), skip
+        // the success feed event — the wake did not actually fire.
+        if (!result.invoked) {
+          log.warn(
+            {
+              jobId: job.id,
+              name: job.name,
+              wakeConversationId,
+              reason: result.reason,
+            },
+            "Wake not invoked; skipping feed event",
+          );
+          processed += 1;
+          continue;
+        }
+
         if (isOneShot) completeOneShot(job.id);
         if (!job.quiet) {
           emitScheduleFeedEvent({


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-defer-bugs.md.

**Gap:** Recurring wake timeout emits false-success feed event
**What was expected:** Skipped wakes should not emit success events
**What was found:** Non-one-shot wake timeouts fell through to the success path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
