### PR TITLE
fix(macos): show "Thinking" instead of "Wrapping up" during streaming

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -290,6 +290,7 @@ function handleTextDelta(
         "first_text_delta",
         "assistant_turn",
         deps.reqId,
+        "Thinking",
       );
     }
     deps.onEvent({
@@ -1096,6 +1097,7 @@ export async function dispatchAgentEvent(
           "tool_result_received",
           "assistant_turn",
           deps.reqId,
+          "Thinking",
         );
 
         // Format web search results into a human-readable string for the client.


### PR DESCRIPTION
## Summary
- The daemon's `emitActivityState` calls for `first_text_delta` and `server_tool_complete` were missing `statusText`, causing the macOS client to fall back to "Wrapping up" during the brief gap before streamed text renders.
- Now sends `"Thinking"` as the status text for both transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
