### PR TITLE
feat: add in-memory background tool registry

### DIFF
--- a/assistant/src/__tests__/background-tool-registry.test.ts
+++ b/assistant/src/__tests__/background-tool-registry.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  _clearRegistryForTesting,
+  type BackgroundTool,
+  cancelBackgroundTool,
+  generateBackgroundToolId,
+  listBackgroundTools,
+  MAX_BACKGROUND_TOOLS,
+  registerBackgroundTool,
+  removeBackgroundTool,
+} from "../tools/background-tool-registry.js";
+
+function makeTool(overrides: Partial<BackgroundTool> = {}): BackgroundTool {
+  return {
+    id: overrides.id ?? generateBackgroundToolId(),
+    toolName: overrides.toolName ?? "bash",
+    conversationId: overrides.conversationId ?? "conv-xyz",
+    command: overrides.command ?? "echo hello",
+    startedAt: overrides.startedAt ?? Date.now(),
+    cancel: overrides.cancel ?? mock(() => {}),
+  };
+}
+
+describe("background-tool-registry", () => {
+  beforeEach(() => {
+    _clearRegistryForTesting();
+  });
+
+  describe("register / list / remove lifecycle", () => {
+    test("registers a tool and lists it", () => {
+      const tool = makeTool({ id: "bg-00000001" });
+      registerBackgroundTool(tool);
+
+      const listed = listBackgroundTools();
+      expect(listed).toHaveLength(1);
+      expect(listed[0]!.id).toBe("bg-00000001");
+    });
+
+    test("removes a tool by ID", () => {
+      const tool = makeTool({ id: "bg-00000002" });
+      registerBackgroundTool(tool);
+      expect(listBackgroundTools()).toHaveLength(1);
+
+      removeBackgroundTool("bg-00000002");
+      expect(listBackgroundTools()).toHaveLength(0);
+    });
+
+    test("removing a non-existent ID is a no-op", () => {
+      registerBackgroundTool(makeTool({ id: "bg-00000003" }));
+      removeBackgroundTool("bg-nonexistent");
+      expect(listBackgroundTools()).toHaveLength(1);
+    });
+  });
+
+  describe("cancelBackgroundTool", () => {
+    test("calls cancel(), removes the entry, and returns true", () => {
+      const cancelFn = mock(() => {});
+      const tool = makeTool({ id: "bg-cancel-1", cancel: cancelFn });
+      registerBackgroundTool(tool);
+
+      const result = cancelBackgroundTool("bg-cancel-1");
+
+      expect(result).toBe(true);
+      expect(cancelFn).toHaveBeenCalledTimes(1);
+      expect(listBackgroundTools()).toHaveLength(0);
+    });
+
+    test("returns false for unknown IDs", () => {
+      const result = cancelBackgroundTool("bg-unknown");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("listBackgroundTools filtering", () => {
+    test("returns all tools when no conversationId is provided", () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-a1", conversationId: "conv-1" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-a2", conversationId: "conv-2" }),
+      );
+
+      expect(listBackgroundTools()).toHaveLength(2);
+    });
+
+    test("filters by conversationId when provided", () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-b1", conversationId: "conv-1" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-b2", conversationId: "conv-2" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-b3", conversationId: "conv-1" }),
+      );
+
+      const filtered = listBackgroundTools("conv-1");
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((t) => t.id).sort()).toEqual(["bg-b1", "bg-b3"]);
+
+      expect(listBackgroundTools("conv-2")).toHaveLength(1);
+      expect(listBackgroundTools("conv-nonexistent")).toHaveLength(0);
+    });
+  });
+
+  describe("MAX_BACKGROUND_TOOLS limit", () => {
+    test("throws when limit is exceeded", () => {
+      for (let i = 0; i < MAX_BACKGROUND_TOOLS; i++) {
+        registerBackgroundTool(makeTool({ id: `bg-lim-${i}` }));
+      }
+
+      expect(() =>
+        registerBackgroundTool(makeTool({ id: "bg-overflow" })),
+      ).toThrow(/Background tool limit reached/);
+      expect(listBackgroundTools()).toHaveLength(MAX_BACKGROUND_TOOLS);
+    });
+
+    test("allows registration after removing one at the limit", () => {
+      for (let i = 0; i < MAX_BACKGROUND_TOOLS; i++) {
+        registerBackgroundTool(makeTool({ id: `bg-cap-${i}` }));
+      }
+
+      removeBackgroundTool("bg-cap-0");
+      expect(() =>
+        registerBackgroundTool(makeTool({ id: "bg-cap-new" })),
+      ).not.toThrow();
+      expect(listBackgroundTools()).toHaveLength(MAX_BACKGROUND_TOOLS);
+    });
+  });
+
+  describe("generateBackgroundToolId", () => {
+    test("returns a bg- prefixed string", () => {
+      const id = generateBackgroundToolId();
+      expect(id).toMatch(/^bg-[a-f0-9]{8}$/);
+    });
+
+    test("generates unique IDs", () => {
+      const ids = new Set(
+        Array.from({ length: 50 }, () => generateBackgroundToolId()),
+      );
+      expect(ids.size).toBe(50);
+    });
+  });
+});

