### PR TITLE
Background mode for bash and host_bash tools

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -1376,6 +1376,85 @@ paths:
                 - eyeStyle
                 - color
               additionalProperties: false
+  /v1/background-tools:
+    get:
+      operationId: backgroundtools_get
+      summary: List active background tools
+      description: List all active background tool executions, optionally filtered by conversationId.
+      tags:
+        - background-tools
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tools:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        toolName:
+                          type: string
+                        conversationId:
+                          type: string
+                        command:
+                          type: string
+                        startedAt:
+                          type: number
+                      required:
+                        - id
+                        - toolName
+                        - conversationId
+                        - command
+                        - startedAt
+                      additionalProperties: false
+                required:
+                  - tools
+                additionalProperties: false
+      parameters:
+        - name: conversationId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by conversation ID
+  /v1/background-tools/cancel:
+    post:
+      operationId: backgroundtools_cancel_post
+      summary: Cancel a background tool
+      description: Cancel an active background tool execution by ID.
+      tags:
+        - background-tools
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cancelled:
+                    type: boolean
+                required:
+                  - cancelled
+                additionalProperties: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+              required:
+                - id
+              additionalProperties: false
   /v1/backups:
     get:
       operationId: backups_get

--- a/assistant/src/__tests__/background-shell-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-bash.test.ts
@@ -76,10 +76,14 @@ const mockRemoveBackgroundTool = mock((_id: string) => {
 });
 const mockGenerateBackgroundToolId = mock(() => "bg-test1234");
 
+const mockIsBackgroundToolLimitReached = mock(() => false);
+
 mock.module("../tools/background-tool-registry.js", () => ({
   registerBackgroundTool: mockRegisterBackgroundTool,
   removeBackgroundTool: mockRemoveBackgroundTool,
   generateBackgroundToolId: mockGenerateBackgroundToolId,
+  isBackgroundToolLimitReached: mockIsBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS: 20,
 }));
 
 // ── Imports (after mocks) ───────────────────────────────────────────────────
