### PR TITLE
feat(daemon): backfill app conversationIds from conversation message history

### DIFF
--- a/assistant/src/__tests__/app-conversation-ids-backfill.test.ts
+++ b/assistant/src/__tests__/app-conversation-ids-backfill.test.ts
@@ -1,0 +1,278 @@
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  addAppConversationId,
+  backfillAppConversationIds,
+  createApp,
+  getApp,
+} from "../memory/app-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { rawRun } from "../memory/raw-query.js";
+
+// Initialize db once for all tests
+initializeDb();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let testDataDir: string;
+
+function freshTempDir(): string {
+  return join(
+    tmpdir(),
+    `vellum-app-backfill-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+}
+
+function makeAppParams(name: string) {
+  return {
+    name,
+    schemaJson: "{}",
+    htmlDefinition: "<h1>Hello</h1>",
+  };
+}
+
+/** Insert a message row with the given conversation_id and content JSON. */
+function insertMessage(
+  conversationId: string,
+  content: unknown[],
+  role = "assistant",
+): void {
+  const id = `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const contentStr = JSON.stringify(content);
+  rawRun(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+    id,
+    conversationId,
+    role,
+    contentStr,
+    Date.now(),
+  );
+}
+
+/** Insert a conversation row so FK constraints are satisfied. */
+function insertConversation(id: string): void {
+  const now = Date.now();
+  rawRun(
+    `INSERT OR IGNORE INTO conversations (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)`,
+    id,
+    "test",
+    now,
+    now,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Clean database tables between tests
+  const db = getDb();
+  db.run(`DELETE FROM messages`);
+  db.run(`DELETE FROM conversations`);
+
+  // Fresh temp dir for app-store filesystem operations
+  testDataDir = freshTempDir();
+  process.env.VELLUM_WORKSPACE_DIR = testDataDir;
+});
+
+afterEach(() => {
+  if (existsSync(testDataDir)) {
+    rmSync(testDataDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// backfillAppConversationIds
+// ---------------------------------------------------------------------------
+
+describe("backfillAppConversationIds", () => {
+  test("populates conversationIds from ui_surface blocks in messages", () => {
+    const app = createApp(makeAppParams("My App"));
+    const convId = "conv-backfill-1";
+    insertConversation(convId);
+
+    // Insert a message with a ui_surface block referencing the app
+    insertMessage(convId, [
+      { type: "text", text: "Here is your app" },
+      {
+        type: "ui_surface",
+        surfaceType: "dynamic_page",
+        data: { appId: app.id, html: "<h1>App</h1>" },
+      },
+    ]);
+
+    backfillAppConversationIds();
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual([convId]);
+  });
+
+  test("handles multiple apps and conversations", () => {
+    const app1 = createApp(makeAppParams("App One"));
+    const app2 = createApp(makeAppParams("App Two"));
+    const conv1 = "conv-multi-1";
+    const conv2 = "conv-multi-2";
+    insertConversation(conv1);
+    insertConversation(conv2);
+
+    // app1 referenced in conv1 and conv2
+    insertMessage(conv1, [
+      {
+        type: "ui_surface",
+        surfaceType: "dynamic_page",
+        data: { appId: app1.id, html: "<h1>A1</h1>" },
+      },
+    ]);
+    insertMessage(conv2, [
+      {
+        type: "ui_surface",
+        surfaceType: "dynamic_page",
+        data: { appId: app1.id, html: "<h1>A1</h1>" },
+      },
+    ]);
+
+    // app2 referenced only in conv2
+    insertMessage(conv2, [
+      {
+        type: "ui_surface",
+        surfaceType: "dynamic_page",
+        data: { appId: app2.id, html: "<h1>A2</h1>" },
+      },
+    ]);
+
+    backfillAppConversationIds();
+
+    const loaded1 = getApp(app1.id);
+    expect(loaded1?.conversationIds?.sort()).toEqual([conv1, conv2].sort());
+
+    const loaded2 = getApp(app2.id);
+    expect(loaded2?.conversationIds).toEqual([conv2]);
+  });
+
+  test("is idempotent — running twice does not duplicate associations", () => {
+    const app = createApp(makeAppParams("Idempotent App"));
+    const convId = "conv-idemp-1";
+    insertConversation(convId);
+
+    insertMessage(convId, [
+      {
+        type: "ui_surface",
+        surfaceType: "dynamic_page",
+        data: { appId: app.id, html: "<h1>App</h1>" },
+      },
+    ]);
+
+    backfillAppConversationIds();
+    backfillAppConversationIds();
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual([convId]);
+  });
+
+  test("apps with no message references remain unchanged", () => {
+    const app = createApp(makeAppParams("Untouched App"));
+    const convId = "conv-unrelated";
+    insertConversation(convId);
+
+    // Insert a message with no ui_surface blocks
+    insertMessage(convId, [{ type: "text", text: "Hello world" }]);
+
+    backfillAppConversationIds();
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toBeUndefined();
+  });
+
+  test("skips malformed message rows without error", () => {
+    const app = createApp(makeAppParams("Robust App"));
+    const convId = "conv-malformed";
+    insertConversation(convId);
+
+    // Insert a message with invalid JSON that happens to match the LIKE filter
+    const msgId = `msg-malformed-${Date.now()}`;
+    rawRun(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)`,
+      msgId,
+      convId,
+      "assistant",
+      'not valid json but has "type":"ui_surface" in it',
+      Date.now(),
+    );
+
+    // Also insert a valid message referencing the app
+    const convId2 = "conv-valid";
+    insertConversation(convId2);
+    insertMessage(convId2, [
+      {
+        type: "ui_surface",
+        surfaceType: "dynamic_page",
+        data: { appId: app.id, html: "<h1>App</h1>" },
+      },
+    ]);
+
+    // Should not throw, and should still process the valid message
+    backfillAppConversationIds();
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual([convId2]);
+  });
+
+  test("skips ui_surface blocks without data.appId", () => {
+    const app = createApp(makeAppParams("No AppId App"));
+    const convId = "conv-no-appid";
+    insertConversation(convId);
+
+    // ui_surface block without appId in data
+    insertMessage(convId, [
+      {
+        type: "ui_surface",
+        surfaceType: "card",
+        data: { title: "Hello", body: "World" },
+      },
+    ]);
+
+    backfillAppConversationIds();
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toBeUndefined();
+  });
+
+  test("preserves existing conversationIds added before backfill", () => {
+    const app = createApp(makeAppParams("Pre-existing App"));
+    const existingConvId = "conv-existing";
+    const backfillConvId = "conv-from-backfill";
+    insertConversation(existingConvId);
+    insertConversation(backfillConvId);
+
+    // Manually add a conversationId before backfill
+    addAppConversationId(app.id, existingConvId);
+
+    // Insert a message referencing the app from a different conversation
+    insertMessage(backfillConvId, [
+      {
+        type: "ui_surface",
+        surfaceType: "dynamic_page",
+        data: { appId: app.id, html: "<h1>App</h1>" },
+      },
+    ]);
+
+    backfillAppConversationIds();
+
+    const loaded = getApp(app.id);
+    expect(loaded?.conversationIds).toEqual([existingConvId, backfillConvId]);
+  });
+});

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -36,7 +36,9 @@ import {
 
 import type { EditEngineResult } from "../tools/shared/filesystem/edit-engine.js";
 import { applyEdit } from "../tools/shared/filesystem/edit-engine.js";
+import { getLogger } from "../util/logger.js";
 import { getDataDir } from "../util/platform.js";
+import { rawAll } from "./raw-query.js";
 
 export interface AppDefinition {
   id: string;
@@ -945,6 +947,88 @@ export function listAppsByConversation(
   return listApps().filter((app) =>
     app.conversationIds?.includes(conversationId),
   );
+}
+
+// ---------------------------------------------------------------------------
+// Backfill: scan message history for ui_surface blocks referencing apps
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-pass scan over the messages table to populate `conversationIds` on
+ * existing app definitions. Finds messages containing `ui_surface` blocks
+ * with a `data.appId`, then calls `addAppConversationId` for each pair.
+ *
+ * Idempotent — `addAppConversationId` deduplicates, so running on every
+ * startup is safe. Wrapped in try/catch so failures never block daemon start.
+ */
+export function backfillAppConversationIds(): void {
+  const log = getLogger("app-store");
+  try {
+    const rows = rawAll<{ conversation_id: string; content: string }>(
+      `SELECT conversation_id, content FROM messages WHERE content LIKE '%"type":"ui_surface"%'`,
+    );
+
+    // Build appId → Set<conversationId> map in a single pass
+    const appConvMap = new Map<string, Set<string>>();
+
+    for (const row of rows) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(row.content);
+      } catch {
+        // Skip rows that fail to parse
+        continue;
+      }
+
+      if (!Array.isArray(parsed)) continue;
+
+      for (const block of parsed) {
+        if (
+          block &&
+          typeof block === "object" &&
+          (block as Record<string, unknown>).type === "ui_surface"
+        ) {
+          const data = (block as Record<string, unknown>).data;
+          if (data && typeof data === "object") {
+            const appId = (data as Record<string, unknown>).appId;
+            if (typeof appId === "string" && appId.length > 0) {
+              let convIds = appConvMap.get(appId);
+              if (!convIds) {
+                convIds = new Set<string>();
+                appConvMap.set(appId, convIds);
+              }
+              convIds.add(row.conversation_id);
+            }
+          }
+        }
+      }
+    }
+
+    // Apply associations
+    let appsUpdated = 0;
+    let associationsAdded = 0;
+
+    for (const [appId, conversationIds] of appConvMap) {
+      let appHadNewAssociation = false;
+      for (const conversationId of conversationIds) {
+        const added = addAppConversationId(appId, conversationId);
+        if (added) {
+          associationsAdded++;
+          appHadNewAssociation = true;
+        }
+      }
+      if (appHadNewAssociation) {
+        appsUpdated++;
+      }
+    }
+
+    log.info(
+      { appsUpdated, associationsAdded },
+      `Backfilled app conversationIds: ${appsUpdated} apps, ${associationsAdded} associations`,
+    );
+  } catch (err) {
+    log.error({ err }, "Failed to backfill app conversationIds");
+  }
 }
 
 export type { EditEngineResult };

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -11,6 +11,7 @@ import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { ensureDataDir, getDbPath } from "../util/platform.js";
+import { backfillAppConversationIds } from "./app-store.js";
 import { getDb, getSqlite } from "./db-connection.js";
 import { migrateToolCreatedItems } from "./graph/bootstrap.js";
 import {
@@ -392,6 +393,9 @@ export function initializeDb(): void {
     migrate231RepairMemoryGraphEventDates,
     migrateActivationState,
     migrateCreateDocumentConversations,
+    function migrateBackfillAppConversationIds() {
+      backfillAppConversationIds();
+    },
   ];
 
   // Run each migration step, catching and logging individual failures so one


### PR DESCRIPTION
## Summary
- Add backfillAppConversationIds() that scans messages table for ui_surface blocks with appIds
- Single-pass scan builds appId→conversationIds map, then patches app definitions
- Register as migration step in db-init.ts (idempotent, non-blocking)

Part of plan: conv-artifacts-open.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
