### PR TITLE
feat(macos): add a credits-style disk-pressure CTA

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -241,6 +241,49 @@ struct CreditsExhaustedBanner: View {
     }
 }
 
+// MARK: - Disk Pressure Banner
+
+/// Inline banner shown while the active assistant is reporting high disk usage.
+struct DiskPressureBanner: View {
+    let alert: DiskPressureAlert
+    let onReviewDiskUsage: () -> Void
+
+    var body: some View {
+        HStack(spacing: VSpacing.xl) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Disk space is running low")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentEmphasized)
+                Text(Self.subtitle(for: alert))
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+
+            Spacer(minLength: VSpacing.lg)
+
+            VButton(label: "Review Disk Usage", style: .primary) {
+                onReviewDiskUsage()
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.surfaceActive)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: VRadius.lg,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0,
+                topTrailingRadius: VRadius.lg
+            )
+        )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .layoutHangSignpost("chat.diskPressureBanner")
+    }
+
+    static func subtitle(for alert: DiskPressureAlert) -> String {
+        "Storage is \(alert.displayPercent)% full."
+    }
+}
+
 // MARK: - Compaction Circuit Open Banner
 
 /// Inline banner shown when the assistant has paused automatic context

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -44,6 +44,8 @@ struct ChatView: View {
     var onSubagentTap: ((String) -> Void)?
     var onAddFunds: (() -> Void)? = nil
     var onOpenModelsAndServices: (() -> Void)? = nil
+    var diskPressureAlert: DiskPressureAlert? = nil
+    var onReviewDiskUsage: (() -> Void)? = nil
     var onBootstrapSendLogs: (() -> Void)?
 
     // MARK: - Recovery Mode (managed assistants only)
@@ -373,6 +375,17 @@ struct ChatView: View {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
                     CreditsExhaustedBanner(
                         onAddFunds: { onAddFunds?() }
+                    )
+                }
+                .padding(.bottom, -VSpacing.sm)
+                .animation(nil, value: queuedMessages.isEmpty)
+            }
+
+            if let diskPressureAlert, let onReviewDiskUsage {
+                centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
+                    DiskPressureBanner(
+                        alert: diskPressureAlert,
+                        onReviewDiskUsage: onReviewDiskUsage
                     )
                 }
                 .padding(.bottom, -VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -959,6 +959,11 @@ struct ActiveChatViewWrapper: View {
                     settingsStore.pendingSettingsTab = .modelsAndServices
                     windowState.selection = .panel(.settings)
                 },
+                diskPressureAlert: AppDelegate.shared?.services.diskPressureMonitor.alert,
+                onReviewDiskUsage: {
+                    settingsStore.requestGeneralSection(.systemResources)
+                    windowState.selection = .panel(.settings)
+                },
                 onBootstrapSendLogs: {
                     AppDelegate.shared?.showLogReportWindow(reason: .bugReport)
                 },

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -186,16 +186,27 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                ScrollView {
-                    selectedTabContent
-                        .padding(.top, VSpacing.lg)
-                        .padding(.trailing, VSpacing.xl)
-                        .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: 900, alignment: .top)
-                        .frame(maxWidth: .infinity)
-                        .background { OverlayScrollerStyle() }
+                ScrollViewReader { scrollProxy in
+                    ScrollView {
+                        selectedTabContent
+                            .padding(.top, VSpacing.lg)
+                            .padding(.trailing, VSpacing.xl)
+                            .padding(.bottom, VSpacing.xl)
+                            .frame(maxWidth: 900, alignment: .top)
+                            .frame(maxWidth: .infinity)
+                            .background { OverlayScrollerStyle() }
+                    }
+                    .scrollContentBackground(.hidden)
+                    .onAppear {
+                        scrollToPendingGeneralSection(using: scrollProxy)
+                    }
+                    .onChange(of: selectedTab) { _, _ in
+                        scrollToPendingGeneralSection(using: scrollProxy)
+                    }
+                    .onChange(of: store.pendingSettingsGeneralSection) { _, _ in
+                        scrollToPendingGeneralSection(using: scrollProxy)
+                    }
                 }
-                .scrollContentBackground(.hidden)
             }
             .frame(maxWidth: .infinity)
         }
