### PR TITLE
fix(daemon): tag /compact slash-command deltas with conversationId

### DIFF
--- a/assistant/src/__tests__/compact-event-conversation-id-guard.test.ts
+++ b/assistant/src/__tests__/compact-event-conversation-id-guard.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Guard test: every `assistant_text_delta` emission in the `/compact` and
+ * other slash-command completion paths must carry `conversationId` on the
+ * message body.
+ *
+ * Without this, a long-running compaction can finish after the user has
+ * switched conversations, and the macOS client's `belongsToConversation(nil)`
+ * check (which accepts nil ids as system events) renders the completion text
+ * into whichever VM is currently active — leaking the message into the
+ * wrong conversation.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const SCANNED_FILES = [
+  "runtime/routes/conversation-routes.ts",
+  "daemon/conversation-process.ts",
+];
+
+describe("compact slash-command emits conversationId on assistant_text_delta", () => {
+  for (const relativePath of SCANNED_FILES) {
+    test(`${relativePath} tags every assistant_text_delta with conversationId`, () => {
+      const fullPath = join(__dirname, "..", relativePath);
+      const source = readFileSync(fullPath, "utf-8");
+
+      // Find every `type: "assistant_text_delta"` literal and inspect the
+      // surrounding object literal for a `conversationId` key. Looking at a
+      // ~200-char window forward covers multi-line object literals while
+      // staying tight enough to avoid matching unrelated nearby code.
+      const TYPE_LITERAL = /type:\s*"assistant_text_delta"/g;
+      const offsets: number[] = [];
+      let match: RegExpExecArray | null;
+      while ((match = TYPE_LITERAL.exec(source)) !== null) {
+        offsets.push(match.index);
+      }
+      expect(offsets.length).toBeGreaterThan(0);
+
+      const violations: string[] = [];
+      for (const offset of offsets) {
+        const window = source.slice(offset, offset + 200);
+        if (!/conversationId/.test(window)) {
+          const lineNumber = source.slice(0, offset).split("\n").length;
+          violations.push(`${relativePath}:${lineNumber}`);
+        }
+      }
+      expect(violations).toEqual([]);
+    });
+  }
+});

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -532,7 +532,11 @@ async function drainSingleMessage(
       if (isModelSlashCommand(next.content)) {
         next.onEvent(await buildModelInfoEvent());
       }
-      next.onEvent({ type: "assistant_text_delta", text: slashResult.message });
+      next.onEvent({
+        type: "assistant_text_delta",
+        text: slashResult.message,
+        conversationId: conversation.conversationId,
+      });
       conversation.traceEmitter.emit(
         "message_complete",
         "Unknown slash command handled",
@@ -621,7 +625,11 @@ async function drainSingleMessage(
       );
       conversation.messages.push(assistantMsg);
 
-      next.onEvent({ type: "assistant_text_delta", text: responseText });
+      next.onEvent({
+        type: "assistant_text_delta",
+        text: responseText,
+        conversationId: conversation.conversationId,
+      });
       conversation.traceEmitter.emit(
         "message_complete",
         "Compact slash command handled",
@@ -1377,7 +1385,11 @@ export async function processMessage(
     if (isModelSlashCommand(content)) {
       onEvent(await buildModelInfoEvent());
     }
-    onEvent({ type: "assistant_text_delta", text: slashResult.message });
+    onEvent({
+      type: "assistant_text_delta",
+      text: slashResult.message,
+      conversationId: conversation.conversationId,
+    });
     conversation.traceEmitter.emit(
       "message_complete",
       "Unknown slash command handled",
@@ -1445,7 +1457,11 @@ export async function processMessage(
       );
       conversation.messages.push(assistantMsg);
 
-      onEvent({ type: "assistant_text_delta", text: responseText });
+      onEvent({
+        type: "assistant_text_delta",
+        text: responseText,
+        conversationId: conversation.conversationId,
+      });
       conversation.traceEmitter.emit(
         "message_complete",
         "Compact slash command handled",

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1818,7 +1818,11 @@ export async function handleSendMessage(
           messageId: persisted.id,
           clientMessageId,
         });
-        onEvent({ type: "assistant_text_delta", text: cannedGreeting });
+        onEvent({
+          type: "assistant_text_delta",
+          text: cannedGreeting,
+          conversationId,
+        });
         onEvent({ type: "message_complete", conversationId });
         conversation.processing = false;
         silentlyWithLog(
@@ -2126,7 +2130,11 @@ export async function handleSendMessage(
         if (modelInfoEvent) {
           onEvent(modelInfoEvent);
         }
-        onEvent({ type: "assistant_text_delta", text: message });
+        onEvent({
+          type: "assistant_text_delta",
+          text: message,
+          conversationId,
+        });
         onEvent({
           type: "message_complete",
           conversationId: conversationId,
@@ -2197,7 +2205,11 @@ export async function handleSendMessage(
         );
         conversation.getMessages().push(assistantMsg);
 
-        onEvent({ type: "assistant_text_delta", text: responseText });
+        onEvent({
+          type: "assistant_text_delta",
+          text: responseText,
+          conversationId,
+        });
         onEvent({ type: "message_complete", conversationId });
       } catch (err) {
         log.error({ err, conversationId }, "Compact command failed");


### PR DESCRIPTION
## Summary
- `/compact` runs `forceCompact()` async (multi-second LLM call) and emits an `assistant_text_delta` after it returns. The delta lacked `conversationId`, so when the user switched conversations during compaction, the macOS client (`belongsToConversation(nil) → true`) rendered the completion text into whichever VM was currently active.
- Tag all 7 `assistant_text_delta` emit sites in the slash-command paths (`conversation-process.ts`, `conversation-routes.ts`) with `conversationId`, mirroring the pattern at `conversation-routes.ts:340`.
- Add `compact-event-conversation-id-guard.test.ts` to prevent regression by scanning both files for `type: "assistant_text_delta"` literals and verifying each carries `conversationId`.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
