### PR TITLE
feat(memory-v2): inject ranked skills into the per-turn memory block

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -1,18 +1,25 @@
 /**
  * Tests for `assistant/src/memory/v2/injection.ts`.
  *
- * Coverage matrix from PR 19 acceptance criteria:
+ * Coverage matrix:
  *   - Empty state seeds the first injection (initial conversation turn).
  *   - Second turn whose `topNow` overlaps prior `everInjected` returns
  *     `toInject = []` and `block = null` (cache-stable empty path).
  *   - A new topic appearing on a later turn injects only the new slug.
  *   - `evictCompactedTurns` re-enables a previously-injected slug —
  *     after eviction the same slug appears again in `toInject`.
+ *   - Skill pipeline: skill-only block, mixed concept-page+skill block,
+ *     both-empty → null, no skill dedup across turns, `top_k_skills: 0`
+ *     short-circuit.
  *
  * Hermetic by design: the embedding backend, qdrant client, and `getConfig`
  * are mocked at the module level so the suite never reaches a real backend.
- * The activation-store uses an in-memory SQLite database so writes are real
- * but contained.
+ * The skill activation pipeline (`selectSkillCandidates`,
+ * `computeSkillActivation`, `selectSkillInjections`) and the skill-store
+ * lookup (`getSkillCapability`) are also mocked at the module level so each
+ * test can stage its skill slate without touching the dedicated skills
+ * Qdrant collection. The activation-store uses an in-memory SQLite database
+ * so writes are real but contained.
  *
  * Tests use a temp workspace (mkdtemp) and never touch `~/.vellum/`. Sample
  * page content uses generic placeholders (Alice, Bob, etc.) per the cross-
@@ -117,6 +124,43 @@ mock.module("@qdrant/js-client-rest", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Skill pipeline mocks
+// ---------------------------------------------------------------------------
+//
+// The skill side of the per-turn pipeline (`selectSkillCandidates`,
+// `computeSkillActivation`, `selectSkillInjections`) has its own dedicated
+// Qdrant collection and embedding round-trips. Rather than threading staged
+// hits through that whole pipeline for every test, we mock the three skill
+// helpers and the synchronous `getSkillCapability` lookup at the module level
+// and let each test stage a `topNow` ordering and the matching `SkillEntry`
+// content directly.
+
+const skillState = {
+  /** Ordered ids `selectSkillInjections.topNow` returns this turn. */
+  topSkillIds: [] as string[],
+  /** id → SkillEntry used by `getSkillCapability`. */
+  entries: new Map<string, SkillEntry>(),
+};
+
+const realActivation = await import("../activation.js");
+mock.module("../activation.js", () => ({
+  ...realActivation,
+  // The injection wiring only consumes `topNow` — the candidate set and
+  // activation map are inputs to `selectSkillInjections`, not anything the
+  // injection logic introspects. Stub them to empty so the test stays focused
+  // on the wiring, not the pipeline internals (covered in activation.test.ts).
+  selectSkillCandidates: async () => new Set<string>(),
+  computeSkillActivation: async () => new Map<string, number>(),
+  selectSkillInjections: ({ topK }: { topK: number }) => ({
+    topNow: skillState.topSkillIds.slice(0, topK),
+  }),
+}));
+
+mock.module("../skill-store.js", () => ({
+  getSkillCapability: (id: string) => skillState.entries.get(id) ?? null,
+}));
+
+// ---------------------------------------------------------------------------
 // Workspace + DB setup
 // ---------------------------------------------------------------------------
 
