### PR TITLE
docs(cli): document vellum terminal command (GTM-96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ It learns how you work, remembers what matters, and acts before you ask. Yours t
 **1. [Download the latest release](https://vellum.ai/download)**
 
 **2. Open the app and pick your mode**
-  - **Local** — everything runs on your machine
   - **Managed** — sign in via Vellum Cloud, no local runtime required
+  - **Local** — everything runs on your machine
 
 **3. Hatch your assistant**
   - Give it a name, a personality, and the keys to your work

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ vellum wake        # start services
 vellum sleep       # stop services, keep data
 vellum client      # interact through the terminal
 vellum ps          # view running assistants
+vellum terminal    # open a shell into a managed assistant container
 vellum upgrade     # upgrade to latest version
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -97,6 +97,55 @@ VELLUM_CUSTOM_HOST=user@10.0.0.1 vellum hatch --remote custom
 
 When hatching on GCP in interactive mode (without `-d`), the CLI displays an animated progress TUI that polls the instance's startup script output in real time. Press `Ctrl+C` to detach -- the instance will continue running in the background.
 
+### `terminal`
+
+Open an interactive shell into a managed assistant container. Useful for debugging, inspecting state, or working alongside the assistant in a shared `tmux` session.
+
+```bash
+vellum terminal [name] [options]
+vellum terminal attach <session> [name] [options]
+vellum terminal list [name] [options]
+```
+
+Only available for managed assistants (those running in a Vellum Cloud container). Local assistants don't have a container to terminal into.
+
+#### Subcommands
+
+| Subcommand         | Description                                                              |
+| ------------------ | ------------------------------------------------------------------------ |
+| _(none)_           | Open an interactive shell session inside the container.                  |
+| `attach <session>` | Attach to an existing `tmux` session by name inside the container.       |
+| `list`             | List the `tmux` sessions currently running inside the container.         |
+
+#### Options
+
+| Option               | Description                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| `[name]`             | Positional. Name of the assistant to target. Defaults to the active assistant.               |
+| `--assistant <name>` | Explicit form of the assistant name. Equivalent to the positional argument.                  |
+
+The active assistant is the one set via `vellum use <name>` (see also `vellum ps`).
+
+#### Examples
+
+```bash
+# Open a shell in the active managed assistant
+vellum terminal
+
+# Target a specific assistant by name
+vellum terminal my-assistant
+vellum terminal --assistant my-assistant
+
+# List running tmux sessions inside the container
+vellum terminal list
+
+# Attach to a named tmux session
+vellum terminal attach my-session
+vellum terminal attach my-session my-assistant
+```
+
+This pairs well with the [`terminal-sessions` skill](https://github.com/vellum-ai/vellum-assistant/tree/main/skills/terminal-sessions), which lets the assistant create and manage its own `tmux` sessions. You can `vellum terminal attach` into one of those sessions to watch the assistant work in real time -- for example, pairing on a long-running Claude Code run.
+
 ### `retire`
 
 Delete a provisioned assistant instance. The cloud provider and connection details are automatically resolved from the saved assistant config (written during `hatch`).

--- a/cli/README.md
+++ b/cli/README.md
@@ -121,10 +121,10 @@ Only available for managed assistants (those running in a Vellum Cloud container
 
 | Option               | Description                                                                                  |
 | -------------------- | -------------------------------------------------------------------------------------------- |
-| `[name]`             | Positional. Name of the assistant to target. Defaults to the active assistant.               |
+| `[name]`             | Positional. Name of the assistant to target. If omitted, defaults to the most recently hatched managed assistant. |
 | `--assistant <name>` | Explicit form of the assistant name. Equivalent to the positional argument.                  |
 
-The active assistant is the one set via `vellum use <name>` (see also `vellum ps`).
+> **Note:** Unlike most other `vellum` commands, `vellum terminal` does not honor the active assistant set by `vellum use` -- it falls back to the most recently hatched managed assistant. If you have multiple managed assistants, pass the name explicitly (positionally or via `--assistant`) to avoid attaching to the wrong one.
 
 #### Examples
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -121,10 +121,10 @@ Only available for managed assistants (those running in a Vellum Cloud container
 
 | Option               | Description                                                                                  |
 | -------------------- | -------------------------------------------------------------------------------------------- |
-| `[name]`             | Positional. Name of the assistant to target. If omitted, defaults to the most recently hatched managed assistant. |
+| `[name]`             | Positional. Name of the assistant to target. Defaults to the active assistant set via `vellum use`. |
 | `--assistant <name>` | Explicit form of the assistant name. Equivalent to the positional argument.                  |
 
-> **Note:** If you have multiple managed assistants, pass the name explicitly (positionally or via `--assistant`) to make sure you land in the right container.
+If no assistant is named and no active assistant is set, the CLI uses the only managed assistant in the lockfile -- or errors out if there's more than one. Use `vellum ps` to see your assistants and `vellum use <name>` to set the active one.
 
 #### Examples
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -124,7 +124,7 @@ Only available for managed assistants (those running in a Vellum Cloud container
 | `[name]`             | Positional. Name of the assistant to target. If omitted, defaults to the most recently hatched managed assistant. |
 | `--assistant <name>` | Explicit form of the assistant name. Equivalent to the positional argument.                  |
 
-> **Note:** Unlike most other `vellum` commands, `vellum terminal` does not honor the active assistant set by `vellum use` -- it falls back to the most recently hatched managed assistant. If you have multiple managed assistants, pass the name explicitly (positionally or via `--assistant`) to avoid attaching to the wrong one.
+> **Note:** If you have multiple managed assistants, pass the name explicitly (positionally or via `--assistant`) to make sure you land in the right container.
 
 #### Examples
 


### PR DESCRIPTION
Documents the new `vellum terminal` CLI command in the assistant repo.

## Changes

**`cli/README.md`** — new `### \`terminal\`` section covering:
- Base command (interactive shell into managed container)
- `attach <session>` subcommand
- `list` subcommand
- `--assistant <name>` flag and positional alternative
- Note that this only works for managed assistants, not local
- Examples for every subcommand
- Cross-link to the `terminal-sessions` skill (the natural pairing)

**`README.md`** (top-level) — adds `vellum terminal` to the Common commands block in the CLI section.

## Linear

https://linear.app/vellum/issue/GTM-96

Companion PR for the marketing docs page is in vellum-assistant-platform.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
