### PR TITLE
feat(macos-home): surface unread badge on Home tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore+SSE.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore+SSE.swift
@@ -22,7 +22,14 @@ extension HomeFeedStore {
                 if Task.isCancelled { break }
                 guard let self else { break }
                 if case .homeFeedUpdated = message {
+                    // Refresh the feed first so the next time the user
+                    // opens Home the new items are already in `items`,
+                    // then notify the wired-in callback (typically
+                    // ``HomeStore.flagUnseenChanges()`` gated on
+                    // off-surface visibility) so the toolbar's unread
+                    // dot lights up on off-surface activity.
                     await self.load()
+                    self.onSSEUpdate?()
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeFeedStore.swift
@@ -48,6 +48,16 @@ public final class HomeFeedStore {
     @ObservationIgnored var sseTask: Task<Void, Never>?
     @ObservationIgnored private var lifecycleObservers: [NSObjectProtocol] = []
 
+    /// Optional callback fired by ``HomeFeedStore+SSE`` after a
+    /// `homeFeedUpdated` SSE event lands. Wired in production to
+    /// ``HomeStore.flagUnseenChanges()`` when the Home tab is not the
+    /// active panel, so the toolbar's unread dot lights up on
+    /// off-surface activity. Optional so existing call sites that
+    /// don't care about cross-store wiring (the test fixtures, plus
+    /// any future surface that just wants the feed) can keep using
+    /// the original two-argument initializer.
+    @ObservationIgnored let onSSEUpdate: (@MainActor () -> Void)?
+
     /// Moment the user last stepped away from the app (from
     /// `willResignActive`). Consumed by the next `load()` as
     /// `timeAwaySeconds = now - lastAwayAt` and then cleared — the
@@ -64,9 +74,14 @@ public final class HomeFeedStore {
 
     // MARK: - Lifecycle
 
-    public init(client: HomeFeedClient, messageStream: AsyncStream<ServerMessage>) {
+    public init(
+        client: HomeFeedClient,
+        messageStream: AsyncStream<ServerMessage>,
+        onSSEUpdate: (@MainActor () -> Void)? = nil
+    ) {
         self.client = client
         self.messageStream = messageStream
+        self.onSSEUpdate = onSSEUpdate
         startListening()
         observeLifecycle()
     }

--- a/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomeStore.swift
@@ -19,8 +19,11 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "HomeS
 /// network blip should not blank the Home page. `isLoading` reflects the
 /// in-flight state of `load()` so views can show a spinner on first fetch.
 ///
-/// `hasUnseenChanges` and `isHomeTabVisible` are stubs declared here so the
-/// public surface is in place; PR 16 drives the unseen-changes logic.
+/// `hasUnseenChanges` is raised by either ``HomeStore+SSE`` (on
+/// `relationshipStateUpdated`) or ``HomeFeedStore+SSE`` (on
+/// `homeFeedUpdated`) when the user is not currently looking at the Home
+/// tab. ``setHomeTabVisible(_:)`` is the single funnel that flips
+/// visibility from the panel host and clears the badge on focus.
 @MainActor
 @Observable
 public final class HomeStore {
@@ -30,14 +33,17 @@ public final class HomeStore {
     public private(set) var state: RelationshipState?
     public private(set) var isLoading: Bool = false
 
-    /// Set when the daemon emits a `relationshipStateUpdated` SSE event while
-    /// the Home tab is not currently visible. Drives a badge on the tab.
-    /// PR 16 wires the producer side; this PR only declares the property.
+    /// Set when the daemon emits an SSE event that affects something
+    /// rendered on the Home tab while the user is currently elsewhere.
+    /// Drives the unread dot on the Home toolbar button. Producers go
+    /// through ``flagUnseenChanges()`` (same-module-only) so the field
+    /// stays read-only at the public API boundary.
     public private(set) var hasUnseenChanges: Bool = false
 
-    /// Toggled by the Home tab host to track visibility for the unseen-changes
-    /// badge logic in PR 16. This PR only declares the property.
-    public var isHomeTabVisible: Bool = false
+    /// Tracks whether the Home tab is currently the active panel. Mutated
+    /// only via ``setHomeTabVisible(_:)`` so the visibility flip and the
+    /// badge clear stay in lockstep.
+    public private(set) var isHomeTabVisible: Bool = false
 
     // MARK: - Non-reactive Bookkeeping
 
@@ -102,19 +108,31 @@ public final class HomeStore {
     }
 
     /// Producer-side flip for the unseen-changes badge. Invoked by the SSE
-    /// handler when an update arrives while the Home tab is not visible.
-    /// Kept at `internal` so the `HomeStore+SSE` extension can drive it
-    /// without exposing it to the rest of the app.
+    /// handlers (``HomeStore+SSE`` and the cross-store callback wired into
+    /// ``HomeFeedStore``) when an update arrives while the Home tab is not
+    /// visible. Kept at `internal` so producers in the same module can drive
+    /// it without exposing the setter to the rest of the app.
     func flagUnseenChanges() {
         hasUnseenChanges = true
     }
 
-    /// Clears the unseen-changes badge. Called by the Home tab host when the
-    /// user navigates to the Home tab. PR 16 will drive the producer side;
-    /// the clearer is exposed here so the acceptance-criteria surface is
-    /// complete.
+    /// Clears the unseen-changes badge. Called by ``setHomeTabVisible(_:)``
+    /// when the user navigates to the Home tab and exposed publicly so
+    /// fixtures and edge-case callers can reset the flag explicitly.
     public func markSeen() {
         hasUnseenChanges = false
+    }
+
+    /// Single funnel for visibility changes. The Home tab host calls this
+    /// from `.onAppear` / `.onDisappear` so the visibility flip and the
+    /// badge clear stay coupled — clearing the badge on focus is the
+    /// behaviour we want every time the tab becomes visible, so encoding
+    /// it here keeps callers from forgetting one of the two steps.
+    public func setHomeTabVisible(_ visible: Bool) {
+        isHomeTabVisible = visible
+        if visible {
+            markSeen()
+        }
     }
 
     // MARK: - Foreground Refresh

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -148,15 +148,26 @@ struct MainWindowView: View {
         // Eagerly construct the Home store so it's ready the moment the user
         // toggles the `home-tab` flag on — even if the panel is opened
         // without an app relaunch.
-        self._homeStore = State(initialValue: HomeStore(
+        let homeStoreInstance = HomeStore(
             client: DefaultHomeStateClient(),
             messageStream: eventStreamClient.subscribe()
-        ))
+        )
+        self._homeStore = State(initialValue: homeStoreInstance)
         // Same eager-construction rationale for the activity feed store
-        // — ready the instant the `home-feed` flag flips on.
+        // — ready the instant the `home-feed` flag flips on. The
+        // `onSSEUpdate` callback is what turns a `home_feed_updated`
+        // SSE event into the Home toolbar's unread dot — gated on the
+        // tab being off-surface so we don't badge while the user is
+        // already looking at the feed.
         self._feedStore = State(initialValue: HomeFeedStore(
             client: DefaultHomeFeedClient(),
-            messageStream: eventStreamClient.subscribe()
+            messageStream: eventStreamClient.subscribe(),
+            onSSEUpdate: { [weak homeStoreInstance] in
+                guard let homeStoreInstance else { return }
+                if !homeStoreInstance.isHomeTabVisible {
+                    homeStoreInstance.flagUnseenChanges()
+                }
+            }
         ))
         // Meet status panel subscribes to the same shared SSE stream.
         self._meetStatusViewModel = State(initialValue: MeetStatusViewModel(

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -324,11 +324,10 @@ extension MainWindowView {
             }
         )
         .onAppear {
-            homeStore.isHomeTabVisible = true
-            homeStore.markSeen()
+            homeStore.setHomeTabVisible(true)
         }
         .onDisappear {
-            homeStore.isHomeTabVisible = false
+            homeStore.setHomeTabVisible(false)
             // Codex P2 feedback (#27467): clear the detail panel so
             // re-entering Home doesn't show a stale split layout when the
             // user leaves Home through routes other than the detail panel's

--- a/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
@@ -334,6 +334,35 @@ final class HomeFeedStoreTests: XCTestCase {
         XCTAssertNil(conversationId)
     }
 
+    /// `onSSEUpdate` is what wires the feed store back into ``HomeStore``
+    /// to raise the unread dot when the Home tab is off-surface. The
+    /// `homeFeedUpdated` SSE handler must invoke it after every
+    /// successful reload — verified here by counting callback fires
+    /// against SSE events.
+    func testSSEEventInvokesOnSSEUpdateCallback() async throws {
+        let initial = makeResponse(items: [makeFeedItem(id: "first")])
+        let client = MockHomeFeedClient(response: initial)
+        let (stream, continuation) = AsyncStream<ServerMessage>.makeStream()
+        let counter = Counter()
+        let store = HomeFeedStore(
+            client: client,
+            messageStream: stream,
+            onSSEUpdate: { counter.increment() }
+        )
+        await store.load()
+        XCTAssertEqual(counter.value, 0, "load() alone must not fire the callback")
+
+        let updated = makeResponse(items: [makeFeedItem(id: "second")])
+        client.setResponse(updated)
+        continuation.yield(.homeFeedUpdated(updatedAt: "2026-04-14T12:00:00Z", newItemCount: 1))
+
+        try await waitUntil(timeout: 2.0) {
+            counter.value == 1 && store.items.map { $0.id } == ["second"]
+        }
+
+        XCTAssertEqual(counter.value, 1, "exactly one callback per SSE event")
+    }
+
     // MARK: - Helpers
 
     private func waitUntil(
@@ -346,5 +375,14 @@ final class HomeFeedStoreTests: XCTestCase {
             try await Task.sleep(nanoseconds: 20_000_000)
         }
         XCTFail("waitUntil timed out after \(timeout)s")
+    }
+
+    /// MainActor-pinned counter used by ``testSSEEventInvokesOnSSEUpdateCallback``
+    /// to count callback fires from inside an `@MainActor` closure without
+    /// reaching for actor-bridging machinery.
+    @MainActor
+    private final class Counter {
+        private(set) var value: Int = 0
+        func increment() { value += 1 }
     }
 }

--- a/clients/macos/vellum-assistantTests/HomeStoreUnseenChangesTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeStoreUnseenChangesTests.swift
@@ -90,7 +90,7 @@ final class HomeStoreUnseenChangesTests: XCTestCase {
         XCTAssertFalse(store.hasUnseenChanges)
 
         // User is elsewhere when the event arrives.
-        store.isHomeTabVisible = false
+        store.setHomeTabVisible(false)
 
         let updated = makeRelationshipState(tier: 3, progressPercent: 80, updatedAt: "2026-04-13T11:00:00Z")
         client.setState(updated)
@@ -121,7 +121,7 @@ final class HomeStoreUnseenChangesTests: XCTestCase {
         XCTAssertFalse(store.hasUnseenChanges)
 
         // User is actively looking at the Home tab.
-        store.isHomeTabVisible = true
+        store.setHomeTabVisible(true)
 
         let updated = makeRelationshipState(tier: 3, progressPercent: 80, updatedAt: "2026-04-13T11:00:00Z")
         client.setState(updated)
@@ -156,7 +156,7 @@ final class HomeStoreUnseenChangesTests: XCTestCase {
         let (store, continuation) = makeStore(client: client)
 
         await store.load()
-        store.isHomeTabVisible = false
+        store.setHomeTabVisible(false)
 
         let updated = makeRelationshipState(tier: 3, progressPercent: 80, updatedAt: "2026-04-13T11:00:00Z")
         client.setState(updated)


### PR DESCRIPTION
## Summary
- Wires the previously-stub `hasUnseenChanges` / `isHomeTabVisible` fields in `HomeStore.swift`.
- SSE handler for `home_feed_updated` increments the unread flag when the Home tab is not focused.
- `PanelCoordinator` renders an unread badge on the Home tab; tab focus clears the badge via `markSeen()`.

Part of plan: home-notif-feed-revamp.md (PR 18 of 21 — final implementation PR)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
