### PR TITLE
feat(home): collapse feed schema to single notification type (v2)

### DIFF
--- a/assistant/src/__tests__/workspace-migration-061-home-feed-notification-only.test.ts
+++ b/assistant/src/__tests__/workspace-migration-061-home-feed-notification-only.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for workspace migration `061-home-feed-notification-only`.
+ *
+ * The migration rewrites `<workspace>/data/home-feed.json` from the
+ * legacy v1 schema (mixed `nudge | digest | action | thread` items
+ * with `source`/`author`/`minTimeAway`) into the collapsed v2 schema
+ * (single `notification` type with no source/author/minTimeAway).
+ *
+ * Cases covered (matching the PR 15 acceptance criteria):
+ *   1. Missing file → no-op (no error).
+ *   2. v1 file with mixed types → only `action` items survive,
+ *      retyped to `notification`, source/author/minTimeAway dropped.
+ *   3. v1 file with all `action` items → all kept, all retyped, fields
+ *      stripped.
+ *   4. v2 file → no-op (idempotent — file unchanged).
+ *   5. Two consecutive runs on a v1 file → second run is a no-op.
+ *
+ * Plus a few defence-in-depth cases: malformed JSON, non-object root.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { homeFeedNotificationOnlyMigration } from "../workspace/migrations/061-home-feed-notification-only.js";
+
+let workspaceDir: string;
+let feedPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-061-test-"));
+  feedPath = join(workspaceDir, "data", "home-feed.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeFeedFile(contents: unknown): void {
+  mkdirSync(join(workspaceDir, "data"), { recursive: true });
+  writeFileSync(feedPath, JSON.stringify(contents, null, 2), "utf-8");
+}
+
+function readFeedFile(): {
+  version: number;
+  items: Array<Record<string, unknown>>;
+  updatedAt: string;
+} {
+  return JSON.parse(readFileSync(feedPath, "utf-8"));
+}
+
+function makeBaseV1Item(
+  overrides: Record<string, unknown> & { id: string; type: string },
+): Record<string, unknown> {
+  return {
+    priority: 50,
+    title: "Test title",
+    summary: "Test summary",
+    timestamp: "2026-04-14T12:00:00.000Z",
+    status: "new",
+    author: "platform",
+    createdAt: "2026-04-14T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("workspace migration 061-home-feed-notification-only", () => {
+  test("has the expected id and description", () => {
+    expect(homeFeedNotificationOnlyMigration.id).toBe(
+      "home-feed-notification-only-v2",
+    );
+    expect(homeFeedNotificationOnlyMigration.description).toContain("v2");
+  });
+
+  test("missing file is a no-op (no error, no file created)", () => {
+    expect(existsSync(feedPath)).toBe(false);
+
+    expect(() =>
+      homeFeedNotificationOnlyMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(existsSync(feedPath)).toBe(false);
+  });
+
+  test("v1 file with mixed types keeps only action entries, rewrites them as notification, strips legacy fields", () => {
+    writeFeedFile({
+      version: 1,
+      updatedAt: "2026-04-14T12:00:00.000Z",
+      items: [
+        makeBaseV1Item({
+          id: "nudge-1",
+          type: "nudge",
+          source: "gmail",
+          minTimeAway: 3600,
+        }),
+        makeBaseV1Item({
+          id: "digest-1",
+          type: "digest",
+          source: "gmail",
+        }),
+        makeBaseV1Item({
+          id: "action-1",
+          type: "action",
+          source: "assistant",
+          author: "assistant",
+          minTimeAway: 0,
+          urgency: "high",
+          conversationId: "conv-abc",
+        }),
+        makeBaseV1Item({
+          id: "thread-1",
+          type: "thread",
+        }),
+        makeBaseV1Item({
+          id: "action-2",
+          type: "action",
+          source: "gmail",
+          author: "platform",
+        }),
+      ],
+    });
+
+    homeFeedNotificationOnlyMigration.run(workspaceDir);
+
+    const out = readFeedFile();
+    expect(out.version).toBe(2);
+    const ids = out.items.map((i) => i.id).sort();
+    expect(ids).toEqual(["action-1", "action-2"]);
+
+    for (const item of out.items) {
+      expect(item.type).toBe("notification");
+      expect(item.source).toBeUndefined();
+      expect(item.author).toBeUndefined();
+      expect(item.minTimeAway).toBeUndefined();
+    }
+
+    // Optional fields that should be carried through.
+    const action1 = out.items.find((i) => i.id === "action-1")!;
+    expect(action1.urgency).toBe("high");
+    expect(action1.conversationId).toBe("conv-abc");
+    expect(action1.title).toBe("Test title");
+    expect(action1.priority).toBe(50);
+
+    expect(typeof out.updatedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(out.updatedAt))).toBe(false);
+  });
+
+  test("v1 file with only action entries keeps every item, retyped and stripped", () => {
+    writeFeedFile({
+      version: 1,
+      updatedAt: "2026-04-14T12:00:00.000Z",
+      items: [
+        makeBaseV1Item({
+          id: "a-1",
+          type: "action",
+          source: "gmail",
+          author: "assistant",
+          minTimeAway: 5,
+        }),
+        makeBaseV1Item({
+          id: "a-2",
+          type: "action",
+          source: "slack",
+          author: "platform",
+        }),
+        makeBaseV1Item({
+          id: "a-3",
+          type: "action",
+          author: "assistant",
+        }),
+      ],
+    });
+
+    homeFeedNotificationOnlyMigration.run(workspaceDir);
+
+    const out = readFeedFile();
+    expect(out.version).toBe(2);
+    expect(out.items).toHaveLength(3);
+    for (const item of out.items) {
+      expect(item.type).toBe("notification");
+      expect(item.source).toBeUndefined();
+      expect(item.author).toBeUndefined();
+      expect(item.minTimeAway).toBeUndefined();
+    }
+    const ids = out.items.map((i) => i.id).sort();
+    expect(ids).toEqual(["a-1", "a-2", "a-3"]);
+  });
+
+  test("v2 file is a no-op (file content and mtime untouched)", () => {
+    const v2 = {
+      version: 2,
+      updatedAt: "2026-04-14T12:00:00.000Z",
+      items: [
+        {
+          id: "n-1",
+          type: "notification",
+          priority: 70,
+          title: "Hello",
+          summary: "World",
+          timestamp: "2026-04-14T12:00:00.000Z",
+          status: "new",
+          createdAt: "2026-04-14T12:00:00.000Z",
+        },
+      ],
+    };
+    writeFeedFile(v2);
+    const before = readFileSync(feedPath, "utf-8");
+    const beforeStat = statSync(feedPath);
+
+    homeFeedNotificationOnlyMigration.run(workspaceDir);
+
+    const after = readFileSync(feedPath, "utf-8");
+    expect(after).toBe(before);
+    // The migration must short-circuit before writing — same mtime.
+    expect(statSync(feedPath).mtimeMs).toBe(beforeStat.mtimeMs);
+  });
+
+  test("idempotent: second run on a freshly migrated file is a no-op", () => {
+    writeFeedFile({
+      version: 1,
+      updatedAt: "2026-04-14T12:00:00.000Z",
+      items: [
+        makeBaseV1Item({
+          id: "a-1",
+          type: "action",
+          source: "gmail",
+          author: "assistant",
+        }),
+        makeBaseV1Item({ id: "n-1", type: "nudge", source: "gmail" }),
+      ],
+    });
+
+    homeFeedNotificationOnlyMigration.run(workspaceDir);
+    const afterFirst = readFileSync(feedPath, "utf-8");
+    const afterFirstStat = statSync(feedPath);
+
+    homeFeedNotificationOnlyMigration.run(workspaceDir);
+    const afterSecond = readFileSync(feedPath, "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(statSync(feedPath).mtimeMs).toBe(afterFirstStat.mtimeMs);
+  });
+
+  // ── Defensive / edge cases ─────────────────────────────────────────
+
+  test("malformed JSON is a no-op (does not throw, leaves file alone)", () => {
+    mkdirSync(join(workspaceDir, "data"), { recursive: true });
+    writeFileSync(feedPath, "{not valid json", "utf-8");
+    const before = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      homeFeedNotificationOnlyMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+  });
+
+  test("non-object root is a no-op", () => {
+    writeFeedFile([1, 2, 3]);
+    const before = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      homeFeedNotificationOnlyMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    expect(readFileSync(feedPath, "utf-8")).toBe(before);
+  });
+
+  test("v1 entries missing required fields are dropped silently", () => {
+    writeFeedFile({
+      version: 1,
+      updatedAt: "2026-04-14T12:00:00.000Z",
+      items: [
+        // Missing required `title` — must be dropped.
+        {
+          id: "broken",
+          type: "action",
+          priority: 50,
+          summary: "Has summary but no title",
+          timestamp: "2026-04-14T12:00:00.000Z",
+          status: "new",
+          createdAt: "2026-04-14T12:00:00.000Z",
+        },
+        // Healthy action — must survive.
+        makeBaseV1Item({ id: "ok", type: "action", source: "gmail" }),
+      ],
+    });
+
+    homeFeedNotificationOnlyMigration.run(workspaceDir);
+
+    const out = readFeedFile();
+    expect(out.version).toBe(2);
+    expect(out.items.map((i) => i.id)).toEqual(["ok"]);
+  });
+
+  test("down() is a no-op (lossy migration)", () => {
+    writeFeedFile({
+      version: 1,
+      updatedAt: "2026-04-14T12:00:00.000Z",
+      items: [makeBaseV1Item({ id: "a", type: "action" })],
+    });
+    homeFeedNotificationOnlyMigration.run(workspaceDir);
+    const after = readFileSync(feedPath, "utf-8");
+
+    expect(() =>
+      homeFeedNotificationOnlyMigration.down(workspaceDir),
+    ).not.toThrow();
+
+    // The forward migration's output is preserved.
+    expect(readFileSync(feedPath, "utf-8")).toBe(after);
+  });
+});

--- a/assistant/src/home/__tests__/feed-types.test.ts
+++ b/assistant/src/home/__tests__/feed-types.test.ts
@@ -8,43 +8,25 @@ import { type FeedItem, feedItemSchema, parseFeedFile } from "../feed-types.js";
 
 const NOW_ISO = "2026-04-14T12:00:00.000Z";
 
-function minimalNudge(): Record<string, unknown> {
+function minimalNotification(): Record<string, unknown> {
   return {
-    id: "nudge-1",
-    type: "nudge",
+    id: "notif-1",
+    type: "notification",
     priority: 50,
     title: "Follow up on the Figma file",
     summary: "You mentioned wanting to review the onboarding designs.",
     timestamp: NOW_ISO,
-    author: "assistant",
     createdAt: NOW_ISO,
   };
 }
 
-function minimalDigest(): Record<string, unknown> {
+function notificationWithActions(): Record<string, unknown> {
   return {
-    id: "digest-gmail",
-    type: "digest",
-    priority: 40,
-    title: "3 new emails",
-    summary: "Since yesterday",
-    source: "gmail",
-    timestamp: NOW_ISO,
-    author: "platform",
-    createdAt: NOW_ISO,
-  };
-}
-
-function minimalAction(): Record<string, unknown> {
-  return {
-    id: "action-1",
-    type: "action",
+    ...minimalNotification(),
+    id: "notif-action-1",
     priority: 60,
     title: "Approve expense report",
     summary: "Pending since Tuesday",
-    timestamp: NOW_ISO,
-    author: "assistant",
-    createdAt: NOW_ISO,
     actions: [
       {
         id: "approve",
@@ -55,59 +37,50 @@ function minimalAction(): Record<string, unknown> {
   };
 }
 
-function minimalThread(): Record<string, unknown> {
-  return {
-    id: "thread-1",
-    type: "thread",
-    priority: 30,
-    title: "Draft reply to Alice",
-    summary: "Waiting on your input",
-    timestamp: NOW_ISO,
-    author: "assistant",
-    createdAt: NOW_ISO,
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Valid minimal items
 // ---------------------------------------------------------------------------
 
 describe("feedItemSchema — valid minimal items", () => {
-  test("valid minimal nudge parses successfully", () => {
-    const parsed = feedItemSchema.parse(minimalNudge());
-    expect(parsed.type).toBe("nudge");
+  test("valid minimal notification parses successfully", () => {
+    const parsed = feedItemSchema.parse(minimalNotification());
+    expect(parsed.type).toBe("notification");
     // `status` defaults to "new" when absent.
     expect(parsed.status).toBe("new");
-    expect(parsed.author).toBe("assistant");
   });
 
-  test("valid minimal digest parses successfully", () => {
-    const parsed = feedItemSchema.parse(minimalDigest());
-    expect(parsed.type).toBe("digest");
-    expect(parsed.source).toBe("gmail");
-    expect(parsed.author).toBe("platform");
-  });
-
-  test("valid minimal action parses successfully", () => {
-    const parsed = feedItemSchema.parse(minimalAction());
-    expect(parsed.type).toBe("action");
+  test("notification with actions array parses and preserves the prompt", () => {
+    const parsed = feedItemSchema.parse(notificationWithActions());
+    expect(parsed.type).toBe("notification");
     expect(parsed.actions).toHaveLength(1);
     expect(parsed.actions?.[0]?.prompt).toBe("Approve the expense report.");
   });
 
-  test("valid minimal thread parses successfully", () => {
-    const parsed = feedItemSchema.parse(minimalThread());
-    expect(parsed.type).toBe("thread");
-  });
-
   test("status defaults to 'new' when omitted", () => {
-    const parsed = feedItemSchema.parse(minimalNudge());
+    const parsed = feedItemSchema.parse(minimalNotification());
     expect(parsed.status).toBe("new");
   });
 
   test("explicit status value is preserved", () => {
-    const parsed = feedItemSchema.parse({ ...minimalNudge(), status: "seen" });
+    const parsed = feedItemSchema.parse({
+      ...minimalNotification(),
+      status: "seen",
+    });
     expect(parsed.status).toBe("seen");
+  });
+
+  test("urgency, conversationId, expiresAt, detailPanel pass through", () => {
+    const parsed = feedItemSchema.parse({
+      ...minimalNotification(),
+      urgency: "high",
+      conversationId: "conv-abc",
+      expiresAt: "2026-04-15T00:00:00.000Z",
+      detailPanel: { kind: "emailDraft" },
+    });
+    expect(parsed.urgency).toBe("high");
+    expect(parsed.conversationId).toBe("conv-abc");
+    expect(parsed.expiresAt).toBe("2026-04-15T00:00:00.000Z");
+    expect(parsed.detailPanel?.kind).toBe("emailDraft");
   });
 });
 
@@ -118,34 +91,34 @@ describe("feedItemSchema — valid minimal items", () => {
 describe("feedItemSchema — priority validation", () => {
   test("rejects priority -1", () => {
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), priority: -1 }),
+      feedItemSchema.parse({ ...minimalNotification(), priority: -1 }),
     ).toThrow();
   });
 
   test("rejects priority 101", () => {
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), priority: 101 }),
+      feedItemSchema.parse({ ...minimalNotification(), priority: 101 }),
     ).toThrow();
   });
 
   test("rejects priority as string '5'", () => {
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), priority: "5" }),
+      feedItemSchema.parse({ ...minimalNotification(), priority: "5" }),
     ).toThrow();
   });
 
   test("rejects non-integer priority (e.g. 50.5)", () => {
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), priority: 50.5 }),
+      feedItemSchema.parse({ ...minimalNotification(), priority: 50.5 }),
     ).toThrow();
   });
 
   test("accepts boundary values 0 and 100", () => {
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), priority: 0 }),
+      feedItemSchema.parse({ ...minimalNotification(), priority: 0 }),
     ).not.toThrow();
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), priority: 100 }),
+      feedItemSchema.parse({ ...minimalNotification(), priority: 100 }),
     ).not.toThrow();
   });
 });
