### PR TITLE
refactor(memory): use runBackgroundJob for consolidation; suppress failure notifications

### DIFF
--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -1,17 +1,16 @@
 /**
  * Tests for `assistant/src/memory/v2/consolidation-job.ts`.
  *
- * Coverage matrix (from PR 20 acceptance criteria):
- *   - Flag off → no provider/wake calls; returns flag_off.
- *   - Flag on, empty buffer → no wake call; returns empty_buffer.
- *   - Flag on, non-empty buffer → bootstrap conversation, wake invoked with
- *     the cutoff-templated prompt, follow-up jobs enqueued.
- *   - Lock file already present → second call returns locked; first call's
- *     in-flight semantics preserved by leaving the lock in place.
- *   - Wake returns invoked: false → orphan conversation cleaned up; no
- *     follow-up jobs enqueued.
- *   - Wake throws → orphan conversation cleaned up; lock released; handler
- *     does NOT propagate the error (treated like any other wake failure).
+ * Coverage matrix:
+ *   - Flag off → no runner call; returns flag_off.
+ *   - Flag on, empty buffer → no runner call; returns empty_buffer.
+ *   - Flag on, non-empty buffer → runner invoked with the cutoff-templated
+ *     prompt and `suppressFailureNotifications: true`; follow-up jobs
+ *     enqueued on success.
+ *   - Lock file already present → second call returns locked.
+ *   - Runner returns ok=false → run_failed surfaced; NO follow-up jobs;
+ *     `emitNotificationSignal` was NOT called as a result of the failure
+ *     (suppression is honored end-to-end).
  *
  * Tests use temp workspaces (mkdtemp) and never touch `~/.vellum/`. Sample
  * content uses generic placeholders (Alice).
@@ -42,31 +41,49 @@ mock.module("../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
-// ── bootstrapConversation mock ──────────────────────────────────────
-let bootstrapCalls = 0;
-let bootstrapLastArgs: Record<string, unknown> | null = null;
+// ── runBackgroundJob mock ───────────────────────────────────────────
+//
+// The consolidation handler delegates the bootstrap + processMessage +
+// timeout + classification + suppress-aware emit to runBackgroundJob.
+// We stub it here and assert (a) the runner is called with
+// `suppressFailureNotifications: true`, and (b) the prompt + callSite
+// + trustContext + origin match what the consolidation surface expects.
+let runnerCalls = 0;
+let runnerLastArgs: Record<string, unknown> | null = null;
+let runnerImpl: () => Promise<{
+  conversationId: string;
+  ok: boolean;
+  error?: Error;
+  errorKind?: string;
+}> = async () => ({ conversationId: "conv-1", ok: true });
 
-mock.module("../../conversation-bootstrap.js", () => ({
-  bootstrapConversation: (opts: Record<string, unknown>) => {
-    bootstrapCalls += 1;
-    bootstrapLastArgs = opts;
-    return { id: `conv-${bootstrapCalls}` };
+mock.module("../../../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: async (opts: Record<string, unknown>) => {
+    runnerCalls += 1;
+    runnerLastArgs = opts;
+    return runnerImpl();
   },
 }));
 
-// ── deleteConversation mock (orphan cleanup path) ───────────────────
-let deleteCalls = 0;
-const deletedIds: string[] = [];
-let deleteShouldThrow = false;
+// ── emitNotificationSignal spy ──────────────────────────────────────
+//
+// The runner is stubbed above, so the real `emit-signal` module never
+// runs in these tests. We mock it as a defensive belt-and-suspenders
+// assertion: even if the runner stub were swapped out for the real
+// implementation, this counter would catch any path that ends up
+// emitting a signal as a result of consolidation failure.
+const emitCalls: Array<Record<string, unknown>> = [];
 
-mock.module("../../conversation-crud.js", () => ({
-  deleteConversation: (id: string) => {
-    deleteCalls += 1;
-    deletedIds.push(id);
-    if (deleteShouldThrow) {
-      throw new Error("simulated delete failure");
-    }
-    return { segmentIds: [], deletedSummaryIds: [] };
+mock.module("../../../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emitCalls.push(params);
+    return {
+      signalId: "sig-1",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    };
   },
 }));
 
@@ -85,28 +102,6 @@ mock.module("../../jobs-store.js", () => ({
     enqueuedJobs.push({ type, payload });
     nextJobIdCounter += 1;
     return `job-${nextJobIdCounter}`;
-  },
-}));
-
-// ── wakeAgentForOpportunity mock ────────────────────────────────────
-let wakeCalls = 0;
-let wakeLastArgs: Record<string, unknown> | null = null;
-let wakeShouldThrow = false;
-let wakeInvoked = true;
-let wakeReason: string | undefined;
-
-mock.module("../../../runtime/agent-wake.js", () => ({
-  wakeAgentForOpportunity: async (opts: Record<string, unknown>) => {
-    wakeCalls += 1;
-    wakeLastArgs = opts;
-    if (wakeShouldThrow) {
-      throw new Error("simulated wake failure");
-    }
-    return {
-      invoked: wakeInvoked,
-      producedToolCalls: false,
-      ...(wakeReason ? { reason: wakeReason } : {}),
-    };
   },
 }));
 
@@ -170,18 +165,12 @@ beforeEach(() => {
   mkdirSync(join(memoryDir(), "concepts"), { recursive: true });
   mkdirSync(join(memoryDir(), "archive"), { recursive: true });
 
-  bootstrapCalls = 0;
-  bootstrapLastArgs = null;
-  deleteCalls = 0;
-  deletedIds.length = 0;
-  deleteShouldThrow = false;
+  runnerCalls = 0;
+  runnerLastArgs = null;
+  runnerImpl = async () => ({ conversationId: "conv-1", ok: true });
+  emitCalls.length = 0;
   enqueuedJobs.length = 0;
   nextJobIdCounter = 0;
-  wakeCalls = 0;
-  wakeLastArgs = null;
-  wakeShouldThrow = false;
-  wakeInvoked = true;
-  wakeReason = undefined;
 });
 
 afterEach(() => {
@@ -191,15 +180,14 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("memoryV2ConsolidateJob — flag off", () => {
-  test("returns flag_off without invoking the wake when flag is off", async () => {
+  test("returns flag_off without invoking the runner when flag is off", async () => {
     _setOverridesForTesting({ "memory-v2-enabled": false });
     writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
 
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result).toEqual({ kind: "flag_off" });
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runnerCalls).toBe(0);
     expect(enqueuedJobs).toHaveLength(0);
     // Lock must NOT linger on the flag-off path — the handler bailed before
     // the lock was acquired.
@@ -218,8 +206,7 @@ describe("memoryV2ConsolidateJob — flag on, empty buffer", () => {
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result).toEqual({ kind: "empty_buffer" });
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runnerCalls).toBe(0);
     expect(enqueuedJobs).toHaveLength(0);
   });
 
@@ -229,8 +216,7 @@ describe("memoryV2ConsolidateJob — flag on, empty buffer", () => {
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result).toEqual({ kind: "empty_buffer" });
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runnerCalls).toBe(0);
     expect(enqueuedJobs).toHaveLength(0);
   });
 
@@ -251,32 +237,37 @@ describe("memoryV2ConsolidateJob — flag on, non-empty buffer", () => {
     );
   });
 
-  test("bootstraps a background conversation and wakes the assistant with a templated prompt", async () => {
+  test("invokes runBackgroundJob with the cutoff-templated prompt and suppressFailureNotifications: true", async () => {
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("invoked");
-    expect(bootstrapCalls).toBe(1);
-    expect(bootstrapLastArgs).toEqual({
-      conversationType: "background",
-      source: "memory_v2_consolidation",
-      origin: "memory_consolidation",
-      systemHint: "Running memory consolidation",
-      groupId: "system:background",
+    expect(runnerCalls).toBe(1);
+    expect(runnerLastArgs).not.toBeNull();
+    expect(runnerLastArgs?.jobName).toBe("memory.consolidate");
+    expect(runnerLastArgs?.source).toBe("memory");
+    expect(runnerLastArgs?.callSite).toBe("mainAgent");
+    expect(runnerLastArgs?.origin).toBe("memory_consolidation");
+    // The whole point of this PR: opt out of activity.failed notifications
+    // because consolidation runs on tight intervals and transient failures
+    // would spam the home feed.
+    expect(runnerLastArgs?.suppressFailureNotifications).toBe(true);
+    expect(runnerLastArgs?.trustContext).toEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
     });
+    expect(typeof runnerLastArgs?.timeoutMs).toBe("number");
+    expect((runnerLastArgs?.timeoutMs as number) > 0).toBe(true);
 
-    expect(wakeCalls).toBe(1);
-    expect(wakeLastArgs?.conversationId).toBe("conv-1");
-    expect(wakeLastArgs?.source).toBe("memory_v2_consolidation");
-
-    // The hint must contain the prompt body with the cutoff timestamp
-    // substituted in. Asserting the placeholder is GONE catches a regression
-    // where `replaceAll` is dropped and the model receives `{{CUTOFF}}`.
-    const hint = wakeLastArgs?.hint as string;
-    expect(hint).toContain("memory consolidation");
-    expect(hint).not.toContain(CUTOFF_PLACEHOLDER);
+    // The prompt must contain the rendered consolidation body with the
+    // cutoff substituted in. Asserting the placeholder is GONE catches a
+    // regression where `replaceAll` is dropped and the model receives
+    // `{{CUTOFF}}` literally.
+    const prompt = runnerLastArgs?.prompt as string;
+    expect(prompt).toContain("memory consolidation");
+    expect(prompt).not.toContain(CUTOFF_PLACEHOLDER);
     // Cutoff is an ISO-8601 timestamp — check the year prefix matches the
     // current year so we know the substitution actually happened.
-    expect(hint).toContain(`${new Date().getFullYear()}`);
+    expect(prompt).toContain(`${new Date().getFullYear()}`);
   });
 
   test("enqueues memory_v2_rebuild_edges and memory_v2_reembed follow-up jobs on success", async () => {
@@ -304,48 +295,46 @@ describe("memoryV2ConsolidateJob — flag on, non-empty buffer", () => {
     expect(existsSync(lockPath())).toBe(false);
   });
 
-  test("returns wake_failed and cleans up the orphan conversation when wake returns invoked: false", async () => {
-    wakeInvoked = false;
-    wakeReason = "no_resolver";
+  test("returns run_failed and skips follow-ups when the runner reports failure", async () => {
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("simulated runner failure"),
+      errorKind: "exception",
+    });
 
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
-    expect(result.kind).toBe("wake_failed");
-    if (result.kind === "wake_failed") {
-      expect(result.reason).toBe("no_resolver");
+    expect(result.kind).toBe("run_failed");
+    if (result.kind === "run_failed") {
+      expect(result.reason).toBe("simulated runner failure");
     }
-    expect(deleteCalls).toBe(1);
-    expect(deletedIds).toEqual(["conv-1"]);
-    // Critical: do NOT enqueue follow-ups when the wake didn't run — there's
-    // nothing for them to operate on.
+    // No follow-ups: the agent's writes may be partial and re-embedding
+    // partial state would be misleading.
     expect(enqueuedJobs).toHaveLength(0);
+    // Lock must still be released on the failure path so the next
+    // scheduled consolidation can re-attempt.
+    expect(existsSync(lockPath())).toBe(false);
   });
 
-  test("returns wake_failed without throwing when wake itself rejects", async () => {
-    wakeShouldThrow = true;
+  test("does NOT emit a notification signal when the runner fails (suppression honored)", async () => {
+    // This is the user-visible payoff of `suppressFailureNotifications: true`:
+    // even when the runner stub reports a failure, the consolidation
+    // handler must not produce any notification side-effect. The runner
+    // itself owns the suppression behavior; this test guards the contract
+    // from the consolidation surface — if a future change ever bypasses
+    // the runner and emits its own signal on the failure path, this assert
+    // will catch it.
+    runnerImpl = async () => ({
+      conversationId: "conv-1",
+      ok: false,
+      error: new Error("network blip"),
+      errorKind: "model_provider",
+    });
 
-    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+    await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
-    expect(result.kind).toBe("wake_failed");
-    if (result.kind === "wake_failed") {
-      expect(result.reason).toBe("simulated wake failure");
-    }
-    // Lock must still be released on the throw path.
-    expect(existsSync(lockPath())).toBe(false);
-    expect(deleteCalls).toBe(1);
-    expect(enqueuedJobs).toHaveLength(0);
-  });
-
-  test("does not propagate when deleteConversation throws on the cleanup path", async () => {
-    wakeInvoked = false;
-    deleteShouldThrow = true;
-
-    await expect(
-      memoryV2ConsolidateJob(makeJob(), CONFIG),
-    ).resolves.toMatchObject({ kind: "wake_failed" });
-
-    expect(deleteCalls).toBe(1);
-    expect(existsSync(lockPath())).toBe(false);
+    expect(emitCalls).toHaveLength(0);
   });
 });
 
@@ -368,8 +357,7 @@ describe("memoryV2ConsolidateJob — concurrent invocations", () => {
     if (result.kind === "locked") {
       expect(result.holder).toContain("9999");
     }
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runnerCalls).toBe(0);
     expect(enqueuedJobs).toHaveLength(0);
     // The pre-seeded lock must NOT be removed by a contender — only the
     // owner releases it.

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -6,11 +6,11 @@
  * rewrites `memory/recent.md`, promotes new essentials/threads, and trims the
  * buffer down to entries that arrived after the run started.
  *
- * Unlike `sweep`, consolidation runs as the assistant: `wakeAgentForOpportunity()`
- * loads the standard system prompt (SOUL.md + IDENTITY.md + persona + memory/*
- * autoloads) and the standard tool surface (read_file, write_file, edit_file,
- * list_files, bash). The hint string carries the prompt body from §10 of the
- * design doc with the cutoff timestamp templated in. Care, judgment, and the
+ * Consolidation runs as the assistant: `runBackgroundJob()` bootstraps a
+ * background conversation and routes the cutoff-templated prompt through
+ * `processMessage`, so the standard system prompt (SOUL.md + IDENTITY.md +
+ * persona + memory/* autoloads) and tool surface (read_file, write_file,
+ * edit_file, list_files, bash) are loaded. Care, judgment, and the
  * assistant's voice are the point — there is no "consolidator persona" to
  * substitute in.
  *
@@ -26,22 +26,26 @@
  *      the next pass.
  *   4. Read `memory/buffer.md`. Bail if empty (no work to do, but the lock
  *      and skip path still log so operators can confirm the schedule fired).
- *   5. Bootstrap a background conversation (mirrors `runUpdateBulletinJobIfNeeded`)
- *      and call `wakeAgentForOpportunity()` with the templated hint. The wake
- *      reuses the assistant's full system prompt + tools.
- *   6. On wake success, enqueue `memory_v2_rebuild_edges` (regenerate
- *      frontmatter from `edges.json`) and `memory_v2_reembed` (re-index any
- *      pages the agent touched). Tracking touched pages via mtime would be
- *      more precise but is fragile across filesystems; the embedder's
- *      content-hash cache makes a conservative full-reembed effectively free.
- *      On wake failure no follow-ups are enqueued — the agent didn't run, so
- *      there's nothing to regenerate or re-embed.
+ *   5. Hand off to `runBackgroundJob()` with the templated prompt. The runner
+ *      handles bootstrap + processMessage + timeout + error classification,
+ *      and (because we set `suppressFailureNotifications: true`) does NOT
+ *      emit an `activity.failed` notification on transient failures —
+ *      consolidation runs on tight intervals, so a network blip or model
+ *      hiccup should not spam the home feed. Sentry-side reporting is
+ *      unchanged.
+ *   6. On success, enqueue `memory_v2_rebuild_edges` (regenerate frontmatter
+ *      from `edges.json`) and `memory_v2_reembed` (re-index any pages the
+ *      agent touched). Tracking touched pages via mtime would be more precise
+ *      but is fragile across filesystems; the embedder's content-hash cache
+ *      makes a conservative full-reembed effectively free. On failure no
+ *      follow-ups are enqueued — the agent's writes may be partial and
+ *      re-embedding partial state would be misleading.
  *   7. Release the lock.
  *
- * The handler never propagates a wake exception: it logs, cleans up the
- * orphan conversation, releases the lock, and returns `wake_failed` so the
- * next scheduled run can re-attempt. A thrown bootstrap error bubbles up and
- * the jobs-worker treats it as a retryable failure.
+ * The handler never propagates exceptions from the run path — `runBackgroundJob`
+ * absorbs them and returns a structured result. A thrown error before the
+ * runner is invoked (e.g. mkdir failures) bubbles up and the jobs-worker
+ * treats it as a retryable failure.
  */
 
 import {
@@ -56,11 +60,9 @@ import { dirname, join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../../config/types.js";
-import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
+import { runBackgroundJob } from "../../runtime/background-job-runner.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
-import { bootstrapConversation } from "../conversation-bootstrap.js";
-import { deleteConversation } from "../conversation-crud.js";
 import {
   enqueueMemoryJob,
   type MemoryJob,
@@ -70,8 +72,19 @@ import { renderConsolidationPrompt } from "./prompts/consolidation.js";
 
 const log = getLogger("memory-v2-consolidate");
 
-/** Source string identifying this wake in `agent-wake` logs and surfaces. */
-const WAKE_SOURCE = "memory_v2_consolidation";
+/** Source string identifying this background conversation in logs and surfaces. */
+const JOB_SOURCE = "memory";
+
+/** Stable identifier surfaced in `runBackgroundJob` logs and notifications. */
+const JOB_NAME = "memory.consolidate";
+
+/**
+ * Hard timeout for the consolidation run. Consolidation reads the buffer,
+ * rewrites several files, and re-encodes essentials/threads — generous
+ * upper bound so a slow run isn't killed mid-edit, but bounded so a stuck
+ * provider can't pin the worker indefinitely.
+ */
+const CONSOLIDATION_TIMEOUT_MS = 15 * 60 * 1000;
 
 /**
  * Follow-up jobs to fan out after a successful consolidation. Both are stubs
@@ -89,13 +102,13 @@ const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [
 /**
  * Job handler. See file header for the full lifecycle. Returns a discriminated
  * union so tests can assert on the path taken (flag-off / locked / empty /
- * invoked) without having to spy on the filesystem.
+ * invoked / failed) without having to spy on the filesystem.
  */
 export type ConsolidationOutcome =
   | { kind: "flag_off" }
   | { kind: "locked"; holder: string }
   | { kind: "empty_buffer" }
-  | { kind: "wake_failed"; reason?: string }
+  | { kind: "run_failed"; reason?: string }
   | {
       kind: "invoked";
       conversationId: string;
@@ -139,53 +152,36 @@ export async function memoryV2ConsolidateJob(
       return { kind: "empty_buffer" };
     }
 
-    // Step 4: bootstrap a background conversation and wake the assistant
-    // with the cutoff-templated prompt. Mirrors the UPDATES.md pattern in
-    // `runUpdateBulletinJobIfNeeded` — the wake runs `mainAgent` against
-    // the assistant's full system prompt, so consolidation thinks and
-    // writes in the assistant's voice.
-    const conversation = bootstrapConversation({
-      conversationType: "background",
-      source: WAKE_SOURCE,
+    // Step 4: hand off to the centralized background-job runner. The runner
+    // bootstraps the conversation, drives `processMessage`, applies the
+    // timeout policy, classifies errors, and — because we opt out via
+    // `suppressFailureNotifications` — does NOT emit an `activity.failed`
+    // notification on transient failures. Consolidation runs on tight
+    // intervals; a network blip or model hiccup should not spam the feed.
+    // Sentry-side reporting is unchanged.
+    const runResult = await runBackgroundJob({
+      jobName: JOB_NAME,
+      source: JOB_SOURCE,
+      prompt: renderConsolidationPrompt(cutoff),
+      trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+      callSite: "mainAgent",
+      timeoutMs: CONSOLIDATION_TIMEOUT_MS,
       origin: "memory_consolidation",
-      systemHint: "Running memory consolidation",
-      groupId: "system:background",
+      suppressFailureNotifications: true,
     });
 
-    let wakeInvoked = false;
-    let failureReason: string | undefined;
-    try {
-      const result = await wakeAgentForOpportunity({
-        conversationId: conversation.id,
-        hint: renderConsolidationPrompt(cutoff),
-        source: WAKE_SOURCE,
-      });
-      wakeInvoked = result.invoked;
-      failureReason = result.reason;
-    } catch (err) {
-      failureReason = err instanceof Error ? err.message : String(err);
+    if (!runResult.ok) {
       log.error(
-        { err, conversationId: conversation.id },
-        "consolidation wake threw; cleaning up and re-enqueuing follow-ups skipped",
+        {
+          conversationId: runResult.conversationId,
+          errorKind: runResult.errorKind,
+          err: runResult.error?.message,
+        },
+        "consolidation run failed; follow-ups skipped",
       );
-    }
-
-    // If the wake never ran (resolver missing, conversation archived,
-    // timeout, exception), clean up the orphan background conversation —
-    // matches the cleanup logic in `runUpdateBulletinJobIfNeeded`. We
-    // do NOT enqueue follow-ups in this branch because no pages changed.
-    if (!wakeInvoked) {
-      try {
-        deleteConversation(conversation.id);
-      } catch (err) {
-        log.warn(
-          { err, conversationId: conversation.id },
-          "consolidation: failed to delete orphan background conversation; continuing",
-        );
-      }
-      return failureReason !== undefined
-        ? { kind: "wake_failed", reason: failureReason }
-        : { kind: "wake_failed" };
+      return runResult.error?.message !== undefined
+        ? { kind: "run_failed", reason: runResult.error.message }
+        : { kind: "run_failed" };
     }
 
     // Step 5: enqueue follow-up jobs. Enqueueing now keeps the dispatch
@@ -207,7 +203,7 @@ export async function memoryV2ConsolidateJob(
 
     log.info(
       {
-        conversationId: conversation.id,
+        conversationId: runResult.conversationId,
         cutoff,
         followUpJobIds,
       },
@@ -215,7 +211,7 @@ export async function memoryV2ConsolidateJob(
     );
     return {
       kind: "invoked",
-      conversationId: conversation.id,
+      conversationId: runResult.conversationId,
       cutoff,
       followUpJobIds,
     };
@@ -286,7 +282,7 @@ function tryAcquireLock(lockPath: string): string | null {
 
 /**
  * Idempotent unlink of the lock file. Called from the `finally` block so a
- * crash in the wake path doesn't leave the lock stranded. ENOENT is swallowed
+ * crash in the run path doesn't leave the lock stranded. ENOENT is swallowed
  * because the lock may have been released by an operator or never created
  * (acquire failed before reaching the lock-write step).
  */


### PR DESCRIPTION
## Summary
- Migrates memory v2 consolidation to `runBackgroundJob` with `suppressFailureNotifications: true`.
- Consolidation runs on tight intervals; transient failures (network blips, re-embed retries) would spam the feed without this opt-out. Sentry reporting is unchanged.

Part of plan: home-notif-feed-revamp.md (PR 9 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
