### PR TITLE
fix(memory): route recall through v2 concept pages under memory-v2-enabled flag

### DIFF
--- a/assistant/src/__tests__/context-search-memory-source.test.ts
+++ b/assistant/src/__tests__/context-search-memory-source.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
-import type { RecallSearchContext } from "../memory/context-search/types.js";
+import type {
+  RecallEvidence,
+  RecallSearchContext,
+  RecallSearchResult,
+} from "../memory/context-search/types.js";
 import type { MemoryNode } from "../memory/graph/types.js";
 
 const loggerModule = import.meta.resolve("../util/logger.js");
@@ -11,6 +16,8 @@ const embeddingBackendModule = import.meta
 const graphSearchModule = import.meta
   .resolve("../memory/graph/graph-search.js");
 const graphStoreModule = import.meta.resolve("../memory/graph/store.js");
+const memoryV2SourceModule = import.meta
+  .resolve("../memory/context-search/sources/memory-v2.js");
 
 const warnCalls: unknown[][] = [];
 mock.module(loggerModule, () => ({
@@ -48,6 +55,11 @@ mock.module(embedModule, () => ({
 }));
 
 mock.module(embeddingBackendModule, () => ({
+  embedWithBackend: async () => ({
+    provider: "test",
+    model: "test-model",
+    vectors: [[0.1, 0.2, 0.3]],
+  }),
   generateSparseEmbedding: (text: string) =>
     text.trim().length === 0
       ? { indices: [], values: [] }
@@ -90,6 +102,28 @@ mock.module(graphStoreModule, () => ({
   },
 }));
 
+const v2Calls: Array<{
+  query: string;
+  context: RecallSearchContext;
+  limit: number;
+}> = [];
+let v2EvidenceReturn: RecallEvidence[] = [];
+
+const realMemoryV2 =
+  await import("../memory/context-search/sources/memory-v2.js");
+
+mock.module(memoryV2SourceModule, () => ({
+  isMemoryV2ReadActive: realMemoryV2.isMemoryV2ReadActive,
+  searchMemoryV2Source: async (
+    query: string,
+    context: RecallSearchContext,
+    limit: number,
+  ): Promise<RecallSearchResult> => {
+    v2Calls.push({ query, context, limit });
+    return { evidence: v2EvidenceReturn };
+  },
+}));
+
 const { searchMemorySource } =
   await import("../memory/context-search/sources/memory.js");
 
@@ -104,6 +138,9 @@ describe("searchMemorySource", () => {
     searchCalls.length = 0;
     hydratedNodes = [];
     getNodesByIdsCalls.length = 0;
+    v2Calls.length = 0;
+    v2EvidenceReturn = [];
+    _setOverridesForTesting({ "memory-v2-enabled": false });
   });
 
   test("hydrates graph hits into memory recall evidence", async () => {
@@ -263,7 +300,89 @@ describe("searchMemorySource", () => {
       "Failed to search memory graph for recall",
     );
   });
+
+  test("routes to v2 source when both v2 gates are on", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    v2EvidenceReturn = [
+      {
+        id: "memory:v2:alice",
+        source: "memory",
+        title: "alice",
+        locator: "memory/concepts/alice.md",
+        excerpt: "Alice prefers concise notes.",
+        score: 0.9,
+        metadata: {
+          path: "memory/concepts/alice.md",
+          slug: "alice",
+          retrieval: "activation",
+        },
+      },
+    ];
+
+    const result = await searchMemorySource(
+      "alice",
+      makeContext({
+        config: makeV2EnabledConfig(),
+      }),
+      6,
+    );
+
+    expect(v2Calls).toHaveLength(1);
+    expect(v2Calls[0]?.query).toBe("alice");
+    expect(v2Calls[0]?.limit).toBe(6);
+    expect(searchCalls).toHaveLength(0);
+    expect(getNodesByIdsCalls).toHaveLength(0);
+    expect(result.evidence.map((e) => e.locator)).toEqual([
+      "memory/concepts/alice.md",
+    ]);
+  });
+
+  test("stays on legacy path when feature flag is on but config.memory.v2.enabled is off", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    searchHits = [{ nodeId: "node-a", score: 0.7, text: "" }];
+    hydratedNodes = [makeNode({ id: "node-a", content: "Legacy hit" })];
+
+    await searchMemorySource(
+      "alice",
+      makeContext({ config: makeV2DisabledConfig() }),
+      5,
+    );
+
+    expect(v2Calls).toHaveLength(0);
+    expect(searchCalls).toHaveLength(1);
+  });
+
+  test("stays on legacy path when feature flag is off", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    searchHits = [{ nodeId: "node-a", score: 0.7, text: "" }];
+    hydratedNodes = [makeNode({ id: "node-a", content: "Legacy hit" })];
+
+    await searchMemorySource(
+      "alice",
+      makeContext({ config: makeV2EnabledConfig() }),
+      5,
+    );
+
+    expect(v2Calls).toHaveLength(0);
+    expect(searchCalls).toHaveLength(1);
+  });
 });
+
+function makeV2EnabledConfig(): AssistantConfig {
+  return {
+    memory: {
+      v2: { enabled: true },
+    },
+  } as unknown as AssistantConfig;
+}
+
+function makeV2DisabledConfig(): AssistantConfig {
+  return {
+    memory: {
+      v2: { enabled: false },
+    },
+  } as unknown as AssistantConfig;
+}
 
 function makeContext(
   overrides: Partial<RecallSearchContext> = {},

--- a/assistant/src/__tests__/context-search-memory-v2-source.test.ts
+++ b/assistant/src/__tests__/context-search-memory-v2-source.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for `assistant/src/memory/context-search/sources/memory-v2.ts`.
+ *
+ * Covers the recall-side adapter the `memory` source delegates to when the
+ * v2 flag is on. Two retrieval paths run in parallel:
+ *   - Activation + 2-hop spreading over the v2 concept-page Qdrant collection.
+ *   - Lexical file-search fallback over `<workspace>/memory/concepts/*.md`.
+ *
+ * The activation path is exercised by mocking `hybridQueryConceptPages`,
+ * `readEdges`, and `readPage`. The lexical fallback is exercised against a
+ * real temp workspace so its directory walk and term scoring run end-to-end.
+ *
+ * Generic placeholders (`alice`, `bob`, etc.) per the cross-cutting safety
+ * rules. Tests are hermetic — no live Qdrant, no embedding backend round-trip.
+ */
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AssistantConfig } from "../config/schema.js";
+import type { RecallSearchContext } from "../memory/context-search/types.js";
+import type { ConceptPage, EdgesIndex } from "../memory/v2/types.js";
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+let denseEmbedReturn: number[] = [0.1, 0.2, 0.3];
+mock.module("../memory/embedding-backend.js", () => ({
+  embedWithBackend: async () => ({
+    provider: "test",
+    model: "test-model",
+    vectors: [denseEmbedReturn],
+  }),
+  generateSparseEmbedding: () => ({ indices: [1], values: [1] }),
+}));
+
+interface QdrantHit {
+  slug: string;
+  denseScore?: number;
+  sparseScore?: number;
+}
+
+let qdrantHits: QdrantHit[] = [];
+let qdrantThrows: Error | null = null;
+const qdrantCalls: Array<{ limit: number }> = [];
+
+mock.module("../memory/v2/qdrant.js", () => ({
+  hybridQueryConceptPages: async (
+    _dense: number[],
+    _sparse: { indices: number[]; values: number[] },
+    limit: number,
+  ): Promise<QdrantHit[]> => {
+    qdrantCalls.push({ limit });
+    if (qdrantThrows) throw qdrantThrows;
+    return qdrantHits;
+  },
+}));
+
+let edgesIdx: EdgesIndex = { version: 1, edges: [] };
+
+mock.module("../memory/v2/edges.js", () => ({
+  readEdges: async (): Promise<EdgesIndex> => edgesIdx,
+}));
+
+const pageStore = new Map<string, ConceptPage>();
+
+mock.module("../memory/v2/page-store.js", () => ({
+  getConceptsDir: (workspaceDir: string): string =>
+    join(workspaceDir, "memory", "concepts"),
+  readPage: async (
+    _workspaceDir: string,
+    slug: string,
+  ): Promise<ConceptPage | null> => pageStore.get(slug) ?? null,
+}));
+
+const { searchMemoryV2Source } =
+  await import("../memory/context-search/sources/memory-v2.js");
+
+const testDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(): string {
+  const dir = realpathSync(
+    mkdtempSync(join(tmpdir(), "context-search-memory-v2-")),
+  );
+  testDirs.push(dir);
+  return dir;
+}
+
+function writeFile(root: string, relativePath: string, body: string): void {
+  const filePath = join(root, relativePath);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, body);
+}
+
+function writeConceptPage(root: string, slug: string, body: string): void {
+  writeFile(
+    root,
+    `memory/concepts/${slug}.md`,
+    `---\nedges: []\nref_files: []\n---\n${body}`,
+  );
+}
+
+function makeConfig(): AssistantConfig {
+  return {
+    memory: {
+      v2: {
+        enabled: true,
+        dense_weight: 0.6,
+        sparse_weight: 0.4,
+        k: 0.5,
+        hops: 2,
+        epsilon: 0.05,
+        d: 0.5,
+        c_user: 1,
+        c_assistant: 0.5,
+        c_now: 0.5,
+        top_k: 8,
+        top_k_skills: 0,
+      },
+    },
+  } as unknown as AssistantConfig;
+}
+
+function makeContext(workingDir: string): RecallSearchContext {
+  return {
+    workingDir,
+    memoryScopeId: "scope-default",
+    conversationId: "conv-test",
+    config: makeConfig(),
+  };
+}
+
+beforeEach(() => {
+  qdrantHits = [];
+  qdrantThrows = null;
+  qdrantCalls.length = 0;
+  edgesIdx = { version: 1, edges: [] };
+  pageStore.clear();
+  denseEmbedReturn = [0.1, 0.2, 0.3];
+});
+
+describe("searchMemoryV2Source", () => {
+  test("returns activation evidence with memory/concepts/<slug>.md locators", async () => {
+    const root = makeTempDir();
+    writeConceptPage(root, "alice", "Alice prefers concise notes.\n");
+
+    qdrantHits = [{ slug: "alice", denseScore: 0.9 }];
+    pageStore.set("alice", {
+      slug: "alice",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Alice prefers concise notes.",
+    });
+
+    const result = await searchMemoryV2Source("alice", makeContext(root), 5);
+
+    expect(result.evidence.length).toBeGreaterThan(0);
+    const activationHit = result.evidence.find(
+      (e) => e.metadata?.retrieval === "activation",
+    );
+    expect(activationHit).toBeDefined();
+    expect(activationHit?.locator).toBe("memory/concepts/alice.md");
+    expect(activationHit?.title).toBe("alice");
+    expect(activationHit?.excerpt).toContain("Alice prefers concise notes");
+    expect(activationHit?.metadata?.path).toBe("memory/concepts/alice.md");
+    expect(activationHit?.metadata?.slug).toBe("alice");
+    expect(qdrantCalls.length).toBeGreaterThan(0);
+  });
+
+  test("falls back to lexical evidence when activation finds nothing", async () => {
+    const root = makeTempDir();
+    writeConceptPage(
+      root,
+      "bob",
+      "# Bob\n\nBob's birthday party plans for next month.\n",
+    );
+
+    qdrantHits = [];
+
+    const result = await searchMemoryV2Source(
+      "birthday party",
+      makeContext(root),
+      5,
+    );
+
+    expect(result.evidence.length).toBeGreaterThan(0);
+    const lexicalHit = result.evidence.find(
+      (e) => e.metadata?.retrieval === "lexical",
+    );
+    expect(lexicalHit).toBeDefined();
+    expect(lexicalHit?.metadata?.path).toBe("memory/concepts/bob.md");
+    expect(lexicalHit?.locator).toMatch(/^memory\/concepts\/bob\.md:\d+$/);
+    expect(lexicalHit?.excerpt).toContain("birthday");
+  });
+
+  test("returns lexical evidence when Qdrant is unavailable", async () => {
+    const root = makeTempDir();
+    writeConceptPage(
+      root,
+      "carol",
+      "# Carol\n\nCarol joined the launch checklist review.\n",
+    );
+
+    qdrantThrows = new Error("qdrant unavailable");
+
+    const result = await searchMemoryV2Source(
+      "launch checklist",
+      makeContext(root),
+      5,
+    );
+
+    expect(result.evidence.length).toBeGreaterThan(0);
+    expect(
+      result.evidence.every((e) => e.metadata?.retrieval === "lexical"),
+    ).toBe(true);
+  });
+
+  test("returns empty when neither activation nor lexical matches anything", async () => {
+    const root = makeTempDir();
+    qdrantHits = [];
+    // No concept pages on disk
+
+    const result = await searchMemoryV2Source("anything", makeContext(root), 5);
+
+    expect(result.evidence).toEqual([]);
+  });
+
+  test("handles a missing memory/concepts directory gracefully", async () => {
+    const root = makeTempDir(); // workspace exists, but no memory/ dir
+    qdrantHits = [];
+
+    const result = await searchMemoryV2Source(
+      "no concepts",
+      makeContext(root),
+      5,
+    );
+
+    expect(result.evidence).toEqual([]);
+  });
+
+  test("respects the recall limit", async () => {
+    const root = makeTempDir();
+    for (let i = 0; i < 5; i++) {
+      const slug = `concept-${i}`;
+      writeConceptPage(
+        root,
+        slug,
+        `# ${slug}\n\nbirthday party reminder ${i}\n`,
+      );
+    }
+
+    qdrantHits = [];
+
+    const result = await searchMemoryV2Source(
+      "birthday party",
+      makeContext(root),
+      2,
+    );
+
+    expect(result.evidence.length).toBeLessThanOrEqual(2);
+  });
+
+  test("activation hits use slug as title and full body as excerpt", async () => {
+    const root = makeTempDir();
+    pageStore.set("alice", {
+      slug: "alice",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Alice memory body content.",
+    });
+    qdrantHits = [{ slug: "alice", denseScore: 0.85 }];
+
+    const result = await searchMemoryV2Source(
+      "alice memory",
+      makeContext(root),
+      5,
+    );
+
+    const hit = result.evidence.find(
+      (e) => e.metadata?.retrieval === "activation",
+    );
+    expect(hit?.title).toBe("alice");
+    expect(hit?.excerpt).toBe("Alice memory body content.");
+  });
+
+  test("returns empty when limit is zero", async () => {
+    const root = makeTempDir();
+    writeConceptPage(root, "alice", "Alice content");
+    qdrantHits = [{ slug: "alice", denseScore: 0.9 }];
+
+    const result = await searchMemoryV2Source("alice", makeContext(root), 0);
+
+    expect(result.evidence).toEqual([]);
+    expect(qdrantCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/__tests__/context-search-pkb-source.test.ts
+++ b/assistant/src/__tests__/context-search-pkb-source.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
 import type { RecallSearchContext } from "../memory/context-search/types.js";
 import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
@@ -193,6 +194,7 @@ describe("PKB context-search source", () => {
     denseThrows = null;
     pkbContext = null;
     nowScratchpad = null;
+    _setOverridesForTesting({ "memory-v2-enabled": false });
   });
 
   test("converts PKB hits to recall evidence with snippets and scores", async () => {
@@ -441,4 +443,51 @@ describe("PKB context-search source", () => {
       },
     ]);
   });
+
+  test("short-circuits to empty when both v2 gates are on", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    denseResults = [
+      {
+        id: "dense-a",
+        score: 0.9,
+        payload: {
+          target_type: "pkb_file",
+          target_id: "a",
+          path: "notes/should-not-appear.md",
+          text: "should not appear",
+        },
+      },
+    ];
+
+    const result = await searchPkbSource(
+      "anything",
+      makeContext({ config: makeV2EnabledConfig() }),
+      5,
+    );
+
+    expect(result).toEqual({ evidence: [] });
+    expect(qdrantSearchCalls).toHaveLength(0);
+    expect(hybridSearchCalls).toHaveLength(0);
+    expect(embedCalls).toHaveLength(0);
+  });
+
+  test("readPkbContextEvidence short-circuits when v2 read is active", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    pkbContext = "should not surface under v2";
+    nowScratchpad = "should not surface under v2";
+
+    const evidence = readPkbContextEvidence(
+      makeContext({ config: makeV2EnabledConfig() }),
+    );
+
+    expect(evidence).toEqual([]);
+  });
 });
