### PR TITLE
fix(memory-v2): exclude disabled skills from catalog seeding and guard empty catalog prune

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -295,6 +295,12 @@ describe("seedV2SkillEntries", () => {
       { summary: skillA, state: "enabled" },
       { summary: skillB, state: "enabled" },
     ];
+    // Remote catalog must be non-empty so catalogAvailable is true and
+    // pruning is not skipped.
+    state.fullCatalog = [
+      { id: "example-skill-a", name: "example-skill-a", description: "A" },
+      { id: "example-skill-b", name: "example-skill-b", description: "B" },
+    ];
     state.embedReturn = [
       [0.1, 0.2, 0.3],
       [0.4, 0.5, 0.6],
@@ -321,6 +327,12 @@ describe("seedV2SkillEntries", () => {
       { summary: unflagged, state: "enabled" },
     ];
     state.flagsEnabled = { "off-flag": false };
+    // Remote catalog must be non-empty so catalogAvailable is true and
+    // pruning is not skipped.
+    state.fullCatalog = [
+      { id: "example-skill-a", name: "example-skill-a", description: "A" },
+      { id: "example-skill-b", name: "example-skill-b", description: "B" },
+    ];
     state.embedReturn = [[0.4, 0.5, 0.6]];
 
     await seedV2SkillEntries();
@@ -391,16 +403,45 @@ describe("seedV2SkillEntries", () => {
     expect(after).toEqual(before);
   });
 
-  test("no enabled skills yields empty cache and a single empty prune call", async () => {
+  test("no enabled skills yields empty cache and no prune when catalog is empty", async () => {
     state.catalog = [];
     state.resolved = [];
+    // fullCatalog defaults to [] — catalog unavailable, so pruning is skipped.
 
     await seedV2SkillEntries();
 
     expect(state.upsertCalls).toHaveLength(0);
-    expect(state.pruneCalls).toHaveLength(1);
-    expect([...state.pruneCalls[0]]).toEqual([]);
+    expect(state.pruneCalls).toHaveLength(0);
     expect(getSkillCapability("anything")).toBeNull();
+  });
+
+  test("no enabled skills prunes when catalog is available", async () => {
+    state.catalog = [];
+    state.resolved = [];
+    state.fullCatalog = [
+      { id: "remote-only", name: "remote-only", description: "Remote skill" },
+    ];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.upsertCalls[0].id).toBe("remote-only");
+    expect(state.pruneCalls).toHaveLength(1);
+    expect([...state.pruneCalls[0]]).toEqual(["remote-only"]);
+  });
+
+  test("skips pruning when catalog fetch returns empty (network failure guard)", async () => {
+    const skillA = makeSummary({ id: "example-skill-a" });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.fullCatalog = []; // Simulates cold cache / network failure
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.pruneCalls).toHaveLength(0);
   });
 });
 

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -100,8 +100,11 @@ export async function seedV2SkillEntries(): Promise<void> {
 
     // Seed uninstalled catalog skills so their activation hints are
     // discoverable by intent (mirrors v1's seedUninstalledCatalogSkillMemories).
+    // Track whether the catalog was available so we can guard pruning below.
+    let catalogAvailable = false;
     try {
       const fullCatalog = await getCatalog();
+      catalogAvailable = fullCatalog.length > 0;
       for (const entry of fullCatalog) {
         if (installedIds.has(entry.id)) continue;
         const flagKey = entry.metadata?.vellum?.["feature-flag"];
@@ -137,8 +140,18 @@ export async function seedV2SkillEntries(): Promise<void> {
       nextEntries.set(seed.id, seed);
     }
 
-    // Prune any points whose id is no longer in the active set.
-    await pruneSkillsExcept(seeds.map((s) => s.id));
+    // Prune stale points. When the catalog is unavailable (empty array from
+    // network failure or cold cache), we cannot enumerate which uninstalled
+    // catalog skills should exist, so skip pruning entirely to avoid
+    // aggressively removing previously-seeded catalog skill embeddings.
+    // Mirrors v1's safeguard in capability-seed.ts (lines 124–143).
+    if (catalogAvailable) {
+      await pruneSkillsExcept(seeds.map((s) => s.id));
+    } else {
+      log.info(
+        "Catalog unavailable — skipping skill pruning to preserve prior catalog embeddings",
+      );
+    }
 
     // Atomically replace the cache only after every step above succeeds.
     entries = nextEntries;


### PR DESCRIPTION
## Summary
Addresses review feedback from #28635:

1. **Disabled skills re-seeded as uninstalled (Codex P1):** Already fixed in #28640 — `installedIds` now includes all installed skill IDs (enabled + disabled) so disabled-but-installed skills are not re-seeded from the catalog.
2. **Empty catalog causes aggressive pruning (Devin):** Track whether `getCatalog()` returned results via `catalogAvailable` flag. When the catalog is empty (network failure / cold cache), skip `pruneSkillsExcept` entirely to avoid removing previously-seeded catalog skill embeddings. Mirrors the v1 safeguard in `capability-seed.ts` (lines 124-143).

## Test plan
- [ ] Verify disabled-but-installed skills do not appear in v2 skill embeddings
- [ ] Simulate empty catalog (cold cache / network failure) and confirm prior catalog embeddings are preserved
- [ ] Verify normal catalog flow still prunes stale skills correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)