### PR TITLE
[LUM-1263] fix(macOS): hide paid badge and cost banner in Your Own OAuth mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -64,8 +64,8 @@ struct IntegrationDetailModal: View {
         authManager.currentUser?.id
     }
 
-    private var isPaid: Bool {
-        (providerMeta?.isPaid ?? false) || (yourOwnMeta?.isPaid ?? false)
+    private var managedIsPaid: Bool {
+        providerMeta?.isPaid ?? false
     }
 
     // MARK: - Body
@@ -77,7 +77,7 @@ struct IntegrationDetailModal: View {
                 ?? "Configure \(displayName) OAuth",
             closeAction: onClose,
             titleAccessory: {
-                if isPaid {
+                if draftMode == "managed" && managedIsPaid {
                     VPaidBadge()
                 }
             }
@@ -179,7 +179,7 @@ struct IntegrationDetailModal: View {
     @ViewBuilder
     private var managedBody: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            if isPaid {
+            if managedIsPaid {
                 VNotification(
                     "Using this integration can result in additional costs.",
                     tone: .warning
@@ -323,12 +323,6 @@ struct IntegrationDetailModal: View {
     private var yourOwnBody: some View {
         let apps = store.yourOwnApps(for: providerKey)
         VStack(alignment: .leading, spacing: VSpacing.md) {
-            if isPaid {
-                VNotification(
-                    "Using this integration can result in additional costs.",
-                    tone: .warning
-                )
-            }
             if store.yourOwnIsLoading(for: providerKey) {
                 yourOwnSkeleton
             } else if apps.isEmpty && !isShowingAddAppForm {


### PR DESCRIPTION
The paid badge (`VPaidBadge`) and additional-costs banner (`VNotification`) in `IntegrationDetailModal` were shown regardless of which OAuth mode tab was active. Only Managed mode incurs extra costs via platform-provided credentials, so "Your Own" mode should not display these indicators. The root cause was a mode-agnostic `isPaid` computed property that OR'd both managed and your-own metadata, plus unconditional banner rendering in both tab bodies.

---

## Root cause analysis

1. **How did the code get into this state?** PR #27512 introduced the paid badge feature across multiple sub-PRs. The `isPaid` computed property was written to OR both `providerMeta?.isPaid` and `yourOwnMeta?.isPaid`, and both `managedBody` and `yourOwnBody` used this same property for their cost banners.

2. **What mistakes or decisions led to it?** The field is named `managed_service_is_paid` on the backend — correctly scoped to managed mode. But the client collapsed this into a mode-agnostic boolean without differentiating which tab was active. The multi-sub-PR structure of #27512 may have made it harder to spot the cross-cutting concern.

3. **Were there warning signs we missed?** The field name itself (`managed_service_is_paid`) signals that the flag is managed-mode-specific. The `OAuthProviderMetadata.isPaid` computed property's docstring says "Whether this provider's managed service incurs additional costs" — the word "managed" was already there but ignored in the modal's usage.

4. **What can we do to prevent this pattern from recurring?** When adding mode-specific UI indicators, verify that each tab/mode only renders indicators relevant to its own context. Review both tab bodies independently rather than sharing a single boolean.

5. **Should we add a guideline to AGENTS.md?** Not warranted — this is a standard "check your conditionals match the context" issue, not a systemic architectural gap.

## Prompt / plan

Investigated [LUM-1263](https://linear.app/vellum/issue/LUM-1263/hide-paid-banner-for-your-own-twitter-oauth-mode). Changes to `IntegrationDetailModal.swift`:
- Title `VPaidBadge`: only show when `draftMode == "managed"` and the managed provider is paid
- `yourOwnBody`: remove the cost-notice `VNotification` block entirely
- `managedBody`: use `managedIsPaid` (reads managed provider metadata directly)
- Remove the unused `isPaid` computed property

## Test plan

- TypeScript typecheck (`bunx tsc --noEmit`): passed
- ESLint (`bun run lint`): passed
- CI skips macOS builds — requires local Xcode verification

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/7491db9565f84ffd8a9d3f5a373f222a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