@@ -177,6 +221,7 @@ afterAll(() => {
 // Static `import type` is fine — types erase, so they don't run module-init
 // code that would race the mocks above.
 import type { DrizzleDb } from "../../db-connection.js";
+import type { SkillEntry } from "../types.js";
 
 const { getSqliteFrom } = await import("../../db-connection.js");
 const { migrateActivationState } =
@@ -214,6 +259,7 @@ function makeConfig(
     k: number;
     hops: number;
     top_k: number;
+    top_k_skills: number;
     epsilon: number;
     dense_weight: number;
     sparse_weight: number;
@@ -229,6 +275,7 @@ function makeConfig(
         k: 0.5,
         hops: 2,
         top_k: 20,
+        top_k_skills: 5,
         epsilon: 0.01,
         dense_weight: 1.0,
         sparse_weight: 0.0,
@@ -270,10 +317,21 @@ function resetState(): void {
   state.sparseReturn = { indices: [1, 2, 3], values: [0.5, 0.5, 0.5] };
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
+  skillState.topSkillIds.length = 0;
+  skillState.entries.clear();
   // The qdrant module caches its client; the cached client may be a
   // MockQdrantClient instance from a sibling test file. Reset to force a
   // fresh `new QdrantClient()` against this file's mock.
   _resetMemoryV2QdrantForTests();
+}
+
+/** Stage the next turn's skill slate and the entries the renderer will look up. */
+function stageSkills(ids: string[], entries: SkillEntry[] = []): void {
+  skillState.topSkillIds.length = 0;
+  skillState.topSkillIds.push(...ids);
+  for (const entry of entries) {
+    skillState.entries.set(entry.id, entry);
+  }
 }
 
 let db: DrizzleDb;
@@ -530,5 +588,211 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.everInjected).toEqual([
       { slug: "phantom-slug", turn: 1 },
     ]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Skill subsection rendering
+  // ---------------------------------------------------------------------------
+
+  test("renders a skill-only block under the same `What I Remember Right Now` header", async () => {
+    // No concept-page candidates this turn — the candidate query and the three
+    // simBatch queries all return empty. The skill pipeline is mocked to
+    // surface a single skill.
+    stageTurn([]);
+    stageSkills(
+      ["example-skill-a"],
+      [
+        {
+          id: "example-skill-a",
+          displayName: "Example Skill A",
+          content:
+            'The "Example Skill A" skill (example-skill-a) is available. Helps with examples.',
+        },
+      ],
+    );
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Help me with examples",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.toInject).toEqual([]);
+    expect(result.block).not.toBeNull();
+    // Same outer wrapping as concept-page-only blocks.
+    expect(result.block).toContain("<memory __injected>");
+    expect(result.block).toContain("## What I Remember Right Now");
+    expect(result.block).toContain("</memory>");
+    // No concept-page sections; skills subsection present with the right
+    // bullet shape and the v1 `→ use skill_load to activate` suffix (the
+    // content matches the `/skill \(/` regex).
+    expect(result.block).not.toContain("### alice-vscode");
+    expect(result.block).toContain("### Skills You Can Use");
+    expect(result.block).toContain(
+      '- The "Example Skill A" skill (example-skill-a) is available. Helps with examples. → use skill_load to activate',
+    );
+  });
+
+  test("renders concept-page sections before the skills subsection in mixed blocks", async () => {
+    // Concept page hits AND a skill — concept-page sections come first, then
+    // the skills subsection.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    stageSkills(
+      ["example-skill-a"],
+      [
+        {
+          id: "example-skill-a",
+          displayName: "Example Skill A",
+          // Content without the `skill (` regex match — no suffix expected.
+          content: "Plain capability description for example-skill-a.",
+        },
+      ],
+    );
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Alice's editor",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.toInject).toEqual(["alice-vscode"]);
+    expect(result.block).not.toBeNull();
+
+    const aliceIdx = result.block!.indexOf("### alice-vscode");
+    const skillsIdx = result.block!.indexOf("### Skills You Can Use");
+    expect(aliceIdx).toBeGreaterThan(-1);
+    expect(skillsIdx).toBeGreaterThan(-1);
+    expect(aliceIdx).toBeLessThan(skillsIdx);
+
+    // Skill content does not match `/skill \(/`, so no activation suffix.
+    expect(result.block).toContain(
+      "- Plain capability description for example-skill-a.",
+    );
+    expect(result.block).not.toContain("→ use skill_load to activate");
+  });
+
+  test("returns null when both concept pages and skills are empty", async () => {
+    // Empty concept-page candidate set (all simBatch + ANN responses empty)
+    // AND no skill ids.
+    stageTurn([]);
+    stageSkills([]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "anything",
+      assistantMessage: "",
+      nowText: "",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.toInject).toEqual([]);
+    expect(result.block).toBeNull();
+  });
+
+  test("re-renders the same top-ranked skill on consecutive turns (no dedup)", async () => {
+    // Skills are stateless: the same id can appear on back-to-back turns.
+    // Stage no concept-page candidates so the block content is purely the
+    // skills subsection.
+    const skillEntry = {
+      id: "example-skill-a",
+      displayName: "Example Skill A",
+      content:
+        'The "Example Skill A" skill (example-skill-a) is available. Helps with examples.',
+    };
+
+    // Turn 1 — only the skill.
+    stageTurn([]);
+    stageSkills(["example-skill-a"], [skillEntry]);
+    const result1 = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "examples",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+    expect(result1.block).not.toBeNull();
+    expect(result1.block).toContain("### Skills You Can Use");
+    expect(result1.block).toContain("example-skill-a");
+
+    // Turn 2 — same skill ranks top again. Persisted state has advanced (the
+    // first call wrote a fresh activation_state row), and `everInjected` was
+    // not touched by the skill pipeline. The skill must still appear.
+    stageTurn([]);
+    stageSkills(["example-skill-a"], [skillEntry]);
+    const result2 = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 2,
+      userMessage: "more examples",
+      assistantMessage: "ok",
+      nowText: "Now",
+      messageId: "msg-2",
+      config: makeConfig(),
+    });
+    expect(result2.block).not.toBeNull();
+    expect(result2.block).toContain("### Skills You Can Use");
+    expect(result2.block).toContain("example-skill-a");
+
+    // The skill content line is identical across the two turns — the renderer
+    // is deterministic in `id → entry` lookup and the entry is unchanged.
+    const skillLine =
+      '- The "Example Skill A" skill (example-skill-a) is available. Helps with examples. → use skill_load to activate';
+    expect(result1.block).toContain(skillLine);
+    expect(result2.block).toContain(skillLine);
+
+    // `everInjected` is untouched by the skill pipeline — both turns left it
+    // empty (no concept pages were injected).
+    const persisted = await hydrate(db, "conv-1");
+    expect(persisted!.everInjected).toEqual([]);
+  });
+
+  test("`top_k_skills: 0` short-circuits to no skills subsection", async () => {
+    // Even when the underlying mock would surface skills, the cap at 0 must
+    // drop them via `selectSkillInjections.topK = 0` → empty `topNow`.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    stageSkills(
+      ["example-skill-a"],
+      [
+        {
+          id: "example-skill-a",
+          displayName: "Example Skill A",
+          content:
+            'The "Example Skill A" skill (example-skill-a) is available.',
+        },
+      ],
+    );
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Alice's editor",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig({ top_k_skills: 0 }),
+    });
+
+    expect(result.toInject).toEqual(["alice-vscode"]);
+    expect(result.block).not.toBeNull();
+    expect(result.block).toContain("### alice-vscode");
+    expect(result.block).not.toContain("### Skills You Can Use");
+    expect(result.block).not.toContain("example-skill-a");
   });
 });

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -28,13 +28,17 @@ import { getWorkspaceDir } from "../../util/platform.js";
 import type { DrizzleDb } from "../db-connection.js";
 import {
   computeOwnActivation,
+  computeSkillActivation,
   selectCandidates,
   selectInjections,
+  selectSkillCandidates,
+  selectSkillInjections,
   spreadActivation,
 } from "./activation.js";
 import { hydrate, save } from "./activation-store.js";
 import { readEdges } from "./edges.js";
 import { readPage } from "./page-store.js";
