### PR TITLE
fix: check background tool limit before spawning process

### DIFF
--- a/assistant/src/__tests__/background-shell-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-bash.test.ts
@@ -76,10 +76,14 @@ const mockRemoveBackgroundTool = mock((_id: string) => {
 });
 const mockGenerateBackgroundToolId = mock(() => "bg-test1234");
 
+const mockIsBackgroundToolLimitReached = mock(() => false);
+
 mock.module("../tools/background-tool-registry.js", () => ({
   registerBackgroundTool: mockRegisterBackgroundTool,
   removeBackgroundTool: mockRemoveBackgroundTool,
   generateBackgroundToolId: mockGenerateBackgroundToolId,
+  isBackgroundToolLimitReached: mockIsBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS: 20,
 }));
 
 // ── Imports (after mocks) ───────────────────────────────────────────────────
@@ -121,6 +125,8 @@ describe("bash tool background mode", () => {
     mockRemoveBackgroundTool.mockClear();
     mockGenerateBackgroundToolId.mockClear();
     mockGenerateBackgroundToolId.mockReturnValue("bg-test1234");
+    mockIsBackgroundToolLimitReached.mockClear();
+    mockIsBackgroundToolLimitReached.mockReturnValue(false);
     registeredTools.length = 0;
 
     const mod = await import("../tools/terminal/shell.js");

--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -18,10 +18,14 @@ const mockGenerateBackgroundToolId = mock(
   () => `bg-test-${String(++bgIdCounter).padStart(4, "0")}`,
 );
 
+const mockIsBackgroundToolLimitReached = mock(() => false);
+
 mock.module("../tools/background-tool-registry.js", () => ({
   registerBackgroundTool: mockRegisterBackgroundTool,
   removeBackgroundTool: mockRemoveBackgroundTool,
   generateBackgroundToolId: mockGenerateBackgroundToolId,
+  isBackgroundToolLimitReached: mockIsBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS: 20,
 }));
 
 // Stub child_process.spawn so we don't actually run commands. The test
@@ -151,6 +155,8 @@ beforeEach(() => {
   mockRegisterBackgroundTool.mockClear();
   mockRemoveBackgroundTool.mockClear();
   mockGenerateBackgroundToolId.mockClear();
+  mockIsBackgroundToolLimitReached.mockClear();
+  mockIsBackgroundToolLimitReached.mockReturnValue(false);
   latestChild = undefined;
 });
 

--- a/assistant/src/tools/background-tool-registry.ts
+++ b/assistant/src/tools/background-tool-registry.ts
@@ -80,6 +80,16 @@ export function generateBackgroundToolId(): string {
 }
 
 /**
+ * Returns `true` when the registry is at or over the {@link MAX_BACKGROUND_TOOLS}
+ * limit, meaning no new background tools can be registered. Callers should
+ * check this **before** spawning a process to avoid leaking untracked
+ * processes.
+ */
+export function isBackgroundToolLimitReached(): boolean {
+  return registry.size >= MAX_BACKGROUND_TOOLS;
+}
+
+/**
  * Clears the entire registry. Intended for test cleanup only — production
  * code should use {@link cancelBackgroundTool} or {@link removeBackgroundTool}.
  */

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -28,6 +28,8 @@ import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import {
   generateBackgroundToolId,
+  isBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS,
   registerBackgroundTool,
   removeBackgroundTool,
 } from "../background-tool-registry.js";
@@ -207,6 +209,15 @@ class HostShellTool implements Tool {
       );
 
       if (background) {
+        // Check the registry limit BEFORE starting the proxy request so we
+        // never leak an untracked proxy when the registry is full.
+        if (isBackgroundToolLimitReached()) {
+          return {
+            content: `Error: background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+            isError: true,
+          };
+        }
+
         const bgId = generateBackgroundToolId();
         const proxyPromise = context.hostBashProxy.request(
           {
@@ -302,6 +313,15 @@ class HostShellTool implements Tool {
     hostEnv.__CONVERSATION_ID = context.conversationId;
 
     if (background) {
+      // Check the registry limit BEFORE spawning so we never leak an
+      // untracked process when the registry is full.
+      if (isBackgroundToolLimitReached()) {
+        return {
+          content: `Error: background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+          isError: true,
+        };
+      }
+
       const bgId = generateBackgroundToolId();
 
       const child = spawn("bash", ["-c", "--", command], {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -18,6 +18,8 @@ import {
 } from "../../util/platform.js";
 import {
   generateBackgroundToolId,
+  isBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS,
   registerBackgroundTool,
   removeBackgroundTool,
 } from "../background-tool-registry.js";
@@ -352,6 +354,15 @@ class ShellTool implements Tool {
     // -----------------------------------------------------------------------
     const background = input.background === true;
     if (background) {
+      // Check the registry limit BEFORE spawning so we never leak an
+      // untracked process when the registry is full.
+      if (isBackgroundToolLimitReached()) {
+        return {
+          content: `Error: background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+          isError: true,
+        };
+      }
+
       const bgId = generateBackgroundToolId();
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for bg-shell-tools.md.

**Gap:** Process leak at MAX_BACKGROUND_TOOLS limit
**What was expected:** Clean error without spawning when registry is full
**What was found:** Process spawned before register, leaks if registry throws

### Changes

- Added `isBackgroundToolLimitReached()` helper to `background-tool-registry.ts` that checks whether the registry is at or over the `MAX_BACKGROUND_TOOLS` limit
- Added pre-spawn limit checks in all three background spawn sites:
  1. `shell.ts` — bash direct background spawn
  2. `host-shell.ts` — host_bash proxy background request
  3. `host-shell.ts` — host_bash direct background spawn
- Each site now returns a clean error result immediately without spawning the process/proxy when the limit is reached
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
