### PR TITLE
Desktop macOS Disk-Pressure CTA

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -118,6 +118,7 @@ extension AppDelegate {
         let assistant = loadAssistantFromLockfile()
 
         configureDaemonTransport(for: assistant)
+        services.diskPressureMonitor.refreshForCurrentAssistant()
 
         // Set recovery credentials for automatic 401 re-bootstrap
         connectionManager.recoveryPlatform = "macos"
@@ -149,6 +150,7 @@ extension AppDelegate {
         // Rebind the menu bar icon observer after transport reconfiguration
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()
+        rebindDiskPressureConnectionObserver()
 
         // Observe the managed-assistant-gone signal (health check 404) once
         // per setup so a retired/deleted platform assistant no longer leaves
@@ -190,6 +192,7 @@ extension AppDelegate {
                 log.info("setupGatewayConnectionManager: skipping connect() — isConnected=\(self.connectionManager.isConnected), isConnecting=\(self.connectionManager.isConnecting)")
             }
             if connectionManager.isConnected {
+                services.diskPressureMonitor.connectionStateChanged(isConnected: true)
                 setupAmbientAgent()
                 refreshAppsCache()
                 refreshSkillsCache()
@@ -200,6 +203,17 @@ extension AppDelegate {
     }
 
     // MARK: - SSE Event Subscription
+
+    func rebindDiskPressureConnectionObserver() {
+        diskPressureConnectionTask?.cancel()
+        diskPressureConnectionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await isConnected in self.connectionManager.isConnectedStream {
+                guard !Task.isCancelled else { break }
+                self.services.diskPressureMonitor.connectionStateChanged(isConnected: isConnected)
+            }
+        }
+    }
 
     /// Subscribe to the event stream and dispatch events to their handlers.
     /// Each event type is handled in a single switch statement.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -156,6 +156,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// (e.g. the async batch STT fallback completing after the user already sent).
     var voiceTranscriptionConsumed = false
     var connectionStatusTask: Task<Void, Never>?
+    var diskPressureConnectionTask: Task<Void, Never>?
     var quickInputAttachmentCancellable: AnyCancellable?
     var avatarChangeObserver: NSObjectProtocol?
     /// Cached circular avatar image for the menu bar icon. Invalidated only
@@ -401,6 +402,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = ChatDiagnosticsStore.shared
 
         MainThreadStallDetector.shared.start()
+        services.diskPressureMonitor.start()
         // Begin observing system memory pressure so subsystems that do
         // periodic main-thread work (e.g. DebugStateWriter) can throttle
         // under warning/critical events instead of compounding the stall.
@@ -833,6 +835,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         tearDownSleepWakeHandlers()
         NSApp.dockTile.badgeLabel = nil
         connectionStatusTask?.cancel()
+        diskPressureConnectionTask?.cancel()
+        services.diskPressureMonitor.stop()
         statusDotLayer?.removeAllAnimations()
         statusDotLayer?.removeFromSuperlayer()
         statusDotLayer = nil

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -4,7 +4,8 @@ import VellumAssistantShared
 /// that were previously declared directly on `AppDelegate`.
 @MainActor
 public final class AppServices {
-    public let connectionManager = GatewayConnectionManager()
+    public let connectionManager: GatewayConnectionManager
+    let diskPressureMonitor: DiskPressureMonitor
 
     public let authManager = AuthManager()
     public let ambientAgent = AmbientAgent()
@@ -23,6 +24,16 @@ public final class AppServices {
         connectionManager: connectionManager,
         eventStreamClient: connectionManager.eventStreamClient
     )
+
+    public init() {
+        let connectionManager = GatewayConnectionManager()
+        self.connectionManager = connectionManager
+        diskPressureMonitor = DiskPressureMonitor(
+            isConnectedProvider: { [weak connectionManager] in
+                connectionManager?.isConnected ?? false
+            }
+        )
+    }
 
     /// Reconfigure the connection for a new assistant.
     func reconfigureConnection(conversationKey: String? = nil) {

--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -20,7 +20,7 @@ final class DiskPressureMonitor {
     typealias ConnectedProvider = @MainActor () -> Bool
 
     static let triggerUsageFraction = 0.85
-    // This one is to prevent flickering of the disk usage alert allegedly
+    /// Keep the banner visible until usage drops comfortably below the trigger.
     static let resolveUsageFraction = 0.80
 
     private let fetchHealthz: HealthzFetcher

--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -1,0 +1,239 @@
+import AppKit
+import Foundation
+import Observation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "DiskPressureMonitor")
+
+struct DiskPressureAlert: Equatable, Sendable {
+    let id: String
+    let assistantId: String
+    let displayPercent: Int
+    let usedMb: Double
+    let totalMb: Double
+}
+
+@MainActor
+@Observable
+final class DiskPressureMonitor {
+    typealias HealthzFetcher = @Sendable () async throws -> DaemonHealthz?
+    typealias ActiveAssistantIdProvider = @MainActor () -> String?
+    typealias ConnectedProvider = @MainActor () -> Bool
+
+    static let triggerUsageFraction = 0.90
+    static let resolveUsageFraction = 0.80
+
+    private let fetchHealthz: HealthzFetcher
+    private let activeAssistantIdProvider: ActiveAssistantIdProvider
+    private let isConnectedProvider: ConnectedProvider
+    private let notificationCenter: NotificationCenter
+    private let cadenceNanoseconds: UInt64
+
+    private(set) var alert: DiskPressureAlert?
+
+    @ObservationIgnored private var activeAssistantId: String?
+    @ObservationIgnored private var alertCycle = 0
+    @ObservationIgnored private var started = false
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
+    @ObservationIgnored private var cadenceTask: Task<Void, Never>?
+    @ObservationIgnored private var appActivationObserver: NSObjectProtocol?
+    @ObservationIgnored private var activeAssistantObserver: NSObjectProtocol?
+
+    var isPressureActive: Bool {
+        alert != nil
+    }
+
+    init(
+        fetchHealthz: @escaping HealthzFetcher = {
+            let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/healthz",
+                timeout: 10
+            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
+            return decoded
+        },
+        activeAssistantIdProvider: @escaping ActiveAssistantIdProvider = {
+            LockfileAssistant.loadActiveAssistantId()
+        },
+        isConnectedProvider: @escaping ConnectedProvider = {
+            AppDelegate.shared?.connectionManager.isConnected ?? false
+        },
+        notificationCenter: NotificationCenter = .default,
+        cadenceNanoseconds: UInt64 = 60_000_000_000
+    ) {
+        self.fetchHealthz = fetchHealthz
+        self.activeAssistantIdProvider = activeAssistantIdProvider
+        self.isConnectedProvider = isConnectedProvider
+        self.notificationCenter = notificationCenter
+        self.cadenceNanoseconds = cadenceNanoseconds
+        self.activeAssistantId = activeAssistantIdProvider()
+    }
+
+    deinit {
+        refreshTask?.cancel()
+        cadenceTask?.cancel()
+        if let appActivationObserver {
+            notificationCenter.removeObserver(appActivationObserver)
+        }
+        if let activeAssistantObserver {
+            notificationCenter.removeObserver(activeAssistantObserver)
+        }
+    }
+
+    func start() {
+        guard !started else { return }
+        started = true
+
+        appActivationObserver = notificationCenter.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshForCurrentAssistant()
+            }
+        }
+
+        activeAssistantObserver = notificationCenter.addObserver(
+            forName: LockfileAssistant.activeAssistantDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshForCurrentAssistant()
+            }
+        }
+
+        let cadenceNanoseconds = self.cadenceNanoseconds
+        cadenceTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: cadenceNanoseconds)
+                guard let self, !Task.isCancelled else { break }
+                self.refreshForCurrentAssistant()
+            }
+        }
+    }
+
+    func stop() {
+        started = false
+        refreshTask?.cancel()
+        refreshTask = nil
+        cadenceTask?.cancel()
+        cadenceTask = nil
+        clearAlert()
+
+        if let appActivationObserver {
+            notificationCenter.removeObserver(appActivationObserver)
+            self.appActivationObserver = nil
+        }
+        if let activeAssistantObserver {
+            notificationCenter.removeObserver(activeAssistantObserver)
+            self.activeAssistantObserver = nil
+        }
+    }
+
+    func connectionStateChanged(isConnected: Bool) {
+        if isConnected {
+            refreshForCurrentAssistant()
+        } else {
+            refreshTask?.cancel()
+            refreshTask = nil
+            clearAlert()
+        }
+    }
+
+    func refreshForCurrentAssistant() {
+        let assistantId = activeAssistantIdProvider()
+        updateActiveAssistant(assistantId)
+
+        guard isConnectedProvider(), assistantId != nil else {
+            refreshTask?.cancel()
+            refreshTask = nil
+            clearAlert()
+            return
+        }
+
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.fetchAndApplyHealthz(for: assistantId)
+        }
+    }
+
+    func applyHealthz(_ healthz: DaemonHealthz?, assistantId: String?) {
+        updateActiveAssistant(assistantId)
+
+        guard let assistantId, let disk = healthz?.disk else {
+            clearAlert()
+            return
+        }
+
+        applyDiskInfo(disk, assistantId: assistantId)
+    }
+
+    private func fetchAndApplyHealthz(for assistantId: String?) async {
+        do {
+            let healthz = try await fetchHealthz()
+            guard !Task.isCancelled else { return }
+            applyHealthz(healthz, assistantId: assistantId)
+        } catch {
+            guard !Task.isCancelled else { return }
+            log.debug("Disk-pressure healthz refresh failed: \(error.localizedDescription, privacy: .public)")
+            applyHealthz(nil, assistantId: assistantId)
+        }
+    }
+
+    private func updateActiveAssistant(_ assistantId: String?) {
+        guard activeAssistantId != assistantId else { return }
+        activeAssistantId = assistantId
+        refreshTask?.cancel()
+        refreshTask = nil
+        clearAlert()
+    }
+
+    private func applyDiskInfo(_ disk: DaemonHealthz.DiskInfo, assistantId: String) {
+        guard let usageFraction = Self.usageFraction(for: disk) else {
+            clearAlert()
+            return
+        }
+
+        if alert == nil {
+            guard usageFraction >= Self.triggerUsageFraction else { return }
+            alertCycle += 1
+        } else if usageFraction < Self.resolveUsageFraction {
+            clearAlert()
+            return
+        }
+
+        let nextAlert = DiskPressureAlert(
+            id: Self.alertId(assistantId: assistantId, cycle: alertCycle),
+            assistantId: assistantId,
+            displayPercent: Self.displayPercent(forUsageFraction: usageFraction),
+            usedMb: disk.usedMb,
+            totalMb: disk.totalMb
+        )
+        if alert != nextAlert {
+            alert = nextAlert
+        }
+    }
+
+    private func clearAlert() {
+        guard alert != nil else { return }
+        alert = nil
+    }
+
+    static func usageFraction(for disk: DaemonHealthz.DiskInfo) -> Double? {
+        guard disk.totalMb > 0, disk.usedMb.isFinite, disk.totalMb.isFinite else {
+            return nil
+        }
+        return disk.usedMb / disk.totalMb
+    }
+
+    static func displayPercent(forUsageFraction usageFraction: Double) -> Int {
+        Int((usageFraction * 100).rounded())
+    }
+
+    static func alertId(assistantId: String, cycle: Int) -> String {
+        "disk-pressure:\(assistantId):\(cycle)"
+    }
+}