@@ -121,6 +125,8 @@ describe("bash tool background mode", () => {
     mockRemoveBackgroundTool.mockClear();
     mockGenerateBackgroundToolId.mockClear();
     mockGenerateBackgroundToolId.mockReturnValue("bg-test1234");
+    mockIsBackgroundToolLimitReached.mockClear();
+    mockIsBackgroundToolLimitReached.mockReturnValue(false);
     registeredTools.length = 0;
 
     const mod = await import("../tools/terminal/shell.js");

--- a/assistant/src/__tests__/background-shell-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-bash.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { WakeOptions } from "../runtime/agent-wake.js";
+import type { BackgroundTool } from "../tools/background-tool-registry.js";
+import type { Tool } from "../tools/types.js";
+
+// ── Mock modules ────────────────────────────────────────────────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target: Record<string, unknown>, _prop: string) => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    timeouts: { shellDefaultTimeoutSec: 120, shellMaxTimeoutSec: 600 },
+    sandbox: {
+      enabled: false,
+      backend: "native",
+      docker: {
+        image: "vellum-sandbox:latest",
+        shell: "bash",
+        cpus: 1,
+        memoryMb: 512,
+        pidsLimit: 256,
+        network: "none",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+mock.module("../tools/network/script-proxy/index.js", () => ({
+  getOrStartSession: mock(() =>
+    Promise.resolve({ session: { id: "mock-session" } }),
+  ),
+  getSessionEnv: mock(() => ({
+    HTTP_PROXY: "http://localhost:9999",
+    HTTPS_PROXY: "http://localhost:9999",
+  })),
+  createSession: () => {},
+  startSession: () => {},
+  stopSession: () => {},
+  getActiveSession: () => null,
+  getSessionsForConversation: () => [],
+  stopAllSessions: () => {},
+  ensureLocalCA: () => {},
+  ensureCombinedCABundle: () => {},
+  issueLeafCert: () => {},
+  getCAPath: () => "",
+  getCombinedCAPath: () => "",
+}));
+
+const mockWakeAgentForOpportunity = mock(
+  (
+    _opts: WakeOptions,
+  ): Promise<{ invoked: boolean; producedToolCalls: boolean }> =>
+    Promise.resolve({ invoked: true, producedToolCalls: false }),
+);
+
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: mockWakeAgentForOpportunity,
+}));
+
+const registeredTools: BackgroundTool[] = [];
+
+const mockRegisterBackgroundTool = mock((tool: BackgroundTool) => {
+  registeredTools.push(tool);
+});
+const mockRemoveBackgroundTool = mock((_id: string) => {
+  const idx = registeredTools.findIndex((t) => t.id === _id);
+  if (idx !== -1) registeredTools.splice(idx, 1);
+});
+const mockGenerateBackgroundToolId = mock(() => "bg-test1234");
+
+mock.module("../tools/background-tool-registry.js", () => ({
+  registerBackgroundTool: mockRegisterBackgroundTool,
+  removeBackgroundTool: mockRemoveBackgroundTool,
+  generateBackgroundToolId: mockGenerateBackgroundToolId,
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────
+
+const baseContext = {
+  workingDir: process.env.VELLUM_WORKSPACE_DIR ?? "/tmp",
+  conversationId: "conv-bg-test",
+  trustClass: "guardian" as const,
+  onOutput: () => {},
+};
+
+/** Poll until `mockFn` has been called at least once (10 s timeout). */
+function waitForWake(
+  mockFn: ReturnType<typeof mock>,
+  timeoutMs = 10_000,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("timed out waiting for wakeAgentForOpportunity")),
+      timeoutMs,
+    );
+    const check = () => {
+      if (mockFn.mock.calls.length > 0) {
+        clearTimeout(timer);
+        return resolve();
+      }
+      setTimeout(check, 50);
+    };
+    check();
+  });
+}
+
+describe("bash tool background mode", () => {
+  let shellTool: Tool;
+
+  beforeEach(async () => {
+    mockWakeAgentForOpportunity.mockClear();
+    mockRegisterBackgroundTool.mockClear();
+    mockRemoveBackgroundTool.mockClear();
+    mockGenerateBackgroundToolId.mockClear();
+    mockGenerateBackgroundToolId.mockReturnValue("bg-test1234");
+    registeredTools.length = 0;
+
+    const mod = await import("../tools/terminal/shell.js");
+    shellTool = mod.shellTool;
+  });
+
+  afterEach(() => {
+    registeredTools.length = 0;
+  });
+
+  test("background: true returns immediately with backgrounded payload", async () => {
+    const result = await shellTool.execute(
+      { command: "echo hello", activity: "test", background: true },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.backgrounded).toBe(true);
+    expect(parsed.id).toBe("bg-test1234");
+
+    // Wait for background process to settle so it doesn't leak into later tests.
+    await waitForWake(mockWakeAgentForOpportunity);
+  });
+
+  test("background process registers in the background tool registry", async () => {
+    await shellTool.execute(
+      { command: "echo hello", activity: "test", background: true },
+      baseContext,
+    );
+
+    expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
+    const registered = mockRegisterBackgroundTool.mock
+      .calls[0]![0] as BackgroundTool;
+    expect(registered.id).toBe("bg-test1234");
+    expect(registered.toolName).toBe("bash");
+    expect(registered.conversationId).toBe("conv-bg-test");
+    expect(registered.command).toBe("echo hello");
+    expect(typeof registered.cancel).toBe("function");
+
+    // Wait for background process to settle so it doesn't leak into later tests.
+    await waitForWake(mockWakeAgentForOpportunity);
+  });
+
+  test("background process completion triggers wakeAgentForOpportunity with stdout", async () => {
+    await shellTool.execute(
+      { command: "echo bg_output_12345", activity: "test", background: true },
+      baseContext,
+    );
+
+    // Wait for the background process to complete and fire the wake.
+    await waitForWake(mockWakeAgentForOpportunity);
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith("bg-test1234");
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+
+    const wakeCall = mockWakeAgentForOpportunity.mock
+      .calls[0]![0] as WakeOptions;
+    expect(wakeCall.conversationId).toBe("conv-bg-test");
+    expect(wakeCall.source).toBe("background-tool");
+    expect(wakeCall.hint).toContain("bg_output_12345");
+    expect(wakeCall.hint).toContain("bg-test1234");
+  });
+
+  test("failing background process delivers an error hint via wake", async () => {
+    await shellTool.execute(
+      { command: "exit 1", activity: "test", background: true },
+      baseContext,
+    );
+
+    // Wait for the background process to complete.
+    await waitForWake(mockWakeAgentForOpportunity);
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith("bg-test1234");
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+
+    const wakeCall = mockWakeAgentForOpportunity.mock
+      .calls[0]![0] as WakeOptions;
+    expect(wakeCall.conversationId).toBe("conv-bg-test");
+    expect(wakeCall.source).toBe("background-tool");
+    expect(wakeCall.hint).toContain("bg-test1234");
+    // The command fails with exit code 1, so the hint should reflect failure
+    expect(wakeCall.hint).toContain("exit=1");
+  });
+
+  test("foreground mode still works when background is not set", async () => {
+    const result = await shellTool.execute(
+      { command: "echo foreground_test_789", activity: "test" },
+      baseContext,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("foreground_test_789");
+    // Background registry should not be touched for foreground commands
+    expect(mockRegisterBackgroundTool).not.toHaveBeenCalled();
+    expect(mockWakeAgentForOpportunity).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -18,10 +18,14 @@ const mockGenerateBackgroundToolId = mock(
   () => `bg-test-${String(++bgIdCounter).padStart(4, "0")}`,
 );
 
+const mockIsBackgroundToolLimitReached = mock(() => false);
+
 mock.module("../tools/background-tool-registry.js", () => ({
   registerBackgroundTool: mockRegisterBackgroundTool,
   removeBackgroundTool: mockRemoveBackgroundTool,
   generateBackgroundToolId: mockGenerateBackgroundToolId,
+  isBackgroundToolLimitReached: mockIsBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS: 20,
 }));
 
 // Stub child_process.spawn so we don't actually run commands. The test
@@ -151,6 +155,8 @@ beforeEach(() => {
   mockRegisterBackgroundTool.mockClear();
   mockRemoveBackgroundTool.mockClear();
   mockGenerateBackgroundToolId.mockClear();
+  mockIsBackgroundToolLimitReached.mockClear();
+  mockIsBackgroundToolLimitReached.mockReturnValue(false);
   latestChild = undefined;
 });
 

--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -241,7 +241,9 @@ describe("host_bash background mode — proxy path", () => {
       mockWakeAgentForOpportunity.mock.calls as unknown[][]
     )[0]![0] as Record<string, unknown>;
     expect(wakeCall.conversationId).toBe("conv-xyz");
-    expect(wakeCall.hint).toBe("proxy success output");
+    expect(wakeCall.hint).toBe(
+      "Background host command completed (id=bg-test-0001):\nproxy success output",
+    );
     expect(wakeCall.source).toBe("background-tool");
   });
 
@@ -300,7 +302,7 @@ describe("host_bash background mode — proxy path", () => {
     const wakeCall = (
       mockWakeAgentForOpportunity.mock.calls as unknown[][]
     )[0]![0] as Record<string, unknown>;
-    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("Background host command failed");
     expect(wakeCall.hint).toContain("proxy transport error");
   });
 
@@ -430,7 +432,7 @@ describe("host_bash background mode — direct execution path", () => {
     const wakeCall = (
       mockWakeAgentForOpportunity.mock.calls as unknown[][]
     )[0]![0] as Record<string, unknown>;
-    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("Background host command failed");
     expect(wakeCall.hint).toContain("spawn ENOENT");
   });
 

--- a/assistant/src/__tests__/background-shell-host-bash.test.ts
+++ b/assistant/src/__tests__/background-shell-host-bash.test.ts
@@ -1,0 +1,466 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before importing the tool under test.
+// ---------------------------------------------------------------------------
+
+const mockWakeAgentForOpportunity = mock(() => Promise.resolve());
+
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: mockWakeAgentForOpportunity,
+}));
+
+const mockRegisterBackgroundTool = mock(() => {});
+const mockRemoveBackgroundTool = mock(() => {});
+let bgIdCounter = 0;
+const mockGenerateBackgroundToolId = mock(
+  () => `bg-test-${String(++bgIdCounter).padStart(4, "0")}`,
+);
+
+mock.module("../tools/background-tool-registry.js", () => ({
+  registerBackgroundTool: mockRegisterBackgroundTool,
+  removeBackgroundTool: mockRemoveBackgroundTool,
+  generateBackgroundToolId: mockGenerateBackgroundToolId,
+}));
+
+// Stub child_process.spawn so we don't actually run commands. The test
+// creates a fake ChildProcess (EventEmitter) and drives it manually.
+type FakeChild = EventEmitter & {
+  pid: number;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof mock>;
+};
+
+let latestChild: FakeChild | undefined;
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = 12345;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = mock(() => {});
+  latestChild = child;
+  return child;
+}
+
+mock.module("node:child_process", () => ({
+  spawn: mock(() => makeFakeChild()),
+}));
+
+const mockConfig = {
+  provider: "anthropic",
+  model: "test",
+  maxTokens: 4096,
+  dataDir: "/tmp",
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  rateLimit: { maxRequestsPerMinute: 0 },
+  secretDetection: {
+    enabled: true,
+    action: "warn" as const,
+    entropyThreshold: 4.0,
+  },
+  auditLog: { retentionDays: 0 },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  loadConfig: () => mockConfig,
+  invalidateConfigCache: () => {},
+  saveConfig: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../tools/terminal/sandbox.js", () => ({
+  wrapCommand: (...args: unknown[]) => ({
+    command: "bash",
+    args: ["-c", "--", args[0]],
+    sandboxed: false,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test — MUST come after mock.module calls.
+// ---------------------------------------------------------------------------
+
+import { hostShellTool } from "../tools/host-terminal/host-shell.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp",
+    conversationId: "conv-xyz",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+function makeMockProxy(result: ToolExecutionResult) {
+  const requestMock = mock(
+    (
+      _input: {
+        command: string;
+        working_dir?: string;
+        timeout_seconds?: number;
+        env?: Record<string, string>;
+      },
+      _conversationId: string,
+      _signal?: AbortSignal,
+    ) => Promise.resolve(result),
+  );
+
+  return {
+    proxy: {
+      isAvailable: () => true,
+      request: requestMock,
+      updateSender: () => {},
+      dispose: () => {},
+      resolve: () => {},
+      hasPendingRequest: () => false,
+    },
+    requestMock,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  bgIdCounter = 0;
+  mockWakeAgentForOpportunity.mockClear();
+  mockRegisterBackgroundTool.mockClear();
+  mockRemoveBackgroundTool.mockClear();
+  mockGenerateBackgroundToolId.mockClear();
+  latestChild = undefined;
+});
+
+afterEach(() => {
+  latestChild = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Proxy path — background: true
+// ---------------------------------------------------------------------------
+
+describe("host_bash background mode — proxy path", () => {
+  test("returns immediately with backgrounded response", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxy output",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.backgrounded).toBe(true);
+    expect(parsed.id).toMatch(/^bg-/);
+    expect(result.isError).toBe(false);
+  });
+
+  test("registers background tool in the registry", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxy output",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
+    const registered = (
+      mockRegisterBackgroundTool.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(registered.toolName).toBe("host_bash");
+    expect(registered.conversationId).toBe("conv-xyz");
+    expect(registered.command).toBe("echo bg-proxy");
+  });
+
+  test("calls wakeAgentForOpportunity on proxy success", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "proxy success output",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    // The proxy resolves immediately in our mock, so the .then() handler runs
+    // in the next microtask. Flush microtasks.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(wakeCall.conversationId).toBe("conv-xyz");
+    expect(wakeCall.hint).toBe("proxy success output");
+    expect(wakeCall.source).toBe("background-tool");
+  });
+
+  test("calls wakeAgentForOpportunity on proxy error result", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "command not found",
+      isError: true,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "bad-command", background: true },
+      ctx,
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(wakeCall.hint).toContain("Background host command failed");
+    expect(wakeCall.hint).toContain("command not found");
+  });
+
+  test("calls wakeAgentForOpportunity on proxy rejection", async () => {
+    const requestMock = mock(() =>
+      Promise.reject(new Error("proxy transport error")),
+    );
+
+    const proxy = {
+      isAvailable: () => true,
+      request: requestMock,
+      updateSender: () => {},
+      dispose: () => {},
+      resolve: () => {},
+      hasPendingRequest: () => false,
+    };
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    await hostShellTool.execute(
+      { command: "echo fail", background: true },
+      ctx,
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("proxy transport error");
+  });
+
+  test("removes background tool from registry on completion", async () => {
+    const proxyResult: ToolExecutionResult = {
+      content: "done",
+      isError: false,
+    };
+    const { proxy } = makeMockProxy(proxyResult);
+
+    const ctx = makeContext({
+      hostBashProxy: proxy as unknown as ToolContext["hostBashProxy"],
+    });
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-proxy", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+
+    // Flush microtasks
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledTimes(1);
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith(parsed.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct execution path — background: true
+// ---------------------------------------------------------------------------
+
+describe("host_bash background mode — direct execution path", () => {
+  test("returns immediately with backgrounded response", async () => {
+    const ctx = makeContext();
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.backgrounded).toBe(true);
+    expect(parsed.id).toMatch(/^bg-/);
+    expect(result.isError).toBe(false);
+  });
+
+  test("registers background tool in the registry", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    expect(mockRegisterBackgroundTool).toHaveBeenCalledTimes(1);
+    const registered = (
+      mockRegisterBackgroundTool.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(registered.toolName).toBe("host_bash");
+    expect(registered.conversationId).toBe("conv-xyz");
+    expect(registered.command).toBe("echo bg-local");
+    expect(typeof registered.cancel).toBe("function");
+  });
+
+  test("calls wakeAgentForOpportunity on process exit", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    expect(latestChild).toBeDefined();
+
+    // Simulate stdout data and process close
+    latestChild!.stdout.emit("data", Buffer.from("hello world\n"));
+    latestChild!.emit("close", 0);
+
+    // Flush microtasks
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(wakeCall.conversationId).toBe("conv-xyz");
+    expect(wakeCall.source).toBe("background-tool");
+    expect(wakeCall.hint).toContain("hello world");
+  });
+
+  test("calls wakeAgentForOpportunity with error hint on non-zero exit", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute({ command: "false", background: true }, ctx);
+
+    expect(latestChild).toBeDefined();
+
+    latestChild!.stderr.emit("data", Buffer.from("something failed\n"));
+    latestChild!.emit("close", 1);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(wakeCall.hint).toContain("Background host command failed");
+  });
+
+  test("calls wakeAgentForOpportunity on spawn error", async () => {
+    const ctx = makeContext();
+
+    await hostShellTool.execute(
+      { command: "echo bg-error", background: true },
+      ctx,
+    );
+
+    expect(latestChild).toBeDefined();
+
+    latestChild!.emit("error", new Error("spawn ENOENT"));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
+    const wakeCall = (
+      mockWakeAgentForOpportunity.mock.calls as unknown[][]
+    )[0]![0] as Record<string, unknown>;
+    expect(wakeCall.hint).toContain("Background host command error");
+    expect(wakeCall.hint).toContain("spawn ENOENT");
+  });
+
+  test("removes background tool from registry on process exit", async () => {
+    const ctx = makeContext();
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-local", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+
+    latestChild!.emit("close", 0);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledTimes(1);
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith(parsed.id);
+  });
+
+  test("removes background tool from registry on spawn error", async () => {
+    const ctx = makeContext();
+
+    const result = await hostShellTool.execute(
+      { command: "echo bg-error", background: true },
+      ctx,
+    );
+
+    const parsed = JSON.parse(result.content);
+
+    latestChild!.emit("error", new Error("spawn ENOENT"));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledTimes(1);
+    expect(mockRemoveBackgroundTool).toHaveBeenCalledWith(parsed.id);
+  });
+});

--- a/assistant/src/__tests__/background-tool-registry.test.ts
+++ b/assistant/src/__tests__/background-tool-registry.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  _clearRegistryForTesting,
+  type BackgroundTool,
+  cancelBackgroundTool,
+  generateBackgroundToolId,
+  listBackgroundTools,
+  MAX_BACKGROUND_TOOLS,
+  registerBackgroundTool,
+  removeBackgroundTool,
+} from "../tools/background-tool-registry.js";
+
+function makeTool(overrides: Partial<BackgroundTool> = {}): BackgroundTool {
+  return {
+    id: overrides.id ?? generateBackgroundToolId(),
+    toolName: overrides.toolName ?? "bash",
+    conversationId: overrides.conversationId ?? "conv-xyz",
+    command: overrides.command ?? "echo hello",
+    startedAt: overrides.startedAt ?? Date.now(),
+    cancel: overrides.cancel ?? mock(() => {}),
+  };
+}
+
+describe("background-tool-registry", () => {
+  beforeEach(() => {
+    _clearRegistryForTesting();
+  });
+
+  describe("register / list / remove lifecycle", () => {
+    test("registers a tool and lists it", () => {
+      const tool = makeTool({ id: "bg-00000001" });
+      registerBackgroundTool(tool);
+
+      const listed = listBackgroundTools();
+      expect(listed).toHaveLength(1);
+      expect(listed[0]!.id).toBe("bg-00000001");
+    });
+
+    test("removes a tool by ID", () => {
+      const tool = makeTool({ id: "bg-00000002" });
+      registerBackgroundTool(tool);
+      expect(listBackgroundTools()).toHaveLength(1);
+
+      removeBackgroundTool("bg-00000002");
+      expect(listBackgroundTools()).toHaveLength(0);
+    });
+
+    test("removing a non-existent ID is a no-op", () => {
+      registerBackgroundTool(makeTool({ id: "bg-00000003" }));
+      removeBackgroundTool("bg-nonexistent");
+      expect(listBackgroundTools()).toHaveLength(1);
+    });
+  });
+
+  describe("cancelBackgroundTool", () => {
+    test("calls cancel(), removes the entry, and returns true", () => {
+      const cancelFn = mock(() => {});
+      const tool = makeTool({ id: "bg-cancel-1", cancel: cancelFn });
+      registerBackgroundTool(tool);
+
+      const result = cancelBackgroundTool("bg-cancel-1");
+
+      expect(result).toBe(true);
+      expect(cancelFn).toHaveBeenCalledTimes(1);
+      expect(listBackgroundTools()).toHaveLength(0);
+    });
+
+    test("returns false for unknown IDs", () => {
+      const result = cancelBackgroundTool("bg-unknown");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("listBackgroundTools filtering", () => {
+    test("returns all tools when no conversationId is provided", () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-a1", conversationId: "conv-1" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-a2", conversationId: "conv-2" }),
+      );
+
+      expect(listBackgroundTools()).toHaveLength(2);
+    });
+
+    test("filters by conversationId when provided", () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-b1", conversationId: "conv-1" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-b2", conversationId: "conv-2" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-b3", conversationId: "conv-1" }),
+      );
+
+      const filtered = listBackgroundTools("conv-1");
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map((t) => t.id).sort()).toEqual(["bg-b1", "bg-b3"]);
+
+      expect(listBackgroundTools("conv-2")).toHaveLength(1);
+      expect(listBackgroundTools("conv-nonexistent")).toHaveLength(0);
+    });
+  });
+
+  describe("MAX_BACKGROUND_TOOLS limit", () => {
+    test("throws when limit is exceeded", () => {
+      for (let i = 0; i < MAX_BACKGROUND_TOOLS; i++) {
+        registerBackgroundTool(makeTool({ id: `bg-lim-${i}` }));
+      }
+
+      expect(() =>
+        registerBackgroundTool(makeTool({ id: "bg-overflow" })),
+      ).toThrow(/Background tool limit reached/);
+      expect(listBackgroundTools()).toHaveLength(MAX_BACKGROUND_TOOLS);
+    });
+
+    test("allows registration after removing one at the limit", () => {
+      for (let i = 0; i < MAX_BACKGROUND_TOOLS; i++) {
+        registerBackgroundTool(makeTool({ id: `bg-cap-${i}` }));
+      }
+
+      removeBackgroundTool("bg-cap-0");
+      expect(() =>
+        registerBackgroundTool(makeTool({ id: "bg-cap-new" })),
+      ).not.toThrow();
+      expect(listBackgroundTools()).toHaveLength(MAX_BACKGROUND_TOOLS);
+    });
+  });
+
+  describe("generateBackgroundToolId", () => {
+    test("returns a bg- prefixed string", () => {
+      const id = generateBackgroundToolId();
+      expect(id).toMatch(/^bg-[a-f0-9]{8}$/);
+    });
+
+    test("generates unique IDs", () => {
+      const ids = new Set(
+        Array.from({ length: 50 }, () => generateBackgroundToolId()),
+      );
+      expect(ids.size).toBe(50);
+    });
+  });
+});

