### PR TITLE
Reduce SSE heartbeat interval from 30s to 7s

### DIFF
--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -58,7 +58,7 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
  *
  * Options (for testing):
  *   hub               -- override the event hub (defaults to process singleton).
- *   heartbeatIntervalMs -- how often to emit keep-alive comments (default 30 s).
+ *   heartbeatIntervalMs -- how often to emit keep-alive comments (default 7 s).
  */
 export function handleSubscribeAssistantEvents(
   args: RouteHandlerArgs,

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -37,8 +37,8 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("events-routes");
 
-/** Keep-alive comment sent to idle clients every 30 s by default. */
-const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+/** Keep-alive comment sent to idle clients every 7 s by default. */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
 
 /**
  * Stream assistant events as Server-Sent Events.


### PR DESCRIPTION
Reduces the keep-alive comment interval on the conversation events SSE route from 30 seconds to 7 seconds. This helps prevent intermediate proxies and load balancers (GCP HTTP(S) LB, vembda httpx client) from treating the connection as idle during quiet periods of a conversation.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/cd48134cd92e43d29140b8f2465dddcb

## Prompt / plan
Reduce the SSE heartbeat interval from 30s to 7s for the main conversation events route.

## Test plan
- Typecheck passes (`bunx tsc --noEmit`)
- Lint passes (`bun run lint`)
- All 26 related tests pass (pre-push hook)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
