### PR TITLE
feat(memory-v2): add skill candidate / activation / injection helpers

### DIFF
--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -67,7 +67,19 @@ const state = {
       points: Array<{ score?: number; payload: Record<string, unknown> }>;
     }>,
   },
+  // Separate response queue for the dedicated `memory_v2_skills` collection
+  // so a test asserting on skill activation does not have to interleave
+  // responses with concept-page queries.
+  skillQueryResponses: {
+    dense: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+    sparse: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+  },
   queryCalls: [] as Array<{
+    collection: string;
     using: string;
     limit: number;
     filter: unknown;
@@ -103,15 +115,20 @@ class MockQdrantClient {
     return {};
   }
   async query(
-    _name: string,
+    name: string,
     params: { using: string; limit: number; filter?: unknown },
   ) {
     state.queryCalls.push({
+      collection: name,
       using: params.using,
       limit: params.limit,
       filter: params.filter,
     });
-    const queue = state.queryResponses[params.using as "dense" | "sparse"];
+    const channel = params.using as "dense" | "sparse";
+    const queue =
+      name === "memory_v2_skills"
+        ? state.skillQueryResponses[channel]
+        : state.queryResponses[channel];
     return queue.shift() ?? { points: [] };
   }
 }
@@ -126,11 +143,16 @@ import type { ActivationState, EdgesIndex } from "../types.js";
 
 const {
   computeOwnActivation,
+  computeSkillActivation,
   selectCandidates,
   selectInjections,
+  selectSkillCandidates,
+  selectSkillInjections,
   spreadActivation,
 } = await import("../activation.js");
 const { _resetMemoryV2QdrantForTests } = await import("../qdrant.js");
