### PR TITLE
fix(home): regenerate openapi.yaml; drop dead lowPriorityCollapsed field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5217,11 +5217,7 @@ paths:
                           type: string
                         type:
                           type: string
-                          enum:
-                            - nudge
-                            - digest
-                            - action
-                            - thread
+                          const: notification
                         priority:
                           type: integer
                           minimum: 0
@@ -5230,14 +5226,6 @@ paths:
                           type: string
                         summary:
                           type: string
-                        source:
-                          type: string
-                          enum:
-                            - gmail
-                            - slack
-                            - calendar
-                            - assistant
-                            - telegram
                         timestamp:
                           type: string
                         status:
@@ -5250,10 +5238,6 @@ paths:
                             - dismissed
                         expiresAt:
                           type: string
-                        minTimeAway:
-                          type: integer
-                          minimum: 0
-                          maximum: 9007199254740991
                         actions:
                           type: array
                           items:
@@ -5294,11 +5278,6 @@ paths:
                           required:
                             - kind
                           additionalProperties: false
-                        author:
-                          type: string
-                          enum:
-                            - assistant
-                            - platform
                         createdAt:
                           type: string
                       required:
@@ -5309,7 +5288,6 @@ paths:
                         - summary
                         - timestamp
                         - status
-                        - author
                         - createdAt
                       additionalProperties: false
                   updatedAt:
@@ -5354,27 +5332,11 @@ paths:
                         - prompt
                         - source
                       additionalProperties: false
-                  lowPriorityCollapsed:
-                    type: object
-                    properties:
-                      count:
-                        type: integer
-                        minimum: 0
-                        maximum: 9007199254740991
-                      itemIds:
-                        type: array
-                        items:
-                          type: string
-                    required:
-                      - count
-                      - itemIds
-                    additionalProperties: false
                 required:
                   - items
                   - updatedAt
                   - contextBanner
                   - suggestedPrompts
-                  - lowPriorityCollapsed
                 additionalProperties: false
       parameters:
         - name: timeAwaySeconds
@@ -5382,9 +5344,7 @@ paths:
           required: true
           schema:
             type: integer
-          description:
-            Seconds since the user was last active in the client. Used to filter items with a `minTimeAway` gate and to
-            compute the context-banner relative-time label.
+          description: Seconds since the user was last active in the client. Used to compute the context-banner relative-time label.
   /v1/home/feed/{id}:
     patch:
       operationId: home_feed_by_id_patch
@@ -5406,11 +5366,7 @@ paths:
                     type: string
                   type:
                     type: string
-                    enum:
-                      - nudge
-                      - digest
-                      - action
-                      - thread
+                    const: notification
                   priority:
                     type: integer
                     minimum: 0
@@ -5419,14 +5375,6 @@ paths:
                     type: string
                   summary:
                     type: string
-                  source:
-                    type: string
-                    enum:
-                      - gmail
-                      - slack
-                      - calendar
-                      - assistant
-                      - telegram
                   timestamp:
                     type: string
                   status:
@@ -5439,10 +5387,6 @@ paths:
                       - dismissed
                   expiresAt:
                     type: string
-                  minTimeAway:
-                    type: integer
-                    minimum: 0
-                    maximum: 9007199254740991
                   actions:
                     type: array
                     items:
@@ -5483,11 +5427,6 @@ paths:
                     required:
                       - kind
                     additionalProperties: false
-                  author:
-                    type: string
-                    enum:
-                      - assistant
-                      - platform
                   createdAt:
                     type: string
                 required:
@@ -5498,7 +5437,6 @@ paths:
                   - summary
                   - timestamp
                   - status
-                  - author
                   - createdAt
                 additionalProperties: false
         "404":

--- a/assistant/src/home/feed-types.ts
+++ b/assistant/src/home/feed-types.ts
@@ -101,16 +101,6 @@ export interface FeedItem {
 }
 
 /**
- * Summary of low-priority items that were collapsed out of the main
- * feed list. The client renders this as a single "N low priority
- * updates" line instead of showing each item individually.
- */
-export interface LowPriorityCollapsed {
-  count: number;
-  itemIds: string[];
-}
-
-/**
  * On-disk file format for `~/.vellum/workspace/data/home-feed.json`.
  *
  * Written by the PR 5 writer, read by the PR 6 HTTP route and
@@ -208,11 +198,6 @@ export const suggestedPromptSchema = z.object({
   icon: z.string().optional(),
   prompt: z.string(),
   source: suggestedPromptSourceSchema,
-});
-
-export const lowPriorityCollapsedSchema = z.object({
-  count: z.number().int().min(0),
-  itemIds: z.array(z.string()),
 });
 
 /** Schema for the on-disk `home-feed.json` file. */

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -26,7 +26,6 @@ import {
   type FeedItem,
   feedItemSchema,
   type FeedItemStatus,
-  lowPriorityCollapsedSchema,
   suggestedPromptSchema,
 } from "../../home/feed-types.js";
 import { patchFeedItemStatus, readHomeFeed } from "../../home/feed-writer.js";