--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -10,8 +10,6 @@ struct DiskPressureAlert: Equatable, Sendable {
     let id: String
     let assistantId: String
     let displayPercent: Int
-    let usedMb: Double
-    let totalMb: Double
 }
 
 @MainActor
@@ -39,10 +37,6 @@ final class DiskPressureMonitor {
     @ObservationIgnored private var cadenceTask: Task<Void, Never>?
     @ObservationIgnored private var appActivationObserver: NSObjectProtocol?
     @ObservationIgnored private var activeAssistantObserver: NSObjectProtocol?
-
-    var isPressureActive: Bool {
-        alert != nil
-    }
 
     init(
         fetchHealthz: @escaping HealthzFetcher = {
@@ -208,9 +202,7 @@ final class DiskPressureMonitor {
         let nextAlert = DiskPressureAlert(
             id: Self.alertId(assistantId: assistantId, cycle: alertCycle),
             assistantId: assistantId,
-            displayPercent: Self.displayPercent(forUsageFraction: usageFraction),
-            usedMb: disk.usedMb,
-            totalMb: disk.totalMb
+            displayPercent: Self.displayPercent(forUsageFraction: usageFraction)
         )
         if alert != nextAlert {
             alert = nextAlert

--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -19,7 +19,8 @@ final class DiskPressureMonitor {
     typealias ActiveAssistantIdProvider = @MainActor () -> String?
     typealias ConnectedProvider = @MainActor () -> Bool
 
-    static let triggerUsageFraction = 0.90
+    static let triggerUsageFraction = 0.85
+    // This one is to prevent flickering of the disk usage alert allegedly
     static let resolveUsageFraction = 0.80
 
     private let fetchHealthz: HealthzFetcher

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -261,7 +261,7 @@ struct DiskPressureBanner: View {
 
             Spacer(minLength: VSpacing.lg)
 
-            VButton(label: "Open Workspace", style: .primary) {
+            VButton(label: "Review Disk Usage", style: .primary) {
                 onReviewDiskUsage()
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -247,6 +247,7 @@ struct CreditsExhaustedBanner: View {
 struct DiskPressureBanner: View {
     let alert: DiskPressureAlert
     let onReviewDiskUsage: () -> Void
+    let onDismiss: () -> Void
 
     var body: some View {
         HStack(spacing: VSpacing.xl) {
@@ -261,8 +262,20 @@ struct DiskPressureBanner: View {
 
             Spacer(minLength: VSpacing.lg)
 
-            VButton(label: "Review Disk Usage", style: .primary) {
-                onReviewDiskUsage()
+            HStack(spacing: VSpacing.sm) {
+                VButton(label: "Review Disk Usage", style: .primary) {
+                    onReviewDiskUsage()
+                }
+
+                VButton(
+                    label: "Dismiss disk space alert",
+                    iconOnly: VIcon.x.rawValue,
+                    style: .ghost,
+                    size: .compact,
+                    tooltip: "Dismiss"
+                ) {
+                    onDismiss()
+                }
             }
         }
         .padding(VSpacing.lg)
@@ -283,6 +296,36 @@ struct DiskPressureBanner: View {
 
     static func subtitle(for alert: DiskPressureAlert) -> String {
         "Storage is \(alert.displayPercent)% full. Try cleaning up unused data, like logs."
+    }
+}
+
+enum DiskPressureBannerDismissalStore {
+    static let dismissalDuration: TimeInterval = 24 * 60 * 60
+
+    private static let keyPrefix = "diskPressureBanner.dismissedUntil."
+
+    static func dismiss(alertId: String, now: Date = Date(), userDefaults: UserDefaults = .standard) {
+        let dismissedUntil = now.addingTimeInterval(dismissalDuration)
+        userDefaults.set(dismissedUntil.timeIntervalSince1970, forKey: key(for: alertId))
+    }
+
+    static func dismissedUntil(for alertId: String, userDefaults: UserDefaults = .standard) -> Date? {
+        let timestamp = userDefaults.double(forKey: key(for: alertId))
+        guard timestamp > 0 else { return nil }
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    static func isDismissed(alertId: String, now: Date = Date(), userDefaults: UserDefaults = .standard) -> Bool {
+        guard let dismissedUntil = dismissedUntil(for: alertId, userDefaults: userDefaults) else { return false }
+        guard dismissedUntil > now else {
+            userDefaults.removeObject(forKey: key(for: alertId))
+            return false
+        }
+        return true
+    }
+
+    private static func key(for alertId: String) -> String {
+        keyPrefix + alertId
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -241,6 +241,49 @@ struct CreditsExhaustedBanner: View {
     }
 }
 
+// MARK: - Disk Pressure Banner
+
+/// Inline banner shown while the active assistant is reporting high disk usage.
+struct DiskPressureBanner: View {
+    let alert: DiskPressureAlert
+    let onReviewDiskUsage: () -> Void
+
+    var body: some View {
+        HStack(spacing: VSpacing.xl) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Disk space is running low")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentEmphasized)
+                Text(Self.subtitle(for: alert))
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentSecondary)
+            }
+
+            Spacer(minLength: VSpacing.lg)
+
+            VButton(label: "Review Disk Usage", style: .primary) {
+                onReviewDiskUsage()
+            }
+        }
+        .padding(VSpacing.lg)
+        .background(VColor.surfaceActive)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: VRadius.lg,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0,
+                topTrailingRadius: VRadius.lg
+            )
+        )
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .layoutHangSignpost("chat.diskPressureBanner")
+    }
+
+    static func subtitle(for alert: DiskPressureAlert) -> String {
+        "Storage is \(alert.displayPercent)% full."
+    }
+}
+
 // MARK: - Compaction Circuit Open Banner
 
 /// Inline banner shown when the assistant has paused automatic context

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -261,7 +261,7 @@ struct DiskPressureBanner: View {
 
             Spacer(minLength: VSpacing.lg)
 
-            VButton(label: "Review Disk Usage", style: .primary) {
+            VButton(label: "Open Workspace", style: .primary) {
                 onReviewDiskUsage()
             }
         }
@@ -279,10 +279,10 @@ struct DiskPressureBanner: View {
         .layoutHangSignpost("chat.diskPressureBanner")
     }
 
-    static let title = "💾 Disk space is running low"
+    static let title = "💾 It looks like you're running out of disk space."
 
     static func subtitle(for alert: DiskPressureAlert) -> String {
-        "Storage is \(alert.displayPercent)% full."
+        "Storage is \(alert.displayPercent)% full. Try cleaning up unused data, like logs."
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -251,7 +251,7 @@ struct DiskPressureBanner: View {
     var body: some View {
         HStack(spacing: VSpacing.xl) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Disk space is running low")
+                Text(Self.title)
                     .font(VFont.bodySmallEmphasised)
                     .foregroundStyle(VColor.contentEmphasized)
                 Text(Self.subtitle(for: alert))
@@ -278,6 +278,8 @@ struct DiskPressureBanner: View {
         .transition(.move(edge: .bottom).combined(with: .opacity))
         .layoutHangSignpost("chat.diskPressureBanner")
     }
+
+    static let title = "💾 Disk space is running low"
 
     static func subtitle(for alert: DiskPressureAlert) -> String {
         "Storage is \(alert.displayPercent)% full."

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -107,6 +107,8 @@ struct ChatView: View {
     @State private var currentMatchIndex = 0
     @State private var showSkeleton = false
     @State private var skeletonDebounceTask: Task<Void, Never>? = nil
+    @State private var diskPressureDismissalRefreshToken = 0
+    @State private var diskPressureDismissalRefreshTask: Task<Void, Never>? = nil
 
     private var isEmptyState: Bool {
         viewModel.paginatedVisibleMessages.isEmpty && viewModel.isHistoryLoaded
@@ -126,6 +128,13 @@ struct ChatView: View {
     private var currentConversation: ConversationModel? {
         guard let conversationManager, let conversationId else { return nil }
         return conversationManager.conversations.first(where: { $0.id == conversationId })
+    }
+
+    private var visibleDiskPressureAlert: DiskPressureAlert? {
+        _ = diskPressureDismissalRefreshToken
+        guard let diskPressureAlert else { return nil }
+        guard !DiskPressureBannerDismissalStore.isDismissed(alertId: diskPressureAlert.id) else { return nil }
+        return diskPressureAlert
     }
 
     var body: some View {
@@ -222,8 +231,17 @@ struct ChatView: View {
                 showSkeleton = false
             }
         }
+        .onAppear {
+            scheduleDiskPressureDismissalRefresh()
+        }
+        .onChange(of: diskPressureAlert?.id) {
+            diskPressureDismissalRefreshToken += 1
+            scheduleDiskPressureDismissalRefresh()
+        }
         .onDisappear {
             removeDragEndMonitors()
+            diskPressureDismissalRefreshTask?.cancel()
+            diskPressureDismissalRefreshTask = nil
         }
     }
 
@@ -381,11 +399,12 @@ struct ChatView: View {
                 .animation(nil, value: queuedMessages.isEmpty)
             }
 
-            if let diskPressureAlert, let onReviewDiskUsage {
+            if let visibleDiskPressureAlert, let onReviewDiskUsage {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
                     DiskPressureBanner(
-                        alert: diskPressureAlert,
-                        onReviewDiskUsage: onReviewDiskUsage
+                        alert: visibleDiskPressureAlert,
+                        onReviewDiskUsage: onReviewDiskUsage,
+                        onDismiss: { dismissDiskPressureAlert(visibleDiskPressureAlert) }
                     )
                 }
                 .padding(.bottom, -VSpacing.sm)
@@ -702,6 +721,36 @@ struct ChatView: View {
     private func sendMessage() {
         if viewModel.isRecording { onMicrophoneToggle() }
         viewModel.sendMessage()
+    }
+
+    private func dismissDiskPressureAlert(_ alert: DiskPressureAlert) {
+        DiskPressureBannerDismissalStore.dismiss(alertId: alert.id)
+        diskPressureDismissalRefreshToken += 1
+        scheduleDiskPressureDismissalRefresh()
+    }
+
+    private func scheduleDiskPressureDismissalRefresh() {
+        diskPressureDismissalRefreshTask?.cancel()
+        diskPressureDismissalRefreshTask = nil
+
+        guard let alert = diskPressureAlert,
+              let dismissedUntil = DiskPressureBannerDismissalStore.dismissedUntil(for: alert.id) else {
+            return
+        }
+
+        let delay = dismissedUntil.timeIntervalSinceNow
+        guard delay > 0 else {
+            diskPressureDismissalRefreshToken += 1
+            return
+        }
+
+        let nanoseconds = UInt64(delay * 1_000_000_000)
+        diskPressureDismissalRefreshTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard !Task.isCancelled else { return }
+            diskPressureDismissalRefreshToken += 1
+            scheduleDiskPressureDismissalRefresh()
+        }
     }
 
     /// Presents an NSOpenPanel as a window-attached sheet for attaching files.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -44,6 +44,8 @@ struct ChatView: View {
     var onSubagentTap: ((String) -> Void)?
     var onAddFunds: (() -> Void)? = nil
     var onOpenModelsAndServices: (() -> Void)? = nil
+    var diskPressureAlert: DiskPressureAlert? = nil
+    var onReviewDiskUsage: (() -> Void)? = nil
     var onBootstrapSendLogs: (() -> Void)?
 
     // MARK: - Recovery Mode (managed assistants only)
@@ -373,6 +375,17 @@ struct ChatView: View {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
                     CreditsExhaustedBanner(
                         onAddFunds: { onAddFunds?() }
+                    )
+                }
+                .padding(.bottom, -VSpacing.sm)
+                .animation(nil, value: queuedMessages.isEmpty)
+            }
+
+            if let diskPressureAlert, let onReviewDiskUsage {
+                centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
+                    DiskPressureBanner(
+                        alert: diskPressureAlert,
+                        onReviewDiskUsage: onReviewDiskUsage
                     )
                 }
                 .padding(.bottom, -VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -81,6 +81,10 @@ public final class MainWindowState {
     /// Transient skill ID to deep-link into when the Intelligence panel opens.
     /// Consumed once by IntelligencePanel/SkillsPanel, then set back to nil.
     var pendingSkillId: String?
+
+    /// Transient tab to deep-link into when the Intelligence panel opens.
+    /// Consumed once by IntelligencePanel, then set back to nil.
+    var pendingIntelligenceTab: String?
     var activeDynamicSurface: UiSurfaceShowMessage?
     var activeDynamicParsedSurface: Surface?
     var workspaceComposerExpanded = false
@@ -283,6 +287,12 @@ public final class MainWindowState {
     /// Navigate to the Intelligence panel and deep-link to a specific skill.
     func showSkill(id: String) {
         pendingSkillId = id
+        showPanel(.intelligence)
+    }
+
+    /// Navigate to the Intelligence panel and show the workspace file browser.
+    func showWorkspace() {
+        pendingIntelligenceTab = "Workspace"
         showPanel(.intelligence)
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -959,6 +959,11 @@ struct ActiveChatViewWrapper: View {
                     settingsStore.pendingSettingsTab = .modelsAndServices
                     windowState.selection = .panel(.settings)
                 },
+                diskPressureAlert: AppDelegate.shared?.services.diskPressureMonitor.alert,
+                onReviewDiskUsage: {
+                    settingsStore.requestGeneralSection(.systemResources)
+                    windowState.selection = .panel(.settings)
+                },
                 onBootstrapSendLogs: {
                     AppDelegate.shared?.showLogReportWindow(reason: .bugReport)
                 },

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -144,7 +144,8 @@ extension MainWindowView {
                 authManager: authManager,
                 assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
-                initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,
+                initialTab: windowState.pendingIntelligenceTab ?? (windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil),
+                pendingTab: $windowState.pendingIntelligenceTab,
                 pendingMemoryId: $windowState.pendingMemoryId,
                 pendingSkillId: $windowState.pendingSkillId
             )
@@ -824,7 +825,8 @@ extension MainWindowView {
                 authManager: authManager,
                 assistantFeatureFlagStore: assistantFeatureFlagStore,
                 showToast: { msg, style in windowState.showToast(message: msg, style: style) },
-                initialTab: windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil,
+                initialTab: windowState.pendingIntelligenceTab ?? (windowState.pendingMemoryId != nil ? "Memories" : windowState.pendingSkillId != nil ? "Skills" : nil),
+                pendingTab: $windowState.pendingIntelligenceTab,
                 pendingMemoryId: $windowState.pendingMemoryId,
                 pendingSkillId: $windowState.pendingSkillId
             )
@@ -961,8 +963,7 @@ struct ActiveChatViewWrapper: View {
                 },
                 diskPressureAlert: AppDelegate.shared?.services.diskPressureMonitor.alert,
                 onReviewDiskUsage: {
-                    settingsStore.requestGeneralSection(.systemResources)
-                    windowState.selection = .panel(.settings)
+                    windowState.showWorkspace()
                 },
                 onBootstrapSendLogs: {
                     AppDelegate.shared?.showLogReportWindow(reason: .bugReport)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -16,6 +16,7 @@ struct IntelligencePanel: View {
     var assistantFeatureFlagStore: AssistantFeatureFlagStore?
     var showToast: ((String, ToastInfo.Style) -> Void)?
     var initialTab: String? = nil
+    @Binding var pendingTab: String?
     @Binding var pendingMemoryId: String?
 
     @State private var selectedTab: IntelligenceTab
@@ -23,7 +24,7 @@ struct IntelligencePanel: View {
     @Binding var pendingSkillId: String?
     @State private var pendingFilePath: String?
 
-    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
+    init(onClose: @escaping () -> Void, onInvokeSkill: ((SkillInfo) -> Void)? = nil, onCreateSkill: (() -> Void)? = nil, onImportMemory: ((String) -> Void)? = nil, connectionManager: GatewayConnectionManager, eventStreamClient: EventStreamClient? = nil, store: SettingsStore? = nil, conversationManager: ConversationManager? = nil, authManager: AuthManager? = nil, assistantFeatureFlagStore: AssistantFeatureFlagStore? = nil, showToast: ((String, ToastInfo.Style) -> Void)? = nil, initialTab: String? = nil, pendingTab: Binding<String?> = .constant(nil), pendingMemoryId: Binding<String?> = .constant(nil), pendingSkillId: Binding<String?> = .constant(nil)) {
         self.onClose = onClose
         self.onInvokeSkill = onInvokeSkill
         self.onCreateSkill = onCreateSkill
@@ -36,9 +37,10 @@ struct IntelligencePanel: View {
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self.showToast = showToast
         self.initialTab = initialTab
+        _pendingTab = pendingTab
         _pendingMemoryId = pendingMemoryId
         _pendingSkillId = pendingSkillId
-        _selectedTab = State(initialValue: IntelligenceTab(rawValue: initialTab ?? "") ?? .identity)
+        _selectedTab = State(initialValue: IntelligenceTab(rawValue: pendingTab.wrappedValue ?? initialTab ?? "") ?? .identity)
     }
 
     private enum IntelligenceTab: String, CaseIterable {
@@ -68,6 +70,12 @@ struct IntelligencePanel: View {
                 withAnimation(VAnimation.fast) { selectedTab = .memories }
             }
         }
+        .onChange(of: pendingTab) {
+            applyPendingTab()
+        }
+        .onAppear {
+            applyPendingTab()
+        }
         .task {
             let info = await IdentityInfo.refreshCache()
             if let name = AssistantDisplayName.firstUserFacing(from: [info?.name]) {
@@ -82,6 +90,13 @@ struct IntelligencePanel: View {
                 }
             }
         }
+    }
+
+    private func applyPendingTab() {
+        guard let pendingTab,
+              let tab = IntelligenceTab(rawValue: pendingTab) else { return }
+        withAnimation(VAnimation.fast) { selectedTab = tab }
+        self.pendingTab = nil
     }
 
     // MARK: - Tab Content

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -186,16 +186,27 @@ struct SettingsPanel: View {
                 settingsNav
                     .frame(width: 200)
 
-                ScrollView {
-                    selectedTabContent
-                        .padding(.top, VSpacing.lg)
-                        .padding(.trailing, VSpacing.xl)
-                        .padding(.bottom, VSpacing.xl)
-                        .frame(maxWidth: 900, alignment: .top)
-                        .frame(maxWidth: .infinity)
-                        .background { OverlayScrollerStyle() }
+                ScrollViewReader { scrollProxy in
+                    ScrollView {
+                        selectedTabContent
+                            .padding(.top, VSpacing.lg)
+                            .padding(.trailing, VSpacing.xl)
+                            .padding(.bottom, VSpacing.xl)
+                            .frame(maxWidth: 900, alignment: .top)
+                            .frame(maxWidth: .infinity)
+                            .background { OverlayScrollerStyle() }
+                    }
+                    .scrollContentBackground(.hidden)
+                    .onAppear {
+                        scrollToPendingGeneralSection(using: scrollProxy)
+                    }
+                    .onChange(of: selectedTab) { _, _ in
+                        scrollToPendingGeneralSection(using: scrollProxy)
+                    }
+                    .onChange(of: store.pendingSettingsGeneralSection) { _, _ in
+                        scrollToPendingGeneralSection(using: scrollProxy)
+                    }
                 }
-                .scrollContentBackground(.hidden)
             }
             .frame(maxWidth: .infinity)
         }
@@ -342,6 +353,17 @@ struct SettingsPanel: View {
                 )
             }
             .padding(VSpacing.lg)
+        }
+    }
+
+    private func scrollToPendingGeneralSection(using scrollProxy: ScrollViewProxy) {
+        guard selectedTab == .general, let section = store.pendingSettingsGeneralSection else { return }
+        Task { @MainActor in
+            await Task.yield()
+            withAnimation(VAnimation.standard) {
+                scrollProxy.scrollTo(section, anchor: .top)
+            }
+            store.pendingSettingsGeneralSection = nil
         }
     }
 
@@ -840,4 +862,3 @@ struct OverlayScrollerStyle: NSViewRepresentable {
     }
     func updateNSView(_ nsView: NSView, context: Context) {}
 }
-

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -221,8 +221,8 @@ private struct ThreadWindowContentView: View {
                     },
                     diskPressureAlert: AppDelegate.shared?.services.diskPressureMonitor.alert,
                     onReviewDiskUsage: {
-                        settingsStore.requestGeneralSection(.systemResources)
-                        AppDelegate.shared?.showSettingsWindow(nil)
+                        AppDelegate.shared?.showMainWindow()
+                        AppDelegate.shared?.mainWindow?.windowState.showWorkspace()
                     },
                     recoveryMode: settingsStore.managedAssistantRecoveryMode,
                     isRecoveryModeExiting: settingsStore.recoveryModeExiting,

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -219,6 +219,11 @@ private struct ThreadWindowContentView: View {
                         settingsStore.pendingSettingsTab = .modelsAndServices
                         AppDelegate.shared?.showSettingsWindow(nil)
                     },
+                    diskPressureAlert: AppDelegate.shared?.services.diskPressureMonitor.alert,
+                    onReviewDiskUsage: {
+                        settingsStore.requestGeneralSection(.systemResources)
+                        AppDelegate.shared?.showSettingsWindow(nil)
+                    },
                     recoveryMode: settingsStore.managedAssistantRecoveryMode,
                     isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                     onResumeAssistant: {

--- a/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/DaemonHealthz.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Health status response from the daemon's `/v1/health` endpoint.
-struct DaemonHealthz: Decodable {
+struct DaemonHealthz: Decodable, Sendable {
     let status: String
     let timestamp: String?
     let version: String?
@@ -19,19 +19,19 @@ struct DaemonHealthz: Decodable {
         self.cpu = cpu
     }
 
-    struct DiskInfo: Decodable {
+    struct DiskInfo: Decodable, Sendable {
         let path: String
         let totalMb: Double
         let usedMb: Double
         let freeMb: Double
     }
 
-    struct MemoryInfo: Decodable {
+    struct MemoryInfo: Decodable, Sendable {
         let currentMb: Double
         let maxMb: Double
     }
 
-    struct CpuInfo: Decodable {
+    struct CpuInfo: Decodable, Sendable {
         let currentPercent: Double
         let maxCores: Int
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -27,6 +27,7 @@ struct SettingsGeneralTab: View {
     @State private var dockerOperationTimeoutTask: Task<Void, Never>?
     @State private var healthzLoaded = false
     @State private var isRefreshingHealthz = false
+    @State private var systemResourcesDeepLinkRequested = false
 
 
     private var currentAssistant: LockfileAssistant? {
@@ -92,6 +93,10 @@ struct SettingsGeneralTab: View {
                 lockfileAssistants = assistants
                 await fetchHealthz()
             }
+            recordSystemResourcesDeepLinkIfNeeded(store.pendingSettingsGeneralSection)
+        }
+        .onChange(of: store.pendingSettingsGeneralSection) { _, section in
+            recordSystemResourcesDeepLinkIfNeeded(section)
         }
         .onChange(of: connectionManager?.isUpdateInProgress) { _, inProgress in
             isServiceGroupUpdateInProgress = inProgress ?? false
@@ -171,20 +176,38 @@ struct SettingsGeneralTab: View {
             healthz = DaemonHealthz()
         }
         healthzLoaded = true
+        systemResourcesDeepLinkRequested = false
     }
 
     // MARK: - System Resources
 
     private var shouldShowSystemResourcesSection: Bool {
-        topology == .managed
-            || Self.hasResourceMetrics(healthz)
-            || store.pendingSettingsGeneralSection == .systemResources
-            || (!healthzLoaded && !selectedAssistantId.isEmpty)
+        Self.shouldShowSystemResourcesSection(
+            topology: topology,
+            healthz: healthz,
+            pendingSection: store.pendingSettingsGeneralSection,
+            deepLinkRequestPending: systemResourcesDeepLinkRequested && !healthzLoaded
+        )
+    }
+
+    nonisolated static func shouldShowSystemResourcesSection(
+        topology: AssistantTopology,
+        healthz: DaemonHealthz?,
+        pendingSection: SettingsGeneralSection?,
+        deepLinkRequestPending: Bool = false
+    ) -> Bool {
+        topology == .managed || hasResourceMetrics(healthz) || pendingSection == .systemResources || deepLinkRequestPending
     }
 
     nonisolated static func hasResourceMetrics(_ healthz: DaemonHealthz?) -> Bool {
         guard let healthz else { return false }
         return healthz.disk != nil || healthz.memory != nil || healthz.cpu != nil
+    }
+
+    private func recordSystemResourcesDeepLinkIfNeeded(_ section: SettingsGeneralSection?) {
+        if section == .systemResources {
+            systemResourcesDeepLinkRequested = true
+        }
     }
 
     /// Resource usage card shown for any assistant that reports metrics. Mirrors

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -61,7 +61,7 @@ struct SettingsGeneralTab: View {
                     updateManager: updateManager
                 )
             }
-            if topology == .managed {
+            if shouldShowSystemResourcesSection {
                 systemResourcesSection
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
@@ -175,12 +175,24 @@ struct SettingsGeneralTab: View {
 
     // MARK: - System Resources
 
-    /// Resource usage card shown for platform-managed assistants. Mirrors the
-    /// disk/memory/CPU rows from the Developer tab so users on the platform can
-    /// see their assistant's resource consumption without enabling dev mode.
+    private var shouldShowSystemResourcesSection: Bool {
+        topology == .managed
+            || Self.hasResourceMetrics(healthz)
+            || store.pendingSettingsGeneralSection == .systemResources
+            || (!healthzLoaded && !selectedAssistantId.isEmpty)
+    }
+
+    nonisolated static func hasResourceMetrics(_ healthz: DaemonHealthz?) -> Bool {
+        guard let healthz else { return false }
+        return healthz.disk != nil || healthz.memory != nil || healthz.cpu != nil
+    }
+
+    /// Resource usage card shown for any assistant that reports metrics. Mirrors
+    /// the disk/memory/CPU rows from the Developer tab so users can review disk
+    /// pressure without enabling dev mode.
     private var systemResourcesSection: some View {
         SettingsCard(
-            title: "System Resources",
+            title: "Storage & Resources",
             accessory: {
                 if isRefreshingHealthz {
                     ProgressView()
@@ -204,7 +216,7 @@ struct SettingsGeneralTab: View {
                     resourceBarRow(
                         label: "Disk Usage:",
                         ratio: disk.usedMb / max(disk.totalMb, 1),
-                        caption: "\(formatMb(disk.usedMb)) used of \(formatMb(disk.totalMb))",
+                        caption: "\(Self.formatMb(disk.usedMb)) used of \(Self.formatMb(disk.totalMb))",
                         accessibilityLabel: "Disk usage"
                     )
                 }
@@ -213,7 +225,7 @@ struct SettingsGeneralTab: View {
                     resourceBarRow(
                         label: "Memory:",
                         ratio: memory.currentMb / max(memory.maxMb, 1),
-                        caption: "\(formatMb(memory.currentMb)) / \(formatMb(memory.maxMb))",
+                        caption: "\(Self.formatMb(memory.currentMb)) / \(Self.formatMb(memory.maxMb))",
                         accessibilityLabel: "Memory usage"
                     )
                 }
@@ -242,6 +254,7 @@ struct SettingsGeneralTab: View {
                 }
             }
         }
+        .id(SettingsGeneralSection.systemResources)
     }
 
     /// A resource row with a label on the left, a capsule usage bar, and a gray
@@ -278,7 +291,7 @@ struct SettingsGeneralTab: View {
         }
     }
 
-    private func formatMb(_ mb: Double) -> String {
+    nonisolated static func formatMb(_ mb: Double) -> String {
         if mb >= 1024 {
             return String(format: "%.1f GB", mb / 1024.0)
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -12,6 +12,10 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Setti
 /// UserDefaults key for tracking explicit key deletions that may not have reached the daemon.
 private let kPendingKeyDeletionTombstones = "pendingKeyDeletionTombstones"
 
+enum SettingsGeneralSection: Hashable {
+    case systemResources
+}
+
 /// Single source of truth for settings state shared between `SettingsPanel`
 /// (main window side panel) and its extracted tab views.
 @MainActor
@@ -21,6 +25,13 @@ public final class SettingsStore: ObservableObject {
     /// Set externally (e.g. via HTTP) to deep-link into a specific settings tab.
     /// SettingsPanel observes this and clears it after applying.
     @Published var pendingSettingsTab: SettingsTab?
+    /// Optional section anchor consumed by the General tab after the tab opens.
+    @Published var pendingSettingsGeneralSection: SettingsGeneralSection?
+
+    func requestGeneralSection(_ section: SettingsGeneralSection) {
+        pendingSettingsTab = .general
+        pendingSettingsGeneralSection = section
+    }
 
     // MARK: - API Key State
 

--- a/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
@@ -4,6 +4,11 @@ import Testing
 @Suite("Chat disk-pressure banner")
 struct ChatDiskPressureBannerTests {
     @Test
+    func titleStartsWithDiskEmoji() {
+        #expect(DiskPressureBanner.title == "💾 Disk space is running low")
+    }
+
+    @Test
     func subtitleUsesMonitorDisplayPercent() {
         let alert = DiskPressureAlert(
             id: "disk-pressure:assistant-123:1",

--- a/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
@@ -8,9 +8,7 @@ struct ChatDiskPressureBannerTests {
         let alert = DiskPressureAlert(
             id: "disk-pressure:assistant-123:1",
             assistantId: "assistant-123",
-            displayPercent: 93,
-            usedMb: 930,
-            totalMb: 1_000
+            displayPercent: 93
         )
 
         #expect(DiskPressureBanner.subtitle(for: alert) == "Storage is 93% full.")

--- a/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct ChatDiskPressureBannerTests {
     @Test
     func titleStartsWithDiskEmoji() {
-        #expect(DiskPressureBanner.title == "💾 Disk space is running low")
+        #expect(DiskPressureBanner.title == "💾 It looks like you're running out of disk space.")
     }
 
     @Test
@@ -16,16 +16,16 @@ struct ChatDiskPressureBannerTests {
             displayPercent: 93
         )
 
-        #expect(DiskPressureBanner.subtitle(for: alert) == "Storage is 93% full.")
+        #expect(DiskPressureBanner.subtitle(for: alert) == "Storage is 93% full. Try cleaning up unused data, like logs.")
     }
 
     @Test @MainActor
-    func reviewDiskUsageRequestsGeneralStorageLanding() {
-        let store = SettingsStore()
+    func reviewDiskUsageRequestsWorkspaceLanding() {
+        let windowState = MainWindowState()
 
-        store.requestGeneralSection(.systemResources)
+        windowState.showWorkspace()
 
-        #expect(store.pendingSettingsTab == .general)
-        #expect(store.pendingSettingsGeneralSection == .systemResources)
+        #expect(windowState.selection == .panel(.intelligence))
+        #expect(windowState.pendingIntelligenceTab == "Workspace")
     }
 }

--- a/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import VellumAssistantLib
 
@@ -27,5 +28,33 @@ struct ChatDiskPressureBannerTests {
 
         #expect(windowState.selection == .panel(.intelligence))
         #expect(windowState.pendingIntelligenceTab == "Workspace")
+    }
+
+    @Test
+    func dismissingAlertSnoozesOnlyThatAlertForTwentyFourHours() {
+        let userDefaults = UserDefaults(suiteName: "ChatDiskPressureBannerTests-\(UUID().uuidString)")!
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        DiskPressureBannerDismissalStore.dismiss(
+            alertId: "disk-pressure:assistant-123:1",
+            now: now,
+            userDefaults: userDefaults
+        )
+
+        #expect(DiskPressureBannerDismissalStore.isDismissed(
+            alertId: "disk-pressure:assistant-123:1",
+            now: now.addingTimeInterval(23 * 60 * 60),
+            userDefaults: userDefaults
+        ))
+        #expect(!DiskPressureBannerDismissalStore.isDismissed(
+            alertId: "disk-pressure:assistant-123:2",
+            now: now,
+            userDefaults: userDefaults
+        ))
+        #expect(!DiskPressureBannerDismissalStore.isDismissed(
+            alertId: "disk-pressure:assistant-123:1",
+            now: now.addingTimeInterval(24 * 60 * 60 + 1),
+            userDefaults: userDefaults
+        ))
     }
 }

--- a/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDiskPressureBannerTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("Chat disk-pressure banner")
+struct ChatDiskPressureBannerTests {
+    @Test
+    func subtitleUsesMonitorDisplayPercent() {
+        let alert = DiskPressureAlert(
+            id: "disk-pressure:assistant-123:1",
+            assistantId: "assistant-123",
+            displayPercent: 93,
+            usedMb: 930,
+            totalMb: 1_000
+        )
+
+        #expect(DiskPressureBanner.subtitle(for: alert) == "Storage is 93% full.")
+    }
+
+    @Test @MainActor
+    func reviewDiskUsageRequestsGeneralStorageLanding() {
+        let store = SettingsStore()
+
+        store.requestGeneralSection(.systemResources)
+
+        #expect(store.pendingSettingsTab == .general)
+        #expect(store.pendingSettingsGeneralSection == .systemResources)
+    }
+}

--- a/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
+++ b/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class DiskPressureMonitorTests: XCTestCase {
+    func testPressureTriggersAtNinetyPercent() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 90, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertEqual(monitor.alert?.assistantId, "assistant-a")
+        XCTAssertEqual(monitor.alert?.displayPercent, 90)
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:1")
+    }
+
+    func testPressureDoesNotTriggerBelowNinetyPercent() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 89.9, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertNil(monitor.alert)
+    }
+
+    func testPressureResolvesOnlyBelowEightyPercent() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        let initialAlertId = monitor.alert?.id
+        monitor.applyHealthz(healthz(usedMb: 80, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertEqual(monitor.alert?.id, initialAlertId)
+        XCTAssertEqual(monitor.alert?.displayPercent, 80)
+
+        monitor.applyHealthz(healthz(usedMb: 79.9, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertNil(monitor.alert)
+    }
+
+    func testNewAlertCycleUsesStableNewId() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:1")
+
+        monitor.applyHealthz(healthz(usedMb: 70, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 91, totalMb: 100), assistantId: "assistant-a")
+
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:2")
+    }
+
+    func testAssistantSwitchClearsStaleAlertAndScopesNextId() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-b")
+
+        XCTAssertEqual(monitor.alert?.assistantId, "assistant-b")
+        XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-b:2")
+    }
+
+    func testUnreachableOrMissingDiskMetricsClearsAlert() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(nil, assistantId: "assistant-a")
+        XCTAssertNil(monitor.alert)
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(DaemonHealthz(status: "ok"), assistantId: "assistant-a")
+        XCTAssertNil(monitor.alert)
+    }
+
+    func testInvalidDiskTotalClearsAlert() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 0), assistantId: "assistant-a")
+
+        XCTAssertNil(monitor.alert)
+    }
+
+    private func makeMonitor(assistantId: String) -> DiskPressureMonitor {
+        DiskPressureMonitor(
+            fetchHealthz: { nil },
+            activeAssistantIdProvider: { assistantId },
+            isConnectedProvider: { true },
+            notificationCenter: NotificationCenter(),
+            cadenceNanoseconds: 1_000_000_000
+        )
+    }
+
+    private func healthz(usedMb: Double, totalMb: Double) -> DaemonHealthz {
+        DaemonHealthz(
+            status: "ok",
+            disk: DaemonHealthz.DiskInfo(
+                path: "/workspace",
+                totalMb: totalMb,
+                usedMb: usedMb,
+                freeMb: max(totalMb - usedMb, 0)
+            )
+        )
+    }
+}

--- a/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
+++ b/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
@@ -3,20 +3,20 @@ import XCTest
 
 @MainActor
 final class DiskPressureMonitorTests: XCTestCase {
-    func testPressureTriggersAtNinetyPercent() {
+    func testPressureTriggersAtEightyFivePercent() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 90, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 85, totalMb: 100), assistantId: "assistant-a")
 
         XCTAssertEqual(monitor.alert?.assistantId, "assistant-a")
-        XCTAssertEqual(monitor.alert?.displayPercent, 90)
+        XCTAssertEqual(monitor.alert?.displayPercent, 85)
         XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:1")
     }
 
-    func testPressureDoesNotTriggerBelowNinetyPercent() {
+    func testPressureDoesNotTriggerBelowEightyFivePercent() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 89.9, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyHealthz(healthz(usedMb: 84.9, totalMb: 100), assistantId: "assistant-a")
 
         XCTAssertNil(monitor.alert)
     }

--- a/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
@@ -25,6 +25,44 @@ struct SettingsGeneralDiskSectionTests {
     }
 
     @Test
+    func localAssistantsDoNotShowResourcesBeforeMetricsLoad() {
+        #expect(!SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: nil
+        ))
+    }
+
+    @Test
+    func explicitDeepLinkShowsResourcesWhileLoading() {
+        #expect(SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: .systemResources
+        ))
+    }
+
+    @Test
+    func rememberedDeepLinkKeepsResourcesVisibleAfterPendingSectionClears() {
+        #expect(SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: nil,
+            deepLinkRequestPending: true
+        ))
+    }
+
+    @Test
+    func completedDeepLinkDoesNotKeepResourcesVisibleWithoutMetrics() {
+        #expect(!SettingsGeneralTab.shouldShowSystemResourcesSection(
+            topology: .local,
+            healthz: nil,
+            pendingSection: nil,
+            deepLinkRequestPending: false
+        ))
+    }
+
+    @Test
     func megabyteFormatterUsesReadableUnits() {
         #expect(SettingsGeneralTab.formatMb(512) == "512 MB")
         #expect(SettingsGeneralTab.formatMb(1_536) == "1.5 GB")

--- a/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsGeneralDiskSectionTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import VellumAssistantLib
+
+@Suite("Settings General disk resources section")
+struct SettingsGeneralDiskSectionTests {
+    @Test
+    func diskMetricsMakeResourceSectionEligible() {
+        let healthz = DaemonHealthz(
+            status: "ok",
+            disk: DaemonHealthz.DiskInfo(
+                path: "/workspace",
+                totalMb: 10_000,
+                usedMb: 9_250,
+                freeMb: 750
+            )
+        )
+
+        #expect(SettingsGeneralTab.hasResourceMetrics(healthz))
+    }
+
+    @Test
+    func assistantsWithoutMetricsAreNotTreatedAsResourceEligible() {
+        #expect(!SettingsGeneralTab.hasResourceMetrics(nil))
+        #expect(!SettingsGeneralTab.hasResourceMetrics(DaemonHealthz(status: "ok")))
+    }
+
+    @Test
+    func megabyteFormatterUsesReadableUnits() {
+        #expect(SettingsGeneralTab.formatMb(512) == "512 MB")
+        #expect(SettingsGeneralTab.formatMb(1_536) == "1.5 GB")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds active-assistant disk-pressure monitoring from `assistants/{assistantId}/healthz` with an 85% trigger / below-80% resolve hysteresis.
- Shows a credits-style in-chat disk-space CTA for the active assistant without mutating transcript history.
- Adds a `Settings > General > Storage & Resources` landing target and routes the CTA there for review/refresh.

## Implementation PRs
- #28668: track active assistant disk pressure
- #28671: add credits-style disk-pressure CTA and settings landing target
- #28677: tighten resources-section deep-link behavior from review feedback

## Validation
- CI passed on #28668, #28671, and #28677 before each merge to the feature branch.
- Focused Swift tests passed for `DiskPressureMonitorTests`, `ChatDiskPressureBannerTests`, and `SettingsGeneralDiskSectionTests`.
- Self-review caught and fixed the threshold/test mismatch introduced by the final 85% threshold update.
- Final run-plan self-review passed for external feedback, plan faithfulness, and integration; quality pass found optional polish only, no must-fix blockers.

## Notes
- Local pre-push hooks can scan generated SwiftPM checkout files under `.build` and report unrelated design-token false positives; focused tests and GitHub CI passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->