### PR TITLE
fix: use OS-assigned port in send-endpoint-busy test to avoid EADDRINUSE

### DIFF
--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -356,9 +356,8 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     conversationFactory: () => Conversation,
     options?: { approvalConversationGenerator?: ApprovalConversationGenerator },
   ): Promise<void> {
-    port = 19000 + Math.floor(Math.random() * 1000);
     server = new RuntimeHttpServer({
-      port,
+      port: 0,
       approvalConversationGenerator: options?.approvalConversationGenerator,
       sendMessageDeps: {
         getOrCreateConversation: async () => conversationFactory(),
@@ -367,6 +366,7 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
       },
     });
     await server.start();
+    port = server.actualPort;
   }
 
   async function stopServer(): Promise<void> {


### PR DESCRIPTION
## Summary
- Replace random port selection (`19000 + Math.floor(Math.random() * 1000)`) with port `0` in `send-endpoint-busy.test.ts`, letting the OS assign a guaranteed-free port
- Read back the actual port via `server.actualPort` after start
- Fixes flaky `EADDRINUSE` failures when 16 parallel CI workers collide on the same random port

## Original prompt
--yolo fix this CI check https://github.com/vellum-ai/vellum-assistant/actions/runs/25028172814
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
