### PR TITLE
feat: add `background` mode to the host_bash tool

### DIFF
--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -1,0 +1,450 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before importing the tool under test.
+// ---------------------------------------------------------------------------
+
+const mockWakeAgentForOpportunity = mock(() => Promise.resolve());
+
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: mockWakeAgentForOpportunity,
+}));
+
+const mockRegisterBackgroundTool = mock(() => {});
+const mockRemoveBackgroundTool = mock(() => {});
+let bgIdCounter = 0;
+const mockGenerateBackgroundToolId = mock(
+  () => `bg-test-${String(++bgIdCounter).padStart(4, "0")}`,
+);
+
+mock.module("../tools/background-tool-registry.js", () => ({
+  registerBackgroundTool: mockRegisterBackgroundTool,
+  removeBackgroundTool: mockRemoveBackgroundTool,
+  generateBackgroundToolId: mockGenerateBackgroundToolId,
+}));
+
+// Stub child_process.spawn so we don't actually run commands. The test
+// creates a fake ChildProcess (EventEmitter) and drives it manually.
+type FakeChild = EventEmitter & {
+  pid: number;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof mock>;
+};
+
+let latestChild: FakeChild | undefined;
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = 12345;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = mock(() => {});
+  latestChild = child;
+  return child;
+}
+
+mock.module("node:child_process", () => ({
+  spawn: mock(() => makeFakeChild()),
+}));
+
+const mockConfig = {
+  provider: "anthropic",
+  model: "test",
+  maxTokens: 4096,
+  dataDir: "/tmp",
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  rateLimit: { maxRequestsPerMinute: 0 },
+  secretDetection: {
+    enabled: true,
+    action: "warn" as const,
+    entropyThreshold: 4.0,
+  },
+  auditLog: { retentionDays: 0 },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../tools/terminal/sandbox.js", () => ({
+  wrapCommand: (...args: unknown[]) => ({
+    command: "bash",
+    args: ["-c", "--", args[0]],
+    sandboxed: false,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test — MUST come after mock.module calls.
+// ---------------------------------------------------------------------------
+
+import { hostShellTool } from "../tools/host-terminal/host-shell.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-xyz",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+function makeMockProxy(result: ToolExecutionResult) {
+  const requestMock = mock(
+    (
+      _input: {
+        command: string;
+        working_dir?: string;
+        timeout_seconds?: number;
+        env?: Record<string, string>;
+      },
+      _conversationId: string,
+      _signal?: AbortSignal,
+    ) => Promise.resolve(result),
+  );
+
+  return {
+    proxy: {
+      isAvailable: () => true,
+      request: requestMock,
+      updateSender: () => {},
+      dispose: () => {},
+      resolve: () => {},
+      hasPendingRequest: () => false,
+    },
+    requestMock,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  bgIdCounter = 0;
+  mockWakeAgentForOpportunity.mockClear();
+  mockRegisterBackgroundTool.mockClear();
+  mockRemoveBackgroundTool.mockClear();
+  mockGenerateBackgroundToolId.mockClear();
+  latestChild = undefined;
+});
+
+afterEach(() => {
+  latestChild = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Proxy path — background: true
+// ---------------------------------------------------------------------------
+
+describe("host_bash background mode — proxy path", () => {
+  test("returns immediately with backgrounded response", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxy output",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.backgrounded).toBe(true);
+    expect(parsed.id).toMatch(/^bg-/);
+    expect(result.isError).toBe(false);
+  });
+
+  test("registers background tool in the registry", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxy output",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterBackgroundTool.mock.calls[0][0];
+    expect(registered.toolName).toBe("host_bash");
+    expect(registered.conversationId).toBe("conv-xyz");
+    expect(registered.command).toBe("echo bg-proxy");
+  });
+
+  test("calls wakeAgentForOpportunity on proxy success", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxy success output",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    // The proxy resolves immediately in our mock, so the .then() handler runs
+    // in the next microtask. Flush microtasks.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    expect(wakeCall.conversationId).toBe("conv-xyz");
+    expect(wakeCall.hint).toBe("proxy success output");
+    expect(wakeCall.source).toBe("background-tool");
+  });
+
+  test("calls wakeAgentForOpportunity on proxy error result", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "command not found",
+      isError: true,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "bad-command", background: true },
+      ctx,
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    expect(wakeCall.hint).toContain("Background host command failed");
+    expect(wakeCall.hint).toContain("command not found");
+  });
+
+  test("calls wakeAgentForOpportunity on proxy rejection", async () => {
+    const requestMock = mock(() =>
+      Promise.reject(new Error("proxy transport error")),
+    );
+
+    const proxy = {
+      isAvailable: () => true,
+      request: requestMock,
+      updateSender: () => {},
+      dispose: () => {},
+      resolve: () => {},
+      hasPendingRequest: () => false,
+    };
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "echo fail", background: true },
+      ctx,
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("proxy transport error");
+  });
+
+  test("removes background tool from registry on completion", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "done",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+
+    // Flush microtasks
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledTimes(1);
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith(parsed.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct execution path — background: true
+// ---------------------------------------------------------------------------
+
+describe("host_bash background mode — direct execution path", () => {
+  test("returns immediately with backgrounded response", async () => {
+    const ctx = makeContext();
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.backgrounded).toBe(true);
+    expect(parsed.id).toMatch(/^bg-/);
+    expect(result.isError).toBe(false);
+  });
+
+  test("registers background tool in the registry", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterBackgroundTool.mock.calls[0][0];
+    expect(registered.toolName).toBe("host_bash");
+    expect(registered.conversationId).toBe("conv-xyz");
+    expect(registered.command).toBe("echo bg-local");
+    expect(typeof registered.cancel).toBe("function");
+  });
+
+  test("calls wakeAgentForOpportunity on process exit", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    expect(latestChild).toBeDefined();
+
+    // Simulate stdout data and process close
+    latestChild!.stdout.emit("data", Buffer.from("hello world\n"));
+    latestChild!.emit("close", 0);
+
+    // Flush microtasks
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    expect(wakeCall.conversationId).toBe("conv-xyz");
+    expect(wakeCall.source).toBe("background-tool");
+    expect(wakeCall.hint).toContain("hello world");
+  });
+
+  test("calls wakeAgentForOpportunity with error hint on non-zero exit", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute({ command: "false", background: true }, ctx);
+
+    expect(latestChild).toBeDefined();
+
+    latestChild!.stderr.emit("data", Buffer.from("something failed\n"));
+    latestChild!.emit("close", 1);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    expect(wakeCall.hint).toContain("Background host command failed");
+  });
+
+  test("calls wakeAgentForOpportunity on spawn error", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute(
+      { command: "echo bg-error", background: true },
+      ctx,
+    );
+
+    expect(latestChild).toBeDefined();
+
+    latestChild!.emit("error", new Error("spawn ENOENT"));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("spawn ENOENT");
+  });
+
+  test("removes background tool from registry on process exit", async () => {
+    const ctx = makeContext();
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+
+    latestChild!.emit("close", 0);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledTimes(1);
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith(parsed.id);
+  });
+
+  test("removes background tool from registry on spawn error", async () => {
+    const ctx = makeContext();
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-error", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+
+    latestChild!.emit("error", new Error("spawn ENOENT"));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledTimes(1);
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith(parsed.id);
+  });
+});

