### PR TITLE
refactor(schedule): use runBackgroundJob runner for wakes

### DIFF
--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -16,6 +16,40 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (value: string) => value,
 }));
 
+// Mock the shared `runBackgroundJob` runner so the scheduler's fresh-bootstrap
+// talk-mode path stays observable in unit tests. Each invocation creates a new
+// conversation row (so downstream lookups reflect reality) and pushes the
+// prompt onto the per-test message log via the supplied `onPrompt` hook.
+let onRunBackgroundJobPrompt:
+  | ((info: { conversationId: string; prompt: string }) => void)
+  | null = null;
+let runBackgroundJobShouldFail = false;
+mock.module("../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: async (opts: { prompt: string; groupId?: string }) => {
+    const { createConversation } =
+      await import("../memory/conversation-crud.js");
+    const conv = createConversation({
+      title: "(test stub)",
+      conversationType: "background",
+      source: "schedule",
+      ...(opts.groupId ? { groupId: opts.groupId } : {}),
+    });
+    onRunBackgroundJobPrompt?.({
+      conversationId: conv.id,
+      prompt: opts.prompt,
+    });
+    if (runBackgroundJobShouldFail) {
+      return {
+        conversationId: conv.id,
+        ok: false,
+        error: new Error("Simulated failure"),
+        errorKind: "exception" as const,
+      };
+    }
+    return { conversationId: conv.id, ok: true };
+  },
+}));
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
@@ -102,6 +136,8 @@ describe("scheduler RRULE execution", () => {
     db.run("DELETE FROM tasks");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
+    onRunBackgroundJobPrompt = null;
+    runBackgroundJobShouldFail = false;
   });
 
   test("RRULE schedule fires and creates cron_runs entry", async () => {
@@ -123,15 +159,18 @@ describe("scheduler RRULE execution", () => {
     forceScheduleDue(schedule.id);
 
     const processedMessages: { conversationId: string; message: string }[] = [];
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
+    onRunBackgroundJobPrompt = ({ conversationId, prompt }) => {
+      processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
-    // processMessage should have been called with the RRULE message
+    // The runner should have been invoked with the RRULE message
     expect(
       processedMessages.some((m) => m.message === "Hello from RRULE"),
     ).toBe(true);
@@ -227,12 +266,15 @@ describe("scheduler RRULE execution", () => {
     );
 
     const processedMessages: string[] = [];
-    const processMessage = async (_conversationId: string, message: string) => {
-      processedMessages.push(message);
+    onRunBackgroundJobPrompt = ({ prompt }) => {
+      processedMessages.push(prompt);
     };
 
     // First tick: the expired schedule should fire its final due run
-    const scheduler1 = startScheduler(processMessage, () => {});
+    const scheduler1 = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler1.stop();
 
@@ -252,7 +294,10 @@ describe("scheduler RRULE execution", () => {
 
     // Second tick: the disabled schedule must NOT fire again
     processedMessages.length = 0;
-    const scheduler2 = startScheduler(processMessage, () => {});
+    const scheduler2 = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
@@ -278,15 +323,18 @@ describe("scheduler RRULE execution", () => {
     forceScheduleDue(schedule.id);
 
     const processedMessages: { conversationId: string; message: string }[] = [];
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
+    onRunBackgroundJobPrompt = ({ conversationId, prompt }) => {
+      processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
-    // processMessage should have been called with the cron message
+    // The runner should have been invoked with the cron message
     expect(processedMessages.some((m) => m.message === "Cron message")).toBe(
       true,
     );
@@ -337,12 +385,10 @@ describe("scheduler RRULE execution", () => {
     // Force the schedule to be due
     forceScheduleDue(schedule.id);
 
-    const processedMessages: string[] = [];
-    const processMessage = async (_conversationId: string, message: string) => {
-      processedMessages.push(message);
-    };
-
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -387,11 +433,14 @@ describe("scheduler RRULE execution", () => {
     forceScheduleDue(schedule.id);
 
     const processedMessages: string[] = [];
-    const processMessage = async (_conversationId: string, message: string) => {
-      processedMessages.push(message);
+    onRunBackgroundJobPrompt = ({ prompt }) => {
+      processedMessages.push(prompt);
     };
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -463,14 +512,14 @@ describe("scheduler RRULE execution", () => {
       forceScheduleDue(schedule.id);
 
       const processedMessages: string[] = [];
-      const processMessage = async (
-        _conversationId: string,
-        message: string,
-      ) => {
-        processedMessages.push(message);
+      onRunBackgroundJobPrompt = ({ prompt }) => {
+        processedMessages.push(prompt);
       };
 
-      const scheduler = startScheduler(processMessage, () => {});
+      const scheduler = startScheduler(
+        async () => {},
+        () => {},
+      );
       await new Promise((resolve) => setTimeout(resolve, 500));
       scheduler.stop();
 
@@ -536,11 +585,14 @@ describe("scheduler RRULE execution", () => {
     expect(getSchedule(schedule.id)!.status).toBe("active");
 
     const processedMessages: { conversationId: string; message: string }[] = [];
-    const processMessage = async (conversationId: string, message: string) => {
-      processedMessages.push({ conversationId, message });
+    onRunBackgroundJobPrompt = ({ conversationId, prompt }) => {
+      processedMessages.push({ conversationId, message: prompt });
     };
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
@@ -617,11 +669,12 @@ describe("scheduler RRULE execution", () => {
 
     expect(getSchedule(schedule.id)!.status).toBe("active");
 
-    const processMessage = async () => {
-      throw new Error("Simulated failure");
-    };
+    runBackgroundJobShouldFail = true;
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler(
+      async () => {},
+      () => {},
+    );
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 

--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -16,6 +16,37 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (value: string) => value,
 }));
 
+// Mock the shared `runBackgroundJob` runner so the scheduler's fresh-bootstrap
+// talk-mode path stays observable in unit tests. Each invocation creates a new
+// conversation row (so `getLastScheduleConversationId` lookups reflect reality)
+// and pushes onto a shared log mirrored by the per-test `processMessage`
+// callback used for the reuse path — that way assertions don't have to know
+// which path a given run took.
+const processedMessages: { conversationId: string; message: string }[] = [];
+let runBackgroundJobShouldFail = false;
+mock.module("../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: async (opts: { prompt: string; groupId?: string }) => {
+    const { createConversation } =
+      await import("../memory/conversation-crud.js");
+    const conv = createConversation({
+      title: "(test stub)",
+      conversationType: "background",
+      source: "schedule",
+      ...(opts.groupId ? { groupId: opts.groupId } : {}),
+    });
+    processedMessages.push({ conversationId: conv.id, message: opts.prompt });
+    if (runBackgroundJobShouldFail) {
+      return {
+        conversationId: conv.id,
+        ok: false,
+        error: new Error("Simulated failure"),
+        errorKind: "exception" as const,
+      };
+    }
+    return { conversationId: conv.id, ok: true };
+  },
+}));
+
 import { deleteConversation } from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
@@ -77,6 +108,8 @@ describe("scheduler conversation reuse", () => {
     db.run("DELETE FROM tasks");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
+    processedMessages.length = 0;
+    runBackgroundJobShouldFail = false;
   });
 
   test("recurring schedule with reuseConversation=true reuses conversation across runs", async () => {
@@ -99,7 +132,6 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const processedMessages: { conversationId: string; message: string }[] = [];
     const processMessage = async (conversationId: string, message: string) => {
       processedMessages.push({ conversationId, message });
     };
@@ -156,7 +188,6 @@ describe("scheduler conversation reuse", () => {
     // WHEN the schedule fires for the first time
     forceScheduleDue(schedule.id);
 
-    const processedMessages: { conversationId: string; message: string }[] = [];
     const processMessage = async (conversationId: string, message: string) => {
       processedMessages.push({ conversationId, message });
     };
@@ -200,7 +231,6 @@ describe("scheduler conversation reuse", () => {
 
     forceScheduleDue(schedule.id);
 
-    const processedMessages: { conversationId: string; message: string }[] = [];
     const processMessage = async (conversationId: string, message: string) => {
       processedMessages.push({ conversationId, message });
     };
@@ -245,7 +275,6 @@ describe("scheduler conversation reuse", () => {
     });
 
     // WHEN the schedule fires
-    const processedMessages: { conversationId: string; message: string }[] = [];
     const processMessage = async (conversationId: string, message: string) => {
       processedMessages.push({ conversationId, message });
     };
@@ -285,7 +314,6 @@ describe("scheduler conversation reuse", () => {
     forceScheduleDue(schedule.id);
 
     let shouldFail = false;
-    const processedMessages: { conversationId: string; message: string }[] = [];
     const processMessage = async (conversationId: string, message: string) => {
       processedMessages.push({ conversationId, message });
       if (shouldFail) throw new Error("Simulated failure");

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -27,11 +27,6 @@ mock.module("../runtime/agent-wake.js", () => ({
   wakeAgentForOpportunity: mockWakeAgentForOpportunity,
 }));
 
-const mockEmitFeedEvent = mock(() => Promise.resolve());
-mock.module("../home/emit-feed-event.js", () => ({
-  emitFeedEvent: mockEmitFeedEvent,
-}));
-
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
@@ -82,7 +77,6 @@ describe("scheduler wake mode", () => {
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     mockWakeAgentForOpportunity.mockClear();
-    mockEmitFeedEvent.mockClear();
   });
 
   test("wake schedule calls wakeAgentForOpportunity with correct args", async () => {
@@ -206,63 +200,6 @@ describe("scheduler wake mode", () => {
       .query("SELECT status FROM cron_jobs WHERE id = ?")
       .get(schedule.id) as { status: string } | null;
     expect(row?.status).toBe("active");
-  });
-
-  test("quiet: true suppresses feed event", async () => {
-    // GIVEN a one-shot wake schedule with quiet: true
-    const schedule = createSchedule({
-      name: "Wake Quiet",
-      message: "Quiet wake",
-      mode: "wake",
-      wakeConversationId: "conv-quiet",
-      quiet: true,
-      nextRunAt: Date.now() - 1000,
-    });
-    forceScheduleDue(schedule.id);
-
-    // WHEN the scheduler fires
-    const scheduler = startScheduler(
-      mock(() => Promise.resolve()),
-      () => {},
-    );
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
-
-    // THEN wakeAgentForOpportunity is called
-    expect(mockWakeAgentForOpportunity).toHaveBeenCalledTimes(1);
-
-    // AND no feed event is emitted
-    expect(mockEmitFeedEvent).not.toHaveBeenCalled();
-  });
-
-  test("quiet: false emits feed event on success", async () => {
-    // GIVEN a one-shot wake schedule with quiet: false (default)
-    const schedule = createSchedule({
-      name: "Wake Loud",
-      message: "Loud wake",
-      mode: "wake",
-      wakeConversationId: "conv-loud",
-      nextRunAt: Date.now() - 1000,
-    });
-    forceScheduleDue(schedule.id);
-
-    // WHEN the scheduler fires
-    const scheduler = startScheduler(
-      mock(() => Promise.resolve()),
-      () => {},
-    );
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    scheduler.stop();
-
-    // THEN a feed event IS emitted
-    expect(mockEmitFeedEvent).toHaveBeenCalledTimes(1);
-    expect(mockEmitFeedEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        source: "assistant",
-        title: "Wake Loud",
-        summary: "Deferred wake fired.",
-      }),
-    );
   });
 
   test("retries wake when wakeAgentForOpportunity returns timeout", async () => {

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -7,6 +7,41 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Mock the shared `runBackgroundJob` runner so the scheduler's fresh-bootstrap
+// talk-mode path stays observable. Each invocation creates a new conversation
+// row and pushes the prompt onto the per-test handler set via
+// `onRunBackgroundJobCall`. `run_task:` schedules use a different code path
+// and do not invoke this runner.
+let onRunBackgroundJobCall:
+  | ((info: {
+      conversationId: string;
+      prompt: string;
+      trustContext: { sourceChannel: string; trustClass: string };
+    }) => void)
+  | null = null;
+mock.module("../runtime/background-job-runner.js", () => ({
+  runBackgroundJob: async (opts: {
+    prompt: string;
+    groupId?: string;
+    trustContext: { sourceChannel: string; trustClass: string };
+  }) => {
+    const { createConversation } =
+      await import("../memory/conversation-crud.js");
+    const conv = createConversation({
+      title: "(test stub)",
+      conversationType: "background",
+      source: "schedule",
+      ...(opts.groupId ? { groupId: opts.groupId } : {}),
+    });
+    onRunBackgroundJobCall?.({
+      conversationId: conv.id,
+      prompt: opts.prompt,
+      trustContext: opts.trustContext,
+    });
+    return { conversationId: conv.id, ok: true };
+  },
+}));
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
@@ -111,6 +146,7 @@ describe("scheduler run_task detection", () => {
     db.run("DELETE FROM tasks");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
+    onRunBackgroundJobCall = null;
   });
 
   test("run_task:<id> messages trigger runTask instead of processMessage", async () => {
@@ -163,7 +199,7 @@ describe("scheduler run_task detection", () => {
     expect(typeof runTaskCalls[0].options?.taskRunId).toBe("string");
   });
 
-  test("regular messages still go through processMessage normally", async () => {
+  test("regular messages route through the runBackgroundJob runner", async () => {
     // Create a regular schedule (no run_task: prefix)
     const schedule = createSchedule({
       name: "Regular Schedule",
@@ -174,36 +210,32 @@ describe("scheduler run_task detection", () => {
 
     forceScheduleDue(schedule.id);
 
-    const processedMessages: Array<{
+    const runnerCalls: Array<{
       conversationId: string;
-      message: string;
-      options?: { trustClass?: string; taskRunId?: string };
+      prompt: string;
+      trustContext: { sourceChannel: string; trustClass: string };
     }> = [];
-    const processMessage = async (
-      conversationId: string,
-      message: string,
-      options?: { trustClass?: string; taskRunId?: string },
-    ) => {
-      processedMessages.push({ conversationId, message, options });
+    onRunBackgroundJobCall = (info) => {
+      runnerCalls.push(info);
     };
 
-    const scheduler = startScheduler(processMessage, () => {});
+    const scheduler = startScheduler(
+      async () => {},
+      () => {},
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler.stop();
 
-    // processMessage should have been called with the regular message
-    expect(
-      processedMessages.some((m) => m.message === "Do something normal"),
-    ).toBe(true);
-    expect(
-      processedMessages.some(
-        (m) =>
-          m.message === "Do something normal" &&
-          m.options?.trustClass === "guardian" &&
-          m.options?.taskRunId === undefined,
-      ),
-    ).toBe(true);
+    // The runner should have been invoked with the schedule message and a
+    // guardian trust context, mirroring the historical inline `processMessage`
+    // call that the migration replaced.
+    expect(runnerCalls.length).toBe(1);
+    expect(runnerCalls[0].prompt).toBe("Do something normal");
+    expect(runnerCalls[0].trustContext).toEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
   });
 
   test("handles task not found gracefully", async () => {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,9 +1,9 @@
 import type { LLMCallSite } from "../config/schemas/llm.js";
-import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation } from "../memory/conversation-crud.js";
 import { invalidateAssistantInferredItemsForConversation } from "../memory/task-memory-cleanup.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
+import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { runSequencesOnce } from "../sequence/engine.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -72,6 +72,14 @@ const TICK_INTERVAL_MS = 15_000;
  * ≈ 5 minutes of total retry window.
  */
 const WAKE_MAX_RETRIES = 20;
+
+/**
+ * Hard timeout for `talk`-mode scheduled jobs. Schedules can do
+ * non-trivial work (research, summarize the day, etc.), so the cap is
+ * generous; it exists primarily so a wedged turn cannot block the next
+ * scheduler tick indefinitely. Mirrors the heartbeat/filing budgets.
+ */
+const SCHEDULE_TALK_TIMEOUT_MS = 30 * 60 * 1000;
 
 export function startScheduler(
   processMessage: ScheduleMessageProcessor,
@@ -155,21 +163,11 @@ async function runScheduleOnce(
         });
         if (isOneShot) {
           completeOneShot(job.id);
-          emitScheduleFeedEvent({
-            title: job.name,
-            summary: "Reminder fired.",
-            dedupKey: `schedule-notify-oneshot:${job.id}`,
-          });
         } else {
           // Track recurring notify-mode success so lastStatus resets to ok
           // and retryCount clears after a transient failure.
           const runId = createScheduleRun(job.id, `notify-ok:${job.id}`);
           completeScheduleRun(runId, { status: "ok" });
-          emitScheduleFeedEvent({
-            title: job.name,
-            summary: "Scheduled notification fired.",
-            dedupKey: `schedule-run:${runId}`,
-          });
         }
       } catch (err) {
         log.warn(
@@ -213,13 +211,6 @@ async function runScheduleOnce(
           error: result.stderr || undefined,
         });
         if (result.exitCode === 0) {
-          if (!job.quiet) {
-            emitScheduleFeedEvent({
-              title: job.name,
-              summary: "Script ran.",
-              dedupKey: `schedule-run:${runId}`,
-            });
-          }
           if (isOneShot) completeOneShot(job.id);
         } else {
           if (isOneShot) failOneShot(job.id);
@@ -310,13 +301,6 @@ async function runScheduleOnce(
         }
 
         if (isOneShot) completeOneShot(job.id);
-        if (!job.quiet) {
-          emitScheduleFeedEvent({
-            title: job.name,
-            summary: "Deferred wake fired.",
-            dedupKey: `schedule-wake:${job.id}`,
-          });
-        }
       } catch (err) {
         log.warn(
           { err, jobId: job.id, name: job.name, wakeConversationId, isOneShot },
@@ -383,13 +367,6 @@ async function runScheduleOnce(
           if (isOneShot) failOneShot(job.id);
         } else {
           completeScheduleRun(runId, { status: "ok" });
-          if (!job.quiet) {
-            emitScheduleFeedEvent({
-              title: job.name,
-              summary: "Scheduled task ran.",
-              dedupKey: `schedule-run:${runId}`,
-            });
-          }
           if (isOneShot) completeOneShot(job.id);
         }
         processed += 1;
@@ -430,71 +407,91 @@ async function runScheduleOnce(
     }
 
     // Reuse the conversation from the last successful run when the flag is set
-    // and a prior conversation still exists; otherwise bootstrap a new one.
-    let conversationId: string | null = null;
-    let conversationReused = false;
+    // and a prior conversation still exists; otherwise route through the
+    // shared `runBackgroundJob` runner (which bootstraps fresh, applies the
+    // standard timeout, and emits `activity.failed` on any failure).
+    const isRruleSetMsg =
+      job.syntax === "rrule" &&
+      job.expression != null &&
+      hasSetConstructs(job.expression);
+
+    let reusedConversationId: string | null = null;
     if (job.reuseConversation && !isOneShot) {
       const lastId = getLastScheduleConversationId(job.id);
       if (lastId && getConversation(lastId)) {
-        conversationId = lastId;
-        conversationReused = true;
+        reusedConversationId = lastId;
       }
     }
-    if (!conversationId) {
-      const conversation = bootstrapConversation({
-        conversationType: "scheduled",
+
+    log.info(
+      {
+        jobId: job.id,
+        name: job.name,
+        syntax: job.syntax,
+        expression: job.expression,
+        isRruleSet: isRruleSetMsg,
+        isOneShot,
+        ...(reusedConversationId
+          ? { conversationId: reusedConversationId }
+          : {}),
+      },
+      isOneShot ? "Executing one-shot schedule" : "Executing schedule",
+    );
+
+    let conversationId: string;
+    let ok: boolean;
+    let errorMsg: string | undefined;
+    const conversationReused = reusedConversationId != null;
+
+    if (reusedConversationId) {
+      // Reuse path: keep using the injected `processMessage` callback so the
+      // existing conversation is continued in place. `runBackgroundJob`
+      // unconditionally bootstraps a new conversation and is therefore not a
+      // drop-in replacement for the reuse semantics.
+      conversationId = reusedConversationId;
+      try {
+        await processMessage(conversationId, job.message, {
+          trustClass: "guardian",
+        });
+        ok = true;
+      } catch (err) {
+        ok = false;
+        errorMsg = err instanceof Error ? err.message : String(err);
+      }
+    } else {
+      // Fresh-bootstrap path: route through the shared runner so failures
+      // surface via `activity.failed` and we get the standard timeout +
+      // error-classification policy applied to every background producer.
+      const result = await runBackgroundJob({
+        jobName: `schedule:${job.id}`,
         source: "schedule",
-        scheduleJobId: job.id,
-        groupId: "system:scheduled",
+        prompt: job.message,
+        trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+        callSite: "mainAgent",
+        timeoutMs: SCHEDULE_TALK_TIMEOUT_MS,
         origin: "schedule",
-        systemHint: isOneShot
-          ? `Reminder: ${job.name}`
-          : `Schedule: ${job.name}`,
+        groupId: "system:scheduled",
       });
-      conversationId = conversation.id;
+      conversationId = result.conversationId;
+      ok = result.ok;
+      errorMsg = result.error?.message;
     }
+
     onScheduleConversationCreated?.({
       conversationId,
       scheduleJobId: job.id,
       title: job.name,
     });
     const runId = createScheduleRun(job.id, conversationId);
-    const isRruleSetMsg =
-      job.syntax === "rrule" &&
-      job.expression != null &&
-      hasSetConstructs(job.expression);
 
-    try {
-      log.info(
-        {
-          jobId: job.id,
-          name: job.name,
-          syntax: job.syntax,
-          expression: job.expression,
-          isRruleSet: isRruleSetMsg,
-          isOneShot,
-          conversationId,
-        },
-        isOneShot ? "Executing one-shot schedule" : "Executing schedule",
-      );
-      await processMessage(conversationId, job.message, {
-        trustClass: "guardian",
-      });
+    if (ok) {
       completeScheduleRun(runId, { status: "ok" });
-      if (!job.quiet) {
-        emitScheduleFeedEvent({
-          title: job.name,
-          summary: isOneShot ? "One-shot reminder ran." : "Scheduled job ran.",
-          dedupKey: `schedule-run:${runId}`,
-        });
-      }
       if (isOneShot) completeOneShot(job.id);
       processed += 1;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+    } else {
       log.warn(
         {
-          err,
+          err: errorMsg,
           jobId: job.id,
           name: job.name,
           syntax: job.syntax,
@@ -506,7 +503,7 @@ async function runScheduleOnce(
           ? "One-shot schedule execution failed"
           : "Schedule execution failed",
       );
-      completeScheduleRun(runId, { status: "error", error: message });
+      completeScheduleRun(runId, { status: "error", error: errorMsg });
       if (isOneShot) failOneShot(job.id);
 
       // Only skip invalidation when the conversation was *actually* reused,
@@ -553,33 +550,4 @@ async function runScheduleOnce(
     log.info({ processed }, "Schedule tick complete");
   }
   return processed;
-}
-
-/**
- * Fire-and-forget home-feed emit for a successful schedule run.
- *
- * Wraps {@link emitFeedEvent} with local error handling so a schema
- * failure or writer hiccup can never interrupt the scheduler tick
- * loop. The dedupKey is always derived from the schedule run id (or
- * the job id, for one-shot notify-mode which fires before a run
- * record is created) so each run lands as its own entry in the
- * activity log — the writer's per-source cap keeps total volume
- * bounded.
- */
-function emitScheduleFeedEvent(params: {
-  title: string;
-  summary: string;
-  dedupKey: string;
-}): void {
-  void emitFeedEvent({
-    source: "assistant",
-    title: params.title,
-    summary: params.summary,
-    dedupKey: params.dedupKey,
-  }).catch((err) => {
-    log.warn(
-      { err, dedupKey: params.dedupKey },
-      "Failed to emit schedule feed event",
-    );
-  });
 }


### PR DESCRIPTION
## Summary
- Migrates `talk`-mode scheduled wakes (fresh-bootstrap path) to the centralized `runBackgroundJob` wrapper. `notify`-mode unchanged (already goes through `emitNotificationSignal`); `script`-mode and `wake`-mode also unaffected by the runner switch.
- The `reuseConversation` branch keeps its inline `processMessage` call: `runBackgroundJob` unconditionally bootstraps a new conversation and is therefore not a drop-in replacement for the reuse semantics. Documented inline.
- Removes scheduler's bespoke `emitFeedEvent` calls + helper; failures now surface via `activity.failed` (emitted by `runBackgroundJob`). Successes no longer write a feed event — the new home-feed pipeline (PRs 4-7) populates from notification signals + the agent's own surfaces. The `quiet` schedule field becomes inert until/unless a future consumer revives it; the field is preserved on the schema for backward compat.
- Talk-mode bootstrapped conversations are now tagged `conversationType: "background"` (not `"scheduled"`); both already count as background per `isBackgroundConversationType`, so downstream consumers (home feed, conversation-agent-loop, list filter) treat them identically. The `scheduleJobId` association is dropped since `runBackgroundJob` doesn't accept it as an option (matched runner signature exactly per plan).
- Audited `runtime/agent-wake.ts`: `wakeAgentForOpportunity` operates on an *existing* conversation (resolves via `getConversation`/`getOrCreateConversation`), it never bootstraps fresh. **Left alone** per plan.

## Test plan
- [x] `bun test src/__tests__/scheduler-recurrence.test.ts` (13 pass)
- [x] `bun test src/__tests__/scheduler-reuse-conversation.test.ts` (5 pass)
- [x] `bun test src/__tests__/scheduler-wake.test.ts` (6 pass — removed two `quiet` feed-event tests that no longer apply)
- [x] `bun test src/__tests__/task-scheduler.test.ts` (6 pass — `regular messages` test reframed against `runBackgroundJob` mock)
- [x] Broader schedule-touching tests (`schedule-store`, `schedule-routes`, `schedule-tools`, `recurrence-engine*`, etc.) — 189 pass
- [x] No `emitFeedEvent` imports/calls remain in `scheduler.ts`
- [x] Talk-mode failures emit `activity.failed` (verified via `runBackgroundJob` source — runner emits on every failure path unless `suppressFailureNotifications` is set; scheduler does not set it)
- [x] `bunx tsc --noEmit` clean for touched files (only pre-existing unrelated errors flagged in prompt remain)

Part of plan: home-notif-feed-revamp.md (PR 8 of 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
