### PR TITLE
fix: allow `defer cancel --all` without `--conversation-id`

### DIFF
--- a/assistant/src/runtime/routes/defer-routes.ts
+++ b/assistant/src/runtime/routes/defer-routes.ts
@@ -53,15 +53,11 @@ const DeferListParams = z.object({
   conversationId: z.string().optional(),
 });
 
-const DeferCancelParams = z
-  .object({
-    id: z.string().optional(),
-    all: z.boolean().optional(),
-    conversationId: z.string().optional(),
-  })
-  .refine((p) => !p.all || p.conversationId, {
-    message: "conversationId is required when cancelling all defers",
-  });
+const DeferCancelParams = z.object({
+  id: z.string().optional(),
+  all: z.boolean().optional(),
+  conversationId: z.string().optional(),
+});
 
 // ── Handlers ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Remove the `.refine()` validation on `DeferCancelParams` that required `conversationId` when `all` is true
- The handler already works correctly with `conversationId` undefined — `listSchedules` returns all defers globally
- This makes `assistant conversations defer cancel --all` work as documented in the help text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