--- a/assistant/src/tools/background-tool-registry.ts
+++ b/assistant/src/tools/background-tool-registry.ts
@@ -1,0 +1,88 @@
+/**
+ * In-memory registry for background tool executions.
+ *
+ * Background tools are long-running processes (e.g. bash, host_bash) that the
+ * agent spawns and returns from immediately. When the process finishes, its
+ * output is delivered back to the conversation via `wakeAgentForOpportunity`.
+ *
+ * The registry tracks active background tools so they can be listed, cancelled,
+ * and cleaned up. The `toolName` field is intentionally generic (not limited to
+ * shell tools) to support extending background execution to non-shell tools in
+ * the future.
+ */
+
+export interface BackgroundTool {
+  id: string;
+  /** Tool type identifier (e.g. "bash", "host_bash"). */
+  toolName: string;
+  conversationId: string;
+  command: string;
+  startedAt: number;
+  /** Kills the process (bash) or aborts the proxy (host_bash). */
+  cancel: () => void;
+}
+
+/** Maximum number of concurrent background tools allowed. */
+export const MAX_BACKGROUND_TOOLS = 20;
+
+const registry = new Map<string, BackgroundTool>();
+
+/**
+ * Registers a background tool in the in-memory store.
+ * Throws if the registry would exceed {@link MAX_BACKGROUND_TOOLS}.
+ */
+export function registerBackgroundTool(tool: BackgroundTool): void {
+  if (registry.size >= MAX_BACKGROUND_TOOLS) {
+    throw new Error(
+      `Background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+    );
+  }
+  registry.set(tool.id, tool);
+}
+
+/** Removes a background tool entry by ID. */
+export function removeBackgroundTool(id: string): void {
+  registry.delete(id);
+}
+
+/**
+ * Returns all registered background tools, optionally filtered by
+ * `conversationId`.
+ */
+export function listBackgroundTools(conversationId?: string): BackgroundTool[] {
+  const all = Array.from(registry.values());
+  if (conversationId === undefined) {
+    return all;
+  }
+  return all.filter((t) => t.conversationId === conversationId);
+}
+
+/**
+ * Cancels a background tool by ID: calls `tool.cancel()`, removes the entry,
+ * and returns `true`. Returns `false` if the ID is not found.
+ */
+export function cancelBackgroundTool(id: string): boolean {
+  const tool = registry.get(id);
+  if (!tool) {
+    return false;
+  }
+  tool.cancel();
+  registry.delete(id);
+  return true;
+}
+
+/**
+ * Generates a short prefixed ID for a background tool.
+ * Format: `bg-<8 hex chars>` (e.g. `bg-a1b2c3d4`).
+ */
+export function generateBackgroundToolId(): string {
+  return `bg-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Clears the entire registry. Intended for test cleanup only — production
+ * code should use {@link cancelBackgroundTool} or {@link removeBackgroundTool}.
+ */
+export function _clearRegistryForTesting(): void {
+  registry.clear();
+}


### PR DESCRIPTION
## Summary
- Add `BackgroundTool` interface and in-memory `Map`-backed registry for tracking background tool executions
- Export `registerBackgroundTool`, `removeBackgroundTool`, `listBackgroundTools`, `cancelBackgroundTool`, and `generateBackgroundToolId`
- Cap at 20 concurrent background tools
- Add unit tests for registry lifecycle, cancellation, filtering, and limit enforcement

Part of plan: bg-shell-tools.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
