### PR TITLE
refactor(watcher): use runBackgroundJob runner

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -531,7 +531,6 @@ async function runScheduleOnce(
   if (watcherNotifier && watcherEscalator) {
     try {
       const watcherProcessed = await runWatchersOnce(
-        processMessage,
         watcherNotifier,
         watcherEscalator,
       );

--- a/assistant/src/watcher/__tests__/engine.test.ts
+++ b/assistant/src/watcher/__tests__/engine.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the watcher engine's Phase 2 (event processing) integration
+ * with `runBackgroundJob`.
+ *
+ * Strategy: stub the watcher store, provider registry, sequence reply
+ * matcher, and `runBackgroundJob` via `mock.module()` so we can drive
+ * the engine without touching the DB or LLM, then assert the runner is
+ * invoked with the expected options shape.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks ──────────────────────────────────────────────────────
+
+interface FakeWatcher {
+  id: string;
+  name: string;
+  providerId: string;
+  enabled: boolean;
+  pollIntervalMs: number;
+  actionPrompt: string;
+  watermark: string | null;
+  conversationId: string | null;
+  status: string;
+  consecutiveErrors: number;
+  lastError: string | null;
+  lastPollAt: number | null;
+  nextPollAt: number;
+  configJson: string | null;
+  credentialService: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface FakeEvent {
+  id: string;
+  watcherId: string;
+  externalId: string;
+  eventType: string;
+  summary: string;
+  payloadJson: string;
+  disposition: string;
+  llmAction: string | null;
+  processedAt: number | null;
+  createdAt: number;
+}
+
+let fakeWatchers: FakeWatcher[] = [];
+let fakePending: FakeEvent[] = [];
+const setConvCalls: Array<{ watcherId: string; conversationId: string }> = [];
+const dispositionCalls: Array<{
+  eventId: string;
+  disposition: string;
+  reason: string;
+}> = [];
+
+mock.module("../watcher-store.js", () => ({
+  claimDueWatchers: () => fakeWatchers,
+  completeWatcherPoll: () => {},
+  failWatcherPoll: () => {},
+  skipWatcherPoll: () => {},
+  disableWatcher: () => {},
+  insertWatcherEvent: () => true,
+  getPendingEvents: () => fakePending,
+  resetStuckWatchers: () => 0,
+  setWatcherConversationId: (watcherId: string, conversationId: string) => {
+    setConvCalls.push({ watcherId, conversationId });
+  },
+  updateEventDisposition: (
+    eventId: string,
+    disposition: string,
+    reason: string,
+  ) => {
+    dispositionCalls.push({ eventId, disposition, reason });
+  },
+}));
+
+mock.module("../provider-registry.js", () => ({
+  getWatcherProvider: () => ({
+    fetchNew: async () => ({ items: [], watermark: "wm" }),
+    getInitialWatermark: async () => "wm",
+  }),
+}));
+
+mock.module("../../sequence/reply-matcher.js", () => ({
+  checkForSequenceReplies: () => [],
+}));
+
+mock.module("../../credential-health/credential-health-service.js", () => ({
+  checkCredentialForProvider: async () => null,
+}));
+
+const runJobCalls: Array<Record<string, unknown>> = [];
+let runJobImpl: () => Promise<{
+  conversationId: string;
+  ok: boolean;
+  error?: Error;
+  errorKind?: string;
+}> = async () => ({ conversationId: "conv-stub", ok: true });
+
+mock.module("../../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: (opts: Record<string, unknown>) => {
+    runJobCalls.push(opts);
+    return runJobImpl();
+  },
+}));
+
+// Import after mocks are in place.
+const { runWatchersOnce } = await import("../engine.js");
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+function makeWatcher(overrides: Partial<FakeWatcher> = {}): FakeWatcher {
+  const now = Date.now();
+  return {
+    id: "watcher-1",
+    name: "Linear inbox",
+    providerId: "linear",
+    enabled: true,
+    pollIntervalMs: 60_000,
+    actionPrompt: "Triage and respond.",
+    watermark: "wm",
+    conversationId: null,
+    status: "polling",
+    consecutiveErrors: 0,
+    lastError: null,
+    lastPollAt: now,
+    nextPollAt: now + 60_000,
+    configJson: null,
+    credentialService: "linear",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<FakeEvent> = {}): FakeEvent {
+  return {
+    id: "evt-1",
+    watcherId: "watcher-1",
+    externalId: "ext-1",
+    eventType: "issue_created",
+    summary: "Investigate flaky CI",
+    payloadJson: '{"title":"Investigate flaky CI"}',
+    disposition: "pending",
+    llmAction: null,
+    processedAt: null,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fakeWatchers = [];
+  fakePending = [];
+  setConvCalls.length = 0;
+  dispositionCalls.length = 0;
+  runJobCalls.length = 0;
+  runJobImpl = async () => ({ conversationId: "conv-stub", ok: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("runWatchersOnce — Phase 2 runBackgroundJob integration", () => {
+  test("invokes runBackgroundJob with the expected options when pending events exist", async () => {
+    fakeWatchers = [makeWatcher()];
+    fakePending = [makeEvent()];
+
+    const processed = await runWatchersOnce(
+      () => {},
+      () => {},
+    );
+
+    expect(processed).toBe(2); // 1 from poll phase + 1 from process phase
+    expect(runJobCalls).toHaveLength(1);
+    const opts = runJobCalls[0];
+    expect(opts.jobName).toBe("watcher:watcher-1");
+    expect(opts.source).toBe("watcher");
+    expect(opts.origin).toBe("watcher");
+    expect(opts.callSite).toBe("mainAgent");
+    expect(opts.timeoutMs).toBe(15 * 60 * 1000);
+    expect(opts.trustContext).toEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
+    expect(typeof opts.prompt).toBe("string");
+    const prompt = opts.prompt as string;
+    expect(prompt).toContain("Watcher: Linear inbox");
+    expect(prompt).toContain("Investigate flaky CI");
+    expect(prompt).toContain("Action prompt:");
+    expect(prompt).toContain("Triage and respond.");
+    expect(prompt).toContain("<watcher-disposition>");
+  });
+
+  test("on success: persists conversation id and marks events silent", async () => {
+    fakeWatchers = [makeWatcher()];
+    fakePending = [makeEvent({ id: "evt-1" }), makeEvent({ id: "evt-2" })];
+    runJobImpl = async () => ({ conversationId: "conv-success", ok: true });
+
+    await runWatchersOnce(
+      () => {},
+      () => {},
+    );
+
+    expect(setConvCalls).toEqual([
+      { watcherId: "watcher-1", conversationId: "conv-success" },
+    ]);
+    expect(dispositionCalls).toHaveLength(2);
+    for (const call of dispositionCalls) {
+      expect(call.disposition).toBe("silent");
+      expect(call.reason).toBe("Processed by LLM");
+    }
+  });
+
+  test("on failure: persists conversation id and marks events with error reason", async () => {
+    fakeWatchers = [makeWatcher()];
+    fakePending = [makeEvent()];
+    runJobImpl = async () => ({
+      conversationId: "conv-fail",
+      ok: false,
+      error: new Error("model exploded"),
+      errorKind: "exception",
+    });
+
+    await runWatchersOnce(
+      () => {},
+      () => {},
+    );
+
+    expect(setConvCalls).toEqual([
+      { watcherId: "watcher-1", conversationId: "conv-fail" },
+    ]);
+    expect(dispositionCalls).toHaveLength(1);
+    expect(dispositionCalls[0].disposition).toBe("error");
+    expect(dispositionCalls[0].reason).toBe("model exploded");
+  });
+
+  test("skips runBackgroundJob entirely when no pending events", async () => {
+    fakeWatchers = [makeWatcher()];
+    fakePending = [];
+
+    await runWatchersOnce(
+      () => {},
+      () => {},
+    );
+
+    expect(runJobCalls).toHaveLength(0);
+    expect(setConvCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/watcher/constants.ts
+++ b/assistant/src/watcher/constants.ts
@@ -2,3 +2,10 @@
 export const DEFAULT_POLL_INTERVAL_MS = 60_000;
 /** Disable watcher after this many consecutive errors. */
 export const MAX_CONSECUTIVE_ERRORS = 5;
+/**
+ * Hard timeout for a single watcher's event-processing background job.
+ * Mirrors the order of magnitude used by sibling background producers
+ * (filing: 15min, heartbeat: 30min) — chosen to keep a wedged tick from
+ * blocking subsequent watchers indefinitely.
+ */
+export const WATCHER_JOB_TIMEOUT_MS = 15 * 60 * 1000;

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -1,15 +1,16 @@
 /**
  * Watcher engine — core polling loop that runs inside the scheduler tick.
  *
- * Claims due watchers, fetches new events from providers, stores them,
- * and processes pending events through a background LLM conversation.
+ * Claims due watchers, fetches new events from providers, and processes
+ * pending events through a background LLM conversation via the shared
+ * `runBackgroundJob` runner so failures surface as `activity.failed`
+ * notifications (see `runtime/background-job-runner.ts`).
  */
 
-import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
-import { addMessage } from "../memory/conversation-crud.js";
+import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { checkForSequenceReplies } from "../sequence/reply-matcher.js";
 import { getLogger } from "../util/logger.js";
-import { MAX_CONSECUTIVE_ERRORS } from "./constants.js";
+import { MAX_CONSECUTIVE_ERRORS, WATCHER_JOB_TIMEOUT_MS } from "./constants.js";
 import { getWatcherProvider } from "./provider-registry.js";
 import {
   claimDueWatchers,
@@ -25,11 +26,6 @@ import {
 } from "./watcher-store.js";
 
 const log = getLogger("watcher-engine");
-
-export type WatcherMessageProcessor = (
-  conversationId: string,
-  message: string,
-) => Promise<unknown>;
 
 export type WatcherNotifier = (notification: {
   title: string;
@@ -60,9 +56,12 @@ export function initWatcherEngine(): void {
 /**
  * Run one watcher tick: claim due watchers, fetch events, process them.
  * Called from the scheduler's runScheduleOnce().
+ *
+ * Each watcher with pending events is processed via `runBackgroundJob`,
+ * which bootstraps a fresh background conversation per tick, applies a
+ * timeout, and emits an `activity.failed` notification on any failure.
  */
 export async function runWatchersOnce(
-  processMessage: WatcherMessageProcessor,
   notify: WatcherNotifier,
   _escalate: WatcherEscalator,
 ): Promise<number> {
@@ -196,98 +195,79 @@ export async function runWatchersOnce(
 
   // ── Phase 2: Process pending events through LLM ─────────────────
   // Process events for all watchers that have pending events,
-  // not just the ones we just polled.
+  // not just the ones we just polled. Each watcher gets a fresh
+  // background conversation per tick via `runBackgroundJob`, which
+  // applies a timeout and surfaces failures as `activity.failed`
+  // notifications on the home feed.
   for (const watcher of claimed) {
     const pendingEvents = getPendingEvents(watcher.id);
     if (pendingEvents.length === 0) continue;
 
-    try {
-      // Get or create a background conversation for this watcher
-      let conversationId = watcher.conversationId;
-      if (!conversationId) {
-        const conv = bootstrapConversation({
-          conversationType: "background",
-          origin: "watcher",
-          systemHint: `Watcher: ${watcher.name}`,
-        });
-        conversationId = conv.id;
-        setWatcherConversationId(watcher.id, conversationId);
-      }
+    const eventSummaries = pendingEvents
+      .map(
+        (e, i) =>
+          `Event ${i + 1} (id: ${e.id}):\n  Type: ${
+            e.eventType
+          }\n  Summary: ${e.summary}\n  Data: ${e.payloadJson}`,
+      )
+      .join("\n\n");
 
-      // Sandwich all dynamic content (action prompt, watcher name, event
-      // data) as an assistant message between fully static user messages.
-      // The assistant role prevents prompt injection — LLMs don't follow
-      // instructions from their own prior output. The action_prompt is
-      // attacker-controllable (set via CLI IPC), watcher.name is too, and
-      // event data comes from external providers (e.g. Linear issue titles)
-      // — none of these should appear in user-role messages.
-      const eventSummaries = pendingEvents
-        .map(
-          (e, i) =>
-            `Event ${i + 1} (id: ${e.id}):\n  Type: ${
-              e.eventType
-            }\n  Summary: ${e.summary}\n  Data: ${e.payloadJson}`,
-        )
-        .join("\n\n");
+    const prompt = [
+      `Watcher: ${watcher.name}`,
+      "",
+      `${pendingEvents.length} event(s):`,
+      "",
+      eventSummaries,
+      "",
+      "---",
+      "",
+      "Action prompt:",
+      watcher.actionPrompt,
+      "",
+      "---",
+      "",
+      "Process the events above according to the action prompt. For each event, include a disposition block:",
+      "<watcher-disposition>",
+      '{"event_id": "...", "disposition": "silent|notify|escalate", "action": "what you did", "title": "notification title", "body": "notification body"}',
+      "</watcher-disposition>",
+    ].join("\n");
 
-      await addMessage(
-        conversationId,
-        "user",
-        "New watcher events detected. The following assistant message contains the watcher name, event data, and configured action prompt.",
-        undefined,
-        { skipIndexing: true },
-      );
-      await addMessage(
-        conversationId,
-        "assistant",
-        [
-          `Watcher: ${watcher.name}`,
-          "",
-          `${pendingEvents.length} event(s):`,
-          "",
-          eventSummaries,
-          "",
-          "---",
-          "",
-          "Action prompt:",
-          watcher.actionPrompt,
-        ].join("\n"),
-        undefined,
-        { skipIndexing: true },
-      );
+    const result = await runBackgroundJob({
+      jobName: `watcher:${watcher.id}`,
+      source: "watcher",
+      prompt,
+      trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+      callSite: "mainAgent",
+      timeoutMs: WATCHER_JOB_TIMEOUT_MS,
+      origin: "watcher",
+    });
 
-      await processMessage(
-        conversationId,
-        [
-          "Process the events above according to the action prompt. For each event, include a disposition block:",
-          "<watcher-disposition>",
-          '{"event_id": "...", "disposition": "silent|notify|escalate", "action": "what you did", "title": "notification title", "body": "notification body"}',
-          "</watcher-disposition>",
-        ].join("\n"),
-      );
+    // Persist the per-tick conversation id so downstream surfaces (UI,
+    // store reads) can link back to the most recent watcher run.
+    setWatcherConversationId(watcher.id, result.conversationId);
 
-      // Parse dispositions from the conversation
-      // For now, mark events as processed. The LLM response handler
-      // would ideally parse <watcher-disposition> blocks, but since
-      // processMessage is async and we don't get the response text back,
-      // we'll mark events as silent by default and let the LLM use
-      // tools to notify/escalate as needed.
+    if (result.ok) {
+      // Mark events as silent by default. The LLM is expected to use
+      // notify/escalate tools for events it deems worth surfacing — we
+      // do not parse <watcher-disposition> blocks back out here.
       for (const event of pendingEvents) {
-        // Default to silent if we can't parse the LLM response
         updateEventDisposition(event.id, "silent", "Processed by LLM");
       }
-
       processed++;
-    } catch (err) {
+    } else {
       log.warn(
-        { err, watcherId: watcher.id },
+        {
+          err: result.error?.message,
+          errorKind: result.errorKind,
+          watcherId: watcher.id,
+        },
         "Failed to process watcher events",
       );
       for (const event of pendingEvents) {
         updateEventDisposition(
           event.id,
           "error",
-          err instanceof Error ? err.message : String(err),
+          result.error?.message ?? "Unknown error",
         );
       }
     }


### PR DESCRIPTION
## Summary
- Migrates watcher engine's background-conversation invocations to the centralized `runBackgroundJob` wrapper.
- Watcher failures now surface via `activity.failed` notifications.

Part of plan: home-notif-feed-revamp.md (PR 10 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
