### PR TITLE
fix: include bgId in host_bash background wake hints

### DIFF
--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -235,7 +235,9 @@ describe("host_bash background mode — proxy path", () => {
       mockWakeAgentForOpportunity.mock.calls as unknown[][]
     )[0]![0] as Record<string, unknown>;
     expect(wakeCall.conversationId).toBe("conv-xyz");
-    expect(wakeCall.hint).toBe("proxy success output");
+    expect(wakeCall.hint).toBe(
+      "Background host command completed (id=bg-test-0001):\nproxy success output",
+    );
     expect(wakeCall.source).toBe("background-tool");
   });
 
@@ -294,7 +296,7 @@ describe("host_bash background mode — proxy path", () => {
     const wakeCall = (
       mockWakeAgentForOpportunity.mock.calls as unknown[][]
     )[0]![0] as Record<string, unknown>;
-    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("Background host command failed");
     expect(wakeCall.hint).toContain("proxy transport error");
   });
 
@@ -424,7 +426,7 @@ describe("host_bash background mode — direct execution path", () => {
     const wakeCall = (
       mockWakeAgentForOpportunity.mock.calls as unknown[][]
     )[0]![0] as Record<string, unknown>;
-    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("Background host command failed");
     expect(wakeCall.hint).toContain("spawn ENOENT");
   });
 

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -222,8 +222,8 @@ class HostShellTool implements Tool {
         proxyPromise
           .then((result) => {
             const hint = result.isError
-              ? `Background host command failed:\n${result.content}`
-              : result.content || "(no output)";
+              ? `Background host command failed (id=${bgId}):\n${result.content}`
+              : `Background host command completed (id=${bgId}):\n${result.content || "(no output)"}`;
             void wakeAgentForOpportunity({
               conversationId: context.conversationId,
               hint,
@@ -233,7 +233,7 @@ class HostShellTool implements Tool {
           .catch((err) => {
             void wakeAgentForOpportunity({
               conversationId: context.conversationId,
-              hint: `Background host command error: ${err instanceof Error ? err.message : String(err)}`,
+              hint: `Background host command failed (id=${bgId}): ${err instanceof Error ? err.message : String(err)}`,
               source: "background-tool",
             });
           })
@@ -351,8 +351,8 @@ class HostShellTool implements Tool {
           timeoutSec,
         );
         const hint = result.isError
-          ? `Background host command failed:\n${result.content}`
-          : result.content || "(no output)";
+          ? `Background host command failed (id=${bgId}):\n${result.content}`
+          : `Background host command completed (id=${bgId}):\n${result.content || "(no output)"}`;
         void wakeAgentForOpportunity({
           conversationId: context.conversationId,
           hint,
@@ -365,7 +365,7 @@ class HostShellTool implements Tool {
         clearTimeout(timer);
         void wakeAgentForOpportunity({
           conversationId: context.conversationId,
-          hint: `Background host command error: ${err.message}`,
+          hint: `Background host command failed (id=${bgId}): ${err.message}`,
           source: "background-tool",
         });
         removeBackgroundTool(bgId);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for bg-shell-tools.md.

**Gap:** Inconsistent hint format between bash and host_bash
**What was expected:** Both tools include bgId in wake hints
**What was found:** host_bash omitted bgId from all hint messages

Updates all six hint locations in host-shell.ts (proxy path success/error, direct path close/error) to include the bgId for correlation, matching the bash tool's pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
