### PR TITLE
fix(memory): drop "## What I Remember Right Now" header from injection blocks

### DIFF
--- a/assistant/src/memory/graph/injection.test.ts
+++ b/assistant/src/memory/graph/injection.test.ts
@@ -192,9 +192,9 @@ describe("assembleContextBlock", () => {
     expect(assembleContextBlock([])).toBe("");
   });
 
-  test("includes the main heading", () => {
+  test("omits the legacy `What I Remember Right Now` heading", () => {
     const result = assembleContextBlock([makeScored()]);
-    expect(result).toContain("## What I Remember Right Now");
+    expect(result).not.toContain("## What I Remember Right Now");
   });
 
   test("puts prospective nodes under Active Threads", () => {

--- a/assistant/src/memory/graph/injection.ts
+++ b/assistant/src/memory/graph/injection.ts
@@ -381,7 +381,7 @@ export function assembleContextBlock(
   }
 
   if (parts.length === 0) return "";
-  return `## What I Remember Right Now\n\n${parts.join("\n\n")}`;
+  return parts.join("\n\n");
 }
 
 function buildSection(nodes: ScoredNode[], maxItems: number): string[] {

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -365,7 +365,7 @@ describe("injectMemoryV2Block", () => {
     expect(result.toInject).toEqual(["alice-vscode"]);
     expect(result.block).not.toBeNull();
     expect(result.block).toContain("<memory>");
-    expect(result.block).toContain("## What I Remember Right Now");
+    expect(result.block).not.toContain("## What I Remember Right Now");
     expect(result.block).toContain("### alice-vscode");
     expect(result.block).toContain("VS Code");
     expect(result.block).toContain("</memory>");
@@ -594,7 +594,7 @@ describe("injectMemoryV2Block", () => {
   // Skill subsection rendering
   // ---------------------------------------------------------------------------
 
-  test("renders a skill-only block under the same `What I Remember Right Now` header", async () => {
+  test("renders a skill-only block in the same `<memory>` wrapper as concept-page-only blocks", async () => {
     // No concept-page candidates this turn — the candidate query and the three
     // simBatch queries all return empty. The skill pipeline is mocked to
     // surface a single skill.
@@ -625,7 +625,7 @@ describe("injectMemoryV2Block", () => {
     expect(result.block).not.toBeNull();
     // Same outer wrapping as concept-page-only blocks.
     expect(result.block).toContain("<memory>");
-    expect(result.block).toContain("## What I Remember Right Now");
+    expect(result.block).not.toContain("## What I Remember Right Now");
     expect(result.block).toContain("</memory>");
     // No concept-page sections; skills subsection present with the right
     // bullet shape and the unconditional `→ use skill_load to activate` suffix.

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -238,7 +238,7 @@ export async function injectMemoryV2Block(
   // the render order. Per-turn: only the new slugs render (prior turns'
   // attachments stay cached on prior user messages). Context-load: full
   // top-K renders so the fresh user message gets a complete activation dump.
-  // Skills are appended after concept-page sections under the same header.
+  // Skills are appended after concept-page sections.
   const block = await renderInjectionBlock(
     workspaceDir,
     slugsToRender,
@@ -269,7 +269,6 @@ export async function injectMemoryV2Block(
  * trailing skills subsection:
  *
  *   <memory>
- *   ## What I Remember Right Now
  *   ### <slug-1>
  *   <body-1>
  *
@@ -281,13 +280,9 @@ export async function injectMemoryV2Block(
  *   - <skill-2 content>
  *   </memory>
  *
- * The same `## What I Remember Right Now` header wraps the block whether
- * the skills section is alone, the concept-page sections are alone, or
- * both are present — keeping the renderer one shape.
- *
  * Returns `null` when both lists collapse to empty after cache misses so
  * the caller can fall through to its empty-block path instead of attaching
- * a header with no contents.
+ * an empty `<memory>` wrapper.
  */
 async function renderInjectionBlock(
   workspaceDir: string,
@@ -320,6 +315,5 @@ async function renderInjectionBlock(
 
   if (sections.length === 0) return null;
 
-  const inner = `## What I Remember Right Now\n\n${sections.join("\n\n")}`;
-  return `<memory>\n${inner}\n</memory>`;
+  return `<memory>\n${sections.join("\n\n")}\n</memory>`;
 }


### PR DESCRIPTION
## Summary
- Remove the `## What I Remember Right Now` markdown header from both memory injection paths (`graph/injection.ts:assembleContextBlock` and `v2/injection.ts:renderInjectionBlock`).
- The `<memory>` wrapper and per-section `###` subheadings already provide the structure; the extra `##` line was preamble that didn't carry information.
- Update tests and the v2 docstring/comment to match the new shape.

## Original prompt
let's get rid of the "## What I Remember Right Now" header in the injection blocks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
