### PR TITLE
Seed mainAgent Opus in initial hatch config

### DIFF
--- a/cli/src/__tests__/config-utils.test.ts
+++ b/cli/src/__tests__/config-utils.test.ts
@@ -85,6 +85,22 @@ describe("config-utils", () => {
     });
   });
 
+  test("buildInitialConfig respects explicit non-default Anthropic models", () => {
+    expect(
+      buildInitialConfig({
+        "llm.default.provider": "anthropic",
+        "llm.default.model": "claude-haiku-4-5-20251001",
+      }),
+    ).toEqual({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+        },
+      },
+    });
+  });
+
   test("buildInitialConfig does not seed Opus for non-Anthropic providers", () => {
     expect(
       buildInitialConfig({

--- a/cli/src/__tests__/config-utils.test.ts
+++ b/cli/src/__tests__/config-utils.test.ts
@@ -101,6 +101,46 @@ describe("config-utils", () => {
     });
   });
 
+  test("buildInitialConfig respects active profile provider overrides", () => {
+    expect(
+      buildInitialConfig({
+        "llm.activeProfile": "fast",
+        "llm.profiles.fast.provider": "openai",
+        "llm.profiles.fast.model": "gpt-5.5",
+      }),
+    ).toEqual({
+      llm: {
+        activeProfile: "fast",
+        profiles: {
+          fast: {
+            provider: "openai",
+            model: "gpt-5.5",
+          },
+        },
+      },
+    });
+  });
+
+  test("buildInitialConfig uses active profile model when deciding to seed", () => {
+    expect(
+      buildInitialConfig({
+        "llm.activeProfile": "fast",
+        "llm.profiles.fast.provider": "anthropic",
+        "llm.profiles.fast.model": "claude-haiku-4-5-20251001",
+      }),
+    ).toEqual({
+      llm: {
+        activeProfile: "fast",
+        profiles: {
+          fast: {
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+      },
+    });
+  });
+
   test("buildInitialConfig does not seed Opus for non-Anthropic providers", () => {
     expect(
       buildInitialConfig({

--- a/cli/src/__tests__/config-utils.test.ts
+++ b/cli/src/__tests__/config-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildInitialConfig, buildNestedConfig } from "../lib/config-utils.js";
+
+describe("config-utils", () => {
+  test("buildNestedConfig only converts dot-notation values", () => {
+    expect(
+      buildNestedConfig({
+        "llm.default.provider": "anthropic",
+        "llm.default.model": "claude-sonnet-4-6",
+      }),
+    ).toEqual({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+      },
+    });
+  });
+
+  test("buildInitialConfig seeds Opus for the Anthropic main thread", () => {
+    expect(
+      buildInitialConfig({
+        "llm.default.provider": "anthropic",
+        "llm.default.model": "claude-sonnet-4-6",
+      }),
+    ).toEqual({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+        callSites: {
+          mainAgent: {
+            model: "claude-opus-4-7",
+            maxTokens: 32000,
+          },
+        },
+      },
+    });
+  });
+
+  test("buildInitialConfig seeds Opus when provider falls back to Anthropic", () => {
+    expect(
+      buildInitialConfig({
+        "services.inference.mode": "managed",
+      }),
+    ).toEqual({
+      services: {
+        inference: {
+          mode: "managed",
+        },
+      },
+      llm: {
+        callSites: {
+          mainAgent: {
+            model: "claude-opus-4-7",
+            maxTokens: 32000,
+          },
+        },
+      },
+    });
+  });
+
+  test("buildInitialConfig preserves explicit mainAgent overrides", () => {
+    expect(
+      buildInitialConfig({
+        "llm.default.provider": "anthropic",
+        "llm.default.model": "claude-sonnet-4-6",
+        "llm.callSites.mainAgent.model": "claude-haiku-4-5-20251001",
+      }),
+    ).toEqual({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+        callSites: {
+          mainAgent: {
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+      },
+    });
+  });
+
+  test("buildInitialConfig does not seed Opus for non-Anthropic providers", () => {
+    expect(
+      buildInitialConfig({
+        "llm.default.provider": "openai",
+        "llm.default.model": "gpt-5.5",
+      }),
+    ).toEqual({
+      llm: {
+        default: {
+          provider: "openai",
+          model: "gpt-5.5",
+        },
+      },
+    });
+  });
+});

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -15,7 +15,7 @@ import {
   VALID_SPECIES,
 } from "../lib/constants";
 import type { RemoteHost, Species } from "../lib/constants";
-import { buildNestedConfig } from "../lib/config-utils";
+import { buildInitialConfig } from "../lib/config-utils";
 import { hatchDocker } from "../lib/docker";
 import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
@@ -123,7 +123,11 @@ export async function buildStartupScript(
   // and export the env var so the daemon reads it on first boot.
   let configWriteBlock = "";
   if (Object.keys(configValues).length > 0) {
-    const configJson = JSON.stringify(buildNestedConfig(configValues), null, 2);
+    const configJson = JSON.stringify(
+      buildInitialConfig(configValues),
+      null,
+      2,
+    );
     configWriteBlock = `
 echo "Writing default workspace config..."
 VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH="/tmp/vellum-initial-config-$$.json"

--- a/cli/src/lib/config-utils.ts
+++ b/cli/src/lib/config-utils.ts
@@ -80,11 +80,12 @@ export function writeInitialConfig(
 function seedAnthropicMainAgentCallSite(config: Record<string, unknown>): void {
   const llm = ensureObject(config, "llm");
 
-  const defaultBlock = readObject(llm.default);
-  const provider = readString(defaultBlock?.provider) ?? ANTHROPIC_PROVIDER;
+  const existingCallSites = readObject(llm.callSites);
+  if (existingCallSites !== null && "mainAgent" in existingCallSites) return;
+
+  const { provider, model } = resolveInitialMainAgentBaseSelection(llm);
   if (provider !== ANTHROPIC_PROVIDER) return;
 
-  const model = readString(defaultBlock?.model);
   if (
     model !== undefined &&
     model !== ANTHROPIC_DEFAULT_MODEL &&
@@ -94,12 +95,34 @@ function seedAnthropicMainAgentCallSite(config: Record<string, unknown>): void {
   }
 
   const callSites = ensureObject(llm, "callSites");
-  if ("mainAgent" in callSites) return;
 
   callSites.mainAgent = {
     model: MAIN_AGENT_OPUS_MODEL,
     maxTokens: MAIN_AGENT_OPUS_MAX_TOKENS,
   };
+}
+
+function resolveInitialMainAgentBaseSelection(llm: Record<string, unknown>): {
+  provider: string;
+  model?: string;
+} {
+  const defaultBlock = readObject(llm.default);
+  let provider = readString(defaultBlock?.provider) ?? ANTHROPIC_PROVIDER;
+  let model = readString(defaultBlock?.model);
+
+  const profiles = readObject(llm.profiles);
+  const activeProfileName = readString(llm.activeProfile);
+  const activeProfile =
+    profiles !== null && activeProfileName !== undefined
+      ? readObject(profiles[activeProfileName])
+      : null;
+
+  if (activeProfile !== null) {
+    provider = readString(activeProfile.provider) ?? provider;
+    model = readString(activeProfile.model) ?? model;
+  }
+
+  return model === undefined ? { provider } : { provider, model };
 }
 
 function ensureObject(

--- a/cli/src/lib/config-utils.ts
+++ b/cli/src/lib/config-utils.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 const ANTHROPIC_PROVIDER = "anthropic";
+const ANTHROPIC_DEFAULT_MODEL = "claude-sonnet-4-6";
 const MAIN_AGENT_OPUS_MODEL = "claude-opus-4-7";
 const MAIN_AGENT_OPUS_MAX_TOKENS = 32000;
 
@@ -82,6 +83,15 @@ function seedAnthropicMainAgentCallSite(config: Record<string, unknown>): void {
   const defaultBlock = readObject(llm.default);
   const provider = readString(defaultBlock?.provider) ?? ANTHROPIC_PROVIDER;
   if (provider !== ANTHROPIC_PROVIDER) return;
+
+  const model = readString(defaultBlock?.model);
+  if (
+    model !== undefined &&
+    model !== ANTHROPIC_DEFAULT_MODEL &&
+    model !== MAIN_AGENT_OPUS_MODEL
+  ) {
+    return;
+  }
 
   const callSites = ensureObject(llm, "callSites");
   if ("mainAgent" in callSites) return;

--- a/cli/src/lib/config-utils.ts
+++ b/cli/src/lib/config-utils.ts
@@ -2,6 +2,10 @@ import { writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
+const ANTHROPIC_PROVIDER = "anthropic";
+const MAIN_AGENT_OPUS_MODEL = "claude-opus-4-7";
+const MAIN_AGENT_OPUS_MAX_TOKENS = 32000;
+
 /**
  * Convert flat dot-notation key=value pairs into a nested config object.
  *
@@ -33,6 +37,20 @@ export function buildNestedConfig(
 }
 
 /**
+ * Build the first-boot workspace config overlay passed to the assistant during
+ * hatch. Anthropic onboarding sets `llm.default.model` to Sonnet so background
+ * fallback work stays cheaper, while the main conversation thread should remain
+ * on Opus via the same call-site override seeded by workspace migration 050.
+ */
+export function buildInitialConfig(
+  configValues: Record<string, string>,
+): Record<string, unknown> {
+  const config = buildNestedConfig(configValues);
+  seedAnthropicMainAgentCallSite(config);
+  return config;
+}
+
+/**
  * Write arbitrary key-value pairs to a temporary JSON file and return its
  * path. The caller passes this path to the daemon via the
  * VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH env var so the daemon can merge the
@@ -49,11 +67,56 @@ export function writeInitialConfig(
 ): string | undefined {
   if (Object.keys(configValues).length === 0) return undefined;
 
-  const config = buildNestedConfig(configValues);
+  const config = buildInitialConfig(configValues);
   const tempPath = join(
     tmpdir(),
     `vellum-default-workspace-config-${process.pid}-${Date.now()}.json`,
   );
   writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n");
   return tempPath;
+}
+
+function seedAnthropicMainAgentCallSite(config: Record<string, unknown>): void {
+  const llm = ensureObject(config, "llm");
+
+  const defaultBlock = readObject(llm.default);
+  const provider = readString(defaultBlock?.provider) ?? ANTHROPIC_PROVIDER;
+  if (provider !== ANTHROPIC_PROVIDER) return;
+
+  const callSites = ensureObject(llm, "callSites");
+  if ("mainAgent" in callSites) return;
+
+  callSites.mainAgent = {
+    model: MAIN_AGENT_OPUS_MODEL,
+    maxTokens: MAIN_AGENT_OPUS_MAX_TOKENS,
+  };
+}
+
+function ensureObject(
+  parent: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const existing = parent[key];
+  if (
+    existing != null &&
+    typeof existing === "object" &&
+    !Array.isArray(existing)
+  ) {
+    return existing as Record<string, unknown>;
+  }
+
+  const next: Record<string, unknown> = {};
+  parent[key] = next;
+  return next;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }


### PR DESCRIPTION
## Summary
- Add a first-boot config builder that seeds `llm.callSites.mainAgent` to Claude Opus 4.7 for Anthropic defaults while keeping `llm.default.model` on Sonnet.
- Route local, Docker, and remote hatch initial config generation through the same builder.
- Add regression coverage for Anthropic, implicit Anthropic fallback, explicit main-agent overrides, and non-Anthropic providers.

## Original prompt
make that proposed change please
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
