### PR TITLE
feat(daemon): add document_conversations junction table and filtering

### DIFF
--- a/assistant/src/__tests__/document-conversations.test.ts
+++ b/assistant/src/__tests__/document-conversations.test.ts
@@ -1,0 +1,332 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import { migrateCreateDocumentConversations } from "../memory/migrations/233-document-conversations.js";
+import * as schema from "../memory/schema.js";
+
+interface TableRow {
+  name: string;
+}
+
+interface ColumnRow {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+interface JunctionRow {
+  surface_id: string;
+  conversation_id: string;
+  created_at: number;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapCheckpointsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function bootstrapConversationsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    )
+  `);
+}
+
+function bootstrapDocumentsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+/** Full bootstrap: checkpoints + conversations + documents (prereqs for the migration). */
+function bootstrapAll(raw: Database): void {
+  bootstrapCheckpointsTable(raw);
+  bootstrapConversationsTable(raw);
+  bootstrapDocumentsTable(raw);
+}
+
+describe("document_conversations migration", () => {
+  test("creates table with expected columns, composite PK, and index", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapAll(raw);
+
+    migrateCreateDocumentConversations(db);
+
+    const tableRow = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='document_conversations'`,
+      )
+      .get() as TableRow | null;
+    expect(tableRow?.name).toBe("document_conversations");
+
+    const columns = raw
+      .query(`PRAGMA table_info(document_conversations)`)
+      .all() as ColumnRow[];
+
+    const byName = new Map(columns.map((c) => [c.name, c]));
+    expect(byName.get("surface_id")?.type).toBe("TEXT");
+    expect(byName.get("surface_id")?.notnull).toBe(1);
+    expect(byName.get("surface_id")?.pk).toBe(1);
+    expect(byName.get("conversation_id")?.type).toBe("TEXT");
+    expect(byName.get("conversation_id")?.notnull).toBe(1);
+    expect(byName.get("conversation_id")?.pk).toBe(2);
+    expect(byName.get("created_at")?.type).toBe("INTEGER");
+    expect(byName.get("created_at")?.notnull).toBe(1);
+
+    // Verify index on conversation_id
+    const indexRow = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_doc_conv_conversation_id'`,
+      )
+      .get() as TableRow | null;
+    expect(indexRow?.name).toBe("idx_doc_conv_conversation_id");
+  });
+
+  test("backfills from existing documents.conversation_id", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapAll(raw);
+
+    // Seed a conversation and a document before running the migration
+    raw
+      .query(`INSERT INTO conversations (id, created_at) VALUES (?, ?)`)
+      .run("conv-1", 1000);
+    raw
+      .query(
+        `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("doc-1", "conv-1", "Test Doc", "content", 2, 1000, 1000);
+
+    migrateCreateDocumentConversations(db);
+
+    const rows = raw
+      .query(
+        `SELECT surface_id, conversation_id, created_at FROM document_conversations`,
+      )
+      .all() as JunctionRow[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.surface_id).toBe("doc-1");
+    expect(rows[0]!.conversation_id).toBe("conv-1");
+    expect(rows[0]!.created_at).toBe(1000);
+  });
+
+  test("saving a document populates the junction table", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapAll(raw);
+    migrateCreateDocumentConversations(db);
+
+    // Insert a conversation + document + junction row manually (simulating saveDocument)
+    raw
+      .query(`INSERT INTO conversations (id, created_at) VALUES (?, ?)`)
+      .run("conv-a", 2000);
+    raw
+      .query(
+        `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("doc-a", "conv-a", "Title A", "body", 1, 2000, 2000);
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-a", "conv-a", 2000);
+
+    const rows = raw
+      .query(
+        `SELECT surface_id, conversation_id FROM document_conversations WHERE surface_id = ?`,
+      )
+      .all("doc-a") as JunctionRow[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.conversation_id).toBe("conv-a");
+  });
+
+  test("saving the same document from a second conversation adds a second row", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapAll(raw);
+    migrateCreateDocumentConversations(db);
+
+    raw
+      .query(`INSERT INTO conversations (id, created_at) VALUES (?, ?)`)
+      .run("conv-a", 2000);
+    raw
+      .query(
+        `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("doc-a", "conv-a", "Title A", "body", 1, 2000, 2000);
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-a", "conv-a", 2000);
+
+    // Associate with a second conversation (no FK to conversations, so conv-b need not exist)
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-a", "conv-b", 3000);
+
+    const rows = raw
+      .query(
+        `SELECT surface_id, conversation_id FROM document_conversations WHERE surface_id = ? ORDER BY conversation_id`,
+      )
+      .all("doc-a") as JunctionRow[];
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.conversation_id).toBe("conv-a");
+    expect(rows[1]!.conversation_id).toBe("conv-b");
+  });
+
+  test("listDocuments with conversationId returns matched conversation_id via junction", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapAll(raw);
+    migrateCreateDocumentConversations(db);
+
+    raw
+      .query(`INSERT INTO conversations (id, created_at) VALUES (?, ?)`)
+      .run("conv-origin", 1000);
+    raw
+      .query(
+        `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("doc-x", "conv-origin", "My Doc", "content here", 2, 1000, 1000);
+
+    // Associate with conv-origin AND conv-viewer
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-x", "conv-origin", 1000);
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-x", "conv-viewer", 2000);
+
+    // Query via junction for conv-viewer — should return conv-viewer as conversation_id
+    const results = raw
+      .query(
+        /*sql*/ `
+        SELECT d.surface_id, dc.conversation_id AS conversation_id,
+               d.title, d.word_count, d.created_at, d.updated_at
+        FROM documents d
+        INNER JOIN document_conversations dc ON d.surface_id = dc.surface_id
+        WHERE dc.conversation_id = ?
+        ORDER BY d.updated_at DESC
+      `,
+      )
+      .all("conv-viewer") as {
+      surface_id: string;
+      conversation_id: string;
+      title: string;
+    }[];
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.surface_id).toBe("doc-x");
+    expect(results[0]!.conversation_id).toBe("conv-viewer"); // matched, not origin
+    expect(results[0]!.title).toBe("My Doc");
+  });
+
+  test("CASCADE: deleting a document removes junction entries", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapAll(raw);
+    migrateCreateDocumentConversations(db);
+
+    raw
+      .query(`INSERT INTO conversations (id, created_at) VALUES (?, ?)`)
+      .run("conv-c", 1000);
+    raw
+      .query(
+        `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("doc-del", "conv-c", "To Delete", "bye", 1, 1000, 1000);
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-del", "conv-c", 1000);
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-del", "conv-d", 2000);
+
+    // Verify junction rows exist
+    let junctionRows = raw
+      .query(`SELECT * FROM document_conversations WHERE surface_id = ?`)
+      .all("doc-del") as JunctionRow[];
+    expect(junctionRows).toHaveLength(2);
+
+    // Delete the document — should cascade to junction table
+    raw.query(`DELETE FROM documents WHERE surface_id = ?`).run("doc-del");
+
+    junctionRows = raw
+      .query(`SELECT * FROM document_conversations WHERE surface_id = ?`)
+      .all("doc-del") as JunctionRow[];
+    expect(junctionRows).toHaveLength(0);
+  });
+
+  test("re-running the migration is idempotent", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapAll(raw);
+
+    migrateCreateDocumentConversations(db);
+
+    // Insert data
+    raw
+      .query(`INSERT INTO conversations (id, created_at) VALUES (?, ?)`)
+      .run("conv-idem", 1000);
+    raw
+      .query(
+        `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("doc-idem", "conv-idem", "Title", "body", 1, 1000, 1000);
+    raw
+      .query(
+        `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+      )
+      .run("doc-idem", "conv-idem", 1000);
+
+    // Re-run should not throw or duplicate data
+    expect(() => migrateCreateDocumentConversations(db)).not.toThrow();
+
+    const rows = raw
+      .query(`SELECT * FROM document_conversations WHERE surface_id = ?`)
+      .all("doc-idem") as JunctionRow[];
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -66,6 +66,7 @@ import {
   migrateConversationsLastMessageAt,
   migrateConversationsThreadTypeIndex,
   migrateCreateConversationGraphMemoryState,
+  migrateCreateDocumentConversations,
   migrateCreateMemoryGraphNodeEdits,
   migrateCreateMemoryGraphTables,
   migrateCreateMemoryRecallLogs,
@@ -390,6 +391,7 @@ export function initializeDb(): void {
     migrate230AcpSessionHistory,
     migrate231RepairMemoryGraphEventDates,
     migrateActivationState,
+    migrateCreateDocumentConversations,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/233-document-conversations.ts
+++ b/assistant/src/memory/migrations/233-document-conversations.ts
@@ -1,0 +1,54 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_document_conversations_v1";
+
+/**
+ * Create the document_conversations junction table.
+ *
+ * Tracks which conversations each document is associated with. A document may
+ * appear in multiple conversations (e.g. opened from search, linked by the
+ * assistant, etc.), so the relationship is many-to-many.
+ *
+ * The FK on surface_id cascades deletes from documents — when a document is
+ * removed, all its conversation associations are cleaned up automatically.
+ *
+ * There is intentionally NO FK to the conversations table. Conversation IDs may
+ * be synthetic or pre-resolved UUIDs that don't yet exist in the conversations
+ * table at insertion time. This means orphaned rows can accumulate when
+ * conversations are deleted. This is acceptable — the rows are tiny (two strings
+ * + timestamp) and the composite PK prevents unbounded growth per document. If
+ * cleanup becomes a concern, add a periodic sweep or hook into the conversation
+ * deletion path in memory/job-handlers/cleanup.ts.
+ *
+ * The migration also backfills from the existing documents.conversation_id column
+ * so that pre-existing document–conversation relationships are preserved.
+ */
+export function migrateCreateDocumentConversations(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS document_conversations (
+        surface_id TEXT NOT NULL,
+        conversation_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
+        PRIMARY KEY (surface_id, conversation_id),
+        FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+      )
+    `);
+
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_doc_conv_conversation_id
+      ON document_conversations(conversation_id)
+    `);
+
+    // Backfill: seed junction table from existing documents.conversation_id
+    raw.exec(/*sql*/ `
+      INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at)
+      SELECT surface_id, conversation_id, created_at
+      FROM documents
+    `);
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -181,6 +181,7 @@ export {
   downActivationState,
   migrateActivationState,
 } from "./232-activation-state.js";
+export { migrateCreateDocumentConversations } from "./233-document-conversations.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -26,6 +26,23 @@ interface DocumentRow {
 type DocumentListRow = Omit<DocumentRow, "content">;
 
 // ---------------------------------------------------------------------------
+// Junction table helper
+// ---------------------------------------------------------------------------
+
+/** Insert a document–conversation association (idempotent via INSERT OR IGNORE). */
+export function addDocumentConversation(
+  surfaceId: string,
+  conversationId: string,
+): void {
+  rawRun(
+    /*sql*/ `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    surfaceId,
+    conversationId,
+    Date.now(),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Shared business logic (used by both message handlers and HTTP routes)
 // ---------------------------------------------------------------------------
 
@@ -54,6 +71,7 @@ function saveDocument(params: {
       now,
       now,
     );
+    addDocumentConversation(params.surfaceId, params.conversationId);
     log.info(
       { surfaceId: params.surfaceId, title: params.title },
       "Saved document",
@@ -123,20 +141,29 @@ function listDocuments(conversationId?: string): Array<{
   updatedAt: number;
 }> {
   try {
-    let query = /*sql*/ `
-      SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
-      FROM documents
-    `;
-    const params: string[] = [];
+    let results: DocumentListRow[];
 
     if (conversationId) {
-      query += " WHERE conversation_id = ?";
-      params.push(conversationId);
+      // Query via junction table so we return the *matched* conversation_id
+      // (not the origin conversation_id from the documents table).
+      results = rawAll<DocumentListRow>(
+        /*sql*/ `
+        SELECT d.surface_id, dc.conversation_id AS conversation_id,
+               d.title, d.word_count, d.created_at, d.updated_at
+        FROM documents d
+        INNER JOIN document_conversations dc ON d.surface_id = dc.surface_id
+        WHERE dc.conversation_id = ?
+        ORDER BY d.updated_at DESC
+        `,
+        conversationId,
+      );
+    } else {
+      results = rawAll<DocumentListRow>(/*sql*/ `
+        SELECT surface_id, conversation_id, title, word_count, created_at, updated_at
+        FROM documents
+        ORDER BY updated_at DESC
+        `);
     }
-
-    query += " ORDER BY updated_at DESC";
-
-    const results = rawAll<DocumentListRow>(query, ...params);
 
     log.info({ count: results.length }, "Listed documents");
     return results.map((row) => ({
@@ -233,13 +260,8 @@ export const ROUTES: RouteDefinition[] = [
       surfaceId: z.string(),
     }),
     handler: ({ body }) => {
-      const {
-        surfaceId,
-        conversationId,
-        title,
-        content,
-        wordCount,
-      } = (body ?? {}) as {
+      const { surfaceId, conversationId, title, content, wordCount } = (body ??
+        {}) as {
         surfaceId?: string;
         conversationId?: string;
         title?: string;


### PR DESCRIPTION
## Summary
- Add document_conversations junction table with FK CASCADE, composite PK, and conversation_id index
- Backfill existing documents into the junction table from their conversation_id
- Update saveDocument to auto-insert into junction table
- Update listDocuments to query via junction table when conversationId filter is provided

Part of plan: conv-artifacts-open.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
