### PR TITLE
fix: respect DEBUG_STDOUT_LOGS in containerized environments

### DIFF
--- a/assistant/src/util/logger.ts
+++ b/assistant/src/util/logger.ts
@@ -142,9 +142,9 @@ function buildRotatingLogger(config: LogFileConfig): pino.Logger {
   // When stdout is not a TTY (e.g. desktop app redirects to a hatch log file),
   // write to the rotating file only — the hatch log already captured early
   // startup output and echoing pino output there is unnecessary duplication.
-  // Exception: in containers, always write to stdout so `docker logs` can
-  // capture daemon output for debugging.
-  if (!process.stdout.isTTY && !getIsContainerized()) {
+  // DEBUG_STDOUT_LOGS opts in to stdout output for any non-TTY environment
+  // (containers, background daemons, etc.).
+  if (!process.stdout.isTTY && !getDebugStdoutLogs()) {
     return pino(
       { name: "assistant", level: "info", serializers: logSerializers },
       pino.multistream([

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -662,6 +662,8 @@ export function serviceDockerRunArgs(opts: {
         "-e",
         "IS_CONTAINERIZED=true",
         "-e",
+        "DEBUG_STDOUT_LOGS=1",
+        "-e",
         `VELLUM_ASSISTANT_NAME=${instanceName}`,
         "-e",
         "VELLUM_CLOUD=docker",


### PR DESCRIPTION
The `buildRotatingLogger` function unconditionally wrote to stdout when `IS_CONTAINERIZED` was set, ignoring the `DEBUG_STDOUT_LOGS` env var. This meant vembda's `ASSISTANT_DEBUG_STDOUT_LOGS=false` had no effect on prod — assistant pods always emitted logs to stdout regardless of the setting.

The regression was introduced by #18390, which added the `IS_CONTAINERIZED` check to fix Docker hatch sentinel detection. That same PR later switched to health check polling (`/readyz`), making the stdout override unnecessary — but the `getIsContainerized()` check was left behind.

Fix: replace `getIsContainerized()` with `getDebugStdoutLogs()` in the `buildRotatingLogger` early-return condition. Additionally, set `DEBUG_STDOUT_LOGS=1` in the CLI's Docker container env so local Docker deployments preserve `docker logs` debugging output. Platform (K8s) containers remain controlled by vembda's `ASSISTANT_DEBUG_STDOUT_LOGS` template conditional.

## Prompt / plan

User reported `ASSISTANT_DEBUG_STDOUT_LOGS=false` not being obeyed in prod vembda. Traced through vembda template rendering → assistant logger initialization to find that `buildRotatingLogger` bypassed the `DEBUG_STDOUT_LOGS` check when containerized.

## Test plan

- Typecheck passes (`bunx tsc --noEmit`)
- Lint passes (`bun run lint`)
- All 806 pre-push tests pass; 1 pre-existing flaky benchmark failure unrelated to this change
- CI passes

## Root cause analysis

1. **How did the code get into this state?** PR #18390 added `getIsContainerized()` to always write to stdout in containers so Docker hatch could detect a startup sentinel via `docker logs`. The same PR then switched to health-check polling, but the stdout override was never reverted.
2. **What mistakes or decisions led to it?** The multi-commit PR solved the problem two ways (stdout logging + health polling) and the first approach wasn't cleaned up after the second was adopted.
3. **Were there warning signs we missed?** The existing `DEBUG_STDOUT_LOGS` env var and the vembda template conditional were both designed to control this behavior — adding an unconditional override should have prompted review of whether it conflicted with the existing control mechanism.
4. **What can we do to prevent this pattern from recurring?** When a PR solves a problem multiple ways across commits, the final review should verify that superseded approaches are removed.
5. **Should we add a guideline to AGENTS.md?** No — this is a standard code review practice, not something that benefits from a permanent rule.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/c928ee89961e4f9587ea5973894eedfc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
