### PR TITLE
fix(memory): keep system_reminder and NOW.md firing under v2

### DIFF
--- a/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
+++ b/assistant/src/__tests__/injector-pkb-v2-silenced.test.ts
@@ -1,15 +1,16 @@
 /**
- * v2 read-side cutover guard for the PKB-derived default injectors.
+ * v2 read-side cutover behavior for the PKB-derived default injectors.
  *
- * When `isMemoryV2ReadActive(getConfig())` is true, the three PKB-shaped
- * injectors (`pkb-context`, `pkb-reminder`, `now-md`) silence themselves so
- * the v2 activation block on the user message owns the read path
- * end-to-end. When v2 is off, they keep producing their existing blocks.
+ * When `isMemoryV2ReadActive(getConfig())` is true:
+ *   - `pkb-context` silences itself (concept pages own retrieval).
+ *   - `pkb-reminder` still fires (its body is generic recall/remember
+ *     guidance) but skips the PKB-search hints — those name PKB paths.
+ *   - `now-md` fires unchanged (workspace state, independent of PKB).
  *
  * Mocks `isMemoryV2ReadActive` at the module level so each test can flip the
  * effective gate state without standing up a full feature-flag + config
  * stack. Mocks the PKB hybrid search so the reminder-with-hints branch can
- * resolve deterministically.
+ * resolve deterministically when called.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -57,7 +58,7 @@ const RUN_MESSAGES: Message[] = [
   { role: "user", content: [{ type: "text", text: "What next?" }] },
 ];
 
-describe("PKB injectors gated on v2 read activity", () => {
+describe("PKB injector v2 cutover behavior", () => {
   beforeEach(() => {
     resetPluginRegistryForTests();
     registerPlugin(defaultInjectorsPlugin);
@@ -81,7 +82,7 @@ describe("PKB injectors gated on v2 read activity", () => {
     expect(texts.some((t) => t.includes("<NOW.md"))).toBe(true);
   });
 
-  test("v2 active → all three PKB injectors return null", async () => {
+  test("v2 active → pkb-context silenced; pkb-reminder + now-md still fire", async () => {
     v2Active = true;
     const result = await applyRuntimeInjections(RUN_MESSAGES, {
       turnContext: makeTurnContext(),
@@ -95,9 +96,29 @@ describe("PKB injectors gated on v2 read activity", () => {
 
     const texts = tailTexts(result.messages);
     expect(texts.some((t) => t.includes("<knowledge_base>"))).toBe(false);
-    expect(texts.some((t) => t.includes("<system_reminder>"))).toBe(false);
-    expect(texts.some((t) => t.includes("<NOW.md"))).toBe(false);
-    // The user's typed text should still survive untouched.
+    expect(texts.some((t) => t.includes("<system_reminder>"))).toBe(true);
+    expect(texts.some((t) => t.includes("<NOW.md"))).toBe(true);
     expect(texts).toContain("What next?");
+  });
+
+  test("v2 active → pkb-reminder body fires without the hybrid-search hints", async () => {
+    v2Active = true;
+    const result = await applyRuntimeInjections(RUN_MESSAGES, {
+      turnContext: makeTurnContext(),
+      pkbActive: true,
+      pkbScopeId: "scope-default",
+      pkbRoot: "/tmp/pkb",
+      pkbConversation: { messages: [] },
+      // Provide a query vector so the v1 path WOULD have called searchPkbFiles
+      // and rendered hints. Under v2, the call is skipped and the reminder
+      // is rendered with empty hints — i.e. no "files look especially
+      // relevant" line.
+      pkbQueryVector: [0.1, 0.2, 0.3],
+    });
+
+    const texts = tailTexts(result.messages);
+    const reminder = texts.find((t) => t.includes("<system_reminder>"));
+    expect(reminder).toBeDefined();
+    expect(reminder).not.toContain("files look especially relevant");
   });
 });

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -97,10 +97,12 @@ function readInjectionInputs(ctx: TurnContext): TurnInjectionInputs {
 }
 
 /**
- * v2 read-side cutover guard. PKB-derived injectors (`pkb-context`,
- * `pkb-reminder`, `now-md`) silence themselves when v2 is reading from
- * concept pages so they don't double up on retrieval the v2 activation
- * block already covers. Mirrors the gate the recall sources use.
+ * v2 read-side cutover guard. The `pkb-context` injector silences itself
+ * under v2 because the `<knowledge_base>` block surfaces PKB content the v2
+ * activation block already covers. The `pkb-reminder` injector still fires
+ * (its body is generic recall/remember guidance) but skips the hybrid-search
+ * hints — those name PKB paths v2 is moving away from. NOW.md is workspace
+ * state independent of PKB and fires unchanged.
  */
 function isPkbInjectionSilencedByV2(): boolean {
   return isMemoryV2ReadActive(getConfig());
@@ -215,9 +217,10 @@ const pkbReminderInjector: Injector = {
     const inputs = readInjectionInputs(ctx);
     const mode = inputs.mode ?? "full";
     if (mode !== "full") return null;
-    if (isPkbInjectionSilencedByV2()) return null;
     if (!inputs.pkbActive) return null;
-    const reminder = await buildPkbReminderWithHints(inputs);
+    const reminder = isPkbInjectionSilencedByV2()
+      ? buildPkbReminder([])
+      : await buildPkbReminderWithHints(inputs);
     return {
       id: "pkb-reminder",
       text: reminder,
@@ -328,7 +331,6 @@ const nowMdInjector: Injector = {
     const inputs = readInjectionInputs(ctx);
     const mode = inputs.mode ?? "full";
     if (mode !== "full") return null;
-    if (isPkbInjectionSilencedByV2()) return null;
     const content = inputs.nowScratchpad;
     if (!content) return null;
     const text = `<NOW.md Always keep this up to date; keep under 10 lines>\n${content}\n</NOW.md>`;


### PR DESCRIPTION
## Summary

- Revert the v2 gate on `now-md`. NOW.md is workspace state independent of PKB and should keep injecting under both v1 and v2.
- Keep `pkb-reminder` firing under v2 — its body is generic recall/remember guidance, not PKB-specific. Skip only the trailing PKB-search hints by calling `buildPkbReminder([])` directly.
- `pkb-context` (`<knowledge_base>`) stays silenced under v2 — that block IS pkb-specific content the v2 activation block already covers.

## Original prompt

wait are we not injecting the <system_reminder> at all in v2? also NOW.md should still get injected in both v1 and v2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
