### PR TITLE
fix(macos): only strip .function modifier for arrow-key nav shortcuts

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -563,8 +563,20 @@ extension AppDelegate {
 
         let (prevModifiers, prevKey) = ShortcutHelper.parseShortcut(prevShortcut)
         let (nextModifiers, nextKey) = ShortcutHelper.parseShortcut(nextShortcut)
-        let prevMods = prevModifiers.subtracting(.function)
-        let nextMods = nextModifiers.subtracting(.function)
+
+        // Only strip .function for arrow-key shortcuts where macOS implicitly
+        // adds the flag. For non-arrow keys, keep .function so that explicit
+        // fn+key bindings (e.g. fn+cmd+k) are not triggered without Fn held.
+        let arrowKeyScalars: Set<UInt32> = [
+            NSUpArrowFunctionKey, NSDownArrowFunctionKey,
+            NSLeftArrowFunctionKey, NSRightArrowFunctionKey
+        ]
+        func isArrowKey(_ key: String) -> Bool {
+            guard let scalar = key.unicodeScalars.first, key.unicodeScalars.count == 1 else { return false }
+            return arrowKeyScalars.contains(scalar.value)
+        }
+        let prevMods = isArrowKey(prevKey) ? prevModifiers.subtracting(.function) : prevModifiers
+        let nextMods = isArrowKey(nextKey) ? nextModifiers.subtracting(.function) : nextModifiers
 
         let handler: (NSEvent) -> NSEvent? = { [weak self] event in
             guard self?.isBootstrapping != true,


### PR DESCRIPTION
## Summary
- Addresses Codex review feedback on #27009 — limits `.function` modifier stripping to arrow-key shortcuts only
- Non-arrow-key shortcuts (e.g. `fn+cmd+k`) now correctly retain `.function` in parsed modifiers, so they won't fire without Fn held

## Test plan
- [ ] Verify `cmd+up`/`cmd+down` conversation navigation still works (arrow keys strip `.function` as before)
- [ ] Verify a custom `fn+cmd+k` navigation shortcut only triggers when Fn is held, not on plain `cmd+k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
