### PR TITLE
fix(memory): default v2 consolidation cadence to 4h

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -18,7 +18,7 @@ describe("MemoryV2ConfigSchema", () => {
       epsilon: 0.01,
       dense_weight: 0.7,
       sparse_weight: 0.3,
-      consolidation_interval_hours: 1,
+      consolidation_interval_hours: 4,
       max_page_chars: 5000,
     });
   });
@@ -153,7 +153,7 @@ describe("MemoryConfigSchema integration with v2 block", () => {
     expect(parsed.v2.d).toBe(0.3);
     expect(parsed.v2.dense_weight).toBe(0.7);
     expect(parsed.v2.sparse_weight).toBe(0.3);
-    expect(parsed.v2.consolidation_interval_hours).toBe(1);
+    expect(parsed.v2.consolidation_interval_hours).toBe(4);
     expect(parsed.v2.max_page_chars).toBe(5000);
   });
 

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -113,7 +113,7 @@ export const MemoryV2ConfigSchema = z
       .positive(
         "memory.v2.consolidation_interval_hours must be a positive integer",
       )
-      .default(1)
+      .default(4)
       .describe(
         "Hours between scheduled consolidation runs that synthesize buffered memories into concept pages",
       ),


### PR DESCRIPTION
## Summary

- Change `memory.v2.consolidation_interval_hours` default from 1 to 4. Workspaces that have already overridden this value in config.json keep their override.
- Schedule tests use explicit interval overrides so they're unaffected.

## Original prompt

can we change it to be every 4 hours instead?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