@@ -342,6 +353,17 @@ struct SettingsPanel: View {
                 )
             }
             .padding(VSpacing.lg)
+        }
+    }
+
+    private func scrollToPendingGeneralSection(using scrollProxy: ScrollViewProxy) {
+        guard selectedTab == .general, let section = store.pendingSettingsGeneralSection else { return }
+        Task { @MainActor in
+            await Task.yield()
+            withAnimation(VAnimation.standard) {
+                scrollProxy.scrollTo(section, anchor: .top)
+            }
+            store.pendingSettingsGeneralSection = nil
         }
     }
 
@@ -840,4 +862,3 @@ struct OverlayScrollerStyle: NSViewRepresentable {
     }
     func updateNSView(_ nsView: NSView, context: Context) {}
 }
-

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -219,6 +219,11 @@ private struct ThreadWindowContentView: View {
                         settingsStore.pendingSettingsTab = .modelsAndServices
                         AppDelegate.shared?.showSettingsWindow(nil)
                     },
+                    diskPressureAlert: AppDelegate.shared?.services.diskPressureMonitor.alert,
+                    onReviewDiskUsage: {
+                        settingsStore.requestGeneralSection(.systemResources)
+                        AppDelegate.shared?.showSettingsWindow(nil)
+                    },
                     recoveryMode: settingsStore.managedAssistantRecoveryMode,
                     isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                     onResumeAssistant: {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -61,7 +61,7 @@ struct SettingsGeneralTab: View {
                     updateManager: updateManager
                 )
             }