--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -202,7 +202,9 @@ describe("host_bash background mode — proxy path", () => {
     );
 
     expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
-    const registered = mockRegisterBackgroundTool.mock.calls[0][0];
+    const registered = (
+      mockRegisterBackgroundTool.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(registered.toolName).toBe("host_bash");
     expect(registered.conversationId).toBe("conv-xyz");
     expect(registered.command).toBe("echo bg-proxy");
@@ -229,7 +231,9 @@ describe("host_bash background mode — proxy path", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(wakeCall.conversationId).toBe("conv-xyz");
     expect(wakeCall.hint).toBe("proxy success output");
     expect(wakeCall.source).toBe("background-tool");
@@ -254,7 +258,9 @@ describe("host_bash background mode — proxy path", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(wakeCall.hint).toContain("Background host command failed");
     expect(wakeCall.hint).toContain("command not found");
   });
@@ -285,7 +291,9 @@ describe("host_bash background mode — proxy path", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(wakeCall.hint).toContain("Background host command error");
     expect(wakeCall.hint).toContain("proxy transport error");
   });
@@ -344,7 +352,9 @@ describe("host_bash background mode — direct execution path", () => {
     );
 
     expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
-    const registered = mockRegisterBackgroundTool.mock.calls[0][0];
+    const registered = (
+      mockRegisterBackgroundTool.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(registered.toolName).toBe("host_bash");
     expect(registered.conversationId).toBe("conv-xyz");
     expect(registered.command).toBe("echo bg-local");
@@ -369,7 +379,9 @@ describe("host_bash background mode — direct execution path", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(wakeCall.conversationId).toBe("conv-xyz");
     expect(wakeCall.source).toBe("background-tool");
     expect(wakeCall.hint).toContain("hello world");
@@ -388,7 +400,9 @@ describe("host_bash background mode — direct execution path", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(wakeCall.hint).toContain("Background host command failed");
   });
 
@@ -407,7 +421,9 @@ describe("host_bash background mode — direct execution path", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-    const wakeCall = mockWakeAgentForOpportunity.mock.calls[0][0];
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
     expect(wakeCall.hint).toContain("Background host command error");
     expect(wakeCall.hint).toContain("spawn ENOENT");
   });

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -273,10 +273,11 @@ describe("host_bash — regression: no proxied-mode additions", () => {
     expect(schemaProps).not.toHaveProperty("credential_ids");
   });
 
-  test("schema only contains the expected properties (command, working_dir, timeout_seconds, activity)", () => {
+  test("schema only contains the expected properties (command, working_dir, timeout_seconds, activity, background)", () => {
     const propertyNames = Object.keys(schemaProps).sort();
     expect(propertyNames).toEqual([
       "activity",
+      "background",
       "command",
       "timeout_seconds",
       "working_dir",

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -23,8 +23,14 @@ import { isCesShellLockdownEnabled } from "../../credential-execution/feature-ga
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
+import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
+import {
+  generateBackgroundToolId,
+  registerBackgroundTool,
+  removeBackgroundTool,
+} from "../background-tool-registry.js";
 import { formatShellOutput } from "../shared/shell-output.js";
 import { buildSanitizedEnv } from "../terminal/safe-env.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
@@ -117,6 +123,11 @@ class HostShellTool implements Tool {
             description:
               "Optional timeout in seconds. Uses configured default and max limits.",
           },
+          background: {
+            type: "boolean",
+            description:
+              "Run the command in the background on the host machine. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
+          },
         },
         required: ["command", "activity"],
       },
@@ -157,6 +168,8 @@ class HostShellTool implements Tool {
         isError: true,
       };
     }
+    const background = input.background === true;
+
     const config = getConfig();
     const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = config.timeouts;
 
@@ -192,6 +205,58 @@ class HostShellTool implements Tool {
         hostLockdownActive,
         context.conversationId,
       );
+
+      if (background) {
+        const bgId = generateBackgroundToolId();
+        const proxyPromise = context.hostBashProxy.request(
+          {
+            command,
+            working_dir: rawWorkingDir as string | undefined,
+            timeout_seconds: normalizedTimeout,
+            env: proxyEnv,
+          },
+          context.conversationId,
+          context.signal,
+        );
+
+        proxyPromise
+          .then((result) => {
+            const hint = result.isError
+              ? `Background host command failed:\n${result.content}`
+              : result.content || "(no output)";
+            void wakeAgentForOpportunity({
+              conversationId: context.conversationId,
+              hint,
+              source: "background-tool",
+            });
+          })
+          .catch((err) => {
+            void wakeAgentForOpportunity({
+              conversationId: context.conversationId,
+              hint: `Background host command error: ${err instanceof Error ? err.message : String(err)}`,
+              source: "background-tool",
+            });
+          })
+          .finally(() => removeBackgroundTool(bgId));
+
+        registerBackgroundTool({
+          id: bgId,
+          toolName: "host_bash",
+          conversationId: context.conversationId,
+          command,
+          startedAt: Date.now(),
+          cancel: () => {
+            // The proxy handles its own timeout; cancel is a no-op since we
+            // cannot easily abort a proxy request after it's been sent.
+          },
+        });
+
+        return {
+          content: JSON.stringify({ backgrounded: true, id: bgId }),
+          isError: false,
+        };
+      }
+
       return context.hostBashProxy.request(
         {
           command,
@@ -221,24 +286,110 @@ class HostShellTool implements Tool {
         timeoutSec,
         conversationId: context.conversationId,
         hostLockdownActive,
+        background,
       },
       "Executing host shell command",
     );
+
+    const hostEnv = buildHostShellEnv();
+    // Inject VELLUM_UNTRUSTED_SHELL=1 so assistant CLI commands self-deny
+    // raw-token/secret reveal flows when invoked from an untrusted shell.
+    if (hostLockdownActive) {
+      hostEnv.VELLUM_UNTRUSTED_SHELL = "1";
+    }
+    // Match `bash` tool behavior so nested assistant CLI calls can bind to
+    // the active conversation when running through host_bash.
+    hostEnv.__CONVERSATION_ID = context.conversationId;
+
+    if (background) {
+      const bgId = generateBackgroundToolId();
+
+      const child = spawn("bash", ["-c", "--", command], {
+        cwd: workingDir,
+        env: hostEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let timedOut = false;
+
+      const killTree = () => {
+        if (child.pid != null) {
+          try {
+            process.kill(-child.pid, "SIGKILL");
+            return;
+          } catch {
+            // Process group may have already exited — fall through.
+          }
+        }
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Child may have already exited.
+        }
+      };
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        killTree();
+      }, timeoutMs);
+
+      child.stdout.on("data", (data: Buffer) => stdoutChunks.push(data));
+      child.stderr.on("data", (data: Buffer) => stderrChunks.push(data));
+
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        const stdout = Buffer.concat(stdoutChunks).toString();
+        const stderr = Buffer.concat(stderrChunks).toString();
+        const result = formatShellOutput(
+          stdout,
+          stderr,
+          code,
+          timedOut,
+          timeoutSec,
+        );
+        const hint = result.isError
+          ? `Background host command failed:\n${result.content}`
+          : result.content || "(no output)";
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint,
+          source: "background-tool",
+        });
+        removeBackgroundTool(bgId);
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint: `Background host command error: ${err.message}`,
+          source: "background-tool",
+        });
+        removeBackgroundTool(bgId);
+      });
+
+      registerBackgroundTool({
+        id: bgId,
+        toolName: "host_bash",
+        conversationId: context.conversationId,
+        command,
+        startedAt: Date.now(),
+        cancel: killTree,
+      });
+
+      return {
+        content: JSON.stringify({ backgrounded: true, id: bgId }),
+        isError: false,
+      };
+    }
 
     return new Promise<ToolExecutionResult>((resolve) => {
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
-
-      const hostEnv = buildHostShellEnv();
-      // Inject VELLUM_UNTRUSTED_SHELL=1 so assistant CLI commands self-deny
-      // raw-token/secret reveal flows when invoked from an untrusted shell.
-      if (hostLockdownActive) {
-        hostEnv.VELLUM_UNTRUSTED_SHELL = "1";
-      }
-      // Match `bash` tool behavior so nested assistant CLI calls can bind to
-      // the active conversation when running through host_bash.
-      hostEnv.__CONVERSATION_ID = context.conversationId;
 
       const child = spawn("bash", ["-c", "--", command], {
         cwd: workingDir,


### PR DESCRIPTION
## Summary
- Add `background` boolean input to the host_bash tool schema
- Proxy path: fire the request without awaiting, wake on proxy resolution
- Direct execution path: spawn detached, return immediately, wake on process exit
- Register/remove from the background tool registry for list/cancel support

Part of plan: bg-shell-tools.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
