### PR TITLE
Revert "fix(oauth): default to managed mode on platform instances (#2…

### DIFF
--- a/assistant/src/cli/commands/oauth/shared.ts
+++ b/assistant/src/cli/commands/oauth/shared.ts
@@ -1,11 +1,6 @@
 import type { Command } from "commander";
 
-import { getIsPlatform } from "../../../config/env-registry.js";
-import {
-  getConfig,
-  getNestedValue,
-  loadRawConfig,
-} from "../../../config/loader.js";
+import { getConfig } from "../../../config/loader.js";
 import {
   getServiceMode,
   type Services,
@@ -45,13 +40,6 @@ export function getManagedServiceConfigKey(provider: string): string | null {
 
 /**
  * Determine whether a provider is running in platform-managed mode.
- *
- * When `IS_PLATFORM=true` and the provider supports managed mode, this
- * defaults to `true` unless the user has explicitly set the service mode
- * to `"your-own"` in the raw config file. This lets platform instances
- * use platform-managed OAuth credentials out of the box without requiring
- * a manual `assistant oauth mode <provider> --set managed` step.
- *
  * Returns false if config is unavailable (e.g. in test environments).
  */
 export function isManagedMode(provider: string): boolean {
@@ -59,22 +47,7 @@ export function isManagedMode(provider: string): boolean {
   if (!managedKey) return false;
   try {
     const services: Services = getConfig().services;
-    const mode = getServiceMode(services, managedKey as keyof Services);
-    if (mode === "managed") return true;
-
-    // On platform instances, default to managed mode for providers that
-    // support it — unless the user explicitly opted into "your-own".
-    if (getIsPlatform()) {
-      const rawMode = getNestedValue(
-        loadRawConfig(),
-        `services.${managedKey}.mode`,
-      );
-      // If the raw config doesn't have an explicit mode entry, the "your-own"
-      // value came from the schema default — override it to managed on platform.
-      if (rawMode === undefined) return true;
-    }
-
-    return false;
+    return getServiceMode(services, managedKey as keyof Services) === "managed";
   } catch {
     return false;
   }

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -1,5 +1,4 @@
-import { getIsPlatform } from "../config/env-registry.js";
-import { getConfig, getNestedValue, loadRawConfig } from "../config/loader.js";
+import { getConfig } from "../config/loader.js";
 import {
   getServiceMode,
   type Services,
@@ -52,15 +51,7 @@ export async function resolveOAuthConnection(
 
   if (managedKey && managedKey in ServicesSchema.shape) {
     const services: Services = getConfig().services;
-    const explicitMode = getServiceMode(services, managedKey as keyof Services);
-    // Treat as managed when explicitly configured OR when on a platform
-    // instance and the user hasn't explicitly opted into "your-own".
-    const effectivelyManaged =
-      explicitMode === "managed" ||
-      (getIsPlatform() &&
-        getNestedValue(loadRawConfig(), `services.${managedKey}.mode`) ===
-          undefined);
-    if (effectivelyManaged) {
+    if (getServiceMode(services, managedKey as keyof Services) === "managed") {
       const client = await VellumPlatformClient.create();
       if (!client || !client.platformAssistantId) {
         const detail = !client


### PR DESCRIPTION
Reverts https://github.com/vellum-ai/vellum-assistant/pull/28629

We'll want to control these defaults at time of hatch rather than at runtime.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
