### PR TITLE
feat(memory): strengthen per-turn remember nudge

### DIFF
--- a/assistant/src/daemon/pkb-reminder-builder.test.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.test.ts
@@ -5,9 +5,9 @@ import { buildPkbReminder } from "./pkb-reminder-builder.js";
 // Byte-for-byte fixture of the base PKB reminder.
 const BASE_REMINDER =
   "<system_reminder>" +
-  "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation" +
-  "\nUse `remember` for anything you learn immediately" +
-  "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
+  "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+  "\nRead any unread workspace files that look even partially relevant." +
   "\n</system_reminder>";
 
 describe("buildPkbReminder", () => {
@@ -19,11 +19,11 @@ describe("buildPkbReminder", () => {
     const out = buildPkbReminder(["projects/alpha.md"]);
     const expected =
       "<system_reminder>" +
-      "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation." +
+      "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+      "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+      "\nRead any unread workspace files that look even partially relevant." +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- projects/alpha.md" +
-      "\nUse `remember` for anything you learn immediately" +
-      "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
       "\n</system_reminder>";
     expect(out).toBe(expected);
 
@@ -40,13 +40,13 @@ describe("buildPkbReminder", () => {
     const out = buildPkbReminder(hints);
     const expected =
       "<system_reminder>" +
-      "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation." +
+      "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+      "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+      "\nRead any unread workspace files that look even partially relevant." +
       "\nBased on the current context, these files look especially relevant:" +
       "\n- a.md" +
       "\n- sub/b.md" +
       "\n- c/d/e.md" +
-      "\nUse `remember` for anything you learn immediately" +
-      "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
       "\n</system_reminder>";
     expect(out).toBe(expected);
 

--- a/assistant/src/daemon/pkb-reminder-builder.ts
+++ b/assistant/src/daemon/pkb-reminder-builder.ts
@@ -1,3 +1,8 @@
+const BODY =
+  "\nCall `remember` this turn for anything concrete the user said — facts, preferences, plans, names, dates, decisions, corrections, felt moments. Default to remembering; skip only obvious noise. This should be your most frequently used tool." +
+  "\nIf you're unsure about something that may live in the workspace — past decisions, prior conversations, files — use `recall` before asking or guessing." +
+  "\nRead any unread workspace files that look even partially relevant.";
+
 /**
  * Render the PKB system_reminder text, optionally with a bulleted list of
  * hint paths that look especially relevant to the current conversation.
@@ -11,23 +16,8 @@
  */
 export function buildPkbReminder(hints: ReadonlyArray<string>): string {
   if (hints.length === 0) {
-    return (
-      "<system_reminder>" +
-      "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation" +
-      "\nUse `remember` for anything you learn immediately" +
-      "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
-      "\n</system_reminder>"
-    );
+    return `<system_reminder>${BODY}\n</system_reminder>`;
   }
-
   const bullets = hints.map((h) => `- ${h}`).join("\n");
-  return (
-    "<system_reminder>" +
-    "\nRead any unread Personal Knowledge Base files that might be even partially relevant to this conversation." +
-    "\nBased on the current context, these files look especially relevant:" +
-    `\n${bullets}` +
-    "\nUse `remember` for anything you learn immediately" +
-    "\nIf you're unsure about something that may have an answer in your workspace, use `recall` to try to find it before asking or making assumptions" +
-    "\n</system_reminder>"
-  );
+  return `<system_reminder>${BODY}\nBased on the current context, these files look especially relevant:\n${bullets}\n</system_reminder>`;
 }


### PR DESCRIPTION
## Summary
- Rewrite the per-user-message system reminder in \`pkb-reminder-builder.ts\` to lead with \`remember\`, expand its categories inline (facts, preferences, plans, names, dates, decisions, corrections, felt moments), and replace stale \"Personal Knowledge Base\" framing with workspace-neutral language that works under both v1 (PKB) and v2 (concept pages).
- Reorder bullets so \`remember\` comes first, \`recall\` second, and the file-reading prompt last — the file-hint sub-bullet now anchors naturally to the workspace-files line.
- Update test fixtures to match the new literal text; behavior, signature, gating (\`pkbActive === true\`), and call sites are unchanged.

## Original prompt
the plan at /Users/sidd/vocify/vellum-assistant/.private/plans/strengthen-remember-nudge.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
