### PR TITLE
feat(memory-v2): add skill-store with seedV2SkillEntries + getSkillCapability

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for `assistant/src/memory/v2/skill-store.ts`.
+ *
+ * Coverage matrix from PR 5 acceptance criteria:
+ *   - `seedV2SkillEntries` enumerates the catalog and calls
+ *     `upsertSkillEmbedding` for each enabled skill.
+ *   - It skips skills whose declared feature flag is disabled.
+ *   - It calls `pruneSkillsExcept` with the active id list.
+ *   - It populates the `entries` cache so `getSkillCapability` returns each entry.
+ *   - It swallows errors from the embedding backend — the function resolves
+ *     and the cache is unchanged from prior state.
+ *
+ * Hermetic by design: the catalog loader, state resolver, embedding backend,
+ * Qdrant module, and feature-flag resolver are all module-mocked so the suite
+ * never reaches a real backend or filesystem.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
+import type { ResolvedSkill } from "../../../config/skill-state.js";
+import type { SkillSummary } from "../../../config/skills.js";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+// ---------------------------------------------------------------------------
+// Programmable test state — drives every mocked dependency below.
+// ---------------------------------------------------------------------------
+
+interface TestState {
+  catalog: SkillSummary[];
+  resolved: ResolvedSkill[];
+  flagsEnabled: Record<string, boolean>;
+  embedThrows: Error | null;
+  embedReturn: number[][];
+  sparseReturn: { indices: number[]; values: number[] };
+  upsertCalls: Array<{
+    id: string;
+    displayName: string;
+    content: string;
+    dense: number[];
+    sparse: { indices: number[]; values: number[] };
+    updatedAt: number;
+  }>;
+  pruneCalls: Array<readonly string[]>;
+  upsertThrows: Error | null;
+}
+
+const state: TestState = {
+  catalog: [],
+  resolved: [],
+  flagsEnabled: {},
+  embedThrows: null,
+  embedReturn: [],
+  sparseReturn: { indices: [1], values: [1] },
+  upsertCalls: [],
+  pruneCalls: [],
+  upsertThrows: null,
+};
+
+// Stub config so resolveSkillStates / mcp augmentation have something to read.
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    memory: {
+      qdrant: { url: "http://127.0.0.1:6333", vectorSize: 3, onDisk: false },
+    },
+    mcp: { servers: {} },
+    skills: { entries: {}, allowBundled: null },
+  }),
+}));
+
+mock.module("../../../config/skills.js", () => ({
+  loadSkillCatalog: () => state.catalog,
+}));
+
+mock.module("../../../config/skill-state.js", () => ({
+  resolveSkillStates: () => state.resolved,
+}));
+
+mock.module("../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string) =>
+    state.flagsEnabled[key] ?? true,
+}));
+
+mock.module("../../embedding-backend.js", () => ({
+  embedWithBackend: async (_config: unknown, inputs: unknown[]) => {
+    if (state.embedThrows) throw state.embedThrows;
+    // Echo the configured per-call vectors back, padded if needed.
+    const vectors = state.embedReturn.length
+      ? state.embedReturn
+      : inputs.map(() => [0.1, 0.2, 0.3]);
+    return { provider: "local", model: "test-model", vectors };
+  },
+  generateSparseEmbedding: () => state.sparseReturn,
+}));
+
+mock.module("../skill-qdrant.js", () => ({
+  upsertSkillEmbedding: async (params: TestState["upsertCalls"][number]) => {
+    if (state.upsertThrows) throw state.upsertThrows;
+    state.upsertCalls.push(params);
+  },
+  pruneSkillsExcept: async (ids: readonly string[]) => {
+    state.pruneCalls.push(ids);
+  },
+}));
+
+// Imported AFTER all mocks are wired so the module under test sees the stubs.
+const { seedV2SkillEntries, getSkillCapability, _resetSkillStoreForTests } =
+  await import("../skill-store.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSummary(overrides: Partial<SkillSummary> = {}): SkillSummary {
+  return {
+    id: "example-skill-a",
+    name: "example-skill-a",
+    displayName: "Example Skill A",
+    description: "Does an example thing A",
+    directoryPath: "/tmp/skills/example-skill-a",
+    skillFilePath: "/tmp/skills/example-skill-a/SKILL.md",
+    source: "managed",
+    ...overrides,
+  };
+}
+
+function resetState(): void {
+  state.catalog = [];
+  state.resolved = [];
+  state.flagsEnabled = {};
+  state.embedThrows = null;
+  state.embedReturn = [];
+  state.sparseReturn = { indices: [1], values: [1] };
+  state.upsertCalls.length = 0;
+  state.pruneCalls.length = 0;
+  state.upsertThrows = null;
+  _resetSkillStoreForTests();
+}
+
+beforeEach(resetState);
+afterEach(resetState);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("seedV2SkillEntries", () => {
+  test("enumerates the catalog and upserts one point per enabled skill", async () => {
+    const skillA = makeSummary({
+      id: "example-skill-a",
+      displayName: "Skill A",
+    });
+    const skillB = makeSummary({
+      id: "example-skill-b",
+      displayName: "Skill B",
+    });
+    state.catalog = [skillA, skillB];
+    state.resolved = [
+      { summary: skillA, state: "enabled" },
+      { summary: skillB, state: "enabled" },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(2);
+    const ids = state.upsertCalls.map((c) => c.id).sort();
+    expect(ids).toEqual(["example-skill-a", "example-skill-b"]);
+
+    // Each upsert carries the per-skill dense + sparse + content payload.
+    const callA = state.upsertCalls.find((c) => c.id === "example-skill-a")!;
+    expect(callA.displayName).toBe("Skill A");
+    expect(callA.dense).toEqual([0.1, 0.2, 0.3]);
+    expect(callA.sparse).toEqual(state.sparseReturn);
+    expect(callA.content).toContain("Skill A");
+    expect(callA.content).toContain("(example-skill-a)");
+    expect(callA.updatedAt).toBeGreaterThan(0);
+  });
+
+  test("skips disabled skills (state !== 'enabled')", async () => {
+    const enabled = makeSummary({ id: "example-skill-a" });
+    const disabled = makeSummary({ id: "example-skill-b" });
+    state.catalog = [enabled, disabled];
+    state.resolved = [
+      { summary: enabled, state: "enabled" },
+      { summary: disabled, state: "disabled" },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.upsertCalls[0].id).toBe("example-skill-a");
+  });
+
+  test("skips skills whose declared feature flag is disabled", async () => {
+    const flagged = makeSummary({
+      id: "example-skill-a",
+      featureFlag: "experimental-flag",
+    });
+    const unflagged = makeSummary({ id: "example-skill-b" });
+    state.catalog = [flagged, unflagged];
+    state.resolved = [
+      { summary: flagged, state: "enabled" },
+      { summary: unflagged, state: "enabled" },
+    ];
+    state.flagsEnabled = { "experimental-flag": false };
+    state.embedReturn = [[0.4, 0.5, 0.6]];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.upsertCalls[0].id).toBe("example-skill-b");
+  });
+
+  test("calls pruneSkillsExcept with the active id list", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    const skillB = makeSummary({ id: "example-skill-b" });
+    state.catalog = [skillA, skillB];
+    state.resolved = [
+      { summary: skillA, state: "enabled" },
+      { summary: skillB, state: "enabled" },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    await seedV2SkillEntries();
+
+    expect(state.pruneCalls).toHaveLength(1);
+    expect([...state.pruneCalls[0]].sort()).toEqual([
+      "example-skill-a",
+      "example-skill-b",
+    ]);
+  });
+
+  test("passes only the active (post-flag-filter) ids to pruneSkillsExcept", async () => {
+    const flagged = makeSummary({
+      id: "example-skill-a",
+      featureFlag: "off-flag",
+    });
+    const unflagged = makeSummary({ id: "example-skill-b" });
+    state.catalog = [flagged, unflagged];
+    state.resolved = [
+      { summary: flagged, state: "enabled" },
+      { summary: unflagged, state: "enabled" },
+    ];
+    state.flagsEnabled = { "off-flag": false };
+    state.embedReturn = [[0.4, 0.5, 0.6]];
+
+    await seedV2SkillEntries();
+
+    expect(state.pruneCalls).toHaveLength(1);
+    expect([...state.pruneCalls[0]]).toEqual(["example-skill-b"]);
+  });
+
+  test("populates the entries cache so getSkillCapability returns each entry", async () => {
+    const skillA = makeSummary({
+      id: "example-skill-a",
+      displayName: "Skill A",
+    });
+    const skillB = makeSummary({
+      id: "example-skill-b",
+      displayName: "Skill B",
+    });
+    state.catalog = [skillA, skillB];
+    state.resolved = [
+      { summary: skillA, state: "enabled" },
+      { summary: skillB, state: "enabled" },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    expect(getSkillCapability("example-skill-a")).toBeNull();
+
+    await seedV2SkillEntries();
+
+    const entryA = getSkillCapability("example-skill-a");
+    const entryB = getSkillCapability("example-skill-b");
+    expect(entryA).not.toBeNull();
+    expect(entryA?.id).toBe("example-skill-a");
+    expect(entryA?.displayName).toBe("Skill A");
+    expect(entryA?.content).toContain("Skill A");
+
+    expect(entryB).not.toBeNull();
+    expect(entryB?.id).toBe("example-skill-b");
+    expect(entryB?.displayName).toBe("Skill B");
+
+    // Unknown ids return null even when the cache is populated.
+    expect(getSkillCapability("unknown-skill")).toBeNull();
+  });
+
+  test("swallows errors from embedWithBackend and leaves prior cache intact", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    // First run populates the cache.
+    await seedV2SkillEntries();
+    const before = getSkillCapability("example-skill-a");
+    expect(before).not.toBeNull();
+
+    // Second run: embedding throws — the function must resolve, the cache
+    // must be unchanged, and no new upsert/prune should have happened.
+    state.upsertCalls.length = 0;
+    state.pruneCalls.length = 0;
+    state.embedThrows = new Error("backend exploded");
+
+    await expect(seedV2SkillEntries()).resolves.toBeUndefined();
+
+    expect(state.upsertCalls).toHaveLength(0);
+    expect(state.pruneCalls).toHaveLength(0);
+    const after = getSkillCapability("example-skill-a");
+    expect(after).toEqual(before);
+  });
+
+  test("no enabled skills yields empty cache and a single empty prune call", async () => {
+    state.catalog = [];
+    state.resolved = [];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(0);
+    expect(state.pruneCalls).toHaveLength(1);
+    expect([...state.pruneCalls[0]]).toEqual([]);
+    expect(getSkillCapability("anything")).toBeNull();
+  });
+});
+
+describe("getSkillCapability", () => {
+  test("returns null before any seed run", () => {
+    expect(getSkillCapability("example-skill-a")).toBeNull();
+  });
+
+  test("returns null for unknown ids after seeding", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    expect(getSkillCapability("does-not-exist")).toBeNull();
+  });
+});

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — Skill catalog → embedded skill entries
+// ---------------------------------------------------------------------------
+//
+// Mirrors v1's `seedSkillGraphNodes` (capability-seed.ts) for the v2 pipeline:
+// enumerate the enabled-skill catalog, render each skill's prose statement via
+// `buildSkillContent`, embed dense + sparse, upsert into the dedicated
+// `memory_v2_skills` Qdrant collection, and prune stale points from prior
+// catalog state.
+//
+// Unlike v1, skill entries are kept in a small in-process cache so the render
+// path can fetch a `SkillEntry` synchronously by id without round-tripping to
+// Qdrant. The cache is replaced atomically at the end of a successful seed
+// run; on error the prior cache stays intact (skills are best-effort).
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { resolveSkillStates } from "../../config/skill-state.js";
+import { loadSkillCatalog } from "../../config/skills.js";
+import { fromSkillSummary } from "../../skills/skill-memory.js";
+import { getLogger } from "../../util/logger.js";
+import {
+  embedWithBackend,
+  generateSparseEmbedding,
+} from "../embedding-backend.js";
+import {
+  augmentMcpSetupDescription,
+  buildSkillContent,
+} from "./skill-content.js";
+import { pruneSkillsExcept, upsertSkillEmbedding } from "./skill-qdrant.js";
+import type { SkillEntry } from "./types.js";
+
+const log = getLogger("memory-v2-skill-store");
+
+/**
+ * Module-level cache of rendered skill entries keyed by skill id. `null` until
+ * the first successful seed run completes; replaced atomically on each
+ * successful re-seed so callers always see a consistent snapshot.
+ */
+let entries: Map<string, SkillEntry> | null = null;
+
+/**
+ * Seed (or re-seed) the v2 skill embedding collection from the live skill
+ * catalog. Idempotent: safe to call repeatedly. Best-effort: never throws —
+ * any failure leaves the prior `entries` cache in place and logs a warning.
+ *
+ * Steps:
+ *   1. Enumerate the local skill catalog and resolve each skill's enabled state
+ *      (`resolveSkillStates`).
+ *   2. Build a `SkillCapabilityInput` per enabled skill, applying the
+ *      mcp-setup augmentation (mirrors v1) and the prose-style content render
+ *      (`buildSkillContent`, capped at 500 chars).
+ *   3. Defense-in-depth feature-flag filter: drop any skill whose declared
+ *      `metadata.vellum.feature-flag` is currently disabled. `resolveSkillStates`
+ *      already enforces this, but we mirror v1's enforcement point so the v2
+ *      collection never holds an embedding for a flag-gated skill if the two
+ *      ever drift.
+ *   4. Embed all `content` strings in a single dense `embedWithBackend` call,
+ *      and a per-skill synchronous `generateSparseEmbedding`.
+ *   5. Upsert one Qdrant point per skill via `upsertSkillEmbedding` (keyed
+ *      deterministically on id so re-runs replace in place).
+ *   6. Call `pruneSkillsExcept` with the active id list to drop any stale
+ *      points from prior catalog state (e.g. uninstalled skills).
+ *   7. Replace the module-level `entries` cache with the freshly built map.
+ */
+export async function seedV2SkillEntries(): Promise<void> {
+  try {
+    const config = getConfig();
+    const catalog = loadSkillCatalog();
+    const resolved = resolveSkillStates(catalog, config);
+    const enabled = resolved.filter((r) => r.state === "enabled");
+
+    // Build the input list, applying the mcp-setup description augmentation
+    // and the defense-in-depth feature-flag filter.
+    const seeds: SkillEntry[] = [];
+    for (const { summary } of enabled) {
+      const flagKey = summary.featureFlag;
+      if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
+
+      const augmented = augmentMcpSetupDescription(fromSkillSummary(summary));
+      const content = buildSkillContent(augmented);
+      seeds.push({ id: summary.id, displayName: summary.displayName, content });
+    }
+
+    // Embed all content strings in one batched call. Sparse vectors are
+    // computed in-process (no network).
+    const { vectors: denseVectors } = await embedWithBackend(
+      config,
+      seeds.map((s) => s.content),
+    );
+
+    const now = Date.now();
+    const nextEntries = new Map<string, SkillEntry>();
+    for (let i = 0; i < seeds.length; i++) {
+      const seed = seeds[i];
+      await upsertSkillEmbedding({
+        ...seed,
+        dense: denseVectors[i],
+        sparse: generateSparseEmbedding(seed.content),
+        updatedAt: now,
+      });
+      nextEntries.set(seed.id, seed);
+    }
+
+    // Prune any points whose id is no longer in the active set.
+    await pruneSkillsExcept(seeds.map((s) => s.id));
+
+    // Atomically replace the cache only after every step above succeeds.
+    entries = nextEntries;
+  } catch (err) {
+    log.warn({ err }, "Failed to seed v2 skill entries");
+  }
+}
+
+/**
+ * Synchronous lookup of a previously-seeded `SkillEntry` by skill id. Returns
+ * `null` when the cache has not yet been populated, when the id is unknown,
+ * or when a prior seed run dropped the id (e.g. the skill was disabled). Used
+ * by the render path to attach skill-related content to outgoing prompts.
+ */
+export function getSkillCapability(id: string): SkillEntry | null {
+  return entries?.get(id) ?? null;
+}
+
+/** @internal Test-only: clear the module-level cache. */
+export function _resetSkillStoreForTests(): void {
+  entries = null;
+}


### PR DESCRIPTION
## Summary
- seedV2SkillEntries: enumerates the skill catalog, embeds each enabled skill, upserts into memory_v2_skills, and prunes stale entries.
- getSkillCapability(id): in-process cache lookup used by the render path.
- Respects feature flags (skips skills whose metadata.vellum.feature-flag is off).

Part of plan: memory-v2-skill-autoinjection.md (PR 5 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
