### PR TITLE
feat(runtime): add runBackgroundJob wrapper for background conversations

### DIFF
--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for `runBackgroundJob()`.
+ *
+ * Strategy: stub `bootstrapConversation`, `processMessage`, and
+ * `emitNotificationSignal` via `mock.module()` and inspect the recorded
+ * calls. We do NOT exercise the real conversation runtime here — the unit
+ * under test is the wrapper's contract:
+ *  - bootstrap is called once
+ *  - processMessage is awaited (or raced against a timeout)
+ *  - failure paths emit `activity.failed` (unless suppressed)
+ *  - the result is always a structured value, never a thrown error
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { TrustContext } from "../../daemon/trust-context.js";
+
+// ── Module mocks ─────────────────────────────────────────────────────
+
+let bootstrapCalls = 0;
+let bootstrapLastArgs: Record<string, unknown> | null = null;
+const STUB_CONVERSATION_ID = "conv-test-1";
+
+mock.module("../../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: (opts: Record<string, unknown>) => {
+    bootstrapCalls += 1;
+    bootstrapLastArgs = opts;
+    return { id: STUB_CONVERSATION_ID };
+  },
+}));
+
+let processMessageImpl: (
+  conversationId: string,
+  content: string,
+  attachmentIds: string[] | undefined,
+  options: Record<string, unknown> | undefined,
+) => Promise<{ messageId: string }> = async () => ({ messageId: "msg-1" });
+const processMessageCalls: Array<{
+  conversationId: string;
+  content: string;
+  options: Record<string, unknown> | undefined;
+}> = [];
+
+mock.module("../../daemon/process-message.js", () => ({
+  processMessage: async (
+    conversationId: string,
+    content: string,
+    attachmentIds: string[] | undefined,
+    options: Record<string, unknown> | undefined,
+  ) => {
+    processMessageCalls.push({ conversationId, content, options });
+    return processMessageImpl(conversationId, content, attachmentIds, options);
+  },
+}));
+
+const emitCalls: Array<Record<string, unknown>> = [];
+let emitImpl: (
+  params: Record<string, unknown>,
+) => Promise<unknown> = async () => ({
+  signalId: "sig-1",
+  deduplicated: false,
+  dispatched: true,
+  reason: "ok",
+  deliveryResults: [],
+});
+
+mock.module("../../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: (params: Record<string, unknown>) => {
+    emitCalls.push(params);
+    return emitImpl(params);
+  },
+}));
+
+// Import after mocks are in place.
+const { runBackgroundJob } = await import("../background-job-runner.js");
+
+// ── Shared fixtures ──────────────────────────────────────────────────
+
+const TRUST_CONTEXT: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+function baseOpts(overrides: Record<string, unknown> = {}) {
+  return {
+    jobName: "test-job",
+    source: "test-source",
+    prompt: "do the test",
+    trustContext: TRUST_CONTEXT,
+    callSite: "heartbeatAgent" as const,
+    timeoutMs: 5_000,
+    origin: "heartbeat" as const,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  bootstrapCalls = 0;
+  bootstrapLastArgs = null;
+  processMessageCalls.length = 0;
+  emitCalls.length = 0;
+  processMessageImpl = async () => ({ messageId: "msg-1" });
+  emitImpl = async () => ({
+    signalId: "sig-1",
+    deduplicated: false,
+    dispatched: true,
+    reason: "ok",
+    deliveryResults: [],
+  });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("runBackgroundJob", () => {
+  test("success path: returns ok=true and emits no notification", async () => {
+    processMessageImpl = async () => ({ messageId: "msg-success" });
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.ok).toBe(true);
+    expect(result.conversationId).toBe(STUB_CONVERSATION_ID);
+    expect(result.error).toBeUndefined();
+    expect(result.errorKind).toBeUndefined();
+    expect(bootstrapCalls).toBe(1);
+    expect(bootstrapLastArgs).toMatchObject({
+      conversationType: "background",
+      source: "test-source",
+      origin: "heartbeat",
+      systemHint: "do the test",
+      groupId: "system:background",
+    });
+    expect(processMessageCalls).toHaveLength(1);
+    expect(processMessageCalls[0].options).toMatchObject({
+      trustContext: TRUST_CONTEXT,
+      callSite: "heartbeatAgent",
+    });
+    expect(emitCalls).toHaveLength(0);
+  });
+
+  test("generic exception: returns ok=false with errorKind=exception and emits activity.failed", async () => {
+    processMessageImpl = async () => {
+      throw new Error("boom");
+    };
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("exception");
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe("boom");
+    expect(result.conversationId).toBe(STUB_CONVERSATION_ID);
+
+    expect(emitCalls).toHaveLength(1);
+    const emitted = emitCalls[0];
+    expect(emitted.sourceEventName).toBe("activity.failed");
+    expect(emitted.sourceChannel).toBe("assistant_tool");
+    expect(emitted.sourceContextId).toBe(STUB_CONVERSATION_ID);
+    expect(emitted.contextPayload).toMatchObject({
+      jobName: "test-job",
+      errorMessage: "boom",
+      errorKind: "exception",
+    });
+    expect(emitted.attentionHints).toMatchObject({
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    });
+  });
+
+  test("timeout: returns ok=false with errorKind=timeout and emits activity.failed", async () => {
+    // Never resolve — force timeout to win the race.
+    processMessageImpl = () => new Promise(() => {});
+
+    const result = await runBackgroundJob(baseOpts({ timeoutMs: 50 }));
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("timeout");
+    expect(result.error?.message).toContain("timed out after 50ms");
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].sourceEventName).toBe("activity.failed");
+    expect(
+      (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
+    ).toBe("timeout");
+  });
+
+  test("suppressFailureNotifications: failure returns ok=false but emits nothing", async () => {
+    processMessageImpl = async () => {
+      throw new Error("suppressed");
+    };
+
+    const result = await runBackgroundJob(
+      baseOpts({ suppressFailureNotifications: true }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("exception");
+    expect(result.error?.message).toBe("suppressed");
+    expect(emitCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -1,0 +1,195 @@
+/**
+ * Centralized boundary wrapper for background-conversation jobs.
+ *
+ * `runBackgroundJob()` consolidates the bootstrap → processMessage → timeout
+ * pattern that every background producer (heartbeat, filing, scheduler, memory
+ * consolidation, watcher, update-bulletin, subagent, sequence) has been
+ * open-coding. Wrapping it here lets us:
+ *
+ *  - apply a single timeout policy
+ *  - classify failures uniformly (timeout / model / tool / generic exception)
+ *  - emit a single `activity.failed` notification on any failure path so the
+ *    home feed and native notification surfaces light up automatically
+ *  - never re-throw — the caller always gets a structured result and decides
+ *    whether to alert further
+ *
+ * Producers that have their own bespoke failure UX (e.g. heartbeat's existing
+ * alerter banner) can opt out of the failure-emit via
+ * `suppressFailureNotifications`.
+ *
+ * NOTE: This runner is not yet called from any production job. Subsequent PRs
+ * migrate each background producer onto it.
+ */
+
+import type { LLMCallSite } from "../config/schemas/llm.js";
+import { processMessage } from "../daemon/process-message.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import type { TitleOrigin } from "../memory/conversation-title-service.js";
+import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import type { AttentionHints } from "../notifications/signal.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("background-job-runner");
+
+const DEFAULT_GROUP_ID = "system:background";
+
+/**
+ * Internal-only sentinel for timeouts. Not exported — callers receive a
+ * `errorKind: "timeout"` instead so they don't depend on the class identity.
+ */
+class BackgroundJobTimeoutError extends Error {
+  override name = "BackgroundJobTimeoutError";
+}
+
+export type BackgroundJobErrorKind =
+  | "timeout"
+  | "model_provider"
+  | "tool"
+  | "exception";
+
+export interface RunBackgroundJobOptions {
+  /** Short stable identifier for logs/notifications, e.g. "heartbeat", "filing". */
+  jobName: string;
+  /** Conversation `source` field (free-form, propagated to clients). */
+  source: string;
+  /** Prompt sent both as `systemHint` to bootstrap and as the first message. */
+  prompt: string;
+  /** Trust context applied to the agent turn. */
+  trustContext: TrustContext;
+  /** LLM call-site identifier — drives provider/model/effort/etc. resolution. */
+  callSite: LLMCallSite;
+  /** Hard timeout for `processMessage` in milliseconds. */
+  timeoutMs: number;
+  /**
+   * When true, failures do NOT emit an `activity.failed` notification.
+   * Use for jobs that own their own failure UX (e.g. heartbeat's alerter).
+   */
+  suppressFailureNotifications?: boolean;
+  /** Conversation grouping id. Defaults to `"system:background"`. */
+  groupId?: string;
+  /** Title origin tag for `bootstrapConversation`. */
+  origin: TitleOrigin;
+}
+
+export interface RunBackgroundJobResult {
+  conversationId: string;
+  ok: boolean;
+  error?: Error;
+  errorKind?: BackgroundJobErrorKind;
+}
+
+function classifyError(err: unknown): BackgroundJobErrorKind {
+  if (err instanceof BackgroundJobTimeoutError) return "timeout";
+  if (!(err instanceof Error)) return "exception";
+
+  const ctorName = err.constructor?.name ?? "";
+  const { message, name } = err;
+
+  if (
+    ctorName.includes("Anthropic") ||
+    ctorName.includes("OpenAI") ||
+    /\brate\b/i.test(message) ||
+    /\b5xx\b/i.test(message) ||
+    /\b401\b/.test(message) ||
+    /\b403\b/.test(message)
+  ) {
+    return "model_provider";
+  }
+
+  if (name === "ToolExecutionError") return "tool";
+
+  return "exception";
+}
+
+/**
+ * Run a background conversation job with timeout, error classification, and
+ * (by default) failure notification emission. Never re-throws.
+ */
+export async function runBackgroundJob(
+  opts: RunBackgroundJobOptions,
+): Promise<RunBackgroundJobResult> {
+  const conversation = bootstrapConversation({
+    conversationType: "background",
+    source: opts.source,
+    origin: opts.origin,
+    systemHint: opts.prompt,
+    groupId: opts.groupId ?? DEFAULT_GROUP_ID,
+  });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const work = processMessage(conversation.id, opts.prompt, undefined, {
+      trustContext: opts.trustContext,
+      callSite: opts.callSite,
+    });
+    // Absorb late rejections: if the timeout wins the race, `work` keeps
+    // running and may eventually reject — swallow so it doesn't surface as
+    // an unhandled rejection.
+    work.catch(() => {});
+
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new BackgroundJobTimeoutError(
+            `Background job '${opts.jobName}' timed out after ${opts.timeoutMs}ms`,
+          ),
+        );
+      }, opts.timeoutMs);
+    });
+
+    await Promise.race([work, timeout]);
+    return { conversationId: conversation.id, ok: true };
+  } catch (err) {
+    const errorKind = classifyError(err);
+    const error = err instanceof Error ? err : new Error(String(err));
+
+    log.error(
+      {
+        err: error.message,
+        errorKind,
+        jobName: opts.jobName,
+        conversationId: conversation.id,
+      },
+      "Background job failed",
+    );
+
+    if (!opts.suppressFailureNotifications) {
+      const hints: AttentionHints = {
+        requiresAction: false,
+        urgency: "medium",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      };
+      emitNotificationSignal({
+        sourceChannel: "assistant_tool",
+        sourceContextId: conversation.id,
+        sourceEventName: "activity.failed",
+        contextPayload: {
+          jobName: opts.jobName,
+          errorMessage: error.message,
+          errorKind,
+        },
+        attentionHints: hints,
+      }).catch((emitErr) => {
+        log.warn(
+          {
+            err: emitErr instanceof Error ? emitErr.message : String(emitErr),
+            jobName: opts.jobName,
+            conversationId: conversation.id,
+          },
+          "Failed to emit activity.failed notification for background job",
+        );
+      });
+    }
+
+    return {
+      conversationId: conversation.id,
+      ok: false,
+      error,
+      errorKind,
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `runBackgroundJob` — a centralized wrapper around bootstrap + processMessage + timeout for background conversations.
- On model error / agent-loop exception / tool error / timeout, emits an `activity.failed` notification via the existing pipeline (suppressible per-job via `suppressFailureNotifications`).
- Not yet called from production; PRs 6-12 migrate jobs onto it.

Part of plan: home-notif-feed-revamp.md (PR 5 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
