### PR TITLE
feat(memory-v2): port buildSkillContent to v2-owned skill-content.ts

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-content.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-content.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for `memory/v2/skill-content.ts` — v2-owned port of v1's
+ * `buildSkillContent` plus the `mcp-setup` description augmentation.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SkillCapabilityInput } from "../../../skills/skill-memory.js";
+
+describe("buildSkillContent", () => {
+  test("renders minimal input with id, displayName, description", async () => {
+    const { buildSkillContent } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "example-skill",
+      displayName: "Example Skill",
+      description: "Does an example thing",
+    };
+    expect(buildSkillContent(input)).toBe(
+      'The "Example Skill" skill (example-skill) is available. Does an example thing.',
+    );
+  });
+
+  test("includes both activationHints and avoidWhen clauses", async () => {
+    const { buildSkillContent } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "example-skill",
+      displayName: "Example Skill",
+      description: "Does an example thing",
+      activationHints: ["user mentions example", "task involves examples"],
+      avoidWhen: ["user is busy", "topic is unrelated"],
+    };
+    const out = buildSkillContent(input);
+    expect(out).toContain(
+      "Use when: user mentions example; task involves examples.",
+    );
+    expect(out).toContain("Avoid when: user is busy; topic is unrelated.");
+  });
+
+  test("caps output at 500 characters", async () => {
+    const { buildSkillContent } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "example-skill",
+      displayName: "Example Skill",
+      description: "x".repeat(1000),
+    };
+    const out = buildSkillContent(input);
+    expect(out.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("augmentMcpSetupDescription", () => {
+  test("is a no-op when id is not mcp-setup", async () => {
+    const { augmentMcpSetupDescription } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "example-skill",
+      displayName: "Example Skill",
+      description: "Does an example thing",
+    };
+    expect(augmentMcpSetupDescription(input)).toBe(input);
+  });
+
+  test("appends 'Configured: <names>' for mcp-setup with enabled servers", async () => {
+    mock.module("../../../config/loader.js", () => ({
+      getConfig: () => ({
+        mcp: {
+          servers: {
+            "example-server": { enabled: true },
+            "another-server": { enabled: true },
+            "disabled-server": { enabled: false },
+          },
+        },
+      }),
+    }));
+    const { augmentMcpSetupDescription } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "mcp-setup",
+      displayName: "MCP Setup",
+      description: "Configures MCP servers",
+    };
+    const out = augmentMcpSetupDescription(input);
+    expect(out.description).toBe(
+      "Configures MCP servers Configured: example-server, another-server",
+    );
+    expect(out.id).toBe("mcp-setup");
+  });
+});

--- a/assistant/src/memory/v2/skill-content.ts
+++ b/assistant/src/memory/v2/skill-content.ts
@@ -1,0 +1,42 @@
+import { getConfig } from "../../config/loader.js";
+import type { SkillCapabilityInput } from "../../skills/skill-memory.js";
+
+/**
+ * Render the prose-style capability statement embedded into the
+ * `memory_v2_skills` Qdrant collection and rendered in
+ * `### Skills You Can Use`. Capped at 500 chars to match v1's behavior.
+ */
+export function buildSkillContent(input: SkillCapabilityInput): string {
+  let content = `The "${input.displayName}" skill (${input.id}) is available. ${input.description}.`;
+  if (input.activationHints && input.activationHints.length > 0) {
+    content += ` Use when: ${input.activationHints.join("; ")}.`;
+  }
+  if (input.avoidWhen && input.avoidWhen.length > 0) {
+    content += ` Avoid when: ${input.avoidWhen.join("; ")}.`;
+  }
+  if (content.length > 500) {
+    content = content.slice(0, 500);
+  }
+  return content;
+}
+
+/**
+ * mcp-setup is special-cased in v1 (`capability-seed.ts:102-112`):
+ * its description is augmented with the list of configured MCP server
+ * names so the model can pattern-match against them. Port verbatim.
+ */
+export function augmentMcpSetupDescription(
+  input: SkillCapabilityInput,
+): SkillCapabilityInput {
+  if (input.id !== "mcp-setup") return input;
+  const servers = getConfig().mcp?.servers;
+  if (!servers) return input;
+  const names = Object.keys(servers).filter(
+    (name) => servers[name]?.enabled !== false,
+  );
+  if (names.length === 0) return input;
+  return {
+    ...input,
+    description: `${input.description} Configured: ${names.join(", ")}`,
+  };
+}


### PR DESCRIPTION
## Summary
- Port v1 buildSkillContent to a v2-owned module so memory/v2 doesn't depend on memory/graph.
- Include the mcp-setup MCP-server-list augmentation, verbatim from v1.

Part of plan: memory-v2-skill-autoinjection.md (PR 3 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
