### PR TITLE
fix(macos): cast NS arrow key constants to UInt32 in scalar set

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -568,8 +568,8 @@ extension AppDelegate {
         // adds the flag. For non-arrow keys, keep .function so that explicit
         // fn+key bindings (e.g. fn+cmd+k) are not triggered without Fn held.
         let arrowKeyScalars: Set<UInt32> = [
-            NSUpArrowFunctionKey, NSDownArrowFunctionKey,
-            NSLeftArrowFunctionKey, NSRightArrowFunctionKey
+            UInt32(NSUpArrowFunctionKey), UInt32(NSDownArrowFunctionKey),
+            UInt32(NSLeftArrowFunctionKey), UInt32(NSRightArrowFunctionKey)
         ]
         func isArrowKey(_ key: String) -> Bool {
             guard let scalar = key.unicodeScalars.first, key.unicodeScalars.count == 1 else { return false }


### PR DESCRIPTION
## Summary

- `NSUpArrowFunctionKey`, `NSDownArrowFunctionKey`, `NSLeftArrowFunctionKey`, `NSRightArrowFunctionKey` are `Int`-typed AppKit constants. The `arrowKeyScalars` set is `Set<UInt32>` (matching `UnicodeScalar.value`), and Swift's array literal type inference does not implicitly bridge `Int` → `UInt32`, so the build fails with `cannot convert value of type 'Int' to expected element type 'Set<UInt32>.ArrayLiteralElement'`.
- Wraps each constant in `UInt32(...)` to satisfy the literal's element type.

## Original prompt

Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift:571:35: error: cannot convert value of type 'Int' to expected element type 'Set<UInt32>.ArrayLiteralElement' (aka 'UInt32')
569 |         // fn+key bindings (e.g. fn+cmd+k) are not triggered without Fn held.
570 |         let arrowKeyScalars: Set<UInt32> = [
571 |             NSUpArrowFunctionKey, NSDownArrowFunctionKey,
    |                                   \`- error: cannot convert value of type 'Int' to expected element type 'Set<UInt32>.ArrayLiteralElement' (aka 'UInt32')
572 |             NSLeftArrowFunctionKey, NSRightArrowFunctionKey
573 |         ]
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