+const { _resetMemoryV2SkillQdrantForTests } =
+  await import("../skill-qdrant.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -143,13 +165,16 @@ function resetState(): void {
   state.sparseReturn = { indices: [1, 2, 3], values: [0.5, 0.5, 0.5] };
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
+  state.skillQueryResponses.dense.length = 0;
+  state.skillQueryResponses.sparse.length = 0;
   state.queryCalls.length = 0;
   // Bun's `mock.module` persists across files in the same process, so the
-  // qdrant module's `_client` singleton can be a MockQdrantClient instance
-  // installed by a sibling test file (e.g. sim.test.ts). Resetting both the
+  // qdrant modules' `_client` singletons may already hold a MockQdrantClient
+  // instance from a sibling test file (e.g. sim.test.ts). Resetting both the
   // cache AND any latched readiness forces a fresh `new QdrantClient()` —
   // which under our mock above resolves to *this* file's MockQdrantClient.
   _resetMemoryV2QdrantForTests();
+  _resetMemoryV2SkillQdrantForTests();
 }
 
 /**
@@ -625,5 +650,307 @@ describe("selectInjections", () => {
       topK: 5,
     });
     expect(out.topNow).toEqual(["alice", "mike", "zeta"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectSkillCandidates
+// ---------------------------------------------------------------------------
+
+/** Stage a single hybrid response on the skills queues (payload key = `id`). */
+function stageSkillHybridResponse(
+  hits: Array<{ id: string; denseScore?: number; sparseScore?: number }>,
+): void {
+  state.skillQueryResponses.dense.push({
+    points: hits
+      .filter((h) => h.denseScore !== undefined)
+      .map((h) => ({ score: h.denseScore, payload: { id: h.id } })),
+  });
+  state.skillQueryResponses.sparse.push({
+    points: hits
+      .filter((h) => h.sparseScore !== undefined)
+      .map((h) => ({ score: h.sparseScore, payload: { id: h.id } })),
+  });
+}
+
+describe("selectSkillCandidates", () => {
+  test("returns hit ids from the skills collection", async () => {
+    stageSkillHybridResponse([
+      { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
+      { id: "example-skill-b", denseScore: 0.3, sparseScore: 1 },
+    ]);
+    const out = await selectSkillCandidates({
+      userText: "user said hello",
+      assistantText: "",
+      nowText: "",
+      config: makeConfig(),
+      topK: 10,
+    });
+    expect(out).toEqual(new Set(["example-skill-a", "example-skill-b"]));
+  });
+
+  test("empty turn text short-circuits without backend calls", async () => {
+    const out = await selectSkillCandidates({
+      userText: "",
+      assistantText: "",
+      nowText: "",
+      config: makeConfig(),
+      topK: 10,
+    });
+    expect(out.size).toBe(0);
+    expect(state.embedCalls).toHaveLength(0);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("topK=0 short-circuits without backend calls", async () => {
+    const out = await selectSkillCandidates({
+      userText: "anything",
+      assistantText: "anything",
+      nowText: "anything",
+      config: makeConfig(),
+      topK: 0,
+    });
+    expect(out.size).toBe(0);
+    expect(state.embedCalls).toHaveLength(0);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("forwards topK and queries the skills collection unrestricted", async () => {
+    stageSkillHybridResponse([
+      { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
+    ]);
+    await selectSkillCandidates({
+      userText: "hello",
+      assistantText: "",
+      nowText: "",
+      config: makeConfig(),
+      topK: 7,
+    });
+    // Both channels (dense + sparse) ran with limit=7 and no slug/id filter,
+    // against the dedicated skills collection.
+    expect(state.queryCalls).toHaveLength(2);
+    for (const call of state.queryCalls) {
+      expect(call.collection).toBe("memory_v2_skills");
+      expect(call.limit).toBe(7);
+      expect(call.filter).toBeUndefined();
+    }
+  });
+
+  test("embeds concatenated turn text exactly once", async () => {
+    stageSkillHybridResponse([]);
+    await selectSkillCandidates({
+      userText: "user line",
+      assistantText: "assistant line",
+      nowText: "now line",
+      config: makeConfig(),
+      topK: 5,
+    });
+    expect(state.embedCalls).toHaveLength(1);
+    expect(state.embedCalls[0].inputs).toEqual([
+      "user line\nassistant line\nnow line",
+    ]);
+    expect(state.sparseCalls).toEqual(["user line\nassistant line\nnow line"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeSkillActivation
+// ---------------------------------------------------------------------------
+
+describe("computeSkillActivation", () => {
+  test("empty candidates short-circuits without backend calls", async () => {
+    const out = await computeSkillActivation({
+      candidates: new Set(),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig(),
+    });
+    expect(out.size).toBe(0);
+    expect(state.embedCalls).toHaveLength(0);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("applies similarity-only formula with no decay term", async () => {
+    // Stage three skill responses — one per `simSkillBatch` call.
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.5 }]); // simU
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.4 }]); // simA
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.2 }]); // simN
+
+    const out = await computeSkillActivation({
+      candidates: new Set(["example-skill-a"]),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig({
+        d: 0.3,
+        c_user: 0.3,
+        c_assistant: 0.2,
+        c_now: 0.2,
+      }),
+    });
+    // No `d · prev` term: 0.3*0.5 + 0.2*0.4 + 0.2*0.2 = 0.15 + 0.08 + 0.04 = 0.27
+    expect(out.get("example-skill-a")).toBeCloseTo(0.27, 6);
+  });
+
+  test("output excludes any decay term — d coefficient is unused", async () => {
+    // The skill activation formula is `c_user·simU + c_assistant·simA +
+    // c_now·simN`. Run with d=0.9 and d=0.0 — if the implementation
+    // accidentally included a `d · prev` term, the two would diverge. The
+    // function has no priorState parameter, so prev=0; both runs must equal
+    // the d-free formula exactly. Stage three sim responses per run.
+    const stage = () => {
+      stageSkillHybridResponse([{ id: "alpha", denseScore: 0.4 }]);
+      stageSkillHybridResponse([{ id: "alpha", denseScore: 0.4 }]);
+      stageSkillHybridResponse([{ id: "alpha", denseScore: 0.4 }]);
+    };
+    const baseConfig = { c_user: 0.3, c_assistant: 0.2, c_now: 0.2 };
+
+    stage();
+    const withHighD = await computeSkillActivation({
+      candidates: new Set(["alpha"]),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig({ ...baseConfig, d: 0.9 }),
+    });
+    stage();
+    const withZeroD = await computeSkillActivation({
+      candidates: new Set(["alpha"]),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig({ ...baseConfig, d: 0.0 }),
+    });
+
+    // Both equal `0.3*0.4 + 0.2*0.4 + 0.2*0.4 = 0.28` — d is ignored.
+    expect(withHighD.get("alpha")).toBeCloseTo(0.28, 6);
+    expect(withZeroD.get("alpha")).toBeCloseTo(0.28, 6);
+  });
+
+  test("clamps over-1.0 results down to [0, 1]", async () => {
+    stageSkillHybridResponse([{ id: "loud-skill", denseScore: 1.0 }]); // simU
+    stageSkillHybridResponse([{ id: "loud-skill", denseScore: 1.0 }]); // simA
+    stageSkillHybridResponse([{ id: "loud-skill", denseScore: 1.0 }]); // simN
+
+    // Coefficients intentionally sum to > 1 so the unclamped result
+    // overshoots — the implementation must still produce <= 1.0.
+    const out = await computeSkillActivation({
+      candidates: new Set(["loud-skill"]),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig({
+        c_user: 0.5,
+        c_assistant: 0.5,
+        c_now: 0.5,
+      }),
+    });
+    expect(out.get("loud-skill")).toBe(1);
+  });
+
+  test("candidate with no sim hits resolves to 0", async () => {
+    stageSkillHybridResponse([]);
+    stageSkillHybridResponse([]);
+    stageSkillHybridResponse([]);
+
+    const out = await computeSkillActivation({
+      candidates: new Set(["ghost-skill"]),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig(),
+    });
+    expect(out.get("ghost-skill")).toBe(0);
+  });
+
+  test("uses the dedicated skills collection and never queries concept pages", async () => {
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.5 }]);
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.5 }]);
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.5 }]);
+
+    await computeSkillActivation({
+      candidates: new Set(["example-skill-a"]),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig(),
+    });
+
+    // Three simSkillBatch calls × 2 channels = 6 total queries, all against
+    // the skills collection. No spread → no extra calls beyond these.
+    expect(state.queryCalls).toHaveLength(6);
+    for (const call of state.queryCalls) {
+      expect(call.collection).toBe("memory_v2_skills");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectSkillInjections
+// ---------------------------------------------------------------------------
+
+describe("selectSkillInjections", () => {
+  test("returns empty when activation is empty", () => {
+    const out = selectSkillInjections({ A: new Map(), topK: 5 });
+    expect(out).toEqual({ topNow: [] });
+  });
+
+  test("returns empty when topK is 0", () => {
+    const out = selectSkillInjections({
+      A: new Map([
+        ["example-skill-a", 0.5],
+        ["example-skill-b", 0.4],
+      ]),
+      topK: 0,
+    });
+    expect(out).toEqual({ topNow: [] });
+  });
+
+  test("ranks by activation descending and trims to topK", () => {
+    const out = selectSkillInjections({
+      A: new Map([
+        ["example-skill-a", 0.1],
+        ["example-skill-b", 0.9],
+        ["example-skill-c", 0.5],
+        ["example-skill-d", 0.3],
+      ]),
+      topK: 2,
+    });
+    expect(out.topNow).toEqual(["example-skill-b", "example-skill-c"]);
+  });
+
+  test("skills are stateless: the same id may be returned on consecutive turns", () => {
+    // No `everInjected` parameter exists — selectSkillInjections takes only
+    // the activation map and topK. So calling it twice with the same A map
+    // returns the same result; there is no dedup against prior turns.
+    const A = new Map([
+      ["example-skill-a", 0.9],
+      ["example-skill-b", 0.5],
+    ]);
+    const turn1 = selectSkillInjections({ A, topK: 5 });
+    const turn2 = selectSkillInjections({ A, topK: 5 });
+    expect(turn1.topNow).toEqual(["example-skill-a", "example-skill-b"]);
+    expect(turn2.topNow).toEqual(turn1.topNow);
+  });
+
+  test("breaks ties by id ascending for deterministic output", () => {
+    const out = selectSkillInjections({
+      A: new Map([
+        ["zeta-skill", 0.5],
+        ["example-skill-a", 0.5],
+        ["mike-skill", 0.5],
+      ]),
+      topK: 5,
+    });
+    expect(out.topNow).toEqual(["example-skill-a", "mike-skill", "zeta-skill"]);
+  });
+
+  test("topK clamps to the available activation entries", () => {
+    const out = selectSkillInjections({
+      A: new Map([["only-skill", 0.7]]),
+      topK: 100,
+    });
+    expect(out.topNow).toEqual(["only-skill"]);
   });
 });

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -71,7 +71,18 @@ const state = {
       points: Array<{ score?: number; payload: Record<string, unknown> }>;
     }>,
   },
