### PR TITLE
test(migrations): consolidate cross-version-compat manifest builders into shared buildTestManifest helper

### DIFF
--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -87,7 +87,10 @@ mock.module("../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
-import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
+import {
+  buildTestManifest,
+  defaultV1Options,
+} from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -233,19 +236,6 @@ function sha256Hex(data: Uint8Array | string): string {
   return createHash("sha256").update(data).digest("hex");
 }
 
-function canonicalizeJson(obj: unknown): string {
-  return JSON.stringify(obj, (_key, value) => {
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      const sorted: Record<string, unknown> = {};
-      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-        sorted[k] = (value as Record<string, unknown>)[k];
-      }
-      return sorted;
-    }
-    return value;
-  });
-}
-
 interface VBundleFile {
   path: string;
   data: Uint8Array;
@@ -264,28 +254,15 @@ function createValidVBundle(
     size_bytes: f.data.length,
   }));
 
-  const manifestWithEmptyChecksum = {
-    schema_version: overrides?.schema_version ?? 1,
-    bundle_id: "00000000-0000-4000-8000-000000000000",
-    created_at: new Date().toISOString(),
-    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-    origin: { mode: "self-hosted-local" as const },
-    compatibility: {
-      min_runtime_version: "0.0.0-test",
-      max_runtime_version: null,
-    },
+  const manifest = buildTestManifest({
     contents,
-    checksum: "",
-    secrets_redacted: false,
-    export_options: {
-      include_logs: false,
-      include_browser_state: false,
-      include_memory_vectors: false,
+    overrides: {
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      ...(overrides?.schema_version !== undefined
+        ? { schema_version: overrides.schema_version }
+        : {}),
     },
-  };
-
-  const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-  const manifest = { ...manifestWithEmptyChecksum, checksum };
+  });
   const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
   const tarEntries = [
@@ -998,34 +975,16 @@ describe("edge cases", () => {
     const dbData2 = new Uint8Array([0x04, 0x05, 0x06]);
 
     // Build a valid v1 manifest that references the second data.
-    const contents = [
-      {
-        path: "data/db/assistant.db",
-        sha256: sha256Hex(dbData2),
-        size_bytes: dbData2.length,
-      },
-    ];
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
-      contents,
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData2),
+          size_bytes: dbData2.length,
+        },
+      ],
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     // Build tar with duplicate data/db/assistant.db entries
@@ -1048,16 +1007,7 @@ describe("edge cases", () => {
     const wrongChecksum =
       "0000000000000000000000000000000000000000000000000000000000000000";
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1065,16 +1015,8 @@ describe("edge cases", () => {
           size_bytes: dbData.length,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1098,16 +1040,7 @@ describe("edge cases", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const ghostSha = sha256Hex(new TextEncoder().encode("ghost-content"));
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1120,16 +1053,8 @@ describe("edge cases", () => {
           size_bytes: 13,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1155,31 +1080,10 @@ describe("edge cases", () => {
     // empty contents array is valid at the field level but rejected by
     // the refine.
     const dbBytes = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
-      contents: [] as Array<{
-        path: string;
-        sha256: string;
-        size_bytes: number;
-      }>,
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+    const manifest = buildTestManifest({
+      contents: [],
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1240,34 +1144,16 @@ describe("edge cases", () => {
     const extraData = new TextEncoder().encode("bonus content");
 
     // Manifest only declares the db file
-    const contents = [
-      {
-        path: "data/db/assistant.db",
-        sha256: sha256Hex(dbData),
-        size_bytes: dbData.length,
-      },
-    ];
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
-      contents,
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData),
+          size_bytes: dbData.length,
+        },
+      ],
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     // Archive has an extra file not in the manifest
@@ -1361,16 +1247,7 @@ describe("diagnostic quality", () => {
     const wrongSha =
       "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1378,16 +1255,8 @@ describe("diagnostic quality", () => {
           size_bytes: dbData.length,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
     const tar = createTarArchive([
       { name: "manifest.json", data: manifestData },
@@ -1406,16 +1275,7 @@ describe("diagnostic quality", () => {
   test("FILE_SIZE_MISMATCH includes file path and both sizes", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1423,16 +1283,8 @@ describe("diagnostic quality", () => {
           size_bytes: 99999,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
     const tar = createTarArchive([
       { name: "manifest.json", data: manifestData },
@@ -1502,16 +1354,7 @@ describe("multiple error accumulation", () => {
 
     // Manifest declares correct db checksum but wrong config checksum and
     // also wrong config size
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1524,16 +1367,8 @@ describe("multiple error accumulation", () => {
           size_bytes: 999,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1719,16 +1554,7 @@ describe("import analyzer edge cases", () => {
     );
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: 1,
-        bundle_id: "00000000-0000-4000-8000-000000000000",
-        created_at: "2026-03-01T00:00:00Z",
-        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-        origin: { mode: "self-hosted-local" },
-        compatibility: {
-          min_runtime_version: "0.0.0-test",
-          max_runtime_version: null,
-        },
+      manifest: buildTestManifest({
         contents: [
           {
             path: "data/db/assistant.db",
@@ -1741,14 +1567,11 @@ describe("import analyzer edge cases", () => {
             size_bytes: 1,
           },
         ],
-        checksum: "test",
-        secrets_redacted: false,
-        export_options: {
-          include_logs: false,
-          include_browser_state: false,
-          include_memory_vectors: false,
+        overrides: {
+          bundle_id: "00000000-0000-4000-8000-000000000000",
+          created_at: "2026-03-01T00:00:00Z",
         },
-      },
+      }),
       pathResolver: resolver,
     });
 
@@ -1766,16 +1589,7 @@ describe("import analyzer edge cases", () => {
     const existingConfig = new Uint8Array(readFileSync(testConfigPath));
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: 1,
-        bundle_id: "00000000-0000-4000-8000-000000000000",
-        created_at: "2026-03-01T00:00:00Z",
-        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-        origin: { mode: "self-hosted-local" },
-        compatibility: {
-          min_runtime_version: "0.0.0-test",
-          max_runtime_version: null,
-        },
+      manifest: buildTestManifest({
         contents: [
           {
             path: "data/db/assistant.db",
@@ -1788,14 +1602,11 @@ describe("import analyzer edge cases", () => {
             size_bytes: existingConfig.length,
           },
         ],
-        checksum: "test",
-        secrets_redacted: false,
-        export_options: {
-          include_logs: false,
-          include_browser_state: false,
-          include_memory_vectors: false,
+        overrides: {
+          bundle_id: "00000000-0000-4000-8000-000000000000",
+          created_at: "2026-03-01T00:00:00Z",
         },
-      },
+      }),
       pathResolver: resolver,
     });
 
@@ -1808,16 +1619,7 @@ describe("import analyzer edge cases", () => {
     const resolver = new DefaultPathResolver(testDir);
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: 1,
-        bundle_id: "00000000-0000-4000-8000-000000000000",
-        created_at: "2026-03-01T00:00:00Z",
-        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-        origin: { mode: "self-hosted-local" },
-        compatibility: {
-          min_runtime_version: "0.0.0-test",
-          max_runtime_version: null,
-        },
+      manifest: buildTestManifest({
         contents: [
           {
             path: "data/db/assistant.db",
@@ -1830,14 +1632,11 @@ describe("import analyzer edge cases", () => {
             size_bytes: 1,
           },
         ],
-        checksum: "test",
-        secrets_redacted: false,
-        export_options: {
-          include_logs: false,
-          include_browser_state: false,
-          include_memory_vectors: false,
+        overrides: {
+          bundle_id: "00000000-0000-4000-8000-000000000000",
+          created_at: "2026-03-01T00:00:00Z",
         },
-      },
+      }),
       pathResolver: resolver,
     });
 

--- a/assistant/src/runtime/migrations/__tests__/v1-test-helpers.ts
+++ b/assistant/src/runtime/migrations/__tests__/v1-test-helpers.ts
@@ -7,6 +7,8 @@
  * keeps every test from re-spelling the same six required option fields.
  */
 
+import { randomUUID } from "node:crypto";
+
 import type {
   BuildVBundleOptions,
   VBundleAssistantInfo,
@@ -14,6 +16,11 @@ import type {
   VBundleExportOptions,
   VBundleOriginInfo,
 } from "../vbundle-builder.js";
+import {
+  computeManifestChecksum,
+  type ManifestFileEntryType,
+  type ManifestType,
+} from "../vbundle-validator.js";
 
 export interface DefaultV1Options {
   assistant: VBundleAssistantInfo;
@@ -66,4 +73,40 @@ export function buildVBundleTestOptions(
     ...defaultV1Options(),
     ...overrides,
   };
+}
+
+/**
+ * Build a v1 ManifestType for tests, mirroring buildManifestObject() in
+ * vbundle-builder.ts. Use this in test fixtures that need a synthetic
+ * manifest rather than calling buildVBundle (e.g. cross-version compat
+ * tests that need to mutate fields between emit and validate).
+ *
+ * Pass `overrides` to override any field after the defaults are applied —
+ * useful for negative-path tests that exercise specific schema rejections.
+ * `schema_version` is widened to `number` so negative tests can write 0/2/etc.
+ * The checksum is computed on the merged shape so overrides take effect.
+ */
+export type BuildTestManifestOverrides = Partial<
+  Omit<ManifestType, "schema_version">
+> & { schema_version?: number };
+
+export function buildTestManifest(input: {
+  contents: ManifestFileEntryType[];
+  overrides?: BuildTestManifestOverrides;
+}): ManifestType {
+  const base = defaultV1Options();
+  const merged = {
+    schema_version: 1,
+    bundle_id: randomUUID(),
+    created_at: new Date().toISOString(),
+    assistant: base.assistant,
+    origin: base.origin,
+    compatibility: base.compatibility,
+    contents: input.contents,
+    checksum: "",
+    secrets_redacted: base.secretsRedacted,
+    export_options: base.exportOptions,
+    ...(input.overrides ?? {}),
+  } as ManifestType;
+  return { ...merged, checksum: computeManifestChecksum(merged) };
 }


### PR DESCRIPTION
## Summary
`migration-cross-version-compatibility.test.ts` previously inlined the v1 `buildManifestObject` flow (`manifestWithEmptyChecksum` / canonicalize / checksum) at ~12 sites. Consolidated into a new `buildTestManifest()` helper in `v1-test-helpers.ts` so test fixtures share one source of truth — same value the plan author called out for the production-side `buildManifestObject()` extraction.

Fix from plan review for vbundle-v1-manifest.md plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
