### PR TITLE
fix(macos): tighten disk resources CTA state

### DIFF
--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -10,8 +10,6 @@ struct DiskPressureAlert: Equatable, Sendable {
     let id: String
     let assistantId: String
     let displayPercent: Int
-    let usedMb: Double
-    let totalMb: Double
 }
 
 @MainActor
@@ -39,10 +37,6 @@ final class DiskPressureMonitor {
     @ObservationIgnored private var cadenceTask: Task<Void, Never>?
     @ObservationIgnored private var appActivationObserver: NSObjectProtocol?
     @ObservationIgnored private var activeAssistantObserver: NSObjectProtocol?
-
-    var isPressureActive: Bool {
-        alert != nil
-    }
 
     init(
         fetchHealthz: @escaping HealthzFetcher = {
@@ -208,9 +202,7 @@ final class DiskPressureMonitor {
         let nextAlert = DiskPressureAlert(
             id: Self.alertId(assistantId: assistantId, cycle: alertCycle),
             assistantId: assistantId,
-            displayPercent: Self.displayPercent(forUsageFraction: usageFraction),
-            usedMb: disk.usedMb,
-            totalMb: disk.totalMb
+            displayPercent: Self.displayPercent(forUsageFraction: usageFraction)
         )
         if alert != nextAlert {
             alert = nextAlert

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -27,6 +27,7 @@ struct SettingsGeneralTab: View {
     @State private var dockerOperationTimeoutTask: Task<Void, Never>?
     @State private var healthzLoaded = false
     @State private var isRefreshingHealthz = false
+    @State private var systemResourcesDeepLinkRequested = false
 
 
     private var currentAssistant: LockfileAssistant? {
@@ -92,6 +93,10 @@ struct SettingsGeneralTab: View {
                 lockfileAssistants = assistants
                 await fetchHealthz()
             }
+            recordSystemResourcesDeepLinkIfNeeded(store.pendingSettingsGeneralSection)
+        }
+        .onChange(of: store.pendingSettingsGeneralSection) { _, section in
+            recordSystemResourcesDeepLinkIfNeeded(section)
         }
         .onChange(of: connectionManager?.isUpdateInProgress) { _, inProgress in
             isServiceGroupUpdateInProgress = inProgress ?? false
@@ -179,21 +184,29 @@ struct SettingsGeneralTab: View {
         Self.shouldShowSystemResourcesSection(
             topology: topology,
             healthz: healthz,
-            pendingSection: store.pendingSettingsGeneralSection
+            pendingSection: store.pendingSettingsGeneralSection,
+            deepLinkRequested: systemResourcesDeepLinkRequested
         )
     }
 
     nonisolated static func shouldShowSystemResourcesSection(
         topology: AssistantTopology,
         healthz: DaemonHealthz?,
-        pendingSection: SettingsGeneralSection?
+        pendingSection: SettingsGeneralSection?,
+        deepLinkRequested: Bool = false
     ) -> Bool {
-        topology == .managed || hasResourceMetrics(healthz) || pendingSection == .systemResources
+        topology == .managed || hasResourceMetrics(healthz) || pendingSection == .systemResources || deepLinkRequested
     }
 
     nonisolated static func hasResourceMetrics(_ healthz: DaemonHealthz?) -> Bool {
         guard let healthz else { return false }
         return healthz.disk != nil || healthz.memory != nil || healthz.cpu != nil
+    }
+
+    private func recordSystemResourcesDeepLinkIfNeeded(_ section: SettingsGeneralSection?) {
+        if section == .systemResources {
+            systemResourcesDeepLinkRequested = true
+        }
     }
 
     /// Resource usage card shown for any assistant that reports metrics. Mirrors

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -176,6 +176,7 @@ struct SettingsGeneralTab: View {
             healthz = DaemonHealthz()
         }
         healthzLoaded = true
+        systemResourcesDeepLinkRequested = false
     }
 
     // MARK: - System Resources
@@ -185,7 +186,7 @@ struct SettingsGeneralTab: View {
             topology: topology,
             healthz: healthz,
             pendingSection: store.pendingSettingsGeneralSection,
-            deepLinkRequested: systemResourcesDeepLinkRequested
+            deepLinkRequestPending: systemResourcesDeepLinkRequested && !healthzLoaded
         )
     }
 
@@ -193,9 +194,9 @@ struct SettingsGeneralTab: View {
         topology: AssistantTopology,
         healthz: DaemonHealthz?,
         pendingSection: SettingsGeneralSection?,
-        deepLinkRequested: Bool = false
+        deepLinkRequestPending: Bool = false
     ) -> Bool {
-        topology == .managed || hasResourceMetrics(healthz) || pendingSection == .systemResources || deepLinkRequested
+        topology == .managed || hasResourceMetrics(healthz) || pendingSection == .systemResources || deepLinkRequestPending
     }
 
     nonisolated static func hasResourceMetrics(_ healthz: DaemonHealthz?) -> Bool {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -176,10 +176,19 @@ struct SettingsGeneralTab: View {
     // MARK: - System Resources
 
     private var shouldShowSystemResourcesSection: Bool {
-        topology == .managed
-            || Self.hasResourceMetrics(healthz)
-            || store.pendingSettingsGeneralSection == .systemResources
-            || (!healthzLoaded && !selectedAssistantId.isEmpty)
+        Self.shouldShowSystemResourcesSection(
+            topology: topology,
+            healthz: healthz,
+            pendingSection: store.pendingSettingsGeneralSection
+        )
+    }
+
+    nonisolated static func shouldShowSystemResourcesSection(
+        topology: AssistantTopology,
+        healthz: DaemonHealthz?,
+        pendingSection: SettingsGeneralSection?
+    ) -> Bool {
+        topology == .managed || hasResourceMetrics(healthz) || pendingSection == .systemResources
     }
 
     nonisolated static func hasResourceMetrics(_ healthz: DaemonHealthz?) -> Bool {

--- a/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
@@ -8,9 +8,7 @@ struct ChatDiskPressureBannerTests {
         let alert = DiskPressureAlert(
             id: "disk-pressure:assistant-123:1",
             assistantId: "assistant-123",
-            displayPercent: 93,
-            usedMb: 930,
-            totalMb: 1_000
+            displayPercent: 93
         )
 
         #expect(DiskPressureBanner.subtitle(for: alert) == "Storage is 93% full.")

--- a/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
@@ -25,6 +25,24 @@ struct SettingsGeneralDiskSectionTests {
     }
 
     @Test
+    func localAssistantsDoNotShowResourcesBeforeMetricsLoad() {
+        #expect(!SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: nil
+        ))
+    }
+
+    @Test
+    func explicitDeepLinkShowsResourcesWhileLoading() {
+        #expect(SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: .systemResources
+        ))
+    }
+
+    @Test
     func megabyteFormatterUsesReadableUnits() {
         #expect(SettingsGeneralTab.formatMb(512) == "512 MB")
         #expect(SettingsGeneralTab.formatMb(1_536) == "1.5 GB")

--- a/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
@@ -43,6 +43,16 @@ struct SettingsGeneralDiskSectionTests {
     }
 
     @Test
+    func rememberedDeepLinkKeepsResourcesVisibleAfterPendingSectionClears() {
+        #expect(SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: nil,
+            deepLinkRequested: true
+        ))
+    }
+
+    @Test
     func megabyteFormatterUsesReadableUnits() {
         #expect(SettingsGeneralTab.formatMb(512) == "512 MB")
         #expect(SettingsGeneralTab.formatMb(1_536) == "1.5 GB")

--- a/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
@@ -48,7 +48,17 @@ struct SettingsGeneralDiskSectionTests {
             topology: .local,
             healthz: nil,
             pendingSection: nil,
-            deepLinkRequested: true
+            deepLinkRequestPending: true
+        ))
+    }
+
+    @Test
+    func completedDeepLinkDoesNotKeepResourcesVisibleWithoutMetrics() {
+        #expect(!SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: nil,
+            deepLinkRequestPending: false
         ))
     }
 


### PR DESCRIPTION
## Summary
- Prevents the General settings resources card from appearing during initial load unless metrics are present or the CTA explicitly deep-linked there.
- Removes unused disk-pressure alert payload fields and active-state helper.
- Adds focused settings tests for the non-flicker and deep-link cases.

Fixes gap identified during plan review for macos-disk-alerts.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
