### PR TITLE
perf(layout): override explicitAlignment to stop O(n×depth) cascade in custom Layout wrappers (LUM-1167)

### DIFF
--- a/clients/shared/DesignSystem/Modifiers/BottomAlignedMinHeightLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/BottomAlignedMinHeightLayout.swift
@@ -46,6 +46,28 @@ public struct BottomAlignedMinHeightLayout: Layout {
             proposal: ProposedViewSize(width: childSize.width, height: childSize.height)
         )
     }
+
+    // MARK: - Alignment (opt out of default cascade)
+
+    /// Returns `nil` to opt out of the default guide-merging cascade.
+    ///
+    /// The default `Layout` protocol implementation iterates every subview
+    /// and recursively queries their alignment guides — O(n × depth). When
+    /// this layout wraps the entire LazyVStack scroll content, the cascade
+    /// walks every visible cell, producing multi-second hangs.
+    ///
+    /// Returning `nil` tells ancestors "no explicit guide value; use default
+    /// positioning", which is correct because this layout positions its
+    /// child via `placeSubviews`, not alignment guides.
+    ///
+    /// Reference: [Layout.explicitAlignment](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu)
+    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+        nil
+    }
+
+    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+        nil
+    }
 }
 
 extension View {

--- a/clients/shared/DesignSystem/Modifiers/WidthCapLayout.swift
+++ b/clients/shared/DesignSystem/Modifiers/WidthCapLayout.swift
@@ -29,6 +29,25 @@ public struct WidthCapLayout: Layout {
             proposal: ProposedViewSize(width: bounds.width, height: bounds.height)
         )
     }
+
+    // MARK: - Alignment (opt out of default cascade)
+
+    /// Returns `nil` to opt out of the default guide-merging cascade.
+    ///
+    /// The default `Layout` protocol implementation iterates every subview
+    /// and recursively queries their alignment guides — O(n × depth).
+    /// Returning `nil` tells ancestors "no explicit guide value; use default
+    /// positioning", which is correct because this layout positions its
+    /// child via `placeSubviews`, not alignment guides.
+    ///
+    /// Reference: [Layout.explicitAlignment](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu)
+    public func explicitAlignment(of guide: HorizontalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+        nil
+    }
+
+    public func explicitAlignment(of guide: VerticalAlignment, in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGFloat? {
+        nil
+    }
 }
 
 extension View {


### PR DESCRIPTION
Overrides `Layout.explicitAlignment` on `BottomAlignedMinHeightLayout` and `WidthCapLayout` to return `nil`, eliminating the O(n×depth) alignment-guide cascade that caused 2000ms+ main-thread hangs (Sentry MACOS-M9, MACOS-JG). Both layouts were introduced to replace `_FlexFrameLayout`, but neither overrode `explicitAlignment` — the default protocol extension merges all subviews' guides, which is the exact same recursive cascade `_FlexFrameLayout` performs. Returning `nil` is safe because both layouts position children via `placeSubviews`, not alignment guides.

## Root cause analysis

1. **How did the code get into this state?** PR #26053 (LUM-944) created `BottomAlignedMinHeightLayout` to replace `.frame(minHeight:alignment:.bottom)` and avoid `_FlexFrameLayout`. The implementation correctly used `placeSubviews` for positioning but missed the `explicitAlignment` override. PR #26007/PR #26092 created `WidthCapLayout` with the same omission.
2. **What was missed?** The Layout protocol has TWO ways to cascade: (a) `_FlexFrameLayout` specifically, and (b) the default `explicitAlignment` protocol extension. PR #26053 only addressed (a). The [Apple docs](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu) state: *"If you don't implement the method, the protocol's default implementation merges the subviews' guides."*
3. **Warning signs:** The prior investigation (LUM-946) identified double-measure as the issue, but the actual root cause is the alignment cascade — SwiftUI [caches `LayoutSubview.sizeThatFits()` results internally](https://developer.apple.com/documentation/swiftui/layout/makecache(subviews:)), so the re-measure in `placeSubviews` hits the cache and is cheap. The Sentry stack showing `explicitAlignment` in the call chain was the real signal.
4. **Prevention:** Any custom `Layout` wrapper that exists to avoid `_FlexFrameLayout` MUST override `explicitAlignment` to return `nil` — otherwise the default extension re-introduces the same cascade. This should be documented in AGENTS.md for future Layout implementations.

## Prompt / plan
LUM-1167: Fix BottomAlignedMinHeightLayout double-measure hang. Deep investigation revealed the actual root cause is the missing `explicitAlignment` override, not the double-measure (which is SwiftUI-cached and cheap).

## Test plan
- Lint checks pass (`check-flexframe.sh`: OK)
- Pre-commit hooks pass (design token guard, generic-examples, secrets check)
- No behavioral change: `explicitAlignment` returning `nil` means "no explicit guide — use default positioning," identical to any view without custom alignment. Placement logic in `sizeThatFits`/`placeSubviews` is unchanged.
- CI does not include macOS builds — user must verify Xcode build locally.

---

- Requested by: @ashleeradka
- Session: https://app.devin.ai/sessions/c36e10ad60664d99be7f6d13875afdb6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
