### PR TITLE
fix(memory-v2): restrict hybridQuerySkills to candidate ids in simSkillBatch

### DIFF
--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -425,7 +425,7 @@ describe("simSkillBatch", () => {
     expect(state.queryCalls).toHaveLength(0);
   });
 
-  test("queries the dedicated skills collection with no filter", async () => {
+  test("queries the dedicated skills collection and forwards an id-IN filter", async () => {
     const config = configWithWeights(0.7, 0.3);
     stageSkillHybridResponse([]);
 
@@ -438,8 +438,14 @@ describe("simSkillBatch", () => {
     expect(state.queryCalls).toHaveLength(2);
     for (const call of state.queryCalls) {
       expect(call.collection).toBe("memory_v2_skills");
-      // Skills are unrestricted: no slug/id filter is forwarded.
-      expect(call.filter).toBeUndefined();
+      // The candidate ids are forwarded as a Qdrant filter so Qdrant scores
+      // exactly the candidate set, not its global top-K. Without this,
+      // candidate ids absent from the global top-K silently score 0.
+      expect(call.filter).toEqual({
+        must: [
+          { key: "id", match: { any: ["example-skill-a", "example-skill-b"] } },
+        ],
+      });
       // Limit equals the candidate count.
       expect(call.limit).toBe(2);
     }
@@ -483,13 +489,19 @@ describe("simSkillBatch", () => {
     expect(out.get("example-skill-b")).toBeCloseTo(0.3, 6);
   });
 
-  test("drops hits whose id is not in the candidate set", async () => {
-    // `hybridQuerySkills` queries the full collection — `simSkillBatch`
-    // must filter the results down to ids the caller asked for.
+  test("forwards candidate ids as the Qdrant restriction; only candidates in result", async () => {
+    // The bug we're guarding against: when the skills collection has more
+    // skills than `ids.length`, calling `hybridQuerySkills` without a filter
+    // returns Qdrant's global top-K. Candidate ids absent from that top-K
+    // would silently score 0. The fix is to forward the candidate ids as a
+    // server-side restriction so Qdrant scores exactly the candidate set.
     const config = configWithWeights(0.7, 0.3);
     stageSkillHybridResponse([
       { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
-      { id: "example-skill-c", denseScore: 0.9, sparseScore: 1 }, // not requested
+      // `example-skill-c` would never be returned in production once the
+      // filter is applied; the post-filter in simSkillBatch defensively
+      // drops it even if a stale payload slips through.
+      { id: "example-skill-c", denseScore: 0.9, sparseScore: 1 },
     ]);
 
     const out = await simSkillBatch(
@@ -498,6 +510,17 @@ describe("simSkillBatch", () => {
       config,
     );
 
+    // The Qdrant filter was forwarded — both channels carry the id-IN
+    // restriction matching the caller's candidate set.
+    expect(state.queryCalls).toHaveLength(2);
+    for (const call of state.queryCalls) {
+      expect(call.filter).toEqual({
+        must: [
+          { key: "id", match: { any: ["example-skill-a", "example-skill-b"] } },
+        ],
+      });
+    }
+    // Only candidate ids appear in the result map.
     expect(out.has("example-skill-a")).toBe(true);
     expect(out.has("example-skill-c")).toBe(false);
   });

--- a/assistant/src/memory/v2/__tests__/skill-qdrant.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-qdrant.test.ts
@@ -57,6 +57,7 @@ const state = {
     query: unknown;
     limit: number;
     with_payload: boolean;
+    filter?: unknown;
   }>,
   scrollCalls: [] as Array<{
     limit?: number;
@@ -120,6 +121,7 @@ class MockQdrantClient {
       query: unknown;
       limit: number;
       with_payload: boolean;
+      filter?: unknown;
     },
   ) {
     state.queryCalls.push(params);
@@ -625,17 +627,73 @@ describe("memory v2 skill qdrant — hybrid query", () => {
     }
   });
 
-  test("does not pass a payload filter (full skill catalog is always queried)", async () => {
+  test("undefined restrictToIds queries the full catalog (no filter)", async () => {
+    state.collectionExistsBeforeCreate = true;
+    state.queryResponses.dense.push({
+      points: [{ score: 0.5, payload: { id: "example-skill-1" } }],
+    });
+    state.queryResponses.sparse.push({
+      points: [{ score: 1, payload: { id: "example-skill-2" } }],
+    });
+
+    const results = await hybridQuerySkills(
+      [0.1],
+      { indices: [1], values: [1] },
+      5,
+    );
+
+    // Both channels ran without any payload filter.
+    expect(state.queryCalls).toHaveLength(2);
+    for (const call of state.queryCalls) {
+      expect(call.filter).toBeUndefined();
+    }
+    // Full results flow through unchanged.
+    expect(results.map((r) => r.id).sort()).toEqual([
+      "example-skill-1",
+      "example-skill-2",
+    ]);
+  });
+
+  test("restrictToIds forwards a Qdrant id-IN filter to BOTH channels", async () => {
     state.collectionExistsBeforeCreate = true;
     state.queryResponses.dense.push({ points: [] });
     state.queryResponses.sparse.push({ points: [] });
 
-    await hybridQuerySkills([0.1], { indices: [1], values: [1] }, 5);
+    await hybridQuerySkills([0.1], { indices: [1], values: [1] }, 5, [
+      "example-skill-a",
+      "example-skill-b",
+    ]);
 
+    expect(state.queryCalls).toHaveLength(2);
+    const usings = state.queryCalls.map((c) => c.using).sort();
+    expect(usings).toEqual(["dense", "sparse"]);
     for (const call of state.queryCalls) {
-      const wholeCall = call as unknown as Record<string, unknown>;
-      expect(wholeCall.filter).toBeUndefined();
+      // Filter is forwarded to both dense and sparse — without this the
+      // sparse channel would still grab the global top-K and corrupt
+      // candidate scoring.
+      expect(call.filter).toEqual({
+        must: [
+          { key: "id", match: { any: ["example-skill-a", "example-skill-b"] } },
+        ],
+      });
     }
+  });
+
+  test("empty restrictToIds short-circuits without hitting Qdrant", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    const results = await hybridQuerySkills(
+      [0.1],
+      { indices: [1], values: [1] },
+      5,
+      [],
+    );
+
+    expect(results).toEqual([]);
+    // No Qdrant calls were made — the function returned before
+    // ensureSkillCollection ran.
+    expect(state.queryCalls).toHaveLength(0);
+    expect(state.collectionExistsCalls).toBe(0);
   });
 
   test("empty Qdrant responses yield []", async () => {

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -110,12 +110,14 @@ export async function simBatch(
  *
  * Differences from `simBatch`:
  *   - Keys are skill `id` values (not concept-page slugs).
- *   - The underlying Qdrant query is **not** restricted to the candidate set.
- *     Skills always query the full collection — there is no equivalent of
- *     `restrictToSlugs`. We then keep only hits whose id is in `ids`.
+ *   - Restricts the query to the caller's candidate ids server-side via
+ *     `hybridQuerySkills`'s `restrictToIds` parameter. Without this, when the
+ *     skills collection has more skills than `ids.length`, Qdrant would
+ *     return its global top-K and candidate ids absent from that top-K would
+ *     silently score 0 — corrupting the activation calculation.
  *
  * Returns a `Map<id, score>` of fused scores in [0, 1]. Ids that did not hit
- * either channel — or that hit but are not in `ids` — are absent from the map.
+ * either channel are absent from the map.
  *
  * Edge cases:
  *   - Empty `ids` → returns an empty map without touching Qdrant or the
@@ -136,15 +138,21 @@ export async function simSkillBatch(
   const denseVector = denseResult.vectors[0];
   const sparseVector = generateSparseEmbedding(text);
 
-  const hits = await hybridQuerySkills(denseVector, sparseVector, ids.length);
+  const hits = await hybridQuerySkills(
+    denseVector,
+    sparseVector,
+    ids.length,
+    ids,
+  );
 
   if (hits.length === 0) {
     return new Map();
   }
 
-  // `hybridQuerySkills` queries the full collection unrestricted; pre-filter
-  // to the caller's candidate set so out-of-set hits don't perturb the
-  // per-batch sparse normalization.
+  // Defensive post-filter — `hybridQuerySkills` restricts server-side, so
+  // every hit should already be in `ids`, but keep this guard so a buggy
+  // payload (e.g. a missing/typoed id index) can't silently inject
+  // out-of-set ids into the score map.
   const idSet = new Set(ids);
   const filtered = hits.filter((h) => idSet.has(h.id));
   if (filtered.length === 0) {

--- a/assistant/src/memory/v2/skill-qdrant.ts
+++ b/assistant/src/memory/v2/skill-qdrant.ts
@@ -295,17 +295,31 @@ export async function pruneSkillsExcept(
  * if it appears in either channel; the missing channel's score is left
  * `undefined` so callers can detect single-channel matches.
  *
- * Unlike `hybridQueryConceptPages`, there is no `restrictToIds` parameter —
- * skill activation always considers the full enabled-skill catalog.
+ * `restrictToIds`, when provided, filters the search server-side to only
+ * those ids (Qdrant `id IN [...]` filter). Used by `simSkillBatch` when the
+ * candidate set is already known so the activation scorer gets scores for
+ * exactly those ids rather than Qdrant's global top-`limit`. An empty list
+ * short-circuits to no results — the caller is asking for "nothing", not
+ * "everything". Undefined queries the full collection (used by
+ * `selectSkillCandidates` to discover candidates from the global top-K).
  */
 export async function hybridQuerySkills(
   dense: number[],
   sparse: SparseEmbedding,
   limit: number,
+  restrictToIds?: readonly string[],
 ): Promise<SkillQueryResult[]> {
+  if (restrictToIds && restrictToIds.length === 0) {
+    // An empty restriction means "no candidates"; skip the round-trip.
+    return [];
+  }
+
   await ensureSkillCollection();
 
   const client = getClient();
+  const filter = restrictToIds
+    ? { must: [{ key: "id", match: { any: [...restrictToIds] } }] }
+    : undefined;
 
   const denseQuery = () =>
     client.query(MEMORY_V2_SKILLS_COLLECTION, {
@@ -313,6 +327,7 @@ export async function hybridQuerySkills(
       using: "dense",
       limit,
       with_payload: true,
+      filter,
     });
   const sparseQuery = () =>
     client.query(MEMORY_V2_SKILLS_COLLECTION, {
@@ -320,6 +335,7 @@ export async function hybridQuerySkills(
       using: "sparse",
       limit,
       with_payload: true,
+      filter,
     });
 
   // Run both queries concurrently — they hit independent named vectors.


### PR DESCRIPTION
## Summary
Fixes a correctness bug in skill activation scoring identified during plan review.

**Bug:** simSkillBatch called hybridQuerySkills without server-side filtering, so when the skills collection has more skills than the candidate count, candidate ids that don't appear in Qdrant's global top-K silently score 0.

**Fix:** Mirror hybridQueryConceptPages's restrictToSlugs pattern — add an optional restrictToIds param to hybridQuerySkills and pass the candidate ids from simSkillBatch.

Plan: memory-v2-skill-autoinjection.md (review fix #1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
