### PR TITLE
fix(credentials): deduplicate secret_request to prevent double-prompting on voice turns

### DIFF
--- a/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
+++ b/assistant/src/__tests__/secret-prompter-channel-fallback.test.ts
@@ -123,4 +123,47 @@ describe("secret prompter channel fallback", () => {
     prompter.resolveSecret(requestId, "val", "store");
     await promise;
   });
+
+  test("wasBroadcast returns true for broadcast requestIds and false after resolve", async () => {
+    const prompter = new SecretPrompter(
+      (msg) => sentMessages.push(msg),
+      (msg) => broadcastMessages.push(msg),
+    );
+    prompter.setChannelContext({
+      channel: "slack",
+      supportsDynamicUi: false,
+    });
+
+    const promise = prompter.prompt("myservice", "apikey", "API Key");
+    const requestId = (broadcastMessages[0] as SecretRequest).requestId;
+
+    // Should be tracked as broadcast
+    expect(prompter.wasBroadcast(requestId)).toBe(true);
+
+    // After resolving, the tracking should be cleaned up
+    prompter.resolveSecret(requestId, "secret", "store");
+    expect(prompter.wasBroadcast(requestId)).toBe(false);
+
+    await promise;
+  });
+
+  test("wasBroadcast returns false for non-broadcast requestIds (desktop channel)", async () => {
+    const prompter = new SecretPrompter(
+      (msg) => sentMessages.push(msg),
+      (msg) => broadcastMessages.push(msg),
+    );
+    prompter.setChannelContext({
+      channel: "macos",
+      supportsDynamicUi: true,
+    });
+
+    const promise = prompter.prompt("myservice", "apikey", "API Key");
+    const requestId = (sentMessages[0] as SecretRequest).requestId;
+
+    // Desktop channel does not broadcast, so wasBroadcast should be false
+    expect(prompter.wasBroadcast(requestId)).toBe(false);
+
+    prompter.resolveSecret(requestId, "secret", "store");
+    await promise;
+  });
 });

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -1152,6 +1152,7 @@ describe("voice-session-bridge", () => {
       ) => {
         handleSecretCalls.push({ requestId, value, delivery });
       },
+      wasSecretBroadcast: () => false,
       abort: () => {},
     } as unknown as Conversation;
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -563,8 +563,15 @@ export async function startVoiceTurn(
         { turnId, service: msg.service, field: msg.field },
         "Auto-resolving secret request for voice turn (no secret-entry UI)",
       );
+      // Check BEFORE resolving — resolveSecret clears the broadcast tracking.
+      const alreadyBroadcast = conversation.wasSecretBroadcast(msg.requestId);
       conversation.handleSecretResponse(msg.requestId, undefined, "store");
-      publishToHub(msg);
+      // Skip publishToHub when the SecretPrompter already broadcast this
+      // requestId to the hub — avoids duplicate secret_request events that
+      // cause prompt flicker / duplicate notifications on connected clients.
+      if (!alreadyBroadcast) {
+        publishToHub(msg);
+      }
       return;
     }
     publishToHub(msg);

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -860,6 +860,15 @@ export class Conversation {
     return this.secretPrompter.hasPendingRequest(requestId);
   }
 
+  /**
+   * Returns true if the given secret requestId was already delivered via
+   * broadcastToAllClients. Callers (e.g. voice-session-bridge) can use this
+   * to skip redundant publishToHub calls that would duplicate the prompt.
+   */
+  wasSecretBroadcast(requestId: string): boolean {
+    return this.secretPrompter.wasBroadcast(requestId);
+  }
+
   handleConfirmationResponse(
     requestId: string,
     decision: UserDecision,

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -36,6 +36,8 @@ export class SecretPrompter {
   private sendToClient: (msg: ServerMessage) => void;
   private broadcastToAllClients?: (msg: ServerMessage) => void;
   private channelContext?: SecretPrompterChannelContext;
+  /** Tracks requestIds that have been broadcast to prevent duplicate delivery when sendToClient also publishes to the same hub. */
+  private broadcastedRequestIds = new Set<string>();
 
   constructor(
     sendToClient: (msg: ServerMessage) => void,
@@ -97,6 +99,7 @@ export class SecretPrompter {
       const timeoutMs = getConfig().timeouts.permissionTimeoutSec * 1000;
       const timer = setTimeout(() => {
         this.pending.delete(requestId);
+        this.broadcastedRequestIds.delete(requestId);
         log.warn({ requestId, service, field }, "Secret prompt timed out");
         resolve({ value: null, delivery: "store" });
       }, timeoutMs);
@@ -120,9 +123,11 @@ export class SecretPrompter {
       };
 
       // When the originating channel cannot render secure prompts, broadcast
-      // to the SSE hub so a connected desktop client can pick it up, AND
-      // send via sendToClient so the voice path can still auto-resolve.
+      // to the SSE hub so a connected desktop client can pick it up.
+      // Track the requestId to prevent duplicate delivery when sendToClient
+      // also publishes to the same hub (e.g. voice path).
       if (!channelSupportsPrompt && this.broadcastToAllClients) {
+        this.broadcastedRequestIds.add(requestId);
         this.broadcastToAllClients(msg);
       }
       this.sendToClient(msg);
@@ -131,6 +136,15 @@ export class SecretPrompter {
 
   hasPendingRequest(requestId: string): boolean {
     return this.pending.has(requestId);
+  }
+
+  /**
+   * Returns true if the given requestId was already delivered via broadcastToAllClients.
+   * Used by event-hub publishing paths to deduplicate — when sendToClient also
+   * publishes to the same hub, callers can skip re-publishing broadcast messages.
+   */
+  wasBroadcast(requestId: string): boolean {
+    return this.broadcastedRequestIds.has(requestId);
   }
 
   /**
@@ -152,6 +166,7 @@ export class SecretPrompter {
     }
     clearTimeout(pending.timer);
     this.pending.delete(requestId);
+    this.broadcastedRequestIds.delete(requestId);
     pending.resolve({ value: value ?? null, delivery: delivery ?? "store" });
   }
 
@@ -163,5 +178,6 @@ export class SecretPrompter {
       );
     }
     this.pending.clear();
+    this.broadcastedRequestIds.clear();
   }
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1158,6 +1158,11 @@ function makeHubPublisher(
         conversationId,
         kind: "secret",
       });
+      // When the SecretPrompter already broadcast this requestId to the hub
+      // (non-UI channel path), skip the duplicate hub publish from sendToClient.
+      if (conversation.wasSecretBroadcast(msg.requestId)) {
+        return;
+      }
     } else {
       registerHostProxyPendingInteraction(msg, conversation, conversationId);
     }


### PR DESCRIPTION
## Summary
- Added `broadcastedRequestIds` Set in `SecretPrompter` to track which requestIds have been delivered via `broadcastToAllClients`
- Exposed `wasBroadcast(requestId)` through `SecretPrompter` and `Conversation` so hub-publishing paths can deduplicate
- `makeHubPublisher` in conversation-routes.ts now skips hub publish for secret_request messages already broadcast
- Voice-session-bridge checks `wasSecretBroadcast` before calling `publishToHub` to prevent duplicate delivery
- Cleanup of broadcast tracking on resolve, timeout, and dispose

## Context
Addresses review feedback from #28637 (Codex P2 + Devin flagged the same concern).

## Test plan
- [x] Added tests for `wasBroadcast` returning true after broadcast and false after resolve
- [x] Added test for `wasBroadcast` returning false on desktop channel (no broadcast)
- [x] Existing channel-fallback tests still pass (broadcast + sendToClient both fire, dedup is at hub level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
