### PR TITLE
fix(clients): add assistants/{assistantId}/ prefix to all GatewayHTTPClient paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -543,7 +543,7 @@ struct AssistantBackupsSection: View {
         defer { isExporting = false }
 
         do {
-            let response = try await GatewayHTTPClient.post(path: "migrations/export", timeout: 3600)
+            let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/migrations/export", timeout: 3600)
 
             guard response.isSuccess else {
                 errorMessage = "Export failed (HTTP \(response.statusCode))"
@@ -693,7 +693,7 @@ struct AssistantBackupsSection: View {
             // overload on `GatewayHTTPClient.get<T>` is convenient but its
             // `configure` closure parameter is not `@Sendable`, which conflicts
             // with strict concurrency when called from @MainActor code.
-            let response = try await GatewayHTTPClient.get(path: "backups", timeout: 15)
+            let response = try await GatewayHTTPClient.get(path: "assistants/{assistantId}/backups", timeout: 15)
             guard response.isSuccess else {
                 errorMessage = "Failed to load backups (HTTP \(response.statusCode))"
                 return

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -228,7 +228,7 @@ struct AssistantTransferSection: View {
         do {
             // Step 1 — Initiate export
             currentStep = "Requesting cloud export..."
-            let exportResponse = try await GatewayHTTPClient.post(path: "migrations/export")
+            let exportResponse = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/migrations/export")
             guard exportResponse.isSuccess else {
                 throw TransferError.exportFailed(statusCode: exportResponse.statusCode)
             }

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -632,7 +632,7 @@ enum LogExporter {
         }
 
         do {
-            let response = try await GatewayHTTPClient.post(path: "logs/export", json: body, timeout: 60)
+            let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/logs/export", json: body, timeout: 60)
             guard response.isSuccess else {
                 log.warning("Export API failed with status \(response.statusCode)")
                 writeExportErrorLog(

--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -41,7 +41,7 @@ public struct InteractionClient: InteractionClientProtocol {
             if let selectedPattern { body["selectedPattern"] = selectedPattern }
             if let selectedScope { body["selectedScope"] = selectedScope }
 
-            let path = try Self.approvalPath(endpoint: "confirm")
+            let path = Self.approvalPath(endpoint: "confirm")
             log.info("[confirm-flow] Sending POST /confirm: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
             let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
             if response.isSuccess {
@@ -72,7 +72,7 @@ public struct InteractionClient: InteractionClientProtocol {
             body["value"] = value ?? ""
             if let delivery { body["delivery"] = delivery }
 
-            let path = try Self.approvalPath(endpoint: "secret")
+            let path = Self.approvalPath(endpoint: "secret")
             let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
             if !response.isSuccess {
                 log.error("sendSecretResponse failed (HTTP \(response.statusCode))")
@@ -87,14 +87,12 @@ public struct InteractionClient: InteractionClientProtocol {
 
     // MARK: - Path Resolution
 
-    /// Returns the appropriate request path for an approval endpoint based on
-    /// the current connection type.
+    /// Returns the assistant-scoped request path for an approval endpoint.
     ///
-    /// Managed connections route through the platform proxy which expects
-    /// `assistants/{assistantId}/<endpoint>`. Non-managed connections (local
-    /// gateway or direct remote runtime) use flat `<endpoint>` paths.
-    private static func approvalPath(endpoint: String) throws -> String {
-        let managed = try GatewayHTTPClient.isConnectionManaged()
-        return managed ? "assistants/{assistantId}/\(endpoint)" : endpoint
+    /// Always uses `assistants/{assistantId}/<endpoint>` — the gateway runtime
+    /// proxy strips the prefix for local connections, and the platform proxy
+    /// expects it for managed connections.
+    private static func approvalPath(endpoint: String) -> String {
+        "assistants/{assistantId}/\(endpoint)"
     }
 }


### PR DESCRIPTION
## Summary
- Added `assistants/{assistantId}/` prefix to 4 GatewayHTTPClient call sites that were using flat paths: `migrations/export` (x2), `backups`, and `logs/export`
- Simplified `InteractionClient.approvalPath()` to always use the prefixed path, removing the managed vs non-managed conditional since both the platform wildcard proxy and the local gateway runtime proxy handle the prefix correctly
- `{assistantId}` is resolved by `GatewayHTTPClient.constructURL()` at request time; for empty assistantId (QR-mode), `assistants//` collapses to `""` automatically

## Original prompt
Update all GatewayHTTPClient usages whose path does NOT start with "assistants/{assistantId}/" to add the prefix so routing is consistent across managed and local connections.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
