### PR TITLE
fix(trust): scope ThresholdClient API paths to assistant

### DIFF
--- a/clients/shared/Network/ThresholdClient.swift
+++ b/clients/shared/Network/ThresholdClient.swift
@@ -90,7 +90,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
 
     public func getGlobalThresholds() async throws -> GlobalThresholds {
         let response = try await GatewayHTTPClient.get(
-            path: "permissions/thresholds", timeout: 10
+            path: "assistants/{assistantId}/permissions/thresholds", timeout: 10
         )
         guard response.isSuccess else {
             log.error("getGlobalThresholds failed (HTTP \(response.statusCode))")
@@ -105,7 +105,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
             "autonomous": thresholds.autonomous,
         ]
         let response = try await GatewayHTTPClient.put(
-            path: "permissions/thresholds", json: body, timeout: 10
+            path: "assistants/{assistantId}/permissions/thresholds", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("setGlobalThresholds failed (HTTP \(response.statusCode))")
@@ -115,7 +115,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
 
     public func getConversationOverride(conversationId: String) async throws -> String? {
         let response = try await GatewayHTTPClient.get(
-            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
+            path: "assistants/{assistantId}/permissions/thresholds/conversations/\(conversationId)", timeout: 10
         )
         if response.statusCode == 404 {
             return nil
@@ -131,7 +131,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
     public func setConversationOverride(conversationId: String, threshold: String) async throws {
         let body: [String: Any] = ["threshold": threshold]
         let response = try await GatewayHTTPClient.put(
-            path: "permissions/thresholds/conversations/\(conversationId)", json: body, timeout: 10
+            path: "assistants/{assistantId}/permissions/thresholds/conversations/\(conversationId)", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("setConversationOverride failed (HTTP \(response.statusCode))")
@@ -141,7 +141,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
 
     public func deleteConversationOverride(conversationId: String) async throws {
         let response = try await GatewayHTTPClient.delete(
-            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
+            path: "assistants/{assistantId}/permissions/thresholds/conversations/\(conversationId)", timeout: 10
         )
         guard response.isSuccess else {
             log.error("deleteConversationOverride failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
- Prefix all `ThresholdClient` API paths with `assistants/{assistantId}/` to match the fix applied to `TrustRuleClient` in b25c543
- Affects global threshold get/set and per-conversation override get/set/delete endpoints
- Ensures threshold operations are properly scoped to the assistant on platform instances

## Original prompt
Apply the same assistants/{assistantId}/ path prefix fix from TrustRuleClient (commit b25c543) to ThresholdClient for risk threshold conversation override paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