--- a/assistant/src/__tests__/background-tool-routes.test.ts
+++ b/assistant/src/__tests__/background-tool-routes.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ROUTES } from "../runtime/routes/background-tool-routes.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+import type { RouteDefinition } from "../runtime/routes/types.js";
+import {
+  _clearRegistryForTesting,
+  registerBackgroundTool,
+} from "../tools/background-tool-registry.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function findRoute(operationId: string): RouteDefinition | undefined {
+  return ROUTES.find((r) => r.operationId === operationId);
+}
+
+function makeTool(overrides: {
+  id: string;
+  toolName?: string;
+  conversationId?: string;
+  command?: string;
+  startedAt?: number;
+}) {
+  return {
+    id: overrides.id,
+    toolName: overrides.toolName ?? "bash",
+    conversationId: overrides.conversationId ?? "conv-1",
+    command: overrides.command ?? "sleep 10",
+    startedAt: overrides.startedAt ?? Date.now(),
+    cancel: mock(() => {}),
+  };
+}
+
+// ── Setup / Teardown ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  _clearRegistryForTesting();
+});
+
+afterEach(() => {
+  _clearRegistryForTesting();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("background tool routes", () => {
+  describe("GET /v1/background-tools (list)", () => {
+    test("returns empty array when no tools are registered", async () => {
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: unknown[];
+      };
+
+      expect(result.tools).toEqual([]);
+    });
+
+    test("returns registered tools with toolName field", async () => {
+      const tool = makeTool({
+        id: "bg-abc123",
+        toolName: "host_bash",
+        conversationId: "conv-1",
+        command: "npm test",
+        startedAt: 1700000000000,
+      });
+      registerBackgroundTool(tool);
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: Array<{
+          id: string;
+          toolName: string;
+          conversationId: string;
+          command: string;
+          startedAt: number;
+        }>;
+      };
+
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools[0]!.id).toBe("bg-abc123");
+      expect(result.tools[0]!.toolName).toBe("host_bash");
+      expect(result.tools[0]!.conversationId).toBe("conv-1");
+      expect(result.tools[0]!.command).toBe("npm test");
+      expect(result.tools[0]!.startedAt).toBe(1700000000000);
+    });
+
+    test("does not include the cancel function in the response", async () => {
+      registerBackgroundTool(makeTool({ id: "bg-1" }));
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: Array<Record<string, unknown>>;
+      };
+
+      expect(result.tools[0]).not.toHaveProperty("cancel");
+    });
+
+    test("filters by conversationId", async () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-1", conversationId: "conv-a" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-2", conversationId: "conv-b" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-3", conversationId: "conv-a" }),
+      );
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({
+        queryParams: { conversationId: "conv-a" },
+      })) as {
+        tools: Array<{ id: string }>;
+      };
+
+      expect(result.tools).toHaveLength(2);
+      expect(result.tools.map((t) => t.id).sort()).toEqual(["bg-1", "bg-3"]);
+    });
+
+    test("returns all tools when conversationId is not provided", async () => {
+      registerBackgroundTool(
+        makeTool({ id: "bg-1", conversationId: "conv-a" }),
+      );
+      registerBackgroundTool(
+        makeTool({ id: "bg-2", conversationId: "conv-b" }),
+      );
+
+      const route = findRoute("background_tool_list")!;
+      const result = (await route.handler({})) as {
+        tools: Array<{ id: string }>;
+      };
+
+      expect(result.tools).toHaveLength(2);
+    });
+  });
+
+  describe("POST /v1/background-tools/cancel", () => {
+    test("cancels a registered tool and returns cancelled: true", async () => {
+      const tool = makeTool({ id: "bg-cancel-me" });
+      registerBackgroundTool(tool);
+
+      const route = findRoute("background_tool_cancel")!;
+      const result = (await route.handler({
+        body: { id: "bg-cancel-me" },
+      })) as {
+        cancelled: boolean;
+      };
+
+      expect(result.cancelled).toBe(true);
+      expect(tool.cancel).toHaveBeenCalled();
+    });
+
+    test("returns cancelled: false for unknown ID", async () => {
+      const route = findRoute("background_tool_cancel")!;
+      const result = (await route.handler({
+        body: { id: "bg-nonexistent" },
+      })) as {
+        cancelled: boolean;
+      };
+
+      expect(result.cancelled).toBe(false);
+    });
+
+    test("throws BadRequestError when id is not provided", async () => {
+      const route = findRoute("background_tool_cancel")!;
+      await expect(route.handler({ body: {} })).rejects.toThrow(
+        BadRequestError,
+      );
+    });
+
+    test("throws BadRequestError when body is empty", async () => {
+      const route = findRoute("background_tool_cancel")!;
+      await expect(route.handler({})).rejects.toThrow(BadRequestError);
+    });
+  });
+});

