### PR TITLE
revert(permission-prompt): use rounded-rectangle Allow/Deny buttons

### DIFF
--- a/clients/shared/Features/Chat/PermissionPromptView.swift
+++ b/clients/shared/Features/Chat/PermissionPromptView.swift
@@ -209,7 +209,7 @@ public struct PermissionPromptView: View {
     private var v3ConfirmationActions: some View {
         HStack(spacing: VSpacing.sm) {
             if onAllowAndSuggestRule != nil {
-                VSplitButton(label: "Allow", style: .primary, size: .compact, action: {
+                VSplitButton(label: "Allow", style: .primary, size: .compact, buttonShape: .roundedRectangle, action: {
                     if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
                         let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
                         onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
@@ -228,12 +228,12 @@ public struct PermissionPromptView: View {
                     #endif
                 }
                 .overlay(
-                    Capsule()
+                    RoundedRectangle(cornerRadius: VRadius.md)
                         .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
                         .allowsHitTesting(false)
                 )
             } else {
-                VButton(label: "Allow", style: .primary, size: .compact, buttonShape: .capsule) {
+                VButton(label: "Allow", style: .primary, size: .compact) {
                     if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
                         let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
                         onAlwaysAllow(confirmation.requestId, option.pattern, scope, "allow")
@@ -242,17 +242,17 @@ public struct PermissionPromptView: View {
                     }
                 }
                 .overlay(
-                    Capsule()
+                    RoundedRectangle(cornerRadius: VRadius.md)
                         .strokeBorder(VColor.primaryBase, lineWidth: keyboardModel?.selectedAction == .allowOnce ? 2 : 0)
                         .allowsHitTesting(false)
                 )
             }
 
-            VButton(label: "Deny", style: .danger, size: .compact, buttonShape: .capsule) {
+            VButton(label: "Deny", style: .danger, size: .compact) {
                 onDeny()
             }
             .overlay(
-                Capsule()
+                RoundedRectangle(cornerRadius: VRadius.md)
                     .strokeBorder(VColor.systemNegativeStrong, lineWidth: keyboardModel?.selectedAction == .dontAllow ? 2 : 0)
                     .allowsHitTesting(false)
             )


### PR DESCRIPTION
## Summary

- Per design feedback, no `ToolConfirmationBubble`-related buttons should be pill-shaped. Follow-up to #28770 which only covered the system-permission card.
- Reverts the Allow split-button and Deny button in `PermissionPromptView` (the v3 confirmation actions used for non-system-permission tools) to `RoundedRectangle(cornerRadius: VRadius.md)`.
- Three corresponding keyboard-focus stroke overlays switch from `Capsule()` to `RoundedRectangle(cornerRadius: VRadius.md)` so the focus border tracks the new shape.

## Changes

- `VSplitButton "Allow"` — pass `buttonShape: .roundedRectangle` (default is `.capsule`).
- `VButton "Allow"` (no-suggest branch) and `VButton "Deny"` — drop `buttonShape: .capsule`, falling through to size-based default which is `RoundedRectangle(VRadius.md)` for `.compact`.
- Three `Capsule()` focus overlays → `RoundedRectangle(cornerRadius: VRadius.md)`.

## Test plan

- [ ] Tool confirmation prompt (non-system permission, e.g. running an `echo` command): Allow + Deny buttons render as rounded rectangles, not pills.
- [ ] Variant where `onAllowAndSuggestRule != nil`: VSplitButton renders rounded with capsule-style chevron split, plus the "Allow & Create Rule" dropdown still works.
- [ ] Keyboard navigation (Tab between buttons): focus stroke is a rounded rectangle that hugs the button shape.
- [ ] Pressed/hover/disabled states still render correctly with the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
