### PR TITLE
refactor(filing): use runBackgroundJob runner

### DIFF
--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -32,8 +32,12 @@ mock.module("../config/loader.js", () => ({
 }));
 
 // Mock conversation store
-const createdConversations: Array<{ title: string; conversationType: string }> =
-  [];
+const createdConversations: Array<{
+  title: string;
+  conversationType: string;
+  source?: string;
+  groupId?: string;
+}> = [];
 let conversationIdCounter = 0;
 
 mock.module("../memory/conversation-crud.js", () => ({
@@ -60,7 +64,12 @@ mock.module("../memory/conversation-crud.js", () => ({
   }),
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
-  createConversation: (opts: { title: string; conversationType: string }) => {
+  createConversation: (opts: {
+    title: string;
+    conversationType: string;
+    source?: string;
+    groupId?: string;
+  }) => {
     createdConversations.push(opts);
     return { id: `conv-${++conversationIdCounter}`, ...opts };
   },
@@ -83,7 +92,9 @@ mock.module("../memory/conversation-title-service.js", () => ({
 }));
 
 // Mock processMessage — FilingService now imports it directly.
-let _testProcessMessage: ((...args: unknown[]) => Promise<{ messageId: string }>) | undefined;
+let _testProcessMessage:
+  | ((...args: unknown[]) => Promise<{ messageId: string }>)
+  | undefined;
 
 mock.module("../daemon/process-message.js", () => ({
   processMessage: async (...args: unknown[]) => {
@@ -132,7 +143,9 @@ describe("FilingService", () => {
       processMessageCalls.push({
         conversationId: args[0] as string,
         content: args[1] as string,
-        options: (args[3] as { speed?: string; callSite?: string } | undefined) ?? undefined,
+        options:
+          (args[3] as { speed?: string; callSite?: string } | undefined) ??
+          undefined,
       });
       return { messageId: "msg-1" };
     });
@@ -160,9 +173,7 @@ describe("FilingService", () => {
   });
 
   function createService(overrides?: {
-    processMessage?: (
-      ...args: unknown[]
-    ) => Promise<{ messageId: string }>;
+    processMessage?: (...args: unknown[]) => Promise<{ messageId: string }>;
   }) {
     if (overrides?.processMessage) {
       setTestProcessMessage(overrides.processMessage);
@@ -175,7 +186,9 @@ describe("FilingService", () => {
     await service.runOnce();
 
     expect(processMessageCalls).toHaveLength(1);
-    expect(processMessageCalls[0].options).toMatchObject({ callSite: "filingAgent" });
+    expect(processMessageCalls[0].options).toMatchObject({
+      callSite: "filingAgent",
+    });
     expect(processMessageCalls[0].options?.callSite).toBe("filingAgent");
   });
 
@@ -210,6 +223,10 @@ describe("FilingService", () => {
     expect(createdConversations).toHaveLength(1);
     expect(createdConversations[0].title).toBe("Generating title...");
     expect(createdConversations[0].conversationType).toBe("background");
+    // Confirms FilingService routes through runBackgroundJob:
+    //   source="filing" + runner-default groupId="system:background".
+    expect(createdConversations[0].source).toBe("filing");
+    expect(createdConversations[0].groupId).toBe("system:background");
   });
 
   describe("runCompactionOnce()", () => {

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -3,8 +3,7 @@ import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import { processMessage } from "../daemon/process-message.js";
-import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
@@ -61,10 +60,6 @@ If the disk shape changed (files split, files moved, files created, files remove
 This is your knowledge base — keep it sharp.`;
 
 export interface FilingDeps {
-  onConversationCreated?: (info: {
-    conversationId: string;
-    title: string;
-  }) => void;
   getCurrentHour?: () => number;
 }
 
@@ -210,15 +205,7 @@ export class FilingService {
     const run = this.executeRun();
     this.activeRun = run;
     try {
-      await Promise.race([
-        run,
-        new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error("Filing execution timed out")),
-            FILING_TIMEOUT_MS,
-          ),
-        ),
-      ]);
+      await run;
     } finally {
       this.activeRun = null;
       this._lastRunAt = Date.now();
@@ -253,15 +240,7 @@ export class FilingService {
     const run = this.executeCompactionRun();
     this.activeCompactionRun = run;
     try {
-      await Promise.race([
-        run,
-        new Promise<never>((_, reject) =>
-          setTimeout(
-            () => reject(new Error("Compaction execution timed out")),
-            FILING_TIMEOUT_MS,
-          ),
-        ),
-      ]);
+      await run;
     } finally {
       this.activeCompactionRun = null;
       this._lastCompactionAt = Date.now();
@@ -302,7 +281,7 @@ export class FilingService {
 
   private executeRun(): Promise<void> {
     return this.executeBackgroundJob({
-      title: "Knowledge base filing",
+      jobName: "filing",
       prompt: FILING_PROMPT_TEMPLATE,
       callSite: "filingAgent",
     });
@@ -310,47 +289,37 @@ export class FilingService {
 
   private executeCompactionRun(): Promise<void> {
     return this.executeBackgroundJob({
-      title: "Knowledge base compaction",
+      jobName: "compaction",
       prompt: COMPACTION_PROMPT_TEMPLATE,
       callSite: "compactionAgent",
     });
   }
 
   private async executeBackgroundJob(opts: {
-    title: string;
+    jobName: string;
     prompt: string;
     callSite: LLMCallSite;
   }): Promise<void> {
-    log.info({ title: opts.title }, "Running background job");
+    log.info({ jobName: opts.jobName }, "Running background job");
 
-    try {
-      const conversation = bootstrapConversation({
-        conversationType: "background",
-        source: "filing",
-        groupId: "system:background",
-        origin: "filing",
-        systemHint: opts.title,
-      });
+    const result = await runBackgroundJob({
+      jobName: opts.jobName,
+      source: "filing",
+      prompt: opts.prompt,
+      trustContext: {
+        sourceChannel: "vellum",
+        trustClass: "guardian",
+      },
+      callSite: opts.callSite,
+      timeoutMs: FILING_TIMEOUT_MS,
+      origin: "filing",
+    });
 
-      this.deps.onConversationCreated?.({
-        conversationId: conversation.id,
-        title: opts.title,
-      });
-
-      await processMessage(conversation.id, opts.prompt, undefined, {
-        trustContext: {
-          sourceChannel: "vellum",
-          trustClass: "guardian",
-        },
-        callSite: opts.callSite,
-      });
-
+    if (result.ok) {
       log.info(
-        { conversationId: conversation.id, title: opts.title },
+        { conversationId: result.conversationId, jobName: opts.jobName },
         "Background job completed",
       );
-    } catch (err) {
-      log.error({ err, title: opts.title }, "Background job failed");
     }
   }
 }


### PR DESCRIPTION
## Summary
- Migrates filing service to the centralized `runBackgroundJob` wrapper.
- Filing failures now surface via `activity.failed` notifications (was: silent log-only).

Part of plan: home-notif-feed-revamp.md (PR 7 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
