### PR TITLE
fix(oauth): default to managed mode on platform instances

### DIFF
--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -1,6 +1,11 @@
 import type { Command } from "commander";
 
-import { getConfig } from "../../../config/loader.js";
+import { getIsPlatform } from "../../../config/env-registry.js";
+import {
+  getConfig,
+  getNestedValue,
+  loadRawConfig,
+} from "../../../config/loader.js";
 import {
   getServiceMode,
   type Services,
@@ -40,6 +45,13 @@ export function getManagedServiceConfigKey(provider: string): string | null {
 
 /**
  * Determine whether a provider is running in platform-managed mode.
+ *
+ * When `IS_PLATFORM=true` and the provider supports managed mode, this
+ * defaults to `true` unless the user has explicitly set the service mode
+ * to `"your-own"` in the raw config file. This lets platform instances
+ * use platform-managed OAuth credentials out of the box without requiring
+ * a manual `assistant oauth mode <provider> --set managed` step.
+ *
  * Returns false if config is unavailable (e.g. in test environments).
  */
 export function isManagedMode(provider: string): boolean {
@@ -47,7 +59,22 @@ export function isManagedMode(provider: string): boolean {
   if (!managedKey) return false;
   try {
     const services: Services = getConfig().services;
-    return getServiceMode(services, managedKey as keyof Services) === "managed";
+    const mode = getServiceMode(services, managedKey as keyof Services);
+    if (mode === "managed") return true;
+
+    // On platform instances, default to managed mode for providers that
+    // support it — unless the user explicitly opted into "your-own".
+    if (getIsPlatform()) {
+      const rawMode = getNestedValue(
+        loadRawConfig(),
+        `services.${managedKey}.mode`,
+      );
+      // If the raw config doesn't have an explicit mode entry, the "your-own"
+      // value came from the schema default — override it to managed on platform.
+      if (rawMode === undefined) return true;
+    }
+
+    return false;
   } catch {
     return false;
   }

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,4 +1,5 @@
-import { getConfig } from "../config/loader.js";
+import { getIsPlatform } from "../config/env-registry.js";
+import { getConfig, getNestedValue, loadRawConfig } from "../config/loader.js";
 import {
   getServiceMode,
   type Services,
@@ -51,7 +52,15 @@ export async function resolveOAuthConnection(
 
   if (managedKey && managedKey in ServicesSchema.shape) {
     const services: Services = getConfig().services;
-    if (getServiceMode(services, managedKey as keyof Services) === "managed") {
+    const explicitMode = getServiceMode(services, managedKey as keyof Services);
+    // Treat as managed when explicitly configured OR when on a platform
+    // instance and the user hasn't explicitly opted into "your-own".
+    const effectivelyManaged =
+      explicitMode === "managed" ||
+      (getIsPlatform() &&
+        getNestedValue(loadRawConfig(), `services.${managedKey}.mode`) ===
+          undefined);
+    if (effectivelyManaged) {
       const client = await VellumPlatformClient.create();
       if (!client || !client.platformAssistantId) {
         const detail = !client


### PR DESCRIPTION
## Summary
- When `IS_PLATFORM=true` and a provider supports managed mode, `isManagedMode()` now returns `true` by default — no manual `assistant oauth mode <provider> --set managed` required.
- The raw config file is checked to distinguish the schema default (`"your-own"`) from an explicit user override, so `--set your-own` is still respected.
- Applied the same fix to `connection-resolver.ts` which independently resolves managed vs BYO at runtime.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/cli/commands/oauth/__tests__/connect.test.ts` — 13 pass
- [x] `bun test src/oauth/connection-resolver.test.ts` — all pass
- [x] `bun test src/cli/commands/oauth/__tests__/mode.test.ts` — all pass
- [ ] Manual: on a platform instance, `assistant oauth connect google` should enter the managed flow without prior `oauth mode --set managed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
