### PR TITLE
feat(memory-v2): add memory_v2_skills Qdrant collection helpers

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-qdrant.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-qdrant.test.ts
@@ -1,0 +1,653 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// Stub getConfig — only the qdrant.url / vectorSize / onDisk fields matter.
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    memory: {
+      qdrant: {
+        url: "http://127.0.0.1:6333",
+        vectorSize: 384,
+        onDisk: true,
+      },
+    },
+  }),
+}));
+
+mock.module("../../qdrant-client.js", () => ({
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+// Mock the underlying @qdrant/js-client-rest package. The mock client
+// records every call and lets each test program the next response.
+type MockPoint = {
+  id: string;
+  vector: { dense: number[]; sparse: { indices: number[]; values: number[] } };
+  payload: {
+    id: string;
+    displayName: string;
+    content: string;
+    updated_at: number;
+  };
+};
+
+type ScrollPoint = {
+  id: string | number;
+  payload: Record<string, unknown>;
+};
+
+const state = {
+  collectionExistsBeforeCreate: false,
+  collectionExistsCalls: 0,
+  createCollectionCalls: 0,
+  createCollectionParams: null as unknown,
+  createIndexCalls: [] as Array<{ field_name: string; field_schema: string }>,
+  upsertCalls: [] as Array<{ wait: boolean; points: MockPoint[] }>,
+  deleteCalls: [] as Array<{
+    wait: boolean;
+    points: Array<string | number>;
+  }>,
+  queryCalls: [] as Array<{
+    using: string;
+    query: unknown;
+    limit: number;
+    with_payload: boolean;
+  }>,
+  scrollCalls: [] as Array<{
+    limit?: number;
+    offset?: string | number;
+    with_payload: boolean;
+    with_vector: boolean;
+  }>,
+  // Per-using → response queue. Each entry is consumed in order.
+  queryResponses: {
+    dense: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+    sparse: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+  },
+  // Pages of scroll results returned in order; each call shifts one. Each
+  // page may set `next_page_offset` to keep paginating.
+  scrollPages: [] as Array<{
+    points: ScrollPoint[];
+    next_page_offset?: string | number | null;
+  }>,
+  createCollectionThrows: null as Error | null,
+};
+
+class MockQdrantClient {
+  constructor(_opts: unknown) {}
+  async collectionExists(_name: string) {
+    state.collectionExistsCalls++;
+    return { exists: state.collectionExistsBeforeCreate };
+  }
+  async createCollection(_name: string, params: unknown) {
+    state.createCollectionCalls++;
+    state.createCollectionParams = params;
+    if (state.createCollectionThrows) throw state.createCollectionThrows;
+    state.collectionExistsBeforeCreate = true;
+    return {};
+  }
+  async createPayloadIndex(
+    _name: string,
+    params: { field_name: string; field_schema: string },
+  ) {
+    state.createIndexCalls.push(params);
+    return {};
+  }
+  async upsert(_name: string, params: { wait: boolean; points: MockPoint[] }) {
+    state.upsertCalls.push(params);
+    return {};
+  }
+  async delete(
+    _name: string,
+    params: { wait: boolean; points: Array<string | number> },
+  ) {
+    state.deleteCalls.push(params);
+    return {};
+  }
+  async query(
+    _name: string,
+    params: {
+      using: string;
+      query: unknown;
+      limit: number;
+      with_payload: boolean;
+    },
+  ) {
+    state.queryCalls.push(params);
+    const queue = state.queryResponses[params.using as "dense" | "sparse"];
+    return queue.shift() ?? { points: [] };
+  }
+  async scroll(
+    _name: string,
+    params: {
+      limit?: number;
+      offset?: string | number;
+      with_payload: boolean;
+      with_vector: boolean;
+    },
+  ) {
+    state.scrollCalls.push(params);
+    const page = state.scrollPages.shift();
+    return page ?? { points: [], next_page_offset: null };
+  }
+}
+
+mock.module("@qdrant/js-client-rest", () => ({
+  QdrantClient: MockQdrantClient,
+}));
+
+const {
+  ensureSkillCollection,
+  upsertSkillEmbedding,
+  deleteSkillEmbedding,
+  pruneSkillsExcept,
+  hybridQuerySkills,
+  MEMORY_V2_SKILLS_COLLECTION,
+  SKILL_NAMESPACE,
+  _resetMemoryV2SkillQdrantForTests,
+} = await import("../skill-qdrant.js");
+const { MEMORY_V2_COLLECTION } = await import("../qdrant.js");
+
+function resetState(): void {
+  state.collectionExistsBeforeCreate = false;
+  state.collectionExistsCalls = 0;
+  state.createCollectionCalls = 0;
+  state.createCollectionParams = null;
+  state.createIndexCalls.length = 0;
+  state.upsertCalls.length = 0;
+  state.deleteCalls.length = 0;
+  state.queryCalls.length = 0;
+  state.scrollCalls.length = 0;
+  state.queryResponses.dense.length = 0;
+  state.queryResponses.sparse.length = 0;
+  state.scrollPages.length = 0;
+  state.createCollectionThrows = null;
+  _resetMemoryV2SkillQdrantForTests();
+}
+
+describe("memory v2 skill qdrant — collection identity", () => {
+  test("uses the documented collection name", () => {
+    expect(MEMORY_V2_SKILLS_COLLECTION).toBe("memory_v2_skills");
+  });
+
+  test("collection name is distinct from the concept-page collection", () => {
+    expect(MEMORY_V2_SKILLS_COLLECTION).not.toBe(MEMORY_V2_COLLECTION);
+  });
+
+  test("namespace is a valid UUID distinct from the concept-page namespace", () => {
+    expect(SKILL_NAMESPACE).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    // SLUG_NAMESPACE in qdrant.ts is "8b9c5d4f-0e1a-4f3b-9c2d-7e8f1a2b3c4d";
+    // we deliberately picked a different one so an id-vs-slug collision
+    // across collections doesn't produce the same point ID.
+    expect(SKILL_NAMESPACE).not.toBe("8b9c5d4f-0e1a-4f3b-9c2d-7e8f1a2b3c4d");
+  });
+});
+
+describe("memory v2 skill qdrant — collection lifecycle", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("creates the collection with named dense + sparse vectors", async () => {
+    state.collectionExistsBeforeCreate = false;
+
+    await ensureSkillCollection();
+
+    expect(state.createCollectionCalls).toBe(1);
+    const params = state.createCollectionParams as {
+      vectors: {
+        dense: { size: number; distance: string; on_disk: boolean };
+      };
+      sparse_vectors: { sparse: Record<string, unknown> };
+      hnsw_config: { on_disk: boolean; m: number; ef_construct: number };
+      on_disk_payload: boolean;
+    };
+    expect(params.vectors.dense).toEqual({
+      size: 384,
+      distance: "Cosine",
+      on_disk: true,
+    });
+    expect(params.sparse_vectors.sparse).toEqual({});
+    expect(params.hnsw_config).toEqual({
+      on_disk: true,
+      m: 16,
+      ef_construct: 100,
+    });
+    expect(params.on_disk_payload).toBe(true);
+
+    // The id payload index is created up front, mirroring how the
+    // concept-page collection eagerly indexes `slug`.
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "id", field_schema: "keyword" },
+    ]);
+  });
+
+  test("re-running ensure on an existing collection is a no-op", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await ensureSkillCollection();
+    await ensureSkillCollection();
+
+    // Existence check fired exactly once thanks to the in-memory readiness
+    // cache; createCollection / createPayloadIndex never ran.
+    expect(state.createCollectionCalls).toBe(0);
+    expect(state.createIndexCalls).toEqual([]);
+    expect(state.collectionExistsCalls).toBe(1);
+  });
+
+  test("treats 409-on-create as success (concurrent creation race)", async () => {
+    state.collectionExistsBeforeCreate = false;
+    const conflict = Object.assign(new Error("Conflict"), { status: 409 });
+    state.createCollectionThrows = conflict;
+
+    await ensureSkillCollection();
+
+    // Falls through without throwing — collectionReady gets latched.
+    expect(state.createCollectionCalls).toBe(1);
+    // Index creation is skipped on the 409 path because the racing peer is
+    // expected to have created it (it ran the same code).
+    expect(state.createIndexCalls).toEqual([]);
+  });
+});
+
+describe("memory v2 skill qdrant — upsert", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("upserts a single point keyed by a deterministic id-derived point id", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await upsertSkillEmbedding({
+      id: "example-skill-1",
+      displayName: "Example Skill 1",
+      content: "The Example Skill 1 (example-skill-1) is available. ...",
+      dense: [0.1, 0.2, 0.3],
+      sparse: { indices: [1, 2], values: [0.5, 0.5] },
+      updatedAt: 1714000000000,
+    });
+
+    expect(state.upsertCalls).toHaveLength(1);
+    const call = state.upsertCalls[0];
+    expect(call.wait).toBe(true);
+    expect(call.points).toHaveLength(1);
+    const [point] = call.points;
+    expect(point.payload).toEqual({
+      id: "example-skill-1",
+      displayName: "Example Skill 1",
+      content: "The Example Skill 1 (example-skill-1) is available. ...",
+      updated_at: 1714000000000,
+    });
+    expect(point.vector.dense).toEqual([0.1, 0.2, 0.3]);
+    expect(point.vector.sparse).toEqual({
+      indices: [1, 2],
+      values: [0.5, 0.5],
+    });
+    // Point ID is a UUID-shaped string derived from the skill id.
+    expect(point.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("two upserts for the same id share the same point id (overwrites in place)", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await upsertSkillEmbedding({
+      id: "example-skill-1",
+      displayName: "Example Skill 1",
+      content: "first",
+      dense: [0.1],
+      sparse: { indices: [1], values: [1] },
+      updatedAt: 1,
+    });
+    await upsertSkillEmbedding({
+      id: "example-skill-1",
+      displayName: "Example Skill 1",
+      content: "second",
+      dense: [0.9],
+      sparse: { indices: [9], values: [0.5] },
+      updatedAt: 2,
+    });
+
+    expect(state.upsertCalls).toHaveLength(2);
+    expect(state.upsertCalls[0].points[0].id).toBe(
+      state.upsertCalls[1].points[0].id,
+    );
+  });
+
+  test("different ids map to different point ids", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await upsertSkillEmbedding({
+      id: "example-skill-1",
+      displayName: "Example Skill 1",
+      content: "a",
+      dense: [0.1],
+      sparse: { indices: [1], values: [1] },
+      updatedAt: 1,
+    });
+    await upsertSkillEmbedding({
+      id: "example-skill-2",
+      displayName: "Example Skill 2",
+      content: "b",
+      dense: [0.1],
+      sparse: { indices: [1], values: [1] },
+      updatedAt: 1,
+    });
+
+    expect(state.upsertCalls[0].points[0].id).not.toBe(
+      state.upsertCalls[1].points[0].id,
+    );
+  });
+});
+
+describe("memory v2 skill qdrant — delete", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("deletes a skill by its deterministic point id", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await deleteSkillEmbedding("example-skill-1");
+
+    expect(state.deleteCalls).toHaveLength(1);
+    const call = state.deleteCalls[0];
+    expect(call.wait).toBe(true);
+    expect(call.points).toHaveLength(1);
+    expect(call.points[0]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("delete is idempotent across repeated calls (no exception)", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await deleteSkillEmbedding("example-skill-1");
+    await deleteSkillEmbedding("example-skill-1");
+
+    expect(state.deleteCalls).toHaveLength(2);
+  });
+
+  test("deletes use the same point id as upserts for the same skill id", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await upsertSkillEmbedding({
+      id: "example-skill-1",
+      displayName: "Example Skill 1",
+      content: "x",
+      dense: [0.1],
+      sparse: { indices: [1], values: [1] },
+      updatedAt: 1,
+    });
+    await deleteSkillEmbedding("example-skill-1");
+
+    expect(state.upsertCalls[0].points[0].id).toBe(
+      String(state.deleteCalls[0].points[0]),
+    );
+  });
+});
+
+describe("memory v2 skill qdrant — prune", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("removes points whose payload.id is not in the active set", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.scrollPages.push({
+      points: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          payload: { id: "example-skill-1" },
+        },
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          payload: { id: "example-skill-2" },
+        },
+      ],
+      next_page_offset: null,
+    });
+
+    await pruneSkillsExcept(["example-skill-1"]);
+
+    // One scroll, one batch delete carrying only the stale point id.
+    expect(state.scrollCalls).toHaveLength(1);
+    expect(state.deleteCalls).toHaveLength(1);
+    expect(state.deleteCalls[0].wait).toBe(true);
+    expect(state.deleteCalls[0].points).toEqual([
+      "22222222-2222-2222-2222-222222222222",
+    ]);
+  });
+
+  test("no-op delete when every live point is in the active set", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.scrollPages.push({
+      points: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          payload: { id: "example-skill-1" },
+        },
+      ],
+      next_page_offset: null,
+    });
+
+    await pruneSkillsExcept(["example-skill-1"]);
+
+    expect(state.scrollCalls).toHaveLength(1);
+    expect(state.deleteCalls).toHaveLength(0);
+  });
+
+  test("paginates via scroll's next_page_offset until exhausted", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.scrollPages.push({
+      points: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          payload: { id: "example-skill-1" },
+        },
+      ],
+      next_page_offset: "next-token",
+    });
+    state.scrollPages.push({
+      points: [
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          payload: { id: "example-skill-2" },
+        },
+      ],
+      next_page_offset: null,
+    });
+
+    await pruneSkillsExcept(["example-skill-1"]);
+
+    // Two scrolls, the second carrying the offset returned by the first.
+    expect(state.scrollCalls).toHaveLength(2);
+    expect(state.scrollCalls[0].offset).toBeUndefined();
+    expect(state.scrollCalls[1].offset).toBe("next-token");
+    // Only the stale point gets deleted.
+    expect(state.deleteCalls).toHaveLength(1);
+    expect(state.deleteCalls[0].points).toEqual([
+      "22222222-2222-2222-2222-222222222222",
+    ]);
+  });
+
+  test("ignores points missing a string payload.id", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.scrollPages.push({
+      points: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          payload: {}, // no id field at all
+        },
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          payload: { id: 42 }, // wrong type
+        },
+        {
+          id: "33333333-3333-3333-3333-333333333333",
+          payload: { id: "example-skill-2" },
+        },
+      ],
+      next_page_offset: null,
+    });
+
+    await pruneSkillsExcept(["example-skill-1"]);
+
+    // Only the well-typed stale id is deleted; malformed payloads are
+    // ignored rather than treated as "stale".
+    expect(state.deleteCalls).toHaveLength(1);
+    expect(state.deleteCalls[0].points).toEqual([
+      "33333333-3333-3333-3333-333333333333",
+    ]);
+  });
+
+  test("idempotent across repeated calls with the same active set", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.scrollPages.push({
+      points: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          payload: { id: "example-skill-1" },
+        },
+      ],
+      next_page_offset: null,
+    });
+    state.scrollPages.push({
+      points: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          payload: { id: "example-skill-1" },
+        },
+      ],
+      next_page_offset: null,
+    });
+
+    await pruneSkillsExcept(["example-skill-1"]);
+    await pruneSkillsExcept(["example-skill-1"]);
+
+    // Both runs scrolled; neither deleted because the live set matches.
+    expect(state.scrollCalls).toHaveLength(2);
+    expect(state.deleteCalls).toHaveLength(0);
+  });
+});
+
+describe("memory v2 skill qdrant — hybrid query", () => {
+  beforeEach(resetState);
+  afterEach(resetState);
+
+  test("runs both dense and sparse queries and returns per-channel scores", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.queryResponses.dense.push({
+      points: [
+        { score: 0.91, payload: { id: "example-skill-1" } },
+        { score: 0.42, payload: { id: "example-skill-2" } },
+      ],
+    });
+    state.queryResponses.sparse.push({
+      points: [
+        { score: 12, payload: { id: "example-skill-1" } },
+        { score: 3, payload: { id: "example-skill-2" } },
+      ],
+    });
+
+    const results = await hybridQuerySkills(
+      [0.1, 0.2, 0.3],
+      { indices: [1, 2], values: [0.5, 0.5] },
+      5,
+    );
+
+    // Both queries fired, with the same limit and the right `using`.
+    expect(state.queryCalls).toHaveLength(2);
+    const usings = state.queryCalls.map((c) => c.using).sort();
+    expect(usings).toEqual(["dense", "sparse"]);
+    expect(state.queryCalls.every((c) => c.limit === 5)).toBe(true);
+    expect(state.queryCalls.every((c) => c.with_payload === true)).toBe(true);
+
+    // Each id exposes both channel scores.
+    expect(results).toHaveLength(2);
+    const skill1 = results.find((r) => r.id === "example-skill-1");
+    const skill2 = results.find((r) => r.id === "example-skill-2");
+    expect(skill1).toEqual({
+      id: "example-skill-1",
+      denseScore: 0.91,
+      sparseScore: 12,
+    });
+    expect(skill2).toEqual({
+      id: "example-skill-2",
+      denseScore: 0.42,
+      sparseScore: 3,
+    });
+  });
+
+  test("dense-only hits leave sparseScore undefined (and vice versa)", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.queryResponses.dense.push({
+      points: [{ score: 0.7, payload: { id: "example-skill-1" } }],
+    });
+    state.queryResponses.sparse.push({
+      points: [{ score: 2, payload: { id: "example-skill-2" } }],
+    });
+
+    const results = await hybridQuerySkills(
+      [0.1],
+      { indices: [1], values: [1] },
+      5,
+    );
+
+    const denseOnly = results.find((r) => r.id === "example-skill-1");
+    const sparseOnly = results.find((r) => r.id === "example-skill-2");
+    expect(denseOnly).toEqual({ id: "example-skill-1", denseScore: 0.7 });
+    expect(denseOnly?.sparseScore).toBeUndefined();
+    expect(sparseOnly).toEqual({ id: "example-skill-2", sparseScore: 2 });
+    expect(sparseOnly?.denseScore).toBeUndefined();
+  });
+
+  test("does not use Qdrant-side RRF fusion (separate per-channel queries)", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.queryResponses.dense.push({ points: [] });
+    state.queryResponses.sparse.push({ points: [] });
+
+    await hybridQuerySkills([0.1], { indices: [1], values: [1] }, 5);
+
+    // Each query is a single-channel call (no `prefetch` + `fusion` shape).
+    for (const call of state.queryCalls) {
+      expect(call).not.toHaveProperty("prefetch");
+      const wholeCall = call as unknown as Record<string, unknown>;
+      expect(wholeCall.fusion).toBeUndefined();
+    }
+  });
+
+  test("does not pass a payload filter (full skill catalog is always queried)", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.queryResponses.dense.push({ points: [] });
+    state.queryResponses.sparse.push({ points: [] });
+
+    await hybridQuerySkills([0.1], { indices: [1], values: [1] }, 5);
+
+    for (const call of state.queryCalls) {
+      const wholeCall = call as unknown as Record<string, unknown>;
+      expect(wholeCall.filter).toBeUndefined();
+    }
+  });
+
+  test("empty Qdrant responses yield []", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.queryResponses.dense.push({ points: [] });
+    state.queryResponses.sparse.push({ points: [] });
+
+    const results = await hybridQuerySkills(
+      [0.1],
+      { indices: [1], values: [1] },
+      5,
+    );
+    expect(results).toEqual([]);
+  });
+});

