### PR TITLE
fix: wire AbortController for proxy-path background cancel

### DIFF
--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -208,6 +208,7 @@ class HostShellTool implements Tool {
 
       if (background) {
         const bgId = generateBackgroundToolId();
+        const abortController = new AbortController();
         const proxyPromise = context.hostBashProxy.request(
           {
             command,
@@ -216,7 +217,7 @@ class HostShellTool implements Tool {
             env: proxyEnv,
           },
           context.conversationId,
-          context.signal,
+          abortController.signal,
         );
 
         proxyPromise
@@ -245,10 +246,7 @@ class HostShellTool implements Tool {
           conversationId: context.conversationId,
           command,
           startedAt: Date.now(),
-          cancel: () => {
-            // The proxy handles its own timeout; cancel is a no-op since we
-            // cannot easily abort a proxy request after it's been sent.
-          },
+          cancel: () => abortController.abort(),
         });
 
         return {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for bg-shell-tools.md.

**Gap:** Proxy cancel is a no-op
**What was expected:** Cancel should abort the proxy request
**What was found:** Cancel callback was a no-op
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
