### PR TITLE
fix(macOS): make feature flag store optional and gate override confirmation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -25,7 +25,7 @@ struct ChatView: View {
     /// directly does NOT subscribe parent views to any changes.
     /// See: https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro
     @Bindable var viewModel: ChatViewModel
-    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore: AssistantFeatureFlagStore?
 
     // MARK: - Settings (from SettingsStore, not viewModel)
 
@@ -501,7 +501,7 @@ struct ChatView: View {
     /// `nil` when no manager is wired (preview/testing) so the pill stays
     /// hidden until a real persistence path exists.
     private var inferenceProfilePicker: ChatProfilePickerConfiguration? {
-        guard assistantFeatureFlagStore.isEnabled("inference-profiles") else { return nil }
+        guard assistantFeatureFlagStore?.isEnabled("inference-profiles") == true else { return nil }
         guard let conversationManager else { return nil }
         return ChatProfilePickerConfiguration(
             current: currentConversation?.inferenceProfile ?? viewModel.pendingInferenceProfile,

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -17,7 +17,7 @@ import VellumAssistantShared
 @MainActor
 struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
-    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore: AssistantFeatureFlagStore?
     var authManager: AuthManager
     @Binding var apiKeyText: String
     var showToast: (String, ToastInfo.Style) -> Void
@@ -133,7 +133,7 @@ struct InferenceServiceCard: View {
                 if isLoggedIn {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
                         managedProviderPicker
-                        if assistantFeatureFlagStore.isEnabled("inference-profiles") {
+                        if assistantFeatureFlagStore?.isEnabled("inference-profiles") == true {
                             activeProfilePicker
                             manageProfilesButton
                         }
@@ -155,7 +155,7 @@ struct InferenceServiceCard: View {
                     apiKeyField
 
                     // Active profile picker + Manage Profiles button
-                    if assistantFeatureFlagStore.isEnabled("inference-profiles") {
+                    if assistantFeatureFlagStore?.isEnabled("inference-profiles") == true {
                         activeProfilePicker
                         manageProfilesButton
                     }
@@ -179,7 +179,7 @@ struct InferenceServiceCard: View {
                 // Per-call-site overrides badge — only visible when the user has
                 // at least one override configured. Tapping opens the overrides
                 // sheet.
-                if assistantFeatureFlagStore.isEnabled("inference-profiles"),
+                if assistantFeatureFlagStore?.isEnabled("inference-profiles") == true,
                    store.overridesCount > 0 {
                     overridesBadge
                 }
@@ -515,8 +515,13 @@ struct InferenceServiceCard: View {
         // managed) where both old and new resolve to the same provider
         // (e.g. both "anthropic") should not prompt because there is no
         // provider switch for overrides to reconcile against.
+        //
+        // Skip the confirmation when inference-profiles is off — the
+        // overrides UI is hidden so showing the dialog would confuse users
+        // who have no way to inspect or manage their overrides.
+        let profilesEnabled = assistantFeatureFlagStore?.isEnabled("inference-profiles") == true
         let providerIdChanged = persistProvider != initialProvider
-        if providerIdChanged {
+        if profilesEnabled && providerIdChanged {
             let overridesPinnedToOldProvider = store.callSiteOverrides.filter {
                 $0.provider == initialProvider
             }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -515,21 +515,27 @@ struct InferenceServiceCard: View {
         // managed) where both old and new resolve to the same provider
         // (e.g. both "anthropic") should not prompt because there is no
         // provider switch for overrides to reconcile against.
-        //
-        // Skip the confirmation when inference-profiles is off — the
-        // overrides UI is hidden so showing the dialog would confuse users
-        // who have no way to inspect or manage their overrides.
-        let profilesEnabled = assistantFeatureFlagStore?.isEnabled("inference-profiles") == true
         let providerIdChanged = persistProvider != initialProvider
-        if profilesEnabled && providerIdChanged {
+        if providerIdChanged {
             let overridesPinnedToOldProvider = store.callSiteOverrides.filter {
                 $0.provider == initialProvider
             }
             if !overridesPinnedToOldProvider.isEmpty {
-                pendingOverrideClears = overridesPinnedToOldProvider
-                pendingOverrideOldProviderName = store.dynamicProviderDisplayName(initialProvider)
-                showOverrideConfirmation = true
-                return
+                let profilesEnabled = assistantFeatureFlagStore?.isEnabled("inference-profiles") == true
+                if profilesEnabled {
+                    // Show the confirmation dialog so the user can choose
+                    // to keep or reset overrides pinned to the old provider.
+                    pendingOverrideClears = overridesPinnedToOldProvider
+                    pendingOverrideOldProviderName = store.dynamicProviderDisplayName(initialProvider)
+                    showOverrideConfirmation = true
+                    return
+                } else {
+                    // When inference-profiles is off the overrides UI is
+                    // hidden, so silently clear stale overrides to prevent
+                    // invisible provider/model mismatches for affected tasks.
+                    performSaveCore(clearingOverrides: overridesPinnedToOldProvider)
+                    return
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Make `@Environment(AssistantFeatureFlagStore.self)` optional in `InferenceServiceCard` and `ChatView` so existing tests don't crash when the store isn't injected into the environment
- Gate the "Keep per-task overrides?" confirmation dialog in `performSave()` behind the `inference-profiles` flag so users with the flag off don't hit a dialog for a feature they can't access

## Original prompt
fixes for both
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
