### PR TITLE
refactor: use runBackgroundJob for update-bulletin job

### DIFF
--- a/assistant/src/__tests__/update-bulletin-job.test.ts
+++ b/assistant/src/__tests__/update-bulletin-job.test.ts
@@ -1,17 +1,10 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { getWorkspacePromptPath } from "../util/platform.js";
 
-// ── fs.readFileSync override (for gap 3 test) ────────────────────────
+// ── fs.readFileSync override (for read-failure test) ─────────────────
 // We mock node:fs so we can inject a readFileSync that throws for the
 // workspace path. All other call sites fall through to the real fs.
 const realReadFileSync = readFileSync;
@@ -54,62 +47,49 @@ mock.module("../config/loader.js", () => ({
   getConfig: () => ({ updates: updatesConfig }),
 }));
 
-// ── bootstrapConversation + wakeAgentForOpportunity mocks ────────────
-let bootstrapCalls = 0;
-let bootstrapLastArgs: Record<string, unknown> | null = null;
-let wakeCalls = 0;
-let wakeLastArgs: Record<string, unknown> | null = null;
-let wakeShouldThrow = false;
-let wakeInvoked = true;
-let wakeProducedToolCalls = false;
-// A side-effect function invoked during wake. Lets tests simulate the
-// agent deleting UPDATES.md while the wake is in flight.
-let wakeSideEffect: (() => void) | null = null;
+// ── runBackgroundJob mock ────────────────────────────────────────────
+let runBackgroundJobCalls = 0;
+let runBackgroundJobLastArgs: Record<string, unknown> | null = null;
+let runBackgroundJobShouldThrow = false;
+let runBackgroundJobOk = true;
+let runBackgroundJobErrorKind:
+  | "timeout"
+  | "model_provider"
+  | "tool"
+  | "exception"
+  | undefined = undefined;
+let runBackgroundJobErrorMessage: string | undefined = undefined;
+// A side-effect function invoked during the job. Lets tests simulate the
+// agent deleting UPDATES.md while the job is running.
+let runBackgroundJobSideEffect: (() => void) | null = null;
 