@@ -157,63 +130,21 @@ describe("feedItemSchema — priority validation", () => {
 describe("feedItemSchema — enum validation", () => {
   test("rejects unknown `type`", () => {
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), type: "banner" }),
+      feedItemSchema.parse({ ...minimalNotification(), type: "banner" }),
     ).toThrow();
+  });
+
+  test("rejects legacy v1 `type` values (nudge/digest/action/thread)", () => {
+    for (const legacy of ["nudge", "digest", "action", "thread"] as const) {
+      expect(() =>
+        feedItemSchema.parse({ ...minimalNotification(), type: legacy }),
+      ).toThrow();
+    }
   });
 
   test("rejects unknown `status`", () => {
     expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), status: "archived" }),
-    ).toThrow();
-  });
-
-  test("rejects unknown `source` (e.g. 'facebook')", () => {
-    expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), source: "facebook" }),
-    ).toThrow();
-  });
-
-  test("rejects unknown `author`", () => {
-    expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), author: "user" }),
-    ).toThrow();
-  });
-
-  test("allows omitted `source`", () => {
-    const raw = minimalNudge();
-    delete (raw as Record<string, unknown>).source;
-    expect(() => feedItemSchema.parse(raw)).not.toThrow();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// minTimeAway validation
-// ---------------------------------------------------------------------------
-
-describe("feedItemSchema — minTimeAway validation", () => {
-  test("accepts non-negative integer", () => {
-    const parsed = feedItemSchema.parse({
-      ...minimalNudge(),
-      minTimeAway: 3600,
-    });
-    expect(parsed.minTimeAway).toBe(3600);
-  });
-
-  test("accepts 0", () => {
-    expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), minTimeAway: 0 }),
-    ).not.toThrow();
-  });
-
-  test("rejects negative values", () => {
-    expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), minTimeAway: -1 }),
-    ).toThrow();
-  });
-
-  test("rejects non-integer values", () => {
-    expect(() =>
-      feedItemSchema.parse({ ...minimalNudge(), minTimeAway: 1.5 }),
+      feedItemSchema.parse({ ...minimalNotification(), status: "archived" }),
     ).toThrow();
   });
 });
