### PR TITLE
fix(credentials): send secret_request via both paths for non-UI channels

### DIFF
--- a/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
+++ b/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
@@ -59,7 +59,7 @@ describe("secret prompter channel fallback", () => {
     expect(sentMessages).toHaveLength(0);
   });
 
-  test("broadcasts secret_request via SSE hub when channel lacks dynamic UI but broadcast is available", async () => {
+  test("broadcasts secret_request via SSE hub AND sends via sendToClient when channel lacks dynamic UI but broadcast is available", async () => {
     const prompter = new SecretPrompter(
       (msg) => sentMessages.push(msg),
       (msg) => broadcastMessages.push(msg),
@@ -71,10 +71,11 @@ describe("secret prompter channel fallback", () => {
 
     const promise = prompter.prompt("myservice", "apikey", "API Key");
 
-    // Should have broadcast the message, not sent via per-channel sender
-    expect(sentMessages).toHaveLength(0);
+    // Should have broadcast AND sent via per-channel sender (voice path needs sendToClient)
     expect(broadcastMessages).toHaveLength(1);
     expect(broadcastMessages[0]!.type).toBe("secret_request");
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]!.type).toBe("secret_request");
 
     // Resolve the prompt so it doesn't hang
     const requestId = (broadcastMessages[0] as SecretRequest).requestId;

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -49,10 +49,6 @@ export class SecretPrompter {
     this.sendToClient = sendToClient;
   }
 
-  updateBroadcast(broadcastToAllClients?: (msg: ServerMessage) => void): void {
-    this.broadcastToAllClients = broadcastToAllClients;
-  }
-
   setChannelContext(ctx: SecretPrompterChannelContext | undefined): void {
     this.channelContext = ctx;
   }
@@ -123,14 +119,13 @@ export class SecretPrompter {
         allowOneTimeSend: config.secretDetection.allowOneTimeSend,
       };
 
-      // Use broadcastToAllClients when the originating channel cannot render
-      // secure prompts — this routes the request to the SSE hub where a
-      // connected desktop client can pick it up.
+      // When the originating channel cannot render secure prompts, broadcast
+      // to the SSE hub so a connected desktop client can pick it up, AND
+      // send via sendToClient so the voice path can still auto-resolve.
       if (!channelSupportsPrompt && this.broadcastToAllClients) {
         this.broadcastToAllClients(msg);
-      } else {
-        this.sendToClient(msg);
       }
+      this.sendToClient(msg);
     });
   }
 


### PR DESCRIPTION
## Summary
- Send secret_request via both `broadcastToAllClients` AND `sendToClient` for non-dynamic-UI channels, fixing voice path regression where secret prompts would block for 5 minutes
- Remove unused `updateBroadcast` method (dead code)

Addresses review feedback on #27019.

## Test plan
- [x] Updated `secret-prompter-channel-fallback.test.ts` to verify both paths receive the message
- [x] Existing test cases for fail-fast and desktop default paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
