### PR TITLE
feat(memory): add isBackgroundConversationType helper

### DIFF
--- a/assistant/src/memory/__tests__/conversation-types.test.ts
+++ b/assistant/src/memory/__tests__/conversation-types.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BACKGROUND_CONVERSATION_TYPES,
+  isBackgroundConversationType,
+} from "../conversation-types.js";
+
+describe("isBackgroundConversationType", () => {
+  test("returns true for background", () => {
+    expect(isBackgroundConversationType("background")).toBe(true);
+  });
+
+  test("returns true for scheduled", () => {
+    expect(isBackgroundConversationType("scheduled")).toBe(true);
+  });
+
+  test("returns false for standard", () => {
+    expect(isBackgroundConversationType("standard")).toBe(false);
+  });
+
+  test("returns false for null", () => {
+    expect(isBackgroundConversationType(null)).toBe(false);
+  });
+
+  test("returns false for undefined", () => {
+    expect(isBackgroundConversationType(undefined)).toBe(false);
+  });
+
+  test("returns false for empty string", () => {
+    expect(isBackgroundConversationType("")).toBe(false);
+  });
+
+  test.each(["chat", "foo", "BACKGROUND", "Scheduled", " background "])(
+    "returns false for unknown string %p",
+    (value) => {
+      expect(isBackgroundConversationType(value)).toBe(false);
+    },
+  );
+});
+
+describe("BACKGROUND_CONVERSATION_TYPES", () => {
+  test("contains exactly background and scheduled", () => {
+    expect([...BACKGROUND_CONVERSATION_TYPES].sort()).toEqual([
+      "background",
+      "scheduled",
+    ]);
+  });
+
+  test("every entry is recognized by isBackgroundConversationType", () => {
+    for (const t of BACKGROUND_CONVERSATION_TYPES) {
+      expect(isBackgroundConversationType(t)).toBe(true);
+    }
+  });
+});

--- a/assistant/src/memory/conversation-types.ts
+++ b/assistant/src/memory/conversation-types.ts
@@ -1,0 +1,21 @@
+// Re-exports the canonical conversation-type union (defined alongside the
+// create path in `conversation-crud.ts`) under a read-side name and provides
+// the shared "is this a non-interactive / background conversation?" predicate
+// used by notification-feed and memory filters.
+
+import type { ConversationCreateType } from "./conversation-crud.js";
+
+export type ConversationType = ConversationCreateType;
+
+export const BACKGROUND_CONVERSATION_TYPES = [
+  "background",
+  "scheduled",
+] as const;
+
+// Tolerant of null/undefined/unknown strings so it can be called directly on
+// raw DB column values without pre-validation.
+export function isBackgroundConversationType(
+  t: ConversationType | string | null | undefined,
+): boolean {
+  return t === "background" || t === "scheduled";
+}


### PR DESCRIPTION
## Summary
- Adds the `isBackgroundConversationType` helper plus `BACKGROUND_CONVERSATION_TYPES` constant for use by upcoming notification-pipeline filters.
- Centralizes the `"background" | "scheduled"` conversation-type membership check so later PRs (notifications side-effect, system-prompt branching) share the same source of truth.

Part of plan: home-notif-feed-revamp.md (PR 1 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