-mock.module("../memory/conversation-bootstrap.js", () => ({
-  bootstrapConversation: (opts: Record<string, unknown>) => {
-    bootstrapCalls += 1;
-    bootstrapLastArgs = opts;
-    return { id: `conv-${bootstrapCalls}` };
-  },
-}));
-
-// ── deleteConversation mock (orphan cleanup path) ────────────────────
-let deleteCalls = 0;
-const deletedIds: string[] = [];
-let deleteShouldThrow = false;
-
-mock.module("../memory/conversation-crud.js", () => ({
-  deleteConversation: (id: string) => {
-    deleteCalls += 1;
-    deletedIds.push(id);
-    if (deleteShouldThrow) {
-      throw new Error("simulated delete failure");
+mock.module("../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: async (opts: Record<string, unknown>) => {
+    runBackgroundJobCalls += 1;
+    runBackgroundJobLastArgs = opts;
+    if (runBackgroundJobSideEffect) {
+      runBackgroundJobSideEffect();
     }
-    return { segmentIds: [], deletedSummaryIds: [] };
-  },
-}));
-
-mock.module("../runtime/agent-wake.js", () => ({
-  wakeAgentForOpportunity: async (opts: Record<string, unknown>) => {
-    wakeCalls += 1;
-    wakeLastArgs = opts;
-    if (wakeSideEffect) {
-      wakeSideEffect();
+    if (runBackgroundJobShouldThrow) {
+      throw new Error("simulated runner failure");
     }
-    if (wakeShouldThrow) {
-      throw new Error("simulated wake failure");
+    if (runBackgroundJobOk) {
+      return {
+        conversationId: `conv-${runBackgroundJobCalls}`,
+        ok: true,
+      };
     }
     return {
-      invoked: wakeInvoked,
-      producedToolCalls: wakeProducedToolCalls,
+      conversationId: `conv-${runBackgroundJobCalls}`,
+      ok: false,
+      error: new Error(runBackgroundJobErrorMessage ?? "simulated failure"),
+      errorKind: runBackgroundJobErrorKind ?? "exception",
     };
   },
 }));
 
-const { runUpdateBulletinJobIfNeeded } = await import(
-  "../prompts/update-bulletin-job.js"
-);
+const { runUpdateBulletinJobIfNeeded } =
+  await import("../prompts/update-bulletin-job.js");
 
 const HASH_CHECKPOINT_KEY = "updates:last_processed_hash";
 const EMPTY_HASH = "empty";
@@ -124,19 +104,15 @@ describe("runUpdateBulletinJobIfNeeded", () => {
   beforeEach(() => {
     store.clear();
     setCheckpointCallCount = 0;
-    bootstrapCalls = 0;
-    bootstrapLastArgs = null;
-    wakeCalls = 0;
-    wakeLastArgs = null;
-    wakeShouldThrow = false;
-    wakeInvoked = true;
-    wakeProducedToolCalls = false;
-    wakeSideEffect = null;
+    runBackgroundJobCalls = 0;
+    runBackgroundJobLastArgs = null;
+    runBackgroundJobShouldThrow = false;
+    runBackgroundJobOk = true;
+    runBackgroundJobErrorKind = undefined;
+    runBackgroundJobErrorMessage = undefined;
+    runBackgroundJobSideEffect = null;
     readFileSyncOverride = null;
     updatesConfig.enabled = true;
-    deleteCalls = 0;
-    deletedIds.length = 0;
-    deleteShouldThrow = false;
     if (existsSync(workspacePath)) {
       rmSync(workspacePath);
     }
@@ -148,38 +124,34 @@ describe("runUpdateBulletinJobIfNeeded", () => {
     }
   });
 
-  test("config disabled — no bootstrap, no wake, no checkpoint change", async () => {
+  test("config disabled — no job, no checkpoint change", async () => {
     updatesConfig.enabled = false;
     writeFileSync(workspacePath, "## Real content", "utf-8");
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runBackgroundJobCalls).toBe(0);
     expect(setCheckpointCallCount).toBe(0);
     expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
   });
 
-  test("file missing, stored hash absent — no wake; stored becomes 'empty'", async () => {
+  test("file missing, stored hash absent — no job; stored becomes 'empty'", async () => {
     expect(existsSync(workspacePath)).toBe(false);
     expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runBackgroundJobCalls).toBe(0);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
   });
 
-  test("file missing, stored hash already 'empty' — no wake; no checkpoint write", async () => {
+  test("file missing, stored hash already 'empty' — no job; no checkpoint write", async () => {
     store.set(HASH_CHECKPOINT_KEY, EMPTY_HASH);
-    // Reset the counter to ignore the priming write above.
     setCheckpointCallCount = 0;
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runBackgroundJobCalls).toBe(0);
     expect(setCheckpointCallCount).toBe(0);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
   });
@@ -189,28 +161,25 @@ describe("runUpdateBulletinJobIfNeeded", () => {
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runBackgroundJobCalls).toBe(0);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
   });
 
-  test("file present with content, wake produced tool calls — bootstrap + wake; stored hash is sha256(trimmed); source/origin are snake_case", async () => {
+  test("file present, job ok=true, file unchanged — stored hash is sha256(trimmed); jobName/source are kebab-case", async () => {
     const content = "## Release 1.2.3\n\nNew thing.\n";
     writeFileSync(workspacePath, content, "utf-8");
-    wakeProducedToolCalls = true;
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
+    expect(runBackgroundJobCalls).toBe(1);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(sha256(content.trim()));
-    // Gap 4: confirm snake_case reached the downstream mocks.
-    expect(bootstrapLastArgs?.source).toBe("updates_bulletin");
-    expect(bootstrapLastArgs?.origin).toBe("updates_bulletin");
-    expect(wakeLastArgs?.source).toBe("updates_bulletin");
+    expect(runBackgroundJobLastArgs?.jobName).toBe("update-bulletin");
+    expect(runBackgroundJobLastArgs?.source).toBe("update-bulletin");
+    expect(runBackgroundJobLastArgs?.origin).toBe("updates_bulletin");
+    expect(runBackgroundJobLastArgs?.callSite).toBe("mainAgent");
   });
 
-  test("file present, stored hash matches current — no wake", async () => {
+  test("file present, stored hash matches current — no job", async () => {
     const content = "## Release 1.2.3\n\nSame content.\n";
     writeFileSync(workspacePath, content, "utf-8");
     store.set(HASH_CHECKPOINT_KEY, sha256(content.trim()));
@@ -218,138 +187,53 @@ describe("runUpdateBulletinJobIfNeeded", () => {
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runBackgroundJobCalls).toBe(0);
     expect(setCheckpointCallCount).toBe(0);
   });
 
-  test("wake returns invoked:false — checkpoint UNCHANGED + orphan conversation is cleaned up", async () => {
-    const content = "## Release Q\n\nResolver-missing scenario.\n";
+  test("runBackgroundJob returns ok=false — checkpoint UNCHANGED so next startup retries", async () => {
+    const content = "## Release Q\n\nFailure scenario.\n";
     writeFileSync(workspacePath, content, "utf-8");
-    wakeInvoked = false;
-    wakeProducedToolCalls = false;
+    runBackgroundJobOk = false;
+    runBackgroundJobErrorKind = "exception";
+    runBackgroundJobErrorMessage = "boom";
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
-    // Critical: do NOT poison the checkpoint (round-1 behavior preserved).
-    expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
-    expect(setCheckpointCallCount).toBe(0);
-    // Belt-and-suspenders: the orphan background conversation bootstrapped
-    // before the wake must be deleted so we don't leak DB rows on every
-    // silent no-op.
-    expect(deleteCalls).toBe(1);
-    expect(deletedIds).toEqual(["conv-1"]);
-  });
-
-  test("wake returns invoked:false AND deleteConversation throws — function still returns (cleanup error is swallowed)", async () => {
-    const content = "## Release Q2\n\nDelete-throws scenario.\n";
-    writeFileSync(workspacePath, content, "utf-8");
-    wakeInvoked = false;
-    wakeProducedToolCalls = false;
-    deleteShouldThrow = true;
-
-    await expect(runUpdateBulletinJobIfNeeded()).resolves.toBeUndefined();
-
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
-    expect(deleteCalls).toBe(1);
-    // Checkpoint still untouched.
+    expect(runBackgroundJobCalls).toBe(1);
+    // Critical: do NOT poison the checkpoint when the job fails.
     expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
     expect(setCheckpointCallCount).toBe(0);
   });
 
-  test("wake invoked normally — deleteConversation is NOT called (happy path)", async () => {
-    const content = "## Release Q3\n\nNormal happy-path scenario.\n";
+  test("runBackgroundJob ok=true + agent deletes file mid-run — stored hash becomes 'empty'", async () => {
+    const content = "## Release X\n\nStuff to process.\n";
     writeFileSync(workspacePath, content, "utf-8");
-    wakeInvoked = true;
-    wakeProducedToolCalls = true;
-
-    await runUpdateBulletinJobIfNeeded();
-
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
-    expect(deleteCalls).toBe(0);
-    expect(deletedIds).toEqual([]);
-  });
-
-  test("wake invoked but no tool calls AND file unchanged — checkpoint UNCHANGED (retry next startup)", async () => {
-    const content = "## Release R\n\nSilent no-op scenario.\n";
-    writeFileSync(workspacePath, content, "utf-8");
-    wakeInvoked = true;
-    wakeProducedToolCalls = false;
-
-    await runUpdateBulletinJobIfNeeded();
-
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
-    expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
-    expect(setCheckpointCallCount).toBe(0);
-  });
-
-  test("wake invoked, no tool calls, but file deleted mid-wake — checkpoint becomes 'empty'", async () => {
-    const content = "## Release S\n\nAgent deleted file.\n";
-    writeFileSync(workspacePath, content, "utf-8");
-    wakeInvoked = true;
-    wakeProducedToolCalls = false;
-    wakeSideEffect = () => {
+    runBackgroundJobSideEffect = () => {
       rmSync(workspacePath);
     };
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
+    expect(runBackgroundJobCalls).toBe(1);
     expect(existsSync(workspacePath)).toBe(false);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
   });
 
-  test("wake invoked + produced tool calls + file unchanged — checkpoint = hash of content (agent decided this is the right state)", async () => {
-    const content = "## Release T\n\nAgent processed, chose to leave file.\n";
-    writeFileSync(workspacePath, content, "utf-8");
-    wakeInvoked = true;
-    wakeProducedToolCalls = true;
-
-    await runUpdateBulletinJobIfNeeded();
-
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
-    expect(store.get(HASH_CHECKPOINT_KEY)).toBe(sha256(content.trim()));
-  });
-
-  test("file present, stored hash differs — wake invoked; stored hash updates", async () => {
+  test("file present, stored hash differs — job invoked; stored hash updates", async () => {
     const oldContent = "## Old";
     const newContent = "## New content v2";
     writeFileSync(workspacePath, newContent, "utf-8");
     store.set(HASH_CHECKPOINT_KEY, sha256(oldContent));
-    wakeProducedToolCalls = true;
 
     await runUpdateBulletinJobIfNeeded();
 
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
+    expect(runBackgroundJobCalls).toBe(1);
     expect(store.get(HASH_CHECKPOINT_KEY)).toBe(sha256(newContent.trim()));
     expect(store.get(HASH_CHECKPOINT_KEY)).not.toBe(sha256(oldContent));
   });
 
-  test("agent deletes file mid-wake (producedToolCalls=true) — stored hash becomes 'empty'", async () => {
-    const content = "## Release X\n\nStuff to process.\n";
-    writeFileSync(workspacePath, content, "utf-8");
-    wakeProducedToolCalls = true;
-    wakeSideEffect = () => {
-      rmSync(workspacePath);
-    };
-
-    await runUpdateBulletinJobIfNeeded();
-
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
-    expect(existsSync(workspacePath)).toBe(false);
-    expect(store.get(HASH_CHECKPOINT_KEY)).toBe(EMPTY_HASH);
-  });
-
-  test("file present but readFileSync throws — checkpoint UNCHANGED; warn logged (gap 3)", async () => {
+  test("file present but readFileSync throws — checkpoint UNCHANGED; warn logged", async () => {
     const content = "## Release U\n\nSimulated read failure.\n";
     writeFileSync(workspacePath, content, "utf-8");
 
@@ -366,22 +250,20 @@ describe("runUpdateBulletinJobIfNeeded", () => {
       readFileSyncOverride = null;
     }
 
-    expect(bootstrapCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(runBackgroundJobCalls).toBe(0);
     expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);
     expect(setCheckpointCallCount).toBe(0);
   });
 
-  test("wake throws — function does not reject; warning logged", async () => {
+  test("runBackgroundJob throws — function does not reject; warning logged", async () => {
     const content = "## Release Z";
     writeFileSync(workspacePath, content, "utf-8");
-    wakeShouldThrow = true;
+    runBackgroundJobShouldThrow = true;
 
     // Must not throw.
     await expect(runUpdateBulletinJobIfNeeded()).resolves.toBeUndefined();
 
-    expect(bootstrapCalls).toBe(1);
-    expect(wakeCalls).toBe(1);
+    expect(runBackgroundJobCalls).toBe(1);
     // Hash was never updated because the try/catch returned before the
     // self-healing step.
     expect(store.has(HASH_CHECKPOINT_KEY)).toBe(false);

--- a/assistant/src/prompts/update-bulletin-job.ts
+++ b/assistant/src/prompts/update-bulletin-job.ts
@@ -6,9 +6,7 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../memory/checkpoints.js";
-import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
-import { deleteConversation } from "../memory/conversation-crud.js";
-import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
+import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { getLogger } from "../util/logger.js";
 import {
   getWorkspaceDirDisplay,
@@ -19,6 +17,12 @@ const log = getLogger("update-bulletin-job");
 
 const HASH_CHECKPOINT_KEY = "updates:last_processed_hash";
 const EMPTY_HASH = "empty";
+/**
+ * Hard timeout for the update-bulletin agent turn. The agent reads a small
+ * markdown file and (usually) deletes it; 10 minutes is generous headroom for
+ * a slow model + any tool calls (e.g. memory writes).
+ */
+const UPDATE_BULLETIN_TIMEOUT_MS = 10 * 60 * 1000;
 
 function updateBulletinHint(): string {
   const workspace = getWorkspaceDirDisplay();
@@ -46,25 +50,27 @@ function readTrimmedContent(path: string): ReadResult {
 /**
  * Fire-and-forget background processor for the release-notes bulletin.
  *
- * If `<workspace>/UPDATES.md` has new (unprocessed) content, this
- * bootstraps a background conversation and wakes the agent loop with a hint
- * pointing at the file. De-duplication uses a sha256 content hash stored in
- * the `updates:last_processed_hash` memory checkpoint — an `"empty"` sentinel
+ * If `<workspace>/UPDATES.md` has new (unprocessed) content, this drives a
+ * background conversation through `runBackgroundJob` with a hint pointing at
+ * the file. De-duplication uses a sha256 content hash stored in the
+ * `updates:last_processed_hash` memory checkpoint — an `"empty"` sentinel
  * represents a missing/blank file so the job skips the common no-op case.
  *
- * The function never throws: any error inside the bootstrap/wake flow is
- * logged at `warn` and swallowed, so callers can safely invoke it in a
- * non-awaited context.
+ * The function never throws: any error inside `runBackgroundJob` is captured
+ * in its structured result (which already emits an `activity.failed`
+ * notification) and surrounding errors are logged at `warn` and swallowed,
+ * so callers can safely invoke it in a non-awaited context.
  *
  * Checkpoint write rules (intentionally conservative — prefer retry over
  * poisoning the checkpoint when state is ambiguous):
  *   - File missing → checkpoint = `EMPTY_HASH`.
  *   - File present but unreadable → checkpoint UNCHANGED, warn logged.
- *   - Wake not invoked (e.g. resolver not yet registered) → UNCHANGED.
- *   - Wake invoked but no tool calls AND file unchanged → UNCHANGED
- *     (indistinguishable from a silent failure; safer to retry).
- *   - Wake invoked + (produced tool calls OR file deleted) → checkpoint
- *     reflects the post-wake state.
+ *   - `runBackgroundJob` returned `ok: false` → checkpoint UNCHANGED so the
+ *     next startup retries. The runner has already emitted an
+ *     `activity.failed` notification.
+ *   - Job ran successfully + file deleted/empty → checkpoint = `EMPTY_HASH`.
+ *   - Job ran successfully + file unchanged → checkpoint = current hash
+ *     (agent intentionally left the file).
  */
 export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
   if (getConfig().updates.enabled === false) {
@@ -97,59 +103,39 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
       return;
     }
 
-    const conv = bootstrapConversation({
-      conversationType: "background",
-      source: "updates_bulletin",
+    const result = await runBackgroundJob({
+      jobName: "update-bulletin",
+      source: "update-bulletin",
       origin: "updates_bulletin",
-      systemHint: "Processing release updates",
-      groupId: "system:background",
-    });
-    const wakeResult = await wakeAgentForOpportunity({
-      conversationId: conv.id,
-      hint: updateBulletinHint(),
-      source: "updates_bulletin",
+      prompt: updateBulletinHint(),
+      trustContext: {
+        sourceChannel: "vellum",
+        trustClass: "guardian",
+      },
+      callSite: "mainAgent",
+      timeoutMs: UPDATE_BULLETIN_TIMEOUT_MS,
     });
 
-    if (!wakeResult.invoked) {
+    if (!result.ok) {
       log.warn(
-        { conversationId: conv.id, reason: wakeResult.reason },
-        "Update bulletin wake silently no-op'd (invoked=false); cleaning up orphan background conversation and leaving checkpoint unchanged so next startup retries",
+        {
+          conversationId: result.conversationId,
+          errorKind: result.errorKind,
+          err: result.error?.message,
+        },
+        "update-bulletin-job: runBackgroundJob returned ok=false; leaving checkpoint unchanged so next startup retries (failure notification already emitted by runner)",
       );
-      // Belt-and-suspenders cleanup: `wakeAgentForOpportunity()` can return
-      // `{invoked: false}` for reasons unrelated to the wake-resolver
-      // registration order (resolver returns null because the conversation
-      // cannot be hydrated, etc.). Without this cleanup each such occurrence
-      // leaks a conversation DB row.
-      //
-      // Wrapped in its own try/catch so a cleanup failure never propagates
-      // out of this fire-and-forget task.
-      //
-      // TODO: the `queueGenerateConversationTitle()` call that
-      // `bootstrapConversation()` fires is already in flight by the time we
-      // reach here. The title service checks `isReplaceableTitle()` before
-      // writing, but the LLM sidechain call itself still runs against the
-      // now-deleted conversation id. Adding a cancellation/existence hook
-      // in `conversation-title-service.ts` would plug this one-call waste,
-      // but this code path is rare, so we accept the one-time cost.
-      try {
-        deleteConversation(conv.id);
-      } catch (err) {
-        log.warn(
-          { err, conversationId: conv.id },
-          "update-bulletin-job: failed to delete orphan background conversation; continuing",
-        );
-      }
       return;
     }
 
-    // Re-read after the wake. We need to know whether the file was deleted
-    // or modified to decide whether to advance the checkpoint.
+    // Re-read after the job completed. We need to know whether the file was
+    // deleted or modified to decide whether to advance the checkpoint.
     const after = readTrimmedContent(updatesPath);
 
     if (after.kind === "error") {
       log.warn(
         { err: after.err, path: updatesPath },
-        "update-bulletin-job: failed to re-read UPDATES.md after wake; leaving checkpoint unchanged so next startup retries",
+        "update-bulletin-job: failed to re-read UPDATES.md after job; leaving checkpoint unchanged so next startup retries",
       );
       return;
     }
@@ -164,26 +150,14 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
       return;
     }
 
-    if (!wakeResult.producedToolCalls) {
-      // Wake returned cleanly but the agent did nothing observable AND the
-      // file is still here. We can't distinguish "agent processed and chose
-      // to no-op" from "silent failure", so leave the checkpoint alone and
-      // let the next startup retry.
-      log.warn(
-        { conversationId: conv.id },
-        "update-bulletin-job: wake produced no tool calls and file is unchanged; leaving checkpoint unchanged so next startup retries",
-      );
-      return;
-    }
-
-    // Wake produced tool calls and the file is still present — the agent
-    // intentionally left it (or modified it). Record the current hash so we
-    // don't re-wake on the same content.
+    // Job succeeded and the file is still present — the agent intentionally
+    // left it (or modified it). Record the current hash so we don't re-process
+    // the same content on next startup.
     setMemoryCheckpoint(HASH_CHECKPOINT_KEY, computeHash(after.content));
   } catch (err) {
     log.warn(
       { err },
-      "update-bulletin-job: wake flow threw; swallowing so callers can fire-and-forget",
+      "update-bulletin-job: outer flow threw; swallowing so callers can fire-and-forget",
     );
     return;
   }


### PR DESCRIPTION
## Summary
- Migrates the update-bulletin job to the centralized `runBackgroundJob` wrapper introduced in PR 5. The runner handles bootstrap, timeout, error classification, and `activity.failed` notification emission, so the job's surrounding code shrinks to just hash-checkpoint bookkeeping and post-run file inspection.
- The post-run decision tree simplifies because `runBackgroundJob.ok` directly maps to "advance the checkpoint" vs "retry next startup". The previous `producedToolCalls`-based heuristic and orphan-cleanup path are no longer needed: the runner uses `processMessage` (which writes the user message and runs the normal agent loop) instead of the opportunistic `wakeAgentForOpportunity` flow, so there is no orphan-conversation case to clean up and "agent did nothing observable" no longer needs to be distinguished from "silent failure".
- Updates `update-bulletin-job.test.ts` to mock `runBackgroundJob` instead of `wakeAgentForOpportunity`/`bootstrapConversation`/`deleteConversation`. All 11 tests pass.

## Subagent manager — deferred (technical mismatch)

PR 11 in the plan also asked to migrate `subagent/manager.ts` to `runBackgroundJob`, but `runBackgroundJob`'s interface does not fit the subagent's spawn flow. The subagent constructs a `Conversation` directly with custom dependencies that the runner cannot accommodate:

- Custom `Provider` chain (CallSiteRoutingProvider + RateLimitProvider with shared timestamps)
- Custom system prompt (`buildSubagentSystemPrompt` for general subagents; parent system-prompt inheritance for forks)
- Custom `ConversationMemoryPolicy` (`subagent:${id}` scope vs default for forks)
- Trust/auth context propagation from parent conversation
- Role-based tool filtering (`setSubagentAllowedTools`)
- Pre-activated skills (`setPreactivatedSkillIds`)
- Wrapped `sendToClient` that envelopes events as `subagent_event`
- `hasSystemPromptOverride`, `setIsSubagent`, fork message-history injection, FORK TASK framing
- Custom `runAgentLoop` invocation with `subagentSpawn` callSite + `overrideProfile`
- Bespoke termination handling (deferred conversation release on enqueued messages, abort/dispose lifecycle, parent-terminal notifications)

`runBackgroundJob` calls `bootstrapConversation` then `processMessage` with a single prompt, no extension points. Forcing the subagent through it would erase all of the above. The right path is to either (a) generalize `runBackgroundJob` to accept a custom runner closure in a follow-up, or (b) leave subagent execution as bespoke. Either way it should be its own PR — `notify_parent` is unaffected by this PR.

Part of plan: home-notif-feed-revamp.md (PR 11 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
