### PR TITLE
feat: add `background` mode to the bash tool

### DIFF
--- a/assistant/src/__tests__/background-shell-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-bash.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { WakeOptions } from "../runtime/agent-wake.js";
+import type { BackgroundTool } from "../tools/background-tool-registry.js";
+import type { Tool } from "../tools/types.js";
+
+// ── Mock modules ────────────────────────────────────────────────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target: Record<string, unknown>, _prop: string) => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600 },
+    sandbox: {
+      enabled: false,
+      backend: "native",
+      docker: {
+        image: "vellum-sandbox:latest",
+        shell: "bash",
+        cpus: 1,
+        memoryMb: 512,
+        pidsLimit: 256,
+        network: "none",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../tools/network/script-proxy/index.js", () => ({
+  getOrStartSession: mock(() =>
+    Promise.resolve({ session: { id: "mock-session" } }),
+  ),
+  getSessionEnv: mock(() => ({
+    HTTP_PROXY: "http://localhost:9999",
+    HTTPS_PROXY: "http://localhost:9999",
+  })),
+  createSession: () => {},
+  startSession: () => {},
+  stopSession: () => {},
+  getActiveSession: () => null,
+  getSessionsForConversation: () => [],
+  stopAllSessions: () => {},
+  ensureLocalCA: () => {},
+  ensureCombinedCABundle: () => {},
+  issueLeafCert: () => {},
+  getCAPath: () => "",
+  getCombinedCAPath: () => "",
+}));
+
+const mockWakeAgentForOpportunity = mock(
+  (
+    _opts: WakeOptions,
+  ): Promise<{ invoked: boolean; producedToolCalls: boolean }> =>
+    Promise.resolve({ invoked: true, producedToolCalls: false }),
+);
+
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: mockWakeAgentForOpportunity,
+}));
+
+const registeredTools: BackgroundTool[] = [];
+
+const mockRegisterBackgroundTool = mock((tool: BackgroundTool) => {
+  registeredTools.push(tool);
+});
+const mockRemoveBackgroundTool = mock((_id: string) => {
+  const idx = registeredTools.findIndex((t) => t.id === _id);
+  if (idx !== -1) registeredTools.splice(idx, 1);
+});
+const mockGenerateBackgroundToolId = mock(() => "bg-test1234");
+
+mock.module("../tools/background-tool-registry.js", () => ({
+  registerBackgroundTool: mockRegisterBackgroundTool,
+  removeBackgroundTool: mockRemoveBackgroundTool,
+  generateBackgroundToolId: mockGenerateBackgroundToolId,
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────
+
+const baseContext = {
+  workingDir: process.env.VELLUM_WORKSPACE_DIR ?? "/tmp",
+  conversationId: "conv-bg-test",
+  trustClass: "guardian" as const,
+  onOutput: () => {},
+};
+
+describe("bash tool background mode", () => {
+  let shellTool: Tool;
+
+  beforeEach(async () => {
+    mockWakeAgentForOpportunity.mockClear();
+    mockRegisterBackgroundTool.mockClear();
+    mockRemoveBackgroundTool.mockClear();
+    mockGenerateBackgroundToolId.mockClear();
+    mockGenerateBackgroundToolId.mockReturnValue("bg-test1234");
+    registeredTools.length = 0;
+
+    const mod = await import("../tools/terminal/shell.js");
+    shellTool = mod.shellTool;
+  });
+
+  afterEach(() => {
+    registeredTools.length = 0;
+  });
+
+  test("background: true returns immediately with backgrounded payload", async () => {
+    const result = await shellTool.execute(
+      { command: "echo hello", activity: "test", background: true },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.backgrounded).toBe(true);
+    expect(parsed.id).toBe("bg-test1234");
+  });
+
+  test("background process registers in the background tool registry", async () => {
+    await shellTool.execute(
+      { command: "echo hello", activity: "test", background: true },
+      baseContext,
+    );
+
+    expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterBackgroundTool.mock
+      .calls[0]![0] as BackgroundTool;
+    expect(registered.id).toBe("bg-test1234");
+    expect(registered.toolName).toBe("bash");
+    expect(registered.conversationId).toBe("conv-bg-test");
+    expect(registered.command).toBe("echo hello");
+    expect(typeof registered.cancel).toBe("function");
+  });
+
+  test("background process completion triggers wakeAgentForOpportunity with stdout", async () => {
+    await shellTool.execute(
+      { command: "echo bg_output_12345", activity: "test", background: true },
+      baseContext,
+    );
+
+    // Wait for the background process to complete and fire the wake.
+    // The process is fast (echo), so a short wait suffices.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith("bg-test1234");
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+
+    const wakeCall = mockWakeAgentForOpportunity.mock
+      .calls[0]![0] as WakeOptions;
+    expect(wakeCall.conversationId).toBe("conv-bg-test");
+    expect(wakeCall.source).toBe("background-tool");
+    expect(wakeCall.hint).toContain("bg_output_12345");
+    expect(wakeCall.hint).toContain("bg-test1234");
+  });
+
+  test("failing background process delivers an error hint via wake", async () => {
+    await shellTool.execute(
+      { command: "exit 1", activity: "test", background: true },
+      baseContext,
+    );
+
+    // Wait for the background process to complete.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith("bg-test1234");
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+
+    const wakeCall = mockWakeAgentForOpportunity.mock
+      .calls[0]![0] as WakeOptions;
+    expect(wakeCall.conversationId).toBe("conv-bg-test");
+    expect(wakeCall.source).toBe("background-tool");
+    expect(wakeCall.hint).toContain("bg-test1234");
+    // The command fails with exit code 1, so the hint should reflect failure
+    expect(wakeCall.hint).toContain("exit=1");
+  });
+
+  test("foreground mode still works when background is not set", async () => {
+    const result = await shellTool.execute(
+      { command: "echo foreground_test_789", activity: "test" },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("foreground_test_789");
+    // Background registry should not be touched for foreground commands
+    expect(mockRegisterBackgroundTool).not.toHaveBeenCalled();
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/__tests__/background-shell-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-bash.test.ts
@@ -91,6 +91,27 @@ const baseContext = {
   onOutput: () => {},
 };
 
+/** Poll until `mockFn` has been called at least once (10 s timeout). */
+function waitForWake(
+  mockFn: ReturnType<typeof mock>,
+  timeoutMs = 10_000,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("timed out waiting for wakeAgentForOpportunity")),
+      timeoutMs,
+    );
+    const check = () => {
+      if (mockFn.mock.calls.length > 0) {
+        clearTimeout(timer);
+        return resolve();
+      }
+      setTimeout(check, 50);
+    };
+    check();
+  });
+}
+
 describe("bash tool background mode", () => {
   let shellTool: Tool;
 
@@ -120,6 +141,9 @@ describe("bash tool background mode", () => {
     const parsed = JSON.parse(result.content);
     expect(parsed.backgrounded).toBe(true);
     expect(parsed.id).toBe("bg-test1234");
+
+    // Wait for background process to settle so it doesn't leak into later tests.
+    await waitForWake(mockWakeAgentForOpportunity);
   });
 
   test("background process registers in the background tool registry", async () => {
@@ -136,6 +160,9 @@ describe("bash tool background mode", () => {
     expect(registered.conversationId).toBe("conv-bg-test");
     expect(registered.command).toBe("echo hello");
     expect(typeof registered.cancel).toBe("function");
+
+    // Wait for background process to settle so it doesn't leak into later tests.
+    await waitForWake(mockWakeAgentForOpportunity);
   });
 
   test("background process completion triggers wakeAgentForOpportunity with stdout", async () => {
@@ -145,8 +172,7 @@ describe("bash tool background mode", () => {
     );
 
     // Wait for the background process to complete and fire the wake.
-    // The process is fast (echo), so a short wait suffices.
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await waitForWake(mockWakeAgentForOpportunity);
 
     expect(mockRemoveBackgroundTool).toHaveBeenCalledWith("bg-test1234");
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
@@ -166,7 +192,7 @@ describe("bash tool background mode", () => {
     );
 
     // Wait for the background process to complete.
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await waitForWake(mockWakeAgentForOpportunity);
 
     expect(mockRemoveBackgroundTool).toHaveBeenCalledWith("bg-test1234");
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -7,6 +8,7 @@ import { isCesShellLockdownEnabled } from "../../credential-execution/feature-ga
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
+import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -14,6 +16,11 @@ import {
   getProtectedDir,
   getWorkspaceDir,
 } from "../../util/platform.js";
+import {
+  generateBackgroundToolId,
+  registerBackgroundTool,
+  removeBackgroundTool,
+} from "../background-tool-registry.js";
 import { resolveCredentialRef } from "../credentials/resolve.js";
 import {
   getOrStartSession,
@@ -135,6 +142,11 @@ class ShellTool implements Tool {
             items: { type: "string" },
             description:
               'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
+          },
+          background: {
+            type: "boolean",
+            description:
+              "Run the command in the background. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
           },
         },
         required: ["command", "activity"],
@@ -323,21 +335,28 @@ class ShellTool implements Tool {
       env.VELLUM_UNTRUSTED_SHELL = "1";
     }
 
-    const result = await new Promise<ToolExecutionResult>((resolve) => {
+    // CES shell lockdown: build deny-read paths for protected credential
+    // data, the protected dir, and data sub-dirs that contain secrets.
+    const denyReadPaths: string[] | undefined = shellLockdownActive
+      ? buildCesProtectedPaths()
+      : undefined;
+
+    const wrapped = wrapCommand(command, context.workingDir, sandboxConfig, {
+      networkMode,
+      denyReadPaths,
+    });
+
+    // -----------------------------------------------------------------------
+    // Background mode: spawn and return immediately. The process output is
+    // delivered to the conversation as a wake when the process exits.
+    // -----------------------------------------------------------------------
+    const background = input.background === true;
+    if (background) {
+      const bgId = generateBackgroundToolId();
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
 
-      // CES shell lockdown: build deny-read paths for protected credential
-      // data, the protected dir, and data sub-dirs that contain secrets.
-      const denyReadPaths: string[] | undefined = shellLockdownActive
-        ? buildCesProtectedPaths()
-        : undefined;
-
-      const wrapped = wrapCommand(command, context.workingDir, sandboxConfig, {
-        networkMode,
-        denyReadPaths,
-      });
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
         env,
@@ -345,24 +364,86 @@ class ShellTool implements Tool {
         detached: true,
       });
 
-      // Kill the entire process tree. Tries the process group first
-      // (negative PID), then falls back to killing the direct child if the
-      // PID is unavailable or the group kill fails.
-      const killTree = () => {
-        if (child.pid != null) {
-          try {
-            process.kill(-child.pid, "SIGKILL");
-            return;
-          } catch {
-            // Process group may have already exited — fall through.
-          }
-        }
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Child may have already exited.
-        }
+      const killTree = buildKillTree(child);
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        killTree();
+      }, timeoutMs);
+
+      child.stdout.on("data", (data: Buffer) => {
+        stdoutChunks.push(data);
+      });
+
+      child.stderr.on("data", (data: Buffer) => {
+        stderrChunks.push(data);
+      });
+
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        removeBackgroundTool(bgId);
+
+        const stdout = Buffer.concat(stdoutChunks).toString();
+        const stderr = Buffer.concat(stderrChunks).toString();
+        const fmtResult = formatShellOutput(
+          stdout,
+          stderr,
+          code,
+          timedOut,
+          timeoutSec,
+        );
+
+        const hint = `Background command completed (id=${bgId}, exit=${code ?? "unknown"}):\n${fmtResult.content}`;
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint,
+          source: "background-tool",
+        });
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        removeBackgroundTool(bgId);
+
+        const hint = `Background command failed (id=${bgId}): ${err.message}`;
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint,
+          source: "background-tool",
+        });
+      });
+
+      registerBackgroundTool({
+        id: bgId,
+        toolName: "bash",
+        conversationId: context.conversationId,
+        command,
+        startedAt: Date.now(),
+        cancel: killTree,
+      });
+
+      return {
+        content: JSON.stringify({ backgrounded: true, id: bgId }),
+        isError: false,
       };
+    }
+
+    // -----------------------------------------------------------------------
+    // Foreground mode: await the process and return its output.
+    // -----------------------------------------------------------------------
+    const result = await new Promise<ToolExecutionResult>((resolve) => {
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let timedOut = false;
+
+      const child = spawn(wrapped.command, wrapped.args, {
+        cwd: context.workingDir,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+
+      const killTree = buildKillTree(child);
 
       const timer = setTimeout(() => {
         timedOut = true;
@@ -426,6 +507,29 @@ class ShellTool implements Tool {
 
     return result;
   }
+}
+
+/**
+ * Kill the entire process tree of a child process. Tries the process group
+ * first (negative PID), then falls back to killing the direct child if the
+ * PID is unavailable or the group kill fails.
+ */
+function buildKillTree(child: ChildProcess): () => void {
+  return () => {
+    if (child.pid != null) {
+      try {
+        process.kill(-child.pid, "SIGKILL");
+        return;
+      } catch {
+        // Process group may have already exited — fall through.
+      }
+    }
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Child may have already exited.
+    }
+  };
 }
 
 export const shellTool: Tool = new ShellTool();


### PR DESCRIPTION
## Summary
- Add `background` boolean input to the bash tool schema
- When set, spawn the process detached from the turn, return immediately with a background tool ID
- On process exit, deliver stdout/stderr to the conversation as a wake via `wakeAgentForOpportunity`
- Register/remove from the background tool registry for list/cancel support

Part of plan: bg-shell-tools.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
