### PR TITLE
fix(macos): remove dead @Environment declaration that crashes on missing injection

### DIFF
--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -112,6 +112,22 @@ CU execution dependencies are protocol-based for testability:
 
 </details>
 
+#### `@Environment` with `@Observable` — always use optional
+
+When placing an `@Observable` object in the SwiftUI environment via `.environment(object)`, **always declare the receiving property as optional** (`Type?`):
+
+```swift
+// ✅ Correct — safe in all hosting contexts
+@Environment(AssistantFeatureFlagStore.self) private var store: AssistantFeatureFlagStore?
+
+// ❌ Wrong — crashes if the object is missing from the environment
+@Environment(AssistantFeatureFlagStore.self) private var store
+```
+
+**Why:** This app uses `NSHostingController` for each window (Main, Thread, settings, etc.), not SwiftUI `WindowGroup` scenes. Environment values do not propagate across separate `NSHostingController` roots — each window must manually inject `.environment(object)`. A non-optional declaration crashes with `Fatal error: No Observable object of type X found` if any hosting path omits the injection. Optional declarations return `nil` instead, matching [Apple's recommendation](https://developer.apple.com/documentation/swiftui/environment): *"In cases where there is no guarantee that an object is in the environment, retrieve an optional version."*
+
+This pattern caused LUM-1206 (EXC_BREAKPOINT crash in `AssistantProgressView`) when a pop-out thread window was missing the injection.
+
 ### Network Layer (`Network/`)
 
 All inference (both computer-use sessions and ambient analysis) goes through the assistant's HTTP API:

--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -114,7 +114,7 @@ CU execution dependencies are protocol-based for testability:
 
 #### `@Environment` with `@Observable` — always use optional
 
-When placing an `@Observable` object in the SwiftUI environment via `.environment(object)`, **always declare the receiving property as optional** (`Type?`):
+When reading an `@Observable` object from the environment, **always declare the property as optional** (`Type?`). Non-optional declarations crash with `Fatal error: No Observable object of type X found` if any `NSHostingController` root omits the `.environment(object)` injection — and this app has multiple independent hosting roots that don't share environments.
 
 ```swift
 // ✅ Correct — safe in all hosting contexts
@@ -124,9 +124,7 @@ When placing an `@Observable` object in the SwiftUI environment via `.environmen
 @Environment(AssistantFeatureFlagStore.self) private var store
 ```
 
-**Why:** This app uses `NSHostingController` for each window (Main, Thread, settings, etc.), not SwiftUI `WindowGroup` scenes. Environment values do not propagate across separate `NSHostingController` roots — each window must manually inject `.environment(object)`. A non-optional declaration crashes with `Fatal error: No Observable object of type X found` if any hosting path omits the injection. Optional declarations return `nil` instead, matching [Apple's recommendation](https://developer.apple.com/documentation/swiftui/environment): *"In cases where there is no guarantee that an object is in the environment, retrieve an optional version."*
-
-This pattern caused LUM-1206 (EXC_BREAKPOINT crash in `AssistantProgressView`) when a pop-out thread window was missing the injection.
+**Ref:** [Apple Environment docs — "retrieve an optional version"](https://developer.apple.com/documentation/swiftui/environment)
 
 ### Network Layer (`Network/`)
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -7,8 +7,6 @@ import Dispatch
 /// Unified container that handles all tool progress states through a single component
 /// that smoothly morphs between phases.
 struct AssistantProgressView: View {
-    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore
-
     let toolCalls: [ToolCallData]
     let isStreaming: Bool
     let hasText: Bool

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -236,8 +236,9 @@ private struct ThreadWindowContentView: View {
                     conversationManager: conversationManager
                 )
                 .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
-                // Required: AssistantProgressView reads this via @Environment
-                // and triggers a SwiftUI assertion crash if it's missing.
+                // ChatView reads AssistantFeatureFlagStore via optional
+                // @Environment — provide it so flag-gated UI works in
+                // pop-out thread windows.
                 .environment(assistantFeatureFlagStore)
                 .padding(.bottom, VSpacing.md)
             }


### PR DESCRIPTION
Removes an unused non-optional `@Environment(AssistantFeatureFlagStore.self)` declaration from `AssistantProgressView` that would crash any `NSHostingController` root that omitted `.environment(featureFlagStore)` injection. Adds AGENTS.md guidance requiring optional declarations for `@Environment` with `@Observable` objects, since AppKit-hosted windows use separate `NSHostingController` roots that don't share environment propagation.

---

## Why this change is needed

`AssistantProgressView` declared `@Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore` as **non-optional** — but the property had zero reads anywhere in the view body. It was dead code left behind after the `permission-controls-v3` flag was GA'd and its usages removed. Despite being unused, the non-optional declaration forced SwiftUI to resolve the object at view evaluation time, crashing with `Fatal error: No Observable object of type AssistantFeatureFlagStore found` if any hosting path omitted the injection.

## Benefits

- **Eliminates crash risk**: Any new window, panel, or test rendering `AssistantProgressView` without injecting `AssistantFeatureFlagStore` would have triggered an `EXC_BREAKPOINT`. Removing the dead declaration makes this impossible.
- **Codifies the safe pattern**: The AGENTS.md guidance ensures all future `@Environment` declarations for `@Observable` objects use the optional form, matching [Apple's recommendation](https://developer.apple.com/documentation/swiftui/environment): *"In cases where there is no guarantee that an object is in the environment, retrieve an optional version."*
- **Corrects stale documentation**: The `ThreadWindow.swift` comment previously said "Required: AssistantProgressView reads this via @Environment" — now correctly references `ChatView`, which actually reads the store (optionally).

## Safety

Zero behavioral change — the property is never accessed in `AssistantProgressView`'s body. Removing it changes no runtime behavior. Verified via grep that `assistantFeatureFlagStore` has zero reads in the file beyond the declaration itself. All instantiation paths (`ChatBubbleToolStatusView`, `ChatBubbleInterleavedContent` → `ChatBubble` → `MessageCellView` → window roots) already inject the store for `ChatView`'s optional usage. CI skips macOS builds, so Swift compilation must be verified locally in Xcode.

## Alternatives not taken

- **Make the property optional instead of removing it**: Rejected — the property is dead code with zero reads in the body. Keeping unused code violates the dead code removal policy and adds noise. Optional would be the correct choice if the property were actually used.
- **Fix a missing injection path**: Not applicable — both window roots (`MainWindowView`, `ThreadWindowContentView`) already inject the store. The crash risk was purely from the dead non-optional declaration, not from a missing injection.
- **Broader migration from singleton to `@Environment`**: The codebase has two parallel feature flag systems: `MacOSClientFeatureFlagManager.shared` (singleton, `scope: "macos"`, 36+ callsites) and `AssistantFeatureFlagStore` (`@Observable` + `@Environment`, `scope: "assistant"`, 2 active callsites). These serve different flag scopes and the dual system is intentional — a broader migration was not warranted for this fix.

## Root Cause Analysis

**How did the code get into this state?** A multi-step flag rollout across 5 PRs in 6 days: the `@Environment` declaration was added for a transitional feature flag (`permission-controls-v3`), the flag was GA'd before the declaration was cleaned up, and the subsequent cleanup PR removed the usages but missed the declaration.

**What mistakes or decisions led to it?** (1) The original PR adding the `@Environment` didn't audit all `NSHostingController` roots for injection coverage. (2) The GA cleanup PR removed flag-checking code but left the declaration as an orphan. (3) A follow-up PR that made the same property optional in sibling views (`ChatView`, `InferenceServiceCard`) missed `AssistantProgressView`.

**Were there warning signs we missed?** A non-optional `@Environment` for an `@Observable` type is inherently risky in an AppKit-hosted app with multiple `NSHostingController` roots. There was no AGENTS.md guidance flagging this as a dangerous pattern.

**What can we do to prevent this from recurring?** The AGENTS.md guidance added in this PR — always use optional for `@Environment` with `@Observable` — addresses the root pattern. This makes the codebase resilient to the common scenario where a new window or test path renders a view without providing all expected environment objects.

**AGENTS.md update**: Added a concise rule under `Dependency Injection` in `clients/macos/AGENTS.md` with a code example and a link to [Apple's Environment documentation](https://developer.apple.com/documentation/swiftui/environment).

## Prompt / plan

Investigated LUM-1206 (Sentry: MACOS-ND, MACOS-P3) from first principles — traced all code paths rendering `AssistantProgressView`, audited every `NSHostingController` root for environment injection, reviewed recent PRs in the area, and verified the property was genuinely unused before choosing removal over optional.

## Test plan

- Verified via grep that `assistantFeatureFlagStore` has zero reads in `AssistantProgressView.swift`
- Traced all instantiation paths through `ChatBubbleToolStatusView` → `ChatBubble` → `MessageCellView` → window roots
- Confirmed both `MainWindowView` and `ThreadWindowContentView` inject the store for `ChatView`'s optional usage
- CI skips macOS builds — requires local Xcode verification

---

- Requested by: @ashleeradka
- Session: https://app.devin.ai/sessions/9d93c2f9593546d49f0217531d6eb990
