### PR TITLE
fix: round-2 cleanup after home-notif-feed-revamp

### DIFF
--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -42,6 +42,22 @@ mock.module("../runtime/background-job-runner.js", () => ({
   },
 }));
 
+// Capture `emitNotificationSignal` calls so tests can assert that scheduled
+// task failures surface via the notification pipeline (home feed + native).
+const emitNotificationCalls: Array<Record<string, unknown>> = [];
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emitNotificationCalls.push(params);
+    return {
+      signalId: "stub-signal",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    };
+  },
+}));
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
@@ -147,6 +163,7 @@ describe("scheduler run_task detection", () => {
     db.run("DELETE FROM messages");
     db.run("DELETE FROM conversations");
     onRunBackgroundJobCall = null;
+    emitNotificationCalls.length = 0;
   });
 
   test("run_task:<id> messages trigger runTask instead of processMessage", async () => {
@@ -264,5 +281,21 @@ describe("scheduler run_task detection", () => {
     expect(runs.length).toBeGreaterThanOrEqual(1);
     expect(runs[0].status).toBe("error");
     expect(runs[0].error).toContain("Task not found");
+
+    // Failed scheduled tasks must surface via the notification pipeline so
+    // they reach the home feed and native macOS notifications. The shape
+    // mirrors what `runBackgroundJob` emits for its own failures.
+    const failureSignal = emitNotificationCalls.find(
+      (p) => p.sourceEventName === "activity.failed",
+    );
+    expect(failureSignal).toBeDefined();
+    expect(failureSignal?.sourceChannel).toBe("scheduler");
+    const payload = failureSignal?.contextPayload as Record<string, unknown>;
+    expect(payload.jobName).toBe("task:nonexistent-task-id");
+    expect(payload.errorKind).toBe("exception");
+    expect(typeof payload.errorMessage).toBe("string");
+    expect(failureSignal?.dedupeKey).toMatch(
+      /^activity-failed:task:nonexistent-task-id:\d{4}-\d{2}-\d{2}$/,
+    );
   });
 });

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -91,7 +91,7 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
   {
     id: "activity.failed",
     description:
-      "Background job execution failed (model error, exception, tool failure, or timeout)",
+      "Background job execution failed (model_provider, exception, or timeout)",
   },
   {
     id: "quick_chat.response_ready",

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -2,6 +2,7 @@ import type { LLMCallSite } from "../config/schemas/llm.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation } from "../memory/conversation-crud.js";
 import { invalidateAssistantInferredItemsForConversation } from "../memory/task-memory-cleanup.js";
+import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { runSequencesOnce } from "../sequence/engine.js";
@@ -352,11 +353,17 @@ async function runScheduleOnce(
         // Track the schedule run using the task's conversation
         const runId = createScheduleRun(job.id, result.conversationId);
         if (result.status === "failed") {
+          const errorMessage = result.error ?? "Task run failed";
           completeScheduleRun(runId, {
             status: "error",
-            error: result.error ?? "Task run failed",
+            error: errorMessage,
           });
           if (isOneShot) failOneShot(job.id);
+          emitTaskActivityFailed({
+            taskId,
+            conversationId: result.conversationId,
+            errorMessage,
+          });
         } else {
           completeScheduleRun(runId, { status: "ok" });
           if (isOneShot) completeOneShot(job.id);
@@ -394,6 +401,11 @@ async function runScheduleOnce(
         const runId = createScheduleRun(job.id, fallbackConversation.id);
         completeScheduleRun(runId, { status: "error", error: message });
         if (isOneShot) failOneShot(job.id);
+        emitTaskActivityFailed({
+          taskId,
+          conversationId: fallbackConversation.id,
+          errorMessage: message,
+        });
       }
       continue;
     }
@@ -551,4 +563,45 @@ async function runScheduleOnce(
     log.info({ processed }, "Schedule tick complete");
   }
   return processed;
+}
+
+/**
+ * Emit an `activity.failed` notification for a failed scheduled task run.
+ * Mirrors the shape `runBackgroundJob` produces for its own failures so the
+ * home feed and native notifications stay consistent regardless of which
+ * code path executed the work. Fire-and-forget — a notification failure
+ * must never break scheduler operation.
+ */
+function emitTaskActivityFailed(args: {
+  taskId: string;
+  conversationId: string;
+  errorMessage: string;
+}): void {
+  const day = new Date().toISOString().slice(0, 10);
+  emitNotificationSignal({
+    sourceChannel: "scheduler",
+    sourceContextId: args.conversationId,
+    sourceEventName: "activity.failed",
+    dedupeKey: `activity-failed:task:${args.taskId}:${day}`,
+    contextPayload: {
+      jobName: `task:${args.taskId}`,
+      errorMessage: args.errorMessage,
+      errorKind: "exception",
+    },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+  }).catch((emitErr) => {
+    log.warn(
+      {
+        err: emitErr instanceof Error ? emitErr.message : String(emitErr),
+        taskId: args.taskId,
+        conversationId: args.conversationId,
+      },
+      "Failed to emit activity.failed notification for scheduled task",
+    );
+  });
 }

--- a/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
+++ b/clients/macos/vellum-assistant/Features/Home/HomePageView.swift
@@ -267,19 +267,22 @@ struct HomePageView<DetailPanel: View>: View {
     /// Icon glyph for a feed item. The v2 schema collapsed all items to
     /// the single `notification` type, so every row uses the same glyph
     /// — a per-item visual language driven by `urgency` or
-    /// `detailPanel.kind` is a future iteration.
-    private func icon(for item: FeedItem) -> VIcon {
+    /// `detailPanel.kind` is a future iteration. The `FeedItem` parameter
+    /// is retained (internal name dropped to flag intentionally unused) so
+    /// a future per-urgency / per-detail-panel-kind dispatch can re-thread
+    /// it without touching every call site.
+    private func icon(for _: FeedItem) -> VIcon {
         .bell
     }
 
     /// Foreground (glyph) color for the recap icon. See the `feed*`
     /// tokens in `ColorTokens.swift`.
-    private func iconForeground(for item: FeedItem) -> Color {
+    private func iconForeground(for _: FeedItem) -> Color {
         VColor.feedDigestStrong
     }
 
     /// Background (circle fill) color for the recap icon.
-    private func iconBackground(for item: FeedItem) -> Color {
+    private func iconBackground(for _: FeedItem) -> Color {
         VColor.feedDigestWeak
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -837,16 +837,19 @@ extension MainWindowView {
 /// With the v2 schema collapsed to a single `.notification` type these
 /// helpers no longer per-type-dispatch — every feed item uses the same
 /// generic glyph. A per-item visual language driven by `urgency` or
-/// `detailPanel.kind` is a future iteration.
-private func iconForFeedItem(_ item: FeedItem) -> VIcon {
+/// `detailPanel.kind` is a future iteration. The `FeedItem` parameter is
+/// retained (named `_` internally to flag intentionally unused) so a
+/// future per-urgency / per-detail-panel-kind dispatch can re-thread it
+/// without touching every call site.
+private func iconForFeedItem(_: FeedItem) -> VIcon {
     .bell
 }
 
-private func iconForegroundForFeedItem(_ item: FeedItem) -> Color {
+private func iconForegroundForFeedItem(_: FeedItem) -> Color {
     VColor.feedDigestStrong
 }
 
-private func iconBackgroundForFeedItem(_ item: FeedItem) -> Color {
+private func iconBackgroundForFeedItem(_: FeedItem) -> Color {
     VColor.feedDigestWeak
 }
 

--- a/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Home/HomePageViewGroupingTests.swift
@@ -71,7 +71,7 @@ final class HomePageViewGroupingTests: XCTestCase {
     /// Constructs a fully-specialized `HomePageView` wired to the supplied
     /// feed store. All callbacks are no-ops and `detailPanel` resolves to
     /// `EmptyView` — the tests never exercise the view body, just the
-    /// pure `groupedFeed(for:)` helper.
+    /// pure `groupedFeed` helper.
     private func makeView(feedStore: HomeFeedStore) -> HomePageView<EmptyView> {
         HomePageView<EmptyView>(
             store: makeHomeStore(),


### PR DESCRIPTION
## Summary
- **Functional**: scheduler now emits `activity.failed` notification when a scheduled task-run fails (was silent — bypassed home feed + native notifications). Hand-rolled emit alongside existing `completeScheduleRun(status: \"error\")` rather than migrating `task-runner.ts` to `runBackgroundJob` (larger refactor; out of scope).
- **Cosmetic**: drop stale `tool failure` from `activity.failed` description in `signal.ts` (round 1 removed the `tool` errorKind).
- **Cosmetic**: mark dead `FeedItem` parameters in 6 icon helpers as `_:` to flag intentionally unused (kept for future per-urgency dispatch).
- **Cosmetic**: fix stale `groupedFeed(for:)` reference in `HomePageViewGroupingTests.swift` docstring.

Part of plan: home-notif-feed-revamp.md (review-fix R2.1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