@@ -56,7 +55,6 @@ const getHomeFeedResponseSchema = z.object({
   updatedAt: z.string(),
   contextBanner: contextBannerSchema,
   suggestedPrompts: z.array(suggestedPromptSchema),
-  lowPriorityCollapsed: lowPriorityCollapsedSchema,
 });
 
 const patchFeedItemRequestSchema = z.object({
@@ -124,21 +122,11 @@ export async function handleGetHomeFeed({
   // context-banner relative-time label.
   const filtered = feed.items;
 
-  const LOW_PRIORITY_THRESHOLD = 30;
-  const lowPriorityItems = filtered.filter(
-    (item) => item.priority < LOW_PRIORITY_THRESHOLD,
-  );
-
   const now = new Date();
   const contextBanner = {
     greeting: computeGreeting(now),
     timeAwayLabel: formatRelativeTime(timeAwaySeconds),
     newCount: filtered.filter((i) => i.status === "new").length,
-  };
-
-  const lowPriorityCollapsed = {
-    count: lowPriorityItems.length,
-    itemIds: lowPriorityItems.map((item) => item.id),
   };
 
   const suggestedPrompts = await getSuggestedPrompts();
@@ -148,7 +136,6 @@ export async function handleGetHomeFeed({
       timeAwayBucket: timeAwayBucket(timeAwaySeconds),
       totalItems: feed.items.length,
       filteredItems: filtered.length,
-      lowPriorityCount: lowPriorityItems.length,
       newCount: contextBanner.newCount,
       suggestedPromptsCount: suggestedPrompts.length,
     },
@@ -160,7 +147,6 @@ export async function handleGetHomeFeed({
     updatedAt: feed.updatedAt,
     contextBanner,
     suggestedPrompts,
-    lowPriorityCollapsed,
   };
 }
 
@@ -251,7 +237,7 @@ export const ROUTES: RouteDefinition[] = [
         type: "integer",
         required: true,
         description:
-          "Seconds since the user was last active in the client. Used to filter items with a `minTimeAway` gate and to compute the context-banner relative-time label.",
+          "Seconds since the user was last active in the client. Used to compute the context-banner relative-time label.",
       },
     ],
     responseBody: getHomeFeedResponseSchema,

--- a/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
@@ -48,8 +48,7 @@ final class HomePageViewGroupingTests: XCTestCase {
                 timeAwayLabel: "",
                 newCount: 0
             ),
-            suggestedPrompts: [],
-            lowPriorityCollapsed: LowPriorityCollapsed(count: 0, itemIds: [])
+            suggestedPrompts: []
         )
         let client = MockHomeFeedClient(response: response)
         let (stream, _) = AsyncStream<ServerMessage>.makeStream()

--- a/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/HomeFeedStoreTests.swift
@@ -54,8 +54,7 @@ final class HomeFeedStoreTests: XCTestCase {
                 timeAwayLabel: "Away for 2 hours",
                 newCount: items.filter { $0.status == .new }.count
             ),
-            suggestedPrompts: suggestedPrompts,
-            lowPriorityCollapsed: LowPriorityCollapsed(count: 0, itemIds: [])
+            suggestedPrompts: suggestedPrompts
         )
     }
 

--- a/clients/shared/Network/FeedItem.swift
+++ b/clients/shared/Network/FeedItem.swift
@@ -190,21 +190,6 @@ public struct SuggestedPrompt: Codable, Sendable, Identifiable, Hashable {
     }
 }
 
-// MARK: - LowPriorityCollapsed
-
-/// Summary of low-priority items that were collapsed out of the main
-/// feed list. The client renders this as a single "N low priority
-/// updates" line instead of showing each item individually.
-public struct LowPriorityCollapsed: Codable, Sendable, Hashable {
-    public let count: Int
-    public let itemIds: [String]
-
-    public init(count: Int, itemIds: [String]) {
-        self.count = count
-        self.itemIds = itemIds
-    }
-}
-
 // MARK: - HomeFeedFile
 
 /// On-disk file format for `~/.vellum/workspace/data/home-feed.json`.

--- a/clients/shared/Network/HomeFeedClient.swift
+++ b/clients/shared/Network/HomeFeedClient.swift
@@ -13,20 +13,17 @@ public struct HomeFeedResponse: Codable, Sendable, Hashable {
     public let updatedAt: Date
     public let contextBanner: ContextBanner
     public let suggestedPrompts: [SuggestedPrompt]
-    public let lowPriorityCollapsed: LowPriorityCollapsed
 
     public init(
         items: [FeedItem],
         updatedAt: Date,
         contextBanner: ContextBanner,
-        suggestedPrompts: [SuggestedPrompt] = [],
-        lowPriorityCollapsed: LowPriorityCollapsed = LowPriorityCollapsed(count: 0, itemIds: [])
+        suggestedPrompts: [SuggestedPrompt] = []
     ) {
         self.items = items
         self.updatedAt = updatedAt
         self.contextBanner = contextBanner
         self.suggestedPrompts = suggestedPrompts
-        self.lowPriorityCollapsed = lowPriorityCollapsed
     }
 
     public init(from decoder: Decoder) throws {
@@ -35,7 +32,6 @@ public struct HomeFeedResponse: Codable, Sendable, Hashable {
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         contextBanner = try container.decode(ContextBanner.self, forKey: .contextBanner)
         suggestedPrompts = try container.decodeIfPresent([SuggestedPrompt].self, forKey: .suggestedPrompts) ?? []
-        lowPriorityCollapsed = try container.decodeIfPresent(LowPriorityCollapsed.self, forKey: .lowPriorityCollapsed) ?? LowPriorityCollapsed(count: 0, itemIds: [])
     }
 }
 


### PR DESCRIPTION
## Summary
- Regenerates `assistant/openapi.yaml` to match the v2 schema (was stale after PR 15; openapi-check CI failing).
- Drops `lowPriorityCollapsed` server-side computation and Swift response field — dead end-to-end after PR 17 removed the low-priority-collapse UI.
- Fixes stale `timeAwaySeconds` param description (was claiming \`minTimeAway\` filter that was removed in PR 15).

Part of plan: home-notif-feed-revamp.md (review-fix R1.2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
