### PR TITLE
fix(oauth): prevent manual-token reconciliation from deleting rows when backend is unreachable

### DIFF
--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -61,6 +61,10 @@ mock.module("../security/secure-keys.js", () => {
   };
   return {
     getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
+    getSecureKeyResultAsync: async (account: string) => ({
+      value: storedKeys.get(account),
+      unreachable: false,
+    }),
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),

--- a/assistant/src/__tests__/manual-token-reconciliation.test.ts
+++ b/assistant/src/__tests__/manual-token-reconciliation.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SecureKeyResult } from "../security/secure-keys.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let secureKeyResults: Record<string, SecureKeyResult> = {};
+let connectionStore: Record<
+  string,
+  { id: string; provider: string; accountInfo?: string | null }
+> = {};
+let deletedConnectionIds: string[] = [];
+let createdConnections: Array<{ provider: string; accountInfo?: string }> = [];
+const warnings: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be registered before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    warn: (msg: string) => warnings.push(msg),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyResultAsync: async (account: string): Promise<SecureKeyResult> =>
+    secureKeyResults[account] ?? { value: undefined, unreachable: false },
+  // Keep getSecureKeyAsync available for any transitive imports
+  getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
+    const result = secureKeyResults[account] ?? {
+      value: undefined,
+      unreachable: false,
+    };
+    return result.value;
+  },
+}));
+
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: (provider: string) =>
+    connectionStore[provider] ?? undefined,
+  deleteConnection: (id: string) => {
+    deletedConnectionIds.push(id);
+    // Remove from store
+    for (const [key, val] of Object.entries(connectionStore)) {
+      if (val.id === id) {
+        delete connectionStore[key];
+        break;
+      }
+    }
+  },
+  createConnection: (params: {
+    oauthAppId: string;
+    provider: string;
+    accountInfo?: string;
+    grantedScopes: string[];
+    hasRefreshToken: boolean;
+  }) => {
+    createdConnections.push({
+      provider: params.provider,
+      accountInfo: params.accountInfo,
+    });
+    connectionStore[params.provider] = {
+      id: `conn-${params.provider}`,
+      provider: params.provider,
+      accountInfo: params.accountInfo ?? null,
+    };
+    return { id: `conn-${params.provider}` };
+  },
+  updateConnection: () => {},
+  upsertApp: async (_provider: string, _clientId: string) => ({
+    id: "app-1",
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import {
+  backfillManualTokenConnections,
+  syncManualTokenConnection,
+} from "../oauth/manual-token-connection.js";
+import { credentialKey } from "../security/credential-key.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setCredentialResult(
+  service: string,
+  field: string,
+  result: SecureKeyResult,
+): void {
+  secureKeyResults[credentialKey(service, field)] = result;
+}
+
+function seedConnection(
+  provider: string,
+  opts?: { accountInfo?: string },
+): void {
+  connectionStore[provider] = {
+    id: `conn-${provider}`,
+    provider,
+    accountInfo: opts?.accountInfo ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("syncManualTokenConnection", () => {
+  beforeEach(() => {
+    secureKeyResults = {};
+    connectionStore = {};
+    deletedConnectionIds = [];
+    createdConnections = [];
+    warnings.length = 0;
+  });
+
+  // ---- Slack: reachable backend, missing tokens -> removes row ----
+
+  test("removes slack_channel connection when bot token is missing and backend is reachable", async () => {
+    seedConnection("slack_channel");
+    setCredentialResult("slack_channel", "bot_token", {
+      value: undefined,
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: "xapp-valid",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toContain("conn-slack_channel");
+    expect(connectionStore["slack_channel"]).toBeUndefined();
+  });
+
+  test("removes slack_channel connection when app token is missing and backend is reachable", async () => {
+    seedConnection("slack_channel");
+    setCredentialResult("slack_channel", "bot_token", {
+      value: "xoxb-valid",
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toContain("conn-slack_channel");
+    expect(connectionStore["slack_channel"]).toBeUndefined();
+  });
+
+  // ---- Telegram: reachable backend, missing tokens -> removes row ----
+
+  test("removes telegram connection when bot token is missing and backend is reachable", async () => {
+    seedConnection("telegram");
+    setCredentialResult("telegram", "bot_token", {
+      value: undefined,
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: "secret-valid",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(deletedConnectionIds).toContain("conn-telegram");
+    expect(connectionStore["telegram"]).toBeUndefined();
+  });
+
+  test("removes telegram connection when webhook secret is missing and backend is reachable", async () => {
+    seedConnection("telegram");
+    setCredentialResult("telegram", "bot_token", {
+      value: "bot-token-valid",
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: undefined,
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(deletedConnectionIds).toContain("conn-telegram");
+    expect(connectionStore["telegram"]).toBeUndefined();
+  });
+
+  // ---- Unreachable backend -> leaves rows untouched ----
+
+  test("leaves slack_channel connection untouched when backend is unreachable", async () => {
+    seedConnection("slack_channel");
+    setCredentialResult("slack_channel", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(createdConnections).toEqual([]);
+    expect(connectionStore["slack_channel"]).toBeDefined();
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("slack_channel");
+    expect(warnings[0]).toContain("unreachable");
+  });
+
+  test("leaves telegram connection untouched when backend is unreachable", async () => {
+    seedConnection("telegram");
+    setCredentialResult("telegram", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(createdConnections).toEqual([]);
+    expect(connectionStore["telegram"]).toBeDefined();
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("telegram");
+    expect(warnings[0]).toContain("unreachable");
+  });
+
+  test("leaves slack_channel connection untouched when only one credential read is unreachable", async () => {
+    seedConnection("slack_channel");
+    // bot_token is readable but app_token backend is unreachable
+    setCredentialResult("slack_channel", "bot_token", {
+      value: "xoxb-valid",
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(connectionStore["slack_channel"]).toBeDefined();
+  });
+
+  // ---- Reachable backend, all tokens present -> ensures connection ----
+
+  test("creates slack_channel connection when all tokens are present", async () => {
+    setCredentialResult("slack_channel", "bot_token", {
+      value: "xoxb-valid",
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: "xapp-valid",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(createdConnections).toEqual([
+      { provider: "slack_channel", accountInfo: undefined },
+    ]);
+  });
+
+  test("creates telegram connection when all tokens are present", async () => {
+    setCredentialResult("telegram", "bot_token", {
+      value: "bot-token",
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: "webhook-secret",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(createdConnections).toEqual([
+      { provider: "telegram", accountInfo: undefined },
+    ]);
+  });
+});
+
+describe("backfillManualTokenConnections", () => {
+  beforeEach(() => {
+    secureKeyResults = {};
+    connectionStore = {};
+    deletedConnectionIds = [];
+    createdConnections = [];
+    warnings.length = 0;
+  });
+
+  test("propagates non-destructive behavior — unreachable backend leaves all rows untouched", async () => {
+    seedConnection("telegram");
+    seedConnection("slack_channel");
+
+    // All credential reads return unreachable
+    setCredentialResult("telegram", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("slack_channel", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await backfillManualTokenConnections();
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(connectionStore["telegram"]).toBeDefined();
+    expect(connectionStore["slack_channel"]).toBeDefined();
+    expect(warnings.length).toBe(2);
+  });
+});

--- a/assistant/src/__tests__/manual-token-reconciliation.test.ts
+++ b/assistant/src/__tests__/manual-token-reconciliation.test.ts
@@ -82,10 +82,8 @@ mock.module("../oauth/oauth-store.js", () => ({
 // Import module under test (after mocks are registered)
 // ---------------------------------------------------------------------------
 
-import {
-  backfillManualTokenConnections,
-  syncManualTokenConnection,
-} from "../oauth/manual-token-connection.js";
+const { backfillManualTokenConnections, syncManualTokenConnection } =
+  await import("../oauth/manual-token-connection.js");
 import { credentialKey } from "../security/credential-key.js";
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -61,6 +61,10 @@ mock.module("../security/secure-keys.js", () => {
   };
   return {
     getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
+    getSecureKeyResultAsync: async (account: string) => ({
+      value: storedKeys.get(account),
+      unreachable: false,
+    }),
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -9,7 +9,8 @@
  */
 
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getSecureKeyResultAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
 import {
   createConnection,
   deleteConnection,
@@ -17,6 +18,8 @@ import {
   updateConnection,
   upsertApp,
 } from "./oauth-store.js";
+
+const log = getLogger("manual-token-connection");
 
 /** Sentinel client_id used for non-OAuth providers that don't have a real app. */
 const MANUAL_TOKEN_CLIENT_ID = "manual-config";
@@ -101,13 +104,19 @@ export async function syncManualTokenConnection(
 ): Promise<void> {
   switch (provider) {
     case "telegram": {
-      const hasBotToken = !!(await getSecureKeyAsync(
+      const botTokenResult = await getSecureKeyResultAsync(
         credentialKey("telegram", "bot_token"),
-      ));
-      const hasWebhookSecret = !!(await getSecureKeyAsync(
+      );
+      const webhookSecretResult = await getSecureKeyResultAsync(
         credentialKey("telegram", "webhook_secret"),
-      ));
-      if (hasBotToken && hasWebhookSecret) {
+      );
+      if (botTokenResult.unreachable || webhookSecretResult.unreachable) {
+        log.warn(
+          "Skipping telegram manual-token reconciliation — credential backend unreachable",
+        );
+        return;
+      }
+      if (botTokenResult.value && webhookSecretResult.value) {
         await ensureManualTokenConnection(provider, accountInfo);
       } else {
         removeManualTokenConnection(provider);
@@ -116,13 +125,19 @@ export async function syncManualTokenConnection(
     }
 
     case "slack_channel": {
-      const hasBotToken = !!(await getSecureKeyAsync(
+      const botTokenResult = await getSecureKeyResultAsync(
         credentialKey("slack_channel", "bot_token"),
-      ));
-      const hasAppToken = !!(await getSecureKeyAsync(
+      );
+      const appTokenResult = await getSecureKeyResultAsync(
         credentialKey("slack_channel", "app_token"),
-      ));
-      if (hasBotToken && hasAppToken) {
+      );
+      if (botTokenResult.unreachable || appTokenResult.unreachable) {
+        log.warn(
+          "Skipping slack_channel manual-token reconciliation — credential backend unreachable",
+        );
+        return;
+      }
+      if (botTokenResult.value && appTokenResult.value) {
         await ensureManualTokenConnection(provider, accountInfo);
       } else {
         removeManualTokenConnection(provider);


### PR DESCRIPTION
## Summary
- Replace `getSecureKeyAsync()` with `getSecureKeyResultAsync()` in manual-token reconciliation
- Skip reconciliation entirely when credential backend is unreachable — prevents startup from deleting valid connection rows
- Only remove/deactivate manual-token connections when backend is reachable and secrets are confirmed absent
- Add tests for reachable/unreachable backend scenarios

Part of plan: cred-health-alert.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
