### PR TITLE
fix(macos): remove .draggable() on pinned app rows to eliminate 2s+ sidebar hang (LUM-1268)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/AppListManager.swift
@@ -173,17 +173,6 @@ final class AppListManager {
         save()
     }
 
-    func reorderPinnedApps(from source: IndexSet, to destination: Int) {
-        var pinned = displayApps.filter(\.isPinned)
-        pinned.move(fromOffsets: source, toOffset: destination)
-        for (order, item) in pinned.enumerated() {
-            if let idx = apps.firstIndex(where: { $0.id == item.id }) {
-                apps[idx].pinnedOrder = order
-            }
-        }
-        save()
-    }
-
     /// Sync apps from the daemon's authoritative list into the local sidebar list.
     /// Adds any apps that don't already exist locally, using their daemon createdAt timestamp.
     /// Removes local apps the daemon no longer reports.
@@ -271,32 +260,6 @@ final class AppListManager {
         guard let index = apps.firstIndex(where: { $0.id == id }) else { return }
         apps[index].lucideIcon = icon.rawValue
         save()
-    }
-
-    /// Move an app to a new position (for drag-and-drop reorder).
-    /// Returns `true` if the reorder was actually performed.
-    @discardableResult
-    func moveApp(sourceId: String, beforeId: String) -> Bool {
-        guard let sourceIdx = apps.firstIndex(where: { $0.id == sourceId }),
-              let targetIdx = apps.firstIndex(where: { $0.id == beforeId }) else { return false }
-        let targetApp = apps[targetIdx]
-
-        // Only reorder when the drop target is pinned
-        guard targetApp.isPinned else { return false }
-
-        if !apps[sourceIdx].isPinned {
-            apps[sourceIdx].isPinned = true
-        }
-        let targetOrder = targetApp.pinnedOrder ?? 0
-        apps[sourceIdx].pinnedOrder = targetOrder
-        for i in apps.indices where apps[i].isPinned && apps[i].id != sourceId {
-            if let order = apps[i].pinnedOrder, order >= targetOrder {
-                apps[i].pinnedOrder = order + 1
-            }
-        }
-        recompactPinnedOrders()
-        save()
-        return true
     }
 
     // MARK: - Persistence

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UniformTypeIdentifiers
 import VellumAssistantShared
 
 /// Top-level sidebar view whose body re-evaluates only when
@@ -333,7 +332,7 @@ struct SidebarView: View {
     // MARK: - Pinned App Helpers
 
     /// A pinned app row — delegates layout to `SidebarPrimaryRow` for both
-    /// expanded and collapsed modes, then adds app-specific context menu and drag.
+    /// expanded and collapsed modes, then adds app-specific context menu.
     @ViewBuilder
     private func sidebarPinnedAppRow(_ app: AppListManager.AppItem, isExpanded: Bool = true) -> some View {
         SidebarPrimaryRow(
@@ -360,7 +359,6 @@ struct SidebarView: View {
                 appListManager.removeApp(id: app.id)
             }
         }
-        .draggable(app.id)
     }
 
     /// Check if a given appId matches the currently active workspace surface.


### PR DESCRIPTION
Removes `.draggable(app.id)` from pinned app rows to eliminate a 2s+ main-thread hang caused by eager `Transferable` protocol witness resolution on every SwiftUI body evaluation. Also removes dead `moveApp(sourceId:beforeId:)` and `reorderPinnedApps(from:to:)` methods that had zero callers from view code.

---

**Root cause analysis:**

1. **How did the code get into this state?** PR #3785 originally added `.draggable(app.id)` paired with a working `.dropDestination(for: String.self)` that called `appListManager.moveApp()`. PR #4783 ("Polish main window layout") redesigned the sidebar and removed both the `.dropDestination` and the `.draggable` along with the entire `sidebarAppItem` function rewrite. Then PR #9627 ("Navigation Sidebar Refresh") re-introduced `.draggable(app.id)` on the new pinned app row function but **did not** re-add a corresponding drop target — the drag source became orphaned.
2. **What was missed?** PR #9627 was a large multi-part PR (light/dark toggle, remove Home Base, elevate pinned apps, unread indicators). The `.draggable(app.id)` was added to the new `sidebarAppItem` function without a corresponding `.dropDestination` or `DropDelegate`, likely carried forward from the original PR #3785 pattern without verifying the drop side was still wired up.
3. **Were there warning signs?** The same family of `Transferable` resolution hangs was later discovered and fixed for conversation rows in LUM-584 (PR #22307, replacing `.dropDestination` with `DropDelegate`) and LUM-813 (PR #24573). Those fixes established that `Transferable`-based modifiers in ForEach bodies are problematic, but the pinned app `.draggable` was in a different code path and wasn't caught.
4. **Prevention:** Drag source modifiers (`.draggable`, `.onDrag`) should always be paired with corresponding drop targets in the same PR. Orphaned drag sources with no drop target are both dead code and a performance liability (the `Transferable` resolution cost is paid even when no drag ever occurs).

**Why this is safe:** The `.draggable(app.id)` modifier had no matching drop target anywhere in the codebase since PR #9627 re-introduced it — `moveApp` and `reorderPinnedApps` had zero callers from view code. Removing a modifier with no functional drop target cannot break any user-visible behavior. The context menu (pin/unpin/open/remove) is a separate modifier and is unaffected.

**Alternatives not taken:**
- *Replace `.draggable(app.id)` with `.onDrag { NSItemProvider(...) }`*: This would fix the performance issue but would preserve dead drag functionality with no drop target. Adding dead code is worse than removing it.
- *Add a proper `DropDelegate` for pinned apps*: Out of scope for a bug fix. If pinned app drag-and-drop reordering is desired, it should be a separate feature PR using `.onDrag` + `DropDelegate` (the pattern established in PR #22307).

**References:**
- [Apple Developer: Making a view into a drag source](https://developer.apple.com/documentation/SwiftUI/Making-a-view-into-a-drag-source) — `.draggable()` resolves `Transferable` at view construction; `.onDrag` defers to drag-start
- PR #22307 (LUM-584): Established the `.dropDestination` → `DropDelegate` pattern for this exact class of hang
- PR #24573 (LUM-813): Same pattern applied to section rows

Closes LUM-1268

---

- Requested by: @ashleeradka
- Session: https://app.devin.ai/sessions/819286122c24460caee2c3ed61d77620
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
