### PR TITLE
fix(providers/anthropic): preserve prompt cache across new user turns

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -374,15 +374,51 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     }>;
 
     const userMessages = sent.filter((m) => m.role === "user");
-    // Only the last user message (turn-starting) gets cache_control
-    for (const user of userMessages.slice(0, -1)) {
-      for (const block of user.content) {
-        expect(block.cache_control).toBeUndefined();
-      }
+    // Oldest user message (Turn 1) has no cache_control
+    for (const block of userMessages[0].content) {
+      expect(block.cache_control).toBeUndefined();
     }
+    // Previous-turn anchor (Turn 2) gets 1h cache on its last block to
+    // preserve the cached prefix across turn transitions
+    const prevTurn = userMessages[userMessages.length - 2];
+    const prevTurnLast = prevTurn.content[prevTurn.content.length - 1];
+    expect(prevTurnLast.cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+    // Current-turn anchor (Turn 3) gets 1h cache on its last block
     const lastUser = userMessages[userMessages.length - 1];
     const lastBlock = lastUser.content[lastUser.content.length - 1];
     expect(lastBlock.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  test("previous-turn anchor is NOT applied during a tool-use loop", async () => {
+    // When the request is mid tool-use (last msg is a tool_result), the
+    // turn-start anchor already covers the long prefix, so we must not
+    // place a second anchor on the prior turn — that would push us over
+    // the 4-breakpoint budget without adding cache value.
+    const messages: Message[] = [
+      userMsg("Turn 1"),
+      assistantMsg("Response 1"),
+      userMsg("Turn 2"),
+      toolUseMsg("tu_1", "bash"),
+      toolResultMsg("tu_1", "output"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{
+        type: string;
+        cache_control?: { type: string; ttl?: string };
+      }>;
+    }>;
+    // Turn 1 user message must have no cache_control (would be the
+    // prev-turn-anchor if we applied it, which we shouldn't here)
+    const turn1 = sent[0];
+    for (const block of turn1.content) {
+      expect(block.cache_control).toBeUndefined();
+    }
   });
 
   // -----------------------------------------------------------------------

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -991,24 +991,48 @@ export class AnthropicProvider implements Provider {
       // TTL is appropriate. Walk backwards to find the last user message
       // with a real text block (skipping tool_result-only messages and
       // synthetic continuation placeholders injected by ensureToolPairing).
-      let turnStartIdx = -1;
-      for (let i = sentMessages.length - 1; i >= 0; i--) {
-        const msg = sentMessages[i];
-        if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
-        const hasText = msg.content.some(
-          (b) =>
-            typeof b !== "string" &&
-            b.type === "text" &&
-            b.text !== SYNTHETIC_CONTINUATION_TEXT,
-        );
-        if (!hasText) continue;
-        const lastBlock = msg.content[msg.content.length - 1];
+      const msgs = sentMessages;
+      const findUserTextMsgIdx = (startIdx: number): number => {
+        for (let i = startIdx; i >= 0; i--) {
+          const msg = msgs[i];
+          if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+          const hasText = msg.content.some(
+            (b) =>
+              typeof b !== "string" &&
+              b.type === "text" &&
+              b.text !== SYNTHETIC_CONTINUATION_TEXT,
+          );
+          if (hasText) return i;
+        }
+        return -1;
+      };
+      const applyCacheControlToLastBlock = (msgIdx: number): void => {
+        const content = msgs[msgIdx].content;
+        if (!Array.isArray(content) || content.length === 0) return;
+        const lastBlock = content[content.length - 1];
         if (typeof lastBlock !== "string") {
           (lastBlock as unknown as Record<string, unknown>).cache_control =
             cacheControl;
         }
-        turnStartIdx = i;
-        break;
+      };
+      const turnStartIdx = findUserTextMsgIdx(msgs.length - 1);
+      if (turnStartIdx >= 0) applyCacheControlToLastBlock(turnStartIdx);
+
+      // Previous-turn anchor: when this request is the first of a new turn
+      // (turn-start is the very last message — no tool-use loop yet), also
+      // place a 1h breakpoint on the *previous* turn-starting user message.
+      // Anthropic only matches the cache at cache_control points present in
+      // the current request, so without this anchor the breakpoint slides
+      // forward each new user turn and the prior cached prefix becomes
+      // unreachable — forcing a full re-creation of history (200K+
+      // cache_creation tokens per new turn). Skipped during tool-use loops
+      // where the current turn-start already covers the same prefix and a
+      // second anchor would blow the 4-breakpoint budget.
+      let prevTurnAnchorIdx = -1;
+      if (turnStartIdx === msgs.length - 1 && turnStartIdx > 0) {
+        prevTurnAnchorIdx = findUserTextMsgIdx(turnStartIdx - 1);
+        if (prevTurnAnchorIdx >= 0)
+          applyCacheControlToLastBlock(prevTurnAnchorIdx);
       }
 
       // Advancing tail: place a short-lived 5m cache breakpoint on the last
@@ -1045,19 +1069,21 @@ export class AnthropicProvider implements Provider {
       }
 
       // Enforce Anthropic API maximum of 4 cache_control blocks.
-      // When the system prompt boundary splits into 2 cached blocks AND
-      // tools + turn-start + advancing-tail breakpoints are all present,
-      // we'd have 5.  Drop the static system block's breakpoint — it's
-      // small (<1K tokens) so the re-read cost is negligible, while the
-      // dynamic block (workspace context) rarely changes mid-session and
-      // benefits more from caching.
-      const hasTailBreakpoint = tailBreakpointApplied;
+      // With the system prompt boundary split into 2 cached blocks AND
+      // tools + turn-start + (tail OR prev-turn-anchor), we'd have 5.
+      // Drop the static system block's breakpoint — it's small (<1K
+      // tokens) so the re-read cost is negligible, while the dynamic
+      // block (workspace context) rarely changes mid-session and
+      // benefits more from caching. Tail and prev-turn-anchor are
+      // mutually exclusive (prev-turn-anchor only fires when turn-start
+      // is the last message, which is the exact condition that suppresses
+      // the tail), so we never exceed 5.
       const hasToolCacheBreakpoint =
         params.tools?.some(
           (t) => "cache_control" in t && t.cache_control != null,
         ) ?? false;
       if (
-        hasTailBreakpoint &&
+        (tailBreakpointApplied || prevTurnAnchorIdx >= 0) &&
         Array.isArray(params.system) &&
         params.system.length === 2 &&
         hasToolCacheBreakpoint


### PR DESCRIPTION
## Summary
- Each new user turn was causing a full prompt-cache re-creation (~200K+ `cache_creation_input_tokens`) because the 1h `cache_control` breakpoint slid forward to the new turn-starting user message, stranding the prior cached prefix — Anthropic only matches at cache_control points present in the *current* request, so the previous breakpoint position became unreachable.
- Place a second 1h breakpoint on the previous turn-starting user message when the request is the first of a new turn, so the cached prefix from the prior turn is reusable. The new and prior anchor are mutually exclusive with the 5m advancing-tail breakpoint (prev-anchor only fires when turn-start is the last message, which is the exact condition that suppresses the tail), so we stay within the 4-breakpoint budget.
- Updated the existing 3-turn test to assert the new prev-anchor placement, and added a regression test covering the tool-use-loop case where the prev-anchor must NOT be applied.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
