### PR TITLE
feat(memory-v2): add top_k_skills config field for skill autoinjection cap

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -16,6 +16,7 @@ describe("MemoryV2ConfigSchema", () => {
       k: 0.5,
       hops: 2,
       top_k: 20,
+      top_k_skills: 5,
       epsilon: 0.01,
       dense_weight: 0.7,
       sparse_weight: 0.3,
@@ -155,6 +156,7 @@ describe("MemoryConfigSchema integration with v2 block", () => {
     expect(parsed.v2.d).toBe(0.3);
     expect(parsed.v2.dense_weight).toBe(0.7);
     expect(parsed.v2.sparse_weight).toBe(0.3);
+    expect(parsed.v2.top_k_skills).toBe(5);
     expect(parsed.v2.consolidation_interval_hours).toBe(4);
     expect(parsed.v2.max_page_chars).toBe(5000);
   });

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -87,6 +87,14 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Number of top-activation concept pages considered for injection per turn",
       ),
+    top_k_skills: z
+      .number({ error: "memory.v2.top_k_skills must be a number" })
+      .int()
+      .nonnegative()
+      .default(5)
+      .describe(
+        "Cap on the per-turn skill-autoinjection slate rendered in `### Skills You Can Use`. 0 disables skill autoinjection without code changes.",
+      ),
     epsilon: z
       .number({ error: "memory.v2.epsilon must be a number" })
       .min(0, "memory.v2.epsilon must be >= 0")


### PR DESCRIPTION
## Summary
- Add memory.v2.top_k_skills config field (default 5) capping the per-turn skill autoinjection slate.
- Foundation for upcoming memory-v2 skill autoinjection pipeline.

Part of plan: memory-v2-skill-autoinjection.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
