### PR TITLE
feat(macOS): gate inference profiles UI behind feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -25,6 +25,7 @@ struct ChatView: View {
     /// directly does NOT subscribe parent views to any changes.
     /// See: https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro
     @Bindable var viewModel: ChatViewModel
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
 
     // MARK: - Settings (from SettingsStore, not viewModel)
 
@@ -500,6 +501,7 @@ struct ChatView: View {
     /// `nil` when no manager is wired (preview/testing) so the pill stays
     /// hidden until a real persistence path exists.
     private var inferenceProfilePicker: ChatProfilePickerConfiguration? {
+        guard assistantFeatureFlagStore.isEnabled("inference-profiles") else { return nil }
         guard let conversationManager else { return nil }
         return ChatProfilePickerConfiguration(
             current: currentConversation?.inferenceProfile ?? viewModel.pendingInferenceProfile,

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -17,6 +17,7 @@ import VellumAssistantShared
 @MainActor
 struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
     var authManager: AuthManager
     @Binding var apiKeyText: String
     var showToast: (String, ToastInfo.Style) -> Void
@@ -132,8 +133,10 @@ struct InferenceServiceCard: View {
                 if isLoggedIn {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         managedProviderPicker
-                        activeProfilePicker
-                        manageProfilesButton
+                        if assistantFeatureFlagStore.isEnabled("inference-profiles") {
+                            activeProfilePicker
+                            manageProfilesButton
+                        }
                         ServiceCardActions(
                             hasChanges: hasChanges,
                             isSaving: store.apiKeySaving,
@@ -152,8 +155,10 @@ struct InferenceServiceCard: View {
                     apiKeyField
 
                     // Active profile picker + Manage Profiles button
-                    activeProfilePicker
-                    manageProfilesButton
+                    if assistantFeatureFlagStore.isEnabled("inference-profiles") {
+                        activeProfilePicker
+                        manageProfilesButton
+                    }
 
                     // Action buttons
                     ServiceCardActions(
@@ -174,7 +179,8 @@ struct InferenceServiceCard: View {
                 // Per-call-site overrides badge — only visible when the user has
                 // at least one override configured. Tapping opens the overrides
                 // sheet.
-                if store.overridesCount > 0 {
+                if assistantFeatureFlagStore.isEnabled("inference-profiles"),
+                   store.overridesCount > 0 {
                     overridesBadge
                 }
             }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -376,6 +376,14 @@
       "label": "Memory v2 (concept-page activation model)",
       "description": "Enables the v2 memory subsystem: prose concept pages with bidirectional edges, activation-based retrieval, and hourly LLM-driven consolidation. v1 graph + PKB stays write-active until cutover.",
       "defaultEnabled": false
+    },
+    {
+      "id": "inference-profiles",
+      "scope": "assistant",
+      "key": "inference-profiles",
+      "label": "Inference Profiles",
+      "description": "Show inference profile picker in chat, active profile dropdown, Manage Profiles button, and per-task overrides link in Settings",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Registers a new `inference-profiles` assistant-scoped feature flag (default off) in the flag registry
- Gates the chat profile picker in `ChatView` behind the flag so it only renders when enabled
- Gates the active profile dropdown, Manage Profiles button, and overrides badge in `InferenceServiceCard` behind the same flag
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
