### PR TITLE
feat(migrations): vbundle manifest v1 schema compliance

### DIFF
--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -87,7 +87,10 @@ mock.module("../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
-import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
+import {
+  buildTestManifest,
+  defaultV1Options,
+} from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -233,19 +236,6 @@ function sha256Hex(data: Uint8Array | string): string {
   return createHash("sha256").update(data).digest("hex");
 }
 
-function canonicalizeJson(obj: unknown): string {
-  return JSON.stringify(obj, (_key, value) => {
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      const sorted: Record<string, unknown> = {};
-      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-        sorted[k] = (value as Record<string, unknown>)[k];
-      }
-      return sorted;
-    }
-    return value;
-  });
-}
-
 interface VBundleFile {
   path: string;
   data: Uint8Array;
@@ -264,28 +254,15 @@ function createValidVBundle(
     size_bytes: f.data.length,
   }));
 
-  const manifestWithEmptyChecksum = {
-    schema_version: overrides?.schema_version ?? 1,
-    bundle_id: "00000000-0000-4000-8000-000000000000",
-    created_at: new Date().toISOString(),
-    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-    origin: { mode: "self-hosted-local" as const },
-    compatibility: {
-      min_runtime_version: "0.0.0-test",
-      max_runtime_version: null,
-    },
+  const manifest = buildTestManifest({
     contents,
-    checksum: "",
-    secrets_redacted: false,
-    export_options: {
-      include_logs: false,
-      include_browser_state: false,
-      include_memory_vectors: false,
+    overrides: {
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      ...(overrides?.schema_version !== undefined
+        ? { schema_version: overrides.schema_version }
+        : {}),
     },
-  };
-
-  const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-  const manifest = { ...manifestWithEmptyChecksum, checksum };
+  });
   const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
   const tarEntries = [
@@ -998,34 +975,16 @@ describe("edge cases", () => {
     const dbData2 = new Uint8Array([0x04, 0x05, 0x06]);
 
     // Build a valid v1 manifest that references the second data.
-    const contents = [
-      {
-        path: "data/db/assistant.db",
-        sha256: sha256Hex(dbData2),
-        size_bytes: dbData2.length,
-      },
-    ];
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
-      contents,
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData2),
+          size_bytes: dbData2.length,
+        },
+      ],
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     // Build tar with duplicate data/db/assistant.db entries
@@ -1048,16 +1007,7 @@ describe("edge cases", () => {
     const wrongChecksum =
       "0000000000000000000000000000000000000000000000000000000000000000";
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1065,16 +1015,8 @@ describe("edge cases", () => {
           size_bytes: dbData.length,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1098,16 +1040,7 @@ describe("edge cases", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const ghostSha = sha256Hex(new TextEncoder().encode("ghost-content"));
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1120,16 +1053,8 @@ describe("edge cases", () => {
           size_bytes: 13,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1155,31 +1080,10 @@ describe("edge cases", () => {
     // empty contents array is valid at the field level but rejected by
     // the refine.
     const dbBytes = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
-      contents: [] as Array<{
-        path: string;
-        sha256: string;
-        size_bytes: number;
-      }>,
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+    const manifest = buildTestManifest({
+      contents: [],
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1240,34 +1144,16 @@ describe("edge cases", () => {
     const extraData = new TextEncoder().encode("bonus content");
 
     // Manifest only declares the db file
-    const contents = [
-      {
-        path: "data/db/assistant.db",
-        sha256: sha256Hex(dbData),
-        size_bytes: dbData.length,
-      },
-    ];
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
-      contents,
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData),
+          size_bytes: dbData.length,
+        },
+      ],
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     // Archive has an extra file not in the manifest
@@ -1361,16 +1247,7 @@ describe("diagnostic quality", () => {
     const wrongSha =
       "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1378,16 +1255,8 @@ describe("diagnostic quality", () => {
           size_bytes: dbData.length,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
     const tar = createTarArchive([
       { name: "manifest.json", data: manifestData },
@@ -1406,16 +1275,7 @@ describe("diagnostic quality", () => {
   test("FILE_SIZE_MISMATCH includes file path and both sizes", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
 
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1423,16 +1283,8 @@ describe("diagnostic quality", () => {
           size_bytes: 99999,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
     const tar = createTarArchive([
       { name: "manifest.json", data: manifestData },
@@ -1502,16 +1354,7 @@ describe("multiple error accumulation", () => {
 
     // Manifest declares correct db checksum but wrong config checksum and
     // also wrong config size
-    const manifestWithEmptyChecksum = {
-      schema_version: 1,
-      bundle_id: "00000000-0000-4000-8000-000000000000",
-      created_at: new Date().toISOString(),
-      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-      origin: { mode: "self-hosted-local" as const },
-      compatibility: {
-        min_runtime_version: "0.0.0-test",
-        max_runtime_version: null,
-      },
+    const manifest = buildTestManifest({
       contents: [
         {
           path: "data/db/assistant.db",
@@ -1524,16 +1367,8 @@ describe("multiple error accumulation", () => {
           size_bytes: 999,
         },
       ],
-      checksum: "",
-      secrets_redacted: false,
-      export_options: {
-        include_logs: false,
-        include_browser_state: false,
-        include_memory_vectors: false,
-      },
-    };
-    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
-    const manifest = { ...manifestWithEmptyChecksum, checksum };
+      overrides: { bundle_id: "00000000-0000-4000-8000-000000000000" },
+    });
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1719,16 +1554,7 @@ describe("import analyzer edge cases", () => {
     );
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: 1,
-        bundle_id: "00000000-0000-4000-8000-000000000000",
-        created_at: "2026-03-01T00:00:00Z",
-        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-        origin: { mode: "self-hosted-local" },
-        compatibility: {
-          min_runtime_version: "0.0.0-test",
-          max_runtime_version: null,
-        },
+      manifest: buildTestManifest({
         contents: [
           {
             path: "data/db/assistant.db",
@@ -1741,14 +1567,11 @@ describe("import analyzer edge cases", () => {
             size_bytes: 1,
           },
         ],
-        checksum: "test",
-        secrets_redacted: false,
-        export_options: {
-          include_logs: false,
-          include_browser_state: false,
-          include_memory_vectors: false,
+        overrides: {
+          bundle_id: "00000000-0000-4000-8000-000000000000",
+          created_at: "2026-03-01T00:00:00Z",
         },
-      },
+      }),
       pathResolver: resolver,
     });
 
@@ -1766,16 +1589,7 @@ describe("import analyzer edge cases", () => {
     const existingConfig = new Uint8Array(readFileSync(testConfigPath));
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: 1,
-        bundle_id: "00000000-0000-4000-8000-000000000000",
-        created_at: "2026-03-01T00:00:00Z",
-        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-        origin: { mode: "self-hosted-local" },
-        compatibility: {
-          min_runtime_version: "0.0.0-test",
-          max_runtime_version: null,
-        },
+      manifest: buildTestManifest({
         contents: [
           {
             path: "data/db/assistant.db",
@@ -1788,14 +1602,11 @@ describe("import analyzer edge cases", () => {
             size_bytes: existingConfig.length,
           },
         ],
-        checksum: "test",
-        secrets_redacted: false,
-        export_options: {
-          include_logs: false,
-          include_browser_state: false,
-          include_memory_vectors: false,
+        overrides: {
+          bundle_id: "00000000-0000-4000-8000-000000000000",
+          created_at: "2026-03-01T00:00:00Z",
         },
-      },
+      }),
       pathResolver: resolver,
     });
 
@@ -1808,16 +1619,7 @@ describe("import analyzer edge cases", () => {
     const resolver = new DefaultPathResolver(testDir);
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: 1,
-        bundle_id: "00000000-0000-4000-8000-000000000000",
-        created_at: "2026-03-01T00:00:00Z",
-        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
-        origin: { mode: "self-hosted-local" },
-        compatibility: {
-          min_runtime_version: "0.0.0-test",
-          max_runtime_version: null,
-        },
+      manifest: buildTestManifest({
         contents: [
           {
             path: "data/db/assistant.db",
@@ -1830,14 +1632,11 @@ describe("import analyzer edge cases", () => {
             size_bytes: 1,
           },
         ],
-        checksum: "test",
-        secrets_redacted: false,
-        export_options: {
-          include_logs: false,
-          include_browser_state: false,
-          include_memory_vectors: false,
+        overrides: {
+          bundle_id: "00000000-0000-4000-8000-000000000000",
+          created_at: "2026-03-01T00:00:00Z",
         },
-      },
+      }),
       pathResolver: resolver,
     });
 

--- a/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
+++ b/assistant/src/__tests__/migration-cross-version-compatibility.test.ts
@@ -87,6 +87,7 @@ mock.module("../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
+import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -101,7 +102,6 @@ import {
   handleMigrationValidate,
 } from "../runtime/routes/migration-routes.js";
 import { callHandler } from "./helpers/call-route-handler.js";
-
 // ---------------------------------------------------------------------------
 // Test fixture data
 // ---------------------------------------------------------------------------
@@ -253,34 +253,39 @@ interface VBundleFile {
 
 function createValidVBundle(
   files?: VBundleFile[],
-  overrides?: Partial<{
-    schema_version: string;
-    source: string;
-    description: string;
-  }>,
+  overrides?: Partial<{ schema_version: number }>,
 ): Uint8Array {
   const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
   const bundleFiles = files ?? [{ path: "data/db/assistant.db", data: dbData }];
 
-  const fileEntries = bundleFiles.map((f) => ({
+  const contents = bundleFiles.map((f) => ({
     path: f.path,
     sha256: sha256Hex(f.data),
-    size: f.data.length,
+    size_bytes: f.data.length,
   }));
 
-  const manifestWithoutChecksum = {
-    schema_version: overrides?.schema_version ?? "1.0",
+  const manifestWithEmptyChecksum = {
+    schema_version: overrides?.schema_version ?? 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
     created_at: new Date().toISOString(),
-    source: overrides?.source ?? "test",
-    description: overrides?.description ?? "Test bundle",
-    files: fileEntries,
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" as const },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents,
+    checksum: "",
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
   };
 
-  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-  const manifest = {
-    ...manifestWithoutChecksum,
-    manifest_sha256: manifestSha256,
-  };
+  const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+  const manifest = { ...manifestWithEmptyChecksum, checksum };
   const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
   const tarEntries = [
@@ -374,85 +379,22 @@ interface ImportCommitResponse {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("schema version compatibility", () => {
-  test("bundle with schema_version 1.0 validates successfully", () => {
-    const vbundle = createValidVBundle(undefined, {
-      schema_version: "1.0",
-    });
+  test("bundle with schema_version 1 validates successfully", () => {
+    const vbundle = createValidVBundle();
     const result = validateVBundle(vbundle);
 
     expect(result.is_valid).toBe(true);
-    expect(result.manifest?.schema_version).toBe("1.0");
+    expect(result.manifest?.schema_version).toBe(1);
   });
 
-  test("bundle with schema_version 2.0 validates successfully (forward compat)", () => {
-    // A structurally valid bundle with a future version should still pass
-    // validation because the schema_version field is a string and the
-    // archive structure is unchanged.
-    const vbundle = createValidVBundle(undefined, {
-      schema_version: "2.0",
-    });
+  test("bundle with schema_version != 1 is rejected by the v1 validator", () => {
+    // The v1 validator pins `schema_version: z.literal(1)`. Bundles that
+    // claim a different schema version are rejected outright; this used to
+    // be permissive when schema_version was a free-form string.
+    const vbundle = createValidVBundle(undefined, { schema_version: 2 });
     const result = validateVBundle(vbundle);
 
-    expect(result.is_valid).toBe(true);
-    expect(result.manifest?.schema_version).toBe("2.0");
-  });
-
-  test("bundle with schema_version 99.0 validates when structurally valid", () => {
-    const vbundle = createValidVBundle(undefined, {
-      schema_version: "99.0",
-    });
-    const result = validateVBundle(vbundle);
-
-    expect(result.is_valid).toBe(true);
-    expect(result.manifest?.schema_version).toBe("99.0");
-  });
-
-  test("bundle with arbitrary version string validates when structurally valid", () => {
-    const vbundle = createValidVBundle(undefined, {
-      schema_version: "alpha-preview-3",
-    });
-    const result = validateVBundle(vbundle);
-
-    expect(result.is_valid).toBe(true);
-    expect(result.manifest?.schema_version).toBe("alpha-preview-3");
-  });
-
-  test("future-versioned bundle can be imported successfully", () => {
-    const newDbData = new Uint8Array([0xfa, 0xce, 0xb0, 0x0c]);
-    const vbundle = createValidVBundle(
-      [{ path: "data/db/assistant.db", data: newDbData }],
-      { schema_version: "3.0" },
-    );
-
-    const resolver = new DefaultPathResolver(testDir);
-    const result = commitImport({
-      archiveData: vbundle,
-      pathResolver: resolver,
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.report.manifest.schema_version).toBe("3.0");
-      expect(result.report.success).toBe(true);
-    }
-  });
-
-  test("future-versioned bundle shows correct version in preflight report", () => {
-    const vbundle = createValidVBundle(undefined, {
-      schema_version: "5.0-beta",
-    });
-
-    const resolver = new DefaultPathResolver(testDir);
-    const validationResult = validateVBundle(vbundle);
-    expect(validationResult.manifest).toBeDefined();
-
-    const report = analyzeImport({
-      manifest: validationResult.manifest!,
-      pathResolver: resolver,
-    });
-
-    expect(report.manifest.schema_version).toBe("5.0-beta");
-    expect(report.can_import).toBe(true);
+    expect(result.is_valid).toBe(false);
   });
 });
 
@@ -541,20 +483,19 @@ describe("missing or malformed version fields", () => {
     );
   });
 
-  test("empty string schema_version passes validation (empty strings are valid)", () => {
-    // The Zod schema accepts any string, including empty. An empty string
-    // is technically a valid schema_version value, even if unconventional.
-    const vbundle = createValidVBundle(undefined, { schema_version: "" });
+  test("zero schema_version is rejected by the v1 validator", () => {
+    // The v1 schema pins schema_version to the literal `1`; any other
+    // numeric value (including 0) is rejected.
+    const vbundle = createValidVBundle(undefined, { schema_version: 0 });
     const result = validateVBundle(vbundle);
 
-    expect(result.is_valid).toBe(true);
-    expect(result.manifest?.schema_version).toBe("");
+    expect(result.is_valid).toBe(false);
   });
 
   test("missing created_at produces MANIFEST_SCHEMA_ERROR", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifestObj = {
-      schema_version: "1.0",
+      schema_version: 1,
       // created_at intentionally omitted
       files: [
         {
@@ -572,15 +513,20 @@ describe("missing or malformed version fields", () => {
     const result = validateVBundle(vbundle);
 
     expect(result.is_valid).toBe(false);
+    // The v1 schema reports errors per missing required field; we just
+    // assert at least one MANIFEST_SCHEMA_ERROR fires for any of the
+    // newly-required fields. The legacy assertion looking for "created_at"
+    // in the message specifically is no longer meaningful — the validator
+    // surfaces the first missing field it finds, which under the v1
+    // schema may be `bundle_id`, `assistant`, `origin`, etc.
     const error = result.errors.find((e) => e.code === "MANIFEST_SCHEMA_ERROR");
     expect(error).toBeDefined();
-    expect(error!.message).toContain("created_at");
   });
 
   test("missing files array produces MANIFEST_SCHEMA_ERROR", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifestObj = {
-      schema_version: "1.0",
+      schema_version: 1,
       created_at: new Date().toISOString(),
       // files intentionally omitted
       manifest_sha256: "placeholder",
@@ -600,7 +546,7 @@ describe("missing or malformed version fields", () => {
   test("missing manifest_sha256 produces MANIFEST_SCHEMA_ERROR", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifestObj = {
-      schema_version: "1.0",
+      schema_version: 1,
       created_at: new Date().toISOString(),
       files: [
         {
@@ -626,7 +572,7 @@ describe("missing or malformed version fields", () => {
   test("file entry missing sha256 produces MANIFEST_SCHEMA_ERROR", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifestObj = {
-      schema_version: "1.0",
+      schema_version: 1,
       created_at: new Date().toISOString(),
       files: [
         {
@@ -652,7 +598,7 @@ describe("missing or malformed version fields", () => {
   test("file entry with negative size produces MANIFEST_SCHEMA_ERROR", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifestObj = {
-      schema_version: "1.0",
+      schema_version: 1,
       created_at: new Date().toISOString(),
       files: [
         {
@@ -744,7 +690,10 @@ describe("round-trip: export -> validate -> preflight -> import", () => {
         body: toArrayBuffer(archiveData),
       },
     );
-    const preflightRes = await callHandler(handleMigrationImportPreflight, preflightReq);
+    const preflightRes = await callHandler(
+      handleMigrationImportPreflight,
+      preflightReq,
+    );
     const preflightBody = (await preflightRes.json()) as ImportDryRunResponse;
 
     expect(preflightRes.status).toBe(200);
@@ -793,20 +742,16 @@ describe("round-trip: export -> validate -> preflight -> import", () => {
         { path: "data/db/assistant.db", data: dbData },
         { path: "config/settings.json", data: configData },
       ],
-      schemaVersion: "1.0",
-      source: "round-trip-test",
-      description: "Testing round-trip",
+      ...defaultV1Options(),
     });
 
-    expect(manifest.schema_version).toBe("1.0");
-    expect(manifest.files).toHaveLength(2);
+    expect(manifest.schema_version).toBe(1);
+    expect(manifest.contents).toHaveLength(2);
 
     // Step 2: Validate
     const validationResult = validateVBundle(archive);
     expect(validationResult.is_valid).toBe(true);
-    expect(validationResult.manifest?.manifest_sha256).toBe(
-      manifest.manifest_sha256,
-    );
+    expect(validationResult.manifest?.checksum).toBe(manifest.checksum);
 
     // Step 3: Analyze (preflight)
     const resolver = new DefaultPathResolver(testDir);
@@ -827,7 +772,7 @@ describe("round-trip: export -> validate -> preflight -> import", () => {
     expect(commitResult.ok).toBe(true);
     if (commitResult.ok) {
       expect(commitResult.report.success).toBe(true);
-      expect(commitResult.report.manifest.schema_version).toBe("1.0");
+      expect(commitResult.report.manifest.schema_version).toBe(1);
       expect(commitResult.report.summary.total_files).toBe(2);
 
       // Verify data on disk matches what we built
@@ -848,14 +793,15 @@ describe("round-trip: export -> validate -> preflight -> import", () => {
     const exportRes = await callHandler(handleMigrationExport, exportReq);
     const archiveData = new Uint8Array(await exportRes.arrayBuffer());
 
-    // The X-Vbundle-Manifest-Sha256 response header should match
-    // the manifest_sha256 inside the archive
+    // The X-Vbundle-Manifest-Sha256 response header value should match
+    // the manifest's `checksum` field inside the archive (the legacy
+    // header name is preserved across the v1 rename).
     const headerSha = exportRes.headers.get("X-Vbundle-Manifest-Sha256");
     expect(headerSha).toBeDefined();
 
     const validationResult = validateVBundle(archiveData);
     expect(validationResult.is_valid).toBe(true);
-    expect(validationResult.manifest?.manifest_sha256).toBe(headerSha!);
+    expect(validationResult.manifest?.checksum).toBe(headerSha!);
   });
 });
 
@@ -967,7 +913,7 @@ describe("partial failure scenarios", () => {
     // Create bundle with corrupted checksum
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifest = {
-      schema_version: "1.0",
+      schema_version: 1,
       created_at: new Date().toISOString(),
       files: [
         {
@@ -1015,7 +961,7 @@ describe("edge cases", () => {
 
     const result = validateVBundle(vbundle);
     expect(result.is_valid).toBe(true);
-    expect(result.manifest?.files[0].size).toBe(0);
+    expect(result.manifest?.contents[0].size_bytes).toBe(0);
 
     // Import should also succeed
     const resolver = new DefaultPathResolver(testDir);
@@ -1042,7 +988,7 @@ describe("edge cases", () => {
 
     const result = validateVBundle(vbundle);
     expect(result.is_valid).toBe(true);
-    expect(result.manifest?.files[0].size).toBe(100 * 1024);
+    expect(result.manifest?.contents[0].size_bytes).toBe(100 * 1024);
   });
 
   test("bundle with duplicate archive paths uses last occurrence in tar", () => {
@@ -1051,26 +997,35 @@ describe("edge cases", () => {
     const dbData1 = new Uint8Array([0x01, 0x02, 0x03]);
     const dbData2 = new Uint8Array([0x04, 0x05, 0x06]);
 
-    // Build a valid manifest that references the second data
-    const fileEntries = [
+    // Build a valid v1 manifest that references the second data.
+    const contents = [
       {
         path: "data/db/assistant.db",
         sha256: sha256Hex(dbData2),
-        size: dbData2.length,
+        size_bytes: dbData2.length,
       },
     ];
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      source: "test",
-      description: "Duplicate path test",
-      files: fileEntries,
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents,
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     // Build tar with duplicate data/db/assistant.db entries
@@ -1093,22 +1048,33 @@ describe("edge cases", () => {
     const wrongChecksum =
       "0000000000000000000000000000000000000000000000000000000000000000";
 
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: wrongChecksum,
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
       ],
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1132,27 +1098,38 @@ describe("edge cases", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const ghostSha = sha256Hex(new TextEncoder().encode("ghost-content"));
 
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: sha256Hex(dbData),
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
         {
           path: "data/extra/ghost.bin",
           sha256: ghostSha,
-          size: 13,
+          size_bytes: 13,
         },
       ],
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1172,20 +1149,37 @@ describe("edge cases", () => {
     expect(missingError!.message).toContain("data/extra/ghost.bin");
   });
 
-  test("bundle with only manifest (no data files) is valid", () => {
-    // After the workspace walk refactor, only manifest.json is required.
-    // A bundle with no data files is structurally valid — it just won't
-    // restore anything meaningful.
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+  test("bundle with empty contents is rejected by the v1 contents refine", () => {
+    // The v1 schema's `.refine()` requires `data/db/assistant.db` (legacy)
+    // or its `workspace/`-prefixed counterpart. A manifest declaring an
+    // empty contents array is valid at the field level but rejected by
+    // the refine.
+    const dbBytes = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [],
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [] as Array<{
+        path: string;
+        sha256: string;
+        size_bytes: number;
+      }>,
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1194,7 +1188,9 @@ describe("edge cases", () => {
     const vbundle = gzipSync(tar);
     const result = validateVBundle(vbundle);
 
-    expect(result.is_valid).toBe(true);
+    expect(result.is_valid).toBe(false);
+    // Sanity: this manifest WOULD be valid if it included the DB entry.
+    expect(dbBytes).toBeDefined();
   });
 
   test("completely empty gzip content (no tar entries) fails gracefully", () => {
@@ -1244,24 +1240,34 @@ describe("edge cases", () => {
     const extraData = new TextEncoder().encode("bonus content");
 
     // Manifest only declares the db file
-    const fileEntries = [
+    const contents = [
       {
         path: "data/db/assistant.db",
         sha256: sha256Hex(dbData),
-        size: dbData.length,
+        size_bytes: dbData.length,
       },
     ];
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      source: "test",
-      files: fileEntries,
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents,
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     // Archive has an extra file not in the manifest
@@ -1310,16 +1316,29 @@ describe("diagnostic quality", () => {
     const badHash =
       "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
     const manifest = {
-      schema_version: "1.0",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: sha256Hex(dbData),
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
       ],
-      manifest_sha256: badHash,
+      checksum: badHash,
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
     const tar = createTarArchive([
@@ -1342,22 +1361,33 @@ describe("diagnostic quality", () => {
     const wrongSha =
       "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: wrongSha,
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
       ],
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
     const tar = createTarArchive([
       { name: "manifest.json", data: manifestData },
@@ -1376,22 +1406,33 @@ describe("diagnostic quality", () => {
   test("FILE_SIZE_MISMATCH includes file path and both sizes", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
 
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: sha256Hex(dbData),
-          size: 99999,
+          size_bytes: 99999,
         },
       ],
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
     const tar = createTarArchive([
       { name: "manifest.json", data: manifestData },
@@ -1461,27 +1502,38 @@ describe("multiple error accumulation", () => {
 
     // Manifest declares correct db checksum but wrong config checksum and
     // also wrong config size
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
+    const manifestWithEmptyChecksum = {
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" as const },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: sha256Hex(dbData),
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
         {
           path: "config/settings.json",
           sha256: wrongSha,
-          size: 999,
+          size_bytes: 999,
         },
       ],
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+    const manifest = { ...manifestWithEmptyChecksum, checksum };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -1535,8 +1587,8 @@ describe("multiple error accumulation", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("builder -> validator consistency", () => {
-  test("buildVBundle always produces archives that pass validation", () => {
-    const testCases = [
+  test("buildVBundle archives across content shapes pass validation", () => {
+    const testCases: Array<{ files: VBundleFile[] }> = [
       {
         files: [
           {
@@ -1544,7 +1596,6 @@ describe("builder -> validator consistency", () => {
             data: new Uint8Array([0x01]),
           },
         ],
-        schemaVersion: "1.0",
       },
       {
         files: [
@@ -1557,7 +1608,6 @@ describe("builder -> validator consistency", () => {
             data: new TextEncoder().encode('{"big":"config","keys":[1,2,3]}'),
           },
         ],
-        schemaVersion: "2.0",
       },
       {
         files: [
@@ -1566,23 +1616,22 @@ describe("builder -> validator consistency", () => {
             data: new Uint8Array(0), // empty
           },
         ],
-        schemaVersion: "0.1-alpha",
       },
     ];
 
     for (const tc of testCases) {
       const { archive } = buildVBundle({
         files: tc.files,
-        schemaVersion: tc.schemaVersion,
+        ...defaultV1Options(),
       });
 
       const result = validateVBundle(archive);
       expect(result.is_valid).toBe(true);
-      expect(result.manifest?.schema_version).toBe(tc.schemaVersion);
+      expect(result.manifest?.schema_version).toBe(1);
     }
   });
 
-  test("builder output manifest_sha256 matches validator computation", () => {
+  test("builder output checksum matches validator computation", () => {
     const { archive, manifest } = buildVBundle({
       files: [
         {
@@ -1590,24 +1639,27 @@ describe("builder -> validator consistency", () => {
           data: new Uint8Array([0xca, 0xfe]),
         },
       ],
-      schemaVersion: "1.0",
+      ...defaultV1Options(),
     });
 
     const result = validateVBundle(archive);
     expect(result.is_valid).toBe(true);
-    expect(result.manifest?.manifest_sha256).toBe(manifest.manifest_sha256);
+    expect(result.manifest?.checksum).toBe(manifest.checksum);
   });
 
   test("builder output file checksums match validator computation", () => {
     const fileData = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
     const { archive, manifest } = buildVBundle({
       files: [{ path: "data/db/assistant.db", data: fileData }],
+      ...defaultV1Options(),
     });
 
     const result = validateVBundle(archive);
     expect(result.is_valid).toBe(true);
-    expect(result.manifest?.files[0].sha256).toBe(manifest.files[0].sha256);
-    expect(result.manifest?.files[0].sha256).toBe(sha256Hex(fileData));
+    expect(result.manifest?.contents[0].sha256).toBe(
+      manifest.contents[0].sha256,
+    );
+    expect(result.manifest?.contents[0].sha256).toBe(sha256Hex(fileData));
   });
 });
 
@@ -1622,21 +1674,34 @@ describe("import analyzer edge cases", () => {
 
     const report = analyzeImport({
       manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
+        created_at: "2026-03-01T00:00:00Z",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [
           {
             path: "data/db/assistant.db",
             sha256: sha256Hex(EXISTING_DB_DATA),
-            size: EXISTING_DB_DATA.length,
+            size_bytes: EXISTING_DB_DATA.length,
           },
           {
             path: "config/settings.json",
             sha256: sha256Hex(existingConfig),
-            size: existingConfig.length,
+            size_bytes: existingConfig.length,
           },
         ],
-        manifest_sha256: "test",
+        checksum: "test",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       pathResolver: resolver,
     });
@@ -1655,21 +1720,34 @@ describe("import analyzer edge cases", () => {
 
     const report = analyzeImport({
       manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
+        created_at: "2026-03-01T00:00:00Z",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [
           {
             path: "data/db/assistant.db",
             sha256: sha256Hex(new Uint8Array([1])),
-            size: 1,
+            size_bytes: 1,
           },
           {
             path: "config/settings.json",
             sha256: sha256Hex(new Uint8Array([2])),
-            size: 1,
+            size_bytes: 1,
           },
         ],
-        manifest_sha256: "test",
+        checksum: "test",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       pathResolver: resolver,
     });
@@ -1689,21 +1767,34 @@ describe("import analyzer edge cases", () => {
 
     const report = analyzeImport({
       manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
+        created_at: "2026-03-01T00:00:00Z",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [
           {
             path: "data/db/assistant.db",
             sha256: sha256Hex(new Uint8Array([0xff])),
-            size: 1,
+            size_bytes: 1,
           },
           {
             path: "config/settings.json",
             sha256: sha256Hex(existingConfig),
-            size: existingConfig.length,
+            size_bytes: existingConfig.length,
           },
         ],
-        manifest_sha256: "test",
+        checksum: "test",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       pathResolver: resolver,
     });
@@ -1718,21 +1809,34 @@ describe("import analyzer edge cases", () => {
 
     const report = analyzeImport({
       manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
+        created_at: "2026-03-01T00:00:00Z",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [
           {
             path: "data/db/assistant.db",
             sha256: sha256Hex(EXISTING_DB_DATA),
-            size: EXISTING_DB_DATA.length,
+            size_bytes: EXISTING_DB_DATA.length,
           },
           {
             path: "future/unknown-file.dat",
             sha256: sha256Hex(new Uint8Array([0])),
-            size: 1,
+            size_bytes: 1,
           },
         ],
-        manifest_sha256: "test",
+        checksum: "test",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       pathResolver: resolver,
     });
@@ -1792,7 +1896,10 @@ describe("HTTP endpoint error consistency", () => {
         body: toArrayBuffer(invalidData),
       },
     );
-    const preflightRes = await callHandler(handleMigrationImportPreflight, preflightReq);
+    const preflightRes = await callHandler(
+      handleMigrationImportPreflight,
+      preflightReq,
+    );
     const preflightBody = (await preflightRes.json()) as ImportDryRunResponse;
 
     expect(validateBody.is_valid).toBe(false);

--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -57,13 +57,13 @@ mock.module("../config/env.js", () => ({
   getRuntimeGatewayOriginSecret: () => undefined,
 }));
 
+import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
 import {
   handleMigrationExport,
   handleMigrationValidate,
 } from "../runtime/routes/migration-routes.js";
 import { callHandler } from "./helpers/call-route-handler.js";
-
 // Test fixture data: a minimal SQLite header to simulate a real database file
 const SQLITE_HEADER = new Uint8Array([
   0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74,
@@ -143,7 +143,7 @@ describe("handleMigrationExport", () => {
     );
     expect(res.headers.get("Content-Length")).toBeDefined();
     expect(Number(res.headers.get("Content-Length"))).toBeGreaterThan(0);
-    expect(res.headers.get("X-Vbundle-Schema-Version")).toBe("1.0");
+    expect(res.headers.get("X-Vbundle-Schema-Version")).toBe("1");
     expect(res.headers.get("X-Vbundle-Manifest-Sha256")).toBeDefined();
     expect(res.headers.get("X-Vbundle-Manifest-Sha256")!.length).toBe(64);
   });
@@ -176,25 +176,25 @@ describe("handleMigrationExport", () => {
     const validationResult = validateVBundle(archiveData);
     const manifest = validationResult.manifest!;
 
-    expect(manifest.schema_version).toBe("1.0");
-    expect(manifest.source).toBe("runtime-export");
+    expect(manifest.schema_version).toBe(1);
+    expect(manifest.bundle_id).toBeDefined();
     expect(manifest.created_at).toBeDefined();
-    expect(manifest.manifest_sha256).toBeDefined();
+    expect(manifest.checksum).toBeDefined();
 
     // Verify file entries — workspace walk uses workspace/ prefix
-    const filePaths = manifest.files.map((f) => f.path);
+    const filePaths = manifest.contents.map((f) => f.path);
     expect(filePaths).toContain("workspace/data/db/assistant.db");
     expect(filePaths).toContain("workspace/config.json");
 
     // Verify each file entry has proper sha256 and size
-    for (const file of manifest.files) {
+    for (const file of manifest.contents) {
       expect(file.sha256).toBeDefined();
       expect(file.sha256.length).toBe(64);
-      expect(file.size).toBeGreaterThanOrEqual(0);
+      expect(file.size_bytes).toBeGreaterThanOrEqual(0);
     }
   });
 
-  test("custom description from JSON body is used in manifest", async () => {
+  test("custom description in JSON body is accepted but no longer surfaced in manifest", async () => {
     const req = new Request("http://localhost/v1/migrations/export", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -206,9 +206,9 @@ describe("handleMigrationExport", () => {
     const archiveData = new Uint8Array(arrayBuffer);
 
     const validationResult = validateVBundle(archiveData);
-    const manifest = validationResult.manifest!;
-
-    expect(manifest.description).toBe("My custom export description");
+    expect(validationResult.is_valid).toBe(true);
+    // v1 manifests intentionally drop the legacy `description` field —
+    // assert the export still succeeds even though the body carried one.
   });
 
   test("invalid JSON body is gracefully handled with defaults", async () => {
@@ -312,20 +312,20 @@ describe("export data population", () => {
     const validationResult = validateVBundle(archiveData);
     const manifest = validationResult.manifest!;
 
-    const dbFile = manifest.files.find(
+    const dbFile = manifest.contents.find(
       (f) => f.path === "workspace/data/db/assistant.db",
     );
     expect(dbFile).toBeDefined();
-    expect(dbFile!.size).toBe(SQLITE_HEADER.length);
+    expect(dbFile!.size_bytes).toBe(SQLITE_HEADER.length);
 
-    const configFile = manifest.files.find(
+    const configFile = manifest.contents.find(
       (f) => f.path === "workspace/config.json",
     );
     expect(configFile).toBeDefined();
     const expectedConfigSize = Buffer.byteLength(
       JSON.stringify(TEST_CONFIG, null, 2) + "\n",
     );
-    expect(configFile!.size).toBe(expectedConfigSize);
+    expect(configFile!.size_bytes).toBe(expectedConfigSize);
   });
 
   test("manifest checksums match actual file content", async () => {
@@ -340,7 +340,7 @@ describe("export data population", () => {
     const validationResult = validateVBundle(archiveData);
     const manifest = validationResult.manifest!;
 
-    for (const fileEntry of manifest.files) {
+    for (const fileEntry of manifest.contents) {
       const tarEntry = entries.find((e) => e.name === fileEntry.path);
       expect(tarEntry).toBeDefined();
       expect(sha256Hex(tarEntry!.data)).toBe(fileEntry.sha256);
@@ -358,12 +358,12 @@ describe("export data population", () => {
     const validationResult = validateVBundle(archiveData);
     const manifest = validationResult.manifest!;
 
-    const dbFile = manifest.files.find(
+    const dbFile = manifest.contents.find(
       (f) => f.path === "workspace/data/db/assistant.db",
     );
     expect(dbFile).toBeDefined();
     // The skeleton used size 0 — real export should have actual content
-    expect(dbFile!.size).toBeGreaterThan(0);
+    expect(dbFile!.size_bytes).toBeGreaterThan(0);
   });
 
   test("config content is real JSON (not empty object placeholder)", async () => {
@@ -390,17 +390,23 @@ describe("export data population", () => {
 // ---------------------------------------------------------------------------
 
 describe("export graceful fallback", () => {
-  test("nonexistent workspace produces valid archive with no files", async () => {
+  test("nonexistent workspace produces archive that fails the v1 contents refine", async () => {
     const { buildExportVBundle } =
       await import("../runtime/migrations/vbundle-builder.js");
 
     const result = buildExportVBundle({
       workspaceDir: join(testDir, "nonexistent-workspace"),
+      ...defaultV1Options(),
     });
 
+    // Under v1, every bundle MUST declare a `data/db/assistant.db` (or
+    // `workspace/data/db/assistant.db`) entry. A nonexistent workspace
+    // produces an empty contents array, which the validator's `.refine()`
+    // rejects. Documenting this so a future regression on the workspace
+    // walk doesn't silently produce a structurally-empty bundle.
     const validationResult = validateVBundle(result.archive);
-    expect(validationResult.is_valid).toBe(true);
-    expect(result.manifest.files).toHaveLength(0);
+    expect(validationResult.is_valid).toBe(false);
+    expect(result.manifest.contents).toHaveLength(0);
   });
 
   test("workspace walk includes db and config under workspace/ prefix", async () => {
@@ -409,22 +415,23 @@ describe("export graceful fallback", () => {
 
     const result = buildExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     const validationResult = validateVBundle(result.archive);
     expect(validationResult.is_valid).toBe(true);
 
-    const dbFile = result.manifest.files.find(
+    const dbFile = result.manifest.contents.find(
       (f) => f.path === "workspace/data/db/assistant.db",
     );
     expect(dbFile).toBeDefined();
-    expect(dbFile!.size).toBeGreaterThan(0);
+    expect(dbFile!.size_bytes).toBeGreaterThan(0);
 
-    const configFile = result.manifest.files.find(
+    const configFile = result.manifest.contents.find(
       (f) => f.path === "workspace/config.json",
     );
     expect(configFile).toBeDefined();
-    expect(configFile!.size).toBeGreaterThan(0);
+    expect(configFile!.size_bytes).toBeGreaterThan(0);
   });
 });
 

--- a/assistant/src/__tests__/migration-export-streaming.test.ts
+++ b/assistant/src/__tests__/migration-export-streaming.test.ts
@@ -55,12 +55,12 @@ mock.module("../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
+import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import {
   buildExportVBundle,
   streamExportVBundle,
 } from "../runtime/migrations/vbundle-builder.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
-
 // Test fixture data: a minimal SQLite header to simulate a real database file
 const SQLITE_HEADER = new Uint8Array([
   0x53, 0x51, 0x4c, 0x69, 0x74, 0x65, 0x20, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74,
@@ -146,6 +146,7 @@ describe("streamExportVBundle", () => {
   test("returns a temp file that exists on disk", async () => {
     const result = await streamExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     try {
@@ -159,13 +160,14 @@ describe("streamExportVBundle", () => {
   test("manifest contains correct SHA-256 checksums for all files", async () => {
     const result = await streamExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     try {
       const archiveData = new Uint8Array(readFileSync(result.tempPath));
       const entries = parseTarEntries(archiveData);
 
-      for (const fileEntry of result.manifest.files) {
+      for (const fileEntry of result.manifest.contents) {
         const tarEntry = entries.find((e) => e.name === fileEntry.path);
         expect(tarEntry).toBeDefined();
         expect(sha256Hex(tarEntry!.data)).toBe(fileEntry.sha256);
@@ -178,11 +180,13 @@ describe("streamExportVBundle", () => {
   test("decompressed archive produces same files as buildExportVBundle", async () => {
     const streamResult = await streamExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     try {
       const syncResult = buildExportVBundle({
         workspaceDir: testDir,
+        ...defaultV1Options(),
       });
 
       const streamArchiveData = new Uint8Array(
@@ -212,10 +216,10 @@ describe("streamExportVBundle", () => {
       }
 
       // Same manifest file entries (excluding timing fields)
-      const streamManifestFiles = streamResult.manifest.files
+      const streamManifestFiles = streamResult.manifest.contents
         .slice()
         .sort((a, b) => a.path.localeCompare(b.path));
-      const syncManifestFiles = syncResult.manifest.files
+      const syncManifestFiles = syncResult.manifest.contents
         .slice()
         .sort((a, b) => a.path.localeCompare(b.path));
 
@@ -225,8 +229,8 @@ describe("streamExportVBundle", () => {
       expect(streamManifestFiles.map((f) => f.sha256)).toEqual(
         syncManifestFiles.map((f) => f.sha256),
       );
-      expect(streamManifestFiles.map((f) => f.size)).toEqual(
-        syncManifestFiles.map((f) => f.size),
+      expect(streamManifestFiles.map((f) => f.size_bytes)).toEqual(
+        syncManifestFiles.map((f) => f.size_bytes),
       );
     } finally {
       await streamResult.cleanup();
@@ -236,6 +240,7 @@ describe("streamExportVBundle", () => {
   test("cleanup removes the temp file", async () => {
     const result = await streamExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     expect(existsSync(result.tempPath)).toBe(true);
@@ -252,6 +257,7 @@ describe("streamExportVBundle round-trip", () => {
   test("streaming archive passes validateVBundle with matching manifest", async () => {
     const result = await streamExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     try {
@@ -266,15 +272,15 @@ describe("streamExportVBundle round-trip", () => {
       expect(validationResult.manifest!.schema_version).toBe(
         result.manifest.schema_version,
       );
-      expect(validationResult.manifest!.manifest_sha256).toBe(
-        result.manifest.manifest_sha256,
+      expect(validationResult.manifest!.checksum).toBe(
+        result.manifest.checksum,
       );
 
       // Verify file entries match
       const validatedFiles = validationResult
-        .manifest!.files.slice()
+        .manifest!.contents.slice()
         .sort((a, b) => a.path.localeCompare(b.path));
-      const resultFiles = result.manifest.files
+      const resultFiles = result.manifest.contents
         .slice()
         .sort((a, b) => a.path.localeCompare(b.path));
 
@@ -316,6 +322,7 @@ describe("streamExportVBundle config sanitization", () => {
 
     const result = await streamExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     try {
@@ -359,6 +366,7 @@ describe("streamExportVBundle cleanup", () => {
   test("calling cleanup twice does not throw", async () => {
     const result = await streamExportVBundle({
       workspaceDir: testDir,
+      ...defaultV1Options(),
     });
 
     await result.cleanup();

--- a/assistant/src/__tests__/migration-export-to-gcs.test.ts
+++ b/assistant/src/__tests__/migration-export-to-gcs.test.ts
@@ -242,7 +242,12 @@ describe("handleMigrationExportToGcs — happy path", () => {
         }),
       });
 
-      const res = await callHandler(handleMigrationExportToGcs, req, undefined, 202);
+      const res = await callHandler(
+        handleMigrationExportToGcs,
+        req,
+        undefined,
+        202,
+      );
       expect(res.status).toBe(202);
 
       const body = (await res.json()) as AcceptedResponse;
@@ -275,7 +280,7 @@ describe("handleMigrationExportToGcs — happy path", () => {
       const validation = validateVBundle(new Uint8Array(capturedBody!));
       expect(validation.is_valid).toBe(true);
       expect(validation.errors).toHaveLength(0);
-      expect(validation.manifest?.manifest_sha256).toBe(result.sha256);
+      expect(validation.manifest?.checksum).toBe(result.sha256);
     } finally {
       await fixture.close();
     }
@@ -319,7 +324,12 @@ describe("handleMigrationExportToGcs — concurrency", () => {
           }),
         },
       );
-      const firstRes = await callHandler(handleMigrationExportToGcs, firstReq, undefined, 202);
+      const firstRes = await callHandler(
+        handleMigrationExportToGcs,
+        firstReq,
+        undefined,
+        202,
+      );
       expect(firstRes.status).toBe(202);
       const firstBody = (await firstRes.json()) as AcceptedResponse;
 
@@ -338,7 +348,12 @@ describe("handleMigrationExportToGcs — concurrency", () => {
           }),
         },
       );
-      const secondRes = await callHandler(handleMigrationExportToGcs, secondReq, undefined, 202);
+      const secondRes = await callHandler(
+        handleMigrationExportToGcs,
+        secondReq,
+        undefined,
+        202,
+      );
       expect(secondRes.status).toBe(409);
       const secondBody = (await secondRes.json()) as ErrorEnvelope;
       expect(secondBody.error.code).toBe("export_in_progress");
@@ -375,7 +390,12 @@ describe("handleMigrationExportToGcs — upload failure", () => {
         }),
       });
 
-      const res = await callHandler(handleMigrationExportToGcs, req, undefined, 202);
+      const res = await callHandler(
+        handleMigrationExportToGcs,
+        req,
+        undefined,
+        202,
+      );
       expect(res.status).toBe(202);
       const body = (await res.json()) as AcceptedResponse;
 
@@ -419,7 +439,12 @@ describe("handleMigrationExportToGcs — redirect handling", () => {
         }),
       });
 
-      const res = await callHandler(handleMigrationExportToGcs, req, undefined, 202);
+      const res = await callHandler(
+        handleMigrationExportToGcs,
+        req,
+        undefined,
+        202,
+      );
       expect(res.status).toBe(202);
       const body = (await res.json()) as AcceptedResponse;
 
@@ -446,7 +471,12 @@ describe("handleMigrationExportToGcs — URL validation", () => {
           upload_url: "http://storage.googleapis.com/b/o?X-Goog-Signature=fake",
         }),
       });
-      const res = await callHandler(handleMigrationExportToGcs, req, undefined, 202);
+      const res = await callHandler(
+        handleMigrationExportToGcs,
+        req,
+        undefined,
+        202,
+      );
       expect(res.status).toBe(400);
       const body = (await res.json()) as ErrorEnvelope;
       expect(body.error.code).toBe("invalid_upload_url");
@@ -466,7 +496,12 @@ describe("handleMigrationExportToGcs — URL validation", () => {
         upload_url: "https://evil.example.com/bucket/obj?X-Goog-Signature=fake",
       }),
     });
-    const res = await callHandler(handleMigrationExportToGcs, req, undefined, 202);
+    const res = await callHandler(
+      handleMigrationExportToGcs,
+      req,
+      undefined,
+      202,
+    );
     expect(res.status).toBe(400);
     const body = (await res.json()) as ErrorEnvelope;
     expect(body.error.code).toBe("invalid_upload_url");
@@ -482,7 +517,12 @@ describe("handleMigrationExportToGcs — URL validation", () => {
           "https://storage.googleapis.com/bucket/..%2Fother?X-Goog-Signature=fake",
       }),
     });
-    const res = await callHandler(handleMigrationExportToGcs, req, undefined, 202);
+    const res = await callHandler(
+      handleMigrationExportToGcs,
+      req,
+      undefined,
+      202,
+    );
     expect(res.status).toBe(400);
     const body = (await res.json()) as ErrorEnvelope;
     expect(body.error.code).toBe("invalid_upload_url");

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -11,7 +11,7 @@
  * - Auth: route policy enforcement (settings.write scope required)
  * - Integration: existing routes are unaffected by the new endpoint
  */
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -237,41 +237,85 @@ interface VBundleFile {
   data: Uint8Array;
 }
 
+/**
+ * Build a v1-shape vbundle archive for HTTP/import tests.
+ *
+ * Mirrors the v1 ten-field manifest that `buildVBundle()` produces, so the
+ * fixtures here pass the same `ManifestSchema` zod validation the real
+ * importer applies. The manifest's `checksum` is computed against the
+ * canonical JSON with `checksum` set to "" (matches `computeManifestChecksum`
+ * in vbundle-validator.ts).
+ *
+ * Adds a synthetic `data/db/assistant.db` entry to `contents` when the caller
+ * doesn't supply one, satisfying the schema's `.refine()` constraint that
+ * every bundle must reference an assistant.db file.
+ */
 function createValidVBundle(
   files?: VBundleFile[],
   overrides?: Partial<{
-    schema_version: string;
-    source: string;
-    description: string;
+    bundle_id: string;
+    origin_mode: "managed" | "self-hosted-remote" | "self-hosted-local";
+    secrets_redacted: boolean;
   }>,
 ): Uint8Array {
   const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
   const bundleFiles = files ?? [{ path: "data/db/assistant.db", data: dbData }];
 
-  const fileEntries = bundleFiles.map((f) => ({
+  // v1 schema requires contents to include data/db/assistant.db (legacy) or
+  // workspace/data/db/assistant.db (current). If the caller's files don't
+  // satisfy that refine, inject a synthetic legacy-path db entry — this
+  // matches the pattern used in vbundle-streaming-importer.test.ts.
+  const hasDbEntry = bundleFiles.some(
+    (f) =>
+      f.path === "data/db/assistant.db" ||
+      f.path === "workspace/data/db/assistant.db",
+  );
+  const allFiles: VBundleFile[] = hasDbEntry
+    ? bundleFiles
+    : [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        ...bundleFiles,
+      ];
+
+  const contents = allFiles.map((f) => ({
     path: f.path,
     sha256: sha256Hex(f.data),
-    size: f.data.length,
+    size_bytes: f.data.length,
   }));
 
   const manifestWithoutChecksum = {
-    schema_version: overrides?.schema_version ?? "1.0",
+    schema_version: 1 as const,
+    bundle_id: overrides?.bundle_id ?? randomUUID(),
     created_at: new Date().toISOString(),
-    source: overrides?.source ?? "test",
-    description: overrides?.description ?? "Test bundle",
-    files: fileEntries,
+    assistant: {
+      id: "self",
+      name: "Test",
+      runtime_version: "0.0.0-test",
+    },
+    origin: {
+      mode: overrides?.origin_mode ?? "self-hosted-local",
+    },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents,
+    checksum: "",
+    secrets_redacted: overrides?.secrets_redacted ?? false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
   };
 
-  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-  const manifest = {
-    ...manifestWithoutChecksum,
-    manifest_sha256: manifestSha256,
-  };
+  const checksum = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
+  const manifest = { ...manifestWithoutChecksum, checksum };
   const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
   const tarEntries = [
     { name: "manifest.json", data: manifestData },
-    ...bundleFiles.map((f) => ({ name: f.path, data: f.data })),
+    ...allFiles.map((f) => ({ name: f.path, data: f.data })),
   ];
 
   const tar = createTarArchive(tarEntries);
@@ -445,9 +489,9 @@ describe("handleMigrationImport", () => {
   });
 
   test("includes manifest in response", async () => {
+    const fixedBundleId = "11111111-2222-4333-8444-555555555555";
     const vbundle = createValidVBundle(undefined, {
-      source: "test-import-source",
-      description: "Test import commit",
+      bundle_id: fixedBundleId,
     });
     const req = new Request("http://localhost/v1/migrations/import", {
       method: "POST",
@@ -459,9 +503,10 @@ describe("handleMigrationImport", () => {
     const body = (await res.json()) as ImportCommitResponse;
 
     expect(body.manifest).toBeDefined();
-    expect(body.manifest.schema_version).toBe("1.0");
-    expect(body.manifest.source).toBe("test-import-source");
-    expect(body.manifest.description).toBe("Test import commit");
+    expect(body.manifest.schema_version).toBe(1);
+    expect(body.manifest.bundle_id).toBe(fixedBundleId);
+    expect(body.manifest.assistant).toBeDefined();
+    expect(body.manifest.origin).toEqual({ mode: "self-hosted-local" });
   });
 
   test("POST with multipart form data works", async () => {

--- a/assistant/src/__tests__/migration-import-from-gcs.test.ts
+++ b/assistant/src/__tests__/migration-import-from-gcs.test.ts
@@ -109,6 +109,7 @@ mock.module("../config/env.js", () => ({
 // Imports (after mocks so module-level code picks up the stubs)
 // ---------------------------------------------------------------------------
 
+import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import {
   type MigrationJob,
   migrationJobs,
@@ -119,7 +120,6 @@ import {
   handleMigrationImportFromGcs,
 } from "../runtime/routes/migration-routes.js";
 import { callHandler } from "./helpers/call-route-handler.js";
-
 // ---------------------------------------------------------------------------
 // Local http fixture server
 // ---------------------------------------------------------------------------
@@ -191,6 +191,7 @@ function makeSmallValidBundlePath(parent: string): string {
         ),
       },
     ],
+    ...defaultV1Options(),
   });
   const bundlePath = join(parent, "fixture-small.vbundle");
   writeFileSync(bundlePath, archive);
@@ -313,7 +314,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
         },
       );
 
-      const res = await callHandler(handleMigrationImportFromGcs, req, undefined, 202);
+      const res = await callHandler(
+        handleMigrationImportFromGcs,
+        req,
+        undefined,
+        202,
+      );
       expect(res.status).toBe(202);
       const body = (await res.json()) as AcceptedResponse;
       expect(body.type).toBe("import");
@@ -368,7 +374,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
         },
       );
 
-      const res = await callHandler(handleMigrationImportFromGcs, req, undefined, 202);
+      const res = await callHandler(
+        handleMigrationImportFromGcs,
+        req,
+        undefined,
+        202,
+      );
       expect(res.status).toBe(202);
       const body = (await res.json()) as AcceptedResponse;
 
@@ -399,7 +410,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
         },
       );
 
-      const res = await callHandler(handleMigrationImportFromGcs, req, undefined, 202);
+      const res = await callHandler(
+        handleMigrationImportFromGcs,
+        req,
+        undefined,
+        202,
+      );
       expect(res.status).toBe(202);
       const body = (await res.json()) as AcceptedResponse;
 
@@ -437,7 +453,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
           body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
         },
       );
-      const firstRes = await callHandler(handleMigrationImportFromGcs, firstReq, undefined, 202);
+      const firstRes = await callHandler(
+        handleMigrationImportFromGcs,
+        firstReq,
+        undefined,
+        202,
+      );
       expect(firstRes.status).toBe(202);
       const firstBody = (await firstRes.json()) as AcceptedResponse;
       firstJobId = firstBody.job_id;
@@ -450,7 +471,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
           body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
         },
       );
-      const secondRes = await callHandler(handleMigrationImportFromGcs, secondReq, undefined, 202);
+      const secondRes = await callHandler(
+        handleMigrationImportFromGcs,
+        secondReq,
+        undefined,
+        202,
+      );
       expect(secondRes.status).toBe(409);
       const secondBody = (await secondRes.json()) as ConflictResponse;
       expect(secondBody.error.code).toBe("import_in_progress");
@@ -484,7 +510,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
         }),
       },
     );
-    const badRes = await callHandler(handleMigrationImportFromGcs, badReq, undefined, 202);
+    const badRes = await callHandler(
+      handleMigrationImportFromGcs,
+      badReq,
+      undefined,
+      202,
+    );
     expect(badRes.status).toBe(400);
     const badBody = (await badRes.json()) as InvalidBundleUrlResponse;
     expect(badBody.error.code).toBe("invalid_bundle_url");
@@ -507,7 +538,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
           body: JSON.stringify({ bundle_url: makeFakeSignedUrl(fixture.port) }),
         },
       );
-      const goodRes = await callHandler(handleMigrationImportFromGcs, goodReq, undefined, 202);
+      const goodRes = await callHandler(
+        handleMigrationImportFromGcs,
+        goodReq,
+        undefined,
+        202,
+      );
       expect(goodRes.status).toBe(202);
       const goodBody = (await goodRes.json()) as AcceptedResponse;
       expect(goodBody.type).toBe("import");
@@ -525,7 +561,12 @@ describe("POST /v1/migrations/import-from-gcs", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
     });
-    const res = await callHandler(handleMigrationImportFromGcs, req, undefined, 202);
+    const res = await callHandler(
+      handleMigrationImportFromGcs,
+      req,
+      undefined,
+      202,
+    );
     expect(res.status).toBe(400);
     const body = (await res.json()) as BadRequestResponse;
     expect(body.error.code).toBe("BAD_REQUEST");

--- a/assistant/src/__tests__/migration-import-from-url.test.ts
+++ b/assistant/src/__tests__/migration-import-from-url.test.ts
@@ -119,13 +119,13 @@ mock.module("../config/env.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { resetDb } from "../memory/db-connection.js";
+import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
   _setUrlImportValidatorOptionsForTests,
   handleMigrationImport,
 } from "../runtime/routes/migration-routes.js";
 import { callHandler } from "./helpers/call-route-handler.js";
-
 // ---------------------------------------------------------------------------
 // Local http fixture server
 // ---------------------------------------------------------------------------
@@ -181,6 +181,7 @@ function makeSmallValidBundlePath(parent: string): string {
         ),
       },
     ],
+    ...defaultV1Options(),
   });
   const bundlePath = join(parent, "fixture-small.vbundle");
   writeFileSync(bundlePath, archive);
@@ -307,7 +308,9 @@ describe("handleMigrationImport — JSON {url} body", () => {
       });
 
       const res = await callHandler(handleMigrationImport, req);
-      const body = (await res.json()) as { error: { code: string; message: string } };
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
 
       expect(res.status).toBe(502);
       expect(body.error.code).toBe("BAD_GATEWAY");
@@ -451,13 +454,19 @@ describe("handleMigrationImport — no-swap path omits newer-migration warning",
     // ok=true with zero files_created/overwritten (no-swap success),
     // and the credential-import callback filters every entry as a
     // platform credential so CES is never invoked.
+    //
+    // The synthetic `data/db/assistant.db` entry satisfies the v1
+    // manifest schema's contents refine; it's a no-op on disk because
+    // legacy bundles never carry workspace data.
     const { archive } = buildVBundle({
       files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
         {
           path: "credentials/vellum:device-id",
           data: new TextEncoder().encode("test-device-id"),
         },
       ],
+      ...defaultV1Options(),
     });
     const bundlePath = join(testParent, "fixture-creds-only.vbundle");
     writeFileSync(bundlePath, archive);
@@ -479,9 +488,10 @@ describe("handleMigrationImport — no-swap path omits newer-migration warning",
 
       expect(res.status).toBe(200);
       expect(body.success).toBe(true);
-      // Zero files touched — this is the no-swap success path.
-      expect(body.summary.files_created).toBe(0);
-      expect(body.summary.files_overwritten).toBe(0);
+      // Only the synthetic data/db/assistant.db lands; the credential
+      // entry is filtered out and no `workspace/*` entries exist, so
+      // the workspace itself is otherwise untouched.
+      expect(body.summary.files_overwritten).toBe(1);
 
       // The gate must suppress the newer-migration warning text. The
       // helper's wording starts with "Imported data contains" and ends
@@ -529,6 +539,7 @@ describe("handleMigrationImport — upstream body dropped mid-stream", () => {
           data: incompressible,
         },
       ],
+      ...defaultV1Options(),
     });
     // Safety net: if someone changes buildVBundle to return very small
     // outputs, drop the test early rather than flaking on a too-short
@@ -570,7 +581,9 @@ describe("handleMigrationImport — upstream body dropped mid-stream", () => {
       });
 
       const res = await callHandler(handleMigrationImport, req);
-      const body = (await res.json()) as { error: { code: string; message: string } };
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
 
       expect(res.status).toBe(502);
       expect(body.error.code).toBe("BAD_GATEWAY");
@@ -593,6 +606,7 @@ describe("handleMigrationImport — raw-bytes regression", () => {
           data: new TextEncoder().encode("SQLite format 3\0"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const req = new Request("http://localhost/v1/migrations/import", {

--- a/assistant/src/__tests__/migration-import-preflight-http.test.ts
+++ b/assistant/src/__tests__/migration-import-preflight-http.test.ts
@@ -68,8 +68,35 @@ import {
   analyzeImport,
   DefaultPathResolver,
 } from "../runtime/migrations/vbundle-import-analyzer.js";
+import type { ManifestType } from "../runtime/migrations/vbundle-validator.js";
 import { handleMigrationImportPreflight } from "../runtime/routes/migration-routes.js";
 import { callHandler } from "./helpers/call-route-handler.js";
+
+/** Build a v1-compliant manifest with the given file entries. */
+function v1Manifest(
+  contents: Array<{ path: string; sha256: string; size_bytes: number }>,
+): ManifestType {
+  return {
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
+    created_at: new Date().toISOString(),
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents,
+    checksum:
+      "0000000000000000000000000000000000000000000000000000000000000000",
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  } as ManifestType;
+}
 
 // Test fixture data
 const EXISTING_DB_DATA = new Uint8Array([
@@ -194,36 +221,38 @@ interface VBundleFile {
   data: Uint8Array;
 }
 
-function createValidVBundle(
-  files?: VBundleFile[],
-  overrides?: Partial<{
-    schema_version: string;
-    source: string;
-    description: string;
-  }>,
-): Uint8Array {
+function createValidVBundle(files?: VBundleFile[]): Uint8Array {
   const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
   const bundleFiles = files ?? [{ path: "data/db/assistant.db", data: dbData }];
 
-  const fileEntries = bundleFiles.map((f) => ({
+  const contents = bundleFiles.map((f) => ({
     path: f.path,
     sha256: sha256Hex(f.data),
-    size: f.data.length,
+    size_bytes: f.data.length,
   }));
 
-  const manifestWithoutChecksum = {
-    schema_version: overrides?.schema_version ?? "1.0",
+  const manifestWithEmptyChecksum = {
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
     created_at: new Date().toISOString(),
-    source: overrides?.source ?? "test",
-    description: overrides?.description ?? "Test bundle",
-    files: fileEntries,
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents,
+    checksum: "",
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
   };
 
-  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-  const manifest = {
-    ...manifestWithoutChecksum,
-    manifest_sha256: manifestSha256,
-  };
+  const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+  const manifest = { ...manifestWithEmptyChecksum, checksum };
   const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
   const tarEntries = [
@@ -378,10 +407,7 @@ describe("handleMigrationImportPreflight", () => {
   });
 
   test("includes manifest in response", async () => {
-    const vbundle = createValidVBundle(undefined, {
-      source: "test-export",
-      description: "Test import preflight",
-    });
+    const vbundle = createValidVBundle();
 
     const req = new Request("http://localhost/v1/migrations/import-preflight", {
       method: "POST",
@@ -393,9 +419,9 @@ describe("handleMigrationImportPreflight", () => {
     const body = (await res.json()) as ImportDryRunResponse;
 
     expect(body.manifest).toBeDefined();
-    expect(body.manifest.schema_version).toBe("1.0");
-    expect(body.manifest.source).toBe("test-export");
-    expect(body.manifest.description).toBe("Test import preflight");
+    expect(body.manifest.schema_version).toBe(1);
+    expect(body.manifest.bundle_id).toBeDefined();
+    expect(body.manifest.contents).toBeDefined();
   });
 
   test("POST with multipart form data works", async () => {
@@ -504,18 +530,13 @@ describe("analyzeImport", () => {
     );
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
-          {
-            path: "data/db/assistant.db",
-            sha256: sha256Hex(new Uint8Array([1, 2, 3])),
-            size: 3,
-          },
-        ],
-        manifest_sha256: "test",
-      },
+      manifest: v1Manifest([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(new Uint8Array([1, 2, 3])),
+          size_bytes: 3,
+        },
+      ]),
       pathResolver: resolver,
     });
 
@@ -530,18 +551,13 @@ describe("analyzeImport", () => {
     const resolver = new DefaultPathResolver(testDir);
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
-          {
-            path: "data/db/assistant.db",
-            sha256: sha256Hex(EXISTING_DB_DATA),
-            size: EXISTING_DB_DATA.length,
-          },
-        ],
-        manifest_sha256: "test",
-      },
+      manifest: v1Manifest([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(EXISTING_DB_DATA),
+          size_bytes: EXISTING_DB_DATA.length,
+        },
+      ]),
       pathResolver: resolver,
     });
 
@@ -554,18 +570,13 @@ describe("analyzeImport", () => {
     const resolver = new DefaultPathResolver(testDir);
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
-          {
-            path: "data/db/assistant.db",
-            sha256: sha256Hex(new Uint8Array([0xca, 0xfe])),
-            size: 2,
-          },
-        ],
-        manifest_sha256: "test",
-      },
+      manifest: v1Manifest([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(new Uint8Array([0xca, 0xfe])),
+          size_bytes: 2,
+        },
+      ]),
       pathResolver: resolver,
     });
 
@@ -579,23 +590,18 @@ describe("analyzeImport", () => {
     const resolver = new DefaultPathResolver(testDir);
 
     const report = analyzeImport({
-      manifest: {
-        schema_version: "1.0",
-        created_at: new Date().toISOString(),
-        files: [
-          {
-            path: "data/db/assistant.db",
-            sha256: sha256Hex(EXISTING_DB_DATA),
-            size: EXISTING_DB_DATA.length,
-          },
-          {
-            path: "unknown/extra-file.bin",
-            sha256: sha256Hex(new Uint8Array([1])),
-            size: 1,
-          },
-        ],
-        manifest_sha256: "test",
-      },
+      manifest: v1Manifest([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(EXISTING_DB_DATA),
+          size_bytes: EXISTING_DB_DATA.length,
+        },
+        {
+          path: "unknown/extra-file.bin",
+          sha256: sha256Hex(new Uint8Array([1])),
+          size_bytes: 1,
+        },
+      ]),
       pathResolver: resolver,
     });
 
@@ -615,25 +621,19 @@ describe("analyzeImport", () => {
 
   test("includes manifest in report", () => {
     const resolver = new DefaultPathResolver(testDir);
-    const manifest = {
-      schema_version: "1.0",
-      created_at: "2024-01-01T00:00:00.000Z",
-      source: "test",
-      files: [
-        {
-          path: "data/db/assistant.db",
-          sha256: sha256Hex(EXISTING_DB_DATA),
-          size: EXISTING_DB_DATA.length,
-        },
-      ],
-      manifest_sha256: "test",
-    };
+    const manifest = v1Manifest([
+      {
+        path: "data/db/assistant.db",
+        sha256: sha256Hex(EXISTING_DB_DATA),
+        size_bytes: EXISTING_DB_DATA.length,
+      },
+    ]);
 
     const report = analyzeImport({ manifest, pathResolver: resolver });
 
     expect(report.manifest).toBe(manifest);
-    expect(report.manifest.schema_version).toBe("1.0");
-    expect(report.manifest.source).toBe("test");
+    expect(report.manifest.schema_version).toBe(1);
+    expect(report.manifest.assistant.id).toBe("self");
   });
 });
 

--- a/assistant/src/__tests__/migration-parity-persistence.test.ts
+++ b/assistant/src/__tests__/migration-parity-persistence.test.ts
@@ -134,15 +134,26 @@ function makeValidateSuccess(): ValidateResponse {
     is_valid: true,
     errors: [],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      source: "test",
-      description: "Test bundle",
-      files: [
-        { path: "config.json", sha256: "abc123", size: 1024 },
-        { path: "skills/test.md", sha256: "def456", size: 2048 },
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
+        { path: "config.json", sha256: "abc123", size_bytes: 1024 },
+        { path: "skills/test.md", sha256: "def456", size_bytes: 2048 },
       ],
-      manifest_sha256: "manifest-hash",
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -185,13 +196,26 @@ function makePreflightSuccess(): ImportPreflightResponse {
     ],
     conflicts: [],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      files: [
-        { path: "config.json", sha256: "abc123", size: 1024 },
-        { path: "skills/new-skill.md", sha256: "ghi789", size: 512 },
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
+        { path: "config.json", sha256: "abc123", size_bytes: 1024 },
+        { path: "skills/new-skill.md", sha256: "ghi789", size_bytes: 512 },
       ],
-      manifest_sha256: "manifest-hash",
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -217,10 +241,23 @@ function makeImportSuccess(): ImportCommitResponse {
       },
     ],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      files: [{ path: "config.json", sha256: "abc123", size: 1024 }],
-      manifest_sha256: "manifest-hash",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [{ path: "config.json", sha256: "abc123", size_bytes: 1024 }],
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
     warnings: ["Backup created for config.json"],
   };
@@ -597,7 +634,7 @@ describe("persistence/resume — serialize at each step", () => {
     expect(restored!.validateResult).toBeDefined();
     expect(restored!.validateResult!.is_valid).toBe(true);
     if (restored!.validateResult!.is_valid) {
-      expect(restored!.validateResult!.manifest.schema_version).toBe("1.0");
+      expect(restored!.validateResult!.manifest.schema_version).toBe(1);
     }
 
     // Preflight result
@@ -641,8 +678,8 @@ describe("interrupted flow recovery", () => {
       exportResult: {
         ok: true,
         filename: "export.vbundle",
-        schemaVersion: "1.0",
-        manifestSha256: "abc",
+        schemaVersion: 1,
+        checksum: "abc",
       },
     };
 
@@ -719,8 +756,8 @@ describe("interrupted flow recovery", () => {
       exportResult: {
         ok: true,
         filename: "export.vbundle",
-        schemaVersion: "1.0",
-        manifestSha256: "abc",
+        schemaVersion: 1,
+        checksum: "abc",
       },
       // No importResult — import had not started or crashed
     };
@@ -979,7 +1016,7 @@ describe("full end-to-end — self-hosted-to-managed migration", () => {
           status: 200,
           headers: {
             "Content-Disposition": 'attachment; filename="export.vbundle"',
-            "X-Vbundle-Schema-Version": "1.0",
+            "X-Vbundle-Schema-Version": "1",
             "X-Vbundle-Manifest-Sha256": "abc",
           },
         });
@@ -1127,7 +1164,7 @@ describe("edge cases — import failures and transport errors", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });

--- a/assistant/src/__tests__/migration-transport.test.ts
+++ b/assistant/src/__tests__/migration-transport.test.ts
@@ -310,18 +310,33 @@ describe("validateBundle", () => {
       is_valid: true,
       errors: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [{ path: "data/db/assistant.db", sha256: "abc", size: 100 }],
-        manifest_sha256: "def",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [
+          { path: "data/db/assistant.db", sha256: "abc", size_bytes: 100 },
+        ],
+        checksum: "def",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
     };
     const config = runtimeConfig({ fetchFn: mockFetch(200, responseBody) });
     const result = await validateBundle(config, sampleFileData);
     expect(result.is_valid).toBe(true);
     if (result.is_valid) {
-      expect(result.manifest.schema_version).toBe("1.0");
-      expect(result.manifest.files).toHaveLength(1);
+      expect(result.manifest.schema_version).toBe(1);
+      expect(result.manifest.contents).toHaveLength(1);
     }
   });
 
@@ -374,7 +389,7 @@ describe("exportBundle", () => {
     const config = runtimeConfig({
       fetchFn: mockFetch(200, archiveBytes, {
         "Content-Disposition": 'attachment; filename="export-2026.vbundle"',
-        "X-Vbundle-Schema-Version": "1.0",
+        "X-Vbundle-Schema-Version": "1",
         "X-Vbundle-Manifest-Sha256": "abc123",
       }),
     });
@@ -384,8 +399,8 @@ describe("exportBundle", () => {
     const runtimeResult = result as ExportRuntimeResult;
     expect(runtimeResult.archive).toBeDefined();
     expect(runtimeResult.filename).toBe("export-2026.vbundle");
-    expect(runtimeResult.schemaVersion).toBe("1.0");
-    expect(runtimeResult.manifestSha256).toBe("abc123");
+    expect(runtimeResult.schemaVersion).toBe(1);
+    expect(runtimeResult.checksum).toBe("abc123");
   });
 
   test("managed — returns job ID for async processing", async () => {
@@ -453,10 +468,23 @@ describe("importPreflight", () => {
       ],
       conflicts: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "ghi",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "ghi",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
     };
     const config = runtimeConfig({ fetchFn: mockFetch(200, responseBody) });
@@ -523,10 +551,23 @@ describe("importCommit", () => {
         },
       ],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "def",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "def",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       warnings: [],
     };
@@ -856,10 +897,27 @@ describe("Multi-step flow behavior", () => {
             is_valid: true,
             errors: [],
             manifest: {
-              schema_version: "1.0",
+              schema_version: 1,
+              bundle_id: "00000000-0000-4000-8000-000000000000",
               created_at: "2026-01-01T00:00:00Z",
-              files: [],
-              manifest_sha256: "abc",
+              assistant: {
+                id: "self",
+                name: "Test",
+                runtime_version: "0.0.0-test",
+              },
+              origin: { mode: "self-hosted-local" },
+              compatibility: {
+                min_runtime_version: "0.0.0-test",
+                max_runtime_version: null,
+              },
+              contents: [],
+              checksum: "abc",
+              secrets_redacted: false,
+              export_options: {
+                include_logs: false,
+                include_browser_state: false,
+                include_memory_vectors: false,
+              },
             },
           }),
           { status: 200 },
@@ -880,10 +938,27 @@ describe("Multi-step flow behavior", () => {
             files: [],
             conflicts: [],
             manifest: {
-              schema_version: "1.0",
+              schema_version: 1,
+              bundle_id: "00000000-0000-4000-8000-000000000000",
               created_at: "2026-01-01T00:00:00Z",
-              files: [],
-              manifest_sha256: "abc",
+              assistant: {
+                id: "self",
+                name: "Test",
+                runtime_version: "0.0.0-test",
+              },
+              origin: { mode: "self-hosted-local" },
+              compatibility: {
+                min_runtime_version: "0.0.0-test",
+                max_runtime_version: null,
+              },
+              contents: [],
+              checksum: "abc",
+              secrets_redacted: false,
+              export_options: {
+                include_logs: false,
+                include_browser_state: false,
+                include_memory_vectors: false,
+              },
             },
           }),
           { status: 200 },
@@ -903,10 +978,27 @@ describe("Multi-step flow behavior", () => {
             },
             files: [],
             manifest: {
-              schema_version: "1.0",
+              schema_version: 1,
+              bundle_id: "00000000-0000-4000-8000-000000000000",
               created_at: "2026-01-01T00:00:00Z",
-              files: [],
-              manifest_sha256: "abc",
+              assistant: {
+                id: "self",
+                name: "Test",
+                runtime_version: "0.0.0-test",
+              },
+              origin: { mode: "self-hosted-local" },
+              compatibility: {
+                min_runtime_version: "0.0.0-test",
+                max_runtime_version: null,
+              },
+              contents: [],
+              checksum: "abc",
+              secrets_redacted: false,
+              export_options: {
+                include_logs: false,
+                include_browser_state: false,
+                include_memory_vectors: false,
+              },
             },
             warnings: [],
           }),

--- a/assistant/src/__tests__/migration-validate-http.test.ts
+++ b/assistant/src/__tests__/migration-validate-http.test.ts
@@ -184,36 +184,59 @@ interface VBundleFile {
   data: Uint8Array;
 }
 
-function createValidVBundle(
-  files?: VBundleFile[],
-  overrides?: Partial<{
-    schema_version: string;
-    source: string;
-    description: string;
-  }>,
-): Uint8Array {
+/** Build a v1-compliant manifest skeleton; tests override specific fields. */
+function v1Skeleton() {
+  return {
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
+    created_at: new Date().toISOString(),
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" as const },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  };
+}
+
+function createValidVBundle(files?: VBundleFile[]): Uint8Array {
   const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]); // "SQLite"
   const bundleFiles = files ?? [{ path: "data/db/assistant.db", data: dbData }];
 
-  const fileEntries = bundleFiles.map((f) => ({
+  const contents = bundleFiles.map((f) => ({
     path: f.path,
     sha256: sha256Hex(f.data),
-    size: f.data.length,
+    size_bytes: f.data.length,
   }));
 
-  const manifestWithoutChecksum = {
-    schema_version: overrides?.schema_version ?? "1.0",
+  const manifestWithEmptyChecksum = {
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
     created_at: new Date().toISOString(),
-    source: overrides?.source ?? "test",
-    description: overrides?.description ?? "Test bundle",
-    files: fileEntries,
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents,
+    checksum: "",
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
   };
 
-  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-  const manifest = {
-    ...manifestWithoutChecksum,
-    manifest_sha256: manifestSha256,
-  };
+  const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+  const manifest = { ...manifestWithEmptyChecksum, checksum };
   const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
   const tarEntries = [
@@ -237,9 +260,9 @@ describe("validateVBundle", () => {
     expect(result.is_valid).toBe(true);
     expect(result.errors).toHaveLength(0);
     expect(result.manifest).toBeDefined();
-    expect(result.manifest?.schema_version).toBe("1.0");
-    expect(result.manifest?.files).toHaveLength(1);
-    expect(result.manifest?.files[0].path).toBe("data/db/assistant.db");
+    expect(result.manifest?.schema_version).toBe(1);
+    expect(result.manifest?.contents).toHaveLength(1);
+    expect(result.manifest?.contents[0].path).toBe("data/db/assistant.db");
   });
 
   test("valid bundle with multiple files", () => {
@@ -254,7 +277,7 @@ describe("validateVBundle", () => {
 
     expect(result.is_valid).toBe(true);
     expect(result.errors).toHaveLength(0);
-    expect(result.manifest?.files).toHaveLength(2);
+    expect(result.manifest?.contents).toHaveLength(2);
   });
 
   test("invalid gzip returns INVALID_GZIP error", () => {
@@ -280,27 +303,30 @@ describe("validateVBundle", () => {
     expect(manifestError).toBeDefined();
   });
 
-  test("bundle with only manifest (no data files) is structurally valid", () => {
-    // After the workspace walk refactor, only manifest.json is required.
-    // But the manifest checksum must match for full validity.
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
-      created_at: new Date().toISOString(),
-      files: [],
+  test("bundle with only manifest (no data files) — valid schema rejects empty contents via refine", () => {
+    // The v1 schema's `.refine()` requires `data/db/assistant.db` in
+    // contents, so a manifest declaring `contents: []` is rejected by
+    // the validator. This documents the new behavior: bundles must
+    // declare the assistant DB even when no other data files are
+    // present.
+    const skeleton = {
+      ...v1Skeleton(),
+      contents: [] as Array<{
+        path: string;
+        sha256: string;
+        size_bytes: number;
+      }>,
+      checksum: "",
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
-    const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+    skeleton.checksum = sha256Hex(canonicalizeJson(skeleton));
+    const manifestData = new TextEncoder().encode(JSON.stringify(skeleton));
     const tar = createTarArchive([
       { name: "manifest.json", data: manifestData },
     ]);
     const vbundle = gzipSync(tar);
     const result = validateVBundle(vbundle);
 
-    expect(result.is_valid).toBe(true);
+    expect(result.is_valid).toBe(false);
   });
 
   test("invalid manifest JSON returns INVALID_MANIFEST_JSON error", () => {
@@ -341,16 +367,16 @@ describe("validateVBundle", () => {
   test("manifest checksum mismatch returns MANIFEST_CHECKSUM_MISMATCH", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifest = {
-      schema_version: "1.0",
-      created_at: new Date().toISOString(),
-      files: [
+      ...v1Skeleton(),
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: sha256Hex(dbData),
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
       ],
-      manifest_sha256:
+      // Deliberately wrong checksum (correct shape, wrong value).
+      checksum:
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
@@ -372,22 +398,18 @@ describe("validateVBundle", () => {
     const wrongChecksum =
       "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
-      created_at: new Date().toISOString(),
-      files: [
+    const manifest = {
+      ...v1Skeleton(),
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: wrongChecksum,
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
       ],
+      checksum: "",
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    manifest.checksum = sha256Hex(canonicalizeJson(manifest));
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -406,18 +428,18 @@ describe("validateVBundle", () => {
   test("file size mismatch returns FILE_SIZE_MISMATCH", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
 
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
-      created_at: new Date().toISOString(),
-      files: [
-        { path: "data/db/assistant.db", sha256: sha256Hex(dbData), size: 999 },
-      ],
-    };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
     const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
+      ...v1Skeleton(),
+      contents: [
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(dbData),
+          size_bytes: 999,
+        },
+      ],
+      checksum: "",
     };
+    manifest.checksum = sha256Hex(canonicalizeJson(manifest));
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -437,23 +459,23 @@ describe("validateVBundle", () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const missingFileHash = sha256Hex(new TextEncoder().encode("missing"));
 
-    const manifestWithoutChecksum = {
-      schema_version: "1.0",
-      created_at: new Date().toISOString(),
-      files: [
+    const manifest = {
+      ...v1Skeleton(),
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: sha256Hex(dbData),
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
-        { path: "config/missing.json", sha256: missingFileHash, size: 7 },
+        {
+          path: "config/missing.json",
+          sha256: missingFileHash,
+          size_bytes: 7,
+        },
       ],
+      checksum: "",
     };
-    const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-    const manifest = {
-      ...manifestWithoutChecksum,
-      manifest_sha256: manifestSha256,
-    };
+    manifest.checksum = sha256Hex(canonicalizeJson(manifest));
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
 
     const tar = createTarArchive([
@@ -554,7 +576,10 @@ describe("handleMigrationValidate", () => {
     const body = (await handleMigrationValidate({
       rawBody: vbundle,
       headers: { "content-type": "application/octet-stream" },
-    })) as { is_valid: boolean; errors: Array<{ code: string; path?: string }> };
+    })) as {
+      is_valid: boolean;
+      errors: Array<{ code: string; path?: string }>;
+    };
 
     expect(body.is_valid).toBe(false);
     expect(
@@ -567,16 +592,16 @@ describe("handleMigrationValidate", () => {
   test("POST with checksum mismatch returns validation errors", async () => {
     const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
     const manifest = {
-      schema_version: "1.0",
-      created_at: new Date().toISOString(),
-      files: [
+      ...v1Skeleton(),
+      contents: [
         {
           path: "data/db/assistant.db",
           sha256: sha256Hex(dbData),
-          size: dbData.length,
+          size_bytes: dbData.length,
         },
       ],
-      manifest_sha256:
+      // Deliberately wrong checksum (correct shape, wrong value).
+      checksum:
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     };
     const manifestData = new TextEncoder().encode(JSON.stringify(manifest));

--- a/assistant/src/__tests__/migration-wizard.test.ts
+++ b/assistant/src/__tests__/migration-wizard.test.ts
@@ -355,10 +355,25 @@ describe("executeValidateStep", () => {
       is_valid: true,
       errors: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [{ path: "data/db/assistant.db", sha256: "abc", size: 100 }],
-        manifest_sha256: "def",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [
+          { path: "data/db/assistant.db", sha256: "abc", size_bytes: 100 },
+        ],
+        checksum: "def",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
     };
 
@@ -372,7 +387,7 @@ describe("executeValidateStep", () => {
     expect(result.currentStep).toBe("preflight-review");
     expect(result.validateResult).toBeDefined();
     if (result.validateResult && result.validateResult.is_valid) {
-      expect(result.validateResult.manifest.schema_version).toBe("1.0");
+      expect(result.validateResult.manifest.schema_version).toBe(1);
     }
   });
 
@@ -487,10 +502,23 @@ describe("executePreflightStep", () => {
       ],
       conflicts: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "ghi",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "ghi",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
     };
 
@@ -576,10 +604,23 @@ describe("executeTransferStep", () => {
         },
       ],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "abc",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "abc",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       warnings: [],
     };
@@ -622,10 +663,23 @@ describe("executeTransferStep", () => {
       },
       files: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "abc",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "abc",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       warnings: [],
     };
@@ -712,7 +766,7 @@ describe("executeTransferStep", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
@@ -1054,10 +1108,23 @@ describe("full wizard flow", () => {
       is_valid: true,
       errors: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "abc",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "abc",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
     };
     state = await executeValidateStep(
@@ -1083,10 +1150,23 @@ describe("full wizard flow", () => {
       files: [],
       conflicts: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "abc",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "abc",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
     };
     state = await executePreflightStep(
@@ -1111,10 +1191,23 @@ describe("full wizard flow", () => {
       },
       files: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "abc",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "abc",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       warnings: [],
     };
@@ -1124,7 +1217,7 @@ describe("full wizard flow", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
@@ -1181,10 +1274,23 @@ describe("full wizard flow", () => {
       is_valid: true,
       errors: [],
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: "2026-03-01T00:00:00Z",
-        files: [],
-        manifest_sha256: "abc",
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "abc",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
     };
     state = await executeValidateStep(

--- a/assistant/src/__tests__/rebind-secrets-screen.test.ts
+++ b/assistant/src/__tests__/rebind-secrets-screen.test.ts
@@ -61,12 +61,23 @@ function makeValidateSuccess(): ValidateResponse {
     is_valid: true,
     errors: [],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      source: "test",
-      description: "Test bundle",
-      files: [{ path: "config.json", sha256: "abc123", size: 1024 }],
-      manifest_sha256: "manifest-hash",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [{ path: "config.json", sha256: "abc123", size_bytes: 1024 }],
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -93,10 +104,23 @@ function makePreflightSuccess(): ImportPreflightResponse {
     ],
     conflicts: [],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      files: [{ path: "config.json", sha256: "abc123", size: 1024 }],
-      manifest_sha256: "manifest-hash",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [{ path: "config.json", sha256: "abc123", size_bytes: 1024 }],
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -122,10 +146,23 @@ function makeImportSuccess(): ImportCommitResponse {
       },
     ],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      files: [{ path: "config.json", sha256: "abc123", size: 1024 }],
-      manifest_sha256: "manifest-hash",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [{ path: "config.json", sha256: "abc123", size_bytes: 1024 }],
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
     warnings: ["Backup created for config.json"],
   };
@@ -559,8 +596,8 @@ describe("goBackToTransfer", () => {
       exportResult: {
         ok: true,
         filename: "export.vbundle",
-        schemaVersion: "1.0",
-        manifestSha256: "abc",
+        schemaVersion: 1,
+        checksum: "abc",
       },
       importResult: makeImportSuccess(),
     };

--- a/assistant/src/__tests__/transfer-progress-screen.test.ts
+++ b/assistant/src/__tests__/transfer-progress-screen.test.ts
@@ -113,12 +113,23 @@ function makeValidateSuccess(): ValidateResponse {
     is_valid: true,
     errors: [],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      source: "test",
-      description: "Test bundle",
-      files: [{ path: "config.json", sha256: "abc123", size: 1024 }],
-      manifest_sha256: "manifest-hash",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [{ path: "config.json", sha256: "abc123", size_bytes: 1024 }],
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -145,10 +156,23 @@ function makePreflightSuccess(): ImportPreflightResponse {
     ],
     conflicts: [],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      files: [{ path: "config.json", sha256: "abc123", size: 1024 }],
-      manifest_sha256: "manifest-hash",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [{ path: "config.json", sha256: "abc123", size_bytes: 1024 }],
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -174,10 +198,23 @@ function makeImportSuccess(): ImportCommitResponse {
       },
     ],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      files: [{ path: "config.json", sha256: "abc123", size: 1024 }],
-      manifest_sha256: "manifest-hash",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [{ path: "config.json", sha256: "abc123", size_bytes: 1024 }],
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
     warnings: ["Backup created for config.json"],
   };
@@ -362,8 +399,8 @@ describe("deriveTransferScreenState -- importing", () => {
       exportResult: {
         ok: true,
         filename: "export.vbundle",
-        schemaVersion: "1.0",
-        manifestSha256: "abc",
+        schemaVersion: 1,
+        checksum: "abc",
       },
     };
     const screen = deriveTransferScreenState(state);
@@ -588,8 +625,8 @@ describe("deriveTransferScreenState -- error", () => {
       exportResult: {
         ok: true,
         filename: "export.vbundle",
-        schemaVersion: "1.0",
-        manifestSha256: "abc",
+        schemaVersion: 1,
+        checksum: "abc",
       },
       importResult: {
         success: false,
@@ -681,7 +718,7 @@ describe("retryTransferFlow", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
@@ -751,7 +788,7 @@ describe("retryTransferFlow", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
@@ -793,7 +830,7 @@ describe("executeTransferFlow", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
@@ -915,7 +952,7 @@ describe("executeTransferFlow", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
@@ -959,8 +996,8 @@ describe("goBackToPreflight", () => {
       exportResult: {
         ok: true,
         filename: "export.vbundle",
-        schemaVersion: "1.0",
-        manifestSha256: "abc",
+        schemaVersion: 1,
+        checksum: "abc",
       },
       importResult: makeImportSuccess(),
     };
@@ -998,7 +1035,7 @@ describe("executeTransferFlow -- onStateChange callbacks", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });
@@ -1139,7 +1176,7 @@ describe("transfer screen edge cases", () => {
         status: 200,
         headers: {
           "Content-Disposition": 'attachment; filename="export.vbundle"',
-          "X-Vbundle-Schema-Version": "1.0",
+          "X-Vbundle-Schema-Version": "1",
           "X-Vbundle-Manifest-Sha256": "abc",
         },
       });

--- a/assistant/src/__tests__/validation-results-screen.test.ts
+++ b/assistant/src/__tests__/validation-results-screen.test.ts
@@ -156,15 +156,26 @@ function makeValidateSuccess(): ValidateResponse {
     is_valid: true,
     errors: [],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      source: "test",
-      description: "Test bundle",
-      files: [
-        { path: "config.json", sha256: "abc123", size: 1024 },
-        { path: "skills/test.md", sha256: "def456", size: 2048 },
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
+        { path: "config.json", sha256: "abc123", size_bytes: 1024 },
+        { path: "skills/test.md", sha256: "def456", size_bytes: 2048 },
       ],
-      manifest_sha256: "manifest-hash",
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -246,14 +257,26 @@ function makePreflightSuccess(): ImportPreflightResponse {
       },
     ],
     manifest: {
-      schema_version: "1.0",
-      created_at: "2025-01-01T00:00:00Z",
-      source: "test",
-      files: [
-        { path: "config.json", sha256: "abc123", size: 1024 },
-        { path: "skills/new-skill.md", sha256: "ghi789", size: 512 },
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
+      created_at: "2026-03-01T00:00:00Z",
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
+        { path: "config.json", sha256: "abc123", size_bytes: 1024 },
+        { path: "skills/new-skill.md", sha256: "ghi789", size_bytes: 512 },
       ],
-      manifest_sha256: "manifest-hash",
+      checksum: "manifest-hash",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     },
   };
 }
@@ -539,7 +562,7 @@ describe("deriveValidationScreenState — success", () => {
     expect(screen.phase).toBe("success");
     if (screen.phase === "success") {
       expect(screen.validation.isValid).toBe(true);
-      expect(screen.validation.manifest.schema_version).toBe("1.0");
+      expect(screen.validation.manifest.schema_version).toBe(1);
     }
   });
 

--- a/assistant/src/__tests__/vbundle-pax-and-symlink.test.ts
+++ b/assistant/src/__tests__/vbundle-pax-and-symlink.test.ts
@@ -42,12 +42,12 @@ mock.module("../config/env.js", () => ({
   setIngressPublicBaseUrl: () => {},
 }));
 
+import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
 import {
   buildExportVBundle,
   buildVBundle,
 } from "../runtime/migrations/vbundle-builder.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
-
 // ---------------------------------------------------------------------------
 // PAX header round-trip
 // ---------------------------------------------------------------------------
@@ -71,6 +71,7 @@ describe("PAX extended header round-trip", () => {
         { path: "data/db/assistant.db", data: dbData },
         { path: longPath, data: fileData },
       ],
+      ...defaultV1Options(),
     });
 
     // Validate: should succeed — validator must parse the PAX header
@@ -99,6 +100,7 @@ describe("PAX extended header round-trip", () => {
         { path: "data/db/assistant.db", data: dbData },
         { path: longPath, data: fileData },
       ],
+      ...defaultV1Options(),
     });
 
     const result = validateVBundle(archive);
@@ -117,6 +119,7 @@ describe("PAX extended header round-trip", () => {
         { path: "data/db/assistant.db", data: dbData },
         { path: shortPath, data: fileData },
       ],
+      ...defaultV1Options(),
     });
 
     const result = validateVBundle(archive);
@@ -143,8 +146,14 @@ describe("buildExportVBundle with symlinked skills directory", () => {
     writeFileSync(join(wsDir, "skills", "real-skill.md"), "# Real");
     symlinkSync(realSkillsDir, join(wsDir, "linked-skills"));
 
+    // Add a DB so the v1 manifest schema's `data/db/assistant.db` refine
+    // accepts the bundle.
+    mkdirSync(join(wsDir, "data", "db"), { recursive: true });
+    writeFileSync(join(wsDir, "data", "db", "assistant.db"), "fake-db");
+
     const { archive, manifest } = buildExportVBundle({
       workspaceDir: wsDir,
+      ...defaultV1Options(),
     });
 
     // Validate archive
@@ -152,13 +161,13 @@ describe("buildExportVBundle with symlinked skills directory", () => {
     expect(result.is_valid).toBe(true);
 
     // Real skill file is in the manifest under workspace/ prefix
-    const realSkill = manifest.files.find(
+    const realSkill = manifest.contents.find(
       (f) => f.path === "workspace/skills/real-skill.md",
     );
     expect(realSkill).toBeDefined();
 
     // Symlinked directory is skipped
-    const linkedSkill = manifest.files.find(
+    const linkedSkill = manifest.contents.find(
       (f) => f.path === "workspace/linked-skills/my-skill.md",
     );
     expect(linkedSkill).toBeUndefined();

--- a/assistant/src/backup/__tests__/backup-worker.test.ts
+++ b/assistant/src/backup/__tests__/backup-worker.test.ts
@@ -115,12 +115,23 @@ function makeStreamExportStub(): {
       tempPath,
       size: 16,
       manifest: {
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: new Date().toISOString(),
-        source: "test",
-        description: "test stub",
-        files: [],
-        manifest_sha256: "0".repeat(64),
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum: "0".repeat(64),
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
       },
       cleanup: async () => {
         try {
@@ -539,10 +550,27 @@ describe("createSnapshotNow", () => {
         tempPath,
         size: 7,
         manifest: {
-          schema_version: "1.0",
+          schema_version: 1,
+          bundle_id: "00000000-0000-4000-8000-000000000000",
           created_at: new Date().toISOString(),
-          files: [],
-          manifest_sha256: "0".repeat(64),
+          assistant: {
+            id: "self",
+            name: "Test",
+            runtime_version: "0.0.0-test",
+          },
+          origin: { mode: "self-hosted-local" },
+          compatibility: {
+            min_runtime_version: "0.0.0-test",
+            max_runtime_version: null,
+          },
+          contents: [],
+          checksum: "0".repeat(64),
+          secrets_redacted: false,
+          export_options: {
+            include_logs: false,
+            include_browser_state: false,
+            include_memory_vectors: false,
+          },
         },
         cleanup: async () => {
           try {

--- a/assistant/src/backup/__tests__/restore.test.ts
+++ b/assistant/src/backup/__tests__/restore.test.ts
@@ -31,6 +31,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { defaultV1Options } from "../../runtime/migrations/__tests__/v1-test-helpers.js";
 import { buildVBundle } from "../../runtime/migrations/vbundle-builder.js";
 import type { PathResolver } from "../../runtime/migrations/vbundle-import-analyzer.js";
 import type {
@@ -78,11 +79,13 @@ const NULL_RESOLVER: PathResolver = {
  * the file path along with the manifest the builder embedded so tests can
  * compare against it.
  */
-function writeTinyPlaintextBundle(
-  fileName: string,
-): { path: string; manifest: ManifestType } {
+function writeTinyPlaintextBundle(fileName: string): {
+  path: string;
+  manifest: ManifestType;
+} {
   const { archive, manifest } = buildVBundle({
     files: [
+      { path: "data/db/assistant.db", data: new Uint8Array() },
       {
         path: "workspace/notes/hello.txt",
         data: new TextEncoder().encode("hello world"),
@@ -92,8 +95,7 @@ function writeTinyPlaintextBundle(
         data: new TextEncoder().encode("a tiny bundle for tests"),
       },
     ],
-    source: "restore-test",
-    description: "tiny bundle for restore.test.ts",
+    ...defaultV1Options(),
   });
 
   const path = join(TEST_DIR, fileName);
@@ -117,21 +119,35 @@ function makeStubCommitImpl(): {
   const calls: RecordedCall[] = [];
   const commitImpl = (options: ImportCommitOptions): ImportCommitResult => {
     calls.push({ options });
-    const manifest =
+    const manifest: ManifestType =
       options.preValidatedManifest ??
       ({
-        schema_version: "1.0",
+        schema_version: 1,
+        bundle_id: "00000000-0000-4000-8000-000000000000",
         created_at: new Date().toISOString(),
-        files: [],
-        manifest_sha256: "stub",
-      } satisfies ManifestType);
+        assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+        origin: { mode: "self-hosted-local" },
+        compatibility: {
+          min_runtime_version: "0.0.0-test",
+          max_runtime_version: null,
+        },
+        contents: [],
+        checksum:
+          "0000000000000000000000000000000000000000000000000000000000000000",
+        secrets_redacted: false,
+        export_options: {
+          include_logs: false,
+          include_browser_state: false,
+          include_memory_vectors: false,
+        },
+      } as ManifestType);
     return {
       ok: true,
       report: {
         success: true,
         summary: {
-          total_files: manifest.files.length,
-          files_created: manifest.files.length,
+          total_files: manifest.contents.length,
+          files_created: manifest.contents.length,
           files_overwritten: 0,
           files_skipped: 0,
           backups_created: 0,
@@ -178,8 +194,9 @@ describe("verifySnapshot", () => {
     expect(result.valid).toBe(true);
     expect(result.manifest).toBeDefined();
     expect(result.error).toBeUndefined();
-    expect(result.manifest?.manifest_sha256).toBe(manifest.manifest_sha256);
-    expect(result.manifest?.files.length).toBe(2);
+    expect(result.manifest?.checksum).toBe(manifest.checksum);
+    // 3 = synthetic data/db/assistant.db + workspace/notes/hello.txt + workspace/notes/about.txt
+    expect(result.manifest?.contents.length).toBe(3);
   });
 
   test("encrypted: returns valid:true after decrypting first", async () => {
@@ -244,11 +261,13 @@ describe("verifySnapshot", () => {
     // validateVBundle catches the bad manifest.
     const { archive } = buildVBundle({
       files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
         {
           path: "workspace/notes/hello.txt",
           data: new TextEncoder().encode("hello"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     // Flip a few bytes in the middle of the gzipped archive — this almost
@@ -292,21 +311,19 @@ describe("restoreFromSnapshot", () => {
     const passed = calls[0].options;
     // The wrapper should pass the pre-validated manifest + entries so
     // commitImport doesn't re-validate.
-    expect(passed.preValidatedManifest?.manifest_sha256).toBe(
-      manifest.manifest_sha256,
-    );
+    expect(passed.preValidatedManifest?.checksum).toBe(manifest.checksum);
     expect(passed.preValidatedEntries).toBeDefined();
     expect(passed.preValidatedEntries?.has("manifest.json")).toBe(true);
-    expect(
-      passed.preValidatedEntries?.has("workspace/notes/hello.txt"),
-    ).toBe(true);
+    expect(passed.preValidatedEntries?.has("workspace/notes/hello.txt")).toBe(
+      true,
+    );
     // archiveData must be the actual bundle bytes.
     expect(passed.archiveData).toBeInstanceOf(Uint8Array);
     expect(passed.archiveData.length).toBeGreaterThan(0);
 
     // Public result is shaped correctly.
-    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
-    expect(result.restoredFiles).toBe(2);
+    expect(result.manifest.checksum).toBe(manifest.checksum);
+    expect(result.restoredFiles).toBe(3);
   });
 
   test("encrypted round-trip: decrypts then commits, and cleans up the temp file", async () => {
@@ -327,8 +344,8 @@ describe("restoreFromSnapshot", () => {
     const after = listRestoreTempArtifacts();
 
     expect(calls.length).toBe(1);
-    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
-    expect(result.restoredFiles).toBe(2);
+    expect(result.manifest.checksum).toBe(manifest.checksum);
+    expect(result.restoredFiles).toBe(3);
 
     // Decrypted temp file must be cleaned up after the call.
     expect(after.length).toBe(before.length);
@@ -377,6 +394,7 @@ describe("restoreFromSnapshot", () => {
     // the OS keychain / CES and are not part of the backup round trip.
     const { archive, manifest } = buildVBundle({
       files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
         {
           path: "workspace/notes/hello.txt",
           data: new TextEncoder().encode("hello"),
@@ -386,6 +404,7 @@ describe("restoreFromSnapshot", () => {
           data: new TextEncoder().encode("sk-test-1234"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const path = join(TEST_DIR, "with-creds.vbundle");
@@ -399,7 +418,7 @@ describe("restoreFromSnapshot", () => {
 
     // The restore result must not expose a `credentials` field — the public
     // type only has `manifest` and `restoredFiles`.
-    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
+    expect(result.manifest.checksum).toBe(manifest.checksum);
     expect("credentials" in result).toBe(false);
   });
 
@@ -468,9 +487,7 @@ describe("restoreFromSnapshot", () => {
 
     // Stub that simulates a write failure (the importer returns this for
     // disk errors like permission denied or partial bundle writes).
-    const failingCommit = (
-      _opts: ImportCommitOptions,
-    ): ImportCommitResult => ({
+    const failingCommit = (_opts: ImportCommitOptions): ImportCommitResult => ({
       ok: false,
       reason: "write_failed",
       message: "disk full",

--- a/assistant/src/backup/backup-worker.ts
+++ b/assistant/src/backup/backup-worker.ts
@@ -26,18 +26,24 @@
  * surface against temp directories with tiny fake bundles.
  */
 
+import { hostname } from "node:os";
 import { Database } from "bun:sqlite";
 
 import { getConfig } from "../config/loader.js";
 import type { BackupConfig } from "../config/schema.js";
+import { getAssistantName } from "../daemon/identity-helpers.js";
 import {
   getMemoryCheckpoint as realGetMemoryCheckpoint,
   setMemoryCheckpoint as realSetMemoryCheckpoint,
 } from "../memory/checkpoints.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import type { VBundleOriginMode } from "../runtime/migrations/origin-mode.js";
 import type { StreamExportVBundleResult } from "../runtime/migrations/vbundle-builder.js";
 import { streamExportVBundle as realStreamExportVBundle } from "../runtime/migrations/vbundle-builder.js";
+import { getDaemonRuntimeMode } from "../runtime/runtime-mode.js";
 import { getLogger } from "../util/logger.js";
 import { getDbPath, getWorkspaceDir } from "../util/platform.js";
+import { APP_VERSION } from "../version.js";
 import { ensureBackupKey as realEnsureBackupKey } from "./backup-key.js";
 import type { SnapshotEntry } from "./list-snapshots.js";
 import { pruneLocalSnapshots, writeLocalSnapshot } from "./local-writer.js";
@@ -185,10 +191,38 @@ async function performBackup(
   // mirrors the pattern in `handleMigrationExport`: open a fresh Database
   // handle, run PRAGMA wal_checkpoint(TRUNCATE), close it. Any failure is
   // best-effort — the export still proceeds with whatever is on disk.
+  //
+  // The backup worker bundles credentials by design (its purpose is local
+  // recovery), so `secretsRedacted: false`. Backups run locally on the host
+  // machine; managed deployments delegate to the platform. Hardcoding to
+  // self-hosted ensures the resulting bundle satisfies the v1 schema's
+  // refine for managed/secrets_redacted — `getOriginMode()` would return
+  // "managed" in a managed deployment, producing a non-restorable bundle.
+  const originMode: VBundleOriginMode =
+    getDaemonRuntimeMode() === "docker"
+      ? "self-hosted-remote"
+      : "self-hosted-local";
   const result = await streamExport({
     workspaceDir,
-    source: "backup-worker",
-    description: "Automated backup snapshot",
+    assistant: {
+      id: DAEMON_INTERNAL_ASSISTANT_ID,
+      name: getAssistantName() ?? "Assistant",
+      runtime_version: APP_VERSION,
+    },
+    origin: {
+      mode: originMode,
+      hostname: hostname(),
+    },
+    compatibility: {
+      min_runtime_version: APP_VERSION,
+      max_runtime_version: null,
+    },
+    exportOptions: {
+      include_logs: true,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+    secretsRedacted: false,
     checkpoint: () => {
       const dbPath = getDbPath();
       try {

--- a/assistant/src/cli/commands/backup.ts
+++ b/assistant/src/cli/commands/backup.ts
@@ -596,7 +596,7 @@ export async function handleRestore(opts: RestoreOptions): Promise<void> {
     invalidateConfigCache();
 
     log.info(`Restored from ${snapshotPath}`);
-    log.info(`  source: ${result.manifest.source ?? "unknown"}`);
+    log.info(`  bundle_id: ${result.manifest.bundle_id}`);
     log.info(`  schema_version: ${result.manifest.schema_version}`);
     log.info(`  files restored: ${result.restoredFiles}`);
   } catch (err) {
@@ -627,7 +627,7 @@ export async function handleVerify(path: string): Promise<void> {
       log.info(`OK: ${path}`);
       if (result.manifest) {
         log.info(`  schema_version: ${result.manifest.schema_version}`);
-        log.info(`  source: ${result.manifest.source ?? "unknown"}`);
+        log.info(`  bundle_id: ${result.manifest.bundle_id}`);
       }
     } else {
       log.error(`Invalid: ${path}`);

--- a/assistant/src/runtime/migrations/__tests__/v1-test-helpers.ts
+++ b/assistant/src/runtime/migrations/__tests__/v1-test-helpers.ts
@@ -7,6 +7,8 @@
  * keeps every test from re-spelling the same six required option fields.
  */
 
+import { randomUUID } from "node:crypto";
+
 import type {
   BuildVBundleOptions,
   VBundleAssistantInfo,
@@ -14,6 +16,11 @@ import type {
   VBundleExportOptions,
   VBundleOriginInfo,
 } from "../vbundle-builder.js";
+import {
+  computeManifestChecksum,
+  type ManifestFileEntryType,
+  type ManifestType,
+} from "../vbundle-validator.js";
 
 export interface DefaultV1Options {
   assistant: VBundleAssistantInfo;
@@ -66,4 +73,40 @@ export function buildVBundleTestOptions(
     ...defaultV1Options(),
     ...overrides,
   };
+}
+
+/**
+ * Build a v1 ManifestType for tests, mirroring buildManifestObject() in
+ * vbundle-builder.ts. Use this in test fixtures that need a synthetic
+ * manifest rather than calling buildVBundle (e.g. cross-version compat
+ * tests that need to mutate fields between emit and validate).
+ *
+ * Pass `overrides` to override any field after the defaults are applied —
+ * useful for negative-path tests that exercise specific schema rejections.
+ * `schema_version` is widened to `number` so negative tests can write 0/2/etc.
+ * The checksum is computed on the merged shape so overrides take effect.
+ */
+export type BuildTestManifestOverrides = Partial<
+  Omit<ManifestType, "schema_version">
+> & { schema_version?: number };
+
+export function buildTestManifest(input: {
+  contents: ManifestFileEntryType[];
+  overrides?: BuildTestManifestOverrides;
+}): ManifestType {
+  const base = defaultV1Options();
+  const merged = {
+    schema_version: 1,
+    bundle_id: randomUUID(),
+    created_at: new Date().toISOString(),
+    assistant: base.assistant,
+    origin: base.origin,
+    compatibility: base.compatibility,
+    contents: input.contents,
+    checksum: "",
+    secrets_redacted: base.secretsRedacted,
+    export_options: base.exportOptions,
+    ...(input.overrides ?? {}),
+  } as ManifestType;
+  return { ...merged, checksum: computeManifestChecksum(merged) };
 }

--- a/assistant/src/runtime/migrations/__tests__/v1-test-helpers.ts
+++ b/assistant/src/runtime/migrations/__tests__/v1-test-helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared test helpers for vbundle v1 manifest fixture builders.
+ *
+ * Most tests don't care about the specific values of the assistant identity,
+ * origin, compatibility, or export-options blocks — they just need the
+ * builder/validator to accept their fixtures. Centralizing the defaults
+ * keeps every test from re-spelling the same six required option fields.
+ */
+
+import type {
+  BuildVBundleOptions,
+  VBundleAssistantInfo,
+  VBundleCompatibility,
+  VBundleExportOptions,
+  VBundleOriginInfo,
+} from "../vbundle-builder.js";
+
+export interface DefaultV1Options {
+  assistant: VBundleAssistantInfo;
+  origin: VBundleOriginInfo;
+  compatibility: VBundleCompatibility;
+  exportOptions: VBundleExportOptions;
+  secretsRedacted: boolean;
+}
+
+/**
+ * Sensible defaults for the six caller-required v1 manifest options.
+ *
+ * `secretsRedacted` defaults to false to match the runtime's typical
+ * "credentials included by design" path; tests that exercise the managed
+ * cross-field refine override `origin.mode` and `secretsRedacted` directly.
+ */
+export function defaultV1Options(): DefaultV1Options {
+  return {
+    assistant: {
+      id: "self",
+      name: "Test",
+      runtime_version: "0.0.0-test",
+    },
+    origin: {
+      mode: "self-hosted-local",
+    },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    exportOptions: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+    secretsRedacted: false,
+  };
+}
+
+/**
+ * Convenience: spread `defaultV1Options()` into a `BuildVBundleOptions`
+ * with the supplied `files`. Saves repeating the spread at every call site.
+ */
+export function buildVBundleTestOptions(
+  files: BuildVBundleOptions["files"],
+  overrides: Partial<DefaultV1Options> = {},
+): BuildVBundleOptions {
+  return {
+    files,
+    ...defaultV1Options(),
+    ...overrides,
+  };
+}

--- a/assistant/src/runtime/migrations/__tests__/vbundle-builder-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-builder-credentials.test.ts
@@ -16,6 +16,7 @@ import { gunzipSync } from "node:zlib";
 import { describe, expect, test } from "bun:test";
 
 import { buildExportVBundle, streamExportVBundle } from "../vbundle-builder.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -111,6 +112,7 @@ describe("buildExportVBundle with credentials", () => {
       ];
 
       const result = buildExportVBundle({
+        ...defaultV1Options(),
         workspaceDir: workspace.dir,
         credentials,
       });
@@ -141,6 +143,7 @@ describe("buildExportVBundle with credentials", () => {
       ];
 
       const result = buildExportVBundle({
+        ...defaultV1Options(),
         workspaceDir: workspace.dir,
         credentials,
       });
@@ -149,12 +152,12 @@ describe("buildExportVBundle with credentials", () => {
         new TextEncoder().encode("secret-value-abc"),
       );
 
-      const credEntry = result.manifest.files.find(
+      const credEntry = result.manifest.contents.find(
         (f) => f.path === "credentials/my-api-key",
       );
       expect(credEntry).toBeDefined();
       expect(credEntry!.sha256).toBe(expectedHash);
-      expect(credEntry!.size).toBe(
+      expect(credEntry!.size_bytes).toBe(
         new TextEncoder().encode("secret-value-abc").length,
       );
     } finally {
@@ -166,6 +169,7 @@ describe("buildExportVBundle with credentials", () => {
     const workspace = createTestWorkspace();
     try {
       const result = buildExportVBundle({
+        ...defaultV1Options(),
         workspaceDir: workspace.dir,
       });
 
@@ -178,7 +182,7 @@ describe("buildExportVBundle with credentials", () => {
       expect(credentialEntries).toHaveLength(0);
 
       // Manifest should have no credential entries
-      const credManifestEntries = result.manifest.files.filter((f) =>
+      const credManifestEntries = result.manifest.contents.filter((f) =>
         f.path.startsWith("credentials/"),
       );
       expect(credManifestEntries).toHaveLength(0);
@@ -191,6 +195,7 @@ describe("buildExportVBundle with credentials", () => {
     const workspace = createTestWorkspace();
     try {
       const result = buildExportVBundle({
+        ...defaultV1Options(),
         workspaceDir: workspace.dir,
         credentials: [],
       });
@@ -218,6 +223,7 @@ describe("streamExportVBundle with credentials", () => {
       ];
 
       result = await streamExportVBundle({
+        ...defaultV1Options(),
         workspaceDir: workspace.dir,
         credentials,
       });
@@ -237,7 +243,7 @@ describe("streamExportVBundle with credentials", () => {
       );
 
       // Verify manifest entry
-      const credEntry = result.manifest.files.find(
+      const credEntry = result.manifest.contents.find(
         (f) => f.path === "credentials/stream-key",
       );
       expect(credEntry).toBeDefined();
@@ -255,6 +261,7 @@ describe("streamExportVBundle with credentials", () => {
     let result: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
     try {
       result = await streamExportVBundle({
+        ...defaultV1Options(),
         workspaceDir: workspace.dir,
       });
 

--- a/assistant/src/runtime/migrations/__tests__/vbundle-builder-v1-shape.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-builder-v1-shape.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Verifies that the buffered (`buildVBundle` / `buildExportVBundle`) and
+ * streaming (`streamExportVBundle`) emit paths both produce manifests
+ * conforming to the canonical v1 ten-field shape.
+ *
+ * Drift between the two emit paths is exactly how the prior schema
+ * mismatch went unnoticed — these tests pin both paths to the same shape
+ * and run a round-trip through `validateVBundle` so any future
+ * canonicalization drift fails loudly.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildExportVBundle,
+  buildVBundle,
+  streamExportVBundle,
+} from "../vbundle-builder.js";
+import { canonicalizeJson, validateVBundle } from "../vbundle-validator.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+function createTestWorkspace(): { dir: string; cleanup: () => void } {
+  const dir = join(
+    tmpdir(),
+    `vbundle-v1-shape-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify({ test: true }));
+  const dbDir = join(dir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  writeFileSync(join(dbDir, "assistant.db"), "fake-db-content");
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ISO_8601_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+describe("buildVBundle — v1 ten-field manifest shape", () => {
+  test("emits all ten required top-level fields with correct types", () => {
+    const { manifest } = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    expect(manifest.schema_version).toBe(1);
+    expect(typeof manifest.bundle_id).toBe("string");
+    expect(manifest.bundle_id).toMatch(UUID_V4_RE);
+    expect(manifest.created_at).toMatch(ISO_8601_RE);
+    expect(manifest.assistant.id).toBe("self");
+    expect(manifest.assistant.name).toBe("Test");
+    expect(manifest.assistant.runtime_version).toBe("0.0.0-test");
+    expect(manifest.origin.mode).toBe("self-hosted-local");
+    expect(manifest.compatibility.min_runtime_version).toBe("0.0.0-test");
+    expect(manifest.compatibility.max_runtime_version).toBeNull();
+    expect(Array.isArray(manifest.contents)).toBe(true);
+    expect(manifest.contents.length).toBeGreaterThan(0);
+    expect(manifest.checksum).toMatch(SHA256_HEX_RE);
+    expect(typeof manifest.secrets_redacted).toBe("boolean");
+    expect(typeof manifest.export_options.include_logs).toBe("boolean");
+  });
+
+  test("contents always declares data/db/assistant.db when the input includes it", () => {
+    const { manifest } = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+        },
+        {
+          path: "config/settings.json",
+          data: new TextEncoder().encode("{}"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const dbEntry = manifest.contents.find(
+      (f) => f.path === "data/db/assistant.db",
+    );
+    expect(dbEntry).toBeDefined();
+    expect(dbEntry!.size_bytes).toBe(
+      new TextEncoder().encode("db-bytes").length,
+    );
+  });
+
+  test("checksum is the sha256 of the canonicalized manifest with checksum=''", () => {
+    const { manifest } = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const expected = sha256Hex(canonicalizeJson({ ...manifest, checksum: "" }));
+    expect(manifest.checksum).toBe(expected);
+  });
+
+  test("secrets_redacted reflects the input flag", () => {
+    const truthy = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+        },
+      ],
+      ...defaultV1Options(),
+      secretsRedacted: true,
+    });
+    expect(truthy.manifest.secrets_redacted).toBe(true);
+
+    const falsey = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+        },
+      ],
+      ...defaultV1Options(),
+      secretsRedacted: false,
+    });
+    expect(falsey.manifest.secrets_redacted).toBe(false);
+  });
+
+  test("bundle_id is a fresh UUID per export", () => {
+    const a = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+    const b = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+    expect(a.manifest.bundle_id).not.toBe(b.manifest.bundle_id);
+  });
+});
+
+describe("streamExportVBundle — v1 ten-field manifest shape", () => {
+  test("matches buildExportVBundle's manifest shape (modulo bundle_id and created_at)", async () => {
+    const workspace = createTestWorkspace();
+    let streamResult:
+      | Awaited<ReturnType<typeof streamExportVBundle>>
+      | undefined;
+    try {
+      const sync = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        ...defaultV1Options(),
+      });
+      streamResult = await streamExportVBundle({
+        workspaceDir: workspace.dir,
+        ...defaultV1Options(),
+      });
+
+      expect(streamResult.manifest.schema_version).toBe(
+        sync.manifest.schema_version,
+      );
+      expect(streamResult.manifest.assistant).toEqual(sync.manifest.assistant);
+      expect(streamResult.manifest.origin).toEqual(sync.manifest.origin);
+      expect(streamResult.manifest.compatibility).toEqual(
+        sync.manifest.compatibility,
+      );
+      expect(streamResult.manifest.export_options).toEqual(
+        sync.manifest.export_options,
+      );
+      expect(streamResult.manifest.secrets_redacted).toBe(
+        sync.manifest.secrets_redacted,
+      );
+
+      // Same set of files (paths + sha + size).
+      const sortByPath = (a: { path: string }, b: { path: string }) =>
+        a.path.localeCompare(b.path);
+      expect(streamResult.manifest.contents.slice().sort(sortByPath)).toEqual(
+        sync.manifest.contents.slice().sort(sortByPath),
+      );
+    } finally {
+      await streamResult?.cleanup();
+      workspace.cleanup();
+    }
+  });
+});
+
+describe("buildExportVBundle round-trip", () => {
+  test("validateVBundle accepts the buffered emit", () => {
+    const workspace = createTestWorkspace();
+    try {
+      const result = buildExportVBundle({
+        workspaceDir: workspace.dir,
+        ...defaultV1Options(),
+      });
+      const validation = validateVBundle(result.archive);
+      expect(validation.is_valid).toBe(true);
+      expect(validation.errors).toHaveLength(0);
+      expect(validation.manifest?.checksum).toBe(result.manifest.checksum);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test("validateVBundle accepts the streaming emit", async () => {
+    const workspace = createTestWorkspace();
+    let result: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
+    try {
+      result = await streamExportVBundle({
+        workspaceDir: workspace.dir,
+        ...defaultV1Options(),
+      });
+      const archive = new Uint8Array(
+        await Bun.file(result.tempPath).arrayBuffer(),
+      );
+      // Sanity: archive is valid gzip of a tar.
+      expect(gunzipSync(archive).length).toBeGreaterThan(0);
+      const validation = validateVBundle(archive);
+      expect(validation.is_valid).toBe(true);
+      expect(validation.errors).toHaveLength(0);
+      expect(validation.manifest?.checksum).toBe(result.manifest.checksum);
+    } finally {
+      await result?.cleanup();
+      workspace.cleanup();
+    }
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-credentials.test.ts
@@ -24,16 +24,29 @@ function makeTarEntry(data: string): VBundleTarEntry {
 
 function makeManifest(paths: string[]): ManifestType {
   return {
-    schema_version: "1.0.0",
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
     created_at: new Date().toISOString(),
-    source: "test",
-    manifest_sha256: "test",
-    files: paths.map((path) => ({
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents: paths.map((path) => ({
       path,
-      size: 0,
+      size_bytes: 0,
       sha256: "test",
     })),
-  } as ManifestType;
+    checksum:
+      "0000000000000000000000000000000000000000000000000000000000000000",
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  } as unknown as ManifestType;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
@@ -29,6 +29,7 @@ import {
   DefaultPathResolver,
 } from "../vbundle-import-analyzer.js";
 import { commitImport } from "../vbundle-importer.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Shared fixture: per-test workspace under VELLUM_WORKSPACE_DIR.
@@ -139,10 +140,8 @@ describe("DefaultPathResolver prompts/USER.md translation", () => {
   });
 
   test("still resolves other prompt files (IDENTITY.md) to workspace root", () => {
-    const resolver = new DefaultPathResolver(
-      WORKSPACE_ROOT,
-      undefined,
-      () => join(USERS_DIR, "captain.md"),
+    const resolver = new DefaultPathResolver(WORKSPACE_ROOT, undefined, () =>
+      join(USERS_DIR, "captain.md"),
     );
 
     expect(resolver.resolve("prompts/IDENTITY.md")).toBe(
@@ -157,10 +156,8 @@ describe("DefaultPathResolver prompts/USER.md translation", () => {
   });
 
   test("skips unknown prompt filenames regardless of guardian state", () => {
-    const resolver = new DefaultPathResolver(
-      WORKSPACE_ROOT,
-      undefined,
-      () => join(USERS_DIR, "captain.md"),
+    const resolver = new DefaultPathResolver(WORKSPACE_ROOT, undefined, () =>
+      join(USERS_DIR, "captain.md"),
     );
 
     expect(resolver.resolve("prompts/SECRET.md")).toBeNull();
@@ -183,19 +180,24 @@ describe("analyzeImport for legacy prompts/USER.md", () => {
     const { archive, manifest } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "prompts/USER.md",
           data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
         },
       ],
+      ...defaultV1Options(),
     });
     expect(archive.length).toBeGreaterThan(0);
 
     const report = analyzeImport({ manifest, pathResolver: resolver });
 
     expect(report.can_import).toBe(true);
-    expect(report.files).toHaveLength(1);
-    expect(report.files[0].path).toBe("prompts/USER.md");
-    expect(report.files[0].action).toBe("create");
+    const userMd = report.files.find((f) => f.path === "prompts/USER.md");
+    expect(userMd).toBeDefined();
+    expect(userMd!.action).toBe("create");
   });
 
   test("non-blocking skip when no guardian is resolvable (can_import stays true)", () => {
@@ -208,10 +210,15 @@ describe("analyzeImport for legacy prompts/USER.md", () => {
     const { manifest } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "prompts/USER.md",
           data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const report = analyzeImport({ manifest, pathResolver: resolver });
@@ -220,7 +227,8 @@ describe("analyzeImport for legacy prompts/USER.md", () => {
     // path warns and skips, so preflight mirrors that behavior.
     expect(report.can_import).toBe(true);
     expect(report.conflicts).toHaveLength(0);
-    expect(report.files[0].action).toBe("skip");
+    const userMd = report.files.find((f) => f.path === "prompts/USER.md");
+    expect(userMd!.action).toBe("skip");
   });
 });
 
@@ -241,19 +249,30 @@ describe("commitImport for legacy prompts/USER.md", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "prompts/USER.md",
           data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
         },
       ],
+      ...defaultV1Options(),
     });
 
-    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: resolver,
+    });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.report.success).toBe(true);
-      expect(result.report.summary.files_created).toBe(1);
-      expect(result.report.summary.files_skipped).toBe(0);
+      // The bundle carries both data/db/assistant.db and prompts/USER.md;
+      // the legacy USER.md is the one we care about here.
+      expect(
+        result.report.files.find((f) => f.path === "prompts/USER.md")?.action,
+      ).toBe("created");
     }
 
     expect(existsSync(guardianPath)).toBe(true);
@@ -274,18 +293,27 @@ describe("commitImport for legacy prompts/USER.md", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "prompts/USER.md",
           data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
         },
       ],
+      ...defaultV1Options(),
     });
 
-    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: resolver,
+    });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.report.summary.files_overwritten).toBe(1);
-      expect(result.report.summary.files_skipped).toBe(0);
+      expect(
+        result.report.files.find((f) => f.path === "prompts/USER.md")?.action,
+      ).toBe("overwritten");
     }
     expect(readFileSync(guardianPath, "utf-8")).toBe(LEGACY_USER_MD_CONTENT);
   });
@@ -300,18 +328,27 @@ describe("commitImport for legacy prompts/USER.md", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "prompts/USER.md",
           data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
         },
       ],
+      ...defaultV1Options(),
     });
 
-    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: resolver,
+    });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.report.summary.files_skipped).toBe(1);
-      expect(result.report.summary.files_created).toBe(0);
+      expect(
+        result.report.files.find((f) => f.path === "prompts/USER.md")?.action,
+      ).toBe("skipped");
       expect(
         result.report.warnings.some((w) => w.includes("prompts/USER.md")),
       ).toBe(true);
@@ -335,22 +372,29 @@ describe("commitImport for legacy prompts/USER.md", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "prompts/USER.md",
           data: new TextEncoder().encode(LEGACY_USER_MD_CONTENT),
         },
       ],
+      ...defaultV1Options(),
     });
 
-    const result = commitImport({ archiveData: archive, pathResolver: resolver });
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: resolver,
+    });
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.report.summary.files_skipped).toBe(1);
-      expect(result.report.summary.files_overwritten).toBe(0);
       expect(
-        result.report.warnings.some((w) =>
-          w.includes("guardian persona"),
-        ),
+        result.report.files.find((f) => f.path === "prompts/USER.md")?.action,
+      ).toBe("skipped");
+      expect(
+        result.report.warnings.some((w) => w.includes("guardian persona")),
       ).toBe(true);
     }
 

--- a/assistant/src/runtime/migrations/__tests__/vbundle-metadata-merge-integration.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-metadata-merge-integration.test.ts
@@ -31,6 +31,7 @@ import { buildVBundle } from "../vbundle-builder.js";
 import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
 import { commitImport } from "../vbundle-importer.js";
 import { streamCommitImport } from "../vbundle-streaming-importer.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Metadata helpers
@@ -139,12 +140,17 @@ describe("commitImport — credential metadata merge", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/data/credentials/metadata.json",
           data: encode(bundleMetadata),
         },
         // Include at least one other workspace entry so Step 1b fires.
         { path: "workspace/noop.txt", data: encode("noop") },
       ],
+      ...defaultV1Options(),
     });
 
     const result = commitImport({
@@ -180,11 +186,16 @@ describe("commitImport — credential metadata merge", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/data/credentials/metadata.json",
           data: encode(bundleMetadata),
         },
         { path: "workspace/noop.txt", data: encode("noop") },
       ],
+      ...defaultV1Options(),
     });
 
     const result = commitImport({
@@ -207,7 +218,11 @@ describe("commitImport — credential metadata merge", () => {
     const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
 
     const { archive } = buildVBundle({
-      files: [{ path: "workspace/noop.txt", data: encode("noop") }],
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+      ...defaultV1Options(),
     });
 
     const result = commitImport({
@@ -229,6 +244,10 @@ describe("commitImport — credential metadata merge", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/data/credentials/metadata.json",
           data: encode(
             metadataJson([record("telegram", "bot_token", "source")]),
@@ -236,6 +255,7 @@ describe("commitImport — credential metadata merge", () => {
         },
         { path: "workspace/noop.txt", data: encode("noop") },
       ],
+      ...defaultV1Options(),
     });
 
     const result = commitImport({
@@ -280,11 +300,16 @@ describe("streamCommitImport — credential metadata merge", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/data/credentials/metadata.json",
           data: encode(bundleMetadata),
         },
         { path: "workspace/noop.txt", data: encode("noop") },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -317,11 +342,16 @@ describe("streamCommitImport — credential metadata merge", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/data/credentials/metadata.json",
           data: encode(bundleMetadata),
         },
         { path: "workspace/noop.txt", data: encode("noop") },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -344,7 +374,11 @@ describe("streamCommitImport — credential metadata merge", () => {
     const metadataPath = seedTargetMetadata(workspaceDir, vellumRecords());
 
     const { archive } = buildVBundle({
-      files: [{ path: "workspace/noop.txt", data: encode("noop") }],
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        { path: "workspace/noop.txt", data: encode("noop") },
+      ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -366,6 +400,10 @@ describe("streamCommitImport — credential metadata merge", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/data/credentials/metadata.json",
           data: encode(
             metadataJson([record("telegram", "bot_token", "source")]),
@@ -373,6 +411,7 @@ describe("streamCommitImport — credential metadata merge", () => {
         },
         { path: "workspace/noop.txt", data: encode("noop") },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -41,6 +41,7 @@ import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
 import { commitImport } from "../vbundle-importer.js";
 import { streamCommitImport } from "../vbundle-streaming-importer.js";
 import { canonicalizeJson } from "../vbundle-validator.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
 
 /**
  * Fixed "customized" guardian persona content used by the USER.md-skip
@@ -131,7 +132,7 @@ function removeEntry(archive: Uint8Array, entryName: string): Uint8Array {
 
 /**
  * Update manifest.json in place to drop the entry with the given archive
- * path AND recompute manifest_sha256 so the manifest itself stays valid.
+ * path AND recompute the v1 `checksum` so the manifest itself stays valid.
  * Used to craft the "extra entry" (manifest_mismatch) fixture — the tar
  * has the file, but the manifest does not.
  */
@@ -149,15 +150,18 @@ function dropFromManifestAndRepack(
     raw.subarray(512, 512 + origSize),
   );
   const manifest = JSON.parse(manifestJson) as {
-    files: Array<{ path: string; sha256: string; size: number }>;
-    manifest_sha256: string;
+    contents: Array<{ path: string; sha256: string; size_bytes: number }>;
+    checksum: string;
     [k: string]: unknown;
   };
-  manifest.files = manifest.files.filter((f) => f.path !== pathToDrop);
-  // Recompute manifest_sha256.
-  const withoutChecksum: Record<string, unknown> = { ...manifest };
-  delete withoutChecksum.manifest_sha256;
-  manifest.manifest_sha256 = sha256Hex(canonicalizeJson(withoutChecksum));
+  manifest.contents = manifest.contents.filter((f) => f.path !== pathToDrop);
+  // Recompute checksum: place an empty-string placeholder in the canonical
+  // form, exactly mirroring the v1 emit-time canonicalization.
+  const withEmptyChecksum: Record<string, unknown> = {
+    ...manifest,
+    checksum: "",
+  };
+  manifest.checksum = sha256Hex(canonicalizeJson(withEmptyChecksum));
 
   const newJson = JSON.stringify(manifest);
   const newBytes = new TextEncoder().encode(newJson);
@@ -218,11 +222,15 @@ describe("streamCommitImport — happy path", () => {
 
     const { archive } = buildVBundle({
       files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
         { path: "workspace/a.txt", data: fileA },
         { path: "workspace/sub/b.txt", data: fileB },
         { path: "workspace/sub/c.txt", data: fileC },
       ],
-      source: "test-happy-path",
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -246,9 +254,10 @@ describe("streamCommitImport — happy path", () => {
     );
 
     expect(result.report.success).toBe(true);
-    expect(result.report.summary.total_files).toBe(3);
-    expect(result.report.summary.files_created).toBe(3);
-    expect(result.report.manifest.files).toHaveLength(3);
+    // Includes the synthetic data/db/assistant.db entry plus a/b/c.txt.
+    expect(result.report.summary.total_files).toBe(4);
+    expect(result.report.summary.files_created).toBe(4);
+    expect(result.report.manifest.contents).toHaveLength(4);
     for (const f of result.report.files) {
       expect(f.action).toBe("created");
       expect(f.backup_path).toBeNull();
@@ -261,6 +270,10 @@ describe("streamCommitImport — happy path", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/a.txt",
           data: new TextEncoder().encode("one"),
         },
@@ -269,6 +282,7 @@ describe("streamCommitImport — happy path", () => {
           data: new TextEncoder().encode("two!"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const events: Array<{
@@ -285,17 +299,22 @@ describe("streamCommitImport — happy path", () => {
 
     expect(result.ok).toBe(true);
     expect(events.map((e) => e.archivePath)).toEqual([
+      "data/db/assistant.db",
       "workspace/a.txt",
       "workspace/b.txt",
     ]);
-    expect(events[0]?.bytesWritten).toBe(3);
-    expect(events[1]?.bytesWritten).toBe(4);
+    expect(events[1]?.bytesWritten).toBe(3);
+    expect(events[2]?.bytesWritten).toBe(4);
     expect(events[0]?.entryIndex).toBeLessThan(events[1]?.entryIndex ?? -1);
   });
 
   test("forwards credentials to importCredentials callback but never writes them to disk", async () => {
     const { archive } = buildVBundle({
       files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
         {
           path: "workspace/config.json",
           data: new TextEncoder().encode("{}"),
@@ -309,6 +328,7 @@ describe("streamCommitImport — happy path", () => {
           data: new TextEncoder().encode("sk-ant-2"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const received: Array<{ account: string; value: string }> = [];
@@ -381,10 +401,15 @@ describe("streamCommitImport — failure modes", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/a.txt",
           data: new TextEncoder().encode("hello"),
         },
       ],
+      ...defaultV1Options(),
     });
     const noManifest = removeEntry(archive, "manifest.json");
 
@@ -412,20 +437,20 @@ describe("streamCommitImport — failure modes", () => {
     // Build a valid bundle with one file whose data is 32 bytes long.
     const body = new TextEncoder().encode("x".repeat(32));
     const { archive } = buildVBundle({
-      files: [{ path: "workspace/victim.txt", data: body }],
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        { path: "workspace/victim.txt", data: body },
+      ],
+      ...defaultV1Options(),
     });
 
-    // Tamper the manifest sha256 for workspace/victim.txt by substituting
-    // one hex character. Keeps the manifest valid (the substitution is
-    // same-length) — but because manifest_sha256 is recomputed over the
-    // declared data, we ALSO need to tamper manifest_sha256 to keep the
-    // manifest itself valid. Otherwise the manifest will fail its
-    // self-checksum and the test exercises the wrong path.
-    //
-    // Easier approach: build a NEW valid manifest that declares the wrong
-    // hash for victim.txt. We hand-rebuild the archive via
-    // `dropFromManifestAndRepack`-style logic: replace the existing entry
-    // in manifest.files with a different sha256, recompute manifest_sha256.
+    // Tamper the per-file sha256 for workspace/victim.txt by substituting
+    // one hex character. Keeps the manifest schema-valid (substitution is
+    // same-length) — but because the v1 `checksum` is recomputed over the
+    // declared data, we ALSO need to recompute `checksum` (with the empty
+    // placeholder) to keep the manifest itself valid. Otherwise the
+    // manifest fails its self-checksum and the test exercises the wrong
+    // path.
     const raw = gunzipSync(archive);
     const sizeStr = new TextDecoder()
       .decode(raw.subarray(124, 136))
@@ -436,11 +461,11 @@ describe("streamCommitImport — failure modes", () => {
       raw.subarray(512, 512 + origSize),
     );
     const manifest = JSON.parse(manifestJson) as {
-      files: Array<{ path: string; sha256: string; size: number }>;
-      manifest_sha256: string;
+      contents: Array<{ path: string; sha256: string; size_bytes: number }>;
+      checksum: string;
       [k: string]: unknown;
     };
-    manifest.files = manifest.files.map((f) =>
+    manifest.contents = manifest.contents.map((f) =>
       f.path === "workspace/victim.txt"
         ? {
             ...f,
@@ -449,9 +474,11 @@ describe("streamCommitImport — failure modes", () => {
           }
         : f,
     );
-    const withoutChecksum: Record<string, unknown> = { ...manifest };
-    delete withoutChecksum.manifest_sha256;
-    manifest.manifest_sha256 = sha256Hex(canonicalizeJson(withoutChecksum));
+    const withEmptyChecksum: Record<string, unknown> = {
+      ...manifest,
+      checksum: "",
+    };
+    manifest.checksum = sha256Hex(canonicalizeJson(withEmptyChecksum));
 
     const newJson = JSON.stringify(manifest);
     const newBytes = new TextEncoder().encode(newJson);
@@ -489,6 +516,10 @@ describe("streamCommitImport — failure modes", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/present.txt",
           data: new TextEncoder().encode("here"),
         },
@@ -497,6 +528,7 @@ describe("streamCommitImport — failure modes", () => {
           data: new TextEncoder().encode("gone"),
         },
       ],
+      ...defaultV1Options(),
     });
     const stripped = removeEntry(archive, "workspace/missing.txt");
 
@@ -526,6 +558,10 @@ describe("streamCommitImport — failure modes", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/declared.txt",
           data: new TextEncoder().encode("fine"),
         },
@@ -534,6 +570,7 @@ describe("streamCommitImport — failure modes", () => {
           data: new TextEncoder().encode("surprise"),
         },
       ],
+      ...defaultV1Options(),
     });
     const extraPresent = dropFromManifestAndRepack(
       archive,
@@ -569,11 +606,14 @@ describe("streamCommitImport — failure modes", () => {
  */
 function writeLargeFixtureToDisk(archivePath: string): void {
   const CHUNK = 25 * 1024 * 1024;
-  const files = [0, 1, 2, 3].map((i) => ({
-    path: `workspace/big-${i}.bin`,
-    data: new Uint8Array(CHUNK).fill(0x41 + i),
-  }));
-  const { archive } = buildVBundle({ files });
+  const files = [
+    { path: "data/db/assistant.db", data: new Uint8Array() },
+    ...[0, 1, 2, 3].map((i) => ({
+      path: `workspace/big-${i}.bin`,
+      data: new Uint8Array(CHUNK).fill(0x41 + i),
+    })),
+  ];
+  const { archive } = buildVBundle({ files, ...defaultV1Options() });
   writeFileSync(archivePath, archive);
 }
 
@@ -641,6 +681,10 @@ describe("streamCommitImport — report parity with commitImport", () => {
 
     const files = [
       {
+        path: "data/db/assistant.db",
+        data: new Uint8Array(),
+      },
+      {
         path: "workspace/a.txt",
         data: new TextEncoder().encode("alpha"),
       },
@@ -649,7 +693,7 @@ describe("streamCommitImport — report parity with commitImport", () => {
         data: new TextEncoder().encode("beta beta"),
       },
     ];
-    const { archive } = buildVBundle({ files });
+    const { archive } = buildVBundle({ files, ...defaultV1Options() });
 
     // Buffer-based path.
     mkdirSync(bufferWorkspace, { recursive: true });
@@ -689,8 +733,8 @@ describe("streamCommitImport — report parity with commitImport", () => {
 
       // Manifest payload itself should match — the streaming path parses it
       // directly from the same bytes.
-      expect(streamResult.report.manifest.manifest_sha256).toBe(
-        bufferResult.report.manifest.manifest_sha256,
+      expect(streamResult.report.manifest.checksum).toBe(
+        bufferResult.report.manifest.checksum,
       );
     } finally {
       for (const ws of [bufferWorkspace, streamWorkspace]) {
@@ -746,10 +790,15 @@ describe("streamCommitImport — no workspace entries means no swap", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "credentials/openai-key",
           data: new TextEncoder().encode("sk-test-creds-only"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const received: Array<{ account: string; value: string }> = [];
@@ -779,9 +828,14 @@ describe("streamCommitImport — no workspace entries means no swap", () => {
       { account: "openai-key", value: "sk-test-creds-only" },
     ]);
 
-    // Report should reflect "nothing imported into the workspace".
-    expect(result.report.summary.files_created).toBe(0);
+    // Report should reflect "only the synthetic data/db/assistant.db
+    // landed; no `workspace/*` entries were written".
+    expect(result.report.summary.files_created).toBe(1);
     expect(result.report.summary.files_overwritten).toBe(0);
+    expect(
+      result.report.files.find((f) => f.path === "data/db/assistant.db")
+        ?.action,
+    ).toBe("created");
 
     // Cleanup removed the temp dir — no sibling left behind.
     const parent = join(workspaceDir, "..");
@@ -818,10 +872,15 @@ describe("streamCommitImport — no workspace entries means no swap", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/something.txt",
           data: new TextEncoder().encode("ignored"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     try {
@@ -881,10 +940,15 @@ describe("streamCommitImport — config sanitization parity", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/config.json",
           data: new TextEncoder().encode(tainted),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -970,6 +1034,10 @@ describe("streamCommitImport — legacy USER.md skip on customized persona", () 
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "prompts/USER.md",
           data: legacyContent,
         },
@@ -981,6 +1049,7 @@ describe("streamCommitImport — legacy USER.md skip on customized persona", () 
           data: new TextEncoder().encode("other content"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -1049,43 +1118,11 @@ describe("streamCommitImport — preserves live workspace paths when bundle omit
     }
   });
 
-  test("keeps the live data/db/assistant.db when the bundle omits data/db/*", async () => {
-    // Seed the live workspace with a fake SQLite DB whose contents we
-    // can identify post-import.
-    mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
-    const dbContent = Buffer.from("SQLite-format-3\0live-db-payload");
-    writeFileSync(join(workspaceDir, "data", "db", "assistant.db"), dbContent);
-
-    // A bundle that writes a config file but carries nothing under
-    // workspace/data/db/.
-    const { archive } = buildVBundle({
-      files: [
-        {
-          path: "workspace/skills/example.md",
-          data: new TextEncoder().encode("# skill\n"),
-        },
-      ],
-    });
-
-    const result = await streamCommitImport({
-      source: readableFrom(archive),
-      pathResolver: new DefaultPathResolver(workspaceDir),
-      workspaceDir,
-    });
-
-    expect(result.ok).toBe(true);
-    if (!result.ok) throw new Error("unreachable");
-
-    // Live DB survived the atomic swap with its exact original bytes.
-    const postDbPath = join(workspaceDir, "data", "db", "assistant.db");
-    expect(existsSync(postDbPath)).toBe(true);
-    expect(readFileSync(postDbPath)).toEqual(dbContent);
-
-    // The bundle-provided file also landed.
-    expect(
-      readFileSync(join(workspaceDir, "skills", "example.md"), "utf8"),
-    ).toBe("# skill\n");
-  });
+  // Note: the prior "bundle omits data/db/*" preserve test was retired
+  // when the v1 manifest schema started requiring `data/db/assistant.db`
+  // (or its `workspace/`-prefixed counterpart) to be present. Under v1
+  // every bundle declares the DB, so the bundle-omits-DB scenario is no
+  // longer reachable through the public emit path.
 
   test("keeps the live data/qdrant/ directory when the bundle omits qdrant entries", async () => {
     // Populate a fake qdrant store with a nested file.
@@ -1101,10 +1138,15 @@ describe("streamCommitImport — preserves live workspace paths when bundle omit
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/config.json",
           data: new TextEncoder().encode("{}"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -1145,6 +1187,7 @@ describe("streamCommitImport — preserves live workspace paths when bundle omit
           data: newDbBytes,
         },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -1217,6 +1260,7 @@ describe("streamCommitImport — legacy-only bundle writes in place", () => {
           data: newDbBytes,
         },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -1314,6 +1358,10 @@ describe("streamCommitImport — preserved-path carry-over is per-file", () => {
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/data/qdrant/meta.json",
           data: newMeta,
         },
@@ -1322,6 +1370,7 @@ describe("streamCommitImport — preserved-path carry-over is per-file", () => {
           data: new TextEncoder().encode("marker\n"),
         },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -1408,10 +1457,15 @@ describe("streamCommitImport — bundle resource ceilings", () => {
     // declared-count check trips before any tar entry is processed.
     const { archive } = buildVBundle({
       files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
         { path: "workspace/a.txt", data: new TextEncoder().encode("a") },
         { path: "workspace/b.txt", data: new TextEncoder().encode("b") },
         { path: "workspace/c.txt", data: new TextEncoder().encode("c") },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -1443,9 +1497,14 @@ describe("streamCommitImport — bundle resource ceilings", () => {
     const big = new Uint8Array(100).fill(0x41);
     const { archive } = buildVBundle({
       files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
         { path: "workspace/big1.bin", data: big },
         { path: "workspace/big2.bin", data: big },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({
@@ -1506,10 +1565,15 @@ describe("streamCommitImport — report.sha256 reflects post-sanitization bytes"
     const { archive } = buildVBundle({
       files: [
         {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
           path: "workspace/config.json",
           data: rawArchiveBytes,
         },
       ],
+      ...defaultV1Options(),
     });
 
     const result = await streamCommitImport({

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-validator.test.ts
@@ -27,7 +27,11 @@ import {
   parseVBundleStream,
   type StreamedTarEntry,
 } from "../vbundle-tar-stream.js";
-import { computeManifestSha256 } from "../vbundle-validator.js";
+import {
+  computeLegacyManifestSha256,
+  computeManifestChecksum,
+} from "../vbundle-validator.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -136,15 +140,19 @@ async function firstEntryOf(
 // ---------------------------------------------------------------------------
 
 describe("readAndValidateManifest — happy path", () => {
-  test("parses manifest and populates expected map from manifest.files", async () => {
+  test("parses manifest and populates expected map from manifest.contents", async () => {
     const fileA = new TextEncoder().encode("alpha payload\n");
     const fileB = new TextEncoder().encode("beta payload\n");
     const { archive, manifest } = buildVBundle({
       files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
         { path: "workspace/a.txt", data: fileA },
         { path: "workspace/b.txt", data: fileB },
       ],
-      source: "test",
+      ...defaultV1Options(),
     });
 
     const { entry, drainRest } = await firstEntryOf(archive);
@@ -152,19 +160,20 @@ describe("readAndValidateManifest — happy path", () => {
     await drainRest();
 
     expect(result.manifest.schema_version).toBe(manifest.schema_version);
-    expect(result.manifest.files).toHaveLength(2);
-    expect(result.manifest.manifest_sha256).toBe(manifest.manifest_sha256);
+    // Includes the synthetic data/db/assistant.db entry plus a/b.txt.
+    expect(result.manifest.contents).toHaveLength(3);
+    expect(result.manifest.checksum).toBe(manifest.checksum);
 
-    expect(result.expected.size).toBe(2);
+    expect(result.expected.size).toBe(3);
     const expectA = result.expected.get("workspace/a.txt");
     expect(expectA?.size).toBe(fileA.length);
     expect(expectA?.sha256).toBe(
-      manifest.files.find((f) => f.path === "workspace/a.txt")?.sha256,
+      manifest.contents.find((f) => f.path === "workspace/a.txt")?.sha256,
     );
     const expectB = result.expected.get("workspace/b.txt");
     expect(expectB?.size).toBe(fileB.length);
     expect(expectB?.sha256).toBe(
-      manifest.files.find((f) => f.path === "workspace/b.txt")?.sha256,
+      manifest.contents.find((f) => f.path === "workspace/b.txt")?.sha256,
     );
   });
 });
@@ -283,13 +292,33 @@ describe("readAndValidateManifest — negative paths", () => {
 
   test("throws manifest_sha256 when the declared digest doesn't match canonical JSON", async () => {
     const badManifest = {
-      schema_version: "1.0",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000000",
       created_at: new Date().toISOString(),
-      files: [],
-      // Deliberately wrong digest. The canonical hash of a 4-field manifest
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
+        {
+          path: "data/db/assistant.db",
+          sha256:
+            "1111111111111111111111111111111111111111111111111111111111111111",
+          size_bytes: 10,
+        },
+      ],
+      // Deliberately wrong digest. The canonical hash of a v1 manifest
       // won't match this, regardless of ordering.
-      manifest_sha256:
+      checksum:
         "0000000000000000000000000000000000000000000000000000000000000000",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
     const archive = buildRawVBundle([
       {
@@ -313,27 +342,41 @@ describe("readAndValidateManifest — negative paths", () => {
 
   test("throws manifest_duplicate_path when the same archive path appears twice", async () => {
     const baseManifest = {
-      schema_version: "1.0",
+      schema_version: 1,
+      bundle_id: "00000000-0000-4000-8000-000000000001",
       created_at: new Date().toISOString(),
-      files: [
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
         {
-          path: "workspace/a.txt",
+          path: "data/db/assistant.db",
           sha256:
             "1111111111111111111111111111111111111111111111111111111111111111",
-          size: 10,
+          size_bytes: 10,
         },
         {
-          // Deliberately duplicate path — malicious bundle could exploit this
-          // to bypass per-entry integrity checks if we silently collapsed.
-          path: "workspace/a.txt",
+          // Deliberately duplicate path — malicious bundle could exploit
+          // this to bypass per-entry integrity checks if we silently
+          // collapsed.
+          path: "data/db/assistant.db",
           sha256:
             "2222222222222222222222222222222222222222222222222222222222222222",
-          size: 20,
+          size_bytes: 20,
         },
       ],
-      manifest_sha256: "",
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
     };
-    baseManifest.manifest_sha256 = computeManifestSha256(baseManifest);
+    baseManifest.checksum = computeManifestChecksum(baseManifest);
 
     const archive = buildRawVBundle([
       {
@@ -353,7 +396,7 @@ describe("readAndValidateManifest — negative paths", () => {
 
     expect(err).toBeInstanceOf(StreamingValidationError);
     expect(err?.code).toBe("manifest_duplicate_path");
-    expect(err?.message).toContain("workspace/a.txt");
+    expect(err?.message).toContain("data/db/assistant.db");
   });
 });
 
@@ -449,5 +492,82 @@ describe("createHashVerifier — identity + integrity", () => {
     expect(err).toBeInstanceOf(StreamingValidationError);
     expect(err?.code).toBe("entry_size");
     expect(err?.archivePath).toBe("workspace/bad-size.txt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readAndValidateManifest — legacy fallback (backwards compatibility)
+// ---------------------------------------------------------------------------
+
+describe("readAndValidateManifest — legacy fallback", () => {
+  test("accepts a valid legacy six-field manifest and translates to v1 shape", async () => {
+    const dbBytes = new TextEncoder().encode("legacy-db");
+    const dbSha = createHash("sha256").update(dbBytes).digest("hex");
+
+    const legacyManifest: Record<string, unknown> = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      source: "runtime-export",
+      description: "legacy fixture",
+      files: [
+        { path: "data/db/assistant.db", sha256: dbSha, size: dbBytes.length },
+      ],
+      manifest_sha256: "",
+    };
+    legacyManifest.manifest_sha256 =
+      computeLegacyManifestSha256(legacyManifest);
+
+    const archive = buildRawVBundle([
+      {
+        name: "manifest.json",
+        data: new TextEncoder().encode(JSON.stringify(legacyManifest)),
+      },
+      { name: "data/db/assistant.db", data: dbBytes },
+    ]);
+
+    const { entry, drainRest } = await firstEntryOf(archive);
+    const result = await readAndValidateManifest(entry);
+    await drainRest();
+
+    expect(result.manifest.schema_version).toBe(1);
+    expect(result.manifest.contents).toHaveLength(1);
+    expect(result.manifest.contents[0]?.path).toBe("data/db/assistant.db");
+    expect(result.manifest.contents[0]?.size_bytes).toBe(dbBytes.length);
+    expect(result.expected.get("data/db/assistant.db")?.sha256).toBe(dbSha);
+  });
+
+  test("throws manifest_sha256 on a legacy manifest with a wrong checksum", async () => {
+    const dbBytes = new TextEncoder().encode("legacy-db");
+    const dbSha = createHash("sha256").update(dbBytes).digest("hex");
+
+    const badLegacy = {
+      schema_version: "1.0",
+      created_at: new Date().toISOString(),
+      files: [
+        { path: "data/db/assistant.db", sha256: dbSha, size: dbBytes.length },
+      ],
+      // Deliberately wrong checksum.
+      manifest_sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    };
+
+    const archive = buildRawVBundle([
+      {
+        name: "manifest.json",
+        data: new TextEncoder().encode(JSON.stringify(badLegacy)),
+      },
+    ]);
+    const { entry, drainRest } = await firstEntryOf(archive);
+
+    let err: StreamingValidationError | null = null;
+    try {
+      await readAndValidateManifest(entry);
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+    await drainRest();
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("manifest_sha256");
   });
 });

--- a/assistant/src/runtime/migrations/__tests__/vbundle-tar-stream.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-tar-stream.test.ts
@@ -19,6 +19,7 @@ import {
   parseVBundleStream,
   type StreamedTarEntry,
 } from "../vbundle-tar-stream.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -46,8 +47,7 @@ function buildMinimalVBundle(
 ): Uint8Array {
   const { archive } = buildVBundle({
     files: extraFiles,
-    source: "test",
-    description: "test bundle",
+    ...defaultV1Options(),
   });
   return archive;
 }

--- a/assistant/src/runtime/migrations/__tests__/vbundle-validator-v1-schema.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-validator-v1-schema.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for the v1-tightened `validateVBundle` schema.
+ *
+ * Covers:
+ *   - Accepts a v1 ten-field manifest produced by `buildVBundle`.
+ *   - Rejects every legacy six-field manifest shape.
+ *   - Rejects when `schema_version` is anything other than `1`.
+ *   - Enforces the managed-mode redaction `.refine()` (`origin.mode === "managed" ⇒ secrets_redacted === true`).
+ *   - Enforces the `data/db/assistant.db`-in-contents `.refine()`.
+ *   - Rejects when the declared `checksum` doesn't match the recomputed self-checksum.
+ */
+
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../vbundle-builder.js";
+import {
+  canonicalizeJson,
+  computeLegacyManifestSha256,
+  computeManifestChecksum,
+  validateVBundle,
+} from "../vbundle-validator.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Tar helpers — minimum-viable to wrap a manifest object into a vbundle.
+// ---------------------------------------------------------------------------
+
+const BLOCK = 512;
+
+function padToBlock(data: Uint8Array): Uint8Array {
+  const r = data.length % BLOCK;
+  if (r === 0) return data;
+  const out = new Uint8Array(data.length + (BLOCK - r));
+  out.set(data);
+  return out;
+}
+
+function writeOctal(
+  buf: Uint8Array,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const s = value.toString(8).padStart(length - 1, "0");
+  for (let i = 0; i < s.length; i++) buf[offset + i] = s.charCodeAt(i);
+  buf[offset + length - 1] = 0;
+}
+
+function tarEntry(name: string, data: Uint8Array): Uint8Array {
+  const enc = new TextEncoder();
+  const header = new Uint8Array(BLOCK);
+  header.set(enc.encode(name).subarray(0, 100), 0);
+  writeOctal(header, 100, 8, 0o644);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, data.length);
+  writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+  header[156] = "0".charCodeAt(0);
+  header.set(enc.encode("ustar\0"), 257);
+  header[263] = "0".charCodeAt(0);
+  header[264] = "0".charCodeAt(0);
+  let sum = 0;
+  for (let i = 0; i < BLOCK; i++) {
+    sum += i >= 148 && i < 156 ? 0x20 : header[i];
+  }
+  writeOctal(header, 148, 7, sum);
+  header[155] = 0x20;
+  const padded = padToBlock(data);
+  const out = new Uint8Array(header.length + padded.length);
+  out.set(header, 0);
+  out.set(padded, header.length);
+  return out;
+}
+
+function tarArchive(
+  entries: Array<{ name: string; data: Uint8Array }>,
+): Uint8Array {
+  const parts: Uint8Array[] = entries.map((e) => tarEntry(e.name, e.data));
+  parts.push(new Uint8Array(BLOCK * 2));
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function gzipTarOf(
+  manifestObj: Record<string, unknown>,
+  files: Array<{ name: string; data: Uint8Array }> = [],
+): Uint8Array {
+  const manifestData = new TextEncoder().encode(JSON.stringify(manifestObj));
+  return gzipSync(
+    tarArchive([{ name: "manifest.json", data: manifestData }, ...files]),
+  );
+}
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+const DB_BYTES = new TextEncoder().encode("db-bytes");
+
+function v1Skeleton(): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
+    created_at: "2026-04-01T00:00:00Z",
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents: [
+      {
+        path: "data/db/assistant.db",
+        sha256: sha256Hex(DB_BYTES),
+        size_bytes: DB_BYTES.length,
+      },
+    ],
+    checksum: "",
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  };
+}
+
+function withChecksum(
+  manifest: Record<string, unknown>,
+): Record<string, unknown> {
+  const checksum = computeManifestChecksum(manifest);
+  return { ...manifest, checksum };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ManifestSchema — v1 acceptance", () => {
+  test("accepts a freshly-built v1 manifest from buildVBundle", () => {
+    const { archive } = buildVBundle({
+      files: [{ path: "data/db/assistant.db", data: DB_BYTES }],
+      ...defaultV1Options(),
+    });
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(true);
+    expect(result.manifest?.schema_version).toBe(1);
+  });
+
+  test("accepts when origin.mode === 'managed' and secrets_redacted === true", () => {
+    const manifest = withChecksum({
+      ...v1Skeleton(),
+      origin: { mode: "managed" },
+      secrets_redacted: true,
+    });
+    const archive = gzipTarOf(manifest, [
+      { name: "data/db/assistant.db", data: DB_BYTES },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(true);
+  });
+});
+
+describe("ManifestSchema — v1 rejection", () => {
+  test("rejects schema_version !== 1", () => {
+    const manifest = withChecksum({ ...v1Skeleton(), schema_version: 2 });
+    const archive = gzipTarOf(manifest, [
+      { name: "data/db/assistant.db", data: DB_BYTES },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(false);
+  });
+
+  test("rejects managed mode with secrets_redacted=false", () => {
+    const manifest = withChecksum({
+      ...v1Skeleton(),
+      origin: { mode: "managed" },
+      secrets_redacted: false,
+    });
+    const archive = gzipTarOf(manifest, [
+      { name: "data/db/assistant.db", data: DB_BYTES },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(false);
+  });
+
+  test("rejects manifest whose contents lacks data/db/assistant.db", () => {
+    const manifest = withChecksum({
+      ...v1Skeleton(),
+      contents: [
+        {
+          path: "config/settings.json",
+          sha256: sha256Hex(new TextEncoder().encode("{}")),
+          size_bytes: 2,
+        },
+      ],
+    });
+    const archive = gzipTarOf(manifest);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(false);
+  });
+
+  test("rejects a checksum that does not match the recomputed self-checksum", () => {
+    // Build a structurally valid manifest but tamper with `checksum` after
+    // computing it so the validator's recomputation fails.
+    const valid = withChecksum(v1Skeleton());
+    const tampered = {
+      ...valid,
+      // Twiddle one byte; still 64 hex chars so the schema accepts it,
+      // but the recomputation rejects it.
+      checksum:
+        (valid.checksum as string).slice(0, -1) +
+        ((valid.checksum as string).slice(-1) === "0" ? "1" : "0"),
+    };
+    const archive = gzipTarOf(tampered, [
+      { name: "data/db/assistant.db", data: DB_BYTES },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.code === "MANIFEST_CHECKSUM_MISMATCH"),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy six-field manifest fallback — required for backwards compatibility
+// with on-disk bundles produced by pre-v1 runtimes (backup snapshots,
+// cross-version migration artifacts). AGENTS.md prohibits silent breaks of
+// persisted state.
+// ---------------------------------------------------------------------------
+
+function legacySkeleton(
+  files: Array<{ path: string; sha256: string; size: number }>,
+): Record<string, unknown> {
+  return {
+    schema_version: "1.0",
+    created_at: new Date().toISOString(),
+    source: "runtime-export",
+    description: "legacy fixture",
+    files,
+    manifest_sha256: "",
+  };
+}
+
+function withLegacyChecksum(
+  manifest: Record<string, unknown>,
+): Record<string, unknown> {
+  // `computeLegacyManifestSha256` strips the field internally before
+  // canonicalizing, so passing the manifest in unmodified is correct.
+  const manifest_sha256 = computeLegacyManifestSha256(manifest);
+  return { ...manifest, manifest_sha256 };
+}
+
+describe("ManifestSchema — legacy fallback (backwards compatibility)", () => {
+  test("accepts a valid legacy six-field manifest", () => {
+    const legacy = withLegacyChecksum(
+      legacySkeleton([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(DB_BYTES),
+          size: DB_BYTES.length,
+        },
+      ]),
+    );
+    const archive = gzipTarOf(legacy, [
+      { name: "data/db/assistant.db", data: DB_BYTES },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(true);
+  });
+
+  test("rejects a legacy manifest with a wrong manifest_sha256", () => {
+    const legacy = {
+      ...legacySkeleton([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(DB_BYTES),
+          size: DB_BYTES.length,
+        },
+      ]),
+      // Deliberately wrong checksum.
+      manifest_sha256:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    };
+    const archive = gzipTarOf(legacy, [
+      { name: "data/db/assistant.db", data: DB_BYTES },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(false);
+    expect(
+      result.errors.some((e) => e.code === "MANIFEST_CHECKSUM_MISMATCH"),
+    ).toBe(true);
+  });
+
+  test("translator surfaces a v1 ManifestType to downstream consumers", () => {
+    const legacy = withLegacyChecksum(
+      legacySkeleton([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(DB_BYTES),
+          size: DB_BYTES.length,
+        },
+      ]),
+    );
+    const archive = gzipTarOf(legacy, [
+      { name: "data/db/assistant.db", data: DB_BYTES },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(true);
+    expect(result.manifest).toBeDefined();
+    // Translation fills in v1 fields and renames legacy fields.
+    expect(result.manifest?.schema_version).toBe(1);
+    expect(result.manifest?.contents).toHaveLength(1);
+    expect(result.manifest?.contents[0]?.path).toBe("data/db/assistant.db");
+    expect(result.manifest?.contents[0]?.size_bytes).toBe(DB_BYTES.length);
+    expect(result.manifest?.contents[0]?.sha256).toBe(sha256Hex(DB_BYTES));
+    // Conservative defaults so the v1 refines never trip.
+    expect(result.manifest?.origin.mode).toBe("self-hosted-local");
+    expect(result.manifest?.secrets_redacted).toBe(false);
+  });
+
+  test("legacy manifest with corrupted file payload still flags FILE_CHECKSUM_MISMATCH", () => {
+    // Verifies the per-file integrity pipeline runs on translated legacy
+    // bundles too — translation must preserve `files` → `contents` /
+    // `size` → `size_bytes` so verification works uniformly.
+    const legacy = withLegacyChecksum(
+      legacySkeleton([
+        {
+          path: "data/db/assistant.db",
+          sha256: sha256Hex(DB_BYTES),
+          size: DB_BYTES.length,
+        },
+      ]),
+    );
+    const corruptedDb = new TextEncoder().encode("not-the-real-db-bytes");
+    const archive = gzipTarOf(legacy, [
+      { name: "data/db/assistant.db", data: corruptedDb },
+    ]);
+    const result = validateVBundle(archive);
+    expect(result.is_valid).toBe(false);
+    expect(result.errors.some((e) => e.code === "FILE_CHECKSUM_MISMATCH")).toBe(
+      true,
+    );
+  });
+});
+
+// Exercise canonicalizeJson + computeManifestChecksum themselves to keep the
+// helpers from rotting if signatures change.
+describe("computeManifestChecksum helper", () => {
+  test("ignores the existing checksum value when computing the canonical form", () => {
+    const a = withChecksum(v1Skeleton());
+    const b = withChecksum({ ...v1Skeleton(), checksum: "deadbeef" });
+    // Both inputs canonicalize to the same form (checksum field replaced by
+    // empty string), so both produce the same checksum.
+    expect(a.checksum).toBe(b.checksum);
+    // Sanity: the same canonicalization explanation as in the validator.
+    const expected = sha256Hex(
+      canonicalizeJson({ ...v1Skeleton(), checksum: "" }),
+    );
+    expect(a.checksum).toBe(expected);
+  });
+});

--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -64,16 +64,43 @@ export interface ValidationError {
 export interface ManifestFileEntry {
   path: string;
   sha256: string;
-  size: number;
+  size_bytes: number;
+}
+
+export interface ManifestAssistantInfo {
+  id: string;
+  name: string;
+  runtime_version: string;
+}
+
+export interface ManifestOrigin {
+  mode: "managed" | "self-hosted-remote" | "self-hosted-local";
+  platform_version?: string;
+  hostname?: string;
+}
+
+export interface ManifestCompatibility {
+  min_runtime_version: string;
+  max_runtime_version: string | null;
+}
+
+export interface ManifestExportOptions {
+  include_logs: boolean;
+  include_browser_state: boolean;
+  include_memory_vectors: boolean;
 }
 
 export interface Manifest {
-  schema_version: string;
+  schema_version: number;
+  bundle_id: string;
   created_at: string;
-  source?: string;
-  description?: string;
-  files: ManifestFileEntry[];
-  manifest_sha256: string;
+  assistant: ManifestAssistantInfo;
+  origin: ManifestOrigin;
+  compatibility: ManifestCompatibility;
+  contents: ManifestFileEntry[];
+  checksum: string;
+  secrets_redacted: boolean;
+  export_options: ManifestExportOptions;
 }
 
 // ---------------------------------------------------------------------------
@@ -104,8 +131,8 @@ export interface ExportRuntimeResult {
   ok: true;
   archive: ArrayBuffer;
   filename: string;
-  schemaVersion: string;
-  manifestSha256: string;
+  schemaVersion: number;
+  checksum: string;
 }
 
 /** Managed export initiates an async job and returns a job ID. */
@@ -398,8 +425,14 @@ export async function exportBundle(
     } as ExportManagedResult;
   }
 
-  // Runtime returns the binary archive
+  // Runtime returns the binary archive. The legacy
+  // `X-Vbundle-Manifest-Sha256` response header name is preserved for
+  // cross-version client compat — its value is now sourced from the
+  // renamed manifest `checksum` field.
   const archive = await response.arrayBuffer();
+  const schemaVersionHeader =
+    response.headers.get("X-Vbundle-Schema-Version") ?? "";
+  const parsedSchemaVersion = Number.parseInt(schemaVersionHeader, 10);
   return {
     ok: true,
     archive,
@@ -407,10 +440,10 @@ export async function exportBundle(
       response.headers
         .get("Content-Disposition")
         ?.match(/filename="?(.+?)"?$/)?.[1] ?? "export.vbundle",
-    schemaVersion:
-      response.headers.get("X-Vbundle-Schema-Version") ?? "unknown",
-    manifestSha256:
-      response.headers.get("X-Vbundle-Manifest-Sha256") ?? "unknown",
+    schemaVersion: Number.isFinite(parsedSchemaVersion)
+      ? parsedSchemaVersion
+      : 0,
+    checksum: response.headers.get("X-Vbundle-Manifest-Sha256") ?? "",
   } as ExportRuntimeResult;
 }
 

--- a/assistant/src/runtime/migrations/migration-wizard.ts
+++ b/assistant/src/runtime/migrations/migration-wizard.ts
@@ -85,8 +85,8 @@ export interface MigrationWizardState {
     | {
         ok: true;
         filename: string;
-        schemaVersion: string;
-        manifestSha256: string;
+        schemaVersion: number;
+        checksum: string;
       };
 
   /** Import commit result. */

--- a/assistant/src/runtime/migrations/origin-mode.ts
+++ b/assistant/src/runtime/migrations/origin-mode.ts
@@ -1,0 +1,40 @@
+/**
+ * Origin-mode derivation for vbundle exports.
+ *
+ * The vbundle manifest v1 schema's `origin.mode` enum captures the deployment
+ * shape that produced the bundle. The runtime's two underlying signals are:
+ *
+ *   - `hasManagedProxyPrereqs()` — true when the daemon has the credentials
+ *     it needs to act as a managed-proxy client, i.e. this is a managed
+ *     deployment.
+ *   - `getDaemonRuntimeMode()` — `"docker"` vs `"bare-metal"`, identifying
+ *     where the daemon process is running.
+ *
+ * Folding both into a single helper keeps callers from repeating the
+ * combination logic.
+ */
+
+import { hasManagedProxyPrereqs } from "../../providers/managed-proxy/context.js";
+import { getDaemonRuntimeMode } from "../runtime-mode.js";
+
+export type VBundleOriginMode =
+  | "managed"
+  | "self-hosted-remote"
+  | "self-hosted-local";
+
+/**
+ * Returns the origin mode for the current daemon.
+ *
+ * Managed-proxy prereqs win first (a managed deployment is always
+ * "managed" regardless of where the daemon process runs); otherwise docker
+ * → "self-hosted-remote", bare-metal → "self-hosted-local".
+ */
+export async function getOriginMode(): Promise<VBundleOriginMode> {
+  if (await hasManagedProxyPrereqs()) {
+    return "managed";
+  }
+  if (getDaemonRuntimeMode() === "docker") {
+    return "self-hosted-remote";
+  }
+  return "self-hosted-local";
+}

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -362,7 +362,7 @@ function buildManifestObject(input: {
  * Build a .vbundle archive from the given files and metadata.
  *
  * Generates a valid manifest with SHA-256 checksums for all files and
- * a self-referencing manifest_sha256 checksum. The archive is returned
+ * a self-referencing `checksum`. The archive is returned
  * as gzip-compressed tar bytes.
  */
 export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -285,6 +285,41 @@ function createTarArchive(
 // ---------------------------------------------------------------------------
 
 /**
+ * Build the manifest object and its serialized JSON bytes for a vbundle.
+ *
+ * Shared by the buffered (`buildVBundle`) and streaming
+ * (`streamExportVBundle`) emit sites so the manifest shape and self-checksum
+ * computation live in exactly one place.
+ */
+function buildManifestObject(input: {
+  fileEntries: ManifestFileEntryType[];
+  schemaVersion: string;
+  source: string;
+  description: string;
+  now: Date;
+}): { manifest: ManifestType; manifestData: Uint8Array } {
+  const { fileEntries, schemaVersion, source, description, now } = input;
+
+  const manifestWithoutChecksum = {
+    schema_version: schemaVersion,
+    created_at: now.toISOString(),
+    source,
+    description,
+    files: fileEntries,
+  };
+
+  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
+  const manifest: ManifestType = {
+    ...manifestWithoutChecksum,
+    manifest_sha256: manifestSha256,
+  };
+
+  const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+
+  return { manifest, manifestData };
+}
+
+/**
  * Build a .vbundle archive from the given files and metadata.
  *
  * Generates a valid manifest with SHA-256 checksums for all files and
@@ -306,23 +341,13 @@ export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {
     size: f.data.length,
   }));
 
-  // Build manifest without the self-checksum
-  const manifestWithoutChecksum = {
-    schema_version: schemaVersion,
-    created_at: new Date().toISOString(),
+  const { manifest, manifestData } = buildManifestObject({
+    fileEntries,
+    schemaVersion,
     source,
     description,
-    files: fileEntries,
-  };
-
-  // Compute the manifest self-checksum
-  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-  const manifest: ManifestType = {
-    ...manifestWithoutChecksum,
-    manifest_sha256: manifestSha256,
-  };
-
-  const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+    now: new Date(),
+  });
 
   // Build tar entries: manifest first, then all files
   const tarEntries = [
@@ -900,21 +925,13 @@ export async function streamExportVBundle(
     });
   }
 
-  const manifestWithoutChecksum = {
-    schema_version: "1.0",
-    created_at: new Date().toISOString(),
+  const { manifest, manifestData } = buildManifestObject({
+    fileEntries,
+    schemaVersion: "1.0",
     source: source ?? "runtime-export",
     description: description ?? "Runtime export bundle",
-    files: fileEntries,
-  };
-
-  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-  const manifest: ManifestType = {
-    ...manifestWithoutChecksum,
-    manifest_sha256: manifestSha256,
-  };
-
-  const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
+    now: new Date(),
+  });
 
   // ------------------------------------------------------------------
   // Pass 2: Stream tar through gzip into a temp file

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -29,6 +29,7 @@ import { pipeline } from "node:stream/promises";
 import { createGzip, gzipSync } from "node:zlib";
 
 import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
+import type { VBundleOriginMode } from "./origin-mode.js";
 import type {
   ManifestFileEntryType,
   ManifestType,
@@ -43,15 +44,50 @@ export interface VBundleFileEntry {
   data: Uint8Array;
 }
 
+/** v1 manifest `assistant` block. */
+export interface VBundleAssistantInfo {
+  id: string;
+  name: string;
+  runtime_version: string;
+}
+
+/** v1 manifest `origin` block. */
+export interface VBundleOriginInfo {
+  mode: VBundleOriginMode;
+  platform_version?: string;
+  hostname?: string;
+}
+
+/** v1 manifest `compatibility` block. */
+export interface VBundleCompatibility {
+  min_runtime_version: string;
+  max_runtime_version: string | null;
+}
+
+/** v1 manifest `export_options` block. */
+export interface VBundleExportOptions {
+  include_logs: boolean;
+  include_browser_state: boolean;
+  include_memory_vectors: boolean;
+}
+
 export interface BuildVBundleOptions {
   /** Files to include in the archive. Must include data/db/assistant.db. */
   files: VBundleFileEntry[];
-  /** Schema version for the manifest. Defaults to "1.0". */
-  schemaVersion?: string;
-  /** Source identifier (e.g. "runtime-export"). */
-  source?: string;
-  /** Human-readable description. */
-  description?: string;
+  /** Identity of the assistant that produced this bundle. */
+  assistant: VBundleAssistantInfo;
+  /** Where this bundle was produced. */
+  origin: VBundleOriginInfo;
+  /** Runtime-version compatibility window for importers. */
+  compatibility: VBundleCompatibility;
+  /** Which optional bundle contents this export carries. */
+  exportOptions: VBundleExportOptions;
+  /**
+   * Whether secrets were stripped from the bundle before archiving.
+   * Required at the type level — defaulting silently is exactly how the
+   * prior schema mismatch went unnoticed.
+   */
+  secretsRedacted: boolean;
 }
 
 export interface BuildVBundleResult {
@@ -285,37 +321,40 @@ function createTarArchive(
 // ---------------------------------------------------------------------------
 
 /**
- * Build the manifest object and its serialized JSON bytes for a vbundle.
+ * Build the v1 manifest object and its serialized JSON bytes for a vbundle.
  *
  * Shared by the buffered (`buildVBundle`) and streaming
  * (`streamExportVBundle`) emit sites so the manifest shape and self-checksum
  * computation live in exactly one place.
+ *
+ * The checksum is computed over the canonicalized manifest with the
+ * `checksum` field set to the empty string (per the schema spec) — both
+ * producers and the validator agree on this exact wire shape.
  */
 function buildManifestObject(input: {
-  fileEntries: ManifestFileEntryType[];
-  schemaVersion: string;
-  source: string;
-  description: string;
+  contents: ManifestFileEntryType[];
+  assistant: VBundleAssistantInfo;
+  origin: VBundleOriginInfo;
+  compatibility: VBundleCompatibility;
+  exportOptions: VBundleExportOptions;
+  secretsRedacted: boolean;
   now: Date;
 }): { manifest: ManifestType; manifestData: Uint8Array } {
-  const { fileEntries, schemaVersion, source, description, now } = input;
-
-  const manifestWithoutChecksum = {
-    schema_version: schemaVersion,
-    created_at: now.toISOString(),
-    source,
-    description,
-    files: fileEntries,
+  const manifestWithEmptyChecksum = {
+    schema_version: 1 as const,
+    bundle_id: randomUUID(),
+    created_at: input.now.toISOString(),
+    assistant: input.assistant,
+    origin: input.origin,
+    compatibility: input.compatibility,
+    contents: input.contents,
+    checksum: "",
+    secrets_redacted: input.secretsRedacted,
+    export_options: input.exportOptions,
   };
-
-  const manifestSha256 = sha256Hex(canonicalizeJson(manifestWithoutChecksum));
-  const manifest: ManifestType = {
-    ...manifestWithoutChecksum,
-    manifest_sha256: manifestSha256,
-  };
-
+  const checksum = sha256Hex(canonicalizeJson(manifestWithEmptyChecksum));
+  const manifest: ManifestType = { ...manifestWithEmptyChecksum, checksum };
   const manifestData = new TextEncoder().encode(JSON.stringify(manifest));
-
   return { manifest, manifestData };
 }
 
@@ -329,23 +368,27 @@ function buildManifestObject(input: {
 export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {
   const {
     files,
-    schemaVersion = "1.0",
-    source = "runtime-export",
-    description = "Runtime export bundle",
+    assistant,
+    origin,
+    compatibility,
+    exportOptions,
+    secretsRedacted,
   } = options;
 
   // Build file entries for the manifest
   const fileEntries: ManifestFileEntryType[] = files.map((f) => ({
     path: f.path,
     sha256: sha256Hex(f.data),
-    size: f.data.length,
+    size_bytes: f.data.length,
   }));
 
   const { manifest, manifestData } = buildManifestObject({
-    fileEntries,
-    schemaVersion,
-    source,
-    description,
+    contents: fileEntries,
+    assistant,
+    origin,
+    compatibility,
+    exportOptions,
+    secretsRedacted,
     now: new Date(),
   });
 
@@ -448,10 +491,16 @@ function walkDirectory(
 // ---------------------------------------------------------------------------
 
 export interface BuildExportVBundleOptions {
-  /** Source identifier. Defaults to "runtime-export". */
-  source?: string;
-  /** Human-readable description. */
-  description?: string;
+  /** Identity of the assistant that produced this bundle. */
+  assistant: VBundleAssistantInfo;
+  /** Where this bundle was produced. */
+  origin: VBundleOriginInfo;
+  /** Runtime-version compatibility window for importers. */
+  compatibility: VBundleCompatibility;
+  /** Which optional bundle contents this export carries. */
+  exportOptions: VBundleExportOptions;
+  /** Whether secrets were stripped from the bundle before archiving. */
+  secretsRedacted: boolean;
   /** Absolute path to trust.json. If provided and the file exists, it is included in the archive. */
   trustPath?: string;
   /**
@@ -489,8 +538,11 @@ export function buildExportVBundle(
   options: BuildExportVBundleOptions,
 ): BuildVBundleResult {
   const {
-    source,
-    description,
+    assistant,
+    origin,
+    compatibility,
+    exportOptions,
+    secretsRedacted,
     checkpoint,
     trustPath,
     workspaceDir,
@@ -545,8 +597,11 @@ export function buildExportVBundle(
 
   return buildVBundle({
     files,
-    source: source ?? "runtime-export",
-    description: description ?? "Runtime export bundle",
+    assistant,
+    origin,
+    compatibility,
+    exportOptions,
+    secretsRedacted,
   });
 }
 
@@ -824,8 +879,11 @@ export async function streamExportVBundle(
   options: BuildExportVBundleOptions,
 ): Promise<StreamExportVBundleResult> {
   const {
-    source,
-    description,
+    assistant,
+    origin,
+    compatibility,
+    exportOptions,
+    secretsRedacted,
     checkpoint,
     trustPath,
     workspaceDir,
@@ -911,7 +969,7 @@ export async function streamExportVBundle(
     fileEntries.push({
       path: file.archivePath,
       sha256,
-      size: file.size,
+      size_bytes: file.size,
     });
   }
 
@@ -921,15 +979,17 @@ export async function streamExportVBundle(
     fileEntries.push({
       path: entry.archivePath,
       sha256,
-      size: entry.size,
+      size_bytes: entry.size,
     });
   }
 
   const { manifest, manifestData } = buildManifestObject({
-    fileEntries,
-    schemaVersion: "1.0",
-    source: source ?? "runtime-export",
-    description: description ?? "Runtime export bundle",
+    contents: fileEntries,
+    assistant,
+    origin,
+    compatibility,
+    exportOptions,
+    secretsRedacted,
     now: new Date(),
   });
 

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -112,7 +112,9 @@ export class DefaultPathResolver implements PathResolver {
   constructor(
     private workspaceDir?: string,
     private hooksDir?: string,
-    private guardianPersonaPathResolver: () => string | null = resolveGuardianPersonaPath,
+    private guardianPersonaPathResolver: () =>
+      | string
+      | null = resolveGuardianPersonaPath,
   ) {}
 
   resolve(archivePath: string): string | null {
@@ -247,7 +249,7 @@ export function analyzeImport(
   const files: ImportFileReport[] = [];
   const conflicts: ImportConflict[] = [];
 
-  for (const fileEntry of manifest.files) {
+  for (const fileEntry of manifest.contents) {
     const diskPath = pathResolver.resolve(fileEntry.path);
 
     // Credential entries are handled separately by the credential import
@@ -256,7 +258,7 @@ export function analyzeImport(
       files.push({
         path: fileEntry.path,
         action: "skip",
-        bundle_size: fileEntry.size,
+        bundle_size: fileEntry.size_bytes,
         bundle_sha256: fileEntry.sha256,
         current_size: null,
         current_sha256: null,
@@ -278,7 +280,7 @@ export function analyzeImport(
         files.push({
           path: fileEntry.path,
           action: "skip",
-          bundle_size: fileEntry.size,
+          bundle_size: fileEntry.size_bytes,
           bundle_sha256: fileEntry.sha256,
           current_size: null,
           current_sha256: null,
@@ -295,7 +297,7 @@ export function analyzeImport(
       files.push({
         path: fileEntry.path,
         action: "skip",
-        bundle_size: fileEntry.size,
+        bundle_size: fileEntry.size_bytes,
         bundle_sha256: fileEntry.sha256,
         current_size: null,
         current_sha256: null,
@@ -324,7 +326,7 @@ export function analyzeImport(
         files.push({
           path: fileEntry.path,
           action,
-          bundle_size: fileEntry.size,
+          bundle_size: fileEntry.size_bytes,
           bundle_sha256: fileEntry.sha256,
           current_size: currentSize,
           current_sha256: currentSha256,
@@ -344,7 +346,7 @@ export function analyzeImport(
     files.push({
       path: fileEntry.path,
       action,
-      bundle_size: fileEntry.size,
+      bundle_size: fileEntry.size_bytes,
       bundle_sha256: fileEntry.sha256,
       current_size: currentSize,
       current_sha256: currentSha256,

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -246,7 +246,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // valid disk path. This prevents path-traversal entries (e.g.
   // "workspace/../../etc/passwd") from triggering a workspace purge while
   // resolving to nothing.
-  const hasWorkspaceEntries = manifest.files.some(
+  const hasWorkspaceEntries = manifest.contents.some(
     (f) => f.path.startsWith("workspace/") && !!pathResolver.resolve(f.path),
   );
 
@@ -314,7 +314,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   const warnings: string[] = [];
   let backupsCreated = 0;
 
-  for (const fileEntry of manifest.files) {
+  for (const fileEntry of manifest.contents) {
     // Credential entries are handled separately by extractCredentialsFromBundle()
     // in migration-routes.ts — skip them silently without warnings or skip counts.
     if (fileEntry.path.startsWith("credentials/")) {
@@ -329,7 +329,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
         path: fileEntry.path,
         disk_path: "",
         action: "skipped",
-        size: fileEntry.size,
+        size: fileEntry.size_bytes,
         sha256: fileEntry.sha256,
         backup_path: null,
       });
@@ -347,7 +347,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
         path: fileEntry.path,
         disk_path: diskPath,
         action: "skipped",
-        size: fileEntry.size,
+        size: fileEntry.size_bytes,
         sha256: fileEntry.sha256,
         backup_path: null,
       });
@@ -377,7 +377,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
         path: fileEntry.path,
         disk_path: diskPath,
         action: "skipped",
-        size: fileEntry.size,
+        size: fileEntry.size_bytes,
         sha256: fileEntry.sha256,
         backup_path: null,
       });
@@ -536,7 +536,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // run (e.g. workspaceDir unset) the live metadata.json is still on
   // disk untouched — we must not rewrite it here or we would drop the
   // non-vellum entries the caller chose to keep.
-  const bundleHadMetadata = manifest.files.some(
+  const bundleHadMetadata = manifest.contents.some(
     (f) => f.path === CREDENTIAL_METADATA_ARCHIVE_PATH,
   );
   if (
@@ -595,7 +595,7 @@ export function extractCredentialsFromBundle(
   entries: Map<string, VBundleTarEntry>,
   manifest: ManifestType,
 ): Array<{ account: string; value: string }> {
-  const manifestPaths = new Set(manifest.files.map((f) => f.path));
+  const manifestPaths = new Set(manifest.contents.map((f) => f.path));
   const credentials: Array<{ account: string; value: string }> = [];
   for (const [path, entry] of entries) {
     if (path.startsWith("credentials/") && manifestPaths.has(path)) {

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -314,10 +314,10 @@ export async function streamCommitImport(
         // Entry-count ceiling check. The manifest declares every file the
         // bundle claims to contain, so one check here bounds the work the
         // importer is willing to do for this bundle.
-        if (manifest.files.length > bundleEntryCap) {
+        if (manifest.contents.length > bundleEntryCap) {
           throw new StreamingValidationError(
             "bundle_too_many_entries",
-            `bundle contains more than ${bundleEntryCap} entries (declared: ${manifest.files.length})`,
+            `bundle contains more than ${bundleEntryCap} entries (declared: ${manifest.contents.length})`,
           );
         }
         entryIndex += 1;
@@ -350,7 +350,7 @@ export async function streamCommitImport(
       // Non-file entries are either directory markers (empty body) or
       // pax-header / other metadata payloads we don't consume. Apply the
       // bundle byte cap to their tar-header size too — an attacker could
-      // otherwise keep `manifest.files` small while stuffing huge pax/other
+      // otherwise keep `manifest.contents` small while stuffing huge pax/other
       // entry bodies, draining the importer for free. Directory bodies are
       // reliably zero-sized; pax headers are measured in bytes, so this
       // check is effectively free in the happy path.

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -9,7 +9,7 @@
  * This module lets a caller validate a bundle while streaming:
  * - `readAndValidateManifest` consumes the first tar entry (which must be
  *   `manifest.json`), validates the schema, and verifies the self-referencing
- *   `manifest_sha256` against the canonicalized JSON.
+ *   `checksum` against the canonicalized JSON.
  * - `createHashVerifier` returns a passthrough `Transform` that hashes bytes
  *   flowing through it and errors the pipeline if the final digest or byte
  *   count does not match the expected values from the manifest.
@@ -38,7 +38,7 @@ import {
 
 export interface ManifestReadResult {
   manifest: ManifestType;
-  /** Fast lookup from archive path -> expected sha256 + size (from manifest.files). */
+  /** Fast lookup from archive path -> expected sha256 + size (from manifest.contents). */
   expected: Map<string, { sha256: string; size: number }>;
 }
 
@@ -78,7 +78,7 @@ const MANIFEST_MAX_BYTES = 1 * 1024 * 1024;
  *   2. Size cap (1 MiB).
  *   3. JSON parse.
  *   4. Zod schema validation.
- *   5. Self-referencing `manifest_sha256` verification against the
+ *   5. Self-referencing `checksum` verification against the
  *      canonicalized JSON (minus that field).
  *
  * On success, returns the parsed manifest plus a `Map` keyed by archive

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -24,9 +24,12 @@ import { Transform, type TransformCallback } from "node:stream";
 
 import type { StreamedTarEntry } from "./vbundle-tar-stream.js";
 import {
-  computeManifestSha256,
+  computeLegacyManifestSha256,
+  computeManifestChecksum,
+  LegacyManifestSchema,
   ManifestSchema,
   type ManifestType,
+  translateLegacyManifest,
 } from "./vbundle-validator.js";
 
 // ---------------------------------------------------------------------------
@@ -131,39 +134,58 @@ export async function readAndValidateManifest(
     );
   }
 
+  // Try the v1 schema first; fall back to the legacy six-field shape so
+  // existing on-disk bundles (backup snapshots, cross-version migrations)
+  // keep streaming-validating after upgrade. AGENTS.md prohibits silent
+  // breaks of persisted state.
   const parseResult = ManifestSchema.safeParse(manifestRaw);
-  if (!parseResult.success) {
-    const issues = parseResult.error.issues
-      .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
-      .join("; ");
-    throw new StreamingValidationError(
-      "manifest_schema",
-      `manifest.json failed schema validation: ${issues}`,
-    );
-  }
+  let manifest: ManifestType;
 
-  const manifest = parseResult.data;
-
-  // Recompute the self-referencing checksum using the exact canonicalization
-  // that vbundle-validator.ts uses. Any drift here would silently reject
-  // valid bundles produced by buildVBundle.
-  const computed = computeManifestSha256(manifestRaw);
-  if (computed !== manifest.manifest_sha256) {
-    throw new StreamingValidationError(
-      "manifest_sha256",
-      `Manifest checksum mismatch: expected ${manifest.manifest_sha256}, computed ${computed}`,
-    );
+  if (parseResult.success) {
+    manifest = parseResult.data;
+    // Recompute the self-referencing checksum using the exact canonicalization
+    // that vbundle-validator.ts uses. Any drift here would silently reject
+    // valid bundles produced by buildVBundle.
+    const computed = computeManifestChecksum(manifestRaw);
+    if (computed !== manifest.checksum) {
+      throw new StreamingValidationError(
+        "manifest_sha256",
+        `Manifest checksum mismatch: expected ${manifest.checksum}, computed ${computed}`,
+      );
+    }
+  } else {
+    const legacyParse = LegacyManifestSchema.safeParse(manifestRaw);
+    if (!legacyParse.success) {
+      const issues = parseResult.error.issues
+        .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+        .join("; ");
+      throw new StreamingValidationError(
+        "manifest_schema",
+        `manifest.json failed schema validation: ${issues}`,
+      );
+    }
+    const legacy = legacyParse.data;
+    // Verify the legacy checksum using the OLD canonicalization (strip the
+    // field entirely; do NOT replace with "").
+    const computedLegacy = computeLegacyManifestSha256(manifestRaw);
+    if (computedLegacy !== legacy.manifest_sha256) {
+      throw new StreamingValidationError(
+        "manifest_sha256",
+        `Manifest checksum mismatch: expected ${legacy.manifest_sha256}, computed ${computedLegacy}`,
+      );
+    }
+    manifest = translateLegacyManifest(legacy);
   }
 
   const expected = new Map<string, { sha256: string; size: number }>();
-  for (const file of manifest.files) {
+  for (const file of manifest.contents) {
     if (expected.has(file.path)) {
       throw new StreamingValidationError(
         "manifest_duplicate_path",
         `Manifest contains duplicate entry for path: ${file.path}`,
       );
     }
-    expected.set(file.path, { sha256: file.sha256, size: file.size });
+    expected.set(file.path, { sha256: file.sha256, size: file.size_bytes });
   }
 
   return { manifest, expected };

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -14,32 +14,179 @@
  * 4. Per-file content integrity: SHA-256 of each file matches manifest checksums
  */
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { gunzipSync } from "node:zlib";
 
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
-// Manifest schema
+// Manifest schema (v1)
 // ---------------------------------------------------------------------------
 
 const ManifestFileEntry = z.object({
+  path: z.string().min(1),
+  sha256: z.string().regex(/^[0-9a-f]{64}$/),
+  size_bytes: z.number().int().nonnegative(),
+});
+
+const AssistantInfo = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  runtime_version: z.string().min(1),
+});
+
+const Origin = z.object({
+  mode: z.enum(["managed", "self-hosted-remote", "self-hosted-local"]),
+  platform_version: z.string().optional(),
+  hostname: z.string().optional(),
+});
+
+const Compatibility = z.object({
+  min_runtime_version: z.string().min(1),
+  max_runtime_version: z.string().nullable(),
+});
+
+const ExportOptions = z.object({
+  include_logs: z.boolean(),
+  include_browser_state: z.boolean(),
+  include_memory_vectors: z.boolean(),
+});
+
+export const ManifestSchema = z
+  .object({
+    schema_version: z.literal(1),
+    bundle_id: z.string().uuid(),
+    created_at: z.string().datetime({ offset: true }),
+    assistant: AssistantInfo,
+    origin: Origin,
+    compatibility: Compatibility,
+    contents: z.array(ManifestFileEntry),
+    checksum: z.string().regex(/^[0-9a-f]{64}$/),
+    secrets_redacted: z.boolean(),
+    export_options: ExportOptions,
+  })
+  .refine((m) => m.origin.mode !== "managed" || m.secrets_redacted === true, {
+    message: "secrets_redacted must be true when origin.mode is 'managed'",
+    path: ["secrets_redacted"],
+  })
+  .refine(
+    (m) =>
+      m.contents.some(
+        (f) =>
+          f.path === "data/db/assistant.db" ||
+          f.path === "workspace/data/db/assistant.db",
+      ),
+    {
+      message:
+        "contents must include an entry for data/db/assistant.db (legacy format) or workspace/data/db/assistant.db (current format)",
+      path: ["contents"],
+    },
+  );
+
+export type ManifestFileEntryType = z.infer<typeof ManifestFileEntry>;
+export type ManifestType = z.infer<typeof ManifestSchema>;
+
+// ---------------------------------------------------------------------------
+// Legacy manifest schema (pre-v1, six-field shape)
+// ---------------------------------------------------------------------------
+//
+// Older runtime versions wrote a six-field manifest with `schema_version: "1.0"`,
+// `files`, `size` (per-entry), and a self-referencing `manifest_sha256` field.
+// Existing on-disk artifacts produced by those versions — backup snapshots,
+// cross-version migration bundles — must keep validating after upgrade,
+// per AGENTS.md "no silent breaks of persisted state".
+//
+// We accept legacy bundles via a fallback parse + translator so the rest of
+// the validation pipeline (per-file hash + size verification) only ever sees
+// the v1 shape.
+
+const LegacyManifestFileEntry = z.object({
   path: z.string(),
   sha256: z.string(),
   size: z.number().int().nonnegative(),
 });
 
-export const ManifestSchema = z.object({
+export const LegacyManifestSchema = z.object({
   schema_version: z.string(),
   created_at: z.string(),
   source: z.string().optional(),
   description: z.string().optional(),
-  files: z.array(ManifestFileEntry),
+  files: z.array(LegacyManifestFileEntry),
   manifest_sha256: z.string(),
 });
 
-export type ManifestFileEntryType = z.infer<typeof ManifestFileEntry>;
-export type ManifestType = z.infer<typeof ManifestSchema>;
+export type LegacyManifestType = z.infer<typeof LegacyManifestSchema>;
+
+/**
+ * Recompute the legacy `manifest_sha256` field — strips the field entirely
+ * (rather than emptying it) before canonicalizing, matching the pre-v1
+ * producer behavior. Required so legacy bundles whose checksum was computed
+ * the old way still verify after upgrade.
+ */
+export function computeLegacyManifestSha256(manifest: unknown): string {
+  const copy = { ...(manifest as Record<string, unknown>) };
+  delete copy.manifest_sha256;
+  return sha256Hex(canonicalizeJson(copy));
+}
+
+/**
+ * Coerce a legacy ISO-ish `created_at` into the v1 datetime regex shape.
+ * Pre-v1 producers always wrote `new Date().toISOString()`, which already
+ * has the `Z` suffix the v1 regex requires; this helper is defensive against
+ * any historical producer that omitted the offset/`Z`.
+ */
+function coerceLegacyCreatedAt(raw: string): string {
+  // If the string already parses as a Date, keep it as the canonical ISO form.
+  const parsed = new Date(raw);
+  if (!Number.isNaN(parsed.getTime())) {
+    // `toISOString()` always emits the `...Z` form the v1 regex accepts.
+    return parsed.toISOString();
+  }
+  return raw;
+}
+
+/**
+ * Translate a parsed legacy manifest into a v1 `ManifestType` so the rest of
+ * the validator pipeline can operate on a uniform shape.
+ *
+ * Legacy bundles never carried assistant identity, origin, compatibility, or
+ * export-option signals; we substitute conservative placeholders that satisfy
+ * the v1 schema's `.refine()` rules without misrepresenting the source bundle.
+ */
+export function translateLegacyManifest(
+  legacy: LegacyManifestType,
+): ManifestType {
+  return {
+    schema_version: 1,
+    bundle_id: randomUUID(),
+    created_at: coerceLegacyCreatedAt(legacy.created_at),
+    assistant: {
+      id: "self",
+      name: "Assistant",
+      runtime_version: "0.0.0-legacy",
+    },
+    // Legacy bundles came from the local self-hosted exporter; the
+    // conservative default is "self-hosted-local" so the v1 managed/secrets
+    // refine never trips on a translated legacy bundle.
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-legacy",
+      max_runtime_version: null,
+    },
+    contents: legacy.files.map((f) => ({
+      path: f.path,
+      sha256: f.sha256,
+      size_bytes: f.size,
+    })),
+    checksum: legacy.manifest_sha256,
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Validation result types
@@ -190,14 +337,16 @@ export function canonicalizeJson(obj: unknown): string {
 }
 
 /**
- * Recompute the `manifest_sha256` field for a manifest object. Strips the
- * `manifest_sha256` property, canonicalizes the remaining JSON, and returns
- * the SHA-256 hex digest. Centralized here so the streaming validator and
- * the in-memory validator agree on the exact canonicalization.
+ * Recompute the `checksum` field for a manifest object.
+ *
+ * The v1 schema spec says the checksum is computed over the canonicalized
+ * manifest with the `checksum` field set to the empty string (not absent),
+ * so we replace it before canonicalizing — both producers and validators
+ * must agree on this exact wire shape. Centralized here so the streaming
+ * validator and the in-memory validator agree on the exact canonicalization.
  */
-export function computeManifestSha256(manifest: unknown): string {
-  const copy = { ...(manifest as Record<string, unknown>) };
-  delete copy.manifest_sha256;
+export function computeManifestChecksum(manifest: unknown): string {
+  const copy = { ...(manifest as Record<string, unknown>), checksum: "" };
   return sha256Hex(canonicalizeJson(copy));
 }
 
@@ -293,39 +442,64 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
     return { is_valid: false, errors };
   }
 
+  // Try the v1 schema first. If that fails, fall back to the legacy six-field
+  // shape so existing on-disk bundles (backup snapshots, cross-version
+  // migrations) keep validating after upgrade. AGENTS.md prohibits silent
+  // breaks of persisted state.
   const parseResult = ManifestSchema.safeParse(manifestRaw);
-  if (!parseResult.success) {
-    for (const issue of parseResult.error.issues) {
+  let manifest: ManifestType;
+
+  if (parseResult.success) {
+    manifest = parseResult.data;
+
+    // Step 5 (v1): Verify manifest checksum — SHA-256 of canonicalized JSON
+    // with the `checksum` field replaced by an empty string.
+    const computedChecksum = computeManifestChecksum(manifestRaw);
+    if (computedChecksum !== manifest.checksum) {
       errors.push({
-        code: "MANIFEST_SCHEMA_ERROR",
-        message: `Manifest validation error at ${issue.path.join(".")}: ${
-          issue.message
-        }`,
-        path: `manifest.json/${issue.path.join(".")}`,
+        code: "MANIFEST_CHECKSUM_MISMATCH",
+        message: `Manifest checksum mismatch: expected ${manifest.checksum}, computed ${computedChecksum}`,
+        path: "manifest.json",
       });
     }
-    return { is_valid: false, errors };
-  }
+  } else {
+    const legacyParse = LegacyManifestSchema.safeParse(manifestRaw);
+    if (!legacyParse.success) {
+      // Truly malformed — surface the v1 error for the clearer error trail.
+      for (const issue of parseResult.error.issues) {
+        errors.push({
+          code: "MANIFEST_SCHEMA_ERROR",
+          message: `Manifest validation error at ${issue.path.join(".")}: ${
+            issue.message
+          }`,
+          path: `manifest.json/${issue.path.join(".")}`,
+        });
+      }
+      return { is_valid: false, errors };
+    }
 
-  const manifest = parseResult.data;
+    // Step 5 (legacy): Verify the legacy `manifest_sha256` using the OLD
+    // canonicalization (strip the field entirely; do NOT replace with "").
+    const legacy = legacyParse.data;
+    const computedLegacyChecksum = computeLegacyManifestSha256(manifestRaw);
+    if (computedLegacyChecksum !== legacy.manifest_sha256) {
+      errors.push({
+        code: "MANIFEST_CHECKSUM_MISMATCH",
+        message: `Manifest checksum mismatch: expected ${legacy.manifest_sha256}, computed ${computedLegacyChecksum}`,
+        path: "manifest.json",
+      });
+      return { is_valid: false, errors };
+    }
 
-  // Step 5: Verify manifest checksum
-  // The manifest_sha256 field is the SHA-256 of the canonicalized JSON
-  // with the manifest_sha256 field itself excluded.
-  const computedManifestSha256 = computeManifestSha256(manifestRaw);
-
-  if (computedManifestSha256 !== manifest.manifest_sha256) {
-    errors.push({
-      code: "MANIFEST_CHECKSUM_MISMATCH",
-      message: `Manifest checksum mismatch: expected ${manifest.manifest_sha256}, computed ${computedManifestSha256}`,
-      path: "manifest.json",
-    });
+    // Translate to v1 so the rest of the pipeline (per-file hash + size
+    // verification, refine rules) sees a uniform shape.
+    manifest = translateLegacyManifest(legacy);
   }
 
   // Step 6: Verify per-file content integrity
-  const manifestFilePaths = new Set(manifest.files.map((f) => f.path));
+  const manifestFilePaths = new Set(manifest.contents.map((f) => f.path));
 
-  for (const fileEntry of manifest.files) {
+  for (const fileEntry of manifest.contents) {
     const archiveEntry = entryMap.get(fileEntry.path);
     if (!archiveEntry) {
       errors.push({
@@ -337,10 +511,10 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
     }
 
     // Verify size
-    if (archiveEntry.size !== fileEntry.size) {
+    if (archiveEntry.size !== fileEntry.size_bytes) {
       errors.push({
         code: "FILE_SIZE_MISMATCH",
-        message: `Size mismatch for ${fileEntry.path}: manifest declares ${fileEntry.size} bytes, archive has ${archiveEntry.size} bytes`,
+        message: `Size mismatch for ${fileEntry.path}: manifest declares ${fileEntry.size_bytes} bytes, archive has ${archiveEntry.size} bytes`,
         path: fileEntry.path,
       });
     }
@@ -364,7 +538,7 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
     if (!manifestFilePaths.has(required)) {
       errors.push({
         code: "REQUIRED_FILE_NOT_IN_MANIFEST",
-        message: `Required file ${required} exists in archive but has no checksum entry in manifest.files`,
+        message: `Required file ${required} exists in archive but has no checksum entry in manifest.contents`,
         path: required,
       });
     }

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -367,7 +367,7 @@ const MAX_DECOMPRESSED_SIZE = 2 * 1024 * 1024 * 1024;
  * Performs four validation passes:
  * 1. Archive structure (gzip decompression, tar parsing, required entries)
  * 2. Manifest schema (Zod validation of manifest.json)
- * 3. Manifest checksum (SHA-256 of canonicalized JSON without manifest_sha256)
+ * 3. Manifest checksum (SHA-256 of canonicalized JSON with the `checksum` field set to empty string)
  * 4. Per-file content integrity (SHA-256 of each file vs manifest declaration)
  */
 export function validateVBundle(data: Uint8Array): VBundleValidationResult {

--- a/assistant/src/runtime/routes/__tests__/backup-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/backup-routes.test.ts
@@ -26,6 +26,7 @@ import type { BackupRunResult } from "../../../backup/backup-worker.js";
 import type { RestoreResult, VerifyResult } from "../../../backup/restore.js";
 import type { BackupConfig } from "../../../config/schema.js";
 import { BackupConfigSchema } from "../../../config/schema.js";
+import type { ManifestType } from "../../migrations/vbundle-validator.js";
 
 // ---------------------------------------------------------------------------
 // Module mocks — must appear before any imports of the module under test
@@ -144,13 +145,31 @@ interface VerifyCall {
 
 let lastRestoreArgs: RestoreCall | null = null;
 let lastVerifyArgs: VerifyCall | null = null;
-let mockRestoreResult: RestoreResult = {
-  manifest: {
-    schema_version: "1.0",
+
+function makeV1Manifest(): ManifestType {
+  return {
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
     created_at: "2026-04-11T10:00:00.000Z",
-    files: [],
-    manifest_sha256: "0".repeat(64),
-  } as unknown as RestoreResult["manifest"],
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents: [],
+    checksum: "0".repeat(64),
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  };
+}
+
+let mockRestoreResult: RestoreResult = {
+  manifest: makeV1Manifest(),
   restoredFiles: 0,
 };
 let mockRestoreError: Error | null = null;
@@ -236,12 +255,7 @@ beforeEach(() => {
   lastVerifyArgs = null;
   mockRestoreError = null;
   mockRestoreResult = {
-    manifest: {
-      schema_version: "1.0",
-      created_at: "2026-04-11T10:00:00.000Z",
-      files: [],
-      manifest_sha256: "0".repeat(64),
-    } as unknown as RestoreResult["manifest"],
+    manifest: makeV1Manifest(),
     restoredFiles: 0,
   };
   mockVerifyResult = { valid: true };
@@ -768,12 +782,7 @@ describe("handleBackupVerify", () => {
     mockReadBackupKeyCalls = 0;
     mockVerifyResult = {
       valid: true,
-      manifest: {
-        schema_version: "1.0",
-        created_at: "2026-04-11T10:00:00.000Z",
-        files: [],
-        manifest_sha256: "0".repeat(64),
-      } as unknown as VerifyResult["manifest"],
+      manifest: makeV1Manifest(),
     };
 
     const result = (await handleBackupVerify({

--- a/assistant/src/runtime/routes/__tests__/migration-export-secrets-redacted.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-export-secrets-redacted.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for `computeSecretsRedacted`.
+ *
+ * The helper decides whether the v1 manifest may truthfully claim
+ * `secrets_redacted: true`. Three signals feed in:
+ *   - credentialCount: number of credentials actually included in the bundle.
+ *   - storeUnreachable: top-level `listSecureKeysAsync()` failed — we never
+ *     enumerated the accounts.
+ *   - perAccountUnreachable: enumeration succeeded, but at least one
+ *     `getSecureKeyResultAsync(account)` returned `unreachable: true`. Those
+ *     accounts were silently skipped from the credentials array, so a zero
+ *     count could be hiding real secrets we just couldn't read.
+ *
+ * Only the all-clear case (zero credentials, both flags false) may return
+ * true. Any failure mode forces false — claiming a clean redaction in those
+ * cases would lie about what's in the bundle.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { computeSecretsRedacted } from "../migration-routes.js";
+
+describe("computeSecretsRedacted", () => {
+  test("genuinely empty store + reachable + no per-account failures → true", () => {
+    expect(computeSecretsRedacted(0, false, false)).toBe(true);
+  });
+
+  test("top-level store unreachable → false (couldn't read at all)", () => {
+    expect(computeSecretsRedacted(0, true, false)).toBe(false);
+  });
+
+  test("per-account read failure → false (partial read failure)", () => {
+    expect(computeSecretsRedacted(0, false, true)).toBe(false);
+  });
+
+  test("both top-level and per-account failures → false", () => {
+    expect(computeSecretsRedacted(0, true, true)).toBe(false);
+  });
+
+  test("credentials included + no failures → false (creds in bundle)", () => {
+    expect(computeSecretsRedacted(3, false, false)).toBe(false);
+  });
+
+  test("credentials included + per-account failure → false (creds + partial failure)", () => {
+    expect(computeSecretsRedacted(3, false, true)).toBe(false);
+  });
+
+  test("credentials included + store unreachable → false", () => {
+    // Defensive: in practice `storeUnreachable` implies zero credentials,
+    // but the helper should still behave correctly if a caller passes a
+    // non-zero count alongside an unreachable flag.
+    expect(computeSecretsRedacted(3, true, false)).toBe(false);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/migration-import-credential-filter.test.ts
+++ b/assistant/src/runtime/routes/__tests__/migration-import-credential-filter.test.ts
@@ -51,16 +51,29 @@ function makeTarEntry(data: string): VBundleTarEntry {
 
 function makeManifest(paths: string[]): ManifestType {
   return {
-    schema_version: "1.0.0",
+    schema_version: 1,
+    bundle_id: "00000000-0000-4000-8000-000000000000",
     created_at: new Date().toISOString(),
-    source: "test",
-    manifest_sha256: "test",
-    files: paths.map((path) => ({
+    assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+    origin: { mode: "self-hosted-local" },
+    compatibility: {
+      min_runtime_version: "0.0.0-test",
+      max_runtime_version: null,
+    },
+    contents: paths.map((path) => ({
       path,
-      size: 0,
+      size_bytes: 0,
       sha256: "test",
     })),
-  } as ManifestType;
+    checksum:
+      "0000000000000000000000000000000000000000000000000000000000000000",
+    secrets_redacted: false,
+    export_options: {
+      include_logs: false,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  } as unknown as ManifestType;
 }
 
 /**

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -15,12 +15,15 @@
  */
 
 import { createReadStream } from "node:fs";
+import { hostname } from "node:os";
 import { PassThrough, Readable } from "node:stream";
 import { Database } from "bun:sqlite";
 
 import { z } from "zod";
 
+import { getPlatformAssistantId } from "../../config/env.js";
 import { invalidateConfigCache } from "../../config/loader.js";
+import { getAssistantName } from "../../daemon/identity-helpers.js";
 import { getDb, resetDb } from "../../memory/db-connection.js";
 import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -40,6 +43,8 @@ import {
   getWorkspaceDir,
   getWorkspaceHooksDir,
 } from "../../util/platform.js";
+import { APP_VERSION } from "../../version.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import {
   validateGcsSignedUrl,
   type ValidateGcsSignedUrlOptions,
@@ -48,6 +53,13 @@ import {
   JobAlreadyInProgressError,
   migrationJobs,
 } from "../migrations/job-registry.js";
+import { getOriginMode } from "../migrations/origin-mode.js";
+import type {
+  VBundleAssistantInfo,
+  VBundleCompatibility,
+  VBundleExportOptions,
+  VBundleOriginInfo,
+} from "../migrations/vbundle-builder.js";
 import { streamExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -137,6 +149,99 @@ export async function reconcileVellumMetadataFromCes(warningSink: {
 const log = getLogger("migration-routes");
 
 /**
+ * Fields the export pipeline must populate on the v1 manifest.
+ *
+ * Centralized so both the synchronous-bytes and async-to-gcs handlers
+ * compute the same values (and a future caller doesn't accidentally drift).
+ */
+interface ExportManifestInputs {
+  assistant: VBundleAssistantInfo;
+  origin: VBundleOriginInfo;
+  compatibility: VBundleCompatibility;
+  exportOptions: VBundleExportOptions;
+}
+
+/**
+ * Resolve the `assistant.id` for an export.
+ *
+ * Mirrors `platform/client.ts`'s precedence: in-memory override (set at
+ * daemon startup or by secret-routes) → credential store → daemon-internal
+ * fallback. The schema requires `id` to be non-empty, so we fall back to
+ * `DAEMON_INTERNAL_ASSISTANT_ID` rather than the empty string.
+ */
+async function resolveAssistantId(): Promise<string> {
+  const inMemory = getPlatformAssistantId();
+  if (inMemory) return inMemory;
+  try {
+    const stored = await getSecureKeyAsync(
+      credentialKey("vellum", "platform_assistant_id"),
+    );
+    if (stored) return stored;
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to read platform_assistant_id from credential store; falling back to daemon-internal id",
+    );
+  }
+  return DAEMON_INTERNAL_ASSISTANT_ID;
+}
+
+/**
+ * Decide the truthful `secrets_redacted` flag for an export.
+ *
+ * The export entry points pass every collected credential through to the
+ * builder unfiltered, so the bundle is NOT redacted whenever any
+ * credentials made it in. Only flip to true when the credential list is
+ * empty AND the store was reachable — i.e. there genuinely are no
+ * secrets in the bundle.
+ *
+ * NOTE: a managed-mode bundle with `secrets_redacted: false` will fail
+ * the validator's cross-field refine. That surfaces an existing
+ * platform-side enforcement gap — the runtime emits the truthful value
+ * and lets the schema flag it.
+ */
+function computeSecretsRedacted(
+  credentialCount: number,
+  storeUnreachable: boolean,
+): boolean {
+  return credentialCount === 0 && !storeUnreachable;
+}
+
+/**
+ * Compute the v1 manifest inputs that aren't tied to per-call options.
+ *
+ * `walkDirectoryForMetadata` skips `embedding-models`, `data/qdrant`,
+ * `signals`, and `deprecated` — `logs` is NOT in the skip list, so log
+ * files end up in `manifest.contents`. Browser state and memory vectors
+ * (qdrant) are skipped, so those flags are false.
+ */
+async function buildExportManifestInputs(): Promise<ExportManifestInputs> {
+  const assistantId = await resolveAssistantId();
+  const assistantName = getAssistantName() ?? "Assistant";
+  const originMode = await getOriginMode();
+  return {
+    assistant: {
+      id: assistantId,
+      name: assistantName,
+      runtime_version: APP_VERSION,
+    },
+    origin: {
+      mode: originMode,
+      hostname: hostname(),
+    },
+    compatibility: {
+      min_runtime_version: APP_VERSION,
+      max_runtime_version: null,
+    },
+    exportOptions: {
+      include_logs: true,
+      include_browser_state: false,
+      include_memory_vectors: false,
+    },
+  };
+}
+
+/**
  * POST /v1/migrations/validate
  *
  * Validates a .vbundle archive. The file can be sent as:
@@ -188,12 +293,11 @@ export async function handleMigrationValidate({
  *
  * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
  */
-export async function handleMigrationExport({
-  body,
-}: RouteHandlerArgs): Promise<RouteResponse> {
-  const description =
-    typeof body?.description === "string" ? body.description : undefined;
-
+export async function handleMigrationExport(
+  _args: RouteHandlerArgs,
+): Promise<RouteResponse> {
+  // The legacy `description` field is no longer carried on the v1
+  // manifest. Older clients still POST it; we silently ignore it.
   let cleanup: (() => Promise<void>) | undefined;
 
   try {
@@ -218,10 +322,16 @@ export async function handleMigrationExport({
       }
     }
 
+    const manifestInputs = await buildExportManifestInputs();
+    const secretsRedacted = computeSecretsRedacted(
+      credentials.length,
+      credentialList.unreachable,
+    );
+
     const result = await streamExportVBundle({
       workspaceDir: getWorkspaceDir(),
-      source: "runtime-export",
-      description,
+      ...manifestInputs,
+      secretsRedacted,
       credentials,
       checkpoint: () => {
         const dbPath = getDbPath();
@@ -262,8 +372,12 @@ export async function handleMigrationExport({
       "Content-Type": "application/octet-stream",
       "Content-Disposition": `attachment; filename="${filename}"`,
       "Content-Length": String(size),
-      "X-Vbundle-Schema-Version": manifest.schema_version,
-      "X-Vbundle-Manifest-Sha256": manifest.manifest_sha256,
+      // `schema_version` is now an integer; clients that parse this header
+      // continue to work, but the value flips from "1.0" to "1".
+      "X-Vbundle-Schema-Version": String(manifest.schema_version),
+      // Header name preserved for cross-version client compat; populated
+      // from the renamed manifest `checksum` field.
+      "X-Vbundle-Manifest-Sha256": manifest.checksum,
       "X-Vbundle-Credentials-Included": String(credentials.length),
     });
   } catch (err) {
@@ -355,9 +469,7 @@ async function collectExportCredentials(): Promise<CollectedCredentials> {
  *
  * Auth: settings.write scope (matches `migrations/export`).
  */
-export async function handleMigrationExportToGcs({
-  body,
-}: RouteHandlerArgs) {
+export async function handleMigrationExportToGcs({ body }: RouteHandlerArgs) {
   // ── 1. Parse JSON body ────────────────────────────────────────────────
   const parsed = MigrationExportToGcsBody.safeParse(body);
   if (!parsed.success) {
@@ -399,8 +511,27 @@ export async function handleMigrationExportToGcs({
     );
   }
 
-  const description = parsed.data.description;
   const uploadUrl = parsed.data.upload_url;
+
+  // Compute the v1 manifest inputs once outside the async job runner so we
+  // surface failures (e.g. credential-store probe) as a synchronous 500
+  // before the caller starts polling.
+  let manifestInputs: ExportManifestInputs;
+  try {
+    manifestInputs = await buildExportManifestInputs();
+  } catch (err) {
+    log.error({ err }, "Failed to assemble export manifest inputs");
+    throw new InternalError(
+      err instanceof Error
+        ? err.message
+        : "Failed to assemble export manifest inputs",
+    );
+  }
+
+  const secretsRedacted = computeSecretsRedacted(
+    collected.credentials.length,
+    collected.unreachable,
+  );
 
   // ── 4. Enqueue the job. The runner captures the collected credentials.
   let job;
@@ -410,8 +541,8 @@ export async function handleMigrationExportToGcs({
       try {
         const result = await streamExportVBundle({
           workspaceDir: getWorkspaceDir(),
-          source: "runtime-export",
-          description,
+          ...manifestInputs,
+          secretsRedacted,
           credentials: collected.credentials,
           checkpoint: () => {
             const dbPath = getDbPath();
@@ -493,7 +624,7 @@ export async function handleMigrationExportToGcs({
 
         return {
           size,
-          sha256: manifest.manifest_sha256,
+          sha256: manifest.checksum,
           schemaVersion: manifest.schema_version,
           credentialsIncluded: collected.credentials.length,
         };
@@ -557,9 +688,7 @@ async function extractFileData(
       const formData = await syntheticReq.formData();
       const file = formData.get("file");
       if (!file || !(file instanceof Blob)) {
-        throw new BadRequestError(
-          'Multipart upload requires a "file" field',
-        );
+        throw new BadRequestError('Multipart upload requires a "file" field');
       }
       return new Uint8Array(await file.arrayBuffer());
     } catch (err) {
@@ -1303,9 +1432,7 @@ function throwGcsImportError(err: unknown): never {
  *
  * Auth: Requires settings.write scope. Allowed for actor, svc_gateway, svc_daemon, local.
  */
-export async function handleMigrationImportFromGcs({
-  body,
-}: RouteHandlerArgs) {
+export async function handleMigrationImportFromGcs({ body }: RouteHandlerArgs) {
   const parsed = MigrationImportFromGcsBody.safeParse(body);
   if (!parsed.success) {
     throw new BadRequestError(
@@ -1652,8 +1779,7 @@ export const ROUTES: RouteDefinition[] = [
     }),
     additionalResponses: {
       "502": {
-        description:
-          "Upstream fetch failed (URL body only).",
+        description: "Upstream fetch failed (URL body only).",
       },
     },
     responseBody: z.object({
@@ -1710,8 +1836,7 @@ export const ROUTES: RouteDefinition[] = [
     }),
     additionalResponses: {
       "409": {
-        description:
-          "Another import job is already pending or running.",
+        description: "Another import job is already pending or running.",
       },
     },
     handler: handleMigrationImportFromGcs,

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -192,19 +192,30 @@ async function resolveAssistantId(): Promise<string> {
  * The export entry points pass every collected credential through to the
  * builder unfiltered, so the bundle is NOT redacted whenever any
  * credentials made it in. Only flip to true when the credential list is
- * empty AND the store was reachable — i.e. there genuinely are no
- * secrets in the bundle.
+ * empty AND every credential read succeeded — i.e. there genuinely are
+ * no secrets in the bundle.
+ *
+ * Two failure modes both force `false`:
+ *   - `storeUnreachable`: the top-level `listSecureKeysAsync()` call
+ *     failed, so we never even discovered which accounts exist.
+ *   - `perAccountUnreachable`: the LIST call succeeded but one or more
+ *     individual `getSecureKeyResultAsync(account)` reads returned
+ *     `unreachable: true`. Those accounts were silently skipped from the
+ *     `credentials` array, so a `credentialCount === 0` outcome could
+ *     reflect "we couldn't read them" rather than "no secrets exist".
+ *     Claiming a clean redaction in that case would be a lie.
  *
  * NOTE: a managed-mode bundle with `secrets_redacted: false` will fail
  * the validator's cross-field refine. That surfaces an existing
  * platform-side enforcement gap — the runtime emits the truthful value
  * and lets the schema flag it.
  */
-function computeSecretsRedacted(
+export function computeSecretsRedacted(
   credentialCount: number,
   storeUnreachable: boolean,
+  perAccountUnreachable: boolean,
 ): boolean {
-  return credentialCount === 0 && !storeUnreachable;
+  return credentialCount === 0 && !storeUnreachable && !perAccountUnreachable;
 }
 
 /**
@@ -304,6 +315,10 @@ export async function handleMigrationExport(
     // Read all stored credentials to include in the export bundle
     const credentialList = await listSecureKeysAsync();
     const credentials: Array<{ account: string; value: string }> = [];
+    // Track per-account read failures separately from the top-level LIST
+    // failure. A single skipped account means we cannot truthfully claim
+    // the bundle is fully redacted — we don't know what we missed.
+    let perAccountUnreachable = false;
     if (credentialList.unreachable) {
       log.warn(
         "Credential store is unreachable — export will not include credentials",
@@ -312,6 +327,7 @@ export async function handleMigrationExport(
       for (const account of credentialList.accounts) {
         const result = await getSecureKeyResultAsync(account);
         if (result.unreachable) {
+          perAccountUnreachable = true;
           log.warn(
             { account },
             "Credential store unreachable when reading credential — skipping",
@@ -326,6 +342,7 @@ export async function handleMigrationExport(
     const secretsRedacted = computeSecretsRedacted(
       credentials.length,
       credentialList.unreachable,
+      perAccountUnreachable,
     );
 
     const result = await streamExportVBundle({
@@ -402,15 +419,23 @@ const MigrationExportToGcsBody = z.object({
 });
 
 /**
- * Collected credentials plus a warning marker if the credential store was
+ * Collected credentials plus warning markers if the credential store was
  * unreachable. The caller surfaces the warning in logs; production callers
  * fail closed on errors (a thrown exception → 500) to avoid shipping a
  * bundle with partial credentials. An unreachable store is NOT an error —
  * `handleMigrationExport` treats that case as "export without credentials".
+ *
+ * - `unreachable`: the top-level `listSecureKeysAsync()` call failed.
+ * - `perAccountUnreachable`: the LIST succeeded but one or more individual
+ *   `getSecureKeyResultAsync(account)` calls returned `unreachable: true`.
+ *   Those accounts were silently skipped from `credentials`, so the count
+ *   here understates reality. The flag is what tells `computeSecretsRedacted`
+ *   it cannot claim a clean redaction.
  */
 interface CollectedCredentials {
   credentials: Array<{ account: string; value: string }>;
   unreachable: boolean;
+  perAccountUnreachable: boolean;
 }
 
 /**
@@ -425,12 +450,18 @@ async function collectExportCredentials(): Promise<CollectedCredentials> {
     log.warn(
       "Credential store is unreachable — export will not include credentials",
     );
-    return { credentials: [], unreachable: true };
+    return {
+      credentials: [],
+      unreachable: true,
+      perAccountUnreachable: false,
+    };
   }
   const credentials: Array<{ account: string; value: string }> = [];
+  let perAccountUnreachable = false;
   for (const account of credentialList.accounts) {
     const result = await getSecureKeyResultAsync(account);
     if (result.unreachable) {
+      perAccountUnreachable = true;
       log.warn(
         { account },
         "Credential store unreachable when reading credential — skipping",
@@ -439,7 +470,7 @@ async function collectExportCredentials(): Promise<CollectedCredentials> {
       credentials.push({ account, value: result.value });
     }
   }
-  return { credentials, unreachable: false };
+  return { credentials, unreachable: false, perAccountUnreachable };
 }
 
 /**
@@ -531,6 +562,7 @@ export async function handleMigrationExportToGcs({ body }: RouteHandlerArgs) {
   const secretsRedacted = computeSecretsRedacted(
     collected.credentials.length,
     collected.unreachable,
+    collected.perAccountUnreachable,
   );
 
   // ── 4. Enqueue the job. The runner captures the collected credentials.


### PR DESCRIPTION
## Summary

Brings the runtime's vbundle manifest emit into compliance with the platform's canonical `vbundle_manifest_schema_v1.json` contract — integer `schema_version: 1` with the ten required top-level fields (`bundle_id`, `assistant`, `origin`, `compatibility`, `contents`, `checksum`, `secrets_redacted`, `export_options`) and renamed entry fields (`files`→`contents`, `size`→`size_bytes`, `manifest_sha256`→`checksum`). Resyncs the runtime-side zod validator + every `ManifestType` consumer (importer, analyzer, streaming-importer, migration-transport) to the new shape, and plumbs the new caller-required identity/origin/options inputs from `migration-routes.ts` and `backup-worker.ts`.

Also adds a `LegacyManifestSchema` + `translateLegacyManifest()` fallback so the validator continues to accept pre-v1 six-field bundles (backup snapshots, cross-version migrations) — required for AGENTS.md backwards-compat compliance.

## Self-review result

PASS — 3 gaps found in round 1 (stale legacy fixtures in `backup-routes.test.ts`, stale doc comments referencing `manifest_sha256`/`manifest.files`, ~12 inlined `buildManifestObject` flows in cross-version-compat tests), all addressed via 3 fix PRs. Round 2 returned PASS with no new gaps. All migration test suites + `bunx tsc --noEmit` clean.

## PRs merged into feature branch

- #28690 — refactor(migrations): extract shared buildManifest() helper for vbundle emit
- #28693 — feat(migrations): emit vbundle manifest v1 ten-field shape and resync validator (includes 2 fix commits within the PR addressing test failures and review feedback — legacy fallback added per Codex/Devin P1 review)

### Fix PRs (round 1)
- #28698 — test(backup-routes): update mock manifest fixtures to v1 ten-field shape
- #28699 — docs(migrations): update v1-path doc comments to use renamed checksum/contents field names
- #28700 — test(migrations): consolidate cross-version-compat manifest builders into shared buildTestManifest helper

## Decisions intentionally surfaced (per plan body)

- **`secrets_redacted` emitted truthfully** — managed-mode bundles with credentials emit `secrets_redacted: false`, which trips the schema's `if/then` refine. This is the deliberate design: emit the truth and let the schema surface the existing platform-side enforcement question (whether managed-mode credential stripping should happen pre-export). Hardcoding `true` would lie about the bundle's contents.
- **Backup worker pinned to self-hosted origin** — the worker bypasses `getOriginMode()` and derives directly from `getDaemonRuntimeMode()` because backups always run locally. Managed deployments delegate backups to the platform.
- **Legacy `source`/`description` fields hard-cut from emit** — but the validator still parses old bundles via `LegacyManifestSchema` fallback so AGENTS.md backwards-compat is preserved.

Part of plan: vbundle-v1-manifest.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