+  // Separate response queue for the dedicated skills collection so a test
+  // querying both concept pages and skills doesn't have to interleave.
+  skillQueryResponses: {
+    dense: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+    sparse: [] as Array<{
+      points: Array<{ score?: number; payload: Record<string, unknown> }>;
+    }>,
+  },
   queryCalls: [] as Array<{
+    collection: string;
     using: string;
     limit: number;
     filter: unknown;
@@ -113,15 +124,20 @@ class MockQdrantClient {
     return {};
   }
   async query(
-    _name: string,
+    name: string,
     params: { using: string; limit: number; filter?: unknown },
   ) {
     state.queryCalls.push({
+      collection: name,
       using: params.using,
       limit: params.limit,
       filter: params.filter,
     });
-    const queue = state.queryResponses[params.using as "dense" | "sparse"];
+    const channel = params.using as "dense" | "sparse";
+    const queue =
+      name === "memory_v2_skills"
+        ? state.skillQueryResponses[channel]
+        : state.queryResponses[channel];
     return queue.shift() ?? { points: [] };
   }
 }
@@ -130,7 +146,10 @@ mock.module("@qdrant/js-client-rest", () => ({
   QdrantClient: MockQdrantClient,
 }));
 
-const { simBatch, clamp01 } = await import("../sim.js");
+const { simBatch, simSkillBatch, clamp01 } = await import("../sim.js");
+const { _resetMemoryV2SkillQdrantForTests } =
+  await import("../skill-qdrant.js");
+const { _resetMemoryV2QdrantForTests } = await import("../qdrant.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -143,7 +162,15 @@ function resetState(): void {
   state.sparseReturn = { indices: [1, 2, 3], values: [0.5, 0.5, 0.5] };
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
+  state.skillQueryResponses.dense.length = 0;
+  state.skillQueryResponses.sparse.length = 0;
   state.queryCalls.length = 0;
+  // Bun's `mock.module` persists across files in the same process, so the
+  // qdrant modules' singletons may already hold a MockQdrantClient instance
+  // from a sibling test file. Reset both readiness caches so each test in
+  // this file gets a fresh `new QdrantClient()` resolved against our mock.
+  _resetMemoryV2QdrantForTests();
+  _resetMemoryV2SkillQdrantForTests();
 }
 
 function configWithWeights(
@@ -359,5 +386,141 @@ describe("simBatch", () => {
       expect(score).toBeGreaterThanOrEqual(0);
       expect(score).toBeLessThanOrEqual(1);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// simSkillBatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Stage a single hybrid response on the dedicated skills queues. Mirrors
+ * `stageHybridResponse` but uses `payload.id` (skills' Qdrant payload key)
+ * instead of `payload.slug`.
+ */
+function stageSkillHybridResponse(
+  hits: Array<{ id: string; denseScore?: number; sparseScore?: number }>,
+): void {
+  state.skillQueryResponses.dense.push({
+    points: hits
+      .filter((h) => h.denseScore !== undefined)
+      .map((h) => ({ score: h.denseScore, payload: { id: h.id } })),
+  });
+  state.skillQueryResponses.sparse.push({
+    points: hits
+      .filter((h) => h.sparseScore !== undefined)
+      .map((h) => ({ score: h.sparseScore, payload: { id: h.id } })),
+  });
+}
+
+describe("simSkillBatch", () => {
+  test("empty id list returns empty map without touching backends", async () => {
+    const config = configWithWeights(0.7, 0.3);
+
+    const out = await simSkillBatch("anything", [], config);
+
+    expect(out.size).toBe(0);
+    expect(state.embedCalls).toHaveLength(0);
+    expect(state.sparseCalls).toHaveLength(0);
+    expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("queries the dedicated skills collection with no filter", async () => {
+    const config = configWithWeights(0.7, 0.3);
+    stageSkillHybridResponse([]);
+
+    await simSkillBatch(
+      "query",
+      ["example-skill-a", "example-skill-b"],
+      config,
+    );
+
+    expect(state.queryCalls).toHaveLength(2);
+    for (const call of state.queryCalls) {
+      expect(call.collection).toBe("memory_v2_skills");
+      // Skills are unrestricted: no slug/id filter is forwarded.
+      expect(call.filter).toBeUndefined();
+      // Limit equals the candidate count.
+      expect(call.limit).toBe(2);
+    }
+  });
+
+  test("fuses dense + sparse with the configured weight blend", async () => {
+    const config = configWithWeights(0.4, 0.6);
+    stageSkillHybridResponse([
+      { id: "example-skill-a", denseScore: 0.5, sparseScore: 4 }, // sparse-norm 1.0
+      { id: "example-skill-b", denseScore: 0.25, sparseScore: 2 }, // sparse-norm 0.5
+    ]);
+
+    const out = await simSkillBatch(
+      "query",
+      ["example-skill-a", "example-skill-b"],
+      config,
+    );
+
+    // example-skill-a: 0.4 * 0.5 + 0.6 * 1.0 = 0.8
+    // example-skill-b: 0.4 * 0.25 + 0.6 * 0.5 = 0.4
+    expect(out.get("example-skill-a")).toBeCloseTo(0.8, 6);
+    expect(out.get("example-skill-b")).toBeCloseTo(0.4, 6);
+  });
+
+  test("dense-only and sparse-only hits are handled symmetrically", async () => {
+    const config = configWithWeights(0.7, 0.3);
+    stageSkillHybridResponse([
+      { id: "example-skill-a", denseScore: 0.5 /* sparse omitted */ },
+      { id: "example-skill-b", sparseScore: 8 /* dense omitted */ },
+    ]);
+
+    const out = await simSkillBatch(
+      "query",
+      ["example-skill-a", "example-skill-b"],
+      config,
+    );
+
+    // example-skill-a: 0.7 * 0.5 + 0.3 * 0   = 0.35
+    // example-skill-b: 0.7 * 0   + 0.3 * 1.0 = 0.30 (sparse-norm = 8/8)
+    expect(out.get("example-skill-a")).toBeCloseTo(0.35, 6);
+    expect(out.get("example-skill-b")).toBeCloseTo(0.3, 6);
+  });
+
+  test("drops hits whose id is not in the candidate set", async () => {
+    // `hybridQuerySkills` queries the full collection — `simSkillBatch`
+    // must filter the results down to ids the caller asked for.
+    const config = configWithWeights(0.7, 0.3);
+    stageSkillHybridResponse([
+      { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
+      { id: "example-skill-c", denseScore: 0.9, sparseScore: 1 }, // not requested
+    ]);
+
+    const out = await simSkillBatch(
+      "query",
+      ["example-skill-a", "example-skill-b"],
+      config,
+    );
+
+    expect(out.has("example-skill-a")).toBe(true);
+    expect(out.has("example-skill-c")).toBe(false);
+  });
+
+  test("returned scores are clamped into [0, 1]", async () => {
+    const config = configWithWeights(0.8, 0.5); // intentionally sums to > 1
+    stageSkillHybridResponse([
+      { id: "example-skill-a", denseScore: 1.0, sparseScore: 1 },
+    ]);
+
+    const out = await simSkillBatch("query", ["example-skill-a"], config);
+
+    expect(out.get("example-skill-a")).toBe(1);
+  });
+
+  test("embeds the query text exactly once via dense + sparse backends", async () => {
+    const config = configWithWeights(0.7, 0.3);
+    stageSkillHybridResponse([]);
+
+    await simSkillBatch("hello skill", ["example-skill-a"], config);
+
+    expect(state.embedCalls).toHaveLength(1);
+    expect(state.embedCalls[0].inputs).toEqual(["hello skill"]);
+    expect(state.sparseCalls).toEqual(["hello skill"]);
   });
 });

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -34,7 +34,8 @@ import {
 } from "../embedding-backend.js";
 import { clampUnitInterval } from "../validation.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
-import { simBatch } from "./sim.js";
+import { simBatch, simSkillBatch } from "./sim.js";
+import { hybridQuerySkills } from "./skill-qdrant.js";
 import type {
   ActivationState,
   EdgesIndex,
@@ -342,4 +343,148 @@ export function selectInjections(
   const toInject = topNow.filter((slug) => !everSet.has(slug));
 
   return { topNow, toInject };
+}
+
+// ---------------------------------------------------------------------------
+// Skill autoinjection — candidate / activation / injection selection
+// ---------------------------------------------------------------------------
+//
+// Skills are stateless: there is no decay carry-over (`d · prev`), no
+// spreading activation, and no `everInjected` dedup. The agent re-presents
+// the top-K active skills every turn so it can drop or pick them up freely.
+// The pipeline therefore reduces to:
+//   1. ANN candidate selection against the dedicated skills collection.
+//   2. Pure similarity-only activation: A_skill = c_user·sim_u +
+//      c_assistant·sim_a + c_now·sim_n, clamped to [0, 1].
+//   3. Top-K by activation, lexicographic tie-break, no injection delta.
+//
+// The activation coefficients are reused from `config.memory.v2.{c_user,
+// c_assistant, c_now}` — the design doc (§9) deliberately shares them with
+// concept-page activation rather than introducing parallel knobs.
+
+export interface SelectSkillCandidatesParams {
+  userText: string;
+  assistantText: string;
+  nowText: string;
+  config: AssistantConfig;
+  /** Top-K size for the ANN query against `memory_v2_skills`. */
+  topK: number;
+}
+
+/**
+ * ANN top-K against the skills collection using the concatenated turn text.
+ * Runs a single embedding pass over `concat(user, assistant, now)` and a
+ * single hybrid Qdrant query — there is no prior-state carry-forward (skills
+ * are stateless).
+ *
+ * Returns a `Set<string>` of skill ids that hit either channel. Empty when
+ * the joined text is empty or `topK <= 0`.
+ */
+export async function selectSkillCandidates(
+  params: SelectSkillCandidatesParams,
+): Promise<Set<string>> {
+  const { userText, assistantText, nowText, config, topK } = params;
+
+  const candidates = new Set<string>();
+  if (topK <= 0) return candidates;
+
+  const annQueryText = [userText, assistantText, nowText]
+    .filter((s) => s.length > 0)
+    .join("\n");
+  if (annQueryText.length === 0) return candidates;
+
+  const denseResult = await embedWithBackend(config, [annQueryText]);
+  const dense = denseResult.vectors[0];
+  const sparse = generateSparseEmbedding(annQueryText);
+  const hits = await hybridQuerySkills(dense, sparse, topK);
+  for (const hit of hits) candidates.add(hit.id);
+
+  return candidates;
+}
+
+export interface ComputeSkillActivationParams {
+  candidates: ReadonlySet<string>;
+  userText: string;
+  assistantText: string;
+  nowText: string;
+  config: AssistantConfig;
+}
+
+/**
+ * Apply the skill-side activation formula (no decay carry-over, no spread):
+ *   A_skill(s) = clamp01(c_user · sim_u + c_assistant · sim_a + c_now · sim_n)
+ *
+ * Reuses the activation coefficients from `config.memory.v2`. The three
+ * `simSkillBatch` calls run concurrently — they hit independent named
+ * vectors and embed independent query texts.
+ *
+ * Empty candidates short-circuits to an empty map without touching the
+ * embedding backend or Qdrant.
+ */
+export async function computeSkillActivation(
+  params: ComputeSkillActivationParams,
+): Promise<Map<string, number>> {
+  const { candidates, userText, assistantText, nowText, config } = params;
+
+  const result = new Map<string, number>();
+  if (candidates.size === 0) return result;
+
+  const { c_user, c_assistant, c_now } = config.memory.v2;
+  const idList = [...candidates];
+
+  const [simUser, simAssistant, simNow] = await Promise.all([
+    simSkillBatch(userText, idList, config),
+    simSkillBatch(assistantText, idList, config),
+    simSkillBatch(nowText, idList, config),
+  ]);
+
+  for (const id of idList) {
+    const value =
+      c_user * (simUser.get(id) ?? 0) +
+      c_assistant * (simAssistant.get(id) ?? 0) +
+      c_now * (simNow.get(id) ?? 0);
+    result.set(id, clampUnitInterval(value));
+  }
+
+  return result;
+}
+
+export interface SelectSkillInjectionsParams {
+  /** Final skill activation map. */
+  A: ReadonlyMap<string, number>;
+  /** Cap on the per-turn skill slate, e.g. `config.memory.v2.skills_top_k`. */
+  topK: number;
+}
+
+export interface SelectSkillInjectionsResult {
+  /**
+   * Top-K skill ids by activation (descending), tie-broken lexicographically.
+   * Skills are re-presented every turn — no `toInject` delta — so the caller
+   * uses this list verbatim to render the skill slate.
+   */
+  topNow: string[];
+}
+
+/**
+ * Pick the top-K skill ids by activation (descending; stable on ties via id
+ * lexicographic order). Skills are stateless — there is no `everInjected`
+ * dedup, so the same id can appear on consecutive turns.
+ *
+ * Returns `{ topNow: [] }` for an empty activation map or `topK <= 0`.
+ */
+export function selectSkillInjections(
+  params: SelectSkillInjectionsParams,
+): SelectSkillInjectionsResult {
+  const { A, topK } = params;
+  if (A.size === 0 || topK <= 0) {
+    return { topNow: [] };
+  }
+
+  const ranked = [...A.entries()].sort(([idA, valA], [idB, valB]) => {
+    if (valB !== valA) return valB - valA; // higher activation first
+    return idA < idB ? -1 : idA > idB ? 1 : 0; // stable tie-break
+  });
+
+  const topNow = ranked.slice(0, topK).map(([id]) => id);
+  return { topNow };
 }

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -32,6 +32,7 @@ import {
 } from "../embedding-backend.js";
 import { clampUnitInterval } from "../validation.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
+import { hybridQuerySkills } from "./skill-qdrant.js";
 
 /**
  * Clamp a value into the closed unit interval [0, 1]. Re-exported under the
@@ -91,30 +92,107 @@ export async function simBatch(
     return new Map();
   }
 
-  // Per-batch sparse normalization: divide by the max sparse score so the
-  // top hit is 1.0 and the rest scale down proportionally.
-  let maxSparse = 0;
-  for (const hit of hits) {
-    if (hit.sparseScore !== undefined && hit.sparseScore > maxSparse) {
-      maxSparse = hit.sparseScore;
-    }
-  }
-
+  const maxSparse = computeMaxSparse(hits);
   const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
     config.memory.v2;
 
   const scores = new Map<string, number>();
   for (const hit of hits) {
-    const dense = hit.denseScore ?? 0;
-    const sparseNormalized =
-      hit.sparseScore !== undefined && maxSparse > 0
-        ? hit.sparseScore / maxSparse
-        : 0;
-    const fused = clamp01(
-      denseWeight * dense + sparseWeight * sparseNormalized,
-    );
-    scores.set(hit.slug, fused);
+    scores.set(hit.slug, fuseHit(hit, maxSparse, denseWeight, sparseWeight));
+  }
+  return scores;
+}
+
+/**
+ * Compute hybrid (dense + sparse) similarity scores between a query text and
+ * a fixed set of candidate skill ids. Mirrors `simBatch` but targets the
+ * dedicated `memory_v2_skills` Qdrant collection via `hybridQuerySkills`.
+ *
+ * Differences from `simBatch`:
+ *   - Keys are skill `id` values (not concept-page slugs).
+ *   - The underlying Qdrant query is **not** restricted to the candidate set.
+ *     Skills always query the full collection — there is no equivalent of
+ *     `restrictToSlugs`. We then keep only hits whose id is in `ids`.
+ *
+ * Returns a `Map<id, score>` of fused scores in [0, 1]. Ids that did not hit
+ * either channel — or that hit but are not in `ids` — are absent from the map.
+ *
+ * Edge cases:
+ *   - Empty `ids` → returns an empty map without touching Qdrant or the
+ *     embedding backend.
+ *   - Empty query text → still queries (dense may still hit), and the sparse
+ *     contribution is zero.
+ */
+export async function simSkillBatch(
+  text: string,
+  ids: readonly string[],
+  config: AssistantConfig,
+): Promise<Map<string, number>> {
+  if (ids.length === 0) {
+    return new Map();
   }
 
+  const denseResult = await embedWithBackend(config, [text]);
+  const denseVector = denseResult.vectors[0];
+  const sparseVector = generateSparseEmbedding(text);
+
+  const hits = await hybridQuerySkills(denseVector, sparseVector, ids.length);
+
+  if (hits.length === 0) {
+    return new Map();
+  }
+
+  // `hybridQuerySkills` queries the full collection unrestricted; pre-filter
+  // to the caller's candidate set so out-of-set hits don't perturb the
+  // per-batch sparse normalization.
+  const idSet = new Set(ids);
+  const filtered = hits.filter((h) => idSet.has(h.id));
+  if (filtered.length === 0) {
+    return new Map();
+  }
+
+  const maxSparse = computeMaxSparse(filtered);
+  const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
+    config.memory.v2;
+
+  const scores = new Map<string, number>();
+  for (const hit of filtered) {
+    scores.set(hit.id, fuseHit(hit, maxSparse, denseWeight, sparseWeight));
+  }
   return scores;
+}
+
+/**
+ * Per-batch sparse-score maximum used for normalization. Hits missing from
+ * the sparse channel contribute 0 (handled by the `undefined` guard).
+ */
+function computeMaxSparse(
+  hits: ReadonlyArray<{ sparseScore?: number }>,
+): number {
+  let max = 0;
+  for (const hit of hits) {
+    if (hit.sparseScore !== undefined && hit.sparseScore > max) {
+      max = hit.sparseScore;
+    }
+  }
+  return max;
+}
+
+/**
+ * Fuse a single hit's dense + sparse scores into a normalized [0, 1] score
+ * via `clamp01(dense_weight · dense + sparse_weight · sparse/maxSparse)`.
+ * Missing-channel scores contribute 0.
+ */
+function fuseHit(
+  hit: { denseScore?: number; sparseScore?: number },
+  maxSparse: number,
+  denseWeight: number,
+  sparseWeight: number,
+): number {
+  const dense = hit.denseScore ?? 0;
+  const sparseNormalized =
+    hit.sparseScore !== undefined && maxSparse > 0
+      ? hit.sparseScore / maxSparse
+      : 0;
+  return clamp01(denseWeight * dense + sparseWeight * sparseNormalized);
 }


### PR DESCRIPTION
## Summary
- selectSkillCandidates: ANN top-K against memory_v2_skills via hybridQuerySkills.
- computeSkillActivation: similarity-only A_skill (no spread, no decay carry-over).
- selectSkillInjections: top-K by activation, NO dedup against everInjected (skills re-present every turn).
- simSkillBatch: skill-side hybrid sim helper modeled on simBatch.

Part of plan: memory-v2-skill-autoinjection.md (PR 6 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
