### PR TITLE
feat(memory-v2): seed skill entries at daemon startup

### DIFF
--- a/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
+++ b/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the memory-v2 skill seed gate invoked from the daemon startup
+ * path (`assistant/src/daemon/memory-v2-startup.ts`).
+ *
+ * The gate is exercised in isolation rather than mounting the full lifecycle
+ * import graph. Coverage matrix from PR 8 acceptance criteria:
+ *   - Case 1: feature flag on + `config.memory.v2.enabled` on → seed runs.
+ *   - Case 2: feature flag off → seed does not run.
+ *   - Case 3: `config.memory.v2.enabled` off (flag on) → seed does not run.
+ *   - Case 4: `seedV2SkillEntries` rejects → gate does not throw and the
+ *     warning is logged.
+ *
+ * The seed call itself is fire-and-forget (`void` + `.catch`); the gate must
+ * never block startup or surface an exception.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/schema.js";
+
+// ---------------------------------------------------------------------------
+// Programmable test state — drives every mocked dependency below.
+// ---------------------------------------------------------------------------
+
+interface TestState {
+  flagOverrides: Record<string, boolean>;
+  seedCallCount: number;
+  seedShouldReject: Error | null;
+  warnCalls: Array<{ obj: unknown; msg: unknown }>;
+}
+
+const state: TestState = {
+  flagOverrides: {},
+  seedCallCount: 0,
+  seedShouldReject: null,
+  warnCalls: [],
+};
+
+// ---------------------------------------------------------------------------
+// Mocks — installed before the module under test is loaded.
+// ---------------------------------------------------------------------------
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: (key: string, _config: unknown): boolean => {
+    const explicit = state.flagOverrides[key];
+    if (typeof explicit === "boolean") return explicit;
+    return true; // undeclared flags default to enabled
+  },
+}));
+
+mock.module("../memory/v2/skill-store.js", () => ({
+  seedV2SkillEntries: async (): Promise<void> => {
+    state.seedCallCount += 1;
+    if (state.seedShouldReject) throw state.seedShouldReject;
+  },
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    warn: (obj: unknown, msg: unknown) => {
+      state.warnCalls.push({ obj, msg });
+    },
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { maybeSeedMemoryV2Skills } =
+  await import("../daemon/memory-v2-startup.js");
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal config shape the gate touches; cast to AssistantConfig at the boundary. */
+function makeConfig(v2Enabled: boolean): AssistantConfig {
+  return {
+    memory: {
+      v2: { enabled: v2Enabled },
+    },
+  } as unknown as AssistantConfig;
+}
+
+/**
+ * Drain all microtasks so any `void`-prefixed promise inside
+ * `maybeSeedMemoryV2Skills` settles before the test asserts. The fire-and-
+ * forget chain involves: dynamic-import settle → `.then` callback →
+ * inner `seedV2SkillEntries` resolution → `.catch` settle. We yield
+ * generously to cover that whole chain regardless of the bundler's task
+ * scheduling.
+ */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("maybeSeedMemoryV2Skills (daemon startup gate)", () => {
+  beforeEach(() => {
+    state.flagOverrides = {};
+    state.seedCallCount = 0;
+    state.seedShouldReject = null;
+    state.warnCalls = [];
+  });
+
+  test("invokes seedV2SkillEntries when flag and config are both enabled", async () => {
+    state.flagOverrides = { "memory-v2-enabled": true };
+    maybeSeedMemoryV2Skills(makeConfig(true));
+    await flushMicrotasks();
+    expect(state.seedCallCount).toBe(1);
+    expect(state.warnCalls).toHaveLength(0);
+  });
+
+  test("does not invoke seedV2SkillEntries when feature flag is off", async () => {
+    state.flagOverrides = { "memory-v2-enabled": false };
+    maybeSeedMemoryV2Skills(makeConfig(true));
+    await flushMicrotasks();
+    expect(state.seedCallCount).toBe(0);
+    expect(state.warnCalls).toHaveLength(0);
+  });
+
+  test("does not invoke seedV2SkillEntries when config.memory.v2.enabled is off", async () => {
+    state.flagOverrides = { "memory-v2-enabled": true };
+    maybeSeedMemoryV2Skills(makeConfig(false));
+    await flushMicrotasks();
+    expect(state.seedCallCount).toBe(0);
+    expect(state.warnCalls).toHaveLength(0);
+  });
+
+  test("does not invoke seedV2SkillEntries when both gates are off", async () => {
+    state.flagOverrides = { "memory-v2-enabled": false };
+    maybeSeedMemoryV2Skills(makeConfig(false));
+    await flushMicrotasks();
+    expect(state.seedCallCount).toBe(0);
+    expect(state.warnCalls).toHaveLength(0);
+  });
+
+  test("swallows seedV2SkillEntries rejections and logs a warning", async () => {
+    state.flagOverrides = { "memory-v2-enabled": true };
+    state.seedShouldReject = new Error("seed failed");
+
+    // The gate must not throw — startup must not block on this.
+    expect(() => maybeSeedMemoryV2Skills(makeConfig(true))).not.toThrow();
+
+    await flushMicrotasks();
+
+    expect(state.seedCallCount).toBe(1);
+    expect(state.warnCalls).toHaveLength(1);
+    const [{ obj, msg }] = state.warnCalls;
+    expect((obj as { err: Error }).err.message).toBe("seed failed");
+    expect(msg).toBe("Failed to seed v2 skill entries");
+  });
+});

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -117,6 +117,7 @@ import {
 } from "./guardian-action-generators.js";
 import { backfillSlackInjectionTemplates } from "./handlers/config-slack-channel.js";
 import { installAssistantSymlink } from "./install-symlink.js";
+import { maybeSeedMemoryV2Skills } from "./memory-v2-startup.js";
 import { runProfilerSweep } from "./profiler-run-store.js";
 import {
   initializeProvidersAndTools,
@@ -768,6 +769,7 @@ export async function runDaemon(): Promise<void> {
           seedUninstalledCatalogSkillMemories,
         } = await import("../memory/graph/capability-seed.js");
         seedSkillGraphNodes();
+        maybeSeedMemoryV2Skills(config);
         await seedCliGraphNodes();
         void seedUninstalledCatalogSkillMemories().catch((err) =>
           log.warn(

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — daemon-startup helpers
+// ---------------------------------------------------------------------------
+//
+// Small focused module that holds the gating + dispatch logic for v2-specific
+// startup work invoked from `lifecycle.ts`. Lives in its own file so the unit
+// test for the gate does not have to mount the entire lifecycle import graph.
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("memory-v2-startup");
+
+/**
+ * Fire-and-forget seed of the v2 parallel skill embedding collection. Gated
+ * on both the `memory-v2-enabled` feature flag and the workspace-level
+ * `config.memory.v2.enabled` switch so v2 modules stay out of the v1 startup
+ * path when v2 is off.
+ *
+ * Uses a dynamic import so v2 code does not load unless the gate passes.
+ * Never awaits — startup must not block on this (see `assistant/CLAUDE.md`
+ * daemon startup philosophy).
+ */
+export function maybeSeedMemoryV2Skills(config: AssistantConfig): void {
+  if (
+    !isAssistantFeatureFlagEnabled("memory-v2-enabled", config) ||
+    !config.memory.v2.enabled
+  ) {
+    return;
+  }
+  void import("../memory/v2/skill-store.js")
+    .then(({ seedV2SkillEntries }) => seedV2SkillEntries())
+    .catch((err) => log.warn({ err }, "Failed to seed v2 skill entries"));
+}


### PR DESCRIPTION
## Summary
- At daemon startup, when memory-v2-enabled flag + config.memory.v2.enabled are both on, seed v2 skill entries via dynamic import.
- Fire-and-forget — the seed never blocks startup; failures are logged.

Part of plan: memory-v2-skill-autoinjection.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
