### PR TITLE
feat(memory-v2): add SkillEntry / SkillEmbeddingPayload types

### DIFF
--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -92,3 +92,34 @@ export const ActivationStateSchema = z.object({
 });
 
 export type ActivationState = z.infer<typeof ActivationStateSchema>;
+
+// ---------------------------------------------------------------------------
+// Skill autoinjection (synthetic in-memory entries, not on-disk pages)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-skill capability snapshot held in-process and embedded into
+ * the `memory_v2_skills` Qdrant collection. `content` is the rendered
+ * `buildSkillContent` string — already capped at 500 chars upstream — and
+ * is what we embed and what we render in `### Skills You Can Use`.
+ */
+export const SkillEntrySchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  content: z.string(),
+});
+
+export type SkillEntry = z.infer<typeof SkillEntrySchema>;
+
+/**
+ * Payload carried alongside each `memory_v2_skills` Qdrant point. Mirrors
+ * the `ConceptPagePayload` shape but keyed on `id` instead of `slug`.
+ */
+export const SkillEmbeddingPayloadSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  content: z.string(),
+  updated_at: z.number().int().nonnegative(),
+});
+
+export type SkillEmbeddingPayload = z.infer<typeof SkillEmbeddingPayloadSchema>;


### PR DESCRIPTION
## Summary
- Add SkillEntry and SkillEmbeddingPayload Zod schemas + inferred TS types to memory/v2/types.ts.
- Type-only scaffolding for the upcoming skill autoinjection pipeline.

Part of plan: memory-v2-skill-autoinjection.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
