### PR TITLE
docs(migrations): update v1-path doc comments to use renamed checksum/contents field names

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -362,7 +362,7 @@ function buildManifestObject(input: {
  * Build a .vbundle archive from the given files and metadata.
  *
  * Generates a valid manifest with SHA-256 checksums for all files and
- * a self-referencing manifest_sha256 checksum. The archive is returned
+ * a self-referencing `checksum`. The archive is returned
  * as gzip-compressed tar bytes.
  */
 export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -9,7 +9,7 @@
  * This module lets a caller validate a bundle while streaming:
  * - `readAndValidateManifest` consumes the first tar entry (which must be
  *   `manifest.json`), validates the schema, and verifies the self-referencing
- *   `manifest_sha256` against the canonicalized JSON.
+ *   `checksum` against the canonicalized JSON.
  * - `createHashVerifier` returns a passthrough `Transform` that hashes bytes
  *   flowing through it and errors the pipeline if the final digest or byte
  *   count does not match the expected values from the manifest.
@@ -38,7 +38,7 @@ import {
 
 export interface ManifestReadResult {
   manifest: ManifestType;
-  /** Fast lookup from archive path -> expected sha256 + size (from manifest.files). */
+  /** Fast lookup from archive path -> expected sha256 + size (from manifest.contents). */
   expected: Map<string, { sha256: string; size: number }>;
 }
 
@@ -78,7 +78,7 @@ const MANIFEST_MAX_BYTES = 1 * 1024 * 1024;
  *   2. Size cap (1 MiB).
  *   3. JSON parse.
  *   4. Zod schema validation.
- *   5. Self-referencing `manifest_sha256` verification against the
+ *   5. Self-referencing `checksum` verification against the
  *      canonicalized JSON (minus that field).
  *
  * On success, returns the parsed manifest plus a `Map` keyed by archive

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -367,7 +367,7 @@ const MAX_DECOMPRESSED_SIZE = 2 * 1024 * 1024 * 1024;
  * Performs four validation passes:
  * 1. Archive structure (gzip decompression, tar parsing, required entries)
  * 2. Manifest schema (Zod validation of manifest.json)
- * 3. Manifest checksum (SHA-256 of canonicalized JSON without manifest_sha256)
+ * 3. Manifest checksum (SHA-256 of canonicalized JSON with the `checksum` field set to empty string)
  * 4. Per-file content integrity (SHA-256 of each file vs manifest declaration)
  */
 export function validateVBundle(data: Uint8Array): VBundleValidationResult {


### PR DESCRIPTION
## Summary
After the v1 rename (`manifest_sha256` → `checksum`, `files` → `contents`), several JSDoc/doc comments in production code still narrated the old field names as if they were current. Updated v1-path comments to v1 names; comments inside legacy-fallback branches (which describe the legacy schema) are intentionally preserved.

Fix from plan review for vbundle-v1-manifest.md plan. Per assistant/CLAUDE.md: 'do not reference code that has been removed'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
