### PR TITLE
feat(notifications): register activity.failed source event

### DIFF
--- a/assistant/src/notifications/__tests__/signal-registry.test.ts
+++ b/assistant/src/notifications/__tests__/signal-registry.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { NOTIFICATION_SOURCE_EVENT_NAMES } from "../signal.js";
+
+describe("NOTIFICATION_SOURCE_EVENT_NAMES", () => {
+  test("includes activity.failed", () => {
+    expect(
+      NOTIFICATION_SOURCE_EVENT_NAMES.some((e) => e.id === "activity.failed"),
+    ).toBe(true);
+  });
+
+  test("still includes activity.complete (regression guard)", () => {
+    expect(
+      NOTIFICATION_SOURCE_EVENT_NAMES.some((e) => e.id === "activity.complete"),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -89,6 +89,11 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
   },
   { id: "activity.complete", description: "Background activity finished" },
   {
+    id: "activity.failed",
+    description:
+      "Background job execution failed (model error, exception, tool failure, or timeout)",
+  },
+  {
     id: "quick_chat.response_ready",
     description: "Quick chat response ready for review",
   },


### PR DESCRIPTION
## Summary
- Registers `activity.failed` in `NOTIFICATION_SOURCE_EVENT_NAMES`.
- Used by the upcoming `runBackgroundJob` runner (PR 5) to emit a failure notification when a background agent loop throws, times out, or hits a tool error.

Part of plan: home-notif-feed-revamp.md (PR 2 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