--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -273,10 +273,11 @@ describe("host_bash — regression: no proxied-mode additions", () => {
     expect(schemaProps).not.toHaveProperty("credential_ids");
   });
 
-  test("schema only contains the expected properties (command, working_dir, timeout_seconds, activity)", () => {
+  test("schema only contains the expected properties (command, working_dir, timeout_seconds, activity, background)", () => {
     const propertyNames = Object.keys(schemaProps).sort();
     expect(propertyNames).toEqual([
       "activity",
+      "background",
       "command",
       "timeout_seconds",
       "working_dir",

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -717,6 +717,17 @@ registerPolicy("browser/execute", {
   allowedPrincipalTypes: ["local"],
 });
 
+// Background tools: local-only (CLI / IPC callers)
+registerPolicy("background-tools", {
+  requiredScopes: ["settings.read"],
+  allowedPrincipalTypes: ["local"],
+});
+
+registerPolicy("background-tools/cancel", {
+  requiredScopes: ["settings.write"],
+  allowedPrincipalTypes: ["local"],
+});
+
 // User-defined routes under /x/*
 registerPolicy("x", {
   requiredScopes: ["settings.read"],

--- a/assistant/src/runtime/routes/background-tool-routes.ts
+++ b/assistant/src/runtime/routes/background-tool-routes.ts
@@ -1,0 +1,94 @@
+/**
+ * Transport-agnostic routes for listing and cancelling background tools.
+ *
+ * Background tools are long-running processes (e.g. bash, host_bash) that the
+ * agent spawns in the background. These routes expose visibility and control
+ * over active background tool executions.
+ */
+
+import { z } from "zod";
+
+import {
+  cancelBackgroundTool,
+  listBackgroundTools,
+} from "../../tools/background-tool-registry.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+// ── Handlers ──────────────────────────────────────────────────────────
+
+async function handleBackgroundToolList({
+  queryParams = {},
+}: RouteHandlerArgs) {
+  const conversationId = queryParams.conversationId || undefined;
+  const tools = listBackgroundTools(conversationId);
+
+  return {
+    tools: tools.map((t) => ({
+      id: t.id,
+      toolName: t.toolName,
+      conversationId: t.conversationId,
+      command: t.command,
+      startedAt: t.startedAt,
+    })),
+  };
+}
+
+async function handleBackgroundToolCancel({ body = {} }: RouteHandlerArgs) {
+  const id = body.id as string | undefined;
+  if (!id) {
+    throw new BadRequestError("id is required");
+  }
+
+  const cancelled = cancelBackgroundTool(id);
+  return { cancelled };
+}
+
+// ── Routes ────────────────────────────────────────────────────────────
+
+const BackgroundToolSchema = z.object({
+  id: z.string(),
+  toolName: z.string(),
+  conversationId: z.string(),
+  command: z.string(),
+  startedAt: z.number(),
+});
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "background_tool_list",
+    endpoint: "background-tools",
+    method: "GET",
+    handler: handleBackgroundToolList,
+    summary: "List active background tools",
+    description:
+      "List all active background tool executions, optionally filtered by conversationId.",
+    tags: ["background-tools"],
+    queryParams: [
+      {
+        name: "conversationId",
+        type: "string",
+        required: false,
+        description: "Filter by conversation ID",
+      },
+    ],
+    responseBody: z.object({
+      tools: z.array(BackgroundToolSchema),
+    }),
+  },
+  {
+    operationId: "background_tool_cancel",
+    endpoint: "background-tools/cancel",
+    method: "POST",
+    handler: handleBackgroundToolCancel,
+    summary: "Cancel a background tool",
+    description: "Cancel an active background tool execution by ID.",
+    tags: ["background-tools"],
+    requestBody: z.object({
+      id: z.string(),
+    }),
+    responseBody: z.object({
+      cancelled: z.boolean(),
+    }),
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -15,6 +15,7 @@ import { ROUTES as APPROVAL_ROUTES } from "./approval-routes.js";
 import { ROUTES as ATTACHMENT_ROUTES } from "./attachment-routes.js";
 import { ROUTES as AUDIO_ROUTES } from "./audio-routes.js";
 import { ROUTES as AVATAR_ROUTES } from "./avatar-routes.js";
+import { ROUTES as BACKGROUND_TOOL_ROUTES } from "./background-tool-routes.js";
 import { ROUTES as BACKUP_ROUTES } from "./backup-routes.js";
 import { ROUTES as BRAIN_GRAPH_ROUTES } from "./brain-graph-routes.js";
 import { ROUTES as BROWSER_ROUTES } from "./browser-routes.js";
@@ -91,6 +92,7 @@ export const ROUTES: RouteDefinition[] = [
   ...APPROVAL_ROUTES,
   ...AUDIO_ROUTES,
   ...AVATAR_ROUTES,
+  ...BACKGROUND_TOOL_ROUTES,
   ...BACKUP_ROUTES,
   ...CACHE_ROUTES,
   ...CALL_ROUTES,

--- a/assistant/src/tools/background-tool-registry.ts
+++ b/assistant/src/tools/background-tool-registry.ts
@@ -80,6 +80,16 @@ export function generateBackgroundToolId(): string {
 }
 
 /**
+ * Returns `true` when the registry is at or over the {@link MAX_BACKGROUND_TOOLS}
+ * limit, meaning no new background tools can be registered. Callers should
+ * check this **before** spawning a process to avoid leaking untracked
+ * processes.
+ */
+export function isBackgroundToolLimitReached(): boolean {
+  return registry.size >= MAX_BACKGROUND_TOOLS;
+}
+
+/**
  * Clears the entire registry. Intended for test cleanup only — production
  * code should use {@link cancelBackgroundTool} or {@link removeBackgroundTool}.
  */

--- a/assistant/src/tools/background-tool-registry.ts
+++ b/assistant/src/tools/background-tool-registry.ts
@@ -1,0 +1,88 @@
+/**
+ * In-memory registry for background tool executions.
+ *
+ * Background tools are long-running processes (e.g. bash, host_bash) that the
+ * agent spawns and returns from immediately. When the process finishes, its
+ * output is delivered back to the conversation via `wakeAgentForOpportunity`.
+ *
+ * The registry tracks active background tools so they can be listed, cancelled,
+ * and cleaned up. The `toolName` field is intentionally generic (not limited to
+ * shell tools) to support extending background execution to non-shell tools in
+ * the future.
+ */
+
+export interface BackgroundTool {
+  id: string;
+  /** Tool type identifier (e.g. "bash", "host_bash"). */
+  toolName: string;
+  conversationId: string;
+  command: string;
+  startedAt: number;
+  /** Kills the process (bash) or aborts the proxy (host_bash). */
+  cancel: () => void;
+}
+
+/** Maximum number of concurrent background tools allowed. */
+export const MAX_BACKGROUND_TOOLS = 20;
+
+const registry = new Map<string, BackgroundTool>();
+
+/**
+ * Registers a background tool in the in-memory store.
+ * Throws if the registry would exceed {@link MAX_BACKGROUND_TOOLS}.
+ */
+export function registerBackgroundTool(tool: BackgroundTool): void {
+  if (registry.size >= MAX_BACKGROUND_TOOLS) {
+    throw new Error(
+      `Background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+    );
+  }
+  registry.set(tool.id, tool);
+}
+
+/** Removes a background tool entry by ID. */
+export function removeBackgroundTool(id: string): void {
+  registry.delete(id);
+}
+
+/**
+ * Returns all registered background tools, optionally filtered by
+ * `conversationId`.
+ */
+export function listBackgroundTools(conversationId?: string): BackgroundTool[] {
+  const all = Array.from(registry.values());
+  if (conversationId === undefined) {
+    return all;
+  }
+  return all.filter((t) => t.conversationId === conversationId);
+}
+
+/**
+ * Cancels a background tool by ID: calls `tool.cancel()`, removes the entry,
+ * and returns `true`. Returns `false` if the ID is not found.
+ */
+export function cancelBackgroundTool(id: string): boolean {
+  const tool = registry.get(id);
+  if (!tool) {
+    return false;
+  }
+  tool.cancel();
+  registry.delete(id);
+  return true;
+}
+
+/**
+ * Generates a short prefixed ID for a background tool.
+ * Format: `bg-<8 hex chars>` (e.g. `bg-a1b2c3d4`).
+ */
+export function generateBackgroundToolId(): string {
+  return `bg-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Clears the entire registry. Intended for test cleanup only — production
+ * code should use {@link cancelBackgroundTool} or {@link removeBackgroundTool}.
+ */
+export function _clearRegistryForTesting(): void {
+  registry.clear();
+}

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -23,8 +23,14 @@ import { isCesShellLockdownEnabled } from "../../credential-execution/feature-ga
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
+import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
+import {
+  generateBackgroundToolId,
+  registerBackgroundTool,
+  removeBackgroundTool,
+} from "../background-tool-registry.js";
 import { formatShellOutput } from "../shared/shell-output.js";
 import { buildSanitizedEnv } from "../terminal/safe-env.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
@@ -117,6 +123,11 @@ class HostShellTool implements Tool {
             description:
               "Optional timeout in seconds. Uses configured default and max limits.",
           },
+          background: {
+            type: "boolean",
+            description:
+              "Run the command in the background on the host machine. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
+          },
         },
         required: ["command", "activity"],
       },
@@ -157,6 +168,8 @@ class HostShellTool implements Tool {
         isError: true,
       };
     }
+    const background = input.background === true;
+
     const config = getConfig();
     const { shellDefaultTimeoutSec, shellMaxTimeoutSec } = config.timeouts;
 
@@ -192,6 +205,58 @@ class HostShellTool implements Tool {
         hostLockdownActive,
         context.conversationId,
       );
+
+      if (background) {
+        const bgId = generateBackgroundToolId();
+        const proxyPromise = context.hostBashProxy.request(
+          {
+            command,
+            working_dir: rawWorkingDir as string | undefined,
+            timeout_seconds: normalizedTimeout,
+            env: proxyEnv,
+          },
+          context.conversationId,
+          context.signal,
+        );
+
+        proxyPromise
+          .then((result) => {
+            const hint = result.isError
+              ? `Background host command failed:\n${result.content}`
+              : result.content || "(no output)";
+            void wakeAgentForOpportunity({
+              conversationId: context.conversationId,
+              hint,
+              source: "background-tool",
+            });
+          })
+          .catch((err) => {
+            void wakeAgentForOpportunity({
+              conversationId: context.conversationId,
+              hint: `Background host command error: ${err instanceof Error ? err.message : String(err)}`,
+              source: "background-tool",
+            });
+          })
+          .finally(() => removeBackgroundTool(bgId));
+
+        registerBackgroundTool({
+          id: bgId,
+          toolName: "host_bash",
+          conversationId: context.conversationId,
+          command,
+          startedAt: Date.now(),
+          cancel: () => {
+            // The proxy handles its own timeout; cancel is a no-op since we
+            // cannot easily abort a proxy request after it's been sent.
+          },
+        });
+
+        return {
+          content: JSON.stringify({ backgrounded: true, id: bgId }),
+          isError: false,
+        };
+      }
+
       return context.hostBashProxy.request(
         {
           command,
@@ -221,24 +286,110 @@ class HostShellTool implements Tool {
         timeoutSec,
         conversationId: context.conversationId,
         hostLockdownActive,
+        background,
       },
       "Executing host shell command",
     );
+
+    const hostEnv = buildHostShellEnv();
+    // Inject VELLUM_UNTRUSTED_SHELL=1 so assistant CLI commands self-deny
+    // raw-token/secret reveal flows when invoked from an untrusted shell.
+    if (hostLockdownActive) {
+      hostEnv.VELLUM_UNTRUSTED_SHELL = "1";
+    }
+    // Match `bash` tool behavior so nested assistant CLI calls can bind to
+    // the active conversation when running through host_bash.
+    hostEnv.__CONVERSATION_ID = context.conversationId;
+
+    if (background) {
+      const bgId = generateBackgroundToolId();
+
+      const child = spawn("bash", ["-c", "--", command], {
+        cwd: workingDir,
+        env: hostEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let timedOut = false;
+
+      const killTree = () => {
+        if (child.pid != null) {
+          try {
+            process.kill(-child.pid, "SIGKILL");
+            return;
+          } catch {
+            // Process group may have already exited — fall through.
+          }
+        }
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Child may have already exited.
+        }
+      };
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        killTree();
+      }, timeoutMs);
+
+      child.stdout.on("data", (data: Buffer) => stdoutChunks.push(data));
+      child.stderr.on("data", (data: Buffer) => stderrChunks.push(data));
+
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        const stdout = Buffer.concat(stdoutChunks).toString();
+        const stderr = Buffer.concat(stderrChunks).toString();
+        const result = formatShellOutput(
+          stdout,
+          stderr,
+          code,
+          timedOut,
+          timeoutSec,
+        );
+        const hint = result.isError
+          ? `Background host command failed:\n${result.content}`
+          : result.content || "(no output)";
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint,
+          source: "background-tool",
+        });
+        removeBackgroundTool(bgId);
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint: `Background host command error: ${err.message}`,
+          source: "background-tool",
+        });
+        removeBackgroundTool(bgId);
+      });
+
+      registerBackgroundTool({
+        id: bgId,
+        toolName: "host_bash",
+        conversationId: context.conversationId,
+        command,
+        startedAt: Date.now(),
+        cancel: killTree,
+      });
+
+      return {
+        content: JSON.stringify({ backgrounded: true, id: bgId }),
+        isError: false,
+      };
+    }
 
     return new Promise<ToolExecutionResult>((resolve) => {
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
-
-      const hostEnv = buildHostShellEnv();
-      // Inject VELLUM_UNTRUSTED_SHELL=1 so assistant CLI commands self-deny
-      // raw-token/secret reveal flows when invoked from an untrusted shell.
-      if (hostLockdownActive) {
-        hostEnv.VELLUM_UNTRUSTED_SHELL = "1";
-      }
-      // Match `bash` tool behavior so nested assistant CLI calls can bind to
-      // the active conversation when running through host_bash.
-      hostEnv.__CONVERSATION_ID = context.conversationId;
 
       const child = spawn("bash", ["-c", "--", command], {
         cwd: workingDir,

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -208,6 +208,7 @@ class HostShellTool implements Tool {
 
       if (background) {
         const bgId = generateBackgroundToolId();
+        const abortController = new AbortController();
         const proxyPromise = context.hostBashProxy.request(
           {
             command,
@@ -216,7 +217,7 @@ class HostShellTool implements Tool {
             env: proxyEnv,
           },
           context.conversationId,
-          context.signal,
+          abortController.signal,
         );
 
         proxyPromise
@@ -245,10 +246,7 @@ class HostShellTool implements Tool {
           conversationId: context.conversationId,
           command,
           startedAt: Date.now(),
-          cancel: () => {
-            // The proxy handles its own timeout; cancel is a no-op since we
-            // cannot easily abort a proxy request after it's been sent.
-          },
+          cancel: () => abortController.abort(),
         });
 
         return {

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -234,8 +234,8 @@ class HostShellTool implements Tool {
         proxyPromise
           .then((result) => {
             const hint = result.isError
-              ? `Background host command failed:\n${result.content}`
-              : result.content || "(no output)";
+              ? `Background host command failed (id=${bgId}):\n${result.content}`
+              : `Background host command completed (id=${bgId}):\n${result.content || "(no output)"}`;
             void wakeAgentForOpportunity({
               conversationId: context.conversationId,
               hint,
@@ -245,7 +245,7 @@ class HostShellTool implements Tool {
           .catch((err) => {
             void wakeAgentForOpportunity({
               conversationId: context.conversationId,
-              hint: `Background host command error: ${err instanceof Error ? err.message : String(err)}`,
+              hint: `Background host command failed (id=${bgId}): ${err instanceof Error ? err.message : String(err)}`,
               source: "background-tool",
             });
           })
@@ -369,8 +369,8 @@ class HostShellTool implements Tool {
           timeoutSec,
         );
         const hint = result.isError
-          ? `Background host command failed:\n${result.content}`
-          : result.content || "(no output)";
+          ? `Background host command failed (id=${bgId}):\n${result.content}`
+          : `Background host command completed (id=${bgId}):\n${result.content || "(no output)"}`;
         void wakeAgentForOpportunity({
           conversationId: context.conversationId,
           hint,
@@ -383,7 +383,7 @@ class HostShellTool implements Tool {
         clearTimeout(timer);
         void wakeAgentForOpportunity({
           conversationId: context.conversationId,
-          hint: `Background host command error: ${err.message}`,
+          hint: `Background host command failed (id=${bgId}): ${err.message}`,
           source: "background-tool",
         });
         removeBackgroundTool(bgId);

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -28,6 +28,8 @@ import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import {
   generateBackgroundToolId,
+  isBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS,
   registerBackgroundTool,
   removeBackgroundTool,
 } from "../background-tool-registry.js";
@@ -207,6 +209,15 @@ class HostShellTool implements Tool {
       );
 
       if (background) {
+        // Check the registry limit BEFORE starting the proxy request so we
+        // never leak an untracked proxy when the registry is full.
+        if (isBackgroundToolLimitReached()) {
+          return {
+            content: `Error: background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+            isError: true,
+          };
+        }
+
         const bgId = generateBackgroundToolId();
         const abortController = new AbortController();
         const proxyPromise = context.hostBashProxy.request(
@@ -300,6 +311,15 @@ class HostShellTool implements Tool {
     hostEnv.__CONVERSATION_ID = context.conversationId;
 
     if (background) {
+      // Check the registry limit BEFORE spawning so we never leak an
+      // untracked process when the registry is full.
+      if (isBackgroundToolLimitReached()) {
+        return {
+          content: `Error: background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+          isError: true,
+        };
+      }
+
       const bgId = generateBackgroundToolId();
 
       const child = spawn("bash", ["-c", "--", command], {

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -357,7 +357,14 @@ class HostShellTool implements Tool {
       child.stdout.on("data", (data: Buffer) => stdoutChunks.push(data));
       child.stderr.on("data", (data: Buffer) => stderrChunks.push(data));
 
+      // Guard against double-wake: when spawn fails (e.g. invalid cwd),
+      // Node emits both 'error' and 'close' for the same child process.
+      // Only the first handler to fire should wake the agent.
+      let completed = false;
+
       child.on("close", (code) => {
+        if (completed) return;
+        completed = true;
         clearTimeout(timer);
         const stdout = Buffer.concat(stdoutChunks).toString();
         const stderr = Buffer.concat(stderrChunks).toString();
@@ -380,6 +387,8 @@ class HostShellTool implements Tool {
       });
 
       child.on("error", (err) => {
+        if (completed) return;
+        completed = true;
         clearTimeout(timer);
         void wakeAgentForOpportunity({
           conversationId: context.conversationId,

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -18,6 +18,8 @@ import {
 } from "../../util/platform.js";
 import {
   generateBackgroundToolId,
+  isBackgroundToolLimitReached,
+  MAX_BACKGROUND_TOOLS,
   registerBackgroundTool,
   removeBackgroundTool,
 } from "../background-tool-registry.js";
@@ -352,6 +354,15 @@ class ShellTool implements Tool {
     // -----------------------------------------------------------------------
     const background = input.background === true;
     if (background) {
+      // Check the registry limit BEFORE spawning so we never leak an
+      // untracked process when the registry is full.
+      if (isBackgroundToolLimitReached()) {
+        return {
+          content: `Error: background tool limit reached (max ${MAX_BACKGROUND_TOOLS}). Cancel an existing background tool before starting a new one.`,
+          isError: true,
+        };
+      }
+
       const bgId = generateBackgroundToolId();
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -390,7 +390,14 @@ class ShellTool implements Tool {
         stderrChunks.push(data);
       });
 
+      // Guard against double-wake: when spawn fails (e.g. invalid cwd),
+      // Node emits both 'error' and 'close' for the same child process.
+      // Only the first handler to fire should wake the agent.
+      let completed = false;
+
       child.on("close", (code) => {
+        if (completed) return;
+        completed = true;
         clearTimeout(timer);
         removeBackgroundTool(bgId);
 
@@ -413,6 +420,8 @@ class ShellTool implements Tool {
       });
 
       child.on("error", (err) => {
+        if (completed) return;
+        completed = true;
         clearTimeout(timer);
         removeBackgroundTool(bgId);
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -7,6 +8,7 @@ import { isCesShellLockdownEnabled } from "../../credential-execution/feature-ga
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
+import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -14,6 +16,11 @@ import {
   getProtectedDir,
   getWorkspaceDir,
 } from "../../util/platform.js";
+import {
+  generateBackgroundToolId,
+  registerBackgroundTool,
+  removeBackgroundTool,
+} from "../background-tool-registry.js";
 import { resolveCredentialRef } from "../credentials/resolve.js";
 import {
   getOrStartSession,
@@ -135,6 +142,11 @@ class ShellTool implements Tool {
             items: { type: "string" },
             description:
               'Optional list of credential IDs to inject via the proxy when network_mode is "proxied".',
+          },
+          background: {
+            type: "boolean",
+            description:
+              "Run the command in the background. The tool returns immediately with a background tool ID. When the process exits, its output is delivered to the conversation as a wake.",
           },
         },
         required: ["command", "activity"],
@@ -323,21 +335,28 @@ class ShellTool implements Tool {
       env.VELLUM_UNTRUSTED_SHELL = "1";
     }
 
-    const result = await new Promise<ToolExecutionResult>((resolve) => {
+    // CES shell lockdown: build deny-read paths for protected credential
+    // data, the protected dir, and data sub-dirs that contain secrets.
+    const denyReadPaths: string[] | undefined = shellLockdownActive
+      ? buildCesProtectedPaths()
+      : undefined;
+
+    const wrapped = wrapCommand(command, context.workingDir, sandboxConfig, {
+      networkMode,
+      denyReadPaths,
+    });
+
+    // -----------------------------------------------------------------------
+    // Background mode: spawn and return immediately. The process output is
+    // delivered to the conversation as a wake when the process exits.
+    // -----------------------------------------------------------------------
+    const background = input.background === true;
+    if (background) {
+      const bgId = generateBackgroundToolId();
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
 
-      // CES shell lockdown: build deny-read paths for protected credential
-      // data, the protected dir, and data sub-dirs that contain secrets.
-      const denyReadPaths: string[] | undefined = shellLockdownActive
-        ? buildCesProtectedPaths()
-        : undefined;
-
-      const wrapped = wrapCommand(command, context.workingDir, sandboxConfig, {
-        networkMode,
-        denyReadPaths,
-      });
       const child = spawn(wrapped.command, wrapped.args, {
         cwd: context.workingDir,
         env,
@@ -345,24 +364,86 @@ class ShellTool implements Tool {
         detached: true,
       });
 
-      // Kill the entire process tree. Tries the process group first
-      // (negative PID), then falls back to killing the direct child if the
-      // PID is unavailable or the group kill fails.
-      const killTree = () => {
-        if (child.pid != null) {
-          try {
-            process.kill(-child.pid, "SIGKILL");
-            return;
-          } catch {
-            // Process group may have already exited — fall through.
-          }
-        }
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Child may have already exited.
-        }
+      const killTree = buildKillTree(child);
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        killTree();
+      }, timeoutMs);
+
+      child.stdout.on("data", (data: Buffer) => {
+        stdoutChunks.push(data);
+      });
+
+      child.stderr.on("data", (data: Buffer) => {
+        stderrChunks.push(data);
+      });
+
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        removeBackgroundTool(bgId);
+
+        const stdout = Buffer.concat(stdoutChunks).toString();
+        const stderr = Buffer.concat(stderrChunks).toString();
+        const fmtResult = formatShellOutput(
+          stdout,
+          stderr,
+          code,
+          timedOut,
+          timeoutSec,
+        );
+
+        const hint = `Background command completed (id=${bgId}, exit=${code ?? "unknown"}):\n${fmtResult.content}`;
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint,
+          source: "background-tool",
+        });
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        removeBackgroundTool(bgId);
+
+        const hint = `Background command failed (id=${bgId}): ${err.message}`;
+        void wakeAgentForOpportunity({
+          conversationId: context.conversationId,
+          hint,
+          source: "background-tool",
+        });
+      });
+
+      registerBackgroundTool({
+        id: bgId,
+        toolName: "bash",
+        conversationId: context.conversationId,
+        command,
+        startedAt: Date.now(),
+        cancel: killTree,
+      });
+
+      return {
+        content: JSON.stringify({ backgrounded: true, id: bgId }),
+        isError: false,
       };
+    }
+
+    // -----------------------------------------------------------------------
+    // Foreground mode: await the process and return its output.
+    // -----------------------------------------------------------------------
+    const result = await new Promise<ToolExecutionResult>((resolve) => {
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let timedOut = false;
+
+      const child = spawn(wrapped.command, wrapped.args, {
+        cwd: context.workingDir,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+      });
+
+      const killTree = buildKillTree(child);
 
       const timer = setTimeout(() => {
         timedOut = true;
@@ -426,6 +507,29 @@ class ShellTool implements Tool {
 
     return result;
   }
+}
+
+/**
+ * Kill the entire process tree of a child process. Tries the process group
+ * first (negative PID), then falls back to killing the direct child if the
+ * PID is unavailable or the group kill fails.
+ */
+function buildKillTree(child: ChildProcess): () => void {
+  return () => {
+    if (child.pid != null) {
+      try {
+        process.kill(-child.pid, "SIGKILL");
+        return;
+      } catch {
+        // Process group may have already exited — fall through.
+      }
+    }
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Child may have already exited.
+    }
+  };
 }
 
 export const shellTool: Tool = new ShellTool();


### PR DESCRIPTION
## Summary
Add a `background` boolean input to the `bash` and `host_bash` tools. When set, the tool spawns the process but returns immediately — the agent's turn completes without waiting. When the background process exits, its output is delivered to the conversation as a wake via `wakeAgentForOpportunity`. An in-memory registry tracks active background tools for list/cancel operations via `GET /v1/background-tools` and `POST /v1/background-tools/cancel`.

## Self-review result
GAPS FOUND — 3 gaps fixed across 3 fix PRs (all passed re-review).

## PRs merged into feature branch
- #28561: feat: add in-memory background tool registry
- #28565: feat: add `background` mode to the bash tool
- #28567: feat: add `background` mode to the host_bash tool
- #28564: feat: add routes for listing and cancelling background tools

### Fix PRs
- #28581: fix: check background tool limit before spawning process
- #28579: fix: wire AbortController for proxy-path background cancel
- #28580: fix: include bgId in host_bash background wake hints

Part of plan: bg-shell-tools.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
