### PR TITLE
feat(memory-v2): add vellum memory v2 reembed-skills CLI subcommand

### DIFF
--- a/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
+++ b/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the `memory v2 reembed-skills` end-to-end pair: the CLI
+ * subcommand and the matching `memory_v2_reembed_skills` IPC route.
+ *
+ * The CLI half mocks `cliIpcCall` and asserts the subcommand dispatches
+ * to `memory_v2_reembed_skills` with an empty body. The route half uses
+ * the real `loadConfig` + flag resolver — flags are toggled via
+ * `_setOverridesForTesting` and `memory.v2.enabled` is toggled via a
+ * per-test `config.json` fixture in the temp workspace. We mock only
+ * `seedV2SkillEntries` so we can assert it was invoked without actually
+ * embedding skills.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+import {
+  _setOverridesForTesting,
+  clearFeatureFlagOverridesCache,
+} from "../config/assistant-feature-flags.js";
+import { invalidateConfigCache } from "../config/loader.js";
+import { getWorkspaceDir } from "../util/platform.js";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — kept minimal. `loadConfig`,
+// `isAssistantFeatureFlagEnabled`, and `getLogger` use their real
+// implementations because we already have first-class test hooks
+// (`_setOverridesForTesting` for flags, a per-test workspace `config.json`
+// for config) that exercise the same code paths the route handler runs in
+// production.
+// ---------------------------------------------------------------------------
+
+let lastIpcCall: { method: string; params?: Record<string, unknown> } | null =
+  null;
+let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
+  ok: true,
+  result: { success: true },
+};
+
+mock.module("../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+}));
+
+let seedCallCount = 0;
+mock.module("../memory/v2/skill-store.js", () => ({
+  seedV2SkillEntries: async () => {
+    seedCallCount += 1;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Imports under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { registerMemoryV2Command } =
+  await import("../cli/commands/memory-v2.js");
+const { ROUTES: memoryV2Routes } =
+  await import("../runtime/routes/memory-v2-routes.js");
+const { RouteError } = await import("../runtime/routes/errors.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildProgramWithStubParent(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeErr: () => {},
+    writeOut: () => {},
+  });
+  program.command("memory").description("Stub parent for tests");
+  registerMemoryV2Command(program);
+  return program;
+}
+
+async function runCommand(args: string[]): Promise<{ exitCode: number }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = (() => true) as typeof process.stdout.write;
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+  try {
+    const program = buildProgramWithStubParent();
+    await program.parseAsync(["node", "assistant", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+  return { exitCode };
+}
+
+/**
+ * Override `memory.v2.enabled` (and any other config paths) by writing a
+ * workspace `config.json` that the real `loadConfig` will pick up.
+ */
+function writeWorkspaceConfig(json: Record<string, unknown>): void {
+  const workspace = getWorkspaceDir();
+  mkdirSync(workspace, { recursive: true });
+  writeFileSync(
+    join(workspace, "config.json"),
+    JSON.stringify(json, null, 2),
+    "utf-8",
+  );
+  invalidateConfigCache();
+}
+
+const reembedSkillsRoute = memoryV2Routes.find(
+  (r) => r.operationId === "memory_v2_reembed_skills",
+);
+
+beforeEach(() => {
+  lastIpcCall = null;
+  mockIpcResult = { ok: true, result: { success: true } };
+  seedCallCount = 0;
+  process.exitCode = 0;
+
+  // Real flag + config defaults: enable both so happy-path tests pass.
+  _setOverridesForTesting({ "memory-v2-enabled": true });
+  writeWorkspaceConfig({ memory: { v2: { enabled: true } } });
+});
+
+afterEach(() => {
+  // Roll back the workspace config + flag overrides between cases so a
+  // gate-off test does not leak into the next case's setup.
+  rmSync(join(getWorkspaceDir(), "config.json"), { force: true });
+  invalidateConfigCache();
+  clearFeatureFlagOverridesCache();
+});
+
+// ---------------------------------------------------------------------------
+// CLI subcommand
+// ---------------------------------------------------------------------------
+
+describe("memory v2 reembed-skills CLI", () => {
+  test("dispatches to memory_v2_reembed_skills with empty body", async () => {
+    const { exitCode } = await runCommand(["memory", "v2", "reembed-skills"]);
+
+    expect(exitCode).toBe(0);
+    expect(lastIpcCall).not.toBeNull();
+    expect(lastIpcCall!.method).toBe("memory_v2_reembed_skills");
+    expect(lastIpcCall!.params).toEqual({ body: {} });
+  });
+
+  test("exits with code 1 on IPC failure", async () => {
+    mockIpcResult = { ok: false, error: "Daemon not running" };
+
+    const { exitCode } = await runCommand(["memory", "v2", "reembed-skills"]);
+
+    expect(exitCode).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IPC route handler
+// ---------------------------------------------------------------------------
+
+describe("memory_v2_reembed_skills route", () => {
+  test("registers under operationId 'memory_v2_reembed_skills'", () => {
+    expect(reembedSkillsRoute).toBeDefined();
+    expect(reembedSkillsRoute!.operationId).toBe("memory_v2_reembed_skills");
+  });
+
+  test("calls seedV2SkillEntries once and returns success", async () => {
+    const result = await reembedSkillsRoute!.handler({ body: {} });
+
+    expect(seedCallCount).toBe(1);
+    expect(result).toEqual({ success: true });
+  });
+
+  test("rejects unknown params", async () => {
+    await expect(
+      reembedSkillsRoute!.handler({ body: { extra: 1 } }),
+    ).rejects.toThrow();
+    expect(seedCallCount).toBe(0);
+  });
+
+  test("throws RouteError when feature flag is off", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+
+    await expect(
+      reembedSkillsRoute!.handler({ body: {} }),
+    ).rejects.toBeInstanceOf(RouteError);
+    expect(seedCallCount).toBe(0);
+  });
+
+  test("throws RouteError when config.memory.v2.enabled is off", async () => {
+    writeWorkspaceConfig({ memory: { v2: { enabled: false } } });
+
+    await expect(
+      reembedSkillsRoute!.handler({ body: {} }),
+    ).rejects.toBeInstanceOf(RouteError);
+    expect(seedCallCount).toBe(0);
+  });
+});

--- a/assistant/src/cli/commands/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2.test.ts
@@ -23,7 +23,7 @@ import { Command } from "commander";
 /** The last `cliIpcCall` invocation captured for assertions. */
 let lastIpcCall: {
   method: string;
-   
+
   params?: any;
 } | null = null;
 
@@ -42,8 +42,7 @@ let logOutput: string[] = [];
 // ---------------------------------------------------------------------------
 
 mock.module("../../../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string,  
-  params?: any) => {
+  cliIpcCall: async (method: string, params?: any) => {
     lastIpcCall = { method, params };
     return mockIpcResult;
   },
@@ -138,7 +137,7 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("subcommand registration", () => {
-  test("registers v2 under memory with all five subcommands", () => {
+  test("registers v2 under memory with all six subcommands", () => {
     const program = buildProgramWithStubParent();
     const memory = program.commands.find((c) => c.name() === "memory");
     expect(memory).toBeDefined();
@@ -150,6 +149,7 @@ describe("subcommand registration", () => {
       "migrate",
       "rebuild-edges",
       "reembed",
+      "reembed-skills",
       "validate",
     ]);
   });
@@ -161,7 +161,7 @@ describe("subcommand registration", () => {
     );
   });
 
-  test("--help lists all five subcommands", () => {
+  test("--help lists all six subcommands", () => {
     const program = buildProgramWithStubParent();
     const memory = program.commands.find((c) => c.name() === "memory")!;
     const v2 = memory.commands.find((c) => c.name() === "v2")!;
@@ -170,6 +170,7 @@ describe("subcommand registration", () => {
     expect(help).toContain("migrate");
     expect(help).toContain("rebuild-edges");
     expect(help).toContain("reembed");
+    expect(help).toContain("reembed-skills");
     expect(help).toContain("activation");
     expect(help).toContain("validate");
   });

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -38,6 +38,7 @@ import { cliIpcCall } from "../../ipc/cli-client.js";
 import type {
   MemoryV2BackfillOp,
   MemoryV2BackfillResult,
+  MemoryV2ReembedSkillsResult,
   MemoryV2ValidateResult,
 } from "../../runtime/routes/memory-v2-routes.js";
 import { log } from "../logger.js";
@@ -104,7 +105,7 @@ bidirectional edges in memory/edges.json, and activation-based retrieval.
 v2 stays gated behind the memory-v2-enabled feature flag — these subcommands
 remain useful operator tools regardless of whether the flag is on.
 
-Subcommands fall into two groups:
+Subcommands fall into three groups:
 
   Mutating (return a jobId enqueued on the memory job queue):
     migrate          One-shot v1->v2 synthesis. Refuses to overwrite an
@@ -113,6 +114,9 @@ Subcommands fall into two groups:
                      memory/edges.json.
     reembed          Refresh dense + sparse vectors for every concept page.
     activation       Refresh persisted activation state for every conversation.
+
+  Mutating (synchronous — runs inside the daemon and returns when done):
+    reembed-skills   Re-seed v2 skill entries from the current skill catalog.
 
   Read-only:
     validate         Print a diagnostic report of orphan edges, oversized
@@ -124,6 +128,7 @@ Examples:
   $ assistant memory v2 migrate --force
   $ assistant memory v2 rebuild-edges
   $ assistant memory v2 reembed
+  $ assistant memory v2 reembed-skills
   $ assistant memory v2 activation`,
   );
 
@@ -203,6 +208,42 @@ Examples:
       await runBackfillOp("reembed");
     });
 
+  // ── reembed-skills ────────────────────────────────────────────────────
+
+  v2.command("reembed-skills")
+    .description(
+      "Re-seed v2 skill entries from the current skill catalog (synchronous)",
+    )
+    .addHelpText(
+      "after",
+      `
+Re-runs the v2 skill catalog seed against the current skill set, replacing
+both the in-process skill cache and the memory_v2_skills Qdrant collection.
+Useful after editing a skill's SKILL.md, after a feature-flag flip changes
+the enabled-skill set, or to recover a corrupted skills collection.
+
+Unlike 'reembed' (concept pages), this runs synchronously inside the
+daemon — the command returns only once the seed completes. Requires both
+the memory-v2-enabled feature flag and memory.v2.enabled to be on.
+
+Examples:
+  $ assistant memory v2 reembed-skills`,
+    )
+    .action(async () => {
+      const result = await cliIpcCall<MemoryV2ReembedSkillsResult>(
+        "memory_v2_reembed_skills",
+        { body: {} },
+      );
+
+      if (!result.ok) {
+        log.error(result.error ?? "Failed to re-seed v2 skill entries");
+        process.exitCode = 1;
+        return;
+      }
+
+      log.info("Skill re-seed complete.");
+    });
+
   // ── activation ────────────────────────────────────────────────────────
 
   v2.command("activation")
@@ -253,10 +294,12 @@ Examples:
   $ assistant memory v2 validate`,
     )
     .action(async () => {
-      const result =
-        await cliIpcCall<MemoryV2ValidateResult>("memory_v2_validate", {
+      const result = await cliIpcCall<MemoryV2ValidateResult>(
+        "memory_v2_validate",
+        {
           body: {},
-        });
+        },
+      );
 
       if (!result.ok) {
         log.error(result.error ?? "Failed to validate memory v2 state");

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -1,11 +1,12 @@
 /**
- * Memory v2 route definitions — backfill + validate.
+ * Memory v2 route definitions — backfill + validate + reembed-skills.
  *
  * Migrated from `ipc/routes/memory-v2-backfill.ts` and
  * `ipc/routes/memory-v2-validate.ts` into the shared ROUTES array.
  */
 import { z } from "zod";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { loadConfig } from "../../config/loader.js";
 import {
   enqueueMemoryJob,
@@ -13,7 +14,9 @@ import {
 } from "../../memory/jobs-store.js";
 import { readEdges, validateEdges } from "../../memory/v2/edges.js";
 import { listPages, readPage } from "../../memory/v2/page-store.js";
+import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { RouteError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 import type { RouteHandlerArgs } from "./types.js";
 
@@ -115,6 +118,42 @@ async function handleValidate({
   };
 }
 
+// ── Reembed skills ──────────────────────────────────────────────────────
+
+const MemoryV2ReembedSkillsParams = z.object({}).strict();
+
+export type MemoryV2ReembedSkillsResult = {
+  success: true;
+};
+
+async function handleReembedSkills({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV2ReembedSkillsResult> {
+  MemoryV2ReembedSkillsParams.parse(body);
+
+  // Gate the route on both the feature flag and the per-workspace config
+  // toggle so the v2 skill collection never gets re-seeded against a
+  // workspace whose v2 subsystem is intentionally off.
+  const config = loadConfig();
+  if (
+    !isAssistantFeatureFlagEnabled("memory-v2-enabled", config) ||
+    !config.memory.v2.enabled
+  ) {
+    throw new RouteError(
+      "Memory v2 is not enabled — flip both the memory-v2-enabled feature flag and memory.v2.enabled to use this command.",
+      "MEMORY_V2_DISABLED",
+      409,
+    );
+  }
+
+  // Unlike the queued backfill jobs above, this is a CLI-driven sync
+  // request: the operator wants the cache replaced before the next prompt
+  // assembly, so we await the seed inline rather than enqueueing it.
+  await seedV2SkillEntries();
+
+  return { success: true };
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -139,5 +178,16 @@ export const ROUTES: RouteDefinition[] = [
       "Read-only structural validation of the v2 workspace — reports orphan edges, oversized pages, and parse failures.",
     tags: ["memory"],
     requestBody: MemoryV2ValidateParams,
+  },
+  {
+    operationId: "memory_v2_reembed_skills",
+    method: "POST",
+    endpoint: "memory/v2/reembed-skills",
+    handler: handleReembedSkills,
+    summary: "Re-seed v2 skill entries from the current skill catalog",
+    description:
+      "Synchronously re-runs seedV2SkillEntries against the current skill catalog. Gated on memory-v2-enabled flag and config.memory.v2.enabled.",
+    tags: ["memory"],
+    requestBody: MemoryV2ReembedSkillsParams,
   },
 ];


### PR DESCRIPTION
## Summary
- vellum memory v2 reembed-skills triggers a fresh v2 skill catalog re-seed via the daemon.
- IPC route memory_v2_reembed_skills awaits seedV2SkillEntries; gated on flag + config.

Part of plan: memory-v2-skill-autoinjection.md (PR 10 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
