### PR TITLE
fix(test): add readPromptFile to heartbeat-feed-event mock

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -101,6 +101,7 @@ mock.module("../../prompts/system-prompt.js", () => ({
   buildCliReferenceSection: () => "",
   ensurePromptFiles: () => {},
   stripCommentLines: (s: string) => s,
+  readPromptFile: () => null,
 }));
 
 // Mock processMessage — HeartbeatService now imports it directly.


### PR DESCRIPTION
## Summary
- The heartbeat-feed-event test fully mocks `prompts/system-prompt.js` (Bun's `mock.module` replaces the entire module).
- Recent commit a8e8ef21dd added `memory/v2/static-context.ts` which statically imports `readPromptFile` from `system-prompt`, but the mock did not export it, causing CI to fail with `SyntaxError: Export named 'readPromptFile' not found`.
- Add `readPromptFile: () => null` to the mock so transitive importers resolve.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25124172662/job/73632604927
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
