### PR TITLE
fix(memory): render full top-K activation block on context-load

### DIFF
--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -403,11 +403,17 @@ export class ConversationGraphMemory {
     // assistantMessage is empty: context-load fires on turn 1 / post-
     // compaction, so there is no immediately-prior assistant turn to
     // weight the activation against.
+    //
+    // Use the raw user text (no >10-char filter) so even short greetings
+    // ("hi") get a fresh top-K activation dump on the first user message.
+    // The activation pipeline is robust to weak ANN signal — it still falls
+    // back to spreading + nowText to surface candidates.
+    const rawUserText = readRawUserText(messages[messages.length - 1]);
     const v2 = await this.maybeRouteV2Injection(
       messages,
       config,
       "context-load",
-      userQuery ?? "",
+      rawUserText ?? userQuery ?? "",
       "",
     );
     if (v2.routed) {
@@ -849,16 +855,31 @@ function injectMemoryBlock(
   ];
 }
 
-/** Extract text content from a user message. */
+/**
+ * Extract text content from a user message for v1's `loadContextMemory`,
+ * skipping very short messages because v1's path embeds a single dense
+ * vector and short queries produce vague results.
+ */
 function extractUserText(message: Message): string | null {
+  const joined = readRawUserText(message);
+  if (!joined) return null;
+  return joined.length > 10 ? joined : null;
+}
+
+/**
+ * Raw user-text reader (no length filter). The v2 activation pipeline can
+ * use even short queries because it spreads activation through the edge
+ * graph and combines user/assistant/now signals, so the ≤10-char guard
+ * v1 needs would unnecessarily starve v2 on short greetings.
+ */
+function readRawUserText(message: Message | undefined): string | null {
+  if (!message) return null;
   const texts = message.content
     .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
     .map((b) => b.text.trim())
     .filter((t) => t.length > 0);
   if (texts.length === 0) return null;
-  const joined = texts.join(" ");
-  // Skip very short messages ("hi", "yes") — they produce vague embeddings
-  return joined.length > 10 ? joined : null;
+  return texts.join(" ");
 }
 
 /**

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -757,6 +757,93 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.everInjected).toEqual([]);
   });
 
+  test("context-load mode renders topNow even when every slug was previously injected", async () => {
+    // Turn 1 (per-turn): seed alice as injected.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Alice's editor",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    // Subsequent context-load (post-compaction or fresh load): alice is
+    // back in the candidate pool. Per-turn would dedup against everInjected
+    // and produce a null block; context-load must re-render the full top-K
+    // because cached attachments don't exist on a fresh load.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 2,
+      userMessage: "Reload context",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-2",
+      mode: "context-load",
+      config: makeConfig(),
+    });
+
+    expect(result.block).not.toBeNull();
+    expect(result.block).toContain("### alice-vscode");
+    // No newly-injected slug — alice was already in everInjected.
+    expect(result.toInject).toEqual([]);
+
+    // everInjected stays a single entry (alice was already there) — context-
+    // load doesn't double-stamp.
+    const persisted = await hydrate(db, "conv-1");
+    expect(persisted!.everInjected).toEqual([
+      { slug: "alice-vscode", turn: 1 },
+    ]);
+  });
+
+  test("context-load mode renders the full top-K on a fresh first turn", async () => {
+    // Turn 1 with no prior state and three candidates. Per-turn and context-
+    // load behave identically when everInjected is empty (toInject == topNow),
+    // but this asserts the contract: a fresh first user message gets the
+    // entire top-K rendered, not just a delta.
+    stageTurn([
+      { slug: "alice-vscode", denseScore: 0.9 },
+      { slug: "bob-coffee", denseScore: 0.8 },
+      { slug: "carol-jazz", denseScore: 0.7 },
+    ]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "hi",
+      assistantMessage: "",
+      nowText: "",
+      messageId: "msg-1",
+      mode: "context-load",
+      config: makeConfig({ top_k: 3 }),
+    });
+
+    expect(result.block).not.toBeNull();
+    expect(result.block).toContain("### alice-vscode");
+    expect(result.block).toContain("### bob-coffee");
+    expect(result.block).toContain("### carol-jazz");
+    expect(result.toInject).toEqual([
+      "alice-vscode",
+      "bob-coffee",
+      "carol-jazz",
+    ]);
+
+    // All three slugs persisted to everInjected so the next per-turn doesn't
+    // re-attach the same content.
+    const persisted = await hydrate(db, "conv-1");
+    expect(persisted!.everInjected.map((e) => e.slug)).toEqual([
+      "alice-vscode",
+      "bob-coffee",
+      "carol-jazz",
+    ]);
+  });
+
   test("`top_k_skills: 0` short-circuits to no skills subsection", async () => {
     // Even when the underlying mock would surface skills, the cap at 0 must
     // drop them via `selectSkillInjections.topK = 0` → empty `topNow`.

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -154,14 +154,21 @@ export async function injectMemoryV2Block(
   const { k, hops, top_k, epsilon } = config.memory.v2;
   const finalActivation = spreadActivation(ownActivation, edgesIdx, k, hops);
 
-  // (6) Pick top-K by activation; subtract everInjected for the injection delta.
+  // (6) Pick top-K by activation. Per-turn turns subtract everInjected for the
+  // injection delta (cache-stable append-only); context-load renders the
+  // entire top-K because it's a fresh load (turn 1 / post-compaction) where
+  // prior cached attachments don't exist or have been thrown away. The user
+  // message gets a complete top-K dump alongside the static
+  // essentials/threads/recent block, then per-turn turns just add deltas.
+  const mode = params.mode ?? "per-turn";
   const priorEverInjected: readonly EverInjectedEntry[] =
     priorState?.everInjected ?? [];
-  const { toInject } = selectInjections({
+  const { topNow, toInject } = selectInjections({
     A: finalActivation,
     priorEverInjected,
     topK: top_k,
   });
+  const slugsToRender = mode === "context-load" ? topNow : toInject;
 
   // (6b) Skill pipeline — a sibling pipeline to the concept-page one above.
   // Skills are stateless: no decay carry-over, no spread, no `everInjected`
@@ -195,14 +202,20 @@ export async function injectMemoryV2Block(
     if (value > epsilon) nextState[slug] = value;
   }
 
-  // Append the freshly injected slugs to everInjected (with their turn) so
-  // future turns can subtract them. We append rather than reset so that
-  // compaction-driven eviction (`evictCompactedTurns`) is the only path that
-  // can re-enable a previously-injected slug. Skills do NOT enter
-  // `everInjected` — they are stateless and re-presented every turn.
+  // Mark every rendered slug as ever-injected so future per-turn deltas don't
+  // re-attach the same content. On context-load this is the full top-K (we
+  // just rendered all of them); on per-turn it's just the newly added slugs.
+  // We append rather than reset so that compaction-driven eviction
+  // (`evictCompactedTurns`) is the only path that can re-enable a previously-
+  // injected slug. Skills do NOT enter `everInjected` — they are stateless
+  // and re-presented every turn.
+  const everInjectedSet = new Set(priorEverInjected.map((entry) => entry.slug));
+  const newlyInjected = slugsToRender.filter(
+    (slug) => !everInjectedSet.has(slug),
+  );
   const nextEverInjected: EverInjectedEntry[] = [
     ...priorEverInjected,
-    ...toInject.map((slug) => ({ slug, turn: currentTurn })),
+    ...newlyInjected.map((slug) => ({ slug, turn: currentTurn })),
   ];
 
   const nextActivationState: ActivationState = {
@@ -215,19 +228,24 @@ export async function injectMemoryV2Block(
 
   await save(database, conversationId, nextActivationState);
 
-  // (7) Cache-stable empty path: nothing new since the last turn AND no
-  // ranked skills to surface.
-  if (toInject.length === 0 && topSkillIds.length === 0) {
+  // (7) Cache-stable empty path: nothing to render AND no ranked skills.
+  if (slugsToRender.length === 0 && topSkillIds.length === 0) {
     return { block: null, toInject: [] };
   }
 
-  // (8) Render. `toInject` is already activation-descending (selectInjections
-  // returns it as a filter of the sorted `topNow`), so it doubles as our
-  // render order. Prior slugs sit unchanged on prior user messages. Skills
-  // are appended after concept-page sections under the same header.
-  const block = await renderInjectionBlock(workspaceDir, toInject, topSkillIds);
+  // (8) Render. Both `topNow` and `toInject` are activation-descending
+  // (selectInjections sorts before slicing), so `slugsToRender` doubles as
+  // the render order. Per-turn: only the new slugs render (prior turns'
+  // attachments stay cached on prior user messages). Context-load: full
+  // top-K renders so the fresh user message gets a complete activation dump.
+  // Skills are appended after concept-page sections under the same header.
+  const block = await renderInjectionBlock(
+    workspaceDir,
+    slugsToRender,
+    topSkillIds,
+  );
 
-  return { block, toInject };
+  return { block, toInject: newlyInjected };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `injectMemoryV2Block` now honors `mode`. Context-load (turn 1 / post-compaction) renders the full top-K from `selectInjections.topNow`; per-turn keeps using the everInjected DELTA. Both modes mark every rendered slug in `everInjected` so subsequent per-turn calls don't re-attach the same content.
- v2 routing in `runContextLoad` now reads the raw user text (no >10-char filter). The filter is still applied for v1's `loadContextMemory` path which needs it; v2's activation pipeline tolerates short queries because it spreads through the edge graph and combines user/assistant/now signals.
- Net effect: the first user message under v2 gets the same `<memory>` activation block subsequent turns get, alongside the static essentials/threads/recent block.

## Original prompt

We should still inject the top 20 activation entries on the first user message (with essentials / threads / recent), not just on the second user message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
