### PR TITLE
Fix defer CLI and wake delivery bugs

### DIFF
--- a/assistant/src/__tests__/conversations-defer-cli.test.ts
+++ b/assistant/src/__tests__/conversations-defer-cli.test.ts
@@ -1,6 +1,31 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { parseDuration } from "../cli/commands/conversations-defer.js";
+
+// ---------------------------------------------------------------------------
+// Mocks for CLI command tests — declared before importing registerCommand
+// ---------------------------------------------------------------------------
+
+const logMessages: { level: string; msg: string }[] = [];
+
+mock.module("../cli/logger.js", () => ({
+  log: {
+    info: (msg: string) => logMessages.push({ level: "info", msg }),
+    warn: (msg: string) => logMessages.push({ level: "warn", msg }),
+    error: (msg: string) => logMessages.push({ level: "error", msg }),
+    debug: () => {},
+  },
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../ipc/cli-client.js", () => ({
+  cliIpcCall: async () => ({ ok: true, result: { defers: [] } }),
+}));
 
 describe("parseDuration", () => {
   test("bare number treated as seconds", () => {
@@ -35,5 +60,91 @@ describe("parseDuration", () => {
 
   test("throws on empty string", () => {
     expect(() => parseDuration("")).toThrow('Invalid duration: ""');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defer CLI option inheritance
+// ---------------------------------------------------------------------------
+
+import { Command } from "commander";
+
+import { registerConversationsDeferCommand } from "../cli/commands/conversations-defer.js";
+
+describe("defer CLI option inheritance", () => {
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    logMessages.length = 0;
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+  });
+
+  function makeProgram(): Command {
+    const program = new Command();
+    program.exitOverride(); // throw instead of calling process.exit
+    const conversations = program.command("conversations");
+    registerConversationsDeferCommand(conversations);
+    return program;
+  }
+
+  test("list subcommand can be parsed without --hint", async () => {
+    const program = makeProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "conversations",
+      "defer",
+      "list",
+    ]);
+    // Should not set a failure exit code — the command parsed successfully
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test("cancel subcommand can be parsed without --hint", async () => {
+    const program = makeProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "conversations",
+      "defer",
+      "cancel",
+      "--all",
+    ]);
+    // Should not set a failure exit code — the command parsed successfully
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  test("create action errors when --hint is omitted", async () => {
+    const program = makeProgram();
+    // Provide --in so we get past the --in/--at check, but omit --hint
+    // Also set a conversation ID env var so we get past that check
+    const origConvId = process.env.__CONVERSATION_ID;
+    process.env.__CONVERSATION_ID = "conv-test-123";
+    try {
+      await program.parseAsync([
+        "node",
+        "test",
+        "conversations",
+        "defer",
+        "--in",
+        "30s",
+      ]);
+      expect(process.exitCode).toBe(1);
+      const errorMsg = logMessages.find((m) => m.level === "error");
+      expect(errorMsg?.msg).toContain(
+        "--hint is required when creating a deferred wake",
+      );
+    } finally {
+      if (origConvId === undefined) {
+        delete process.env.__CONVERSATION_ID;
+      } else {
+        process.env.__CONVERSATION_ID = origConvId;
+      }
+    }
   });
 });

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -16,8 +16,12 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (value: string) => value,
 }));
 
-const mockWakeAgentForOpportunity = mock(() =>
-  Promise.resolve({ invoked: true, producedToolCalls: false }),
+const mockWakeAgentForOpportunity = mock(
+  (): Promise<{
+    invoked: boolean;
+    producedToolCalls: boolean;
+    reason?: string;
+  }> => Promise.resolve({ invoked: true, producedToolCalls: false }),
 );
 mock.module("../runtime/agent-wake.js", () => ({
   wakeAgentForOpportunity: mockWakeAgentForOpportunity,
@@ -259,5 +263,94 @@ describe("scheduler wake mode", () => {
         summary: "Deferred wake fired.",
       }),
     );
+  });
+
+  test("retries wake when wakeAgentForOpportunity returns timeout", async () => {
+    // GIVEN wakeAgentForOpportunity returns timeout on first call, then succeeds
+    mockWakeAgentForOpportunity
+      .mockResolvedValueOnce({
+        invoked: false,
+        producedToolCalls: false,
+        reason: "timeout",
+      })
+      .mockResolvedValueOnce({
+        invoked: true,
+        producedToolCalls: false,
+      });
+
+    const schedule = createSchedule({
+      name: "Wake Retry",
+      message: "Retry after timeout",
+      mode: "wake",
+      wakeConversationId: "conv-retry",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+
+    // WHEN the first tick runs (fires immediately from startScheduler)
+    await new Promise((resolve) => origSetTimeout(resolve, 600));
+
+    // THEN the job is NOT completed — it's reverted to 'active' for retry
+    const rowAfterFirst = getRawDb()
+      .query("SELECT status, retry_count FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string; retry_count: number } | null;
+    expect(rowAfterFirst?.status).toBe("active");
+    expect(rowAfterFirst?.retry_count).toBe(1);
+
+    // WHEN the second tick fires (call runOnce directly to avoid waiting for setInterval)
+    await scheduler.runOnce();
+    scheduler.stop();
+
+    // THEN the job IS completed (status = 'fired')
+    const rowAfterSecond = getRawDb()
+      .query("SELECT status FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string } | null;
+    expect(rowAfterSecond?.status).toBe("fired");
+
+    // AND wakeAgentForOpportunity was called twice total
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(2);
+  });
+
+  test("fails wake after max retries on persistent timeout", async () => {
+    // GIVEN wakeAgentForOpportunity always returns timeout
+    mockWakeAgentForOpportunity.mockResolvedValue({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "timeout",
+    });
+
+    const schedule = createSchedule({
+      name: "Wake Max Retry",
+      message: "Always busy",
+      mode: "wake",
+      wakeConversationId: "conv-busy",
+      nextRunAt: Date.now() - 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    // Simulate having already retried up to the max (set retry_count = 20)
+    getRawDb().run("UPDATE cron_jobs SET retry_count = 20 WHERE id = ?", [
+      schedule.id,
+    ]);
+
+    // WHEN the scheduler fires (first tick runs immediately from startScheduler)
+    const scheduler = startScheduler(
+      mock(() => Promise.resolve()),
+      () => {},
+    );
+    await new Promise((resolve) => origSetTimeout(resolve, 600));
+    scheduler.stop();
+
+    // THEN the job is permanently failed (status = 'cancelled', enabled = false)
+    const row = getRawDb()
+      .query("SELECT status, enabled FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string; enabled: number } | null;
+    expect(row?.status).toBe("cancelled");
+    expect(row?.enabled).toBe(0);
   });
 });

--- a/assistant/src/cli/commands/conversations-defer.ts
+++ b/assistant/src/cli/commands/conversations-defer.ts
@@ -79,7 +79,7 @@ export function registerConversationsDeferCommand(parent: Command): void {
     .description("Create a deferred wake for a conversation")
     .option("--in <duration>", "Delay before firing (e.g. 60, 60s, 5m, 1h)")
     .option("--at <iso8601>", "Absolute ISO 8601 fire time")
-    .requiredOption("--hint <text>", "Hint message for the wake")
+    .option("--hint <text>", "Hint message for the wake")
     .option("--name <text>", "Name for the deferred wake", "Deferred wake")
     .option("--json", "Output result as JSON")
     .addHelpText(
@@ -103,7 +103,7 @@ Examples:
         opts: {
           in?: string;
           at?: string;
-          hint: string;
+          hint?: string;
           name: string;
           json?: boolean;
         },
@@ -124,6 +124,17 @@ Examples:
 
         if (!opts.in && !opts.at) {
           const msg = "Either --in or --at must be provided";
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: msg }));
+          } else {
+            log.error(`Error: ${msg}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        if (!opts.hint) {
+          const msg = "--hint is required when creating a deferred wake";
           if (opts.json) {
             log.info(JSON.stringify({ ok: false, error: msg }));
           } else {
@@ -328,10 +339,9 @@ Examples:
           }
         }
 
-        const result = await cliIpcCall<{ cancelled: number }>(
-          "defer_cancel",
-          { body: ipcParams },
-        );
+        const result = await cliIpcCall<{ cancelled: number }>("defer_cancel", {
+          body: ipcParams,
+        });
 
         if (!result.ok) {
           if (opts.json) {

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -527,7 +527,7 @@ export function retryOneShot(id: string): void {
  * disabled. Used when a wake has exceeded its retry cap and should not
  * be retried further.
  */
-export function failOneShotPermanently(id: string, error?: string): void {
+export function failOneShotPermanently(id: string): void {
   const db = getDb();
   const now = Date.now();
   db.update(scheduleJobs)
@@ -539,9 +539,6 @@ export function failOneShotPermanently(id: string, error?: string): void {
     })
     .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
     .run();
-  if (error) {
-    logger.warn({ scheduleId: id, error }, "One-shot permanently failed");
-  }
 }
 
 /**

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -512,15 +512,10 @@ export function failOneShot(id: string): void {
 export function retryOneShot(id: string): void {
   const db = getDb();
   const now = Date.now();
-  const row = db
-    .select({ retryCount: scheduleJobs.retryCount })
-    .from(scheduleJobs)
-    .where(eq(scheduleJobs.id, id))
-    .get();
   db.update(scheduleJobs)
     .set({
       status: "active",
-      retryCount: (row?.retryCount ?? 0) + 1,
+      retryCount: sql`${scheduleJobs.retryCount} + 1`,
       updatedAt: now,
     })
     .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -505,6 +505,51 @@ export function failOneShot(id: string): void {
 }
 
 /**
+ * Revert a one-shot from 'firing' back to 'active' and increment its
+ * retry count. Used when a wake times out waiting for an idle conversation
+ * — the job should be retried on the next scheduler tick.
+ */
+export function retryOneShot(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  const row = db
+    .select({ retryCount: scheduleJobs.retryCount })
+    .from(scheduleJobs)
+    .where(eq(scheduleJobs.id, id))
+    .get();
+  db.update(scheduleJobs)
+    .set({
+      status: "active",
+      retryCount: (row?.retryCount ?? 0) + 1,
+      updatedAt: now,
+    })
+    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+    .run();
+}
+
+/**
+ * Permanently fail a one-shot schedule by marking it as cancelled and
+ * disabled. Used when a wake has exceeded its retry cap and should not
+ * be retried further.
+ */
+export function failOneShotPermanently(id: string, error?: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(scheduleJobs)
+    .set({
+      status: "cancelled",
+      enabled: false,
+      lastStatus: "error",
+      updatedAt: now,
+    })
+    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+    .run();
+  if (error) {
+    logger.warn({ scheduleId: id, error }, "One-shot permanently failed");
+  }
+}
+
+/**
  * Cancel a one-shot schedule. Sets status to 'cancelled' and disables it.
  * Returns true if a row was actually updated (i.e., it was in 'active' status).
  */

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -294,6 +294,23 @@ async function runScheduleOnce(
           continue;
         }
 
+        // Guard: if the wake was not invoked for any reason (timeout on
+        // a recurring schedule, not_found, archived, no_resolver), skip
+        // the success feed event — the wake did not actually fire.
+        if (!result.invoked) {
+          log.warn(
+            {
+              jobId: job.id,
+              name: job.name,
+              wakeConversationId,
+              reason: result.reason,
+            },
+            "Wake not invoked; skipping feed event",
+          );
+          processed += 1;
+          continue;
+        }
+
         if (isOneShot) completeOneShot(job.id);
         if (!job.quiet) {
           emitScheduleFeedEvent({

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -274,10 +274,7 @@ async function runScheduleOnce(
               },
               "Wake timed out and exceeded max retries — permanently failing",
             );
-            failOneShotPermanently(
-              job.id,
-              `Conversation remained busy for ${job.retryCount} retries (~${Math.round((job.retryCount * TICK_INTERVAL_MS) / 60_000)} minutes)`,
-            );
+            failOneShotPermanently(job.id);
           } else {
             log.warn(
               {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -304,6 +304,7 @@ async function runScheduleOnce(
             },
             "Wake not invoked; skipping feed event",
           );
+          if (isOneShot) completeOneShot(job.id);
           processed += 1;
           continue;
         }

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -19,7 +19,9 @@ import {
   completeScheduleRun,
   createScheduleRun,
   failOneShot,
+  failOneShotPermanently,
   getLastScheduleConversationId,
+  retryOneShot,
   type RoutingIntent,
 } from "./schedule-store.js";
 
@@ -63,6 +65,13 @@ export interface SchedulerHandle {
 }
 
 const TICK_INTERVAL_MS = 15_000;
+
+/**
+ * Maximum number of times a wake can be retried after a timeout before
+ * being permanently failed. At 15-second scheduler intervals, 20 retries
+ * ≈ 5 minutes of total retry window.
+ */
+const WAKE_MAX_RETRIES = 20;
 
 export function startScheduler(
   processMessage: ScheduleMessageProcessor,
@@ -246,11 +255,45 @@ async function runScheduleOnce(
           { jobId: job.id, name: job.name, wakeConversationId, isOneShot },
           "Executing wake schedule",
         );
-        await wakeAgentForOpportunity({
+        const result = await wakeAgentForOpportunity({
           conversationId: wakeConversationId,
           hint: job.message,
           source: "defer",
         });
+
+        if (result.reason === "timeout" && isOneShot) {
+          // The conversation is busy processing a tool call. Retry on
+          // the next scheduler tick unless we've exceeded the retry cap.
+          if (job.retryCount >= WAKE_MAX_RETRIES) {
+            log.warn(
+              {
+                jobId: job.id,
+                name: job.name,
+                wakeConversationId,
+                retryCount: job.retryCount,
+              },
+              "Wake timed out and exceeded max retries — permanently failing",
+            );
+            failOneShotPermanently(
+              job.id,
+              `Conversation remained busy for ${job.retryCount} retries (~${Math.round((job.retryCount * TICK_INTERVAL_MS) / 60_000)} minutes)`,
+            );
+          } else {
+            log.warn(
+              {
+                jobId: job.id,
+                name: job.name,
+                wakeConversationId,
+                retryCount: job.retryCount,
+              },
+              "Wake timed out waiting for idle conversation — will retry on next tick",
+            );
+            retryOneShot(job.id);
+          }
+          processed += 1;
+          continue;
+        }
+
         if (isOneShot) completeOneShot(job.id);
         if (!job.quiet) {
           emitScheduleFeedEvent({


### PR DESCRIPTION
## Summary
Fix two bugs in the `assistant conversations defer` CLI:
1. `--hint` was declared as `.requiredOption()` on the parent `defer` command, which leaked into all subcommands (`list`, `cancel`), causing them to fail before executing.
2. Deferred wakes that fired during active tool calls were silently dropped after a 30-second `waitUntilIdle` timeout, with no retry or requeue.

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs (all passed re-review).

## PRs merged into feature branch
- #28530: fix: make `--hint` optional on parent `defer` command to unblock subcommands
- #28531: fix: retry deferred wakes that fire during active tool calls instead of dropping them

### Fix PRs
- #28535: fix: make retryOneShot use single atomic UPDATE
- #28536: fix: skip feed event when wake is not invoked
- #28537: fix: remove misleading error param from failOneShotPermanently

Part of plan: fix-defer-bugs.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
