### PR TITLE
chore: remove departed users from github-slack mapping

### DIFF
--- a/.github/config/github_slack_mapping.yaml
+++ b/.github/config/github_slack_mapping.yaml
@@ -3,11 +3,9 @@ github_to_slack_all_notifications:
   AnitaKirkovska: U060M1MUT7F
   ashleeradka: U06LGSYA9JP
   awlevin: U07CLDQ4TB3
-  vincent0426: U08CJM4D56D
   TirmanSidhu: U08ASQYPTB6
   emmiekehoe: U08Q1QHGKTM
   alex-nork: U095KUZ3L20
-  tkheyfets: U09AWSU8XM1
   Jasonnnz: U09DVL1JN3V
   vex-assistant-bot[bot]: U0ALUGLCUFJ
 


### PR DESCRIPTION
## Summary
- Remove `vincent0426` and `tkheyfets` from `github_to_slack_all_notifications` mapping since they are no longer active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
