### PR TITLE
feat(macos): track active assistant disk pressure

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -118,6 +118,7 @@ extension AppDelegate {
         let assistant = loadAssistantFromLockfile()
 
         configureDaemonTransport(for: assistant)
+        services.diskPressureMonitor.refreshForCurrentAssistant()
 
         // Set recovery credentials for automatic 401 re-bootstrap
         connectionManager.recoveryPlatform = "macos"
@@ -149,6 +150,7 @@ extension AppDelegate {
         // Rebind the menu bar icon observer after transport reconfiguration
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()
+        rebindDiskPressureConnectionObserver()
 
         // Observe the managed-assistant-gone signal (health check 404) once
         // per setup so a retired/deleted platform assistant no longer leaves
@@ -190,6 +192,7 @@ extension AppDelegate {
                 log.info("setupGatewayConnectionManager: skipping connect() — isConnected=\(self.connectionManager.isConnected), isConnecting=\(self.connectionManager.isConnecting)")
             }
             if connectionManager.isConnected {
+                services.diskPressureMonitor.connectionStateChanged(isConnected: true)
                 setupAmbientAgent()
                 refreshAppsCache()
                 refreshSkillsCache()
@@ -200,6 +203,17 @@ extension AppDelegate {
     }
 
     // MARK: - SSE Event Subscription
+
+    func rebindDiskPressureConnectionObserver() {
+        diskPressureConnectionTask?.cancel()
+        diskPressureConnectionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await isConnected in self.connectionManager.isConnectedStream {
+                guard !Task.isCancelled else { break }
+                self.services.diskPressureMonitor.connectionStateChanged(isConnected: isConnected)
+            }
+        }
+    }
 
     /// Subscribe to the event stream and dispatch events to their handlers.
     /// Each event type is handled in a single switch statement.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -156,6 +156,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// (e.g. the async batch STT fallback completing after the user already sent).
     var voiceTranscriptionConsumed = false
     var connectionStatusTask: Task<Void, Never>?
+    var diskPressureConnectionTask: Task<Void, Never>?
     var quickInputAttachmentCancellable: AnyCancellable?
     var avatarChangeObserver: NSObjectProtocol?
     /// Cached circular avatar image for the menu bar icon. Invalidated only
@@ -401,6 +402,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = ChatDiagnosticsStore.shared
 
         MainThreadStallDetector.shared.start()
+        services.diskPressureMonitor.start()
         // Begin observing system memory pressure so subsystems that do
         // periodic main-thread work (e.g. DebugStateWriter) can throttle
         // under warning/critical events instead of compounding the stall.
@@ -833,6 +835,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         tearDownSleepWakeHandlers()
         NSApp.dockTile.badgeLabel = nil
         connectionStatusTask?.cancel()
+        diskPressureConnectionTask?.cancel()
+        services.diskPressureMonitor.stop()
         statusDotLayer?.removeAllAnimations()
         statusDotLayer?.removeFromSuperlayer()
         statusDotLayer = nil

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -4,7 +4,8 @@ import VellumAssistantShared
 /// that were previously declared directly on `AppDelegate`.
 @MainActor
 public final class AppServices {
-    public let connectionManager = GatewayConnectionManager()
+    public let connectionManager: GatewayConnectionManager
+    let diskPressureMonitor: DiskPressureMonitor
 
     public let authManager = AuthManager()
     public let ambientAgent = AmbientAgent()
@@ -23,6 +24,16 @@ public final class AppServices {
         connectionManager: connectionManager,
         eventStreamClient: connectionManager.eventStreamClient
     )
+
+    public init() {
+        let connectionManager = GatewayConnectionManager()
+        self.connectionManager = connectionManager
+        diskPressureMonitor = DiskPressureMonitor(
+            isConnectedProvider: { [weak connectionManager] in
+                connectionManager?.isConnected ?? false
+            }
+        )
+    }
 
     /// Reconfigure the connection for a new assistant.
     func reconfigureConnection(conversationKey: String? = nil) {

--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -1,0 +1,239 @@
+import AppKit
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "DiskPressureMonitor")
+
+struct DiskPressureAlert: Equatable, Sendable {
+    let id: String
+    let assistantId: String
+    let displayPercent: Int
+    let usedMb: Double
+    let totalMb: Double
+}
+
+@MainActor
+@Observable
+final class DiskPressureMonitor {
+    typealias HealthzFetcher = @Sendable () async throws -> DaemonHealthz?
+    typealias ActiveAssistantIdProvider = @MainActor () -> String?
+    typealias ConnectedProvider = @MainActor () -> Bool
+
+    static let triggerUsageFraction = 0.90
+    static let resolveUsageFraction = 0.80
+
+    private let fetchHealthz: HealthzFetcher
+    private let activeAssistantIdProvider: ActiveAssistantIdProvider
+    private let isConnectedProvider: ConnectedProvider
+    private let notificationCenter: NotificationCenter
+    private let cadenceNanoseconds: UInt64
+
+    private(set) var alert: DiskPressureAlert?
+
+    @ObservationIgnored private var activeAssistantId: String?
+    @ObservationIgnored private var alertCycle = 0
+    @ObservationIgnored private var started = false
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
+    @ObservationIgnored private var cadenceTask: Task<Void, Never>?
+    @ObservationIgnored private var appActivationObserver: NSObjectProtocol?
+    @ObservationIgnored private var activeAssistantObserver: NSObjectProtocol?
+
+    var isPressureActive: Bool {
+        alert != nil
+    }
+
+    init(
+        fetchHealthz: @escaping HealthzFetcher = {
+            let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/healthz",
+                timeout: 10
+            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
+            return decoded
+        },
+        activeAssistantIdProvider: @escaping ActiveAssistantIdProvider = {
+            LockfileAssistant.loadActiveAssistantId()
+        },
+        isConnectedProvider: @escaping ConnectedProvider = {
+            AppDelegate.shared?.connectionManager.isConnected ?? false
+        },
+        notificationCenter: NotificationCenter = .default,
+        cadenceNanoseconds: UInt64 = 60_000_000_000
+    ) {
+        self.fetchHealthz = fetchHealthz
+        self.activeAssistantIdProvider = activeAssistantIdProvider
+        self.isConnectedProvider = isConnectedProvider
+        self.notificationCenter = notificationCenter
+        self.cadenceNanoseconds = cadenceNanoseconds
+        self.activeAssistantId = activeAssistantIdProvider()
+    }
+
+    deinit {
+        refreshTask?.cancel()
+        cadenceTask?.cancel()
+        if let appActivationObserver {
+            notificationCenter.removeObserver(appActivationObserver)
+        }
+        if let activeAssistantObserver {
+            notificationCenter.removeObserver(activeAssistantObserver)
+        }
+    }
+
+    func start() {
+        guard !started else { return }
+        started = true
+
+        appActivationObserver = notificationCenter.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshForCurrentAssistant()
+            }
+        }
+
+        activeAssistantObserver = notificationCenter.addObserver(
+            forName: LockfileAssistant.activeAssistantDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshForCurrentAssistant()
+            }
+        }
+
+        let cadenceNanoseconds = self.cadenceNanoseconds
+        cadenceTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: cadenceNanoseconds)
+                guard let self, !Task.isCancelled else { break }
+                self.refreshForCurrentAssistant()
+            }
+        }
+    }
+
+    func stop() {
+        started = false
+        refreshTask?.cancel()
+        refreshTask = nil
+        cadenceTask?.cancel()
+        cadenceTask = nil
+        clearAlert()
+
+        if let appActivationObserver {
+            notificationCenter.removeObserver(appActivationObserver)
+            self.appActivationObserver = nil
+        }
+        if let activeAssistantObserver {
+            notificationCenter.removeObserver(activeAssistantObserver)
+            self.activeAssistantObserver = nil
+        }
+    }
+
+    func connectionStateChanged(isConnected: Bool) {
+        if isConnected {
+            refreshForCurrentAssistant()
+        } else {
+            refreshTask?.cancel()
+            refreshTask = nil
+            clearAlert()
+        }
+    }
+
+    func refreshForCurrentAssistant() {
+        let assistantId = activeAssistantIdProvider()
+        updateActiveAssistant(assistantId)
+
+        guard isConnectedProvider(), assistantId != nil else {
+            refreshTask?.cancel()
+            refreshTask = nil
+            clearAlert()
+            return
+        }
+
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.fetchAndApplyHealthz(for: assistantId)
+        }
+    }
+
+    func applyHealthz(_ healthz: DaemonHealthz?, assistantId: String?) {
+        updateActiveAssistant(assistantId)
+
+        guard let assistantId, let disk = healthz?.disk else {
+            clearAlert()
+            return
+        }
+
+        applyDiskInfo(disk, assistantId: assistantId)
+    }
+
+    private func fetchAndApplyHealthz(for assistantId: String?) async {
+        do {
+            let healthz = try await fetchHealthz()
+            guard !Task.isCancelled else { return }
+            applyHealthz(healthz, assistantId: assistantId)
+        } catch {
+            guard !Task.isCancelled else { return }
+            log.debug("Disk-pressure healthz refresh failed: \(error.localizedDescription, privacy: .public)")
+            applyHealthz(nil, assistantId: assistantId)
+        }
+    }
+
+    private func updateActiveAssistant(_ assistantId: String?) {
+        guard activeAssistantId != assistantId else { return }
+        activeAssistantId = assistantId
+        refreshTask?.cancel()
+        refreshTask = nil
+        clearAlert()
+    }
+
+    private func applyDiskInfo(_ disk: DaemonHealthz.DiskInfo, assistantId: String) {
+        guard let usageFraction = Self.usageFraction(for: disk) else {
+            clearAlert()
+            return
+        }
+
+        if alert == nil {
+            guard usageFraction >= Self.triggerUsageFraction else { return }
+            alertCycle += 1
+        } else if usageFraction < Self.resolveUsageFraction {
+            clearAlert()
+            return
+        }
+
+        let nextAlert = DiskPressureAlert(
+            id: Self.alertId(assistantId: assistantId, cycle: alertCycle),
+            assistantId: assistantId,
+            displayPercent: Self.displayPercent(forUsageFraction: usageFraction),
+            usedMb: disk.usedMb,
+            totalMb: disk.totalMb
+        )
+        if alert != nextAlert {
+            alert = nextAlert
+        }
+    }
+
+    private func clearAlert() {
+        guard alert != nil else { return }
+        alert = nil
+    }
+
+    static func usageFraction(for disk: DaemonHealthz.DiskInfo) -> Double? {
+        guard disk.totalMb > 0, disk.usedMb.isFinite, disk.totalMb.isFinite else {
+            return nil
+        }
+        return disk.usedMb / disk.totalMb
+    }
+
+    static func displayPercent(forUsageFraction usageFraction: Double) -> Int {
+        Int((usageFraction * 100).rounded())
+    }
+
+    static func alertId(assistantId: String, cycle: Int) -> String {
+        "disk-pressure:\(assistantId):\(cycle)"
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Health status response from the daemon's `/v1/health` endpoint.
-struct DaemonHealthz: Decodable {
+struct DaemonHealthz: Decodable, Sendable {
     let status: String
     let timestamp: String?
     let version: String?
@@ -19,19 +19,19 @@ struct DaemonHealthz: Decodable {
         self.cpu = cpu
     }
 
-    struct DiskInfo: Decodable {
+    struct DiskInfo: Decodable, Sendable {
         let path: String
         let totalMb: Double
         let usedMb: Double
         let freeMb: Double
     }
 
-    struct MemoryInfo: Decodable {
+    struct MemoryInfo: Decodable, Sendable {
         let currentMb: Double
         let maxMb: Double
     }
 
-    struct CpuInfo: Decodable {
+    struct CpuInfo: Decodable, Sendable {
         let currentPercent: Double
         let maxCores: Int
     }

--- a/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
+++ b/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class DiskPressureMonitorTests: XCTestCase {
+    func testPressureTriggersAtNinetyPercent() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 90, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertEqual(monitor.alert?.assistantId, "assistant-a")
+        XCTAssertEqual(monitor.alert?.displayPercent, 90)
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:1")
+    }
+
+    func testPressureDoesNotTriggerBelowNinetyPercent() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 89.9, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertNil(monitor.alert)
+    }
+
+    func testPressureResolvesOnlyBelowEightyPercent() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        let initialAlertId = monitor.alert?.id
+        monitor.applyHealthz(healthz(usedMb: 80, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertEqual(monitor.alert?.id, initialAlertId)
+        XCTAssertEqual(monitor.alert?.displayPercent, 80)
+
+        monitor.applyHealthz(healthz(usedMb: 79.9, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertNil(monitor.alert)
+    }
+
+    func testNewAlertCycleUsesStableNewId() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:1")
+
+        monitor.applyHealthz(healthz(usedMb: 70, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 91, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:2")
+    }
+
+    func testAssistantSwitchClearsStaleAlertAndScopesNextId() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-b")
+
+        XCTAssertEqual(monitor.alert?.assistantId, "assistant-b")
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-b:2")
+    }
+
+    func testUnreachableOrMissingDiskMetricsClearsAlert() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(nil, assistantId: "assistant-a")
+        XCTAssertNil(monitor.alert)
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(DaemonHealthz(status: "ok"), assistantId: "assistant-a")
+        XCTAssertNil(monitor.alert)
+    }
+
+    func testInvalidDiskTotalClearsAlert() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 0), assistantId: "assistant-a")
+
+        XCTAssertNil(monitor.alert)
+    }
+
+    private func makeMonitor(assistantId: String) -> DiskPressureMonitor {
+        DiskPressureMonitor(
+            fetchHealthz: { nil },
+            activeAssistantIdProvider: { assistantId },
+            isConnectedProvider: { true },
+            notificationCenter: NotificationCenter(),
+            cadenceNanoseconds: 1_000_000_000
+        )
+    }
+
+    private func healthz(usedMb: Double, totalMb: Double) -> DaemonHealthz {
+        DaemonHealthz(
+            status: "ok",
+            disk: DaemonHealthz.DiskInfo(
+                path: "/workspace",
+                totalMb: totalMb,
+                usedMb: usedMb,
+                freeMb: max(totalMb - usedMb, 0)
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary\n- Adds active-assistant disk-pressure monitoring backed by healthz disk metrics.\n- Applies 90% trigger / 80% resolve hysteresis and assistant-scoped alert identity.\n- Clears stale alert state across assistant switches, reconnect failures, and missing metrics.\n\nPart of plan: macos-disk-alerts.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
