### PR TITLE
fix(macOS): conditionally strip .function from event modifiers based on arrow-key check

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -585,18 +585,18 @@ extension AppDelegate {
             // Don't steal shortcuts from text views (e.g. Cmd+Up/Down for caret movement)
             if NSApp.mainWindow?.firstResponder is NSTextView { return event }
 
-            // Arrow keys include .numericPad and .function in modifierFlags — strip both
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-                .subtracting([.numericPad, .function])
+            // Strip .numericPad always; strip .function only when comparing against arrow-key shortcuts
+            let baseMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                .subtracting(.numericPad)
 
             if !prevShortcut.isEmpty,
-               mods == prevMods,
+               (isArrowKey(prevKey) ? baseMods.subtracting(.function) : baseMods) == prevMods,
                event.charactersIgnoringModifiers?.lowercased() == prevKey.lowercased() {
                 Task { @MainActor in self?.selectPreviousConversation() }
                 return nil
             }
             if !nextShortcut.isEmpty,
-               mods == nextMods,
+               (isArrowKey(nextKey) ? baseMods.subtracting(.function) : baseMods) == nextMods,
                event.charactersIgnoringModifiers?.lowercased() == nextKey.lowercased() {
                 Task { @MainActor in self?.selectNextConversation() }
                 return nil


### PR DESCRIPTION
## Summary
- Addresses review feedback from #28636
- The previous fix correctly retained `.function` in `prevMods`/`nextMods` for non-arrow keys, but the event handler still unconditionally stripped `.function` from event modifiers. This meant `fn+key` shortcuts for non-arrow keys could never match.
- Fix: compute `baseMods` (strip only `.numericPad`), then conditionally strip `.function` per-comparison only when the shortcut key is an arrow key.

## Test plan
- [ ] Verify arrow-key nav shortcuts (e.g. `cmd+opt+up/down`) still work
- [ ] Verify fn+key nav shortcuts (e.g. `fn+cmd+k`) now correctly trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
