### PR TITLE
feat(memory): silence PKB injectors when v2 read is active

### DIFF
--- a/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
+++ b/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
@@ -1,0 +1,103 @@
+/**
+ * v2 read-side cutover guard for the PKB-derived default injectors.
+ *
+ * When `isMemoryV2ReadActive(getConfig())` is true, the three PKB-shaped
+ * injectors (`pkb-context`, `pkb-reminder`, `now-md`) silence themselves so
+ * the v2 activation block on the user message owns the read path
+ * end-to-end. When v2 is off, they keep producing their existing blocks.
+ *
+ * Mocks `isMemoryV2ReadActive` at the module level so each test can flip the
+ * effective gate state without standing up a full feature-flag + config
+ * stack. Mocks the PKB hybrid search so the reminder-with-hints branch can
+ * resolve deterministically.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let v2Active = false;
+
+mock.module("../memory/context-search/sources/memory-v2.js", () => ({
+  isMemoryV2ReadActive: () => v2Active,
+}));
+
+mock.module("../memory/pkb/pkb-search.js", () => ({
+  searchPkbFiles: async () => [],
+}));
+
+const { applyRuntimeInjections } =
+  await import("../daemon/conversation-runtime-assembly.js");
+const { defaultInjectorsPlugin } =
+  await import("../plugins/defaults/injectors.js");
+const { registerPlugin, resetPluginRegistryForTests } =
+  await import("../plugins/registry.js");
+import type { TurnContext } from "../plugins/types.js";
+import type { Message } from "../providers/types.js";
+
+function makeTurnContext(): TurnContext {
+  return {
+    requestId: "req-test-1",
+    conversationId: "conv-test-1",
+    turnIndex: 0,
+    trust: {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    },
+  };
+}
+
+function tailTexts(messages: Message[]): string[] {
+  const tail = messages[messages.length - 1];
+  return tail.content
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text);
+}
+
+const PKB_CONTEXT = "essentials of the project";
+const NOW_CONTENT = "Current focus: shipping G2.1";
+const RUN_MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "What next?" }] },
+];
+
+describe("PKB injectors gated on v2 read activity", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+    registerPlugin(defaultInjectorsPlugin);
+    v2Active = false;
+  });
+
+  test("v2 inactive → pkb-context, pkb-reminder, and now-md all produce blocks", async () => {
+    const result = await applyRuntimeInjections(RUN_MESSAGES, {
+      turnContext: makeTurnContext(),
+      pkbContext: PKB_CONTEXT,
+      pkbActive: true,
+      pkbScopeId: "scope-default",
+      pkbRoot: "/tmp/pkb",
+      pkbConversation: { messages: [] },
+      nowScratchpad: NOW_CONTENT,
+    });
+
+    const texts = tailTexts(result.messages);
+    expect(texts.some((t) => t.includes("<knowledge_base>"))).toBe(true);
+    expect(texts.some((t) => t.includes("<system_reminder>"))).toBe(true);
+    expect(texts.some((t) => t.includes("<NOW.md"))).toBe(true);
+  });
+
+  test("v2 active → all three PKB injectors return null", async () => {
+    v2Active = true;
+    const result = await applyRuntimeInjections(RUN_MESSAGES, {
+      turnContext: makeTurnContext(),
+      pkbContext: PKB_CONTEXT,
+      pkbActive: true,
+      pkbScopeId: "scope-default",
+      pkbRoot: "/tmp/pkb",
+      pkbConversation: { messages: [] },
+      nowScratchpad: NOW_CONTENT,
+    });
+
+    const texts = tailTexts(result.messages);
+    expect(texts.some((t) => t.includes("<knowledge_base>"))).toBe(false);
+    expect(texts.some((t) => t.includes("<system_reminder>"))).toBe(false);
+    expect(texts.some((t) => t.includes("<NOW.md"))).toBe(false);
+    // The user's typed text should still survive untouched.
+    expect(texts).toContain("What next?");
+  });
+});

--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -26,6 +26,7 @@ import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { extname, isAbsolute, join, relative, sep } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../../../config/schema.js";
 import { getLogger } from "../../../util/logger.js";
 import { embedWithRetry } from "../../embed.js";
 import { generateSparseEmbedding } from "../../embedding-backend.js";
@@ -41,14 +42,15 @@ import type {
 } from "../types.js";
 
 /**
- * True when both v2 gates are on. Single source of truth shared by the
- * `memory` source (which then delegates to v2) and the `pkb` source (which
- * short-circuits because v2 absorbs PKB as a read source).
+ * True when both v2 gates are on. Single source of truth shared by the recall
+ * `memory` source (which delegates to v2), the `pkb` source (which
+ * short-circuits because v2 absorbs PKB as a read source), and the per-turn
+ * PKB injectors (which go silent so v2 owns the read path end-to-end).
  */
