### PR TITLE
feat(client): add ConversationArtifact model, client, and fix document autosave

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -58,6 +58,11 @@ final class DocumentManager {
         self.wordCount = initialContent.split(whereSeparator: \.isWhitespace).count
         self.hasActiveDocument = true
 
+        // Persist initial content to the daemon so the document reaches the junction table
+        if !initialContent.isEmpty {
+            scheduleAutoSave()
+        }
+
         // Initialize editor with content (or store as pending if coordinator not ready)
         if let coordinator = editorCoordinator {
             coordinator.setInitialContent(title: title, markdown: initialContent)
@@ -116,6 +121,7 @@ final class DocumentManager {
         self.title = title
         self.currentContent = content
         self.wordCount = wordCount
+        scheduleAutoSave()
     }
 
     func closeDocument() {

--- a/clients/shared/Features/Chat/ConversationArtifact.swift
+++ b/clients/shared/Features/Chat/ConversationArtifact.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// The type of artifact associated with a conversation.
+public enum ArtifactType: Sendable, Equatable, Hashable {
+    case app
+    case document
+}
+
+/// A unified representation of an artifact (app or document) associated with a conversation.
+public struct ConversationArtifact: Identifiable, Equatable, Hashable, Sendable {
+    public let id: String
+    public let type: ArtifactType
+    public let title: String
+    public let appId: String?
+    public let surfaceId: String?
+
+    public init(id: String, type: ArtifactType, title: String, appId: String? = nil, surfaceId: String? = nil) {
+        self.id = id
+        self.type = type
+        self.title = title
+        self.appId = appId
+        self.surfaceId = surfaceId
+    }
+}

--- a/clients/shared/Network/AppsClient.swift
+++ b/clients/shared/Network/AppsClient.swift
@@ -9,6 +9,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppsC
 /// version history for both local and shared apps.
 public protocol AppsClientProtocol {
     func fetchAppsList() async -> AppsListResponse?
+    func fetchAppsList(conversationId: String?) async -> AppsListResponse?
     func openApp(id: String) async -> AppOpenResult?
     func deleteApp(id: String) async -> AppDeleteResponse?
     func fetchAppPreview(appId: String) async -> AppPreviewResponse?
@@ -23,6 +24,13 @@ public protocol AppsClientProtocol {
     func forkSharedApp(uuid: String) async -> ForkSharedAppResponseMessage?
     func shareAppCloud(appId: String) async -> ShareAppCloudResponse?
     func fetchAppData(appId: String, method: String, recordId: String?, data: [String: AnyCodable]?, surfaceId: String, callId: String) async -> AppDataResponse?
+}
+
+/// Default implementation so existing conformances only need the no-arg variant.
+public extension AppsClientProtocol {
+    func fetchAppsList(conversationId: String?) async -> AppsListResponse? {
+        return await fetchAppsList()
+    }
 }
 
 /// REST shape returned by `/v1/apps/:id/open`.
@@ -122,9 +130,18 @@ public struct AppsClient: AppsClientProtocol {
     // MARK: - Local Apps
 
     public func fetchAppsList() async -> AppsListResponse? {
+        return await fetchAppsList(conversationId: nil)
+    }
+
+    public func fetchAppsList(conversationId: String?) async -> AppsListResponse? {
         do {
+            var params: [String: String] = [:]
+            if let conversationId { params["conversationId"] = conversationId }
+
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/apps", timeout: 10
+                path: "assistants/{assistantId}/apps",
+                params: params.isEmpty ? nil : params,
+                timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchAppsList failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/ConversationArtifactsClient.swift
+++ b/clients/shared/Network/ConversationArtifactsClient.swift
@@ -1,0 +1,72 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ConversationArtifactsClient")
+
+/// Client for fetching all artifacts (apps and documents) associated with a conversation.
+public protocol ConversationArtifactsClientProtocol {
+    func fetchArtifacts(conversationId: String) async -> [ConversationArtifact]
+}
+
+/// Concrete implementation that fetches apps and documents concurrently and merges them
+/// into a unified, sorted list of ``ConversationArtifact`` values.
+public struct ConversationArtifactsClient: ConversationArtifactsClientProtocol {
+    private let appsClient: AppsClientProtocol
+    private let documentClient: DocumentClientProtocol
+
+    public init(
+        appsClient: AppsClientProtocol = AppsClient(),
+        documentClient: DocumentClientProtocol = DocumentClient()
+    ) {
+        self.appsClient = appsClient
+        self.documentClient = documentClient
+    }
+
+    public func fetchArtifacts(conversationId: String) async -> [ConversationArtifact] {
+        async let appsResponse = appsClient.fetchAppsList(conversationId: conversationId)
+        async let docsResponse = documentClient.fetchList(conversationId: conversationId)
+        let (apps, docs) = await (appsResponse, docsResponse)
+
+        var artifacts: [ConversationArtifact] = []
+
+        if let apps {
+            let appArtifacts = apps.apps.map { app in
+                ConversationArtifact(
+                    id: app.id,
+                    type: .app,
+                    title: app.name,
+                    appId: app.id,
+                    surfaceId: nil
+                )
+            }
+            artifacts.append(contentsOf: appArtifacts)
+        } else {
+            log.warning("fetchArtifacts: apps fetch failed for conversationId=\(conversationId)")
+        }
+
+        if let docs {
+            let docArtifacts = docs.documents.map { doc in
+                ConversationArtifact(
+                    id: doc.surfaceId,
+                    type: .document,
+                    title: doc.title,
+                    appId: nil,
+                    surfaceId: doc.surfaceId
+                )
+            }
+            artifacts.append(contentsOf: docArtifacts)
+        } else {
+            log.warning("fetchArtifacts: documents fetch failed for conversationId=\(conversationId)")
+        }
+
+        // Sort: apps first, then documents; each group alphabetical by title
+        artifacts.sort { lhs, rhs in
+            if lhs.type != rhs.type {
+                return lhs.type == .app
+            }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+
+        return artifacts
+    }
+}


### PR DESCRIPTION
## Summary
- Add ConversationArtifact model and ConversationArtifactsClient for fetching artifacts by conversation
- Update AppsClient to support ?conversationId= query param
- Fix DocumentManager autosave: createDocument and updateContent now schedule saves

Part of plan: conv-artifacts-open.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