--- a/assistant/src/memory/v2/skill-qdrant.ts
+++ b/assistant/src/memory/v2/skill-qdrant.ts
@@ -1,0 +1,401 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — Qdrant collection for skill autoinjection
+// ---------------------------------------------------------------------------
+//
+// Owns a dedicated Qdrant collection, keyed by skill `id`, that holds dense +
+// sparse embeddings of every enabled skill's `buildSkillContent` snippet. The
+// collection is separate from `memory_v2_concept_pages` because skills are
+// stateless (no `everInjected` dedup, no on-disk concept pages, no edges) and
+// re-presented every turn — keeping them in their own collection means skill
+// pruning and reseeding never touches concept-page state.
+//
+// Mirrors the dense + sparse named-vectors layout used by
+// `ensureConceptPageCollection` in `qdrant.ts`. Connection settings — URL,
+// vector size, on-disk storage — flow through the same env → config
+// precedence as v1 via `resolveQdrantUrl` and `config.memory.qdrant.*`.
+//
+// Per-channel queries: `hybridQuerySkills` runs separate dense and sparse
+// queries (no Qdrant-side RRF). Callers do their own weighted-sum fusion using
+// `dense_weight` / `sparse_weight` from `config.memory.v2`, which RRF fusion
+// would discard.
+
+import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
+import { v5 as uuidv5 } from "uuid";
+
+import { getConfig } from "../../config/loader.js";
+import { getLogger } from "../../util/logger.js";
+import type { SparseEmbedding } from "../embedding-types.js";
+import { resolveQdrantUrl } from "../qdrant-client.js";
+
+const log = getLogger("memory-v2-skill-qdrant");
+
+/** Name of the dedicated Qdrant collection holding skill embeddings. */
+export const MEMORY_V2_SKILLS_COLLECTION = "memory_v2_skills";
+
+/**
+ * Stable UUIDv5 namespace used to derive a deterministic Qdrant point ID from
+ * a skill id. The namespace is an arbitrary fixed UUID; what matters is that
+ * the same id always maps to the same point ID so upserts replace in place
+ * instead of accumulating duplicates. Distinct from `qdrant.ts`'s
+ * `SLUG_NAMESPACE` so a skill id that happens to collide with a concept-page
+ * slug still maps to a different point ID across the two collections.
+ */
+export const SKILL_NAMESPACE = "f1903e7f-1b9d-4c15-ac46-3540b8b0a9f6";
+
+/** Per-channel score for a single skill hit returned by hybrid query. */
+export interface SkillQueryResult {
+  id: string;
+  /**
+   * Dense cosine similarity, when the id appeared in the dense top-`limit`.
+   * `undefined` if the id only appeared in the sparse channel.
+   */
+  denseScore?: number;
+  /**
+   * Sparse score, when the id appeared in the sparse top-`limit`.
+   * `undefined` if the id only appeared in the dense channel. Lives on a
+   * different scale than `denseScore` — callers must normalize before fusing.
+   */
+  sparseScore?: number;
+}
+
+let _client: QdrantRestClient | null = null;
+let _collectionReady = false;
+
+/** Lazily create a Qdrant REST client bound to the resolved URL. */
+function getClient(): QdrantRestClient {
+  if (_client) return _client;
+  const config = getConfig();
+  _client = new QdrantRestClient({
+    url: resolveQdrantUrl(config),
+    checkCompatibility: false,
+  });
+  return _client;
+}
+
+/**
+ * Create the v2 skills collection if it does not already exist.
+ * Idempotent: a no-op when the collection is already present.
+ *
+ * Vector layout mirrors `ensureConceptPageCollection` — named dense (cosine,
+ * configurable size + on-disk) and sparse vectors. The vector size and
+ * on-disk flag inherit from `config.memory.qdrant` so v2 stays aligned with
+ * the user's existing embedding backend without separate knobs.
+ */
+export async function ensureSkillCollection(): Promise<void> {
+  if (_collectionReady) return;
+
+  const client = getClient();
+  const config = getConfig();
+  const vectorSize = config.memory.qdrant.vectorSize;
+  const onDisk = config.memory.qdrant.onDisk;
+
+  try {
+    const exists = await client.collectionExists(MEMORY_V2_SKILLS_COLLECTION);
+    if (exists.exists) {
+      _collectionReady = true;
+      return;
+    }
+  } catch (err) {
+    // Treat "not found"-shaped errors as "needs creation" and fall through.
+    if (!isCollectionMissing(err)) throw err;
+  }
+
+  log.info(
+    { collection: MEMORY_V2_SKILLS_COLLECTION, vectorSize },
+    "Creating Qdrant collection for memory v2 skills",
+  );
+
+  try {
+    await client.createCollection(MEMORY_V2_SKILLS_COLLECTION, {
+      vectors: {
+        dense: {
+          size: vectorSize,
+          distance: "Cosine",
+          on_disk: onDisk,
+        },
+      },
+      sparse_vectors: {
+        sparse: {}, // Qdrant auto-infers sparse vector params
+      },
+      hnsw_config: {
+        on_disk: onDisk,
+        m: 16,
+        ef_construct: 100,
+      },
+      on_disk_payload: onDisk,
+    });
+  } catch (err) {
+    // 409 = a concurrent caller created the collection — that's fine.
+    if (
+      err instanceof Error &&
+      "status" in err &&
+      (err as { status: number }).status === 409
+    ) {
+      _collectionReady = true;
+      return;
+    }
+    throw err;
+  }
+
+  // Eagerly index `id` so future per-id filters (e.g. inspecting a single
+  // skill's stored payload) don't pay a one-time indexing cost. Mirrors the
+  // up-front `slug` index in `ensureConceptPageCollection`.
+  await client.createPayloadIndex(MEMORY_V2_SKILLS_COLLECTION, {
+    field_name: "id",
+    field_schema: "keyword",
+  });
+
+  _collectionReady = true;
+}
+
+/**
+ * Upsert a skill's dense + sparse embedding. The point ID is derived
+ * deterministically from the skill id so subsequent calls for the same id
+ * replace the prior point in place rather than accumulating duplicates.
+ */
+export async function upsertSkillEmbedding(params: {
+  id: string;
+  displayName: string;
+  content: string;
+  dense: number[];
+  sparse: SparseEmbedding;
+  updatedAt: number;
+}): Promise<void> {
+  await ensureSkillCollection();
+
+  const { id, displayName, content, dense, sparse, updatedAt } = params;
+  const client = getClient();
+  const pointId = pointIdForId(id);
+
+  const upsertOnce = () =>
+    client.upsert(MEMORY_V2_SKILLS_COLLECTION, {
+      wait: true,
+      points: [
+        {
+          id: pointId,
+          vector: { dense, sparse },
+          payload: {
+            id,
+            displayName,
+            content,
+            updated_at: updatedAt,
+          },
+        },
+      ],
+    });
+
+  try {
+    await upsertOnce();
+  } catch (err) {
+    if (isCollectionMissing(err)) {
+      _collectionReady = false;
+      await ensureSkillCollection();
+      await upsertOnce();
+      return;
+    }
+    throw err;
+  }
+}
+
+/** Remove the embedding for a skill id. Idempotent: no-op when the id is absent. */
+export async function deleteSkillEmbedding(id: string): Promise<void> {
+  await ensureSkillCollection();
+
+  const client = getClient();
+  const doDelete = () =>
+    client.delete(MEMORY_V2_SKILLS_COLLECTION, {
+      wait: true,
+      points: [pointIdForId(id)],
+    });
+
+  try {
+    await doDelete();
+  } catch (err) {
+    if (isCollectionMissing(err)) {
+      _collectionReady = false;
+      await ensureSkillCollection();
+      await doDelete();
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Remove every skill point whose `payload.id` is not in `activeIds`. Used by
+ * `seedV2SkillEntries` to drop stale points after a skill is uninstalled or
+ * disabled. Idempotent: when the live points already equal `activeIds`,
+ * the function performs a single scroll and no deletes.
+ *
+ * Implementation: paginate the collection with the Qdrant `scroll` API
+ * (payload-only, no vectors) and delete by point ID for any payload whose
+ * `id` is missing from the active set.
+ */
+export async function pruneSkillsExcept(
+  activeIds: readonly string[],
+): Promise<void> {
+  await ensureSkillCollection();
+
+  const client = getClient();
+  const activeSet = new Set(activeIds);
+
+  const doPrune = async (): Promise<void> => {
+    const stalePointIds: Array<string | number> = [];
+    let offset: string | number | undefined = undefined;
+    // Guard against a pathological pagination loop.
+    const maxIterations = 10_000;
+    const batchSize = 256;
+    for (let i = 0; i < maxIterations; i++) {
+      const result = await client.scroll(MEMORY_V2_SKILLS_COLLECTION, {
+        limit: batchSize,
+        with_payload: true,
+        with_vector: false,
+        ...(offset !== undefined ? { offset } : {}),
+      });
+      for (const point of result.points) {
+        const payloadId = (point.payload as { id?: unknown } | null)?.id;
+        if (typeof payloadId !== "string") continue;
+        if (!activeSet.has(payloadId)) {
+          stalePointIds.push(point.id);
+        }
+      }
+      const next = result.next_page_offset;
+      if (next == null) break;
+      offset = typeof next === "string" ? next : (next as number);
+    }
+
+    if (stalePointIds.length === 0) return;
+
+    await client.delete(MEMORY_V2_SKILLS_COLLECTION, {
+      wait: true,
+      points: stalePointIds,
+    });
+  };
+
+  try {
+    await doPrune();
+  } catch (err) {
+    if (isCollectionMissing(err)) {
+      _collectionReady = false;
+      await ensureSkillCollection();
+      await doPrune();
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Run separate dense and sparse queries against the skills collection and
+ * return per-channel scores per skill id. Callers fuse these — typically via
+ * a normalized weighted-sum — because RRF would discard the score magnitudes
+ * the activation formula needs.
+ *
+ * Each channel returns up to `limit` hits. A skill is included in the result
+ * if it appears in either channel; the missing channel's score is left
+ * `undefined` so callers can detect single-channel matches.
+ *
+ * Unlike `hybridQueryConceptPages`, there is no `restrictToIds` parameter —
+ * skill activation always considers the full enabled-skill catalog.
+ */
+export async function hybridQuerySkills(
+  dense: number[],
+  sparse: SparseEmbedding,
+  limit: number,
+): Promise<SkillQueryResult[]> {
+  await ensureSkillCollection();
+
+  const client = getClient();
+
+  const denseQuery = () =>
+    client.query(MEMORY_V2_SKILLS_COLLECTION, {
+      query: dense,
+      using: "dense",
+      limit,
+      with_payload: true,
+    });
+  const sparseQuery = () =>
+    client.query(MEMORY_V2_SKILLS_COLLECTION, {
+      query: sparse,
+      using: "sparse",
+      limit,
+      with_payload: true,
+    });
+
+  // Run both queries concurrently — they hit independent named vectors.
+  const runQueries = async () => Promise.all([denseQuery(), sparseQuery()]);
+
+  let denseResults;
+  let sparseResults;
+  try {
+    [denseResults, sparseResults] = await runQueries();
+  } catch (err) {
+    if (isCollectionMissing(err)) {
+      _collectionReady = false;
+      await ensureSkillCollection();
+      [denseResults, sparseResults] = await runQueries();
+    } else {
+      throw err;
+    }
+  }
+
+  // Merge by id. Missing-side scores stay undefined so the fuser can tell
+  // "no match in this channel" apart from "match with score 0".
+  const merged = new Map<string, SkillQueryResult>();
+  for (const point of denseResults.points ?? []) {
+    const id = (point.payload as { id?: unknown } | null)?.id;
+    if (typeof id !== "string") continue;
+    merged.set(id, { id, denseScore: point.score ?? 0 });
+  }
+  for (const point of sparseResults.points ?? []) {
+    const id = (point.payload as { id?: unknown } | null)?.id;
+    if (typeof id !== "string") continue;
+    const existing = merged.get(id);
+    if (existing) {
+      existing.sparseScore = point.score ?? 0;
+    } else {
+      merged.set(id, { id, sparseScore: point.score ?? 0 });
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+/**
+ * Detect "collection not found" errors so callers can reset readiness and
+ * retry after an external deletion (e.g. workspace reset). Re-implemented
+ * locally rather than imported from `qdrant.ts` to keep this module
+ * self-contained — the helper is small and the duplication is cleaner than
+ * exporting an internal detail across files.
+ */
+function isCollectionMissing(err: unknown): boolean {
+  if (
+    err &&
+    typeof err === "object" &&
+    "status" in err &&
+    (err as { status: number }).status === 404
+  ) {
+    return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    msg.includes("Not found") ||
+    msg.includes("doesn't exist") ||
+    msg.includes("not found")
+  );
+}
+
+/**
+ * Derive the deterministic Qdrant point ID for a skill id. Qdrant requires
+ * UUID/integer IDs; UUIDv5 keeps the mapping stable across processes so
+ * upserts replace in place.
+ */
+function pointIdForId(id: string): string {
+  return uuidv5(id, SKILL_NAMESPACE);
+}
+
+/** @internal Test-only: reset module-level singletons. */
+export function _resetMemoryV2SkillQdrantForTests(): void {
+  _client = null;
+  _collectionReady = false;
+}


### PR DESCRIPTION
## Summary
- Add memory_v2_skills Qdrant collection: ensureSkillCollection, upsertSkillEmbedding, deleteSkillEmbedding, hybridQuerySkills, pruneSkillsExcept.
- Mirrors qdrant.ts (concept pages) but keyed on skill id rather than slug.

Part of plan: memory-v2-skill-autoinjection.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
