### PR TITLE
revert(tool-confirmation): use rounded-rectangle approve/deny buttons

### DIFF
--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -115,11 +115,11 @@ public struct ToolConfirmationBubble: View {
                     #endif
                 }
 
-                VButton(label: "I\u{2019}ve granted it", style: .outlined, buttonShape: .capsule) {
+                VButton(label: "I\u{2019}ve granted it", style: .outlined) {
                     onAllow()
                 }
 
-                VButton(label: "Skip", style: .outlined, buttonShape: .capsule) {
+                VButton(label: "Skip", style: .outlined) {
                     onDeny()
                 }
             }


### PR DESCRIPTION
## Summary

- The system permission card's **"I've granted it"** (approve) and **"Skip"** (deny) buttons were given `buttonShape: .capsule` in #28644 to match the broader split-button capsule style.
- Reverting just those two to the size-based default — `RoundedRectangle(cornerRadius: VRadius.md)` — per design feedback.
- The primary **"Open System Settings"** CTA in the same row is intentionally left as `.capsule` (different action, different role).

## Test plan

- [ ] Visually confirm the approve/deny buttons in the system permission card render as rounded rectangles (not pills) in `ToolConfirmationBubble`.
- [ ] Visually confirm `Open System Settings` remains capsule-shaped.
- [ ] Confirm hover, focus, and pressed states still render correctly with the rectangular shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
