### PR TITLE
Align new assistant main model status

### DIFF
--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -20,6 +20,11 @@ const resolveSlashMock = mock(
 );
 
 mock.module("../daemon/conversation-slash.js", () => ({
+  resolveMainAgentStatusConfig: () => ({
+    maxInputTokens: 200000,
+    model: "claude-opus-4-7",
+    provider: "anthropic",
+  }),
   resolveSlash: resolveSlashMock,
 }));
 
@@ -268,7 +273,11 @@ function makeConversation() {
 function makeRequest(content: string, extras: Record<string, unknown> = {}) {
   return new Request("http://localhost/v1/messages", {
     method: "POST",
-    headers: { "Content-Type": "application/json", "x-vellum-actor-principal-id": "test-user", "x-vellum-principal-type": "actor" },
+    headers: {
+      "Content-Type": "application/json",
+      "x-vellum-actor-principal-id": "test-user",
+      "x-vellum-principal-type": "actor",
+    },
     body: JSON.stringify({
       conversationKey: "slash-test-key",
       content,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -25,6 +25,7 @@ import type {
   TurnInterfaceContext,
 } from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import {
@@ -1330,8 +1331,11 @@ export async function runAgentLoopImpl(
     // and proactively invoke the reducer if already above budget. This avoids
     // a wasted provider round-trip that would just fail with context_too_large.
     const config = getConfig();
-    const overflowRecovery = config.llm.default.contextWindow.overflowRecovery;
-    const providerMaxTokens = config.llm.default.contextWindow.maxInputTokens;
+    const turnLlmConfig = resolveCallSiteConfig(turnCallSite, config.llm, {
+      overrideProfile: turnOverrideProfile,
+    });
+    const overflowRecovery = turnLlmConfig.contextWindow.overflowRecovery;
+    const providerMaxTokens = turnLlmConfig.contextWindow.maxInputTokens;
     // Widen safety margin for large conversations where estimation error
     // compounds across many messages with tool results.
     const baseSafetyMargin = overflowRecovery.safetyMarginRatio;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -18,7 +18,6 @@ import {
   type TurnChannelContext,
   type TurnInterfaceContext,
 } from "../channels/types.js";
-import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { ContextWindowResult } from "../context/window-manager.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
@@ -42,6 +41,7 @@ import type {
 import type { ChannelCapabilities } from "./conversation-runtime-assembly.js";
 import {
   classifySlash,
+  resolveMainAgentStatusConfig,
   resolveSlash,
   type SlashContext,
 } from "./conversation-slash.js";
@@ -233,15 +233,15 @@ function resolveQueuedTurnInterfaceContext(
 function buildSlashContext(
   conversation: ProcessConversationContext,
 ): SlashContext {
-  const config = getConfig();
   const turnInterface = conversation.getTurnInterfaceContext();
+  const statusConfig = resolveMainAgentStatusConfig();
   return {
     messageCount: conversation.messages.length,
     inputTokens: conversation.usageStats.inputTokens,
     outputTokens: conversation.usageStats.outputTokens,
-    maxInputTokens: config.llm.default.contextWindow.maxInputTokens,
-    model: config.llm.default.model,
-    provider: config.llm.default.provider,
+    maxInputTokens: statusConfig.maxInputTokens,
+    model: statusConfig.model,
+    provider: statusConfig.provider,
     estimatedCost: conversation.usageStats.estimatedCost,
     userMessageInterface: turnInterface?.userMessageInterface,
   };

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -1,4 +1,5 @@
 import type { InterfaceId } from "../channels/types.js";
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { getConfiguredProviders } from "../providers/provider-availability.js";
@@ -21,6 +22,20 @@ export interface SlashContext {
   userMessageInterface?: InterfaceId;
 }
 
+export function resolveMainAgentStatusConfig(): {
+  maxInputTokens: number;
+  model: string;
+  provider: string;
+} {
+  const config = getConfig();
+  const resolved = resolveCallSiteConfig("mainAgent", config.llm);
+  return {
+    maxInputTokens: resolved.contextWindow.maxInputTokens,
+    model: resolved.model,
+    provider: resolved.provider,
+  };
+}
+
 // ── Deprecated model-switching shortcuts ─────────────────────────────
 
 /**
@@ -39,7 +54,7 @@ const DEPRECATED_MODEL_SHORTCUTS = new Set([
 // ── /models command ──────────────────────────────────────────────────
 
 async function resolveModelList(): Promise<SlashResolution> {
-  const config = getConfig();
+  const currentMainAgent = resolveMainAgentStatusConfig();
   const configuredProviders = new Set<string>(await getConfiguredProviders());
 
   const lines = ["Available models:\n"];
@@ -54,8 +69,7 @@ async function resolveModelList(): Promise<SlashResolution> {
     lines.push(`**${providerName}** ${status}`);
     for (const { id, displayName } of models) {
       const isCurrent =
-        config.llm.default.provider === provider &&
-        config.llm.default.model === id;
+        currentMainAgent.provider === provider && currentMainAgent.model === id;
       const current = isCurrent ? " **[current]**" : "";
       lines.push(`  - ${displayName} (\`${id}\`)${current}`);
     }

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -17,7 +17,6 @@ import {
   parseInterfaceId,
   supportsHostProxy,
 } from "../channels/types.js";
-import { getConfig } from "../config/loader.js";
 import {
   getAttachmentsByIds,
   getSourcePathsForAttachments,
@@ -44,7 +43,11 @@ import type { Conversation } from "./conversation.js";
 import { buildSlackMetaForPersistence } from "./conversation-messaging.js";
 import { formatCompactResult } from "./conversation-process.js";
 import { resolveChannelCapabilities } from "./conversation-runtime-assembly.js";
-import { resolveSlash, type SlashContext } from "./conversation-slash.js";
+import {
+  resolveMainAgentStatusConfig,
+  resolveSlash,
+  type SlashContext,
+} from "./conversation-slash.js";
 import {
   getOrCreateConversation as getOrCreateActiveConversation,
   mergeConversationOptions,
@@ -374,15 +377,15 @@ export async function processMessage(
     sourceInterface,
   );
 
-  const config = getConfig();
   const serverInterfaceCtx = conversation.getTurnInterfaceContext();
+  const statusConfig = resolveMainAgentStatusConfig();
   const slashContext: SlashContext = {
     messageCount: conversation.getMessages().length,
     inputTokens: conversation.usageStats.inputTokens,
     outputTokens: conversation.usageStats.outputTokens,
-    maxInputTokens: config.llm.default.contextWindow.maxInputTokens,
-    model: config.llm.default.model,
-    provider: config.llm.default.provider,
+    maxInputTokens: statusConfig.maxInputTokens,
+    model: statusConfig.model,
+    provider: statusConfig.provider,
     estimatedCost: conversation.usageStats.estimatedCost,
     userMessageInterface: serverInterfaceCtx?.userMessageInterface,
   };

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -35,6 +35,7 @@ import {
   isModelSlashCommand,
 } from "../../daemon/conversation-process.js";
 import {
+  resolveMainAgentStatusConfig,
   resolveSlash,
   type SlashContext,
 } from "../../daemon/conversation-slash.js";
@@ -2033,14 +2034,14 @@ export async function handleSendMessage(
 
   // Resolve slash commands before persisting or running the agent loop.
   const rawContent = content ?? "";
-  const config = getConfig();
+  const statusConfig = resolveMainAgentStatusConfig();
   const slashContext: SlashContext = {
     messageCount: conversation.getMessages().length,
     inputTokens: conversation.usageStats.inputTokens,
     outputTokens: conversation.usageStats.outputTokens,
-    maxInputTokens: config.llm.default.contextWindow.maxInputTokens,
-    model: config.llm.default.model,
-    provider: config.llm.default.provider,
+    maxInputTokens: statusConfig.maxInputTokens,
+    model: statusConfig.model,
+    provider: statusConfig.provider,
     estimatedCost: conversation.usageStats.estimatedCost,
     userMessageInterface: sourceInterface,
   };

--- a/cli/src/__tests__/config-utils.test.ts
+++ b/cli/src/__tests__/config-utils.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, test } from "bun:test";
 
 import { buildInitialConfig, buildNestedConfig } from "../lib/config-utils.js";
 
+const anthropicProfiles = {
+  "quality-optimized": {
+    provider: "anthropic",
+    model: "claude-opus-4-7",
+    maxTokens: 32000,
+    effort: "max",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  balanced: {
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  "cost-optimized": {
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+  },
+};
+
 describe("config-utils", () => {
   test("buildNestedConfig only converts dot-notation values", () => {
     expect(
@@ -31,10 +55,11 @@ describe("config-utils", () => {
           provider: "anthropic",
           model: "claude-sonnet-4-6",
         },
+        profiles: anthropicProfiles,
+        activeProfile: "balanced",
         callSites: {
           mainAgent: {
-            model: "claude-opus-4-7",
-            maxTokens: 32000,
+            profile: "quality-optimized",
           },
         },
       },
@@ -53,10 +78,11 @@ describe("config-utils", () => {
         },
       },
       llm: {
+        profiles: anthropicProfiles,
+        activeProfile: "balanced",
         callSites: {
           mainAgent: {
-            model: "claude-opus-4-7",
-            maxTokens: 32000,
+            profile: "quality-optimized",
           },
         },
       },
@@ -76,6 +102,8 @@ describe("config-utils", () => {
           provider: "anthropic",
           model: "claude-sonnet-4-6",
         },
+        profiles: anthropicProfiles,
+        activeProfile: "balanced",
         callSites: {
           mainAgent: {
             model: "claude-haiku-4-5-20251001",

--- a/cli/src/lib/config-utils.ts
+++ b/cli/src/lib/config-utils.ts
@@ -6,6 +6,33 @@ const ANTHROPIC_PROVIDER = "anthropic";
 const ANTHROPIC_DEFAULT_MODEL = "claude-sonnet-4-6";
 const MAIN_AGENT_OPUS_MODEL = "claude-opus-4-7";
 const MAIN_AGENT_OPUS_MAX_TOKENS = 32000;
+const QUALITY_OPTIMIZED_PROFILE = "quality-optimized";
+const BALANCED_PROFILE = "balanced";
+const COST_OPTIMIZED_PROFILE = "cost-optimized";
+
+const ANTHROPIC_PROFILES: Record<string, Record<string, unknown>> = {
+  [QUALITY_OPTIMIZED_PROFILE]: {
+    provider: ANTHROPIC_PROVIDER,
+    model: MAIN_AGENT_OPUS_MODEL,
+    maxTokens: MAIN_AGENT_OPUS_MAX_TOKENS,
+    effort: "max",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  [BALANCED_PROFILE]: {
+    provider: ANTHROPIC_PROVIDER,
+    model: ANTHROPIC_DEFAULT_MODEL,
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  [COST_OPTIMIZED_PROFILE]: {
+    provider: ANTHROPIC_PROVIDER,
+    model: "claude-haiku-4-5-20251001",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+  },
+};
 
 /**
  * Convert flat dot-notation key=value pairs into a nested config object.
@@ -47,6 +74,7 @@ export function buildInitialConfig(
   configValues: Record<string, string>,
 ): Record<string, unknown> {
   const config = buildNestedConfig(configValues);
+  seedAnthropicInferenceProfiles(config);
   seedAnthropicMainAgentCallSite(config);
   return config;
 }
@@ -77,6 +105,22 @@ export function writeInitialConfig(
   return tempPath;
 }
 
+function seedAnthropicInferenceProfiles(config: Record<string, unknown>): void {
+  const llm = ensureObject(config, "llm");
+  const { provider, model } = resolveInitialMainAgentBaseSelection(llm);
+  if (!isDefaultAnthropicOnboardingSelection(provider, model)) return;
+
+  const profiles = ensureObject(llm, "profiles");
+  for (const [name, profile] of Object.entries(ANTHROPIC_PROFILES)) {
+    if (readObject(profiles[name]) !== null) continue;
+    profiles[name] = cloneObject(profile);
+  }
+
+  if (readString(llm.activeProfile) === undefined) {
+    llm.activeProfile = BALANCED_PROFILE;
+  }
+}
+
 function seedAnthropicMainAgentCallSite(config: Record<string, unknown>): void {
   const llm = ensureObject(config, "llm");
 
@@ -84,22 +128,19 @@ function seedAnthropicMainAgentCallSite(config: Record<string, unknown>): void {
   if (existingCallSites !== null && "mainAgent" in existingCallSites) return;
 
   const { provider, model } = resolveInitialMainAgentBaseSelection(llm);
-  if (provider !== ANTHROPIC_PROVIDER) return;
-
-  if (
-    model !== undefined &&
-    model !== ANTHROPIC_DEFAULT_MODEL &&
-    model !== MAIN_AGENT_OPUS_MODEL
-  ) {
-    return;
-  }
+  if (!isDefaultAnthropicOnboardingSelection(provider, model)) return;
 
   const callSites = ensureObject(llm, "callSites");
+  const qualityProfile = readObject(
+    readObject(llm.profiles)?.[QUALITY_OPTIMIZED_PROFILE],
+  );
 
-  callSites.mainAgent = {
-    model: MAIN_AGENT_OPUS_MODEL,
-    maxTokens: MAIN_AGENT_OPUS_MAX_TOKENS,
-  };
+  callSites.mainAgent = isAnthropicOpusProfile(qualityProfile)
+    ? { profile: QUALITY_OPTIMIZED_PROFILE }
+    : {
+        model: MAIN_AGENT_OPUS_MODEL,
+        maxTokens: MAIN_AGENT_OPUS_MAX_TOKENS,
+      };
 }
 
 function resolveInitialMainAgentBaseSelection(llm: Record<string, unknown>): {
@@ -123,6 +164,35 @@ function resolveInitialMainAgentBaseSelection(llm: Record<string, unknown>): {
   }
 
   return model === undefined ? { provider } : { provider, model };
+}
+
+function isDefaultAnthropicOnboardingSelection(
+  provider: string,
+  model?: string,
+): boolean {
+  return (
+    provider === ANTHROPIC_PROVIDER &&
+    (model === undefined ||
+      model === ANTHROPIC_DEFAULT_MODEL ||
+      model === MAIN_AGENT_OPUS_MODEL)
+  );
+}
+
+function isAnthropicOpusProfile(
+  profile: Record<string, unknown> | null,
+): boolean {
+  if (profile === null) return false;
+
+  const provider = readString(profile.provider);
+  const model = readString(profile.model);
+  return (
+    (provider === undefined || provider === ANTHROPIC_PROVIDER) &&
+    model === MAIN_AGENT_OPUS_MODEL
+  );
+}
+
+function cloneObject(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
 
 function ensureObject(


### PR DESCRIPTION
## Summary
- Seed default Anthropic inference profiles in first-boot hatch config overlays, with balanced active and mainAgent pinned to quality-optimized.
- Resolve /status and /models against the mainAgent call site so validation shows the actual main-thread model instead of llm.default.
- Keep explicit non-default/provider choices and existing mainAgent overrides intact.

## Original prompt
this didnt seem to work. im not sure what the problem is. here is how i validated that a brand new hatched assistant is still using sonnet. my approach might have been wrong - i forgot inference profiles recently went out. it's possible we should have just assumed and used values set in the profiles
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
