### PR TITLE
fix(ci): fix test failures in cache and memory-v2-backfill tests

### DIFF
--- a/assistant/src/cli/commands/__tests__/cache.test.ts
+++ b/assistant/src/cli/commands/__tests__/cache.test.ts
@@ -80,7 +80,7 @@ mock.module("../../../util/logger.js", () => ({
   }),
 }));
 
-mock.module("node:fs", () => ({
+mock.module("../cache-fs.js", () => ({
   readFileSync: (path: string, encoding?: BufferEncoding) => {
     if (path === "/dev/stdin") {
       if (mockStdinContent === null) {

--- a/assistant/src/cli/commands/cache-fs.ts
+++ b/assistant/src/cli/commands/cache-fs.ts
@@ -1,0 +1,8 @@
+/**
+ * Thin re-export of `node:fs` functions used by the cache CLI command.
+ *
+ * This indirection exists solely so tests can `mock.module("./cache-fs.js")`
+ * without mocking all of `node:fs` — which causes bun's test runner to hang
+ * on exit.
+ */
+export { existsSync, readFileSync } from "node:fs";

--- a/assistant/src/cli/commands/cache.ts
+++ b/assistant/src/cli/commands/cache.ts
@@ -5,12 +5,11 @@
  * cache IPC routes (`cache/set`, `cache/get`, `cache/delete`).
  */
 
-import { existsSync, readFileSync } from "node:fs";
-
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
 import { log } from "../logger.js";
+import { existsSync, readFileSync } from "./cache-fs.js";
 
 // ── Constants ─────────────────────────────────────────────────────────
 

--- a/assistant/src/ipc/routes/__tests__/memory-v2-backfill.test.ts
+++ b/assistant/src/ipc/routes/__tests__/memory-v2-backfill.test.ts
@@ -35,9 +35,22 @@ mock.module("../../../memory/jobs-store.js", () => ({
     nextJobId += 1;
     return `test-job-${nextJobId}`;
   },
+  upsertAutoAnalysisJob: () => {},
+  upsertDebouncedJob: () => `test-debounced-${++nextJobId}`,
+  hasActiveJobOfType: () => false,
+  enqueuePruneOldLlmRequestLogsJob: () => `test-prune-${++nextJobId}`,
+  enqueuePruneOldConversationsJob: () => `test-prune-conv-${++nextJobId}`,
+  claimMemoryJobs: () => [],
+  completeMemoryJob: () => {},
+  deferMemoryJob: () => "deferred",
+  failMemoryJob: () => {},
+  resetRunningJobsToPending: () => 0,
+  failStalledJobs: () => 0,
+  getMemoryJobCounts: () => ({}),
 }));
 
-const { ROUTES: memoryV2Routes } = await import("../../../runtime/routes/memory-v2-routes.js");
+const { ROUTES: memoryV2Routes } =
+  await import("../../../runtime/routes/memory-v2-routes.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -45,7 +58,9 @@ const { ROUTES: memoryV2Routes } = await import("../../../runtime/routes/memory-
 
 type BackfillResult = { jobId: string };
 
-const backfillRoute = memoryV2Routes.find(r => r.operationId === "memory_v2_backfill")!;
+const backfillRoute = memoryV2Routes.find(
+  (r) => r.operationId === "memory_v2_backfill",
+)!;
 
 async function runRoute(
   params: Record<string, unknown>,

--- a/meta/bun.lock
+++ b/meta/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "vellum",
       "dependencies": {
-        "@vellumai/assistant": "0.6.5",
-        "@vellumai/cli": "0.6.5",
-        "@vellumai/credential-executor": "0.6.5",
-        "@vellumai/vellum-gateway": "0.6.5",
+        "@vellumai/assistant": "0.6.6",
+        "@vellumai/cli": "0.6.6",
+        "@vellumai/credential-executor": "0.6.6",
+        "@vellumai/vellum-gateway": "0.6.6",
       },
       "devDependencies": {
         "@types/bun": "1.3.12",
@@ -243,13 +243,13 @@
 
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
-    "@vellumai/assistant": ["@vellumai/assistant@0.6.5", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@anthropic-ai/sdk": "0.78.0", "@google/genai": "1.45.0", "@modelcontextprotocol/sdk": "1.27.1", "@qdrant/js-client-rest": "1.17.0", "@resvg/resvg-js": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@sentry/node": "10.43.0", "@vellumai/service-contracts": "file:../packages/service-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "archiver": "7.0.1", "commander": "13.1.0", "croner": "10.0.1", "dotenv": "17.3.1", "drizzle-orm": "0.45.2", "jszip": "3.10.1", "marked": "18.0.0", "minimatch": "10.2.4", "openai": "6.29.0", "pino": "9.14.0", "pino-pretty": "13.1.3", "playwright": "1.58.2", "postgres": "3.4.8", "qrcode": "1.5.4", "rrule": "2.8.1", "tar-stream": "3.1.7", "tldts": "7.0.25", "tree-sitter-bash": "0.25.1", "uuid": "11.1.0", "web-tree-sitter": "0.26.5", "yaml": "2.8.2", "zod": "4.3.6" }, "bin": { "assistant": "src/index.ts" } }, "sha512-gJzI6epB6nyzdzo7xRge/a1kcg6/Vkk3Bb+YteJ4Gih/nYkcOxwzUMwu0cX4wZU8G/nwhQWztMQwA8ryy3Cfdg=="],
+    "@vellumai/assistant": ["@vellumai/assistant@0.6.6", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@anthropic-ai/sdk": "0.78.0", "@google/genai": "1.45.0", "@modelcontextprotocol/sdk": "1.27.1", "@qdrant/js-client-rest": "1.17.0", "@resvg/resvg-js": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@sentry/node": "10.43.0", "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "archiver": "7.0.1", "commander": "13.1.0", "croner": "10.0.1", "dotenv": "17.3.1", "drizzle-orm": "0.45.2", "jszip": "3.10.1", "marked": "18.0.0", "minimatch": "10.2.4", "openai": "6.29.0", "pino": "9.14.0", "pino-pretty": "13.1.3", "playwright": "1.58.2", "postgres": "3.4.8", "qrcode": "1.5.4", "rrule": "2.8.1", "tar-stream": "3.1.7", "tldts": "7.0.25", "tree-sitter-bash": "0.25.1", "uuid": "11.1.0", "web-tree-sitter": "0.26.5", "yaml": "2.8.2", "zod": "4.3.6" }, "bin": { "assistant": "src/index.ts" } }, "sha512-CqTRPxvepxjZYUsOd1wCiGwsyLODpkG6WIyHUwfwitzQXHNueIhDDM0ZljHOB0VJDUDMtvqf5UKmiFnMVbcMLQ=="],
 
-    "@vellumai/cli": ["@vellumai/cli@0.6.5", "", { "dependencies": { "chalk": "5.6.2", "ink": "6.8.0", "jsqr": "1.4.0", "nanoid": "5.1.7", "pngjs": "7.0.0", "qrcode-terminal": "0.12.0", "react": "19.2.4", "react-devtools-core": "6.1.5" }, "bin": { "vellum": "src/index.ts" } }, "sha512-U53nGI1RQAlRTBxQT9jWnE1Hs20/xtSCRH1wn6WI3wPSkfBho3GmR1uQyrvW8EksDaGlMxX0e+A6ldlqiAq6dA=="],
+    "@vellumai/cli": ["@vellumai/cli@0.6.6", "", { "dependencies": { "chalk": "5.6.2", "ink": "6.8.0", "jsqr": "1.4.0", "nanoid": "5.1.7", "pngjs": "7.0.0", "qrcode-terminal": "0.12.0", "react": "19.2.4", "react-devtools-core": "6.1.5" }, "bin": { "vellum": "src/index.ts" } }, "sha512-CEPb7C6waQl2qNfytoJ6butdsi76uuLZoO7770AeF6ZaUPPbX1R9UWYjW4Y4kZHO/j9ePcIUqcz7MpNZ5bpXJw=="],
 
-    "@vellumai/credential-executor": ["@vellumai/credential-executor@0.6.5", "", { "dependencies": { "@vellumai/service-contracts": "file:../packages/service-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "pino": "9.14.0", "pino-pretty": "13.1.3" }, "bin": { "credential-executor": "src/main.ts", "credential-executor-managed": "src/managed-main.ts" } }, "sha512-dRu4EjlZcmXgUZaB/6thcGXJ0T/j1rWN0tZIsUxnfCe+AaWMxXGpEBTEOqLA75kwWJ0aeCgA2osgTPCmy5q2ZA=="],
+    "@vellumai/credential-executor": ["@vellumai/credential-executor@0.6.6", "", { "dependencies": { "@vellumai/ces-contracts": "file:../packages/ces-contracts", "@vellumai/credential-storage": "file:../packages/credential-storage", "@vellumai/egress-proxy": "file:../packages/egress-proxy", "pino": "9.14.0", "pino-pretty": "13.1.3" }, "bin": { "credential-executor": "src/main.ts", "credential-executor-managed": "src/managed-main.ts" } }, "sha512-IP3l+Og2XEOagj+Eic3wNk3DLY20WDe12Bd/xSs17px56fWoTggfQR+ap4zs+gQjmyO4nvtfC83dwZBLKMxlaw=="],
 
-    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.6.5", "", { "dependencies": { "@vellumai/service-contracts": "file:../packages/service-contracts", "drizzle-kit": "0.30.6", "drizzle-orm": "0.45.2", "file-type": "21.3.0", "minimatch": "10.2.4", "pino": "9.14.0", "pino-pretty": "13.1.3", "uuid": "13.0.0", "zod": "4.3.6" } }, "sha512-9uJGyQJeC+wb+V1cL3HVwa7mPoWdFVW0FtiC57d14ds/qPWMHO5HPl5L/ZDeEQthpU1VkSveCHiehgWRINYfEw=="],
+    "@vellumai/vellum-gateway": ["@vellumai/vellum-gateway@0.6.6", "", { "dependencies": { "@vellumai/ces-contracts": "file:../packages/ces-contracts", "drizzle-kit": "0.30.6", "drizzle-orm": "0.45.2", "file-type": "21.3.0", "minimatch": "10.2.4", "pino": "9.14.0", "pino-pretty": "13.1.3", "uuid": "13.0.0", "zod": "4.3.6" } }, "sha512-hdtOE7NTt92eAXMv9vkyIcWHOdSi0hgUQBA5GV867aHOZHNzSrvMguydht9YJzBxvSd1ldx2DW6PU6Ub4M9ErQ=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -897,19 +897,19 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
-    "@vellumai/assistant/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "bundled": true }],
+    "@vellumai/assistant/@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", { "bundled": true }],
 
     "@vellumai/assistant/@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", { "bundled": true }],
 
     "@vellumai/assistant/@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", { "bundled": true }],
 
-    "@vellumai/credential-executor/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "bundled": true }],
+    "@vellumai/credential-executor/@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", { "bundled": true }],
 
     "@vellumai/credential-executor/@vellumai/credential-storage": ["@vellumai/credential-storage@file:../packages/credential-storage", { "bundled": true }],
 
     "@vellumai/credential-executor/@vellumai/egress-proxy": ["@vellumai/egress-proxy@file:../packages/egress-proxy", { "bundled": true }],
 
-    "@vellumai/vellum-gateway/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", {}],
+    "@vellumai/vellum-gateway/@vellumai/ces-contracts": ["@vellumai/ces-contracts@file:../packages/ces-contracts", {}],
 
     "@vellumai/vellum-gateway/uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 


### PR DESCRIPTION
## Summary
- **cache.test.ts timeout**: The test mocked all of `node:fs` via `mock.module`, which caused bun's test runner to hang on exit (killed after 120s). Fixed by extracting fs deps into a thin `cache-fs.ts` wrapper and mocking that instead.
- **memory-v2-backfill.test.ts**: The `jobs-store.js` mock only exported `enqueueMemoryJob`, but transitive imports needed other exports (`upsertAutoAnalysisJob`, `upsertDebouncedJob`, etc.). Added all missing stubs.

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/25069775701

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