+
+function makeV2EnabledConfig(): AssistantConfig {
+  return {
+    memory: {
+      v2: { enabled: true },
+    },
+  } as unknown as AssistantConfig;
+}

--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -1,0 +1,572 @@
+// ---------------------------------------------------------------------------
+// Memory v2 — `recall` adapter for the `memory` source
+// ---------------------------------------------------------------------------
+//
+// When the v2 flag is on, the `memory` recall source reads from the v2
+// concept-page subsystem (under `<workspace>/memory/concepts/`) instead of
+// the legacy graph. Two retrieval paths run in parallel and merge:
+//
+//   1. Activation + 2-hop spreading. ANN top-K against the v2 concept-page
+//      Qdrant collection seeds the candidate set; fused dense+sparse scores
+//      become A_o; `spreadActivation` walks 1- and 2-hop neighbors via
+//      `edges.json`; we pick the top-N by final activation.
+//   2. Lexical file-search fallback. Walks `memory/concepts/*.md` and
+//      term-matches the query so the agent can still find pages activation
+//      missed (rare-term queries, slug literals, etc.). Mirrors the pkb
+//      lexical fallback bit-for-bit so behavior is symmetric across sources.
+//
+// Both paths emit `RecallEvidence` with `source: "memory"` and locator
+// `memory/concepts/<slug>.md` so the recall agent can hand them to
+// `inspect_workspace_paths` to read full pages.
+//
+// Failures in either path degrade gracefully — if Qdrant is unavailable we
+// still surface lexical hits, and vice versa.
+
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
+import { extname, isAbsolute, join, relative, sep } from "node:path";
+
+import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
+import { getLogger } from "../../../util/logger.js";
+import { embedWithRetry } from "../../embed.js";
+import { generateSparseEmbedding } from "../../embedding-backend.js";
+import { spreadActivation } from "../../v2/activation.js";
+import { readEdges } from "../../v2/edges.js";
+import { getConceptsDir, readPage } from "../../v2/page-store.js";
+import { hybridQueryConceptPages } from "../../v2/qdrant.js";
+import { clampUnitInterval } from "../../validation.js";
+import type {
+  RecallEvidence,
+  RecallSearchContext,
+  RecallSearchResult,
+} from "../types.js";
+
+/**
+ * True when both v2 gates are on. Single source of truth shared by the
+ * `memory` source (which then delegates to v2) and the `pkb` source (which
+ * short-circuits because v2 absorbs PKB as a read source).
+ */
+export function isMemoryV2ReadActive(context: RecallSearchContext): boolean {
+  return (
+    isAssistantFeatureFlagEnabled("memory-v2-enabled", context.config) &&
+    context.config.memory.v2.enabled
+  );
+}
+
+const log = getLogger("context-search-memory-v2-source");
+
+/**
+ * Top-K size for the un-restricted ANN candidate query against the v2
+ * concept-page collection. Larger than the per-call recall limit so spreading
+ * has neighbors to pull in.
+ */
+const MEMORY_V2_ANN_CANDIDATE_LIMIT = 50;
+
+/** Cap individual concept-page files we are willing to read for lexical scan. */
+const MEMORY_V2_LEXICAL_MAX_FILE_SIZE_BYTES = 256 * 1024;
+const MEMORY_V2_LEXICAL_EXCERPT_LINE_RADIUS = 1;
+const MEMORY_V2_LEXICAL_EXCERPT_MAX_CHARS = 600;
+
+/** Excerpt length for activation hits — full body for short pages, trimmed otherwise. */
+const MEMORY_V2_PAGE_EXCERPT_MAX_CHARS = 1_200;
+
+/** Stop words filtered from query tokens before lexical matching. */
+const NON_SALIENT_RECALL_TERMS = new Set([
+  "a",
+  "about",
+  "and",
+  "any",
+  "as",
+  "asked",
+  "being",
+  "details",
+  "detail",
+  "find",
+  "for",
+  "from",
+  "get",
+  "give",
+  "happened",
+  "include",
+  "included",
+  "including",
+  "is",
+  "it",
+  "me",
+  "of",
+  "on",
+  "or",
+  "recipient",
+  "referred",
+  "relevant",
+  "should",
+  "tell",
+  "that",
+  "the",
+  "thing",
+  "timing",
+  "to",
+  "was",
+  "were",
+  "what",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "with",
+]);
+
+export async function searchMemoryV2Source(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallSearchResult> {
+  const normalizedLimit = Math.max(0, Math.floor(limit));
+  if (normalizedLimit === 0) {
+    return { evidence: [] };
+  }
+
+  const [activationEvidence, lexicalEvidence] = await Promise.all([
+    activationEvidenceSafe(query, context, normalizedLimit),
+    lexicalEvidenceSafe(query, context, normalizedLimit * 2),
+  ]);
+
+  return {
+    evidence: mergeMemoryV2Evidence(activationEvidence, lexicalEvidence).slice(
+      0,
+      normalizedLimit,
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Activation path
+// ---------------------------------------------------------------------------
+
+async function activationEvidenceSafe(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallEvidence[]> {
+  try {
+    return await activationEvidence(query, context, limit);
+  } catch (err) {
+    log.warn(
+      { err },
+      "Memory v2 activation recall failed; degrading to lexical-only",
+    );
+    return [];
+  }
+}
+
+async function activationEvidence(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallEvidence[]> {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery.length === 0) return [];
+
+  const denseResult = await embedWithRetry(context.config, [trimmedQuery], {
+    signal: context.signal,
+  });
+  const denseVector = denseResult.vectors[0];
+  if (!denseVector || denseVector.length === 0) return [];
+  const sparseVector = generateSparseEmbedding(trimmedQuery);
+
+  const hits = await hybridQueryConceptPages(
+    denseVector,
+    sparseVector,
+    MEMORY_V2_ANN_CANDIDATE_LIMIT,
+  );
+  if (hits.length === 0) return [];
+
+  const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
+    context.config.memory.v2;
+
+  let maxSparse = 0;
+  for (const hit of hits) {
+    if (hit.sparseScore !== undefined && hit.sparseScore > maxSparse) {
+      maxSparse = hit.sparseScore;
+    }
+  }
+
+  const ownActivation = new Map<string, number>();
+  for (const hit of hits) {
+    const dense = hit.denseScore ?? 0;
+    const sparseNormalized =
+      hit.sparseScore !== undefined && maxSparse > 0
+        ? hit.sparseScore / maxSparse
+        : 0;
+    ownActivation.set(
+      hit.slug,
+      clampUnitInterval(denseWeight * dense + sparseWeight * sparseNormalized),
+    );
+  }
+
+  const edgesIdx = await readEdges(context.workingDir);
+  const { k, hops } = context.config.memory.v2;
+  const finalActivation = spreadActivation(ownActivation, edgesIdx, k, hops);
+
+  const ranked = [...finalActivation.entries()]
+    .sort(([slugA, valA], [slugB, valB]) => {
+      if (valB !== valA) return valB - valA;
+      return slugA < slugB ? -1 : slugA > slugB ? 1 : 0;
+    })
+    .slice(0, limit);
+
+  const pages = await Promise.all(
+    ranked.map(async ([slug, score]) => {
+      try {
+        const page = await readPage(context.workingDir, slug);
+        if (!page) return null;
+        return { slug, score, body: page.body.trim() };
+      } catch (err) {
+        log.warn({ err, slug }, "Failed to read concept page during recall");
+        return null;
+      }
+    }),
+  );
+
+  const evidence: RecallEvidence[] = [];
+  for (const entry of pages) {
+    if (!entry || entry.body.length === 0) continue;
+    const locator = `memory/concepts/${entry.slug}.md`;
+    evidence.push({
+      id: `memory:v2:${entry.slug}`,
+      source: "memory",
+      title: entry.slug,
+      locator,
+      excerpt: truncateExcerpt(entry.body, MEMORY_V2_PAGE_EXCERPT_MAX_CHARS),
+      score: entry.score,
+      metadata: {
+        path: locator,
+        slug: entry.slug,
+        retrieval: "activation",
+      },
+    });
+  }
+  return evidence;
+}
+
+// ---------------------------------------------------------------------------
+// Lexical fallback
+// ---------------------------------------------------------------------------
+
+interface MemoryV2LexicalMatch {
+  slug: string;
+  excerpt: string;
+  lineNumber: number;
+  score: number;
+  matchedTerms: string[];
+}
+
+async function lexicalEvidenceSafe(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallEvidence[]> {
+  try {
+    return await lexicalEvidence(query, context, limit);
+  } catch (err) {
+    log.warn({ err }, "Memory v2 lexical recall fallback failed");
+    return [];
+  }
+}
+
+async function lexicalEvidence(
+  query: string,
+  context: RecallSearchContext,
+  limit: number,
+): Promise<RecallEvidence[]> {
+  const queryTerms = tokenizeSalientRecallTerms(query);
+  if (queryTerms.size === 0 || limit <= 0) return [];
+
+  const conceptsRoot = await resolveContainedConceptsRoot(context.workingDir);
+  if (!conceptsRoot) return [];
+
+  const matches: MemoryV2LexicalMatch[] = [];
+  await walkConceptsDirectory(
+    conceptsRoot,
+    conceptsRoot,
+    queryTerms,
+    matches,
+    context.signal,
+  );
+
+  return matches
+    .sort(compareLexicalMatches)
+    .slice(0, limit)
+    .map(toLexicalEvidence);
+}
+
+async function resolveContainedConceptsRoot(
+  workingDir: string,
+): Promise<string | null> {
+  try {
+    const workspaceRoot = await realpath(workingDir);
+    const conceptsRoot = await realpath(getConceptsDir(workspaceRoot));
+    if (!isPathInsideRoot(conceptsRoot, workspaceRoot)) {
+      return null;
+    }
+    const rootStats = await stat(conceptsRoot);
+    return rootStats.isDirectory() ? conceptsRoot : null;
+  } catch {
+    return null;
+  }
+}
+
+async function walkConceptsDirectory(
+  directoryPath: string,
+  conceptsRoot: string,
+  queryTerms: ReadonlySet<string>,
+  matches: MemoryV2LexicalMatch[],
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  throwIfAborted(signal);
+
+  let entries;
+  try {
+    entries = await readdir(directoryPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    throwIfAborted(signal);
+
+    const entryPath = join(directoryPath, entry.name);
+    let entryRealPath;
+    try {
+      entryRealPath = await realpath(entryPath);
+    } catch {
+      continue;
+    }
+
+    if (!isPathInsideRoot(entryRealPath, conceptsRoot)) continue;
+
+    let entryStats;
+    try {
+      entryStats = await stat(entryRealPath);
+    } catch {
+      continue;
+    }
+
+    if (entryStats.isDirectory()) {
+      await walkConceptsDirectory(
+        entryRealPath,
+        conceptsRoot,
+        queryTerms,
+        matches,
+        signal,
+      );
+      continue;
+    }
+
+    if (
+      !entryStats.isFile() ||
+      entryStats.size > MEMORY_V2_LEXICAL_MAX_FILE_SIZE_BYTES ||
+      extname(entryRealPath).toLowerCase() !== ".md"
+    ) {
+      continue;
+    }
+
+    const match = await searchConceptFile(
+      entryRealPath,
+      conceptsRoot,
+      queryTerms,
+    );
+    if (match) matches.push(match);
+  }
+}
+
+async function searchConceptFile(
+  filePath: string,
+  conceptsRoot: string,
+  queryTerms: ReadonlySet<string>,
+): Promise<MemoryV2LexicalMatch | null> {
+  let contents;
+  try {
+    contents = await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const lines = contents.split(/\r?\n/);
+  const bestLine = findBestLine(lines, queryTerms);
+  if (!bestLine) return null;
+
+  const slug = slugFromConceptPath(conceptsRoot, filePath);
+  const slugTerms = termOverlap(tokenizeSalientRecallTerms(slug), queryTerms);
+  const score =
+    bestLine.matchedTerms.size / queryTerms.size + slugTerms.size * 0.35;
+
+  return {
+    slug,
+    excerpt: buildLexicalExcerpt(lines, bestLine.lineIndex),
+    lineNumber: bestLine.lineIndex + 1,
+    score,
+    matchedTerms: [...bestLine.matchedTerms].sort(),
+  };
+}
+
+function findBestLine(
+  lines: readonly string[],
+  queryTerms: ReadonlySet<string>,
+): { lineIndex: number; matchedTerms: Set<string> } | null {
+  let best: {
+    lineIndex: number;
+    matchedTerms: Set<string>;
+    score: number;
+  } | null = null;
+
+  lines.forEach((line, lineIndex) => {
+    const lineTerms = tokenizeSalientRecallTerms(line);
+    const matchedTerms = termOverlap(lineTerms, queryTerms);
+    if (matchedTerms.size === 0) return;
+
+    const score = matchedTerms.size * 10 + Math.min(lineTerms.size, 12) / 100;
+    if (!best || score > best.score) {
+      best = { lineIndex, matchedTerms, score };
+    }
+  });
+
+  return best;
+}
+
+function buildLexicalExcerpt(
+  lines: readonly string[],
+  lineIndex: number,
+): string {
+  const start = Math.max(0, lineIndex - MEMORY_V2_LEXICAL_EXCERPT_LINE_RADIUS);
+  const end = Math.min(
+    lines.length,
+    lineIndex + MEMORY_V2_LEXICAL_EXCERPT_LINE_RADIUS + 1,
+  );
+  const excerpt = lines
+    .slice(start, end)
+    .map((line, offset) => `${start + offset + 1}: ${line.trimEnd()}`)
+    .join("\n")
+    .trim();
+
+  if (excerpt.length <= MEMORY_V2_LEXICAL_EXCERPT_MAX_CHARS) return excerpt;
+
+  const focusedLine = `${lineIndex + 1}: ${lines[lineIndex]?.trimEnd() ?? ""}`;
+  if (focusedLine.length <= MEMORY_V2_LEXICAL_EXCERPT_MAX_CHARS) {
+    return focusedLine;
+  }
+  return `${focusedLine
+    .slice(0, MEMORY_V2_LEXICAL_EXCERPT_MAX_CHARS - 3)
+    .trimEnd()}...`;
+}
+
+function toLexicalEvidence(match: MemoryV2LexicalMatch): RecallEvidence {
+  const locator = `memory/concepts/${match.slug}.md:${match.lineNumber}`;
+  return {
+    id: `memory:v2:lexical:${match.slug}:${match.lineNumber}`,
+    source: "memory",
+    title: match.slug,
+    locator,
+    excerpt: match.excerpt,
+    score: match.score,
+    metadata: {
+      path: `memory/concepts/${match.slug}.md`,
+      slug: match.slug,
+      lineNumber: match.lineNumber,
+      matchedTerms: match.matchedTerms,
+      retrieval: "lexical",
+    },
+  };
+}
+
+function compareLexicalMatches(
+  a: MemoryV2LexicalMatch,
+  b: MemoryV2LexicalMatch,
+): number {
+  if (b.score !== a.score) return b.score - a.score;
+  const slugCompare = a.slug.localeCompare(b.slug);
+  if (slugCompare !== 0) return slugCompare;
+  return a.lineNumber - b.lineNumber;
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+function mergeMemoryV2Evidence(
+  activationEvidence: readonly RecallEvidence[],
+  lexicalEvidence: readonly RecallEvidence[],
+): RecallEvidence[] {
+  // Activation hits already encode "this page is the best match for the query"
+  // and carry the full body excerpt. Lexical hits sometimes target the same
+  // slug at a specific line — keep both since the line-level excerpt can pin
+  // the agent to the right region of a long page, but dedupe identical (slug,
+  // excerpt) pairs that the two paths happen to produce.
+  const seen = new Set<string>();
+  const merged: RecallEvidence[] = [];
+  for (const item of [
+    ...activationEvidence,
+    ...[...lexicalEvidence].sort(
+      (a, b) => (b.score ?? 0) - (a.score ?? 0) || a.id.localeCompare(b.id),
+    ),
+  ]) {
+    const key = `${item.locator}\0${normalizeExcerpt(item.excerpt)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(item);
+  }
+  return merged;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from pkb.ts so behavior stays symmetric)
+// ---------------------------------------------------------------------------
+
+function tokenizeSalientRecallTerms(text: string): Set<string> {
+  const terms = (text.toLowerCase().match(/[a-z0-9_]+/g) ?? []).filter(
+    (term) => term.length >= 2 && !NON_SALIENT_RECALL_TERMS.has(term),
+  );
+  return new Set(terms);
+}
+
+function termOverlap(
+  haystackTerms: ReadonlySet<string>,
+  queryTerms: ReadonlySet<string>,
+): Set<string> {
+  const matchedTerms = new Set<string>();
+  for (const term of queryTerms) {
+    if (haystackTerms.has(term)) matchedTerms.add(term);
+  }
+  return matchedTerms;
+}
+
+function normalizeExcerpt(excerpt: string): string {
+  return excerpt.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function isPathInsideRoot(pathToCheck: string, rootRealPath: string): boolean {
+  const pathRelativeToRoot = relative(rootRealPath, pathToCheck);
+  return (
+    pathRelativeToRoot === "" ||
+    (!pathRelativeToRoot.startsWith("..") && !isAbsolute(pathRelativeToRoot))
+  );
+}
+
+function slugFromConceptPath(conceptsRoot: string, filePath: string): string {
+  const rel = relative(conceptsRoot, filePath).split(sep).join("/");
+  const withoutExt = rel.endsWith(".md") ? rel.slice(0, -3) : rel;
+  return withoutExt;
+}
+
+function truncateExcerpt(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars - 3).trimEnd()}...`;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("Memory v2 recall search aborted");
+  }
+}

--- a/assistant/src/memory/context-search/sources/memory.ts
+++ b/assistant/src/memory/context-search/sources/memory.ts
@@ -9,6 +9,7 @@ import type {
   RecallSearchContext,
   RecallSearchResult,
 } from "../types.js";
+import { isMemoryV2ReadActive, searchMemoryV2Source } from "./memory-v2.js";
 
 const log = getLogger("context-search-memory-source");
 
@@ -20,6 +21,10 @@ export async function searchMemorySource(
   const normalizedLimit = Math.max(0, Math.floor(limit));
   if (normalizedLimit === 0) {
     return { evidence: [] };
+  }
+
+  if (isMemoryV2ReadActive(context)) {
+    return searchMemoryV2Source(query, context, normalizedLimit);
   }
 
   let queryVector: number[] | null = null;

--- a/assistant/src/memory/context-search/sources/pkb.ts
+++ b/assistant/src/memory/context-search/sources/pkb.ts
@@ -15,6 +15,7 @@ import type {
   RecallSearchContext,
   RecallSearchResult,
 } from "../types.js";
+import { isMemoryV2ReadActive } from "./memory-v2.js";
 
 const log = getLogger("context-search-pkb-source");
 
@@ -75,6 +76,10 @@ export async function searchPkbSource(
   context: RecallSearchContext,
   limit: number,
 ): Promise<RecallSearchResult> {
+  if (isMemoryV2ReadActive(context)) {
+    return { evidence: [] };
+  }
+
   const semanticEvidence: RecallEvidence[] = [];
 
   try {
@@ -132,8 +137,12 @@ export async function searchPkbSource(
 }
 
 export function readPkbContextEvidence(
-  _context: RecallSearchContext,
+  context: RecallSearchContext,
 ): RecallEvidence[] {
+  if (isMemoryV2ReadActive(context)) {
+    return [];
+  }
+
   const evidence: RecallEvidence[] = [];
 
   const pkbContext = readPkbContext();

--- a/assistant/src/memory/context-search/sources/workspace.ts
+++ b/assistant/src/memory/context-search/sources/workspace.ts
@@ -24,6 +24,7 @@ const PATH_LITERAL_PATTERN =
 const WORKSPACE_BUCKETS: readonly WorkspaceBucket[] = [
   { name: "root", relativePath: "", budget: 100, rootFilesOnly: true },
   { name: "pkb", relativePath: "pkb", budget: 500 },
+  { name: "memory", relativePath: "memory", budget: 500 },
   { name: "journal", relativePath: "journal", budget: 250 },
   { name: "scratch", relativePath: "scratch", budget: 500 },
   { name: "users", relativePath: "users", budget: 250 },
@@ -1050,6 +1051,8 @@ function getPathPriorityBoost(relativePath: string): number {
   if (relativePath.startsWith("journal/")) return 0.25;
   if (relativePath.startsWith("pkb/archive/")) return -0.15;
   if (relativePath.startsWith("pkb/")) return 0.2;
+  if (relativePath.startsWith("memory/concepts/")) return 0.4;
+  if (relativePath.startsWith("memory/")) return 0.2;
   if (
     relativePath.startsWith("conversations/") ||
     relativePath.startsWith("backups/") ||

--- a/assistant/src/memory/v2/page-store.ts
+++ b/assistant/src/memory/v2/page-store.ts
@@ -69,7 +69,7 @@ export function slugify(input: string): string {
 // Path helpers
 // ---------------------------------------------------------------------------
 
-function getConceptsDir(workspaceDir: string): string {
+export function getConceptsDir(workspaceDir: string): string {
   return join(workspaceDir, "memory", "concepts");
 }
 


### PR DESCRIPTION
## Summary

- The `recall` tool's `memory` source now reads from v2 concept pages when both `memory-v2-enabled` and `config.memory.v2.enabled` are on; it stays on the legacy graph otherwise. v2 retrieval combines ANN + activation + 2-hop spreading with a lexical file-search fallback over `<workspace>/memory/concepts/*.md`.
- The `pkb` source short-circuits to empty under v2 (concept pages absorb pkb as the read source per the flag's stated cutover; pkb files stay write-active).
- Workspace source gets a dedicated `memory` bucket and path-priority boost so general file search treats concept pages as a first-class area.

The model-facing tool schema is unchanged — semantics shift, surface stays put.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
