### PR TITLE
fix(credential-health): distinguish backend-unreachable from missing token

### DIFF
--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // ── Mutable state for mocks ──────────────────────────────────────────
 
 const secureKeyValues = new Map<string, string>();
+const unreachableKeys = new Set<string>();
 
 let mockProviders: Array<{
   provider: string;
@@ -36,6 +37,10 @@ let mockFetchThrows = false;
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: secureKeyValues.get(account),
+    unreachable: unreachableKeys.has(account),
+  }),
   setSecureKeyAsync: async () => {},
   deleteSecureKeyAsync: async () => "deleted",
   listSecureKeysAsync: async () => [],
@@ -140,11 +145,16 @@ function setToken(connectionId: string, token = "mock-token") {
   secureKeyValues.set(`oauth_connection/${connectionId}/access_token`, token);
 }
 
+function markUnreachable(key: string) {
+  unreachableKeys.add(key);
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("credential-health-service", () => {
   beforeEach(() => {
     secureKeyValues.clear();
+    unreachableKeys.clear();
     mockProviders = [];
     mockConnections = new Map();
     mockFetchResponse = { ok: true, status: 200 };
@@ -189,6 +199,30 @@ describe("credential-health-service", () => {
     expect(report.results[0]!.status).toBe("missing_token");
     expect(report.results[0]!.canAutoRecover).toBe(false);
     expect(report.unhealthy).toHaveLength(1);
+  });
+
+  test("returns unreachable when credential backend is unreachable", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1");
+    // Don't set token, but mark the path as unreachable
+    markUnreachable("oauth_connection/conn-1/access_token");
+
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0]!.status).toBe("unreachable");
+    expect(report.results[0]!.canAutoRecover).toBe(true);
+    expect(report.unhealthy).toHaveLength(1);
+  });
+
+  test("returns missing_token (not unreachable) when backend is reachable but token absent", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1");
+    // Don't set token, don't mark unreachable — genuinely missing
+
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0]!.status).toBe("missing_token");
+    expect(report.results[0]!.canAutoRecover).toBe(false);
   });
 
   test("returns expired when token is past expiresAt without refresh token", async () => {
@@ -388,6 +422,40 @@ describe("credential-health-service", () => {
 
       const report = await checkAllCredentials();
       expect(report.results[0]!.status).toBe("healthy");
+    });
+
+    test("slack_channel returns unreachable when credential backend is down", async () => {
+      addProvider("slack_channel", {
+        pingUrl: "https://slack.com/api/auth.test",
+      });
+      addConnection("slack_channel", "conn-slack", {
+        expiresAt: null,
+        hasRefreshToken: false,
+        grantedScopes: [],
+      });
+      // Don't set token, mark the manual-token path as unreachable
+      markUnreachable("credential/slack_channel/bot_token");
+
+      const report = await checkAllCredentials();
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]!.status).toBe("unreachable");
+      expect(report.results[0]!.canAutoRecover).toBe(true);
+    });
+
+    test("telegram returns unreachable when credential backend is down", async () => {
+      addProvider("telegram");
+      addConnection("telegram", "conn-tg", {
+        expiresAt: null,
+        hasRefreshToken: false,
+        grantedScopes: [],
+      });
+      // Don't set token, mark the manual-token path as unreachable
+      markUnreachable("credential/telegram/bot_token");
+
+      const report = await checkAllCredentials();
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]!.status).toBe("unreachable");
+      expect(report.results[0]!.canAutoRecover).toBe(true);
     });
   });
 

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -22,7 +22,7 @@ import {
   listActiveConnectionsByProvider,
   listProviders,
 } from "../oauth/oauth-store.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getSecureKeyResultAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("credential-health");
@@ -40,6 +40,7 @@ export type CredentialHealthStatus =
   | "expiring"
   | "expired"
   | "missing_token"
+  | "unreachable"
   | "missing_scopes"
   | "revoked"
   | "ping_failed";
@@ -173,8 +174,16 @@ async function checkConnection(
   const tokenPath =
     manualTokenAccessCredentialKey(provider) ??
     oauthConnectionAccessTokenPath(connectionId);
-  const token = await getSecureKeyAsync(tokenPath);
-  if (!token) {
+  const tokenResult = await getSecureKeyResultAsync(tokenPath);
+  if (!tokenResult.value) {
+    if (tokenResult.unreachable) {
+      return {
+        ...base,
+        status: "unreachable",
+        details: `Credential backend is temporarily unreachable for ${provider}. Token status unknown.`,
+        canAutoRecover: true,
+      };
+    }
     return {
       ...base,
       status: "missing_token",
@@ -182,6 +191,7 @@ async function checkConnection(
       canAutoRecover: false,
     };
   }
+  const token = tokenResult.value;
 
   // 2. Check token expiry
   if (isTokenExpired(expiresAt)) {


### PR DESCRIPTION
## Summary
- Add `unreachable` status to `CredentialHealthStatus` to distinguish transient credential backend unavailability from genuinely missing tokens
- Replace `getSecureKeyAsync()` with `getSecureKeyResultAsync()` in credential health checks to preserve the `unreachable` flag
- Add tests for standard and manual-token unreachable scenarios

Closes JARVIS-581

Part of plan: cred-health-alert.md (PR 1a of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
