### PR TITLE
fix(memory-v2): exclude installed-but-disabled skills from catalog seeding

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
 import type { ResolvedSkill } from "../../../config/skill-state.js";
 import type { SkillSummary } from "../../../config/skills.js";
+import type { CatalogSkill } from "../../../skills/catalog-install.js";
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
@@ -31,6 +32,8 @@ mock.module("../../../util/logger.js", () => ({
 interface TestState {
   catalog: SkillSummary[];
   resolved: ResolvedSkill[];
+  fullCatalog: CatalogSkill[];
+  fullCatalogThrows: Error | null;
   flagsEnabled: Record<string, boolean>;
   embedThrows: Error | null;
   embedReturn: number[][];
@@ -49,6 +52,8 @@ interface TestState {
 const state: TestState = {
   catalog: [],
   resolved: [],
+  fullCatalog: [],
+  fullCatalogThrows: null,
   flagsEnabled: {},
   embedThrows: null,
   embedReturn: [],
@@ -104,6 +109,13 @@ mock.module("../skill-qdrant.js", () => ({
   },
 }));
 
+mock.module("../../../skills/catalog-cache.js", () => ({
+  getCatalog: async () => {
+    if (state.fullCatalogThrows) throw state.fullCatalogThrows;
+    return state.fullCatalog;
+  },
+}));
+
 // Imported AFTER all mocks are wired so the module under test sees the stubs.
 const { seedV2SkillEntries, getSkillCapability, _resetSkillStoreForTests } =
   await import("../skill-store.js");
@@ -128,6 +140,8 @@ function makeSummary(overrides: Partial<SkillSummary> = {}): SkillSummary {
 function resetState(): void {
   state.catalog = [];
   state.resolved = [];
+  state.fullCatalog = [];
+  state.fullCatalogThrows = null;
   state.flagsEnabled = {};
   state.embedThrows = null;
   state.embedReturn = [];
@@ -194,6 +208,63 @@ describe("seedV2SkillEntries", () => {
 
     expect(state.upsertCalls).toHaveLength(1);
     expect(state.upsertCalls[0].id).toBe("example-skill-a");
+  });
+
+  test("does not re-seed an installed-but-disabled skill from the remote catalog", async () => {
+    // Regression for https://github.com/vellum-ai/vellum-assistant/pull/28635
+    // (Codex P1): if `seenIds` is built only from enabled skills, a locally
+    // installed-but-disabled skill falls through to the catalog loop and gets
+    // embedded as if it were a discoverable uninstalled skill — contradicting
+    // the user's explicit disablement.
+    const enabledSkill = makeSummary({ id: "example-skill-a" });
+    const disabledSkill = makeSummary({ id: "example-skill-b" });
+    state.catalog = [enabledSkill, disabledSkill];
+    state.resolved = [
+      { summary: enabledSkill, state: "enabled" },
+      { summary: disabledSkill, state: "disabled" },
+    ];
+    // The remote catalog also contains the disabled skill (same id) — the
+    // seed function must NOT pull it back in via `getCatalog()`.
+    state.fullCatalog = [
+      {
+        id: "example-skill-b",
+        name: "example-skill-b",
+        description: "Disabled skill that also lives in the remote catalog",
+      },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.upsertCalls[0].id).toBe("example-skill-a");
+  });
+
+  test("seeds genuinely uninstalled catalog skills alongside enabled installed skills", async () => {
+    const installed = makeSummary({ id: "example-skill-a" });
+    state.catalog = [installed];
+    state.resolved = [{ summary: installed, state: "enabled" }];
+    state.fullCatalog = [
+      {
+        id: "example-skill-a",
+        name: "example-skill-a",
+        description: "Installed (must not duplicate)",
+      },
+      {
+        id: "uninstalled-skill",
+        name: "uninstalled-skill",
+        description: "Discoverable from the catalog",
+      },
+    ];
+    state.embedReturn = [
+      [0.1, 0.2, 0.3],
+      [0.4, 0.5, 0.6],
+    ];
+
+    await seedV2SkillEntries();
+
+    const ids = state.upsertCalls.map((c) => c.id).sort();
+    expect(ids).toEqual(["example-skill-a", "uninstalled-skill"]);
   });
 
   test("skips skills whose declared feature flag is disabled", async () => {

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -79,10 +79,16 @@ export async function seedV2SkillEntries(): Promise<void> {
     const resolved = resolveSkillStates(catalog, config);
     const enabled = resolved.filter((r) => r.state === "enabled");
 
+    // Track every locally-installed skill id (regardless of enabled/disabled
+    // state) so the catalog-seeding loop below treats them all as "installed"
+    // and never re-seeds a disabled skill from `getCatalog()` as if it were
+    // uninstalled. Mirrors v1's `seedUninstalledCatalogSkillMemories`, which
+    // keys off `loadSkillCatalog()` (the installed set) for the same reason.
+    const installedIds = new Set<string>(catalog.map((s) => s.id));
+
     // Build the input list, applying the mcp-setup description augmentation
     // and the defense-in-depth feature-flag filter.
     const seeds: SkillEntry[] = [];
-    const seenIds = new Set<string>();
     for (const { summary } of enabled) {
       const flagKey = summary.featureFlag;
       if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
@@ -90,7 +96,6 @@ export async function seedV2SkillEntries(): Promise<void> {
       const augmented = augmentMcpSetupDescription(fromSkillSummary(summary));
       const content = buildSkillContent(augmented);
       seeds.push({ id: summary.id, content });
-      seenIds.add(summary.id);
     }
 
     // Seed uninstalled catalog skills so their activation hints are
@@ -98,13 +103,12 @@ export async function seedV2SkillEntries(): Promise<void> {
     try {
       const fullCatalog = await getCatalog();
       for (const entry of fullCatalog) {
-        if (seenIds.has(entry.id)) continue;
+        if (installedIds.has(entry.id)) continue;
         const flagKey = entry.metadata?.vellum?.["feature-flag"];
         if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config))
           continue;
         const content = buildSkillContent(fromCatalogSkill(entry));
         seeds.push({ id: entry.id, content });
-        seenIds.add(entry.id);
       }
     } catch (err) {
       log.warn(


### PR DESCRIPTION
## Summary
- The v2 skill seed loop built its dedupe set (\`seenIds\`) from \`enabled\` skills only, so a locally installed-but-disabled skill fell through to the \`getCatalog()\` loop and got embedded as if it were a discoverable uninstalled skill — contradicting the resolved state and causing the assistant to surface activation hints for skills the user turned off.
- Build the set from the full local catalog instead (rename: \`installedIds\`), mirroring v1's \`seedUninstalledCatalogSkillMemories\` which keys off \`loadSkillCatalog()\` for the same reason.
- Add regression tests covering both the bug case (installed-but-disabled skill that also exists in the remote catalog must not be seeded) and the genuine-uninstalled case (uninstalled catalog skills still get seeded alongside enabled installed ones).

## Original prompt
address the comment on https://github.com/vellum-ai/vellum-assistant/pull/28635
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
