### PR TITLE
fix(memory-v2): drop dead /skill \(/ conditional in skill render

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -629,8 +629,7 @@ describe("injectMemoryV2Block", () => {
     expect(result.block).toContain("## What I Remember Right Now");
     expect(result.block).toContain("</memory>");
     // No concept-page sections; skills subsection present with the right
-    // bullet shape and the v1 `→ use skill_load to activate` suffix (the
-    // content matches the `/skill \(/` regex).
+    // bullet shape and the unconditional `→ use skill_load to activate` suffix.
     expect(result.block).not.toContain("### alice-vscode");
     expect(result.block).toContain("### Skills You Can Use");
     expect(result.block).toContain(
@@ -648,8 +647,8 @@ describe("injectMemoryV2Block", () => {
         {
           id: "example-skill-a",
           displayName: "Example Skill A",
-          // Content without the `skill (` regex match — no suffix expected.
-          content: "Plain capability description for example-skill-a.",
+          content:
+            'The "Example Skill A" skill (example-skill-a) is available. Helps with examples.',
         },
       ],
     );
@@ -674,11 +673,10 @@ describe("injectMemoryV2Block", () => {
     expect(skillsIdx).toBeGreaterThan(-1);
     expect(aliceIdx).toBeLessThan(skillsIdx);
 
-    // Skill content does not match `/skill \(/`, so no activation suffix.
+    // The activation suffix is always appended for skills.
     expect(result.block).toContain(
-      "- Plain capability description for example-skill-a.",
+      '- The "Example Skill A" skill (example-skill-a) is available. Helps with examples. → use skill_load to activate',
     );
-    expect(result.block).not.toContain("→ use skill_load to activate");
   });
 
   test("returns null when both concept pages and skills are empty", async () => {

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -289,17 +289,12 @@ async function renderInjectionBlock(
     sections.push(`### ${entry.slug}\n${entry.body}`);
   }
 
-  // Skills subsection — drop ids the cache no longer knows. Append the
-  // `→ use skill_load to activate` suffix when the rendered content matches
-  // the v1 regex (ported verbatim from `memory/graph/injection.ts`).
+  // v2's skills collection is skills-only, so the activation suffix always applies.
   const skillLines: string[] = [];
   for (const id of skillIds) {
     const entry = getSkillCapability(id);
     if (!entry) continue;
-    const suffix = /skill \(/.test(entry.content)
-      ? " → use skill_load to activate"
-      : "";
-    skillLines.push(`- ${entry.content}${suffix}`);
+    skillLines.push(`- ${entry.content} → use skill_load to activate`);
   }
   if (skillLines.length > 0) {
     sections.push(`### Skills You Can Use\n${skillLines.join("\n")}`);


### PR DESCRIPTION
## Summary
v2's skills collection is skills-only, so the v1 regex that distinguished skill from CLI capability nodes is always true here. Drop the dead conditional and the misleading negative test case.

Plan: memory-v2-skill-autoinjection.md (review fix #2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
