### PR TITLE
[LUM-1267] Update VSplitButton to capsule shape with chevron direction and shape control

### DIFF
--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -193,8 +193,14 @@ public struct VMenu<Content: View>: View {
         #endif
         .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        #if os(iOS)
+        // On macOS, shadow is handled natively by VMenuPanel (hasShadow = true)
+        // to avoid ghost artifacts from stale SwiftUI shadow pixels in the
+        // window's backing store. On iOS there is no VMenuPanel, so the
+        // SwiftUI shadow is still needed.
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 1.5, x: 0, y: 1)
         .shadow(color: VColor.auxBlack.opacity(0.1), radius: 6, x: 0, y: 4)
+        #endif
         #if os(macOS)
         // --- SwiftUI-native keyboard focus (WWDC23 "The SwiftUI cookbook for focus") ---
         // Primary key-handling path: the VStack receives focus and .onKeyPress fires.

--- a/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenu.swift
@@ -318,12 +318,24 @@ public enum VMenuItemVariant {
 
 /// Size variants for `VMenuItem`.
 public enum VMenuItemSize {
-    /// Compact menu item — 13pt DM Sans, matching sidebar conversation rows.
+    /// Mini menu item — same styling as compact but without the 32pt
+    /// minimum row height. Use for single-item dropdowns where the
+    /// standard row height creates too much whitespace.
+    case mini
+    /// Compact menu item — 32pt minimum row height, matching sidebar rows.
     case compact
     /// Regular menu item — delegates to `VNavItem` (14pt `VFont.bodyMediumDefault`).
     case regular
 
     fileprivate var font: Font { VFont.bodyMediumDefault }
+
+    /// Whether to apply `VSize.rowMinHeight` as a minimum height constraint.
+    fileprivate var enforcesMinHeight: Bool {
+        switch self {
+        case .mini: return false
+        case .compact, .regular: return true
+        }
+    }
 }
 
 // MARK: - VMenuItem
@@ -476,7 +488,7 @@ public struct VMenuItem<Trailing: View>: View {
             .padding(.leading, VSpacing.xs)
             .padding(.trailing, VSpacing.sm)
             .padding(.vertical, VSpacing.xs)
-            .frame(minHeight: VSize.rowMinHeight)
+            .frame(minHeight: size.enforcesMinHeight ? VSize.rowMinHeight : nil)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(highlightBackground)
             .animation(VAnimation.fast, value: isHovered)

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuCoordinator.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuCoordinator.swift
@@ -548,28 +548,30 @@ public final class VMenuCoordinator {
 
     private func installClickMonitor() {
         removeClickMonitor()
-        DispatchQueue.main.async { [weak self] in
-            self?.clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
-                guard let self else { return event }
-                let mouseLocation = NSEvent.mouseLocation
+        // Installed synchronously — addLocalMonitorForEvents only catches
+        // future events, not the current event being processed, so the
+        // opening click won't trigger an immediate dismiss.
+        // Reference: https://developer.apple.com/documentation/appkit/nsevent/addlocalmonitorforevents(matching:handler:)
+        clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
+            guard let self else { return event }
+            let mouseLocation = NSEvent.mouseLocation
 
-                for panel in self.panels {
-                    let locationInPanel = panel.convertPoint(fromScreen: mouseLocation)
-                    let panelBounds = panel.contentView?.bounds ?? .zero
-                    if panelBounds.contains(locationInPanel) {
-                        return event
-                    }
-                }
-
-                // Skip dismiss if click is in the trigger's excluded rect — let the
-                // trigger button handle closing so it doesn't immediately reopen.
-                if let excludeRect = self.excludeRect, excludeRect.contains(mouseLocation) {
+            for panel in self.panels {
+                let locationInPanel = panel.convertPoint(fromScreen: mouseLocation)
+                let panelBounds = panel.contentView?.bounds ?? .zero
+                if panelBounds.contains(locationInPanel) {
                     return event
                 }
+            }
 
-                self.dismissAll()
+            // Skip dismiss if click is in the trigger's excluded rect — let the
+            // trigger button handle closing so it doesn't immediately reopen.
+            if let excludeRect = self.excludeRect, excludeRect.contains(mouseLocation) {
                 return event
             }
+
+            self.dismissAll()
+            return event
         }
     }
 

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -198,17 +198,25 @@ public class VMenuPanel: NSPanel {
         // Register with coordinator — it installs the unified click monitor
         coordinator.registerRootPanel(panel, sourceWindow: resolvedSourceWindow, excludeRect: excludeRect, onDismiss: onDismiss)
 
-        // Reveal the panel and notify VoiceOver on the next run-loop cycle,
-        // after SwiftUI has completed its first render pass.
+        // Reveal the panel after SwiftUI has completed its full render pass.
+        // A single run-loop cycle is sometimes insufficient — SwiftUI's
+        // Metal-backed rendering pipeline can split across 2+ frames
+        // (background/shadow first, then text layout). Double-pumping
+        // the main queue ensures both phases complete before reveal.
+        // Guard on contentView != nil rather than isVisible: contentView
+        // is set to nil synchronously in close(), making it a reliable
+        // indicator that the panel has been dismissed.
         DispatchQueue.main.async { [weak panel] in
-            guard let panel, panel.isVisible else { return }
-            panel.alphaValue = 1
-            NSAccessibility.post(element: panel, notification: .created)
-            if let contentView = panel.contentView,
-               let firstChild = contentView.accessibilityChildren()?.first {
-                NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
-            } else if let contentView = panel.contentView {
-                NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
+            DispatchQueue.main.async { [weak panel] in
+                guard let panel, panel.contentView != nil else { return }
+                panel.alphaValue = 1
+                NSAccessibility.post(element: panel, notification: .created)
+                if let contentView = panel.contentView,
+                   let firstChild = contentView.accessibilityChildren()?.first {
+                    NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
+                } else if let contentView = panel.contentView {
+                    NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
+                }
             }
         }
 
@@ -280,20 +288,21 @@ public class VMenuPanel: NSPanel {
 
         let origin = anchoredOrigin(for: menuSize, anchorRect: itemRect)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
-        // Fade-in guard — same as show(), prevents ghost flash from
-        // SwiftUI's multi-phase rendering pipeline.
+        // Fade-in guard — same rationale as show().
         panel.alphaValue = 0
         panel.makeKeyAndOrderFront(nil)
 
         DispatchQueue.main.async { [weak panel] in
-            guard let panel, panel.isVisible else { return }
-            panel.alphaValue = 1
-            NSAccessibility.post(element: panel, notification: .created)
-            if let contentView = panel.contentView,
-               let firstChild = contentView.accessibilityChildren()?.first {
-                NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
-            } else if let contentView = panel.contentView {
-                NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
+            DispatchQueue.main.async { [weak panel] in
+                guard let panel, panel.contentView != nil else { return }
+                panel.alphaValue = 1
+                NSAccessibility.post(element: panel, notification: .created)
+                if let contentView = panel.contentView,
+                   let firstChild = contentView.accessibilityChildren()?.first {
+                    NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
+                } else if let contentView = panel.contentView {
+                    NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
+                }
             }
         }
 
@@ -414,7 +423,17 @@ public class VMenuPanel: NSPanel {
         alphaValue = 0
         contentView = nil
 
-        // 2. Explicitly order out before super.close() so the
+        // 2. Detach from parent BEFORE ordering out. Child windows
+        //    are re-ordered when their parent orders front
+        //    (https://developer.apple.com/documentation/appkit/nswindow/addchildwindow(_:ordered:)).
+        //    If the parent processes a click-through between orderOut
+        //    and removeChildWindow, it could briefly re-order this
+        //    panel back on screen.
+        if let parentWindow = parent {
+            parentWindow.removeChildWindow(self)
+        }
+
+        // 3. Explicitly order out before super.close() so the
         //    window server removes the surface immediately rather
         //    than waiting for the close→orderOut path which can
         //    leave a stale compositor entry for one frame.
@@ -422,10 +441,6 @@ public class VMenuPanel: NSPanel {
 
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil
-
-        if let parentWindow = parent {
-            parentWindow.removeChildWindow(self)
-        }
 
         let handler = dismissHandler
         dismissHandler = nil

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -378,11 +378,17 @@ public class VMenuPanel: NSPanel {
             VMenuPanel.activeRootPanel = nil
         }
 
-        // Make the panel fully transparent and remove its SwiftUI
-        // content immediately so no shadow/background artifacts
-        // persist during the removeChildWindow → orderOut transition.
+        // Make the panel fully transparent immediately so no
+        // shadow/background artifacts persist during teardown.
         alphaValue = 0
-        contentView = nil
+
+        // Capture the coordinator before releasing contentView,
+        // because the NSHostingView (contentView) holds the only
+        // strong reference to the coordinator via the SwiftUI
+        // environment. The panel's `coordinator` property is weak,
+        // so releasing contentView would deallocate the coordinator
+        // before panelWasClosed() can fire.
+        let coord = coordinator
 
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil
@@ -399,10 +405,15 @@ public class VMenuPanel: NSPanel {
         super.close()
 
         if managedByCoordinator && !isClosingFromCoordinator {
-            coordinator?.panelWasClosed(self)
+            coord?.panelWasClosed(self)
         } else if !managedByCoordinator {
             handler?()
         }
+
+        // Remove the SwiftUI content after all callbacks have fired,
+        // so the coordinator (held alive by `coord`) can complete its
+        // cleanup before the NSHostingView is released.
+        contentView = nil
     }
 
     public override func cancelOperation(_ sender: Any?) {

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -86,7 +86,7 @@ public class VMenuPanel: NSPanel {
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
-            defer: true
+            defer: false
         )
         // isFloatingPanel sets level to .floating by default — do not
         // override with .popUpMenu, which is level 101 and causes the panel
@@ -186,6 +186,14 @@ public class VMenuPanel: NSPanel {
         // guarantees SwiftUI has completed its first full render pass before
         // the panel becomes visible.
         panel.alphaValue = 0
+
+        // Pre-populate the backing store while the panel is still invisible.
+        // With defer:false the window device exists immediately, so display()
+        // forces the compositor to render the current (transparent) content
+        // into the backing store before the window is ordered in. This
+        // eliminates the race where makeKeyAndOrderFront shows a stale or
+        // partially-rendered backing store for a single frame.
+        panel.display()
         panel.makeKeyAndOrderFront(nil)
 
         // Attach as a child window so the menu stays grouped with its
@@ -239,7 +247,7 @@ public class VMenuPanel: NSPanel {
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
-            defer: true
+            defer: false
         )
         panel.isFloatingPanel = true
         panel.isOpaque = false
@@ -288,8 +296,9 @@ public class VMenuPanel: NSPanel {
 
         let origin = anchoredOrigin(for: menuSize, anchorRect: itemRect)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
-        // Fade-in guard — same rationale as show().
+        // Fade-in guard + backing store pre-population — same rationale as show().
         panel.alphaValue = 0
+        panel.display()
         panel.makeKeyAndOrderFront(nil)
 
         DispatchQueue.main.async { [weak panel] in
@@ -417,11 +426,16 @@ public class VMenuPanel: NSPanel {
         // panelWasClosed() can fire.
         let coord = coordinator
 
-        // 1. Make invisible + strip SwiftUI content in one
-        //    synchronous block so the compositor never sees a
-        //    "transparent window with a shadow backing-store" frame.
+        // 1. Make invisible + strip SwiftUI content, then force the
+        //    backing store to repaint as transparent. With .buffered
+        //    backing, the window server retains the last-rendered frame
+        //    independently of the view hierarchy. Without display(),
+        //    the stale frame (VMenu background + shadow) persists in
+        //    the backing store and can flash if the window is briefly
+        //    re-ordered before orderOut takes effect.
         alphaValue = 0
         contentView = nil
+        display()
 
         // 2. Detach from parent BEFORE ordering out. Child windows
         //    are re-ordered when their parent orders front

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -179,6 +179,13 @@ public class VMenuPanel: NSPanel {
             $0.isVisible && $0.frame.contains(screenPoint) && !($0 is VMenuPanel)
         })
 
+        // Show the panel invisible initially. SwiftUI's rendering pipeline
+        // may split into two phases — background/shadow first, then text —
+        // producing a 1-frame flash of an empty rounded rect with shadow
+        // (the "ghost"). Holding alpha at 0 until the next run-loop cycle
+        // guarantees SwiftUI has completed its first full render pass before
+        // the panel becomes visible.
+        panel.alphaValue = 0
         panel.makeKeyAndOrderFront(nil)
 
         // Attach as a child window so the menu stays grouped with its
@@ -191,13 +198,17 @@ public class VMenuPanel: NSPanel {
         // Register with coordinator — it installs the unified click monitor
         coordinator.registerRootPanel(panel, sourceWindow: resolvedSourceWindow, excludeRect: excludeRect, onDismiss: onDismiss)
 
-        // Notify VoiceOver that a new menu appeared so it navigates into it.
-        DispatchQueue.main.async {
+        // Reveal the panel and notify VoiceOver on the next run-loop cycle,
+        // after SwiftUI has completed its first render pass.
+        DispatchQueue.main.async { [weak panel] in
+            guard let panel, panel.isVisible else { return }
+            panel.alphaValue = 1
             NSAccessibility.post(element: panel, notification: .created)
-            if let firstChild = hostingView.accessibilityChildren()?.first {
+            if let contentView = panel.contentView,
+               let firstChild = contentView.accessibilityChildren()?.first {
                 NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
-            } else {
-                NSAccessibility.post(element: hostingView, notification: .focusedUIElementChanged)
+            } else if let contentView = panel.contentView {
+                NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
             }
         }
 
@@ -269,15 +280,20 @@ public class VMenuPanel: NSPanel {
 
         let origin = anchoredOrigin(for: menuSize, anchorRect: itemRect)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
+        // Fade-in guard — same as show(), prevents ghost flash from
+        // SwiftUI's multi-phase rendering pipeline.
+        panel.alphaValue = 0
         panel.makeKeyAndOrderFront(nil)
 
-        // Notify VoiceOver that a new submenu appeared.
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak panel] in
+            guard let panel, panel.isVisible else { return }
+            panel.alphaValue = 1
             NSAccessibility.post(element: panel, notification: .created)
-            if let firstChild = hostingView.accessibilityChildren()?.first {
+            if let contentView = panel.contentView,
+               let firstChild = contentView.accessibilityChildren()?.first {
                 NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
-            } else {
-                NSAccessibility.post(element: hostingView, notification: .focusedUIElementChanged)
+            } else if let contentView = panel.contentView {
+                NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
             }
         }
 

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -120,10 +120,13 @@ public class VMenuPanel: NSPanel {
         hostingView.sizingOptions = [.intrinsicContentSize]
         panel.contentView = hostingView
 
-        // Force a layout pass so the SwiftUI content is fully measured before
-        // reading fittingSize. Without this, NSHostingView may return a size
-        // that only includes the VMenu chrome (background + padding) without
-        // accounting for the actual menu items.
+        // Force a full layout pass so the SwiftUI content is correctly measured.
+        // invalidateIntrinsicContentSize() marks the cached size as stale;
+        // layoutSubtreeIfNeeded() then forces a synchronous recomputation.
+        // Without both, NSHostingView may occasionally return a fittingSize
+        // that only reflects the VMenu chrome (background + shadow inset)
+        // without accounting for the actual menu items.
+        hostingView.invalidateIntrinsicContentSize()
         hostingView.layoutSubtreeIfNeeded()
 
         let fittingSize = hostingView.fittingSize
@@ -233,6 +236,7 @@ public class VMenuPanel: NSPanel {
         hostingView.sizingOptions = [.intrinsicContentSize]
         panel.contentView = hostingView
 
+        hostingView.invalidateIntrinsicContentSize()
         hostingView.layoutSubtreeIfNeeded()
 
         let fittingSize = hostingView.fittingSize
@@ -360,6 +364,11 @@ public class VMenuPanel: NSPanel {
         if self === VMenuPanel.activeRootPanel {
             VMenuPanel.activeRootPanel = nil
         }
+
+        // Make the panel fully transparent before any teardown so that
+        // SwiftUI-rendered shadows don't flash during the removeChildWindow
+        // → orderOut compositor transition.
+        alphaValue = 0
 
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -132,6 +132,17 @@ public class VMenuPanel: NSPanel {
             height: max(fittingSize.height, 1)
         )
 
+        // Disable intrinsic-content-size-based resizing now that we have the
+        // correct size. On macOS 13.3+, NSHostingView re-advertises its
+        // SwiftUI content's intrinsic size to the containing window on every
+        // layout pass. If SwiftUI re-lays out (e.g. focus changes via .task),
+        // the intrinsic size can temporarily diverge from fittingSize, causing
+        // the panel to shrink to near-zero — producing a ghost shadow artifact
+        // with no visible content. Setting sizingOptions to empty makes our
+        // explicit setFrame the single source of truth for panel geometry.
+        // Reference: https://mjtsai.com/blog/2023/08/03/how-nshostingview-determines-its-sizing/
+        hostingView.sizingOptions = []
+
         let origin = clampedOrigin(for: menuSize, cursorAt: screenPoint, anchor: anchor)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
 
@@ -229,6 +240,9 @@ public class VMenuPanel: NSPanel {
             width: max(fittingSize.width, 1),
             height: max(fittingSize.height, 1)
         )
+
+        // Lock panel geometry — see comment in show() for rationale.
+        hostingView.sizingOptions = []
 
         let origin = anchoredOrigin(for: menuSize, anchorRect: itemRect)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -31,10 +31,6 @@ public class VMenuPanel: NSPanel {
     /// (submenus via showAnchored) are managed by the coordinator, not here.
     private static weak var activeRootPanel: VMenuPanel?
 
-    /// Extra padding added around the VMenu content so its shadow can render
-    /// without being clipped by the hosting view's bounds.
-    static let shadowInset: CGFloat = 14
-
     /// Show SwiftUI content in a floating panel at the given screen point.
     ///
     /// Creates a `VMenuCoordinator` internally so submenu support is always available.
@@ -86,7 +82,7 @@ public class VMenuPanel: NSPanel {
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
-            defer: false
+            defer: true
         )
         // isFloatingPanel sets level to .floating by default — do not
         // override with .popUpMenu, which is level 101 and causes the panel
@@ -95,7 +91,11 @@ public class VMenuPanel: NSPanel {
         panel.isFloatingPanel = true
         panel.isOpaque = false
         panel.backgroundColor = .clear
-        panel.hasShadow = false
+        // Native window shadow — the compositor draws this outside the window
+        // bounds and removes it atomically with the window on close/orderOut.
+        // This avoids ghost artifacts caused by SwiftUI .shadow() pixels
+        // persisting in the .buffered backing store after contentView is removed.
+        panel.hasShadow = true
         // ARC manages the panel lifetime — disable AppKit's legacy
         // release-on-close which adds an extra release() call inside
         // super.close() and can conflict with ARC reference counting.
@@ -128,7 +128,6 @@ public class VMenuPanel: NSPanel {
             .environment(\.vMenuDismiss, { [weak coordinator] in coordinator?.dismissAll() })
             .environment(\.vMenuCoordinator, coordinator)
             .environment(\.vMenuPanelLevel, 0)
-            .padding(Self.shadowInset)
         // Use NSHostingView directly as contentView — no FirstMouseView wrapper.
         // This preserves the natural NSPanel → NSHostingView → SwiftUI accessibility
         // hierarchy that VoiceOver needs for both navigation and action activation.
@@ -179,21 +178,9 @@ public class VMenuPanel: NSPanel {
             $0.isVisible && $0.frame.contains(screenPoint) && !($0 is VMenuPanel)
         })
 
-        // Show the panel invisible initially. SwiftUI's rendering pipeline
-        // may split into two phases — background/shadow first, then text —
-        // producing a 1-frame flash of an empty rounded rect with shadow
-        // (the "ghost"). Holding alpha at 0 until the next run-loop cycle
-        // guarantees SwiftUI has completed its first full render pass before
-        // the panel becomes visible.
+        // Start invisible — reveal after SwiftUI completes its first render
+        // pass so the panel never flashes an incomplete frame.
         panel.alphaValue = 0
-
-        // Pre-populate the backing store while the panel is still invisible.
-        // With defer:false the window device exists immediately, so display()
-        // forces the compositor to render the current (transparent) content
-        // into the backing store before the window is ordered in. This
-        // eliminates the race where makeKeyAndOrderFront shows a stale or
-        // partially-rendered backing store for a single frame.
-        panel.display()
         panel.makeKeyAndOrderFront(nil)
 
         // Attach as a child window so the menu stays grouped with its
@@ -206,25 +193,18 @@ public class VMenuPanel: NSPanel {
         // Register with coordinator — it installs the unified click monitor
         coordinator.registerRootPanel(panel, sourceWindow: resolvedSourceWindow, excludeRect: excludeRect, onDismiss: onDismiss)
 
-        // Reveal the panel after SwiftUI has completed its full render pass.
-        // A single run-loop cycle is sometimes insufficient — SwiftUI's
-        // Metal-backed rendering pipeline can split across 2+ frames
-        // (background/shadow first, then text layout). Double-pumping
-        // the main queue ensures both phases complete before reveal.
-        // Guard on contentView != nil rather than isVisible: contentView
-        // is set to nil synchronously in close(), making it a reliable
-        // indicator that the panel has been dismissed.
+        // Reveal after SwiftUI completes its render pass. Guard on
+        // contentView != nil (set to nil synchronously in close()) so
+        // a panel dismissed before the reveal fires stays invisible.
         DispatchQueue.main.async { [weak panel] in
-            DispatchQueue.main.async { [weak panel] in
-                guard let panel, panel.contentView != nil else { return }
-                panel.alphaValue = 1
-                NSAccessibility.post(element: panel, notification: .created)
-                if let contentView = panel.contentView,
-                   let firstChild = contentView.accessibilityChildren()?.first {
-                    NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
-                } else if let contentView = panel.contentView {
-                    NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
-                }
+            guard let panel, panel.contentView != nil else { return }
+            panel.alphaValue = 1
+            NSAccessibility.post(element: panel, notification: .created)
+            if let contentView = panel.contentView,
+               let firstChild = contentView.accessibilityChildren()?.first {
+                NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
+            } else if let contentView = panel.contentView {
+                NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
             }
         }
 
@@ -247,12 +227,12 @@ public class VMenuPanel: NSPanel {
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
-            defer: false
+            defer: true
         )
         panel.isFloatingPanel = true
         panel.isOpaque = false
         panel.backgroundColor = .clear
-        panel.hasShadow = false
+        panel.hasShadow = true
         panel.isReleasedWhenClosed = false
         panel.acceptsMouseMovedEvents = true
         panel.setAccessibilityRoleDescription(NSLocalizedString("menu", comment: "Accessibility role description for VMenu panel"))
@@ -269,7 +249,6 @@ public class VMenuPanel: NSPanel {
             .environment(\.vMenuDismiss, { [weak coordinator] in coordinator?.dismissAll() })
             .environment(\.vMenuCoordinator, coordinator)
             .environment(\.vMenuPanelLevel, childLevel)
-            .padding(Self.shadowInset)
             .onHover { hovering in
                 if hovering {
                     coordinator.cancelGraceTimer()
@@ -296,22 +275,18 @@ public class VMenuPanel: NSPanel {
 
         let origin = anchoredOrigin(for: menuSize, anchorRect: itemRect)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
-        // Fade-in guard + backing store pre-population — same rationale as show().
         panel.alphaValue = 0
-        panel.display()
         panel.makeKeyAndOrderFront(nil)
 
         DispatchQueue.main.async { [weak panel] in
-            DispatchQueue.main.async { [weak panel] in
-                guard let panel, panel.contentView != nil else { return }
-                panel.alphaValue = 1
-                NSAccessibility.post(element: panel, notification: .created)
-                if let contentView = panel.contentView,
-                   let firstChild = contentView.accessibilityChildren()?.first {
-                    NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
-                } else if let contentView = panel.contentView {
-                    NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
-                }
+            guard let panel, panel.contentView != nil else { return }
+            panel.alphaValue = 1
+            NSAccessibility.post(element: panel, notification: .created)
+            if let contentView = panel.contentView,
+               let firstChild = contentView.accessibilityChildren()?.first {
+                NSAccessibility.post(element: firstChild, notification: .focusedUIElementChanged)
+            } else if let contentView = panel.contentView {
+                NSAccessibility.post(element: contentView, notification: .focusedUIElementChanged)
             }
         }
 
@@ -326,19 +301,19 @@ public class VMenuPanel: NSPanel {
             ?? NSScreen.main?.visibleFrame
             ?? .zero
 
-        var x = cursor.x - shadowInset
+        var x = cursor.x
 
         // Horizontal overflow
         if x + size.width > screen.maxX {
-            x = cursor.x - size.width + shadowInset
+            x = cursor.x - size.width
         }
         if x < screen.minX {
             x = screen.minX
         }
 
         // Vertical positioning with flip-then-clamp
-        let belowY = cursor.y - size.height + shadowInset
-        let aboveY = cursor.y - shadowInset
+        let belowY = cursor.y - size.height
+        let aboveY = cursor.y
         var y: CGFloat
 
         switch anchor {
@@ -375,18 +350,14 @@ public class VMenuPanel: NSPanel {
             ?? NSScreen.main?.visibleFrame
             ?? .zero
 
-        // The child panel has `shadowInset` padding on all sides. To align
-        // the child's VISUAL left edge with the anchor's right edge, offset
-        // the panel origin left by shadowInset.
-        var x = anchorRect.maxX - shadowInset
+        var x = anchorRect.maxX
         // Align child's visual top with anchor's top.
         // macOS y-axis is bottom-up: anchorRect.maxY is the top edge.
-        // The child's visual top is at panel.origin.y + size.height - shadowInset.
-        var y = anchorRect.maxY - size.height + shadowInset
+        var y = anchorRect.maxY - size.height
 
         // Right overflow: flip to left side of anchor
         if x + size.width > screen.maxX {
-            x = anchorRect.minX - size.width + shadowInset
+            x = anchorRect.minX - size.width
         }
         // Left overflow
         if x < screen.minX {
@@ -426,32 +397,17 @@ public class VMenuPanel: NSPanel {
         // panelWasClosed() can fire.
         let coord = coordinator
 
-        // 1. Make invisible + strip SwiftUI content, then force the
-        //    backing store to repaint as transparent. With .buffered
-        //    backing, the window server retains the last-rendered frame
-        //    independently of the view hierarchy. Without display(),
-        //    the stale frame (VMenu background + shadow) persists in
-        //    the backing store and can flash if the window is briefly
-        //    re-ordered before orderOut takes effect.
         alphaValue = 0
-        contentView = nil
-        display()
 
-        // 2. Detach from parent BEFORE ordering out. Child windows
-        //    are re-ordered when their parent orders front
-        //    (https://developer.apple.com/documentation/appkit/nswindow/addchildwindow(_:ordered:)).
-        //    If the parent processes a click-through between orderOut
-        //    and removeChildWindow, it could briefly re-order this
-        //    panel back on screen.
+        // Detach from parent BEFORE ordering out. Child windows
+        // are re-ordered when their parent orders front
+        // (https://developer.apple.com/documentation/appkit/nswindow/addchildwindow(_:ordered:)).
         if let parentWindow = parent {
             parentWindow.removeChildWindow(self)
         }
 
-        // 3. Explicitly order out before super.close() so the
-        //    window server removes the surface immediately rather
-        //    than waiting for the close→orderOut path which can
-        //    leave a stale compositor entry for one frame.
         orderOut(nil)
+        contentView = nil
 
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -248,26 +248,41 @@ public class VMenuPanel: NSPanel {
             ?? .zero
 
         var x = cursor.x - shadowInset
-        var y: CGFloat
 
-        switch anchor {
-        case .below:
-            y = cursor.y - size.height + shadowInset
-        case .above:
-            y = cursor.y - shadowInset
-        }
-
+        // Horizontal overflow
         if x + size.width > screen.maxX {
             x = cursor.x - size.width + shadowInset
         }
         if x < screen.minX {
             x = screen.minX
         }
-        if y < screen.minY {
-            y = cursor.y - shadowInset
+
+        // Vertical positioning with flip-then-clamp
+        let belowY = cursor.y - size.height + shadowInset
+        let aboveY = cursor.y - shadowInset
+        var y: CGFloat
+
+        switch anchor {
+        case .below:
+            y = belowY
+            // Overflows bottom → try flipping above
+            if y < screen.minY {
+                y = aboveY
+            }
+        case .above:
+            y = aboveY
+            // Overflows top → try flipping below
+            if y + size.height > screen.maxY {
+                y = belowY
+            }
         }
+
+        // Final clamp to screen bounds
         if y + size.height > screen.maxY {
             y = screen.maxY - size.height
+        }
+        if y < screen.minY {
+            y = screen.minY
         }
 
         return CGPoint(x: x, y: y)

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -120,6 +120,12 @@ public class VMenuPanel: NSPanel {
         hostingView.sizingOptions = [.intrinsicContentSize]
         panel.contentView = hostingView
 
+        // Force a layout pass so the SwiftUI content is fully measured before
+        // reading fittingSize. Without this, NSHostingView may return a size
+        // that only includes the VMenu chrome (background + padding) without
+        // accounting for the actual menu items.
+        hostingView.layoutSubtreeIfNeeded()
+
         let fittingSize = hostingView.fittingSize
         let menuSize = CGSize(
             width: max(fittingSize.width, 1),
@@ -215,6 +221,8 @@ public class VMenuPanel: NSPanel {
         let hostingView = NSHostingView(rootView: paddedContent)
         hostingView.sizingOptions = [.intrinsicContentSize]
         panel.contentView = hostingView
+
+        hostingView.layoutSubtreeIfNeeded()
 
         let fittingSize = hostingView.fittingSize
         let menuSize = CGSize(

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -2,6 +2,16 @@
 import SwiftUI
 import AppKit
 
+// MARK: - VMenuAnchorEdge
+
+/// Controls whether a VMenuPanel appears below or above the anchor point.
+public enum VMenuAnchorEdge {
+    /// Menu top aligns with the anchor point, extending downward (default).
+    case below
+    /// Menu bottom aligns with the anchor point, extending upward.
+    case above
+}
+
 // MARK: - VMenuPanel
 
 /// A borderless, floating NSPanel that hosts a SwiftUI `VMenu` at a given
@@ -46,6 +56,7 @@ public class VMenuPanel: NSPanel {
     @discardableResult
     public static func show<Content: View>(
         at screenPoint: CGPoint,
+        anchor: VMenuAnchorEdge = .below,
         sourceWindow: NSWindow? = nil,
         sourceAppearance: NSAppearance? = nil,
         excludeRect: CGRect? = nil,
@@ -115,7 +126,7 @@ public class VMenuPanel: NSPanel {
             height: max(fittingSize.height, 1)
         )
 
-        let origin = clampedOrigin(for: menuSize, cursorAt: screenPoint)
+        let origin = clampedOrigin(for: menuSize, cursorAt: screenPoint, anchor: anchor)
         panel.setFrame(CGRect(origin: origin, size: menuSize), display: true)
 
         // Resolve the parent window for child-window attachment. Prefer the
@@ -231,13 +242,20 @@ public class VMenuPanel: NSPanel {
     // MARK: - Positioning
 
     /// Calculate panel origin clamped to the visible bounds of the screen containing the cursor.
-    private static func clampedOrigin(for size: CGSize, cursorAt cursor: CGPoint) -> CGPoint {
+    private static func clampedOrigin(for size: CGSize, cursorAt cursor: CGPoint, anchor: VMenuAnchorEdge = .below) -> CGPoint {
         let screen = NSScreen.screens.first(where: { $0.frame.contains(cursor) })?.visibleFrame
             ?? NSScreen.main?.visibleFrame
             ?? .zero
 
         var x = cursor.x - shadowInset
-        var y = cursor.y - size.height + shadowInset
+        var y: CGFloat
+
+        switch anchor {
+        case .below:
+            y = cursor.y - size.height + shadowInset
+        case .above:
+            y = cursor.y - shadowInset
+        }
 
         if x + size.width > screen.maxX {
             x = cursor.x - size.width + shadowInset

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -63,11 +63,24 @@ public class VMenuPanel: NSPanel {
         @ViewBuilder content: () -> Content,
         onDismiss: @escaping () -> Void
     ) -> VMenuPanel {
-        // Dismiss any existing root panel before showing a new one.
+        // Dismiss ALL existing VMenuPanel trees before showing a new one.
         // This matches NSMenu's native behavior: only one menu visible at a time.
-        // Using the coordinator's dismissAll() ensures the entire panel tree
-        // (root + submenus) is closed and the old onDismiss handler fires.
-        activeRootPanel?.coordinator?.dismissAll()
+        //
+        // We sweep NSApp.windows instead of relying solely on the
+        // activeRootPanel weak reference. If a panel's last strong
+        // Swift reference is released without calling close() (e.g., due
+        // to SwiftUI view recreation or @State reset), the weak ref
+        // becomes nil but the panel remains on screen — the window
+        // server retains ordered-in windows independently of ARC.
+        // The sweep catches these orphaned panels.
+        for window in NSApp.windows {
+            guard let existing = window as? VMenuPanel, existing.isVisible else { continue }
+            if let coordinator = existing.coordinator {
+                coordinator.dismissAll()
+            } else {
+                existing.close()
+            }
+        }
 
         let panel = VMenuPanel(
             contentRect: .zero,
@@ -365,10 +378,11 @@ public class VMenuPanel: NSPanel {
             VMenuPanel.activeRootPanel = nil
         }
 
-        // Make the panel fully transparent before any teardown so that
-        // SwiftUI-rendered shadows don't flash during the removeChildWindow
-        // → orderOut compositor transition.
+        // Make the panel fully transparent and remove its SwiftUI
+        // content immediately so no shadow/background artifacts
+        // persist during the removeChildWindow → orderOut transition.
         alphaValue = 0
+        contentView = nil
 
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil

--- a/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VMenuPanel.swift
@@ -96,6 +96,11 @@ public class VMenuPanel: NSPanel {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
+        // ARC manages the panel lifetime — disable AppKit's legacy
+        // release-on-close which adds an extra release() call inside
+        // super.close() and can conflict with ARC reference counting.
+        // Reference: https://developer.apple.com/documentation/appkit/nswindow/isreleasedwhenclosed
+        panel.isReleasedWhenClosed = false
         // Enable mouse-moved events so the coordinator's local monitor can detect
         // mouse movement over the panel and clear keyboard focus appropriately.
         panel.acceptsMouseMovedEvents = true
@@ -221,6 +226,7 @@ public class VMenuPanel: NSPanel {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
+        panel.isReleasedWhenClosed = false
         panel.acceptsMouseMovedEvents = true
         panel.setAccessibilityRoleDescription(NSLocalizedString("menu", comment: "Accessibility role description for VMenu panel"))
         panel.setAccessibilitySubrole(.standardWindow)
@@ -378,23 +384,29 @@ public class VMenuPanel: NSPanel {
             VMenuPanel.activeRootPanel = nil
         }
 
-        // Make the panel fully transparent immediately so no
-        // shadow/background artifacts persist during teardown.
-        alphaValue = 0
-
-        // Capture the coordinator before releasing contentView,
-        // because the NSHostingView (contentView) holds the only
-        // strong reference to the coordinator via the SwiftUI
-        // environment. The panel's `coordinator` property is weak,
-        // so releasing contentView would deallocate the coordinator
-        // before panelWasClosed() can fire.
+        // Capture the coordinator before releasing contentView.
+        // The NSHostingView (contentView) holds the only strong
+        // reference to the coordinator via the SwiftUI environment.
+        // The panel's `coordinator` property is weak, so releasing
+        // contentView would deallocate the coordinator before
+        // panelWasClosed() can fire.
         let coord = coordinator
+
+        // 1. Make invisible + strip SwiftUI content in one
+        //    synchronous block so the compositor never sees a
+        //    "transparent window with a shadow backing-store" frame.
+        alphaValue = 0
+        contentView = nil
+
+        // 2. Explicitly order out before super.close() so the
+        //    window server removes the surface immediately rather
+        //    than waiting for the close→orderOut path which can
+        //    leave a stale compositor entry for one frame.
+        orderOut(nil)
 
         clickMonitor.flatMap(NSEvent.removeMonitor)
         clickMonitor = nil
 
-        // Detach from parent window before closing so the parent's
-        // child window list stays clean.
         if let parentWindow = parent {
             parentWindow.removeChildWindow(self)
         }
@@ -409,11 +421,6 @@ public class VMenuPanel: NSPanel {
         } else if !managedByCoordinator {
             handler?()
         }
-
-        // Remove the SwiftUI content after all callbacks have fired,
-        // so the coordinator (held alive by `coord`) can complete its
-        // cleanup before the NSHostingView is released.
-        contentView = nil
     }
 
     public override func cancelOperation(_ sender: Any?) {

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -4,6 +4,14 @@ public struct VButton: View {
     public enum Style: Hashable { case primary, danger, dangerOutline, dangerGhost, outlined, ghost, contrast }
     public enum Size: Hashable { case regular, compact, pill, inline, pillRegular, pillLarge }
 
+    /// Controls the outer shape of the button.
+    public enum ButtonShape: Hashable {
+        /// Pill / capsule ends (fully rounded).
+        case capsule
+        /// Rounded rectangle matching `VRadius.md`.
+        case roundedRectangle
+    }
+
     public let label: String
     public var leftIcon: String? = nil
     public var rightIcon: String? = nil
@@ -20,6 +28,7 @@ public struct VButton: View {
     public var iconRotation: Angle? = nil
     /// Override the default foreground color for both text and icons.
     public var tintColor: Color? = nil
+    public var buttonShape: ButtonShape? = nil
     public let action: () -> Void
 
     @Environment(\.isEnabled) private var isEnabled
@@ -31,7 +40,7 @@ public struct VButton: View {
     /// state (set by external `.disabled()` modifiers up the view hierarchy).
     private var effectivelyDisabled: Bool { isDisabled || !isEnabled }
 
-    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, iconOnly: String? = nil, style: Style = .primary, size: Size = .regular, isFullWidth: Bool = false, isDisabled: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil, tooltip: String? = nil, accessibilityID: String? = nil, iconColor: Color? = nil, iconRotation: Angle? = nil, tintColor: Color? = nil, action: @escaping () -> Void) {
+    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, iconOnly: String? = nil, style: Style = .primary, size: Size = .regular, isFullWidth: Bool = false, isDisabled: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil, tooltip: String? = nil, accessibilityID: String? = nil, iconColor: Color? = nil, iconRotation: Angle? = nil, tintColor: Color? = nil, buttonShape: ButtonShape? = nil, action: @escaping () -> Void) {
         self.label = label
         self.leftIcon = leftIcon ?? icon
         self.rightIcon = rightIcon
@@ -47,6 +56,7 @@ public struct VButton: View {
         self.iconColor = iconColor
         self.iconRotation = iconRotation
         self.tintColor = tintColor
+        self.buttonShape = buttonShape
         self.action = action
     }
 
@@ -85,7 +95,8 @@ public struct VButton: View {
             isActive: isActive,
             isFocused: isFocused,
             iconSize: iconSize,
-            tintColor: tintColor
+            tintColor: tintColor,
+            buttonShape: buttonShape
         ))
         .onHover { hovering in
             isHovered = effectivelyDisabled ? false : hovering
@@ -144,13 +155,14 @@ public struct VButtonStyle: ButtonStyle {
     let isFocused: Bool
     let iconSize: CGFloat?
     let tintColor: Color?
+    let buttonShape: VButton.ButtonShape?
 
     /// Creates an icon-only button style for custom button compositions.
     public static func iconOnly(style: VButton.Style = .ghost, isHovered: Bool, isFocused: Bool = false, isActive: Bool = false, iconSize: CGFloat? = nil) -> VButtonStyle {
-        VButtonStyle(style: style, size: .regular, isHovered: isHovered, isFullWidth: false, isIconOnly: true, isActive: isActive, isFocused: isFocused, iconSize: iconSize, tintColor: nil)
+        VButtonStyle(style: style, size: .regular, isHovered: isHovered, isFullWidth: false, isIconOnly: true, isActive: isActive, isFocused: isFocused, iconSize: iconSize, tintColor: nil, buttonShape: nil)
     }
 
-    init(style: VButton.Style, size: VButton.Size = .regular, isHovered: Bool, isFullWidth: Bool, isIconOnly: Bool = false, isActive: Bool = false, isFocused: Bool = false, iconSize: CGFloat? = nil, tintColor: Color? = nil) {
+    init(style: VButton.Style, size: VButton.Size = .regular, isHovered: Bool, isFullWidth: Bool, isIconOnly: Bool = false, isActive: Bool = false, isFocused: Bool = false, iconSize: CGFloat? = nil, tintColor: Color? = nil, buttonShape: VButton.ButtonShape? = nil) {
         self.style = style
         self.size = size
         self.isHovered = isHovered
@@ -160,13 +172,25 @@ public struct VButtonStyle: ButtonStyle {
         self.isFocused = isFocused
         self.iconSize = iconSize
         self.tintColor = tintColor
+        self.buttonShape = buttonShape
     }
 
     @Environment(\.isEnabled) private var isEnabled
 
     public func makeBody(configuration: Configuration) -> some View {
-        let cornerRadius: CGFloat = (size == .pill || size == .pillRegular || size == .pillLarge) ? VRadius.pill : VRadius.md
-        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+        let resolvedShape: AnyInsettableShape = {
+            switch buttonShape {
+            case .capsule:
+                return AnyInsettableShape(Capsule())
+            case .roundedRectangle:
+                return AnyInsettableShape(RoundedRectangle(cornerRadius: VRadius.md))
+            case nil:
+                // Default: pill sizes get pill radius, others get VRadius.md.
+                let cornerRadius: CGFloat = (size == .pill || size == .pillRegular || size == .pillLarge) ? VRadius.pill : VRadius.md
+                return AnyInsettableShape(RoundedRectangle(cornerRadius: cornerRadius))
+            }
+        }()
+        let shape = resolvedShape
 
         configuration.label
             .foregroundStyle(foregroundColor)

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -230,6 +230,10 @@ public struct VSplitButton<MenuContent: View>: View {
             return
         }
 
+        // Resign first responder so text fields release focus before the
+        // menu panel becomes key. Matches ComposerPillMenu / VDropdown.
+        window.makeFirstResponder(nil)
+
         // Anchor point in screen coordinates (y-up).
         // .below: bottom-left of dropdown zone; .above: top-left of dropdown zone.
         let anchorY = chevronDirection == .up ? dropdownFrame.minY : dropdownFrame.maxY

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -1,11 +1,20 @@
 import SwiftUI
 
 public struct VSplitButton<MenuContent: View>: View {
+    /// Controls the chevron icon direction and, on macOS, the menu pop direction.
+    public enum ChevronDirection {
+        /// Chevron points down; menu appears below (default).
+        case down
+        /// Chevron points up; on macOS the menu appears above via VMenuPanel.
+        case up
+    }
+
     public let label: String
     public var icon: String?
     public var style: VButton.Style
     public var size: VButton.Size
     public var isDisabled: Bool
+    public var chevronDirection: ChevronDirection
     public var accessibilityID: String?
     public let action: () -> Void
     @ViewBuilder public let menuContent: () -> MenuContent
@@ -13,12 +22,19 @@ public struct VSplitButton<MenuContent: View>: View {
     @State private var isPrimaryHovered = false
     @State private var isDropdownHovered = false
 
+    #if os(macOS)
+    @State private var buttonFrame: CGRect = .zero
+    @State private var activePanel: VMenuPanel?
+    @State private var isMenuOpen = false
+    #endif
+
     public init(
         label: String,
         icon: String? = nil,
         style: VButton.Style = .primary,
         size: VButton.Size = .regular,
         isDisabled: Bool = false,
+        chevronDirection: ChevronDirection = .down,
         accessibilityID: String? = nil,
         action: @escaping () -> Void,
         @ViewBuilder menuContent: @escaping () -> MenuContent
@@ -28,6 +44,7 @@ public struct VSplitButton<MenuContent: View>: View {
         self.style = style
         self.size = size
         self.isDisabled = isDisabled
+        self.chevronDirection = chevronDirection
         self.accessibilityID = accessibilityID
         self.action = action
         self.menuContent = menuContent
@@ -38,9 +55,12 @@ public struct VSplitButton<MenuContent: View>: View {
     /// Dropdown zone is square (width == height).
     private var dropdownWidth: CGFloat { zoneHeight }
 
+    private var chevronIcon: VIcon {
+        chevronDirection == .up ? .chevronUp : .chevronDown
+    }
+
     public var body: some View {
-        let cornerRadius = VRadius.md
-        let shape = RoundedRectangle(cornerRadius: cornerRadius)
+        let shape = Capsule()
 
         HStack(spacing: 0) {
             // Primary action zone
@@ -66,34 +86,8 @@ public struct VSplitButton<MenuContent: View>: View {
             // Divider
             divider
 
-            // Dropdown zone — visual layer + invisible Menu overlay
-            ZStack(alignment: .center) {
-                // Visual layer: background + centered icon
-                zoneBackgroundColor(isHovered: isDropdownHovered)
-                    .frame(width: dropdownWidth, height: zoneHeight)
-
-                VIconView(.chevronDown, size: 11)
-                    .foregroundStyle(foregroundColor)
-                    .frame(width: dropdownWidth, height: zoneHeight)
-                    .allowsHitTesting(false)
-
-                // Interactive layer: fills entire zone
-                Menu {
-                    menuContent()
-                } label: {
-                    Color.clear
-                        .frame(width: dropdownWidth, height: zoneHeight)
-                        .contentShape(Rectangle())
-                }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .accessibilityLabel("\(label) options")
-            }
-            .frame(width: dropdownWidth, height: zoneHeight)
-            .onHover { hovering in
-                isDropdownHovered = isDisabled ? false : hovering
-            }
-            .pointerCursor()
+            // Dropdown zone
+            dropdownZone
         }
         .fixedSize()
         .clipShape(shape)
@@ -109,7 +103,142 @@ public struct VSplitButton<MenuContent: View>: View {
         .animation(VAnimation.fast, value: isPrimaryHovered)
         .animation(VAnimation.fast, value: isDropdownHovered)
         .optionalSplitButtonAccessibilityID(accessibilityID)
+        #if os(macOS)
+        .overlay {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { buttonFrame = geo.frame(in: .global) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        buttonFrame = newFrame
+                    }
+            }
+        }
+        #endif
     }
+
+    // MARK: - Dropdown Zone
+
+    @ViewBuilder
+    private var dropdownZone: some View {
+        #if os(macOS)
+        if chevronDirection == .up {
+            upwardDropdownZone
+        } else {
+            defaultDropdownZone
+        }
+        #else
+        defaultDropdownZone
+        #endif
+    }
+
+    /// Default dropdown using SwiftUI Menu.
+    private var defaultDropdownZone: some View {
+        ZStack(alignment: .center) {
+            zoneBackgroundColor(isHovered: isDropdownHovered)
+                .frame(width: dropdownWidth, height: zoneHeight)
+
+            VIconView(chevronIcon, size: 11)
+                .foregroundStyle(foregroundColor)
+                .frame(width: dropdownWidth, height: zoneHeight)
+                .allowsHitTesting(false)
+
+            Menu {
+                menuContent()
+            } label: {
+                Color.clear
+                    .frame(width: dropdownWidth, height: zoneHeight)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .accessibilityLabel("\(label) options")
+        }
+        .frame(width: dropdownWidth, height: zoneHeight)
+        .onHover { hovering in
+            isDropdownHovered = isDisabled ? false : hovering
+        }
+        .pointerCursor()
+    }
+
+    #if os(macOS)
+    /// Upward dropdown using VMenuPanel, anchored above the button.
+    private var upwardDropdownZone: some View {
+        ZStack(alignment: .center) {
+            zoneBackgroundColor(isHovered: isDropdownHovered)
+                .frame(width: dropdownWidth, height: zoneHeight)
+
+            VIconView(.chevronUp, size: 11)
+                .foregroundStyle(foregroundColor)
+                .frame(width: dropdownWidth, height: zoneHeight)
+                .allowsHitTesting(false)
+
+            Button {
+                if isMenuOpen {
+                    activePanel?.close()
+                    activePanel = nil
+                    isMenuOpen = false
+                } else {
+                    showMenuAbove()
+                }
+            } label: {
+                Color.clear
+                    .frame(width: dropdownWidth, height: zoneHeight)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(label) options")
+        }
+        .frame(width: dropdownWidth, height: zoneHeight)
+        .onHover { hovering in
+            isDropdownHovered = isDisabled ? false : hovering
+        }
+        .pointerCursor()
+    }
+
+    private func showMenuAbove() {
+        guard !isMenuOpen else { return }
+        isMenuOpen = true
+
+        guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
+            isMenuOpen = false
+            return
+        }
+
+        // Convert the button's top-left from SwiftUI (y-down) to screen (y-up) coordinates.
+        let topLeftInWindow = CGPoint(x: buttonFrame.minX, y: buttonFrame.minY)
+        let screenPoint = window.convertPoint(toScreen: NSPoint(
+            x: topLeftInWindow.x,
+            y: window.frame.height - topLeftInWindow.y
+        ))
+
+        // Compute button rect in screen coordinates for the excludeRect so
+        // clicks on the button itself don't dismiss the menu.
+        let buttonScreenOrigin = window.convertPoint(toScreen: NSPoint(
+            x: buttonFrame.minX,
+            y: window.frame.height - buttonFrame.maxY
+        ))
+        let buttonScreenRect = CGRect(
+            origin: buttonScreenOrigin,
+            size: CGSize(width: buttonFrame.width, height: buttonFrame.height)
+        )
+
+        let appearance = window.effectiveAppearance
+        activePanel = VMenuPanel.show(
+            at: screenPoint,
+            anchor: .above,
+            sourceWindow: window,
+            sourceAppearance: appearance,
+            excludeRect: buttonScreenRect
+        ) {
+            VMenu {
+                menuContent()
+            }
+        } onDismiss: {
+            isMenuOpen = false
+            activePanel = nil
+        }
+    }
+    #endif
 
     // MARK: - Divider
 
@@ -117,12 +246,10 @@ public struct VSplitButton<MenuContent: View>: View {
     private var divider: some View {
         switch style {
         case .primary, .danger:
-            // For filled styles, pad the divider and fill behind it with the base color
-            // so no transparency leaks through between the two zones
             ZStack {
                 Rectangle()
                     .fill(filledBaseColor)
-                    .frame(width: 1 + 2, height: zoneHeight) // 1px divider + 1px padding each side
+                    .frame(width: 1 + 2, height: zoneHeight)
                 Rectangle()
                     .fill(VColor.auxWhite.opacity(0.3))
                     .frame(width: 1, height: zoneHeight)

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -32,7 +32,7 @@ public struct VSplitButton<MenuContent: View>: View {
     @State private var isDropdownHovered = false
 
     #if os(macOS)
-    @State private var buttonFrame: CGRect = .zero
+    @State private var dropdownFrame: CGRect = .zero
     @State private var activePanel: VMenuPanel?
     @State private var isMenuOpen = false
     #endif
@@ -123,17 +123,6 @@ public struct VSplitButton<MenuContent: View>: View {
         .animation(VAnimation.fast, value: isPrimaryHovered)
         .animation(VAnimation.fast, value: isDropdownHovered)
         .optionalSplitButtonAccessibilityID(accessibilityID)
-        #if os(macOS)
-        .overlay {
-            GeometryReader { geo in
-                Color.clear
-                    .onAppear { buttonFrame = geo.frame(in: .global) }
-                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
-                        buttonFrame = newFrame
-                    }
-            }
-        }
-        #endif
     }
 
     // MARK: - Dropdown Zone
@@ -213,6 +202,15 @@ public struct VSplitButton<MenuContent: View>: View {
             isDropdownHovered = isDisabled ? false : hovering
         }
         .pointerCursor()
+        .overlay {
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { dropdownFrame = geo.frame(in: .global) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        dropdownFrame = newFrame
+                    }
+            }
+        }
     }
 
     private func showMenuAbove() {
@@ -224,22 +222,22 @@ public struct VSplitButton<MenuContent: View>: View {
             return
         }
 
-        // Convert the button's top-left from SwiftUI (y-down) to screen (y-up) coordinates.
-        let topLeftInWindow = CGPoint(x: buttonFrame.minX, y: buttonFrame.minY)
+        // Convert the dropdown zone's top-left from SwiftUI (y-down) to screen (y-up) coordinates.
+        let topLeftInWindow = CGPoint(x: dropdownFrame.minX, y: dropdownFrame.minY)
         let screenPoint = window.convertPoint(toScreen: NSPoint(
             x: topLeftInWindow.x,
             y: window.frame.height - topLeftInWindow.y
         ))
 
-        // Compute button rect in screen coordinates for the excludeRect so
-        // clicks on the button itself don't dismiss the menu.
-        let buttonScreenOrigin = window.convertPoint(toScreen: NSPoint(
-            x: buttonFrame.minX,
-            y: window.frame.height - buttonFrame.maxY
+        // Exclude only the dropdown zone so clicks on the primary action
+        // half correctly dismiss the menu via VMenuPanel's click monitor.
+        let dropdownScreenOrigin = window.convertPoint(toScreen: NSPoint(
+            x: dropdownFrame.minX,
+            y: window.frame.height - dropdownFrame.maxY
         ))
-        let buttonScreenRect = CGRect(
-            origin: buttonScreenOrigin,
-            size: CGSize(width: buttonFrame.width, height: buttonFrame.height)
+        let dropdownScreenRect = CGRect(
+            origin: dropdownScreenOrigin,
+            size: CGSize(width: dropdownFrame.width, height: dropdownFrame.height)
         )
 
         let appearance = window.effectiveAppearance
@@ -248,11 +246,16 @@ public struct VSplitButton<MenuContent: View>: View {
             anchor: .above,
             sourceWindow: window,
             sourceAppearance: appearance,
-            excludeRect: buttonScreenRect
+            excludeRect: dropdownScreenRect
         ) {
             VMenu {
                 menuContent()
             }
+            // Dismiss the panel on any tap so plain Button items (not just
+            // VMenuItem) close the menu after their action fires.
+            .simultaneousGesture(TapGesture().onEnded {
+                activePanel?.close()
+            })
         } onDismiss: {
             isMenuOpen = false
             activePanel = nil

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -130,18 +130,15 @@ public struct VSplitButton<MenuContent: View>: View {
     @ViewBuilder
     private var dropdownZone: some View {
         #if os(macOS)
-        if chevronDirection == .up {
-            upwardDropdownZone
-        } else {
-            defaultDropdownZone
-        }
+        macOSDropdownZone
         #else
-        defaultDropdownZone
+        iOSDropdownZone
         #endif
     }
 
-    /// Default dropdown using SwiftUI Menu.
-    private var defaultDropdownZone: some View {
+    #if !os(macOS)
+    /// iOS fallback using SwiftUI's native Menu.
+    private var iOSDropdownZone: some View {
         ZStack(alignment: .center) {
             zoneBackgroundColor(isHovered: isDropdownHovered)
                 .frame(width: dropdownWidth, height: zoneHeight)
@@ -168,15 +165,16 @@ public struct VSplitButton<MenuContent: View>: View {
         }
         .pointerCursor()
     }
+    #endif
 
     #if os(macOS)
-    /// Upward dropdown using VMenuPanel, anchored above the button.
-    private var upwardDropdownZone: some View {
+    /// macOS dropdown using VMenu + VMenuPanel for both directions.
+    private var macOSDropdownZone: some View {
         ZStack(alignment: .center) {
             zoneBackgroundColor(isHovered: isDropdownHovered)
                 .frame(width: dropdownWidth, height: zoneHeight)
 
-            VIconView(.chevronUp, size: 11)
+            VIconView(chevronIcon, size: 11)
                 .foregroundStyle(foregroundColor)
                 .frame(width: dropdownWidth, height: zoneHeight)
                 .allowsHitTesting(false)
@@ -187,7 +185,7 @@ public struct VSplitButton<MenuContent: View>: View {
                     activePanel = nil
                     isMenuOpen = false
                 } else {
-                    showMenuAbove()
+                    showMenu()
                 }
             } label: {
                 Color.clear
@@ -213,7 +211,11 @@ public struct VSplitButton<MenuContent: View>: View {
         }
     }
 
-    private func showMenuAbove() {
+    private var menuAnchor: VMenuAnchorEdge {
+        chevronDirection == .up ? .above : .below
+    }
+
+    private func showMenu() {
         guard !isMenuOpen else { return }
         isMenuOpen = true
 
@@ -222,11 +224,12 @@ public struct VSplitButton<MenuContent: View>: View {
             return
         }
 
-        // Convert the dropdown zone's top-left from SwiftUI (y-down) to screen (y-up) coordinates.
-        let topLeftInWindow = CGPoint(x: dropdownFrame.minX, y: dropdownFrame.minY)
+        // Anchor point in screen coordinates (y-up).
+        // .below: bottom-left of dropdown zone; .above: top-left of dropdown zone.
+        let anchorY = chevronDirection == .up ? dropdownFrame.minY : dropdownFrame.maxY
         let screenPoint = window.convertPoint(toScreen: NSPoint(
-            x: topLeftInWindow.x,
-            y: window.frame.height - topLeftInWindow.y
+            x: dropdownFrame.minX,
+            y: window.frame.height - anchorY
         ))
 
         // Exclude only the dropdown zone so clicks on the primary action
@@ -243,7 +246,7 @@ public struct VSplitButton<MenuContent: View>: View {
         let appearance = window.effectiveAppearance
         activePanel = VMenuPanel.show(
             at: screenPoint,
-            anchor: .above,
+            anchor: menuAnchor,
             sourceWindow: window,
             sourceAppearance: appearance,
             excludeRect: dropdownScreenRect

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -9,12 +9,21 @@ public struct VSplitButton<MenuContent: View>: View {
         case up
     }
 
+    /// Controls the outer shape of the split button.
+    public enum ButtonShape {
+        /// Pill / capsule ends (fully rounded).
+        case capsule
+        /// Rounded rectangle matching `VRadius.md`.
+        case roundedRectangle
+    }
+
     public let label: String
     public var icon: String?
     public var style: VButton.Style
     public var size: VButton.Size
     public var isDisabled: Bool
     public var chevronDirection: ChevronDirection
+    public var buttonShape: ButtonShape
     public var accessibilityID: String?
     public let action: () -> Void
     @ViewBuilder public let menuContent: () -> MenuContent
@@ -35,6 +44,7 @@ public struct VSplitButton<MenuContent: View>: View {
         size: VButton.Size = .regular,
         isDisabled: Bool = false,
         chevronDirection: ChevronDirection = .down,
+        buttonShape: ButtonShape = .capsule,
         accessibilityID: String? = nil,
         action: @escaping () -> Void,
         @ViewBuilder menuContent: @escaping () -> MenuContent
@@ -45,6 +55,7 @@ public struct VSplitButton<MenuContent: View>: View {
         self.size = size
         self.isDisabled = isDisabled
         self.chevronDirection = chevronDirection
+        self.buttonShape = buttonShape
         self.accessibilityID = accessibilityID
         self.action = action
         self.menuContent = menuContent
@@ -59,8 +70,17 @@ public struct VSplitButton<MenuContent: View>: View {
         chevronDirection == .up ? .chevronUp : .chevronDown
     }
 
+    private var resolvedShape: AnyInsettableShape {
+        switch buttonShape {
+        case .capsule:
+            return AnyInsettableShape(Capsule())
+        case .roundedRectangle:
+            return AnyInsettableShape(RoundedRectangle(cornerRadius: VRadius.md))
+        }
+    }
+
     public var body: some View {
-        let shape = Capsule()
+        let shape = resolvedShape
 
         HStack(spacing: 0) {
             // Primary action zone
@@ -358,4 +378,25 @@ private extension View {
             self
         }
     }
+}
+
+// MARK: - AnyInsettableShape
+
+/// Type-erased `InsettableShape` so VSplitButton can switch between
+/// `Capsule` and `RoundedRectangle` at runtime while still using
+/// `strokeBorder` (which requires `InsettableShape`).
+private struct AnyInsettableShape: InsettableShape {
+    private let _path: (CGRect) -> Path
+    private let _sizeThatFits: (ProposedViewSize) -> CGSize
+    private let _inset: (CGFloat) -> AnyInsettableShape
+
+    init<S: InsettableShape>(_ shape: S) {
+        _path = shape.path
+        _sizeThatFits = shape.sizeThatFits
+        _inset = { AnyInsettableShape(shape.inset(by: $0)) }
+    }
+
+    func path(in rect: CGRect) -> Path { _path(rect) }
+    func sizeThatFits(_ proposal: ProposedViewSize) -> CGSize { _sizeThatFits(proposal) }
+    func inset(by amount: CGFloat) -> AnyInsettableShape { _inset(amount) }
 }

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -394,23 +394,3 @@ private extension View {
     }
 }
 
-// MARK: - AnyInsettableShape
-
-/// Type-erased `InsettableShape` so VSplitButton can switch between
-/// `Capsule` and `RoundedRectangle` at runtime while still using
-/// `strokeBorder` (which requires `InsettableShape`).
-private struct AnyInsettableShape: InsettableShape {
-    private let _path: (CGRect) -> Path
-    private let _sizeThatFits: (ProposedViewSize) -> CGSize
-    private let _inset: (CGFloat) -> AnyInsettableShape
-
-    init<S: InsettableShape>(_ shape: S) {
-        _path = shape.path
-        _sizeThatFits = shape.sizeThatFits
-        _inset = { AnyInsettableShape(shape.inset(by: $0)) }
-    }
-
-    func path(in rect: CGRect) -> Path { _path(rect) }
-    func sizeThatFits(_ proposal: ProposedViewSize) -> CGSize { _sizeThatFits(proposal) }
-    func inset(by amount: CGFloat) -> AnyInsettableShape { _inset(amount) }
-}

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -35,6 +35,10 @@ public struct VSplitButton<MenuContent: View>: View {
     @State private var dropdownFrame: CGRect = .zero
     @State private var activePanel: VMenuPanel?
     @State private var isMenuOpen = false
+    /// Monotonic counter to distinguish stale dismiss handlers from swept
+    /// panels. Each showMenu() increments this; the onDismiss closure
+    /// captures the current value and only resets state if it still matches.
+    @State private var menuGeneration: UInt = 0
     #endif
 
     public init(
@@ -217,6 +221,8 @@ public struct VSplitButton<MenuContent: View>: View {
 
     private func showMenu() {
         guard !isMenuOpen else { return }
+        menuGeneration &+= 1
+        let currentGeneration = menuGeneration
         isMenuOpen = true
 
         guard let window = NSApp.keyWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
@@ -254,7 +260,13 @@ public struct VSplitButton<MenuContent: View>: View {
             VMenu {
                 menuContent()
             }
-        } onDismiss: {
+        } onDismiss: { [currentGeneration] in
+            // Only reset state if this is still the active generation.
+            // VMenuPanel.show() sweeps existing panels before creating a
+            // new one, which fires the old panel's onDismiss synchronously.
+            // Without this guard, the sweep would set isMenuOpen = false
+            // while the new panel is being created, causing state desync.
+            guard self.menuGeneration == currentGeneration else { return }
             isMenuOpen = false
             activePanel = nil
         }

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -268,6 +268,14 @@ public struct VSplitButton<MenuContent: View>: View {
 
     // MARK: - Divider
 
+    private var isDividerVisible: Bool {
+        if isPrimaryHovered || isDropdownHovered { return true }
+        #if os(macOS)
+        if isMenuOpen { return true }
+        #endif
+        return false
+    }
+
     @ViewBuilder
     private var divider: some View {
         switch style {
@@ -277,20 +285,20 @@ public struct VSplitButton<MenuContent: View>: View {
                     .fill(filledBaseColor)
                     .frame(width: 1 + 2, height: zoneHeight)
                 Rectangle()
-                    .fill(VColor.auxWhite.opacity(0.3))
+                    .fill(VColor.auxWhite.opacity(isDividerVisible ? 0.3 : 0))
                     .frame(width: 1, height: zoneHeight)
             }
         case .outlined, .dangerOutline:
             Rectangle()
-                .fill(borderColor)
+                .fill(borderColor.opacity(isDividerVisible ? 1 : 0))
                 .frame(width: 1, height: zoneHeight)
         case .ghost, .dangerGhost:
             Rectangle()
-                .fill(VColor.borderBase)
+                .fill(VColor.borderBase.opacity(isDividerVisible ? 1 : 0))
                 .frame(width: 1, height: zoneHeight)
         case .contrast:
             Rectangle()
-                .fill(VColor.auxWhite.opacity(0.3))
+                .fill(VColor.auxWhite.opacity(isDividerVisible ? 0.3 : 0))
                 .frame(width: 1, height: zoneHeight)
         }
     }

--- a/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VSplitButton.swift
@@ -254,11 +254,6 @@ public struct VSplitButton<MenuContent: View>: View {
             VMenu {
                 menuContent()
             }
-            // Dismiss the panel on any tap so plain Button items (not just
-            // VMenuItem) close the menu after their action fires.
-            .simultaneousGesture(TapGesture().onEnded {
-                activePanel?.close()
-            })
         } onDismiss: {
             isMenuOpen = false
             activePanel = nil

--- a/clients/shared/DesignSystem/Core/Shapes/AnyInsettableShape.swift
+++ b/clients/shared/DesignSystem/Core/Shapes/AnyInsettableShape.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// Type-erased `InsettableShape` enabling runtime shape switching while
+/// preserving `strokeBorder` support (which requires `InsettableShape`).
+public struct AnyInsettableShape: InsettableShape {
+    private let _path: (CGRect) -> Path
+    private let _sizeThatFits: (ProposedViewSize) -> CGSize
+    private let _inset: (CGFloat) -> AnyInsettableShape
+
+    public init<S: InsettableShape>(_ shape: S) {
+        _path = shape.path
+        _sizeThatFits = shape.sizeThatFits
+        _inset = { AnyInsettableShape(shape.inset(by: $0)) }
+    }
+
+    public func path(in rect: CGRect) -> Path { _path(rect) }
+    public func sizeThatFits(_ proposal: ProposedViewSize) -> CGSize { _sizeThatFits(proposal) }
+    public func inset(by amount: CGFloat) -> AnyInsettableShape { _inset(amount) }
+}

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -349,6 +349,14 @@ struct ButtonsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
+                                Text("Rounded Rect").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, buttonShape: .roundedRectangle, action: {}) {
+                                    Button("Allow once") {}
+                                    Button("Allow always") {}
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Long Label").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow for this conversation", icon: VIcon.check.rawValue, style: .primary, action: {}) {
                                     Button("Allow once") {}

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -390,17 +390,44 @@ struct ButtonsGallerySection: View {
                                 }
                             }
 
+                        }
+                    }
+                }
+
+                VCard {
+                    VStack(alignment: .leading, spacing: VSpacing.xl) {
+                        Text("Menu Item Sizes")
+                            .font(VFont.bodySmallEmphasised)
+                            .foregroundStyle(VColor.contentSecondary)
+
+                        HStack(spacing: VSpacing.lg) {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Mini Items").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                Text("Mini").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
                                     VMenuItem(label: "Allow & Create Rule", size: .mini) {}
                                 }
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
-                                Text("Compact Items").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                Text("Compact (default)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
-                                    VMenuItem(label: "Allow & Create Rule", size: .compact) {}
+                                    VMenuItem(label: "Allow & Create Rule") {}
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: VSpacing.md) {
+                                Text("Compact (multiple)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
+                                    VMenuItem(label: "Allow once") {}
+                                    VMenuItem(label: "Allow & Create Rule") {}
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: VSpacing.md) {
+                                Text("Mini (multiple)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
+                                    VMenuItem(label: "Allow once", size: .mini) {}
+                                    VMenuItem(label: "Allow & Create Rule", size: .mini) {}
                                 }
                             }
                         }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -329,6 +329,26 @@ struct ButtonsGallerySection: View {
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
+                                Text("Contrast").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VSplitButton(label: "Copy SVG", style: .contrast, action: {}) {
+                                    Button("Copy SVG") {}
+                                    Button("Copy Data URL") {}
+                                    Button("Download SVG") {}
+                                    Button("Download PNG") {}
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: VSpacing.md) {
+                                Text("Chevron Up").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VSplitButton(label: "Copy SVG", style: .contrast, chevronDirection: .up, action: {}) {
+                                    Button("Copy SVG") {}
+                                    Button("Copy Data URL") {}
+                                    Button("Download SVG") {}
+                                    Button("Download PNG") {}
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Long Label").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow for this conversation", icon: VIcon.check.rawValue, style: .primary, action: {}) {
                                     Button("Allow once") {}

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -86,6 +86,32 @@ struct ButtonsGallerySection: View {
                     }
                 }
 
+                // Button Shapes
+                Text("Button Shapes")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentSecondary)
+
+                VCard {
+                    HStack(spacing: VSpacing.xl) {
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Default (Rounded Rect)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VButton(label: "Continue", icon: VIcon.arrowRight.rawValue, style: .primary) {}
+                        }
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Capsule").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VButton(label: "Continue", icon: VIcon.arrowRight.rawValue, style: .primary, buttonShape: .capsule) {}
+                        }
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Rounded Rect (explicit)").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VButton(label: "Continue", icon: VIcon.arrowRight.rawValue, style: .primary, buttonShape: .roundedRectangle) {}
+                        }
+                        VStack(alignment: .leading, spacing: VSpacing.md) {
+                            Text("Capsule Outlined").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                            VButton(label: "Save", style: .outlined, buttonShape: .capsule) {}
+                        }
+                    }
+                }
+
                 Divider().background(VColor.borderBase).padding(.vertical, VSpacing.md)
 
                 // MARK: - VButton (Icon Only — Ghost)

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -389,6 +389,20 @@ struct ButtonsGallerySection: View {
                                     VMenuItem(label: "Allow always") {}
                                 }
                             }
+
+                            VStack(alignment: .leading, spacing: VSpacing.md) {
+                                Text("Mini Items").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
+                                    VMenuItem(label: "Allow & Create Rule", size: .mini) {}
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: VSpacing.md) {
+                                Text("Compact Items").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
+                                VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
+                                    VMenuItem(label: "Allow & Create Rule", size: .compact) {}
+                                }
+                            }
                         }
                     }
                 }

--- a/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ButtonsGallerySection.swift
@@ -326,13 +326,13 @@ struct ButtonsGallerySection: View {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Primary").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, action: {}) {
-                                    Section("Duration") {
-                                        Button("Allow once") {}
-                                        Button("Allow for this session") {}
+                                    VMenuSection(header: "Duration") {
+                                        VMenuItem(label: "Allow once") {}
+                                        VMenuItem(label: "Allow for this session") {}
                                     }
-                                    Section("Scope") {
-                                        Button("Allow for this project") {}
-                                        Button("Allow always") {}
+                                    VMenuSection(header: "Scope") {
+                                        VMenuItem(label: "Allow for this project") {}
+                                        VMenuItem(label: "Allow always") {}
                                     }
                                 }
                             }
@@ -340,53 +340,53 @@ struct ButtonsGallerySection: View {
                             VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Outlined").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Save", style: .outlined, action: {}) {
-                                    Button("Save as draft") {}
-                                    Button("Save and publish") {}
-                                    Button("Save as template") {}
+                                    VMenuItem(label: "Save as draft") {}
+                                    VMenuItem(label: "Save and publish") {}
+                                    VMenuItem(label: "Save as template") {}
                                 }
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Danger").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Delete", icon: VIcon.trash.rawValue, style: .danger, action: {}) {
-                                    Button("Delete selected") {}
-                                    Button("Delete all") {}
+                                    VMenuItem(label: "Delete selected") {}
+                                    VMenuItem(label: "Delete all", variant: .destructive) {}
                                 }
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Contrast").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Copy SVG", style: .contrast, action: {}) {
-                                    Button("Copy SVG") {}
-                                    Button("Copy Data URL") {}
-                                    Button("Download SVG") {}
-                                    Button("Download PNG") {}
+                                    VMenuItem(label: "Copy SVG") {}
+                                    VMenuItem(label: "Copy Data URL") {}
+                                    VMenuItem(label: "Download SVG") {}
+                                    VMenuItem(label: "Download PNG") {}
                                 }
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Chevron Up").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Copy SVG", style: .contrast, chevronDirection: .up, action: {}) {
-                                    Button("Copy SVG") {}
-                                    Button("Copy Data URL") {}
-                                    Button("Download SVG") {}
-                                    Button("Download PNG") {}
+                                    VMenuItem(label: "Copy SVG") {}
+                                    VMenuItem(label: "Copy Data URL") {}
+                                    VMenuItem(label: "Download SVG") {}
+                                    VMenuItem(label: "Download PNG") {}
                                 }
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Rounded Rect").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow", icon: VIcon.check.rawValue, style: .primary, buttonShape: .roundedRectangle, action: {}) {
-                                    Button("Allow once") {}
-                                    Button("Allow always") {}
+                                    VMenuItem(label: "Allow once") {}
+                                    VMenuItem(label: "Allow always") {}
                                 }
                             }
 
                             VStack(alignment: .leading, spacing: VSpacing.md) {
                                 Text("Long Label").font(VFont.labelDefault).foregroundStyle(VColor.contentTertiary)
                                 VSplitButton(label: "Allow for this conversation", icon: VIcon.check.rawValue, style: .primary, action: {}) {
-                                    Button("Allow once") {}
-                                    Button("Allow always") {}
+                                    VMenuItem(label: "Allow once") {}
+                                    VMenuItem(label: "Allow always") {}
                                 }
                             }
                         }

--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -222,7 +222,7 @@ public struct PermissionPromptView: View {
                     }
                 }
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
+                    Capsule()
                         .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
                         .allowsHitTesting(false)
                 )

--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -217,9 +217,15 @@ public struct PermissionPromptView: View {
                         onAllow()
                     }
                 }) {
-                    DismissableMenuAction(label: "Allow & Create Rule") {
+                    #if os(macOS)
+                    VMenuItem(label: "Allow & Create Rule", size: .mini) {
                         onAllowAndSuggestRule?()
                     }
+                    #else
+                    Button("Allow & Create Rule") {
+                        onAllowAndSuggestRule?()
+                    }
+                    #endif
                 }
                 .overlay(
                     Capsule()
@@ -325,32 +331,5 @@ public struct PermissionPromptView: View {
         default:
             break
         }
-    }
-}
-
-// MARK: - DismissableMenuAction
-
-/// A lightweight menu action that reads `vMenuDismiss` from the
-/// environment to auto-dismiss the parent VMenu on tap.
-/// Used instead of `VMenuItem` when a compact, single-line action
-/// is needed without VMenuItem's 32pt minimum row height.
-private struct DismissableMenuAction: View {
-    let label: String
-    let action: () -> Void
-    @Environment(\.vMenuDismiss) private var dismiss
-
-    var body: some View {
-        Button {
-            dismiss?()
-            action()
-        } label: {
-            Text(label)
-                .font(VFont.bodyMediumDefault)
-                .foregroundStyle(VColor.contentSecondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
     }
 }

--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -272,6 +272,14 @@ public struct PermissionPromptView: View {
         removeKeyMonitor()
         keyboardModel = ToolConfirmationKeyboardModel(actions: actions)
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // If a VMenuPanel is key (e.g. the VSplitButton dropdown is open),
+            // let the panel's responder chain handle Escape / Enter / Tab so the
+            // user can navigate and dismiss the menu without triggering a
+            // permission action. VMenuPanel uses a regular NSWindow (not a nested
+            // NSMenu event loop), so local monitors fire before its responders.
+            if NSApp.keyWindow is VMenuPanel {
+                return event
+            }
             // If an editable text view (e.g. the composer) is the first responder,
             // let the event pass through so it can handle Enter/Tab/Escape normally.
             // Non-editable text views (e.g. selectable command previews inside the

--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -217,7 +217,7 @@ public struct PermissionPromptView: View {
                         onAllow()
                     }
                 }) {
-                    VMenuItem(label: "Allow & Create Rule") {
+                    DismissableMenuAction(label: "Allow & Create Rule") {
                         onAllowAndSuggestRule?()
                     }
                 }
@@ -325,5 +325,32 @@ public struct PermissionPromptView: View {
         default:
             break
         }
+    }
+}
+
+// MARK: - DismissableMenuAction
+
+/// A lightweight menu action that reads `vMenuDismiss` from the
+/// environment to auto-dismiss the parent VMenu on tap.
+/// Used instead of `VMenuItem` when a compact, single-line action
+/// is needed without VMenuItem's 32pt minimum row height.
+private struct DismissableMenuAction: View {
+    let label: String
+    let action: () -> Void
+    @Environment(\.vMenuDismiss) private var dismiss
+
+    var body: some View {
+        Button {
+            dismiss?()
+            action()
+        } label: {
+            Text(label)
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
     }
 }

--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -227,7 +227,7 @@ public struct PermissionPromptView: View {
                         .allowsHitTesting(false)
                 )
             } else {
-                VButton(label: "Allow", style: .primary, size: .compact) {
+                VButton(label: "Allow", style: .primary, size: .compact, buttonShape: .capsule) {
                     if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
                         let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
                         onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
@@ -242,7 +242,7 @@ public struct PermissionPromptView: View {
                 )
             }
 
-            VButton(label: "Deny", style: .danger, size: .compact) {
+            VButton(label: "Deny", style: .danger, size: .compact, buttonShape: .capsule) {
                 onDeny()
             }
             .overlay(

--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -217,7 +217,7 @@ public struct PermissionPromptView: View {
                         onAllow()
                     }
                 }) {
-                    Button("Allow & Create Rule") {
+                    VMenuItem(label: "Allow & Create Rule") {
                         onAllowAndSuggestRule?()
                     }
                 }
@@ -236,7 +236,7 @@ public struct PermissionPromptView: View {
                     }
                 }
                 .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
+                    Capsule()
                         .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
                         .allowsHitTesting(false)
                 )
@@ -246,7 +246,7 @@ public struct PermissionPromptView: View {
                 onDeny()
             }
             .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
+                Capsule()
                     .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
                     .allowsHitTesting(false)
             )

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -107,7 +107,7 @@ public struct ToolConfirmationBubble: View {
                 .foregroundStyle(VColor.contentSecondary)
 
             HStack(spacing: VSpacing.sm) {
-                VButton(label: "Open System Settings", style: .primary) {
+                VButton(label: "Open System Settings", style: .primary, buttonShape: .capsule) {
                     #if os(macOS)
                     if let url = confirmation.settingsURL {
                         NSWorkspace.shared.open(url)
@@ -115,11 +115,11 @@ public struct ToolConfirmationBubble: View {
                     #endif
                 }
 
-                VButton(label: "I\u{2019}ve granted it", style: .outlined) {
+                VButton(label: "I\u{2019}ve granted it", style: .outlined, buttonShape: .capsule) {
                     onAllow()
                 }
 
-                VButton(label: "Skip", style: .outlined) {
+                VButton(label: "Skip", style: .outlined, buttonShape: .capsule) {
                     onDeny()
                 }
             }


### PR DESCRIPTION
Fixes a ghost outline artifact in VMenuPanel — a white rounded rectangle with shadow but no menu items that appeared ~1/25 open/close cycles. The root cause was SwiftUI's `.shadow()` modifier rendering shadow pixels into the `.buffered` backing store, which persisted after `contentView = nil` because `display()` with no content view is a no-op. Switches VMenuPanel to the native `hasShadow = true` compositor shadow (matching every other transparent panel in the codebase), which is removed atomically with the window — eliminating the entire class of ghost artifacts.

Also includes VSplitButton redesign: capsule shape by default, chevron direction support (`.up`/`.down`), VButton shape configurability, VMenuItem `.mini` size, and all callers migrated to use VMenuItem.

## Prompt / plan

Root cause investigation of ghost outline artifact in VMenuPanel. Identified that VMenuPanel was the only transparent borderless panel in the codebase using `hasShadow = false` with SwiftUI `.shadow()` — all 11 other panels use native `hasShadow = true`. The SwiftUI shadow rendered pixels into the `.buffered` backing store, which persisted after `contentView = nil` because `NSWindow.display()` is a no-op with no content view. The native compositor shadow is drawn outside the window bounds and removed atomically on close/orderOut.

## Test plan

- CI passes (no macOS build in CI — user must verify Xcode builds locally)
- Manual testing: open/close VSplitButton dropdown 25+ rapid cycles to verify no ghost outline
- Verify shadow appearance on VMenuPanel menus matches design intent
- Verify context menus, VDropdown, sidebar menus all look correct

---

- Requested by: @jasonzhou1993
- Session: https://app.devin.ai/sessions/8ca17e9290774cfda04192241720dcbb

Requested by: @Jasonnnz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
