### PR TITLE
docs(memory): cap edges at 20 per page in consolidation prompt

### DIFF
--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -118,7 +118,13 @@ When you bind two concepts, edit \`memory/edges.json\` to add an entry for the t
 }
 \`\`\`
 
-Edge density target: 5–10 per mature page. New pages: as many as fit naturally; they'll accumulate. Don't pad. Every edge should reflect a real conceptual binding from source.
+Edge density target: 5-10 per mature page. New pages: as many as fit naturally; they'll accumulate.
+
+Don't pad. Every edge should reflect a real conceptual binding from source.
+
+HARD LIMIT of 20 edges on any page. If a page is connected to everything, it's the same as being connected to nothing.
+
+If a page has more than 20 edges, you must either split the page or prune edges to at most 20 of the most important edges.
 
 ### 4. Page size — hard tiers, no rationalization
 


### PR DESCRIPTION
## Summary
- Hard limit of 20 edges per page; if exceeded, split the page or prune to the 20 most important edges
- Reformats the Edges section into separate paragraphs so each rule lands distinctly during consolidation

## Original prompt
update the Edges section of the consolidation prompt
\`\`\`
Edge density target: 5-10 per mature page. New pages: as many as fit naturally; they'll accumulate.
Don't pad. Every edge should reflect a real conceptual binding from source.
HARD LIMIT of 20 edges on any page. If a page is connected to everything, it's the same as being connected to nothing.
If a page has more than 20 edges, you must either split the page or prune edges to at most 20 of the most important edges.
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
