### PR TITLE
fix(ci): unblock anthropic-provider, memory-v2-backfill, and cache tests

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -1657,7 +1657,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     expect(sent[4].content[0].text).toBe("Follow-up question");
   });
 
-  test("multi-turn with workspace injection: only last user message gets 1h cache", async () => {
+  test("multi-turn with workspace injection: prev-turn + last user message get 1h cache", async () => {
     const messages: Message[] = [
       {
         role: "user",
@@ -1705,14 +1705,21 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     const userMsgs = sent.filter((m) => m.role === "user");
     expect(userMsgs).toHaveLength(3);
 
-    // Earlier user messages: no cache_control
-    for (const user of userMsgs.slice(0, -1)) {
-      for (const block of user.content) {
-        expect(block.cache_control).toBeUndefined();
-      }
+    // Oldest user message (turn 1): no cache_control
+    for (const block of userMsgs[0].content) {
+      expect(block.cache_control).toBeUndefined();
     }
 
-    // Last user message (turn 3): 1h cache on last block only
+    // Previous-turn anchor (turn 2): 1h cache on last block to preserve the
+    // cached prefix across turn transitions
+    const prevTurn = userMsgs[userMsgs.length - 2];
+    expect(prevTurn.content[0].cache_control).toBeUndefined();
+    expect(prevTurn.content[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+
+    // Current-turn anchor (turn 3): 1h cache on last block
     const lastUser = userMsgs[userMsgs.length - 1];
     expect(lastUser.content[0].cache_control).toBeUndefined();
     expect(lastUser.content[1].cache_control).toEqual({

--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -11,13 +11,20 @@
  *   - JSON output shape and exit-code behavior on IPC errors
  */
 
-import {
-  existsSync as actualExistsSync,
-  readFileSync as actualReadFileSync,
-} from "node:fs";
+import * as nodeFs from "node:fs";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
+
+// Snapshot the real fs functions into local constants BEFORE the
+// `mock.module("node:fs", ...)` below replaces the module's live bindings.
+// A bare `import { readFileSync as actualReadFileSync }` is an ESM live
+// binding — once the module is mocked the binding resolves to the mock,
+// so the fall-through call inside the mock recurses into itself and hangs.
+// Storing the function in a local variable captures the value at this
+// point and is unaffected by the later module replacement.
+const actualReadFileSync = nodeFs.readFileSync;
+const actualExistsSync = nodeFs.existsSync;
 
 // ---------------------------------------------------------------------------
 // Mock state

--- a/assistant/src/ipc/routes/__tests__/memory-v2-backfill.test.ts
+++ b/assistant/src/ipc/routes/__tests__/memory-v2-backfill.test.ts
@@ -17,6 +17,8 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import * as realJobsStore from "../../../memory/jobs-store.js";
+
 // ---------------------------------------------------------------------------
 // Module-level mock — capture every enqueue call so each test can assert the
 // route forwarded the correct (type, payload) tuple. The route file is
@@ -29,7 +31,14 @@ const enqueueCalls: Array<{
 }> = [];
 let nextJobId = 0;
 
+// Spread the real module's exports so transitive importers (e.g.
+// memory/auto-analysis-enqueue.ts pulled in via the CLI program → memory
+// indexer chain) get every named export they bind to at module-load time;
+// only `enqueueMemoryJob` is overridden so the route under test forwards
+// to the test stub. jobs-store.ts has no side-effecting top-level
+// statements, so loading it for the spread is safe.
 mock.module("../../../memory/jobs-store.js", () => ({
+  ...realJobsStore,
   enqueueMemoryJob: (type: string, payload: Record<string, unknown>) => {
     enqueueCalls.push({ type, payload });
     nextJobId += 1;
@@ -37,7 +46,8 @@ mock.module("../../../memory/jobs-store.js", () => ({
   },
 }));
 
-const { ROUTES: memoryV2Routes } = await import("../../../runtime/routes/memory-v2-routes.js");
+const { ROUTES: memoryV2Routes } =
+  await import("../../../runtime/routes/memory-v2-routes.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -45,7 +55,9 @@ const { ROUTES: memoryV2Routes } = await import("../../../runtime/routes/memory-
 
 type BackfillResult = { jobId: string };
 
-const backfillRoute = memoryV2Routes.find(r => r.operationId === "memory_v2_backfill")!;
+const backfillRoute = memoryV2Routes.find(
+  (r) => r.operationId === "memory_v2_backfill",
+)!;
 
 async function runRoute(
   params: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- Update multi-turn cache test to expect prev-turn anchor introduced in #28642.
- Spread real jobs-store exports into memory-v2-backfill mock so transitive importers (auto-analysis-enqueue chain pulled in via skill-store -> catalog-cache after #28635) keep resolving.
- Snapshot node:fs functions into locals before `mock.module` replaces the live ESM bindings, fixing the infinite-recursion hang in cache.test.ts.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25071353647/job/73452211303
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
