### PR TITLE
feat: add routes for listing and cancelling background tools

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1376,6 +1376,85 @@ paths:
                 - eyeStyle
                 - color
               additionalProperties: false
+  /v1/background-tools:
+    get:
+      operationId: backgroundtools_get
+      summary: List active background tools
+      description: List all active background tool executions, optionally filtered by conversationId.
+      tags:
+        - background-tools
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tools:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        toolName:
+                          type: string
+                        conversationId:
+                          type: string
+                        command:
+                          type: string
+                        startedAt:
+                          type: number
+                      required:
+                        - id
+                        - toolName
+                        - conversationId
+                        - command
+                        - startedAt
+                      additionalProperties: false
+                required:
+                  - tools
+                additionalProperties: false
+      parameters:
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by conversation ID
+  /v1/background-tools/cancel:
+    post:
+      operationId: backgroundtools_cancel_post
+      summary: Cancel a background tool
+      description: Cancel an active background tool execution by ID.
+      tags:
+        - background-tools
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cancelled:
+                    type: boolean
+                required:
+                  - cancelled
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+              required:
+                - id
+              additionalProperties: false
   /v1/backups:
     get:
       operationId: backups_get

--- a/assistant/src/__tests__/background-tool-routes.test.ts
+++ b/assistant/src/__tests__/background-tool-routes.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ROUTES } from "../runtime/routes/background-tool-routes.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+import type { RouteDefinition } from "../runtime/routes/types.js";
+import {
+  _clearRegistryForTesting,
+  registerBackgroundTool,
+} from "../tools/background-tool-registry.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function findRoute(operationId: string): RouteDefinition | undefined {
+  return ROUTES.find((r) => r.operationId === operationId);
+}
+
+function makeTool(overrides: {
+  id: string;
+  toolName?: string;
+  conversationId?: string;
+  command?: string;
+  startedAt?: number;
+}) {
+  return {
+    id: overrides.id,
+    toolName: overrides.toolName ?? "bash",
+    conversationId: overrides.conversationId ?? "conv-1",
+    command: overrides.command ?? "sleep 10",
+    startedAt: overrides.startedAt ?? Date.now(),
+    cancel: mock(() => {}),
+  };
+}
+
+// ── Setup / Teardown ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  _clearRegistryForTesting();
+});
+
+afterEach(() => {
+  _clearRegistryForTesting();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("background tool routes", () => {
+  describe("GET /v1/background-tools (list)", () => {
+    test("returns empty array when no tools are registered", async () => {
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: unknown[];
+      };
+
+      expect(result.tools).toEqual([]);
+    });
+
+    test("returns registered tools with toolName field", async () => {
+      const tool = makeTool({
+        id: "bg-abc123",
+        toolName: "host_bash",
+        conversationId: "conv-1",
+        command: "npm test",
+        startedAt: 1700000000000,
+      });
+      registerBackgroundTool(tool);
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: Array<{
+          id: string;
+          toolName: string;
+          conversationId: string;
+          command: string;
+          startedAt: number;
+        }>;
+      };
+
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools[0]!.id).toBe("bg-abc123");
+      expect(result.tools[0]!.toolName).toBe("host_bash");
+      expect(result.tools[0]!.conversationId).toBe("conv-1");
+      expect(result.tools[0]!.command).toBe("npm test");
+      expect(result.tools[0]!.startedAt).toBe(1700000000000);
+    });
+
+    test("does not include the cancel function in the response", async () => {
+      registerBackgroundTool(makeTool({ id: "bg-1" }));
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: Array<Record<string, unknown>>;
+      };
+
+      expect(result.tools[0]).not.toHaveProperty("cancel");
+    });
+
+    test("filters by conversationId", async () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-1", conversationId: "conv-a" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-2", conversationId: "conv-b" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-3", conversationId: "conv-a" }),
+      );
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({
+        queryParams: { conversationId: "conv-a" },
+      })) as {
+        tools: Array<{ id: string }>;
+      };
+
+      expect(result.tools).toHaveLength(2);
+      expect(result.tools.map((t) => t.id).sort()).toEqual(["bg-1", "bg-3"]);
+    });
+
+    test("returns all tools when conversationId is not provided", async () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-1", conversationId: "conv-a" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-2", conversationId: "conv-b" }),
+      );
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: Array<{ id: string }>;
+      };
+
+      expect(result.tools).toHaveLength(2);
+    });
+  });
+
+  describe("POST /v1/background-tools/cancel", () => {
+    test("cancels a registered tool and returns cancelled: true", async () => {
+      const tool = makeTool({ id: "bg-cancel-me" });
+      registerBackgroundTool(tool);
+
+      const route = findRoute("background_tool_cancel")!;
+      const result = (await route.handler({
+        body: { id: "bg-cancel-me" },
+      })) as {
+        cancelled: boolean;
+      };
+
+      expect(result.cancelled).toBe(true);
+      expect(tool.cancel).toHaveBeenCalled();
+    });
+
+    test("returns cancelled: false for unknown ID", async () => {
+      const route = findRoute("background_tool_cancel")!;
+      const result = (await route.handler({
+        body: { id: "bg-nonexistent" },
+      })) as {
+        cancelled: boolean;
+      };
+
+      expect(result.cancelled).toBe(false);
+    });
+
+    test("throws BadRequestError when id is not provided", async () => {
+      const route = findRoute("background_tool_cancel")!;
+      await expect(route.handler({ body: {} })).rejects.toThrow(
+        BadRequestError,
+      );
+    });
+
+    test("throws BadRequestError when body is empty", async () => {
+      const route = findRoute("background_tool_cancel")!;
+      await expect(route.handler({})).rejects.toThrow(BadRequestError);
+    });
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -717,6 +717,17 @@ registerPolicy("browser/execute", {
   allowedPrincipalTypes: ["local"],
 });
 
+// Background tools: local-only (CLI / IPC callers)
+registerPolicy("background-tools", {
+  requiredScopes: ["settings.read"],
+  allowedPrincipalTypes: ["local"],
+});
+
+registerPolicy("background-tools/cancel", {
+  requiredScopes: ["settings.write"],
+  allowedPrincipalTypes: ["local"],
+});
+
 // User-defined routes under /x/*
 registerPolicy("x", {
   requiredScopes: ["settings.read"],

--- a/assistant/src/runtime/routes/background-tool-routes.ts
+++ b/assistant/src/runtime/routes/background-tool-routes.ts
@@ -1,0 +1,94 @@
+/**
+ * Transport-agnostic routes for listing and cancelling background tools.
+ *
+ * Background tools are long-running processes (e.g. bash, host_bash) that the
+ * agent spawns in the background. These routes expose visibility and control
+ * over active background tool executions.
+ */
+
+import { z } from "zod";
+
+import {
+  cancelBackgroundTool,
+  listBackgroundTools,
+} from "../../tools/background-tool-registry.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ── Handlers ──────────────────────────────────────────────────────────
+
+async function handleBackgroundToolList({
+  queryParams = {},
+}: RouteHandlerArgs) {
+  const conversationId = queryParams.conversationId || undefined;
+  const tools = listBackgroundTools(conversationId);
+
+  return {
+    tools: tools.map((t) => ({
+      id: t.id,
+      toolName: t.toolName,
+      conversationId: t.conversationId,
+      command: t.command,
+      startedAt: t.startedAt,
+    })),
+  };
+}
+
+async function handleBackgroundToolCancel({ body = {} }: RouteHandlerArgs) {
+  const id = body.id as string | undefined;
+  if (!id) {
+    throw new BadRequestError("id is required");
+  }
+
+  const cancelled = cancelBackgroundTool(id);
+  return { cancelled };
+}
+
+// ── Routes ────────────────────────────────────────────────────────────
+
+const BackgroundToolSchema = z.object({
+  id: z.string(),
+  toolName: z.string(),
+  conversationId: z.string(),
+  command: z.string(),
+  startedAt: z.number(),
+});
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "background_tool_list",
+    endpoint: "background-tools",
+    method: "GET",
+    handler: handleBackgroundToolList,
+    summary: "List active background tools",
+    description:
+      "List all active background tool executions, optionally filtered by conversationId.",
+    tags: ["background-tools"],
+    queryParams: [
+      {
+        name: "conversationId",
+        type: "string",
+        required: false,
+        description: "Filter by conversation ID",
+      },
+    ],
+    responseBody: z.object({
+      tools: z.array(BackgroundToolSchema),
+    }),
+  },
+  {
+    operationId: "background_tool_cancel",
+    endpoint: "background-tools/cancel",
+    method: "POST",
+    handler: handleBackgroundToolCancel,
+    summary: "Cancel a background tool",
+    description: "Cancel an active background tool execution by ID.",
+    tags: ["background-tools"],
+    requestBody: z.object({
+      id: z.string(),
+    }),
+    responseBody: z.object({
+      cancelled: z.boolean(),
+    }),
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -15,6 +15,7 @@ import { ROUTES as APPROVAL_ROUTES } from "./approval-routes.js";
 import { ROUTES as ATTACHMENT_ROUTES } from "./attachment-routes.js";
 import { ROUTES as AUDIO_ROUTES } from "./audio-routes.js";
 import { ROUTES as AVATAR_ROUTES } from "./avatar-routes.js";
+import { ROUTES as BACKGROUND_TOOL_ROUTES } from "./background-tool-routes.js";
 import { ROUTES as BACKUP_ROUTES } from "./backup-routes.js";
 import { ROUTES as BRAIN_GRAPH_ROUTES } from "./brain-graph-routes.js";
 import { ROUTES as BROWSER_ROUTES } from "./browser-routes.js";
@@ -91,6 +92,7 @@ export const ROUTES: RouteDefinition[] = [
   ...APPROVAL_ROUTES,
   ...AUDIO_ROUTES,
   ...AVATAR_ROUTES,
+  ...BACKGROUND_TOOL_ROUTES,
   ...BACKUP_ROUTES,
   ...CACHE_ROUTES,
   ...CALL_ROUTES,


### PR DESCRIPTION
## Summary
- Add `GET /v1/background-tools` route to list active background tool executions
- Add `POST /v1/background-tools/cancel` route to cancel a background tool by ID
- Register routes in the shared ROUTES array for dual HTTP + IPC exposure

Part of plan: bg-shell-tools.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