+import { getSkillCapability } from "./skill-store.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -159,6 +163,29 @@ export async function injectMemoryV2Block(
     topK: top_k,
   });
 
+  // (6b) Skill pipeline — a sibling pipeline to the concept-page one above.
+  // Skills are stateless: no decay carry-over, no spread, no `everInjected`
+  // dedup. The top-K relevant skills are re-presented every turn so the
+  // agent can drop and pick them up freely.
+  const skillCandidates = await selectSkillCandidates({
+    userText: userMessage,
+    assistantText: assistantMessage,
+    nowText,
+    config,
+    topK: config.memory.v2.top_k_skills,
+  });
+  const skillActivation = await computeSkillActivation({
+    candidates: skillCandidates,
+    userText: userMessage,
+    assistantText: assistantMessage,
+    nowText,
+    config,
+  });
+  const { topNow: topSkillIds } = selectSkillInjections({
+    A: skillActivation,
+    topK: config.memory.v2.top_k_skills,
+  });
+
   // Build the next persisted state regardless of whether we render anything:
   // even on a "no new injection" turn, prior-state activations decay via the
   // candidate-set carry-forward and need to be rewritten so `epsilon`-trimmed
@@ -171,7 +198,8 @@ export async function injectMemoryV2Block(
   // Append the freshly injected slugs to everInjected (with their turn) so
   // future turns can subtract them. We append rather than reset so that
   // compaction-driven eviction (`evictCompactedTurns`) is the only path that
-  // can re-enable a previously-injected slug.
+  // can re-enable a previously-injected slug. Skills do NOT enter
+  // `everInjected` — they are stateless and re-presented every turn.
   const nextEverInjected: EverInjectedEntry[] = [
     ...priorEverInjected,
     ...toInject.map((slug) => ({ slug, turn: currentTurn })),
@@ -187,15 +215,17 @@ export async function injectMemoryV2Block(
 
   await save(database, conversationId, nextActivationState);
 
-  // (7) Cache-stable empty path: nothing new since the last turn.
-  if (toInject.length === 0) {
+  // (7) Cache-stable empty path: nothing new since the last turn AND no
+  // ranked skills to surface.
+  if (toInject.length === 0 && topSkillIds.length === 0) {
     return { block: null, toInject: [] };
   }
 
   // (8) Render. `toInject` is already activation-descending (selectInjections
   // returns it as a filter of the sorted `topNow`), so it doubles as our
-  // render order. Prior slugs sit unchanged on prior user messages.
-  const block = await renderInjectionBlock(workspaceDir, toInject);
+  // render order. Prior slugs sit unchanged on prior user messages. Skills
+  // are appended after concept-page sections under the same header.
+  const block = await renderInjectionBlock(workspaceDir, toInject, topSkillIds);
 
   return { block, toInject };
 }
@@ -205,14 +235,20 @@ export async function injectMemoryV2Block(
 // ---------------------------------------------------------------------------
 
 /**
- * Render the `<memory __injected>` block for a list of slugs.
+ * Render the `<memory __injected>` block for a list of slugs and a list of
+ * ranked skill ids.
  *
- * Slugs are read in parallel via `readPage`. Pages whose file has gone
- * missing between selection and render (e.g. consolidation deleted them)
- * are silently dropped — the activation state still records them in
+ * Concept pages are read in parallel via `readPage`. Pages whose file has
+ * gone missing between selection and render (e.g. consolidation deleted
+ * them) are silently dropped — the activation state still records them in
  * `everInjected` so we don't keep re-attempting on every turn.
  *
- * The block shape is the §5 layout from the design doc:
+ * Skill ids are looked up via `getSkillCapability`. Ids that the cache no
+ * longer knows (e.g. uninstalled mid-run) are silently dropped, mirroring
+ * the missing-pages behavior.
+ *
+ * The block shape is the §5 layout from the design doc, with an optional
+ * trailing skills subsection:
  *
  *   <memory __injected>
  *   ## What I Remember Right Now
@@ -221,15 +257,24 @@ export async function injectMemoryV2Block(
  *
  *   ### <slug-2>
  *   <body-2>
+ *
+ *   ### Skills You Can Use
+ *   - <skill-1 content>
+ *   - <skill-2 content>
  *   </memory>
  *
- * Returns `null` when every requested slug is missing on disk so the caller
- * can fall through to its empty-block path instead of attaching a header
- * with no contents.
+ * The same `## What I Remember Right Now` header wraps the block whether
+ * the skills section is alone, the concept-page sections are alone, or
+ * both are present — keeping the renderer one shape.
+ *
+ * Returns `null` when both lists collapse to empty after cache misses so
+ * the caller can fall through to its empty-block path instead of attaching
+ * a header with no contents.
  */
 async function renderInjectionBlock(
   workspaceDir: string,
   slugs: string[],
+  skillIds: string[],
 ): Promise<string | null> {
   const pages = await Promise.all(
     slugs.map(async (slug) => {
@@ -243,6 +288,23 @@ async function renderInjectionBlock(
     if (!entry || entry.body.length === 0) continue;
     sections.push(`### ${entry.slug}\n${entry.body}`);
   }
+
+  // Skills subsection — drop ids the cache no longer knows. Append the
+  // `→ use skill_load to activate` suffix when the rendered content matches
+  // the v1 regex (ported verbatim from `memory/graph/injection.ts`).
+  const skillLines: string[] = [];
+  for (const id of skillIds) {
+    const entry = getSkillCapability(id);
+    if (!entry) continue;
+    const suffix = /skill \(/.test(entry.content)
+      ? " → use skill_load to activate"
+      : "";
+    skillLines.push(`- ${entry.content}${suffix}`);
+  }
+  if (skillLines.length > 0) {
+    sections.push(`### Skills You Can Use\n${skillLines.join("\n")}`);
+  }
+
   if (sections.length === 0) return null;
 
   const inner = `## What I Remember Right Now\n\n${sections.join("\n\n")}`;


### PR DESCRIPTION
## Summary
- Run skill pipeline parallel to concept-page pipeline in injectMemoryV2Block.
- Render '### Skills You Can Use' subsection with top-K relevant skills (no dedup; re-presented every turn).
- Block emits when EITHER concept-page injections OR skill candidates are non-empty.

Part of plan: memory-v2-skill-autoinjection.md (PR 7 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