-export function isMemoryV2ReadActive(context: RecallSearchContext): boolean {
+export function isMemoryV2ReadActive(config: AssistantConfig): boolean {
   return (
-    isAssistantFeatureFlagEnabled("memory-v2-enabled", context.config) &&
-    context.config.memory.v2.enabled
+    isAssistantFeatureFlagEnabled("memory-v2-enabled", config) &&
+    config.memory.v2.enabled
   );
 }
 

--- a/assistant/src/memory/context-search/sources/memory.ts
+++ b/assistant/src/memory/context-search/sources/memory.ts
@@ -23,7 +23,7 @@ export async function searchMemorySource(
     return { evidence: [] };
   }
 
-  if (isMemoryV2ReadActive(context)) {
+  if (isMemoryV2ReadActive(context.config)) {
     return searchMemoryV2Source(query, context, normalizedLimit);
   }
 

--- a/assistant/src/memory/context-search/sources/pkb.ts
+++ b/assistant/src/memory/context-search/sources/pkb.ts
@@ -76,7 +76,7 @@ export async function searchPkbSource(
   context: RecallSearchContext,
   limit: number,
 ): Promise<RecallSearchResult> {
-  if (isMemoryV2ReadActive(context)) {
+  if (isMemoryV2ReadActive(context.config)) {
     return { evidence: [] };
   }
 
@@ -139,7 +139,7 @@ export async function searchPkbSource(
 export function readPkbContextEvidence(
   context: RecallSearchContext,
 ): RecallEvidence[] {
-  if (isMemoryV2ReadActive(context)) {
+  if (isMemoryV2ReadActive(context.config)) {
     return [];
   }
 

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -44,8 +44,10 @@
 
 import { resolve } from "node:path";
 
+import { getConfig } from "../../config/loader.js";
 import { getInContextPkbPaths } from "../../daemon/pkb-context-tracker.js";
 import { buildPkbReminder } from "../../daemon/pkb-reminder-builder.js";
+import { isMemoryV2ReadActive } from "../../memory/context-search/sources/memory-v2.js";
 import { searchPkbFiles } from "../../memory/pkb/pkb-search.js";
 import { getLogger } from "../../util/logger.js";
 import { registerPlugin } from "../registry.js";
@@ -92,6 +94,16 @@ export const DEFAULT_INJECTOR_ORDER = {
 
 function readInjectionInputs(ctx: TurnContext): TurnInjectionInputs {
   return ctx.injectionInputs ?? {};
+}
+
+/**
+ * v2 read-side cutover guard. PKB-derived injectors (`pkb-context`,
+ * `pkb-reminder`, `now-md`) silence themselves when v2 is reading from
+ * concept pages so they don't double up on retrieval the v2 activation
+ * block already covers. Mirrors the gate the recall sources use.
+ */
+function isPkbInjectionSilencedByV2(): boolean {
+  return isMemoryV2ReadActive(getConfig());
 }
 
 /**
@@ -173,6 +185,7 @@ const pkbContextInjector: Injector = {
     const inputs = readInjectionInputs(ctx);
     const mode = inputs.mode ?? "full";
     if (mode !== "full") return null;
+    if (isPkbInjectionSilencedByV2()) return null;
     if (!inputs.pkbContext) return null;
     return {
       id: "pkb-context",
@@ -202,6 +215,7 @@ const pkbReminderInjector: Injector = {
     const inputs = readInjectionInputs(ctx);
     const mode = inputs.mode ?? "full";
     if (mode !== "full") return null;
+    if (isPkbInjectionSilencedByV2()) return null;
     if (!inputs.pkbActive) return null;
     const reminder = await buildPkbReminderWithHints(inputs);
     return {
@@ -314,6 +328,7 @@ const nowMdInjector: Injector = {
     const inputs = readInjectionInputs(ctx);
     const mode = inputs.mode ?? "full";
     if (mode !== "full") return null;
+    if (isPkbInjectionSilencedByV2()) return null;
     const content = inputs.nowScratchpad;
     if (!content) return null;
     const text = `<NOW.md Always keep this up to date; keep under 10 lines>\n${content}\n</NOW.md>`;


### PR DESCRIPTION
## Summary

- The three PKB-derived default injectors (`pkb-context`, `pkb-reminder`, `now-md`) now silence themselves when `memory-v2-enabled` + `config.memory.v2.enabled` are both on. The per-turn v2 activation block on the user message already covers this retrieval; PKB injection on top of it duplicates content and burns prompt-cache real estate.
- `isMemoryV2ReadActive` now takes `AssistantConfig` directly (was `RecallSearchContext`) so the daemon-side injectors can call it without synthesizing a search context. Three existing recall-source callsites updated.

## Original prompt

#2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
