### PR TITLE
feat(macOS): add conversation artifacts button and popover to chat view

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -21,6 +21,7 @@ extension Notification.Name {
     static let refreshAppsCache = Notification.Name("MainWindow.refreshAppsCache")
     static let assistantFeatureFlagDidChange = Notification.Name("assistantFeatureFlagDidChange")
     static let localBootstrapCompleted = Notification.Name("localBootstrapCompleted")
+    static let documentDidSave = Notification.Name("DocumentManager.documentDidSave")
 }
 
 private let apiKeyLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "APIKeyManager")

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -45,6 +45,8 @@ struct ChatView: View {
     var onAddFunds: (() -> Void)? = nil
     var onOpenModelsAndServices: (() -> Void)? = nil
     var onBootstrapSendLogs: (() -> Void)?
+    var onOpenConversationApp: ((ConversationArtifact) -> Void)? = nil
+    var onOpenConversationDocument: ((ConversationArtifact) -> Void)? = nil
 
     // MARK: - Recovery Mode (managed assistants only)
 
@@ -172,20 +174,29 @@ struct ChatView: View {
             return .handled
         }
         .overlay(alignment: .topTrailing) {
-            if isSearchActive {
-                ChatSearchBar(
-                    searchText: $searchText,
-                    matchCount: searchMatches.count,
-                    currentMatchIndex: currentMatchIndex,
-                    onPrevious: { navigateMatch(delta: -1) },
-                    onNext: { navigateMatch(delta: 1) },
-                    onDismiss: { dismissSearch() }
-                )
-                .padding(.trailing, VSpacing.xl)
-                .padding(.top, VSpacing.sm)
-                .transition(.opacity.combined(with: .move(edge: .top)))
-                .layoutHangSignpost("chat.searchBar")
+            VStack(alignment: .trailing, spacing: VSpacing.sm) {
+                if isSearchActive {
+                    ChatSearchBar(
+                        searchText: $searchText,
+                        matchCount: searchMatches.count,
+                        currentMatchIndex: currentMatchIndex,
+                        onPrevious: { navigateMatch(delta: -1) },
+                        onNext: { navigateMatch(delta: 1) },
+                        onDismiss: { dismissSearch() }
+                    )
+                    .layoutHangSignpost("chat.searchBar")
+                }
+                if !isEmptyState && !shouldShowSkeleton && !isBootstrapping {
+                    ConversationArtifactsButton(
+                        artifacts: viewModel.conversationArtifacts,
+                        onOpenApp: { onOpenConversationApp?($0) },
+                        onOpenDocument: { onOpenConversationDocument?($0) }
+                    )
+                }
             }
+            .padding(.trailing, VSpacing.xl)
+            .padding(.top, VSpacing.sm)
+            .transition(.opacity.combined(with: .move(edge: .top)))
         }
         .animation(VAnimation.fast, value: isSearchActive)
         .onChange(of: searchText) {

--- a/clients/macos/vellum-assistant/Features/Chat/ConversationArtifactsButton.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ConversationArtifactsButton.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Compact button that shows the count of conversation artifacts (apps and documents).
+/// Tapping it opens a popover listing each artifact with appropriate actions.
+struct ConversationArtifactsButton: View {
+    let artifacts: [ConversationArtifact]
+    let onOpenApp: (ConversationArtifact) -> Void
+    let onOpenDocument: (ConversationArtifact) -> Void
+
+    @State private var isPopoverPresented = false
+    @State private var hoveredArtifactId: String?
+
+    var body: some View {
+        if artifacts.isEmpty {
+            EmptyView()
+        } else {
+            Button {
+                isPopoverPresented.toggle()
+            } label: {
+                HStack(spacing: VSpacing.xxs) {
+                    VIconView(.layers, size: 14)
+                    Text("\(artifacts.count)")
+                        .font(VFont.labelSmall)
+                }
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(.horizontal, VSpacing.sm)
+                .padding(.vertical, VSpacing.xs)
+                .background(VColor.surfaceOverlay)
+                .cornerRadius(VRadius.md)
+                .overlay(
+                    RoundedRectangle(cornerRadius: VRadius.md)
+                        .stroke(VColor.borderBase, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Conversation artifacts, \(artifacts.count) items")
+            .popover(isPresented: $isPopoverPresented, arrowEdge: .bottom) {
+                popoverContent
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var popoverContent: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            Text("Artifacts")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .padding(.horizontal, VSpacing.md)
+                .padding(.top, VSpacing.md)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(artifacts) { artifact in
+                        artifactRow(artifact)
+                    }
+                }
+            }
+            .padding(.bottom, VSpacing.sm)
+        }
+        .frame(width: 240)
+        .frame(maxHeight: 300)
+        .background(VColor.surfaceOverlay)
+        .cornerRadius(VRadius.lg)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.borderBase, lineWidth: 1)
+        )
+        .vShadow(VShadow.sm)
+    }
+
+    @ViewBuilder
+    private func artifactRow(_ artifact: ConversationArtifact) -> some View {
+        let isHovered = hoveredArtifactId == artifact.id
+        Button {
+            isPopoverPresented = false
+            switch artifact.type {
+            case .app:
+                onOpenApp(artifact)
+            case .document:
+                onOpenDocument(artifact)
+            }
+        } label: {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(artifact.type == .app ? .appWindow : .fileText, size: 14)
+                    .foregroundStyle(VColor.contentSecondary)
+                Text(artifact.title)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(isHovered ? VColor.surfaceBase : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            hoveredArtifactId = hovering ? artifact.id : nil
+        }
+        .accessibilityLabel(artifact.type == .app
+            ? "Open app: \(artifact.title)"
+            : "Open document: \(artifact.title)")
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -192,6 +192,7 @@ final class DocumentManager {
         if success {
             lastSaveError = nil
             log.info("Document saved successfully")
+            NotificationCenter.default.post(name: .documentDidSave, object: nil)
         } else {
             lastSaveError = error ?? "Unknown error"
             log.error("Document save failed: \(error ?? "unknown")")

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -712,6 +712,24 @@ extension MainWindowView {
                 onVoiceModeToggle: isVoiceModeEnabled ? {
                     toggleVoiceMode()
                 } : nil,
+                onOpenConversationApp: { [connectionManager, eventStreamClient] artifact in
+                    guard let appId = artifact.appId else { return }
+                    Task {
+                        await AppsClient.openAppAndDispatchSurface(
+                            id: appId,
+                            connectionManager: connectionManager,
+                            eventStreamClient: eventStreamClient
+                        )
+                    }
+                },
+                onOpenConversationDocument: { artifact in
+                    guard let surfaceId = artifact.surfaceId else { return }
+                    NotificationCenter.default.post(
+                        name: .openDocumentEditor,
+                        object: nil,
+                        userInfo: ["documentSurfaceId": surfaceId]
+                    )
+                },
                 conversationId: conversationManager.activeConversationId ?? conversationManager.draftLocalId,
                 anchorMessageId: $conversationManager.pendingAnchorMessageId,
                 highlightedMessageId: $conversationManager.highlightedMessageId
@@ -919,6 +937,8 @@ struct ActiveChatViewWrapper: View {
     var onEndVoiceMode: (() -> Void)? = nil
     var onDictateToggle: (() -> Void)? = nil
     var onVoiceModeToggle: (() -> Void)? = nil
+    var onOpenConversationApp: ((ConversationArtifact) -> Void)? = nil
+    var onOpenConversationDocument: ((ConversationArtifact) -> Void)? = nil
     var conversationId: UUID?
     @Binding var anchorMessageId: UUID?
     @Binding var highlightedMessageId: UUID?
@@ -962,6 +982,8 @@ struct ActiveChatViewWrapper: View {
                 onBootstrapSendLogs: {
                     AppDelegate.shared?.showLogReportWindow(reason: .bugReport)
                 },
+                onOpenConversationApp: onOpenConversationApp,
+                onOpenConversationDocument: onOpenConversationDocument,
                 recoveryMode: settingsStore.managedAssistantRecoveryMode,
                 isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                 onResumeAssistant: {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -228,6 +228,24 @@ private struct ThreadWindowContentView: View {
                         settingsStore.pendingSettingsTab = .developer
                         AppDelegate.shared?.showSettingsWindow(nil)
                     },
+                    onOpenConversationApp: { [viewModel] artifact in
+                        guard let appId = artifact.appId else { return }
+                        Task {
+                            await AppsClient.openAppAndDispatchSurface(
+                                id: appId,
+                                connectionManager: viewModel.connectionManager,
+                                eventStreamClient: viewModel.eventStreamClient
+                            )
+                        }
+                    },
+                    onOpenConversationDocument: { artifact in
+                        guard let surfaceId = artifact.surfaceId else { return }
+                        NotificationCenter.default.post(
+                            name: .openDocumentEditor,
+                            object: nil,
+                            userInfo: ["documentSurfaceId": surfaceId]
+                        )
+                    },
                     anchorMessageId: $anchorMessageId,
                     highlightedMessageId: $highlightedMessageId,
                     isInteractionEnabled: true,

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -255,6 +255,10 @@ final class ChatActionHandler {
 
         case .uiSurfaceShow(let msg):
             vm.handleSurfaceShow(msg)
+            // Refresh artifacts when a new dynamic_page or document_preview surface appears.
+            if msg.surfaceType == "dynamic_page" || msg.surfaceType == "document_preview" {
+                vm.fetchConversationArtifacts()
+            }
 
         case .uiSurfaceUndoResult(let msg):
             vm.handleSurfaceUndoResult(msg)
@@ -377,6 +381,9 @@ final class ChatActionHandler {
             guard vm.compactionCircuitOpenUntil != nil else { return }
             vm.compactionCircuitOpenUntil = nil
             log.info("Auto-compaction resumed (circuit breaker closed)")
+
+        case .appFilesChanged:
+            vm.fetchConversationArtifacts()
 
         default:
             break

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -655,6 +655,14 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// response handler can display the correct resolved state (the server does
     /// not echo back the action in its acknowledgement).
     @ObservationIgnored private var pendingGuardianActions: [String: String] = [:]
+
+    // MARK: - Conversation Artifacts
+
+    /// Apps and documents associated with the current conversation.
+    public var conversationArtifacts: [ConversationArtifact] = []
+    @ObservationIgnored private var artifactsClient: ConversationArtifactsClientProtocol = ConversationArtifactsClient()
+    @ObservationIgnored private var artifactsFetchTask: Task<Void, Never>?
+
     public var conversationId: String? {
         didSet {
             // If the daemon reconnected before this VM had a conversation ID, a deferred
@@ -663,11 +671,18 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 needsOfflineFlush = false
                 flushOfflineQueue()
             }
+            // Refresh conversation artifacts when conversation changes.
+            if conversationId != oldValue {
+                conversationArtifacts = []
+                artifactsFetchTask?.cancel()
+                fetchConversationArtifacts()
+            }
         }
     }
     @ObservationIgnored private var reconnectObserver: NSObjectProtocol?
     @ObservationIgnored private var eventStreamReconnectObserver: NSObjectProtocol?
     @ObservationIgnored private var appPreviewCapturedObserver: NSObjectProtocol?
+    @ObservationIgnored private var documentDidSaveObserver: NSObjectProtocol?
     /// Debounces rapid-fire transport reconnect notifications so only one
     /// history reload is triggered per reconnect burst (500ms settle window).
     @ObservationIgnored private var reconnectDebounceTask: Task<Void, Never>?
@@ -1253,6 +1268,17 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             }
         }
 
+        // Refresh conversation artifacts when a document is saved successfully.
+        documentDidSaveObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("DocumentManager.documentDidSave"),
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.fetchConversationArtifacts()
+            }
+        }
+
         // Subscribe to the shared memory pressure monitor so we can
         // aggressively trim the message list when the OS warns of low memory.
         // This prevents the app from being jettisoned on devices with limited
@@ -1359,6 +1385,23 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
 
     func sendUserMessage(_ text: String, displayText: String? = nil, attachments: [UserMessageAttachment]? = nil, queuedMessageId: UUID? = nil, automated: Bool = false, bypassSecretCheck: Bool = false) {
         sendCoordinator.sendUserMessage(text, displayText: displayText, attachments: attachments, queuedMessageId: queuedMessageId, automated: automated, bypassSecretCheck: bypassSecretCheck)
+    }
+
+    // MARK: - Conversation Artifacts Fetching
+
+    public func fetchConversationArtifacts() {
+        artifactsFetchTask?.cancel()
+        guard let conversationId else {
+            conversationArtifacts = []
+            return
+        }
+        let capturedId = conversationId
+        artifactsFetchTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await self.artifactsClient.fetchArtifacts(conversationId: capturedId)
+            guard !Task.isCancelled, self.conversationId == capturedId else { return }
+            self.conversationArtifacts = result
+        }
     }
 
     // MARK: - Offline Queue Flush (forwarded to MessageSendCoordinator)
@@ -2406,6 +2449,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         if let observer = appPreviewCapturedObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = documentDidSaveObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        artifactsFetchTask?.cancel()
     }
 
     // MARK: - Connection diagnostics


### PR DESCRIPTION
## Summary
- Add artifact fetching to ChatViewModel with stale-result guards and event-driven refresh
- Create ConversationArtifactsButton with popover listing apps and documents
- Wire into ChatView via callbacks, connected in PanelCoordinator and ThreadWindow
- Add documentDidSave notification for artifact refresh after document persistence

Part of plan: conv-artifacts-open.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
