### PR TITLE
chore: remove birthday-builds workspace bucket

### DIFF
--- a/assistant/src/__tests__/context-search-workspace-source.test.ts
+++ b/assistant/src/__tests__/context-search-workspace-source.test.ts
@@ -109,10 +109,10 @@ describe("searchWorkspaceSource", () => {
     writeWorkspaceFile(root, ".hidden.md", "needle hidden");
     writeWorkspaceFile(
       root,
-      ".birthday-builds/.format-rec.md",
+      ".notes/.format-rec.md",
       "needle safe hidden file",
     );
-    writeWorkspaceFile(root, ".birthday-builds/cake.md", "needle safe hidden");
+    writeWorkspaceFile(root, ".notes/cake.md", "needle safe hidden");
     writeWorkspaceFile(root, ".git/config.md", "needle git");
     writeWorkspaceFile(root, ".private/notes.md", "needle private");
     writeWorkspaceFile(root, "node_modules/pkg/index.md", "needle dependency");
@@ -136,9 +136,9 @@ describe("searchWorkspaceSource", () => {
     const result = await searchWorkspaceSource("needle", makeContext(root), 10);
 
     expect(result.evidence.map((item) => item.locator)).toEqual([
-      ".birthday-builds/.format-rec.md:1",
-      ".birthday-builds/cake.md:1",
       ".hidden.md:1",
+      ".notes/.format-rec.md:1",
+      ".notes/cake.md:1",
       "src/readme.md:1",
     ]);
   });
@@ -182,11 +182,6 @@ describe("searchWorkspaceSource", () => {
         "sharedneedle scratch filler",
       );
     }
-    writeWorkspaceFile(
-      root,
-      ".birthday-builds/format.md",
-      "formatneedle hidden authored decision",
-    );
     writeWorkspaceFile(root, "work/source.md", "workneedle live authored doc");
     writeWorkspaceFile(
       root,
@@ -199,17 +194,13 @@ describe("searchWorkspaceSource", () => {
     );
 
     const result = await searchWorkspaceSource(
-      "sharedneedle formatneedle workneedle appneedle",
+      "sharedneedle workneedle appneedle",
       makeContext(root),
       10,
     );
 
     expect(result.evidence.map((item) => item.title)).toEqual(
-      expect.arrayContaining([
-        ".birthday-builds/format.md",
-        "work/source.md",
-        "data/apps/example-app.json",
-      ]),
+      expect.arrayContaining(["work/source.md", "data/apps/example-app.json"]),
     );
   });
 
@@ -519,21 +510,17 @@ describe("inspectWorkspacePaths", () => {
   test("inspects up to five safe surfaced files and reports unsafe paths", async () => {
     const root = makeTempDir();
     writeWorkspaceFile(root, "scratch/handoff.md", "handoff exact truth");
-    writeWorkspaceFile(
-      root,
-      ".birthday-builds/format.md",
-      "hidden exact truth",
-    );
+    writeWorkspaceFile(root, ".notes/format.md", "hidden exact truth");
 
     const result = await inspectWorkspacePaths(
-      ["scratch/handoff.md", ".birthday-builds/format.md", "../secret.md"],
+      ["scratch/handoff.md", ".notes/format.md", "../secret.md"],
       "unrelated query terms",
       makeContext(root),
     );
 
     expect(result.evidence.map((item) => item.title)).toEqual([
       "scratch/handoff.md",
-      ".birthday-builds/format.md",
+      ".notes/format.md",
     ]);
     expect(result.errors).toEqual([
       {

--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -25,7 +25,6 @@ const WORKSPACE_BUCKETS: readonly WorkspaceBucket[] = [
   { name: "root", relativePath: "", budget: 100, rootFilesOnly: true },
   { name: "pkb", relativePath: "pkb", budget: 500 },
   { name: "journal", relativePath: "journal", budget: 250 },
-  { name: "birthday-builds", relativePath: ".birthday-builds", budget: 250 },
   { name: "scratch", relativePath: "scratch", budget: 500 },
   { name: "users", relativePath: "users", budget: 250 },
   { name: "work", relativePath: "work", budget: 250 },
@@ -1045,7 +1044,6 @@ function scoreMatch(options: {
 function getPathPriorityBoost(relativePath: string): number {
   if (relativePath.startsWith("data/apps/")) return 0.65;
   if (relativePath.startsWith("scratch/location-tracker/")) return 0.65;
-  if (relativePath.startsWith(".birthday-builds/")) return 0.6;
   if (relativePath.startsWith("work/")) return 0.45;
   if (relativePath.startsWith("scratch/")) return 0.35;
   if (relativePath.startsWith("users/")) return 0.3;


### PR DESCRIPTION
## Summary
- Remove the `.birthday-builds` workspace bucket entry and its path priority boost from `context-search/sources/workspace.ts`. Files in any hidden non-blocklisted directory now fall through to the default \"other\" bucket without a special boost.
- Update `context-search-workspace-source.test.ts` fixtures from `.birthday-builds` to a generic `.notes` hidden directory and adjust expected orderings/assertions to reflect the removed priority boost.

## Original prompt
get rid of all references to "birthday-builds"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
