### PR TITLE
fix: reject unknown parameters in skill tool execution

### DIFF
--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -270,6 +270,103 @@ describe("createSkillToolsFromManifest", () => {
 });
 
 // ---------------------------------------------------------------------------
+// createSkillTool — unknown parameter validation
+// ---------------------------------------------------------------------------
+
+describe("createSkillTool — unknown parameter validation", () => {
+  test("rejects input with unknown parameters", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({ executor: "echo.ts" }),
+      "my-skill",
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute(
+      { query: "hello", unsubscribe: true },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown parameter "unsubscribe"');
+    expect(result.content).toContain("Supported parameters");
+    expect(result.content).toContain('"query"');
+  });
+
+  test("rejects multiple unknown parameters", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({ executor: "echo.ts" }),
+      "my-skill",
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute(
+      { query: "hello", foo: 1, bar: 2 },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown parameters");
+    expect(result.content).toContain('"foo"');
+    expect(result.content).toContain('"bar"');
+  });
+
+  test("allows input with only known parameters", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({ executor: "echo.ts" }),
+      "my-skill",
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute({ query: "hello" }, makeContext());
+
+    expect(result.isError).toBe(false);
+  });
+
+  test("allows empty input when schema has no required fields", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({
+        executor: "echo.ts",
+        input_schema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+      }),
+      "my-skill",
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute({}, makeContext());
+
+    expect(result.isError).toBe(false);
+  });
+
+  test("skips validation when schema has no properties", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({
+        executor: "echo.ts",
+        input_schema: { type: "object" },
+      }),
+      "my-skill",
+      tempDir,
+      hash,
+    );
+
+    const result = await tool.execute({ anything: "goes" }, makeContext());
+
+    expect(result.isError).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createSkillTool — expectedSkillVersionHash plumbing
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -21,7 +21,8 @@
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "executor": "tools/messaging-auth-test.ts",
       "execution_target": "host"
@@ -58,7 +59,8 @@
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "executor": "tools/messaging-list-conversations.ts",
       "execution_target": "host"
@@ -96,6 +98,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
+        "additionalProperties": false,
         "required": ["conversation_id"]
       },
       "executor": "tools/messaging-read.ts",
@@ -130,6 +133,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
+        "additionalProperties": false,
         "required": ["query"]
       },
       "executor": "tools/messaging-search.ts",
@@ -187,6 +191,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
+        "additionalProperties": false,
         "required": ["conversation_id", "text", "confidence"]
       },
       "executor": "tools/messaging-send.ts",
@@ -221,6 +226,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
+        "additionalProperties": false,
         "required": ["conversation_id"]
       },
       "executor": "tools/messaging-mark-read.ts",
@@ -254,7 +260,8 @@
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "executor": "tools/messaging-analyze-style.ts",
       "execution_target": "host"
@@ -301,6 +308,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
+        "additionalProperties": false,
         "required": ["action"]
       },
       "executor": "tools/messaging-draft.ts",
@@ -342,7 +350,8 @@
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "executor": "tools/messaging-sender-digest.ts",
       "execution_target": "host"
@@ -380,6 +389,7 @@
             "description": "Set to true ONLY when the user's most recent message contains explicit approval language for this specific action (e.g. 'archive these', 'yes do it', 'go ahead'). Do NOT set this when the user merely described what they want without confirming, or when acting on prior instructions without fresh confirmation in this turn."
           }
         },
+        "additionalProperties": false,
         "required": ["query", "confidence"]
       },
       "executor": "tools/messaging-archive-by-sender.ts",

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -16,6 +16,31 @@ const riskMap: Record<SkillToolEntry["risk"], RiskLevel> = {
 };
 
 /**
+ * Validate that all keys in `input` are declared in the tool's input_schema
+ * properties. Returns an error result listing unknown parameters, or undefined
+ * if validation passes.
+ */
+function validateNoUnknownParams(
+  toolName: string,
+  input: Record<string, unknown>,
+  schema: SkillToolEntry["input_schema"],
+): ToolExecutionResult | undefined {
+  const properties = schema?.properties;
+  if (!properties) return undefined;
+
+  const knownKeys = new Set(Object.keys(properties));
+  const unknownKeys = Object.keys(input).filter((k) => !knownKeys.has(k));
+  if (unknownKeys.length === 0) return undefined;
+
+  const listed = unknownKeys.map((k) => `"${k}"`).join(", ");
+  const supported = [...knownKeys].map((k) => `"${k}"`).join(", ");
+  return {
+    content: `Unknown parameter${unknownKeys.length > 1 ? "s" : ""} ${listed} for tool "${toolName}". Supported parameters: ${supported}. Remove unsupported parameters and retry.`,
+    isError: true,
+  };
+}
+
+/**
  * Create a runtime Tool object from a manifest entry.
  * Maps SkillToolEntry metadata to the Tool interface and routes execution
  * through the skill script runner.
@@ -50,6 +75,13 @@ export function createSkillTool(
       input: Record<string, unknown>,
       context: ToolContext,
     ): Promise<ToolExecutionResult> {
+      const validationError = validateNoUnknownParams(
+        entry.name,
+        input,
+        entry.input_schema,
+      );
+      if (validationError) return validationError;
+
       return runSkillToolScript(skillDir, entry.executor, input, context, {
         target: entry.execution_target,
         expectedSkillVersionHash: versionHash,


### PR DESCRIPTION
## Summary
- Add centralized unknown-parameter validation in `skill-tool-factory.ts` — runs before every skill tool execution, compares input keys against schema properties, returns a clear error listing unknowns and supported params
- Add `additionalProperties: false` to all 10 messaging tool schemas in `TOOLS.json` as LLM-facing signal
- Add 5 tests covering unknown param rejection, known-only pass-through, empty input, and schema-less fallback

## Original prompt
Bug: Several messaging/gmail skill tools accept unknown or unsupported parameters and silently ignore them instead of returning an error. Example: messaging_archive_by_sender accepts unsubscribe:true but does nothing with it — no error, no warning in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
