### PR TITLE
feat(memory): disable v2 sweep by default

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -8,6 +8,7 @@ describe("MemoryV2ConfigSchema", () => {
     const parsed = MemoryV2ConfigSchema.parse({});
     expect(parsed).toEqual({
       enabled: false,
+      sweep_enabled: false,
       d: 0.3,
       c_user: 0.3,
       c_assistant: 0.2,
@@ -150,6 +151,7 @@ describe("MemoryConfigSchema integration with v2 block", () => {
     const parsed = MemoryConfigSchema.parse({});
     expect(parsed.v2).toBeDefined();
     expect(parsed.v2.enabled).toBe(false);
+    expect(parsed.v2.sweep_enabled).toBe(false);
     expect(parsed.v2.d).toBe(0.3);
     expect(parsed.v2.dense_weight).toBe(0.7);
     expect(parsed.v2.sparse_weight).toBe(0.3);

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -25,6 +25,12 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Whether the v2 memory subsystem (concept-page activation model) is enabled. Independent of the memory-v2-enabled feature flag — both must be true for v2 to run.",
       ),
+    sweep_enabled: z
+      .boolean({ error: "memory.v2.sweep_enabled must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether the v2 idle-debounced sweep job is enabled. Off by default — `remember()` is the primary capture path; opt in only when the model is missing entries the sweep would have caught.",
+      ),
     d: z
       .number({ error: "memory.v2.d must be a number" })
       .min(0, "memory.v2.d must be >= 0")

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -219,15 +219,18 @@ export async function indexMessageNow(
       }
 
       // Memory v2 sweep mirrors graph_extract's debounce: when the v2
-      // flag + config are on, every extraction trigger also enqueues a
-      // sweep. The sweep itself reads recent messages globally, so the
-      // `conversationId` here is just the dedup key — one pending row
-      // per active conversation. Both gates ensure the job remains a
-      // no-op when v2 is off.
+      // flag + config are on AND `sweep_enabled` is set, every extraction
+      // trigger also enqueues a sweep. The sweep itself reads recent
+      // messages globally, so the `conversationId` here is just the dedup
+      // key — one pending row per active conversation. All three gates
+      // (feature flag, v2 master toggle, sweep_enabled) must be true.
+      // `sweep_enabled` defaults to false because `remember()` is the
+      // primary capture path; the sweep is opt-in.
       if (
         triggerConfig != null &&
         isAssistantFeatureFlagEnabled("memory-v2-enabled", triggerConfig) &&
-        triggerConfig.memory.v2.enabled
+        triggerConfig.memory.v2.enabled &&
+        triggerConfig.memory.v2.sweep_enabled
       ) {
         upsertDebouncedJob(
           "memory_v2_sweep",

--- a/assistant/src/memory/v2/__tests__/sweep-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/sweep-job.test.ts
@@ -93,8 +93,16 @@ const { memoryV2SweepJob } = await import("../sweep-job.js");
 // (resolution is purely from the overrides + registry caches), so we hand
 // the handler a minimal stand-in instead of materializing the full default
 // config — which would otherwise pull in heavy schemas this test doesn't
-// exercise.
-const CONFIG = {} as Parameters<typeof memoryV2SweepJob>[1];
+// exercise. The handler reads `config.memory.v2.sweep_enabled`, so the
+// `flag on` cases need the field set; the `flag off` case bails before
+// the check and uses the bare empty stand-in.
+const CONFIG = {
+  memory: { v2: { sweep_enabled: true } },
+} as Parameters<typeof memoryV2SweepJob>[1];
+const CONFIG_FLAG_OFF = {} as Parameters<typeof memoryV2SweepJob>[1];
+const CONFIG_SWEEP_OFF = {
+  memory: { v2: { sweep_enabled: false } },
+} as Parameters<typeof memoryV2SweepJob>[1];
 
 function makeJob(): Parameters<typeof memoryV2SweepJob>[0] {
   return {
@@ -208,7 +216,22 @@ describe("memoryV2SweepJob — flag off", () => {
     _setOverridesForTesting({ "memory-v2-enabled": false });
     providerStub = makeEntriesProvider(["should-not-be-written"]);
 
-    const written = await memoryV2SweepJob(makeJob(), CONFIG);
+    const written = await memoryV2SweepJob(makeJob(), CONFIG_FLAG_OFF);
+
+    expect(written).toBe(0);
+    expect(providerCalls).toHaveLength(0);
+    expect(existsSync(join(tmpWorkspace, "memory", "buffer.md"))).toBe(false);
+  });
+});
+
+describe("memoryV2SweepJob — flag on, sweep_enabled off", () => {
+  test("returns 0 without invoking the provider when sweep_enabled is false", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    // No message seeding required — the sweep_enabled bail short-circuits
+    // before any DB or workspace reads.
+    providerStub = makeEntriesProvider(["should-not-be-written"]);
+
+    const written = await memoryV2SweepJob(makeJob(), CONFIG_SWEEP_OFF);
 
     expect(written).toBe(0);
     expect(providerCalls).toHaveLength(0);

--- a/assistant/src/memory/v2/sweep-job.ts
+++ b/assistant/src/memory/v2/sweep-job.ts
@@ -13,9 +13,10 @@
  * extraction-trigger path. Until then this handler is invoked only by
  * `memory_v2_sweep` rows enqueued explicitly (tests, future CLI).
  *
- * Skipped entirely when the `memory-v2-enabled` feature flag is off — keeps
- * the sweep dormant in v1-only workspaces even if a stale row sits in the
- * queue at flag-flip time.
+ * Skipped entirely when the `memory-v2-enabled` feature flag is off, or when
+ * `config.memory.v2.sweep_enabled` is false — keeps the sweep dormant in
+ * v1-only workspaces and in v2 workspaces that haven't opted in, even if a
+ * stale row sits in the queue at flag-flip time.
  */
 
 import { readFileSync } from "node:fs";
@@ -105,6 +106,11 @@ export async function memoryV2SweepJob(
 ): Promise<number> {
   if (!isAssistantFeatureFlagEnabled("memory-v2-enabled", config)) {
     log.debug("memory-v2-enabled flag off; sweep skipped");
+    return 0;
+  }
+
+  if (!config.memory?.v2?.sweep_enabled) {
+    log.debug("memory.v2.sweep_enabled is false; sweep skipped");
     return 0;
   }
 


### PR DESCRIPTION
## Summary
- Add `memory.v2.sweep_enabled` config field (default `false`); both `indexer.ts` and the sweep handler gate on it so the idle-debounced sweep stops running by default in v2 workspaces.
- `remember()` is the primary capture path; the sweep was redundant and pricey (one provider call per active conversation per idle window). Existing v2 users who want it back can set `memory.v2.sweep_enabled = true`.
- Schema default + handler defense-in-depth bail so stale `memory_v2_sweep` rows in the queue become no-ops after a config flip.

## Original prompt
it (disable the sweep job by default)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