@@ -223,31 +154,26 @@ describe("feedItemSchema — minTimeAway validation", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseFeedFile", () => {
-  test("accepts empty file with version 1", () => {
+  test("accepts empty file with version 2", () => {
     const parsed = parseFeedFile({
-      version: 1,
+      version: 2,
       items: [],
       updatedAt: NOW_ISO,
     });
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(2);
     expect(parsed.items).toEqual([]);
     expect(parsed.updatedAt).toBe(NOW_ISO);
   });
 
   test("accepts file with multiple valid items", () => {
     const parsed = parseFeedFile({
-      version: 1,
-      items: [
-        minimalNudge(),
-        minimalDigest(),
-        minimalAction(),
-        minimalThread(),
-      ],
+      version: 2,
+      items: [minimalNotification(), notificationWithActions()],
       updatedAt: NOW_ISO,
     });
-    expect(parsed.items).toHaveLength(4);
+    expect(parsed.items).toHaveLength(2);
     const types = parsed.items.map((i: FeedItem) => i.type);
-    expect(types).toEqual(["nudge", "digest", "action", "thread"]);
+    expect(types).toEqual(["notification", "notification"]);
   });
 
   test("throws on non-object input", () => {
@@ -257,17 +183,23 @@ describe("parseFeedFile", () => {
     expect(() => parseFeedFile(42)).toThrow();
   });
 
-  test("throws on wrong version", () => {
+  test("throws on legacy v1 version", () => {
     expect(() =>
-      parseFeedFile({ version: 2, items: [], updatedAt: NOW_ISO }),
+      parseFeedFile({ version: 1, items: [], updatedAt: NOW_ISO }),
+    ).toThrow();
+  });
+
+  test("throws on unknown version", () => {
+    expect(() =>
+      parseFeedFile({ version: 99, items: [], updatedAt: NOW_ISO }),
     ).toThrow();
   });
 
   test("throws when an item in the file is invalid", () => {
     expect(() =>
       parseFeedFile({
-        version: 1,
-        items: [{ ...minimalNudge(), priority: 999 }],
+        version: 2,
+        items: [{ ...minimalNotification(), priority: 999 }],
         updatedAt: NOW_ISO,
       }),
     ).toThrow();

--- a/assistant/src/home/__tests__/feed-writer.test.ts
+++ b/assistant/src/home/__tests__/feed-writer.test.ts
@@ -43,29 +43,23 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
 const {
   HOME_FEED_FILENAME,
   HOME_FEED_VERSION,
-  MAX_ACTIONS_PER_SOURCE,
   appendFeedItem,
   getHomeFeedPath,
   patchFeedItemStatus,
   readHomeFeed,
 } = await import("../feed-writer.js");
 
-type FeedItemType = "nudge" | "digest" | "action" | "thread";
-type FeedItemAuthor = "assistant" | "platform";
 type FeedItemStatus = "new" | "seen" | "acted_on";
-type FeedItemSource = "gmail" | "slack" | "calendar" | "assistant";
 
 interface TestFeedItem {
   id: string;
-  type: FeedItemType;
+  type: "notification";
   priority: number;
   title: string;
   summary: string;
-  source?: FeedItemSource;
   timestamp: string;
   status: FeedItemStatus;
   expiresAt?: string;
-  author: FeedItemAuthor;
   createdAt: string;
 }
 
@@ -73,13 +67,12 @@ function makeItem(
   overrides: Partial<TestFeedItem> & { id: string },
 ): TestFeedItem {
   return {
-    type: "nudge",
+    type: "notification",
     priority: 50,
     title: "Test",
     summary: "Test summary",
     timestamp: "2026-04-14T12:00:00.000Z",
     status: "new",
-    author: "platform",
     createdAt: "2026-04-14T12:00:00.000Z",
     ...overrides,
   };
@@ -127,7 +120,7 @@ describe("feed-writer", () => {
   });
 
   describe("readHomeFeed", () => {
-    test("missing file returns an empty v1 HomeFeedFile", () => {
+    test("missing file returns an empty v2 HomeFeedFile", () => {
       const feed = readHomeFeed();
       expect(feed.version).toBe(HOME_FEED_VERSION);
       expect(feed.items).toEqual([]);
@@ -139,17 +132,15 @@ describe("feed-writer", () => {
       const past = new Date(Date.now() - 60_000).toISOString();
       const future = new Date(Date.now() + 60_000).toISOString();
       const file = {
-        version: 1,
+        version: 2,
         updatedAt: "2026-04-14T12:00:00.000Z",
         items: [
           makeItem({
             id: "expired",
-            type: "action",
             expiresAt: past,
           }),
           makeItem({
             id: "live",
-            type: "action",
             expiresAt: future,
           }),
         ],
@@ -167,119 +158,125 @@ describe("feed-writer", () => {
       const feed = readHomeFeed();
       expect(feed.items).toEqual([]);
     });
+
+    test("v1 file (legacy schema) fails Zod validation and falls back to empty", () => {
+      // Defensive: if the workspace migration has not yet run (e.g. on
+      // first daemon boot before migrations land, or a corrupted
+      // migration checkpoint), the writer's read path must degrade
+      // gracefully rather than throwing.
+      mkdirSync(join(workspaceDir, "data"), { recursive: true });
+      const v1File = {
+        version: 1,
+        updatedAt: "2026-04-14T12:00:00.000Z",
+        items: [
+          {
+            id: "legacy",
+            type: "nudge",
+            priority: 50,
+            title: "Legacy",
+            summary: "Legacy summary",
+            source: "gmail",
+            author: "platform",
+            timestamp: "2026-04-14T12:00:00.000Z",
+            status: "new",
+            createdAt: "2026-04-14T12:00:00.000Z",
+          },
+        ],
+      };
+      writeFileSync(
+        getHomeFeedPath(),
+        JSON.stringify(v1File, null, 2),
+        "utf-8",
+      );
+
+      const feed = readHomeFeed();
+      expect(feed.items).toEqual([]);
+    });
   });
 
   describe("appendFeedItem", () => {
-    test("appends a single nudge to disk", async () => {
+    test("appends a single notification to disk as v2", async () => {
       await appendFeedItem(
         makeItem({
-          id: "nudge-1",
-          type: "nudge",
-          source: "gmail",
+          id: "notif-1",
           title: "New email",
           summary: "You have a new email",
         }),
       );
       const decoded = readFileJson();
-      expect(decoded.version).toBe(1);
+      expect(decoded.version).toBe(2);
       expect(decoded.items).toHaveLength(1);
-      expect(decoded.items[0]!.id).toBe("nudge-1");
+      expect(decoded.items[0]!.id).toBe("notif-1");
+      expect(decoded.items[0]!.type).toBe("notification");
       expect(decoded.items[0]!.title).toBe("New email");
     });
 
-    test("second digest from the same source replaces the first", async () => {
+    test("incoming item with the same id replaces the existing entry in place", async () => {
+      // The v2 merge rule: same-id replaces (preserving array
+      // position); otherwise append. Older entries with the same id
+      // must NOT linger in the list as duplicates.
       await appendFeedItem(
         makeItem({
-          id: "digest-old",
-          type: "digest",
-          source: "gmail",
-          title: "Old digest",
+          id: "dup",
+          title: "Original title",
           createdAt: "2026-04-14T10:00:00.000Z",
         }),
       );
       await appendFeedItem(
         makeItem({
-          id: "digest-new",
-          type: "digest",
-          source: "gmail",
-          title: "New digest",
+          id: "other",
+          title: "Other entry",
           createdAt: "2026-04-14T11:00:00.000Z",
         }),
       );
-
-      const decoded = readFileJson();
-      const digests = decoded.items.filter((i) => i.type === "digest");
-      expect(digests).toHaveLength(1);
-      expect(digests[0]!.id).toBe("digest-new");
-      expect(digests[0]!.title).toBe("New digest");
-    });
-
-    test("assistant nudge overwrites an existing platform nudge for the same source", async () => {
       await appendFeedItem(
         makeItem({
-          id: "platform-nudge",
-          type: "nudge",
-          source: "slack",
-          author: "platform",
-          title: "Platform baseline",
-        }),
-      );
-      await appendFeedItem(
-        makeItem({
-          id: "assistant-nudge",
-          type: "nudge",
-          source: "slack",
-          author: "assistant",
-          title: "Assistant override",
+          id: "dup",
+          title: "Refreshed title",
+          createdAt: "2026-04-14T12:00:00.000Z",
         }),
       );
 
       const decoded = readFileJson();
-      const nudges = decoded.items.filter(
-        (i) => i.type === "nudge" && i.source === "slack",
-      );
-      expect(nudges).toHaveLength(1);
-      expect(nudges[0]!.author).toBe("assistant");
-      expect(nudges[0]!.title).toBe("Assistant override");
+      const matching = decoded.items.filter((i) => i.id === "dup");
+      expect(matching).toHaveLength(1);
+      expect(matching[0]!.title).toBe("Refreshed title");
+      expect(decoded.items.find((i) => i.id === "other")).toBeDefined();
     });
 
-    test("platform nudge over an existing assistant nudge is a no-op", async () => {
+    test("distinct ids all persist (no implicit dedup beyond same-id)", async () => {
       await appendFeedItem(
         makeItem({
-          id: "assistant-nudge",
-          type: "nudge",
-          source: "slack",
-          author: "assistant",
-          title: "Assistant original",
+          id: "a",
+          title: "First",
+          createdAt: "2026-04-14T10:00:00.000Z",
         }),
       );
       await appendFeedItem(
         makeItem({
-          id: "platform-nudge",
-          type: "nudge",
-          source: "slack",
-          author: "platform",
-          title: "Stale platform baseline",
+          id: "b",
+          title: "Second",
+          createdAt: "2026-04-14T11:00:00.000Z",
+        }),
+      );
+      await appendFeedItem(
+        makeItem({
+          id: "c",
+          title: "Third",
+          createdAt: "2026-04-14T12:00:00.000Z",
         }),
       );
 
       const decoded = readFileJson();
-      const nudges = decoded.items.filter(
-        (i) => i.type === "nudge" && i.source === "slack",
-      );
-      expect(nudges).toHaveLength(1);
-      expect(nudges[0]!.author).toBe("assistant");
-      expect(nudges[0]!.title).toBe("Assistant original");
+      expect(decoded.items).toHaveLength(3);
+      const ids = new Set(decoded.items.map((i) => i.id));
+      expect(ids).toEqual(new Set(["a", "b", "c"]));
     });
 
-    test("action without expiresAt is persisted with no auto-fade", async () => {
-      // Action items are the feed's activity log — they must persist
-      // until the user dismisses them. The writer used to fill in a
-      // 24h default expiresAt; that behavior is intentionally gone.
+    test("item without expiresAt is persisted as-is (no auto-fade)", async () => {
       await appendFeedItem(
         makeItem({
-          id: "action-1",
-          type: "action",
+          id: "no-expiry",
           createdAt: "2026-04-14T12:00:00.000Z",
         }),
       );
@@ -288,206 +285,17 @@ describe("feed-writer", () => {
       expect(decoded.items[0]!.expiresAt).toBeUndefined();
     });
 
-    test("action with an explicit expiresAt is left untouched", async () => {
+    test("explicit expiresAt is left untouched", async () => {
       const explicit = "2026-04-15T00:00:00.000Z";
       await appendFeedItem(
         makeItem({
-          id: "action-2",
-          type: "action",
+          id: "with-expiry",
           expiresAt: explicit,
           createdAt: "2026-04-14T12:00:00.000Z",
         }),
       );
       const decoded = readFileJson();
       expect(decoded.items[0]!.expiresAt).toBe(explicit);
-    });
-
-    test("action with same id updates the existing entry in place", async () => {
-      // Deterministic-dedup callers (emit-feed-event.ts dedupKey)
-      // emit the same id on repeat signals; the writer must refresh
-      // the existing entry rather than append a duplicate, otherwise
-      // the same event would show up N times until the per-source
-      // cap trimmed it.
-      await appendFeedItem(
-        makeItem({
-          id: "emit:gmail:unread-msg-42",
-          type: "action",
-          source: "gmail",
-          title: "Unread from Alice",
-          createdAt: "2026-04-14T10:00:00.000Z",
-        }),
-      );
-      await appendFeedItem(
-        makeItem({
-          id: "emit:gmail:unread-msg-42",
-          type: "action",
-          source: "gmail",
-          title: "Unread from Alice (refreshed)",
-          createdAt: "2026-04-14T12:00:00.000Z",
-        }),
-      );
-
-      const decoded = readFileJson();
-      const matching = decoded.items.filter(
-        (i) => i.id === "emit:gmail:unread-msg-42",
-      );
-      expect(matching).toHaveLength(1);
-      expect(matching[0]!.title).toBe("Unread from Alice (refreshed)");
-    });
-
-    test("multiple actions with the same (type, source) all persist", async () => {
-      // Actions must not collapse onto each other by (type, source) —
-      // each append is a distinct entry in the activity log.
-      await appendFeedItem(
-        makeItem({
-          id: "action-a",
-          type: "action",
-          source: "gmail",
-          title: "Acted A",
-          createdAt: "2026-04-14T10:00:00.000Z",
-        }),
-      );
-      await appendFeedItem(
-        makeItem({
-          id: "action-b",
-          type: "action",
-          source: "gmail",
-          title: "Acted B",
-          createdAt: "2026-04-14T11:00:00.000Z",
-        }),
-      );
-      await appendFeedItem(
-        makeItem({
-          id: "action-c",
-          type: "action",
-          source: "gmail",
-          title: "Acted C",
-          createdAt: "2026-04-14T12:00:00.000Z",
-        }),
-      );
-
-      const decoded = readFileJson();
-      const gmailActions = decoded.items.filter(
-        (i) => i.type === "action" && i.source === "gmail",
-      );
-      expect(gmailActions).toHaveLength(3);
-      const ids = new Set(gmailActions.map((i) => i.id));
-      expect(ids).toEqual(new Set(["action-a", "action-b", "action-c"]));
-    });
-
-    test("per-source action cap keeps only the N most recent per source", async () => {
-      // Append MAX+5 actions for gmail, interleaved with a handful of
-      // slack actions and a digest. Cap must apply only to the
-      // overflowing source.
-      const overflow = MAX_ACTIONS_PER_SOURCE + 5;
-      for (let i = 0; i < overflow; i++) {
-        await appendFeedItem(
-          makeItem({
-            id: `gmail-${i}`,
-            type: "action",
-            source: "gmail",
-            title: `Gmail action ${i}`,
-            createdAt: new Date(
-              Date.parse("2026-04-14T00:00:00.000Z") + i * 60_000,
-            ).toISOString(),
-          }),
-        );
-      }
-      await appendFeedItem(
-        makeItem({
-          id: "slack-1",
-          type: "action",
-          source: "slack",
-          title: "Slack action",
-          createdAt: "2026-04-14T12:00:00.000Z",
-        }),
-      );
-      await appendFeedItem(
-        makeItem({
-          id: "digest-1",
-          type: "digest",
-          source: "gmail",
-          title: "Gmail digest",
-          createdAt: "2026-04-14T12:01:00.000Z",
-        }),
-      );
-
-      const decoded = readFileJson();
-      const gmailActions = decoded.items.filter(
-        (i) => i.type === "action" && i.source === "gmail",
-      );
-      expect(gmailActions).toHaveLength(MAX_ACTIONS_PER_SOURCE);
-
-      // The kept ids are the MAX most recent by createdAt — i.e. the
-      // final MAX entries of the 0..overflow-1 sequence.
-      const keptIds = new Set(gmailActions.map((i) => i.id));
-      for (let i = overflow - MAX_ACTIONS_PER_SOURCE; i < overflow; i++) {
-        expect(keptIds.has(`gmail-${i}`)).toBe(true);
-      }
-      for (let i = 0; i < overflow - MAX_ACTIONS_PER_SOURCE; i++) {
-        expect(keptIds.has(`gmail-${i}`)).toBe(false);
-      }
-
-      // Slack is under the cap and the digest is a different type —
-      // both untouched by the prune.
-      expect(decoded.items.filter((i) => i.id === "slack-1")).toHaveLength(1);
-      expect(decoded.items.filter((i) => i.type === "digest")).toHaveLength(1);
-    });
-
-    test("action items without a source are not subject to the cap", async () => {
-      const n = MAX_ACTIONS_PER_SOURCE + 3;
-      for (let i = 0; i < n; i++) {
-        await appendFeedItem(
-          makeItem({
-            id: `sourceless-${i}`,
-            type: "action",
-            title: `Sourceless ${i}`,
-            createdAt: new Date(
-              Date.parse("2026-04-14T00:00:00.000Z") + i * 60_000,
-            ).toISOString(),
-          }),
-        );
-      }
-      const decoded = readFileJson();
-      const sourceless = decoded.items.filter(
-        (i) => i.type === "action" && i.source === undefined,
-      );
-      expect(sourceless).toHaveLength(n);
-    });
-
-    test("thread updates replace the existing thread with the same id in place", async () => {
-      await appendFeedItem(
-        makeItem({
-          id: "thread-A",
-          type: "thread",
-          title: "Thread v1",
-          priority: 80,
-          createdAt: "2026-04-14T12:00:00.000Z",
-        }),
-      );
-      await appendFeedItem(
-        makeItem({
-          id: "thread-B",
-          type: "thread",
-          title: "Other thread",
-          priority: 60,
-          createdAt: "2026-04-14T11:00:00.000Z",
-        }),
-      );
-      await appendFeedItem(
-        makeItem({
-          id: "thread-A",
-          type: "thread",
-          title: "Thread v2 updated",
-          priority: 80,
-          createdAt: "2026-04-14T12:00:00.000Z",
-        }),
-      );
-
-      const decoded = readFileJson();
-      expect(decoded.items).toHaveLength(2);
-      const threadA = decoded.items.find((i) => i.id === "thread-A");
-      expect(threadA?.title).toBe("Thread v2 updated");
     });
 
     test("items sort by priority desc then createdAt desc", async () => {
@@ -527,7 +335,6 @@ describe("feed-writer", () => {
       await appendFeedItem(
         makeItem({
           id: "item-1",
-          type: "nudge",
           title: "Original",
         }),
       );
@@ -545,7 +352,7 @@ describe("feed-writer", () => {
     });
 
     test("returns null for an unknown id", async () => {
-      await appendFeedItem(makeItem({ id: "known", type: "nudge" }));
+      await appendFeedItem(makeItem({ id: "known" }));
       const result = await patchFeedItemStatus("unknown", "seen");
       expect(result).toBeNull();
     });
@@ -556,7 +363,6 @@ describe("feed-writer", () => {
       await appendFeedItem(
         makeItem({
           id: "fail-item",
-          type: "nudge",
           title: "Pre-fail title",
         }),
       );
@@ -594,13 +400,10 @@ describe("feed-writer", () => {
   });
 
   describe("concurrency", () => {
-    test("10 concurrent appends of items with distinct (type,source) pairs all land", async () => {
+    test("10 concurrent appends with distinct ids all land", async () => {
       const items = Array.from({ length: 10 }, (_, i) =>
         makeItem({
           id: `distinct-${i}`,
-          type: "nudge",
-          // No source → no (type,source) dedupe at all; every item
-          // lands as-is. This is the purest concurrent-append test.
           title: `Item ${i}`,
           createdAt: new Date(
             Date.parse("2026-04-14T12:00:00.000Z") + i * 1000,
@@ -624,14 +427,12 @@ describe("feed-writer", () => {
       await appendFeedItem(
         makeItem({
           id: "new-1",
-          type: "nudge",
           status: "new",
         }),
       );
       await appendFeedItem(
         makeItem({
           id: "new-2",
-          type: "nudge",
           status: "new",
           createdAt: "2026-04-14T12:00:01.000Z",
         }),
@@ -639,7 +440,6 @@ describe("feed-writer", () => {
       await appendFeedItem(
         makeItem({
           id: "seen-1",
-          type: "nudge",
           status: "seen",
           createdAt: "2026-04-14T12:00:02.000Z",
         }),
@@ -664,7 +464,6 @@ describe("feed-writer", () => {
       await appendFeedItem(
         makeItem({
           id: "x",
-          type: "nudge",
           status: "new",
         }),
       );

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -2,9 +2,8 @@
  * Home activity feed data contract.
  *
  * Defines the shape of `FeedItem`s shown in the macOS Home page feed
- * section (nudges, digests, actions, threads) plus the on-disk file
- * format written by the daemon feed writer (PR 5) and served by the
- * daemon HTTP route (PR 6).
+ * section plus the on-disk file format written by the daemon feed
+ * writer (PR 5) and served by the daemon HTTP route (PR 6).
  *
  * The TDD contract field originally named `ttl` is renamed internally
  * to `expiresAt` — it is an absolute ISO-8601 timestamp, not a
@@ -14,6 +13,15 @@
  * a translation layer at the route boundary; within the daemon, all
  * internal types use `expiresAt`.
  *
+ * **v2 schema collapse** — feed items now have a single `notification`
+ * type. The legacy `nudge | digest | action | thread` distinctions
+ * (and the `source` / `author` / `minTimeAway` fields that supported
+ * them) have been removed; everything that lands in the home feed is
+ * a notification, with the writer's only merge rule being "same `id`
+ * replaces in place, otherwise append". Workspace migration
+ * `061-home-feed-notification-only` rewrites pre-v2 files on first
+ * boot.
+ *
  * A structurally compatible Swift mirror lives at
  * `clients/shared/Network/FeedItem.swift` (PR 3). Any change here
  * must be mirrored there.
@@ -22,34 +30,10 @@
 import { z } from "zod";
 
 /** High-level kind of feed item — drives which Swift view renders it. */
-export type FeedItemType = "nudge" | "digest" | "action" | "thread";
+export type FeedItemType = "notification";
 
 /** User-facing lifecycle of a feed item. */
 export type FeedItemStatus = "new" | "seen" | "acted_on" | "dismissed";
-
-/**
- * Origin of the underlying event.
- *
- * In v1 this is constrained to a closed set so the Swift icon mapping
- * stays exhaustive. Future sources will be added explicitly rather
- * than letting arbitrary strings slip through.
- */
-export type FeedItemSource =
-  | "gmail"
-  | "slack"
-  | "calendar"
-  | "assistant"
-  | "telegram";
-
-/**
- * Internal field used by the hybrid authoring resolver (PR 5 writer).
- *
- * Not part of the TDD public interface — it distinguishes items the
- * assistant produced on its own from items the platform baseline
- * generators (e.g. Gmail digest in PR 12) produced, so assistant
- * overrides can win over platform defaults for the same source.
- */
-export type FeedItemAuthor = "assistant" | "platform";
 
 /** Visual urgency treatment — controls badge color independently of sort priority. */
 export type FeedItemUrgency = "low" | "medium" | "high" | "critical";
@@ -84,8 +68,7 @@ export interface FeedItemDetailPanel {
 /**
  * A single item rendered in the Home feed.
  *
- * Mirrors the TDD contract plus two internal-only fields:
- *   - `author`  — hybrid-authoring resolver discriminator
+ * Mirrors the TDD contract plus one internal-only field:
  *   - `createdAt` — when the writer recorded the item (distinct from
  *                   `timestamp`, which is the event time). Used for
  *                   TTL sweeps and stable ordering.
@@ -100,16 +83,12 @@ export interface FeedItem {
   priority: number;
   title: string;
   summary: string;
-  /** Optional; when present must be one of the v1 sources. */
-  source?: FeedItemSource;
   /** Event time (ISO-8601). */
   timestamp: string;
   /** Defaults to `"new"` at parse time. */
   status: FeedItemStatus;
   /** Absolute ISO-8601 expiry timestamp (renamed from TDD `ttl`). */
   expiresAt?: string;
-  /** Minimum seconds the user must be away before the item is shown. */
-  minTimeAway?: number;
   actions?: FeedAction[];
   /** Visual urgency treatment — controls badge color independently of sort priority. */
   urgency?: FeedItemUrgency;
@@ -117,8 +96,6 @@ export interface FeedItem {
   conversationId?: string;
   /** Server-driven detail panel descriptor; when present, the client opens this panel kind. */
   detailPanel?: FeedItemDetailPanel;
-  /** Internal: who authored this item. */
-  author: FeedItemAuthor;
   /** Internal: ISO-8601 writer-record time, used for ordering + TTL. */
   createdAt: string;
 }
@@ -137,11 +114,12 @@ export interface LowPriorityCollapsed {
  * On-disk file format for `~/.vellum/workspace/data/home-feed.json`.
  *
  * Written by the PR 5 writer, read by the PR 6 HTTP route and
- * `parseFeedFile` below. `version` is pinned to `1`; future format
- * changes bump this and live behind a workspace migration.
+ * `parseFeedFile` below. `version` is pinned to `2` (collapsed schema);
+ * pre-v2 files are rewritten by workspace migration
+ * `061-home-feed-notification-only`.
  */
 export interface HomeFeedFile {
-  version: 1;
+  version: 2;
   items: FeedItem[];
   updatedAt: string;
 }
@@ -171,19 +149,9 @@ export interface SuggestedPrompt {
 // Zod schemas
 // ---------------------------------------------------------------------------
 
-const feedItemTypeSchema = z.enum(["nudge", "digest", "action", "thread"]);
+const feedItemTypeSchema = z.literal("notification");
 
 const feedItemStatusSchema = z.enum(["new", "seen", "acted_on", "dismissed"]);
-
-const feedItemSourceSchema = z.enum([
-  "gmail",
-  "slack",
-  "calendar",
-  "assistant",
-  "telegram",
-]);
-
-const feedItemAuthorSchema = z.enum(["assistant", "platform"]);
 
 const feedItemUrgencySchema = z.enum(["low", "medium", "high", "critical"]);
 
@@ -215,10 +183,6 @@ const feedItemDetailPanelSchema = z.object({
  *     silent coercion tends to mask writer bugs.
  *   - `status` defaults to `"new"` so the writer does not need to
  *     set it on every append.
- *   - `source` is optional but, when present, must be one of the
- *     four v1 sources — unknown values (e.g. `"facebook"`) are
- *     rejected rather than silently passed through.
- *   - `minTimeAway` is a non-negative integer number of seconds.
  */
 export const feedItemSchema = z.object({
   id: z.string(),
@@ -226,16 +190,13 @@ export const feedItemSchema = z.object({
   priority: z.number().int().min(0).max(100),
   title: z.string(),
   summary: z.string(),
-  source: feedItemSourceSchema.optional(),
   timestamp: z.string(),
   status: feedItemStatusSchema.default("new"),
   expiresAt: z.string().optional(),
-  minTimeAway: z.number().int().min(0).optional(),
   actions: z.array(feedActionSchema).optional(),
   urgency: feedItemUrgencySchema.optional(),
   conversationId: z.string().optional(),
   detailPanel: feedItemDetailPanelSchema.optional(),
-  author: feedItemAuthorSchema,
   createdAt: z.string(),
 });
 
@@ -256,7 +217,7 @@ export const lowPriorityCollapsedSchema = z.object({
 
 /** Schema for the on-disk `home-feed.json` file. */
 const homeFeedFileSchema = z.object({
-  version: z.literal(1),
+  version: z.literal(2),
   items: z.array(feedItemSchema),
   updatedAt: z.string(),
 });

--- a/assistant/src/home/feed-writer.ts
+++ b/assistant/src/home/feed-writer.ts
@@ -2,41 +2,26 @@
  * Home activity feed writer.
  *
  * Owns `<workspace>/data/home-feed.json`, the daemon-side source of
- * truth for the macOS Home page activity feed. Handles the merge
- * semantics defined by the TDD / plan:
+ * truth for the macOS Home page activity feed.
  *
- *   - Digest replacement: at most one digest per `source`. A fresh
- *     digest for a source replaces any prior digest for the same
- *     source in place.
- *   - Thread in-place update: if an incoming `thread` item shares its
+ * **v2 merge semantics** — the schema collapse to a single
+ * `notification` type also collapses the writer's merge rules to a
+ * single rule:
+ *
+ *   - **Same `id` replaces in place**: if an incoming item shares its
  *     `id` with an existing item, replace that item while preserving
  *     its array position so the UI does not jitter on updates.
- *   - Author resolution: for matching `(type, source)` pairs the
- *     hybrid-authoring precedence is `assistant` beats `platform` —
- *     an assistant item overwrites an existing platform item for the
- *     same pair, but a platform item never overwrites an existing
- *     assistant item (no-op). Applies to nudges; actions are exempt
- *     (see next bullet).
- *   - Action append-without-replace: `action` items are the feed's
- *     activity log and never merge by `(type, source)` — each append
- *     becomes a distinct entry so successive background-job events
- *     don't collapse onto each other. A same-`id` action is the one
- *     exception: it performs an in-place update (same semantics as
- *     threads) so callers using a deterministic dedup id via
- *     `emit-feed-event.ts` can refresh an entry without appending a
- *     duplicate. Callers that want to auto-expire an action item
- *     must set `expiresAt` explicitly; the writer does NOT fill in
- *     a default expiry.
- *   - Per-source action cap: after merge, each source keeps at most
- *     {@link MAX_ACTIONS_PER_SOURCE} action items (most recent by
- *     `createdAt`). Older actions for that source are dropped so the
- *     on-disk file can't balloon as background jobs emit events.
- *     Action items without a `source` are unbounded and passed
- *     through untouched.
- *   - TTL filter on read: `readHomeFeed` drops any item whose
+ *     Otherwise, append. The pre-v2 type-specific branches (digest
+ *     replacement by source, thread same-id update, action
+ *     append-without-replace, hybrid-author resolution, per-source
+ *     action cap) are gone — they were holdovers from a multi-type
+ *     vocabulary that no longer exists.
+ *
+ *   - **TTL filter on read**: `readHomeFeed` drops any item whose
  *     `expiresAt` is in the past. This is a stateless sweep — the
  *     writer does not rewrite the file on read, so concurrent reads
- *     never race the writer.
+ *     never race the writer. Callers that want auto-expiry must set
+ *     `expiresAt` explicitly; the writer does NOT fill in a default.
  *
  * Concurrent writers are coalesced with the exact same "latest wins"
  * pattern as `relationship-state-writer.ts`: at most one compute+write
@@ -69,16 +54,7 @@ const log = getLogger("home-feed-writer");
 export const HOME_FEED_FILENAME = "home-feed.json";
 
 /** On-disk file-format version. Bump + migrate if the shape changes. */
-export const HOME_FEED_VERSION = 1;
-
-/**
- * Per-source volume cap for `action` items. When the post-merge item
- * list has more than this many action items for a single source, the
- * oldest (by `createdAt`) are dropped until the count is back within
- * the cap. Other item types are unaffected, and action items without
- * a `source` are also unaffected.
- */
-export const MAX_ACTIONS_PER_SOURCE = 20;
+export const HOME_FEED_VERSION = 2;
 
 /**
  * Canonical path to the home-feed snapshot
@@ -238,8 +214,6 @@ async function runWrite(): Promise<void> {
     items = mergeIncoming(items, incoming);
   }
 
-  items = pruneActionsPerSource(items);
-
   // Track the per-patch result so callers can distinguish an update
   // from an unknown-id no-op. We collect resolvers first and fire them
   // after the write lands so the resolved `FeedItem` matches on-disk
@@ -298,126 +272,21 @@ async function runWrite(): Promise<void> {
 }
 
 /**
- * Apply the merge semantics for a single incoming item against the
+ * Apply the v2 merge rule for a single incoming item against the
  * current item list and return a new list. Pure function — the input
  * array is not mutated.
+ *
+ * Same-`id` replaces in place (preserving array position so the UI
+ * does not jitter); otherwise the item is appended.
  */
 function mergeIncoming(items: FeedItem[], incoming: FeedItem): FeedItem[] {
-  // Digest replacement: one digest per source wins.
-  if (incoming.type === "digest" && incoming.source) {
-    const filtered = items.filter(
-      (i) => !(i.type === "digest" && i.source === incoming.source),
-    );
-    filtered.push(incoming);
-    return filtered;
+  const idx = items.findIndex((i) => i.id === incoming.id);
+  if (idx !== -1) {
+    const copy = items.slice();
+    copy[idx] = incoming;
+    return copy;
   }
-
-  // Thread in-place update: same id wins, preserve position.
-  if (incoming.type === "thread") {
-    const idx = items.findIndex(
-      (i) => i.type === "thread" && i.id === incoming.id,
-    );
-    if (idx !== -1) {
-      const copy = items.slice();
-      copy[idx] = incoming;
-      return copy;
-    }
-  }
-
-  // Action append-without-replace: each action item is a distinct
-  // activity-log entry and must NOT collapse onto an existing action
-  // for the same (type, source) pair. The per-source volume cap in
-  // `pruneActionsPerSource` keeps the log from growing unbounded.
-  //
-  // Exception: same-id in-place update. Callers that want
-  // deterministic dedup (e.g. via `emit-feed-event.ts`'s `dedupKey`)
-  // produce a stable id per logical event; a second emit with the
-  // same id refreshes the existing entry in place rather than
-  // appending a duplicate.
-  if (incoming.type === "action") {
-    const idx = items.findIndex(
-      (i) => i.type === "action" && i.id === incoming.id,
-    );
-    if (idx !== -1) {
-      const copy = items.slice();
-      copy[idx] = incoming;
-      return copy;
-    }
-    return [...items, incoming];
-  }
-
-  // Author resolution: for matching (type, source) pairs, assistant
-  // beats platform. A platform-authored incoming item against an
-  // existing assistant item is a no-op. Applies to nudges (actions
-  // short-circuit above).
-  if (incoming.source) {
-    const existingIdx = items.findIndex(
-      (i) => i.type === incoming.type && i.source === incoming.source,
-    );
-    if (existingIdx !== -1) {
-      const existing = items[existingIdx]!;
-      if (existing.author === "assistant" && incoming.author === "platform") {
-        // Platform can't overwrite assistant — no-op.
-        return items;
-      }
-      if (existing.author === "platform" && incoming.author === "assistant") {
-        const copy = items.slice();
-        copy[existingIdx] = incoming;
-        return copy;
-      }
-    }
-  }
-
   return [...items, incoming];
-}
-
-/**
- * Enforce the per-source volume cap on `action` items. For each
- * source that has more than {@link MAX_ACTIONS_PER_SOURCE} actions in
- * the post-merge list, keep the most recent by `createdAt` and drop
- * the rest. Other item types and action items without a `source` are
- * passed through untouched. Stable with respect to non-affected items.
- */
-function pruneActionsPerSource(items: FeedItem[]): FeedItem[] {
-  const actionsBySource = new Map<string, FeedItem[]>();
-  for (const item of items) {
-    if (item.type !== "action" || !item.source) continue;
-    const bucket = actionsBySource.get(item.source);
-    if (bucket) {
-      bucket.push(item);
-    } else {
-      actionsBySource.set(item.source, [item]);
-    }
-  }
-
-  const overflowing: string[] = [];
-  for (const [source, bucket] of actionsBySource) {
-    if (bucket.length > MAX_ACTIONS_PER_SOURCE) overflowing.push(source);
-  }
-  if (overflowing.length === 0) return items;
-
-  const keepIds = new Set<string>();
-  for (const source of overflowing) {
-    const bucket = actionsBySource.get(source)!.slice();
-    bucket.sort((a, b) => {
-      const am = Date.parse(a.createdAt);
-      const bm = Date.parse(b.createdAt);
-      if (Number.isNaN(am) && Number.isNaN(bm)) return 0;
-      if (Number.isNaN(am)) return 1;
-      if (Number.isNaN(bm)) return -1;
-      return bm - am;
-    });
-    for (const item of bucket.slice(0, MAX_ACTIONS_PER_SOURCE)) {
-      keepIds.add(item.id);
-    }
-  }
-
-  return items.filter((item) => {
-    if (item.type !== "action") return true;
-    if (!item.source) return true;
-    if (!overflowing.includes(item.source)) return true;
-    return keepIds.has(item.id);
-  });
 }
 
 /**

--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -102,9 +102,11 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls).toHaveLength(1);
     const appended = appendCalls[0]!;
     expect(appended.id).toBe("notif:sig-test-1");
-    expect(appended.type).toBe("action");
-    expect(appended.source).toBe("assistant");
-    expect(appended.author).toBe("assistant");
+    expect(appended.type).toBe("notification");
+    // v2 dropped source/author — the side effect must construct items
+    // without those fields.
+    expect((appended as { source?: unknown }).source).toBeUndefined();
+    expect((appended as { author?: unknown }).author).toBeUndefined();
     expect(appended.priority).toBe(50);
     expect(appended.status).toBe("new");
     expect(appended.title).toBe("Background job done");

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -63,9 +63,7 @@ export async function writeHomeFeedItemForSignal(
 
   const item: FeedItem = {
     id: `notif:${signal.signalId}`,
-    type: "action",
-    source: "assistant",
-    author: "assistant",
+    type: "notification",
     priority: 50,
     title: renderedCopy?.title ?? payloadTitle ?? signal.sourceEventName,
     summary: renderedCopy?.body ?? payloadBody ?? signal.sourceEventName,

--- a/assistant/src/runtime/routes/__tests__/home-feed-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/home-feed-routes.test.ts
@@ -147,17 +147,14 @@ function homeFeedRouteDefinitions() {
 
 type FeedItemFixture = {
   id: string;
-  type: "nudge" | "digest" | "action" | "thread";
+  type: "notification";
   priority: number;
   title: string;
   summary: string;
-  source?: "gmail" | "slack" | "calendar" | "assistant";
   timestamp: string;
   status: "new" | "seen" | "acted_on";
   expiresAt?: string;
-  minTimeAway?: number;
   actions?: Array<{ id: string; label: string; prompt: string }>;
-  author: "assistant" | "platform";
   createdAt: string;
 };
 
@@ -165,13 +162,12 @@ function makeItem(
   overrides: Partial<FeedItemFixture> & { id: string },
 ): FeedItemFixture {
   return {
-    type: "nudge",
+    type: "notification",
     priority: 50,
     title: "Test",
     summary: "Test summary",
     timestamp: "2026-04-14T12:00:00.000Z",
     status: "new",
-    author: "platform",
     createdAt: "2026-04-14T12:00:00.000Z",
     ...overrides,
   };
@@ -184,7 +180,7 @@ function writeFeedFile(items: FeedItemFixture[]): void {
     path,
     JSON.stringify(
       {
-        version: 1,
+        version: 2,
         updatedAt: "2026-04-14T12:00:00.000Z",
         items,
       },
@@ -350,18 +346,12 @@ describe("handleGetHomeFeed", () => {
     expect(typeof body.contextBanner.greeting).toBe("string");
   });
 
-  test("filters out items whose minTimeAway exceeds timeAwaySeconds", async () => {
-    writeFeedFile([
-      makeItem({
-        id: "gated",
-        type: "nudge",
-        minTimeAway: 3600,
-      }),
-      makeItem({
-        id: "ungated",
-        type: "nudge",
-      }),
-    ]);
+  test("returns every item regardless of timeAwaySeconds (v2 dropped minTimeAway gating)", async () => {
+    // The v2 schema no longer carries `minTimeAway`, and the route
+    // handler no longer gates on it — every item flows through. The
+    // `timeAwaySeconds` query parameter survives only because the
+    // context banner's relative-time label is derived from it.
+    writeFeedFile([makeItem({ id: "a" }), makeItem({ id: "b" })]);
 
     const res = await handleGetHomeFeed(
       new Request("http://localhost/v1/home/feed?timeAwaySeconds=60"),
@@ -371,20 +361,13 @@ describe("handleGetHomeFeed", () => {
       items: Array<{ id: string }>;
       contextBanner: { newCount: number };
     };
-    const ids = body.items.map((i) => i.id);
-    expect(ids).toContain("ungated");
-    expect(ids).not.toContain("gated");
-    expect(body.contextBanner.newCount).toBe(1);
+    const ids = body.items.map((i) => i.id).sort();
+    expect(ids).toEqual(["a", "b"]);
+    expect(body.contextBanner.newCount).toBe(2);
   });
 
-  test("includes items when timeAwaySeconds >= minTimeAway", async () => {
-    writeFeedFile([
-      makeItem({
-        id: "gated",
-        type: "nudge",
-        minTimeAway: 3600,
-      }),
-    ]);
+  test("contextBanner.timeAwayLabel reflects the supplied timeAwaySeconds", async () => {
+    writeFeedFile([makeItem({ id: "any" })]);
 
     const res = await handleGetHomeFeed(
       new Request("http://localhost/v1/home/feed?timeAwaySeconds=7200"),
@@ -395,7 +378,7 @@ describe("handleGetHomeFeed", () => {
       contextBanner: { newCount: number; timeAwayLabel: string };
     };
     expect(body.items).toHaveLength(1);
-    expect(body.items[0]!.id).toBe("gated");
+    expect(body.items[0]!.id).toBe("any");
     expect(body.contextBanner.newCount).toBe(1);
     expect(body.contextBanner.timeAwayLabel).toBe("2 hours ago");
   });
@@ -496,7 +479,6 @@ describe("handlePostFeedAction", () => {
     writeFeedFile([
       makeItem({
         id: "item-1",
-        type: "action",
         actions: [
           {
             id: "reply",
@@ -547,7 +529,6 @@ describe("handlePostFeedAction", () => {
     writeFeedFile([
       makeItem({
         id: "item-2",
-        type: "action",
         actions: [{ id: "reply", label: "Reply", prompt: "hi" }],
       }),
     ]);
@@ -567,7 +548,6 @@ describe("handlePostFeedAction", () => {
     writeFeedFile([
       makeItem({
         id: "item-3",
-        type: "action",
         actions: [{ id: "reply", label: "Reply", prompt: "hi" }],
       }),
     ]);

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -118,10 +118,11 @@ export async function handleGetHomeFeed({
   const timeAwaySeconds = parsed;
 
   const feed = readHomeFeed();
-  const filtered = feed.items.filter((item) => {
-    if (item.minTimeAway === undefined) return true;
-    return item.minTimeAway <= timeAwaySeconds;
-  });
+  // v2 schema dropped per-item `minTimeAway` gating; surface every item
+  // and let the client decide what to render based on its own
+  // session state. `timeAwaySeconds` survives only to feed the
+  // context-banner relative-time label.
+  const filtered = feed.items;
 
   const LOW_PRIORITY_THRESHOLD = 30;
   const lowPriorityItems = filtered.filter(

--- a/assistant/src/workspace/migrations/061-home-feed-notification-only.ts
+++ b/assistant/src/workspace/migrations/061-home-feed-notification-only.ts
@@ -1,0 +1,197 @@
+/**
+ * Workspace migration `061-home-feed-notification-only`.
+ *
+ * Rewrites `<workspace>/data/home-feed.json` from the legacy v1 schema
+ * (mixed `nudge | digest | action | thread` types with `source`,
+ * `author`, `minTimeAway` fields) into the collapsed v2 schema (single
+ * `notification` type, no source/author/minTimeAway).
+ *
+ * Behaviour:
+ *   - Missing file → no-op.
+ *   - Malformed JSON → log and no-op (daemon startup must never block;
+ *     the writer's `readHomeFeed()` already treats unreadable files as
+ *     empty so the next append cycle naturally rewrites a clean file).
+ *   - Already v2 → no-op (idempotent).
+ *   - v1 (or any non-v2 shape with an `items` array): drop entries
+ *     whose `type !== "action"` (legacy nudge/digest/thread items have
+ *     no v2 analogue and weren't surfaced as live notifications anyway,
+ *     per PR 15 of the home-notif-feed-revamp plan); for kept entries
+ *     drop `source` / `author` / `minTimeAway` and rewrite `type` to
+ *     `"notification"`. Persist as `{ version: 2, items, updatedAt }`.
+ *
+ * Idempotent: running the migration a second time on a v2 file is a
+ * no-op. The runner's checkpoint also skips re-runs, but this in-file
+ * guard keeps the migration safe even if the checkpoint is wiped.
+ *
+ * `down()` is a no-op — the legacy v1 fields (`source`, `author`,
+ * `minTimeAway`, the four item types) were dropped during the
+ * forward migration and cannot be recovered. Rolling back to v1 from
+ * v2 would also leave the writer producing a shape the older code
+ * cannot parse, so a real rollback would require reverting the writer
+ * code in lockstep.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-061-home-feed-notification-only");
+
+const HOME_FEED_RELATIVE_PATH = join("data", "home-feed.json");
+
+/** v2 file format. Mirrors `HomeFeedFile` in `home/feed-types.ts`. */
+interface V2HomeFeedFile {
+  version: 2;
+  items: V2FeedItem[];
+  updatedAt: string;
+}
+
+/**
+ * v2 item shape. Inlined rather than imported from `home/feed-types.ts`
+ * so the migration stays self-contained — per AGENTS.md migrations
+ * should minimise cross-module coupling so they remain stable as code
+ * around them evolves.
+ */
+interface V2FeedItem {
+  id: string;
+  type: "notification";
+  priority: number;
+  title: string;
+  summary: string;
+  timestamp: string;
+  status: string;
+  expiresAt?: string;
+  actions?: unknown[];
+  urgency?: string;
+  conversationId?: string;
+  detailPanel?: unknown;
+  createdAt: string;
+}
+
+export const homeFeedNotificationOnlyMigration: WorkspaceMigration = {
+  id: "home-feed-notification-only-v2",
+  description:
+    "Rewrite home-feed.json into v2 schema (single 'notification' type)",
+
+  run(workspaceDir: string): void {
+    const path = join(workspaceDir, HOME_FEED_RELATIVE_PATH);
+    if (!existsSync(path)) {
+      return;
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(readFileSync(path, "utf-8"));
+    } catch (err) {
+      // Daemon startup must never block on a parse failure here. The
+      // writer's read path also treats malformed files as empty, so
+      // skipping the migration just means the next append cycle will
+      // overwrite the file with a fresh v2 snapshot.
+      log.warn(
+        { err, path },
+        "Failed to parse home-feed.json; skipping migration",
+      );
+      return;
+    }
+
+    if (!isPlainObject(raw)) {
+      log.warn({ path }, "home-feed.json is not an object; skipping migration");
+      return;
+    }
+
+    if (raw.version === 2) {
+      // Already migrated.
+      return;
+    }
+
+    const rawItems = Array.isArray(raw.items) ? raw.items : [];
+    const items: V2FeedItem[] = [];
+    for (const entry of rawItems) {
+      const migrated = migrateItem(entry);
+      if (migrated) items.push(migrated);
+    }
+
+    const next: V2HomeFeedFile = {
+      version: 2,
+      items,
+      updatedAt: new Date().toISOString(),
+    };
+
+    try {
+      writeFileSync(path, JSON.stringify(next, null, 2), "utf-8");
+      log.info(
+        { path, items: items.length },
+        "Rewrote home-feed.json to v2 schema",
+      );
+    } catch (err) {
+      log.warn(
+        { err, path },
+        "Failed to write migrated home-feed.json; leaving prior file in place",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Lossy migration — legacy fields (source/author/minTimeAway and
+    // nudge/digest/thread items) cannot be reconstructed. The writer
+    // code itself only emits v2 now, so rolling back would also leave
+    // the file in a shape the v1 reader could not parse without
+    // reverting feed-writer.ts in lockstep.
+  },
+};
+
+/**
+ * Convert a single legacy item into a v2 item, or return `null` to
+ * drop it. Only `type === "action"` items survive — legacy
+ * nudge/digest/thread entries have no v2 analogue and were not
+ * surfaced as live notifications by PR 4's wiring (only assistant-
+ * authored `action` items reached the live feed via
+ * `home-feed-side-effect.ts`).
+ */
+function migrateItem(entry: unknown): V2FeedItem | null {
+  if (!isPlainObject(entry)) return null;
+  if (entry.type !== "action") return null;
+
+  // Required fields — fail-soft on missing critical strings rather
+  // than throwing, so a single bad legacy entry does not lose the
+  // rest of the items.
+  if (
+    typeof entry.id !== "string" ||
+    typeof entry.title !== "string" ||
+    typeof entry.summary !== "string" ||
+    typeof entry.timestamp !== "string" ||
+    typeof entry.createdAt !== "string"
+  ) {
+    return null;
+  }
+  const priority =
+    typeof entry.priority === "number" && Number.isInteger(entry.priority)
+      ? entry.priority
+      : 50;
+  const status = typeof entry.status === "string" ? entry.status : "new";
+
+  const out: V2FeedItem = {
+    id: entry.id,
+    type: "notification",
+    priority,
+    title: entry.title,
+    summary: entry.summary,
+    timestamp: entry.timestamp,
+    status,
+    createdAt: entry.createdAt,
+  };
+  if (typeof entry.expiresAt === "string") out.expiresAt = entry.expiresAt;
+  if (Array.isArray(entry.actions)) out.actions = entry.actions;
+  if (typeof entry.urgency === "string") out.urgency = entry.urgency;
+  if (typeof entry.conversationId === "string") {
+    out.conversationId = entry.conversationId;
+  }
+  if (isPlainObject(entry.detailPanel)) out.detailPanel = entry.detailPanel;
+  return out;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -58,6 +58,7 @@ import { repairStaleGeminiModelIdsMigration } from "./057-repair-stale-gemini-mo
 import { releaseNotesAcpSessionsUiMigration } from "./058-release-notes-acp-sessions-ui.js";
 import { movePidToWorkspaceMigration } from "./059-move-pid-to-workspace.js";
 import { memoryV2InitMigration } from "./060-memory-v2-init.js";
+import { homeFeedNotificationOnlyMigration } from "./061-home-feed-notification-only.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -127,4 +128,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesAcpSessionsUiMigration,
   movePidToWorkspaceMigration,
   memoryV2InitMigration,
+  homeFeedNotificationOnlyMigration,
 ];


### PR DESCRIPTION
## Summary
- Collapses `FeedItemType` to a single `notification` kind. Drops `source`, `author`, `minTimeAway` fields. Bumps `HomeFeedFile` version 1 → 2.
- Simplifies `feed-writer.ts` — removes per-source action cap and type-specific merge branches. New rule: same-id replacement, else append.
- Adds workspace migration `061-home-feed-notification-only` that drops legacy `nudge`/`digest`/`thread` entries and rewrites `action` entries as `notification` (idempotent, append-only).
- Adapts `home-feed-side-effect.ts` to construct v2 items.

Part of plan: home-notif-feed-revamp.md (PR 15 of 21)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
