### PR TITLE
fix: remove misleading error param from failOneShotPermanently

### DIFF
--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -532,7 +532,7 @@ export function retryOneShot(id: string): void {
  * disabled. Used when a wake has exceeded its retry cap and should not
  * be retried further.
  */
-export function failOneShotPermanently(id: string, error?: string): void {
+export function failOneShotPermanently(id: string): void {
   const db = getDb();
   const now = Date.now();
   db.update(scheduleJobs)
@@ -544,9 +544,6 @@ export function failOneShotPermanently(id: string, error?: string): void {
     })
     .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
     .run();
-  if (error) {
-    logger.warn({ scheduleId: id, error }, "One-shot permanently failed");
-  }
 }
 
 /**

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -274,10 +274,7 @@ async function runScheduleOnce(
               },
               "Wake timed out and exceeded max retries — permanently failing",
             );
-            failOneShotPermanently(
-              job.id,
-              `Conversation remained busy for ${job.retryCount} retries (~${Math.round((job.retryCount * TICK_INTERVAL_MS) / 60_000)} minutes)`,
-            );
+            failOneShotPermanently(job.id);
           } else {
             log.warn(
               {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-defer-bugs.md.

**Gap:** failOneShotPermanently error param misleading + double-logging
**What was expected:** Error should be persisted or param removed
**What was found:** error param only logged (not persisted) and caller already logs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
