### PR TITLE
feat(notifications): add writeHomeFeedItemForSignal helper

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { FeedItem } from "../../home/feed-types.js";
+import type { NotificationSignal } from "../signal.js";
+import type {
+  NotificationDecision,
+  NotificationDeliveryResult,
+} from "../types.js";
+
+// ── Module mocks ───────────────────────────────────────────────────────
+//
+// `mock.module` is hoisted, so these intercepts apply before the module
+// under test resolves its imports. Closures over the module-scoped
+// arrays/flag below let each test reset state via `beforeEach` and
+// inspect captured calls afterwards.
+
+const appendCalls: FeedItem[] = [];
+const conversationLookups: string[] = [];
+let conversationRow: { conversationType: string } | null = null;
+let conversationLookupShouldThrow = false;
+
+mock.module("../../home/feed-writer.js", () => ({
+  appendFeedItem: async (item: FeedItem) => {
+    appendCalls.push(item);
+  },
+}));
+
+mock.module("../../memory/conversation-crud.js", () => ({
+  getConversation: (id: string) => {
+    conversationLookups.push(id);
+    if (conversationLookupShouldThrow) {
+      throw new Error("simulated conversation lookup failure");
+    }
+    return conversationRow;
+  },
+}));
+
+const { writeHomeFeedItemForSignal } =
+  await import("../home-feed-side-effect.js");
+
+// ── Test fixtures ──────────────────────────────────────────────────────
+
+function makeSignal(
+  overrides: Partial<NotificationSignal> = {},
+): NotificationSignal {
+  return {
+    signalId: "sig-test-1",
+    createdAt: 1700000000000,
+    sourceChannel: "scheduler",
+    sourceContextId: "conv-source-1",
+    sourceEventName: "schedule.notify",
+    contextPayload: {},
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: false,
+      visibleInSourceNow: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeDecision(
+  overrides: Partial<NotificationDecision> = {},
+): NotificationDecision {
+  return {
+    shouldNotify: true,
+    selectedChannels: [],
+    reasoningSummary: "test",
+    renderedCopy: {},
+    dedupeKey: "dk-1",
+    confidence: 1,
+    fallbackUsed: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  appendCalls.length = 0;
+  conversationLookups.length = 0;
+  conversationRow = null;
+  conversationLookupShouldThrow = false;
+});
+
+describe("writeHomeFeedItemForSignal", () => {
+  test("background conversation signal writes a feed item with rendered copy", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal();
+    const decision = makeDecision({
+      renderedCopy: {
+        vellum: {
+          title: "Background job done",
+          body: "Summary of what happened.",
+        },
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, decision, []);
+
+    expect(conversationLookups).toEqual(["conv-source-1"]);
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    const appended = appendCalls[0]!;
+    expect(appended.id).toBe("notif:sig-test-1");
+    expect(appended.type).toBe("action");
+    expect(appended.source).toBe("assistant");
+    expect(appended.author).toBe("assistant");
+    expect(appended.priority).toBe(50);
+    expect(appended.status).toBe("new");
+    expect(appended.title).toBe("Background job done");
+    expect(appended.summary).toBe("Summary of what happened.");
+    expect(appended.urgency).toBe("medium");
+    expect(typeof appended.timestamp).toBe("string");
+    expect(appended.createdAt).toBe(appended.timestamp);
+  });
+
+  test("non-background conversation with no async hint returns null and does not write", async () => {
+    conversationRow = { conversationType: "standard" };
+    const signal = makeSignal({
+      attentionHints: {
+        requiresAction: false,
+        urgency: "low",
+        isAsyncBackground: false,
+        visibleInSourceNow: true,
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item).toBeNull();
+    expect(appendCalls).toHaveLength(0);
+  });
+
+  test("isAsyncBackground hint writes even when sourceContextId does not resolve", async () => {
+    // No conversation row matches; the conversation lookup is bypassed
+    // entirely because the hint short-circuits the filter.
+    conversationLookupShouldThrow = true;
+    const signal = makeSignal({
+      sourceContextId: "not-a-conversation-id",
+      attentionHints: {
+        requiresAction: false,
+        urgency: "high",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item).not.toBeNull();
+    expect(appendCalls).toHaveLength(1);
+    expect(appendCalls[0]!.urgency).toBe("high");
+    // The async-background short-circuit must not consult the conversation store.
+    expect(conversationLookups).toHaveLength(0);
+  });
+
+  test("vellum delivery result conversationId propagates onto the feed item", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal();
+    const deliveryResults: NotificationDeliveryResult[] = [
+      {
+        channel: "telegram",
+        destination: "chat-1",
+        status: "sent",
+        conversationId: "conv-telegram-1",
+      },
+      {
+        channel: "vellum",
+        destination: "vellum-client",
+        status: "sent",
+        conversationId: "conv-vellum-1",
+      },
+    ];
+
+    const item = await writeHomeFeedItemForSignal(
+      signal,
+      makeDecision(),
+      deliveryResults,
+    );
+
+    expect(item?.conversationId).toBe("conv-vellum-1");
+    expect(appendCalls[0]!.conversationId).toBe("conv-vellum-1");
+  });
+
+  test("falls back to sourceEventName when no rendered copy or payload title is present", async () => {
+    conversationRow = { conversationType: "scheduled" };
+    const signal = makeSignal({
+      sourceEventName: "watcher.notification",
+      contextPayload: {},
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision(), []);
+
+    expect(item?.title).toBe("watcher.notification");
+    expect(item?.summary).toBe("watcher.notification");
+  });
+});

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -1,0 +1,113 @@
+/**
+ * Home-feed side effect for the notification pipeline.
+ *
+ * Writes a `FeedItem` into the home activity feed when a notification
+ * signal originates from a non-interactive (background or scheduled)
+ * conversation, or carries the `isAsyncBackground` attention hint.
+ *
+ * Producer flows like the scheduler, watchers, and background activity
+ * jobs already emit through `emitNotificationSignal()` — this helper
+ * mirrors the high-signal subset of that traffic into the home feed so
+ * the macOS Home page surfaces them alongside other activity.
+ */
+import {
+  type FeedItem,
+  feedItemSchema,
+  type FeedItemUrgency,
+} from "../home/feed-types.js";
+import { appendFeedItem } from "../home/feed-writer.js";
+import { getConversation } from "../memory/conversation-crud.js";
+import { isBackgroundConversationType } from "../memory/conversation-types.js";
+import { getLogger } from "../util/logger.js";
+import type { NotificationSignal } from "./signal.js";
+import type {
+  NotificationDecision,
+  NotificationDeliveryResult,
+} from "./types.js";
+
+const log = getLogger("home-feed-side-effect");
+
+const FEED_ITEM_URGENCIES: ReadonlySet<string> = new Set<FeedItemUrgency>([
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+/**
+ * Append a `FeedItem` for the given notification signal when the
+ * filter criteria pass.
+ *
+ * Returns the persisted `FeedItem`, or `null` if the signal does not
+ * qualify for home-feed mirroring (non-background origin AND no
+ * `isAsyncBackground` hint) or if schema validation fails.
+ */
+export async function writeHomeFeedItemForSignal(
+  signal: NotificationSignal,
+  decision: NotificationDecision,
+  deliveryResults: NotificationDeliveryResult[],
+): Promise<FeedItem | null> {
+  if (!shouldMirrorToHomeFeed(signal)) return null;
+
+  const renderedCopy = decision.renderedCopy.vellum;
+  const payloadTitle = readPayloadString(signal.contextPayload, "title");
+  const payloadBody = readPayloadString(signal.contextPayload, "body");
+
+  const conversationId = deliveryResults.find(
+    (r) => r.channel === "vellum",
+  )?.conversationId;
+  const urgency = FEED_ITEM_URGENCIES.has(signal.attentionHints.urgency)
+    ? (signal.attentionHints.urgency as FeedItemUrgency)
+    : undefined;
+  const now = new Date().toISOString();
+
+  const item: FeedItem = {
+    id: `notif:${signal.signalId}`,
+    type: "action",
+    source: "assistant",
+    author: "assistant",
+    priority: 50,
+    title: renderedCopy?.title ?? payloadTitle ?? signal.sourceEventName,
+    summary: renderedCopy?.body ?? payloadBody ?? signal.sourceEventName,
+    timestamp: now,
+    createdAt: now,
+    status: "new",
+    ...(urgency ? { urgency } : {}),
+    ...(conversationId ? { conversationId } : {}),
+  };
+
+  try {
+    feedItemSchema.parse(item);
+  } catch (err) {
+    log.warn(
+      { err, signalId: signal.signalId },
+      "FeedItem failed schema validation; skipping home-feed write",
+    );
+    return null;
+  }
+
+  await appendFeedItem(item);
+  return item;
+}
+
+/**
+ * `sourceContextId` is best-effort — it may not be a conversation id
+ * (e.g. scheduler job id, watcher event id), so a lookup failure
+ * falls through to "not a background conversation" rather than throwing.
+ */
+function shouldMirrorToHomeFeed(signal: NotificationSignal): boolean {
+  if (signal.attentionHints.isAsyncBackground) return true;
+  if (!signal.sourceContextId) return false;
+  try {
+    const row = getConversation(signal.sourceContextId);
+    return isBackgroundConversationType(row?.conversationType);
+  } catch {
+    return false;
+  }
+}
+
+function readPayloadString(payload: unknown, key: string): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const value = (payload as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}


### PR DESCRIPTION
## Summary
- Adds `writeHomeFeedItemForSignal` — a side-effect helper that writes a home-feed entry when a notification signal originates from a background/scheduled conversation (or carries `isAsyncBackground`).
- No production callsite yet; PR 4 wires it into `emitNotificationSignal`.

Part of plan: home-notif-feed-revamp.md (PR 3 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
