### PR TITLE
feat(daemon): track conversationIds on apps and support filtering

### DIFF
--- a/assistant/src/__tests__/app-conversation-ids.test.ts
+++ b/assistant/src/__tests__/app-conversation-ids.test.ts
@@ -1,0 +1,151 @@
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  addAppConversationId,
+  createApp,
+  getApp,
+  listAppsByConversation,
+} from "../memory/app-store.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let testDataDir: string;
+
+function freshTempDir(): string {
+  return join(
+    tmpdir(),
+    `vellum-app-conv-id-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+}
+
+function makeAppParams(name: string) {
+  return {
+    name,
+    schemaJson: "{}",
+    htmlDefinition: "<h1>Hello</h1>",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  testDataDir = freshTempDir();
+  process.env.VELLUM_WORKSPACE_DIR = testDataDir;
+});
+
+afterEach(() => {
+  if (existsSync(testDataDir)) {
+    rmSync(testDataDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// addAppConversationId
+// ---------------------------------------------------------------------------
+
+describe("addAppConversationId", () => {
+  test("appends conversationId and returns true", () => {
+    const app = createApp(makeAppParams("Test App"));
+    const result = addAppConversationId(app.id, "conv-abc");
+    expect(result).toBe(true);
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual(["conv-abc"]);
+  });
+
+  test("deduplicates — returns false when conversationId already present", () => {
+    const app = createApp(makeAppParams("Test App"));
+    addAppConversationId(app.id, "conv-abc");
+    const result = addAppConversationId(app.id, "conv-abc");
+    expect(result).toBe(false);
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual(["conv-abc"]);
+  });
+
+  test("returns false for non-existent app", () => {
+    const result = addAppConversationId("nonexistent-id", "conv-abc");
+    expect(result).toBe(false);
+  });
+
+  test("does not change updatedAt", () => {
+    const app = createApp(makeAppParams("Test App"));
+    const originalUpdatedAt = app.updatedAt;
+
+    // Wait a tick so Date.now() would differ if updatedAt were bumped
+    const before = Date.now();
+    while (Date.now() === before) {
+      // busy-wait for at least 1ms
+    }
+
+    addAppConversationId(app.id, "conv-abc");
+
+    const loaded = getApp(app.id);
+    expect(loaded?.updatedAt).toBe(originalUpdatedAt);
+  });
+
+  test("initializes conversationIds from undefined", () => {
+    const app = createApp(makeAppParams("Fresh App"));
+    // Verify the app has no conversationIds initially
+    const initial = getApp(app.id);
+    expect(initial?.conversationIds).toBeUndefined();
+
+    addAppConversationId(app.id, "conv-xyz");
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual(["conv-xyz"]);
+  });
+
+  test("appends multiple distinct conversationIds", () => {
+    const app = createApp(makeAppParams("Multi Conv App"));
+    addAppConversationId(app.id, "conv-1");
+    addAppConversationId(app.id, "conv-2");
+    addAppConversationId(app.id, "conv-3");
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual(["conv-1", "conv-2", "conv-3"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listAppsByConversation
+// ---------------------------------------------------------------------------
+
+describe("listAppsByConversation", () => {
+  test("filters apps by conversationId", () => {
+    const app1 = createApp(makeAppParams("App One"));
+    const app2 = createApp(makeAppParams("App Two"));
+    createApp(makeAppParams("App Three"));
+
+    addAppConversationId(app1.id, "conv-shared");
+    addAppConversationId(app2.id, "conv-shared");
+    addAppConversationId(app1.id, "conv-only-one");
+
+    const shared = listAppsByConversation("conv-shared");
+    expect(shared).toHaveLength(2);
+    const ids = shared.map((a) => a.id).sort();
+    expect(ids).toEqual([app1.id, app2.id].sort());
+
+    const onlyOne = listAppsByConversation("conv-only-one");
+    expect(onlyOne).toHaveLength(1);
+    expect(onlyOne[0].id).toBe(app1.id);
+  });
+
+  test("returns empty array for unknown conversationId", () => {
+    createApp(makeAppParams("Some App"));
+    const result = listAppsByConversation("conv-nonexistent");
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when no apps exist", () => {
+    const result = listAppsByConversation("conv-any");
+    expect(result).toEqual([]);
+  });
+});

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 
 import {
+  addAppConversationId,
   getApp,
   getAppDirPath,
   getAppPreview,
@@ -2016,6 +2017,14 @@ export async function surfaceProxyResolver(
     const openMode = input.open_mode as string | undefined;
     const app = getApp(appId);
     if (!app) return { content: `App not found: ${appId}`, isError: true };
+
+    // Track conversation association (best-effort — failures must not break open flow).
+    try {
+      addAppConversationId(appId, ctx.conversationId);
+    } catch (err) {
+      log.warn({ err, appId }, "Failed to track conversation ID on app_open");
+    }
+
     // Generate a minimal fallback preview from app metadata so that the
     // surface is always rendered as a clickable preview card (not an
     // un-clickable fallback chip) after conversation restart.

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -8,6 +8,7 @@
  */
 
 import { generateAppIcon } from "../media/app-icon-generator.js";
+import { addAppConversationId } from "../memory/app-store.js";
 import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { deliverVerificationSlack } from "../runtime/verification-outbound-actions.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
@@ -89,6 +90,16 @@ registerHook(
         description?: string;
       };
       if (parsed.id) {
+        // Track conversation association (best-effort).
+        try {
+          addAppConversationId(parsed.id, ctx.conversationId);
+        } catch (err) {
+          log.warn(
+            { err, appId: parsed.id },
+            "Failed to track conversation ID on app_create",
+          );
+        }
+
         // The apps directory may have just been created — ensure the
         // filesystem watcher is running so subsequent file edits
         // trigger live reload.
@@ -149,6 +160,17 @@ registerHook(
   (_name, input, _result, { ctx, broadcastToAllClients }) => {
     const appId = input.app_id as string | undefined;
     if (!appId) return;
+
+    // Track conversation association (best-effort).
+    try {
+      addAppConversationId(appId, ctx.conversationId);
+    } catch (err) {
+      log.warn(
+        { err, appId },
+        "Failed to track conversation ID on app_refresh",
+      );
+    }
+
     notifyAppChanged(ctx, appId, broadcastToAllClients, { fileChange: true });
   },
 );

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -55,6 +55,8 @@ export interface AppDefinition {
   formatVersion?: number;
   /** Filesystem directory/file stem. Frozen at creation -- never changes on rename. */
   dirName?: string;
+  /** Conversation IDs that have interacted with this app (create/open/refresh). */
+  conversationIds?: string[];
 }
 
 /**
@@ -899,6 +901,50 @@ export function editAppFile(
     writeFileSync(resolved, result.updatedContent, "utf-8");
   }
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Conversation association helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Associate a conversation with an app. Writes directly to the JSON metadata
+ * file without bumping `updatedAt` so the app list ordering is preserved.
+ *
+ * @returns `true` if the association was added, `false` if the app was not
+ *   found or the conversationId was already present (dedup).
+ */
+export function addAppConversationId(
+  appId: string,
+  conversationId: string,
+): boolean {
+  const app = getApp(appId);
+  if (!app) return false;
+
+  const existing = app.conversationIds ?? [];
+  if (existing.includes(conversationId)) return false;
+
+  const { dirName } = resolveAppDir(appId);
+  const dir = getAppsDir();
+  const jsonPath = join(dir, `${dirName}.json`);
+
+  const raw = readFileSync(jsonPath, "utf-8");
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  parsed.conversationIds = [...existing, conversationId];
+  writeFileSync(jsonPath, JSON.stringify(parsed, null, 2));
+
+  return true;
+}
+
+/**
+ * Return all apps associated with a given conversation ID.
+ */
+export function listAppsByConversation(
+  conversationId: string,
+): AppDefinition[] {
+  return listApps().filter((app) =>
+    app.conversationIds?.includes(conversationId),
+  );
 }
 
 export type { EditEngineResult };

--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -28,6 +28,7 @@ import {
   restoreAppVersion,
 } from "../../memory/app-git-service.js";
 import {
+  type AppDefinition,
   createApp,
   createAppRecord,
   deleteApp,
@@ -37,6 +38,7 @@ import {
   getAppPreview,
   isMultifileApp,
   listApps,
+  listAppsByConversation,
   queryAppRecords,
   resolveAppDir,
   resolveEffectiveAppHtml,
@@ -69,7 +71,7 @@ function getSharedAppsDir(): string {
 // Extracted business logic
 // ---------------------------------------------------------------------------
 
-function listAppsFiltered(): Array<{
+function listAppsFiltered(apps?: AppDefinition[]): Array<{
   id: string;
   name: string;
   description?: string;
@@ -78,7 +80,7 @@ function listAppsFiltered(): Array<{
   version: string;
   contentId: string;
 }> {
-  return listApps().map((a) => {
+  return (apps ?? listApps()).map((a) => {
     const version = a.version ?? "1.0.0";
     const contentId = computeContentId(a.name);
     return {
@@ -354,7 +356,11 @@ async function openBundle(filePath: string): Promise<Record<string, unknown>> {
 // Route handlers
 // ---------------------------------------------------------------------------
 
-function handleListApps() {
+function handleListApps({ queryParams }: RouteHandlerArgs) {
+  const conversationId = queryParams?.conversationId;
+  if (conversationId) {
+    return { apps: listAppsFiltered(listAppsByConversation(conversationId)) };
+  }
   return { apps: listAppsFiltered() };
 }
 
@@ -511,10 +517,7 @@ function handleUpdatePreview({ pathParams, body }: RouteHandlerArgs) {
   return { success: true, appId };
 }
 
-async function handleGetHistory({
-  pathParams,
-  queryParams,
-}: RouteHandlerArgs) {
+async function handleGetHistory({ pathParams, queryParams }: RouteHandlerArgs) {
   const appId = pathParams?.id as string;
   const limit = queryParams?.limit ? Number(queryParams.limit) : undefined;
   const versions = await getAppHistory(appId, limit);
@@ -578,6 +581,13 @@ export const ROUTES: RouteDefinition[] = [
     summary: "List apps",
     description: "Return all locally installed apps.",
     tags: ["apps"],
+    queryParams: [
+      {
+        name: "conversationId",
+        schema: { type: "string" },
+        description: "Filter apps by conversation ID",
+      },
+    ],
     responseBody: z.object({
       apps: z.array(z.unknown()).describe("Array of app summary objects"),
     }),
@@ -716,8 +726,7 @@ export const ROUTES: RouteDefinition[] = [
     policyKey: "apps/open",
     handler: handleOpenApp,
     summary: "Open an app",
-    description:
-      "Compile (if needed) and return the app's HTML for rendering.",
+    description: "Compile (if needed) and return the app's HTML for rendering.",
     tags: ["apps"],
     responseBody: z.object({
       appId: z.string(),


### PR DESCRIPTION
## Summary
- Add conversationIds field to AppDefinition and helpers to track/query app-conversation associations
- Hook into app_create, app_refresh, and app_open to record conversationIds
- Add ?conversationId= query param to GET /v1/apps endpoint

Part of plan: conv-artifacts-open.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
