### PR TITLE
fix(macOS): pointer cursor on inline-link CTAs in info banners

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -491,6 +491,7 @@ struct SettingsPanel: View {
                     .foregroundStyle(VColor.primaryBase)
                 }
                 .buttonStyle(.plain)
+                .pointerCursor()
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -73,6 +73,7 @@ struct VoiceSettingsView: View {
                 .foregroundStyle(VColor.primaryBase)
             }
             .buttonStyle(.plain)
+            .pointerCursor()
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.sm)


### PR DESCRIPTION
## Summary
- Add `.pointerCursor()` to the "View pricing" button in the Models & Services billing banner (`SettingsPanel.swift:482-493`)
- Add `.pointerCursor()` to the "Go to Models & Services" button in the Voice settings info banner (`VoiceSettingsView.swift:61-75`)

Both buttons render an underlined link + arrow-up-right icon as a navigation CTA inside an info banner, but neither was applying the pointing-hand cursor on hover.

Note: these banners are bespoke HStacks that visually mimic VNotification, not actual VNotification components. Migrating them to real VNotification is a separate cleanup.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
