### PR TITLE
fix: route credential health alerts to Background sidebar group

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -355,6 +355,10 @@ export class HeartbeatService {
             missingScopes: result.missingScopes,
           },
           routingIntent: "single_channel",
+          conversationMetadata: {
+            source: "heartbeat",
+            groupId: "system:background",
+          },
         });
       } catch (err) {
         log.error(


### PR DESCRIPTION
## Problem

Credential health alert notifications emitted via `emitNotificationSignal` were missing `conversationMetadata`, so the notification pipeline defaulted to `source: 'notification'` with no `groupId`. This caused the resulting conversation to land in **Recents** (`system:all`) instead of the **Background** group (`system:background`) where other heartbeat-originated conversations live.

## Fix

Add `conversationMetadata` with `source: 'heartbeat'` and `groupId: 'system:background'` to the `emitNotificationSignal` call in `notifyUnhealthyCredentials`, matching the pattern used by the heartbeat conversation bootstrap.

## Testing

- Trigger a credential health alert (e.g. revoke an OAuth token)
- Verify the resulting conversation appears in the Background sidebar group, not Recents
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
