### PR TITLE
chore(memory-v2): drop dead mock + fix skills_top_k JSDoc typo

### DIFF
--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -158,10 +158,6 @@ mock.module("../memory/graph/capability-seed.js", () => ({
   seedUninstalledCatalogSkillMemories: async () => {},
 }));
 
-mock.module("../memory/v2/skill-store.js", () => ({
-  seedV2SkillEntries: mock(async () => {}),
-}));
-
 mock.module("../daemon/memory-v2-startup.js", () => ({
   maybeSeedMemoryV2Skills: mockMaybeSeedMemoryV2Skills,
 }));

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -452,7 +452,7 @@ export async function computeSkillActivation(
 export interface SelectSkillInjectionsParams {
   /** Final skill activation map. */
   A: ReadonlyMap<string, number>;
-  /** Cap on the per-turn skill slate, e.g. `config.memory.v2.skills_top_k`. */
+  /** Cap on the per-turn skill slate, e.g. `config.memory.v2.top_k_skills`. */
   topK: number;
 }
 


### PR DESCRIPTION
## Summary
Two trivial cleanups from round-2 plan review:
- Drop the dead mock.module("../memory/v2/skill-store.js", ...) block in handlers-skills-memory-v2-reseed.test.ts (the test now mocks maybeSeedMemoryV2Skills from memory-v2-startup.js instead).
- Fix the JSDoc typo `config.memory.v2.skills_top_k` → `config.memory.v2.top_k_skills` in activation.ts.

Plan: memory-v2-skill-autoinjection.md (round-2 cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