-            if topology == .managed {
+            if shouldShowSystemResourcesSection {
                 systemResourcesSection
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
@@ -175,12 +175,24 @@ struct SettingsGeneralTab: View {
 
     // MARK: - System Resources
 
-    /// Resource usage card shown for platform-managed assistants. Mirrors the
-    /// disk/memory/CPU rows from the Developer tab so users on the platform can
-    /// see their assistant's resource consumption without enabling dev mode.
+    private var shouldShowSystemResourcesSection: Bool {
+        topology == .managed
+            || Self.hasResourceMetrics(healthz)
+            || store.pendingSettingsGeneralSection == .systemResources
+            || (!healthzLoaded && !selectedAssistantId.isEmpty)
+    }
+
+    nonisolated static func hasResourceMetrics(_ healthz: DaemonHealthz?) -> Bool {
+        guard let healthz else { return false }
+        return healthz.disk != nil || healthz.memory != nil || healthz.cpu != nil
+    }
+
+    /// Resource usage card shown for any assistant that reports metrics. Mirrors
+    /// the disk/memory/CPU rows from the Developer tab so users can review disk
+    /// pressure without enabling dev mode.
     private var systemResourcesSection: some View {
         SettingsCard(
-            title: "System Resources",
+            title: "Storage & Resources",
             accessory: {
                 if isRefreshingHealthz {
                     ProgressView()
@@ -204,7 +216,7 @@ struct SettingsGeneralTab: View {
                     resourceBarRow(
                         label: "Disk Usage:",
                         ratio: disk.usedMb / max(disk.totalMb, 1),
-                        caption: "\(formatMb(disk.usedMb)) used of \(formatMb(disk.totalMb))",
+                        caption: "\(Self.formatMb(disk.usedMb)) used of \(Self.formatMb(disk.totalMb))",
                         accessibilityLabel: "Disk usage"
                     )
                 }
@@ -213,7 +225,7 @@ struct SettingsGeneralTab: View {
                     resourceBarRow(
                         label: "Memory:",
                         ratio: memory.currentMb / max(memory.maxMb, 1),
-                        caption: "\(formatMb(memory.currentMb)) / \(formatMb(memory.maxMb))",
+                        caption: "\(Self.formatMb(memory.currentMb)) / \(Self.formatMb(memory.maxMb))",
                         accessibilityLabel: "Memory usage"
                     )
                 }
@@ -242,6 +254,7 @@ struct SettingsGeneralTab: View {
                 }
             }
         }
+        .id(SettingsGeneralSection.systemResources)
     }
 
     /// A resource row with a label on the left, a capsule usage bar, and a gray
@@ -278,7 +291,7 @@ struct SettingsGeneralTab: View {
         }
     }
 
-    private func formatMb(_ mb: Double) -> String {
+    nonisolated static func formatMb(_ mb: Double) -> String {
         if mb >= 1024 {
             return String(format: "%.1f GB", mb / 1024.0)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -12,6 +12,10 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Setti
 /// UserDefaults key for tracking explicit key deletions that may not have reached the daemon.
 private let kPendingKeyDeletionTombstones = "pendingKeyDeletionTombstones"
 
+enum SettingsGeneralSection: Hashable {
+    case systemResources
+}
+
 /// Single source of truth for settings state shared between `SettingsPanel`
 /// (main window side panel) and its extracted tab views.
 @MainActor
@@ -21,6 +25,13 @@ public final class SettingsStore: ObservableObject {
     /// Set externally (e.g. via HTTP) to deep-link into a specific settings tab.
     /// SettingsPanel observes this and clears it after applying.
     @Published var pendingSettingsTab: SettingsTab?
+    /// Optional section anchor consumed by the General tab after the tab opens.
+    @Published var pendingSettingsGeneralSection: SettingsGeneralSection?
+
+    func requestGeneralSection(_ section: SettingsGeneralSection) {
+        pendingSettingsTab = .general
+        pendingSettingsGeneralSection = section
+    }
 
     // MARK: - API Key State
 

--- a/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("Chat disk-pressure banner")
+struct ChatDiskPressureBannerTests {
+    @Test
+    func subtitleUsesMonitorDisplayPercent() {
+        let alert = DiskPressureAlert(
+            id: "disk-pressure:assistant-123:1",
+            assistantId: "assistant-123",
+            displayPercent: 93,
+            usedMb: 930,
+            totalMb: 1_000
+        )
+
+        #expect(DiskPressureBanner.subtitle(for: alert) == "Storage is 93% full.")
+    }
+
+    @Test @MainActor
+    func reviewDiskUsageRequestsGeneralStorageLanding() {
+        let store = SettingsStore()
+
+        store.requestGeneralSection(.systemResources)
+
+        #expect(store.pendingSettingsTab == .general)
+        #expect(store.pendingSettingsGeneralSection == .systemResources)
+    }
+}

--- a/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("Settings General disk resources section")
+struct SettingsGeneralDiskSectionTests {
+    @Test
+    func diskMetricsMakeResourceSectionEligible() {
+        let healthz = DaemonHealthz(
+            status: "ok",
+            disk: DaemonHealthz.DiskInfo(
+                path: "/workspace",
+                totalMb: 10_000,
+                usedMb: 9_250,
+                freeMb: 750
+            )
+        )
+
+        #expect(SettingsGeneralTab.hasResourceMetrics(healthz))
+    }
+
+    @Test
+    func assistantsWithoutMetricsAreNotTreatedAsResourceEligible() {
+        #expect(!SettingsGeneralTab.hasResourceMetrics(nil))
+        #expect(!SettingsGeneralTab.hasResourceMetrics(DaemonHealthz(status: "ok")))
+    }
+
+    @Test
+    func megabyteFormatterUsesReadableUnits() {
+        #expect(SettingsGeneralTab.formatMb(512) == "512 MB")
+        #expect(SettingsGeneralTab.formatMb(1_536) == "1.5 GB")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a disk-pressure banner to the chat CTA stack using active assistant monitor state.
- Adds a Settings > General storage landing target for disk usage review.
- Wires main and pop-out chat surfaces to route Review Disk Usage into settings.

Apple refs checked (2026-04-28): SwiftUI ScrollViewReader/scrollTo; SwiftUI accessible descriptions/accessibilityLabel.

Part of plan: macos-disk-alerts.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
