### PR TITLE
refactor(oauth): centralize access-token key resolution across OAuth and manual-token providers

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -195,6 +195,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/integrations/slack/share.ts", // Slack share routes credential lookup
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
+      "oauth/credential-token-resolver.ts", // centralized access-token key resolution for OAuth and manual-token providers
       "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "runtime/routes/migration-routes.ts", // migration import credential restore

--- a/assistant/src/__tests__/credential-token-resolver.test.ts
+++ b/assistant/src/__tests__/credential-token-resolver.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mutable state for mocks ──────────────────────────────────────────
+
+const secureKeyValues = new Map<string, string>();
+const unreachableKeys = new Set<string>();
+
+// ── Module mocks ─────────────────────────────────────────────────────
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: secureKeyValues.get(account),
+    unreachable: unreachableKeys.has(account),
+  }),
+  setSecureKeyAsync: async () => {},
+  deleteSecureKeyAsync: async () => "deleted",
+  listSecureKeysAsync: async () => [],
+  getProviderKeyAsync: async () => undefined,
+  getMaskedProviderKey: () => undefined,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  }),
+}));
+
+// ── Import under test ────────────────────────────────────────────────
+
+const { resolveAccessTokenKey, getConnectionAccessTokenResult } =
+  await import("../oauth/credential-token-resolver.js");
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("credential-token-resolver", () => {
+  beforeEach(() => {
+    secureKeyValues.clear();
+    unreachableKeys.clear();
+  });
+
+  describe("resolveAccessTokenKey", () => {
+    test("slack_channel resolves to credential/slack_channel/bot_token", () => {
+      expect(resolveAccessTokenKey("slack_channel", "conn-123")).toBe(
+        "credential/slack_channel/bot_token",
+      );
+    });
+
+    test("telegram resolves to credential/telegram/bot_token", () => {
+      expect(resolveAccessTokenKey("telegram", "conn-456")).toBe(
+        "credential/telegram/bot_token",
+      );
+    });
+
+    test("standard OAuth provider resolves to oauth_connection/<id>/access_token", () => {
+      expect(resolveAccessTokenKey("google", "conn-789")).toBe(
+        "oauth_connection/conn-789/access_token",
+      );
+    });
+
+    test("unknown provider resolves to oauth_connection/<id>/access_token", () => {
+      expect(resolveAccessTokenKey("github", "conn-abc")).toBe(
+        "oauth_connection/conn-abc/access_token",
+      );
+    });
+  });
+
+  describe("getConnectionAccessTokenResult", () => {
+    test("returns token value and key for slack_channel using bot_token path", async () => {
+      secureKeyValues.set("credential/slack_channel/bot_token", "xoxb-valid");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "slack_channel",
+        connectionId: "conn-slack",
+      });
+
+      expect(result.value).toBe("xoxb-valid");
+      expect(result.unreachable).toBe(false);
+      expect(result.key).toBe("credential/slack_channel/bot_token");
+    });
+
+    test("returns undefined for slack_channel when bot_token is absent even if oauth path is set", async () => {
+      // Simulate the bug scenario: OAuth access-token path is populated but
+      // the manual-token path is not. The resolver must NOT fall through to
+      // the OAuth path for manual-token providers.
+      secureKeyValues.set(
+        "oauth_connection/conn-slack/access_token",
+        "should-be-ignored",
+      );
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "slack_channel",
+        connectionId: "conn-slack",
+      });
+
+      expect(result.value).toBeUndefined();
+      expect(result.key).toBe("credential/slack_channel/bot_token");
+    });
+
+    test("returns token for standard OAuth provider via connection path", async () => {
+      secureKeyValues.set(
+        "oauth_connection/conn-google/access_token",
+        "ya29.token",
+      );
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "google",
+        connectionId: "conn-google",
+      });
+
+      expect(result.value).toBe("ya29.token");
+      expect(result.unreachable).toBe(false);
+      expect(result.key).toBe("oauth_connection/conn-google/access_token");
+    });
+
+    test("returns unreachable when credential backend is down", async () => {
+      unreachableKeys.add("credential/telegram/bot_token");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "telegram",
+        connectionId: "conn-tg",
+      });
+
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(true);
+      expect(result.key).toBe("credential/telegram/bot_token");
+    });
+
+    test("returns undefined (not unreachable) when token is genuinely missing", async () => {
+      const result = await getConnectionAccessTokenResult({
+        provider: "google",
+        connectionId: "conn-missing",
+      });
+
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(false);
+      expect(result.key).toBe("oauth_connection/conn-missing/access_token");
+    });
+  });
+
+  describe("regression: oauth ping slack_channel uses bot_token", () => {
+    // The root cause of false credential health alerts was that some code paths
+    // looked up tokens at oauth_connection/<id>/access_token for ALL providers,
+    // while manual-token providers (slack_channel, telegram) actually store
+    // their tokens at credential/<provider>/bot_token. The centralized resolver
+    // ensures ALL consumers agree on the path.
+
+    test("slack_channel token lookup goes to credential/slack_channel/bot_token, not oauth path", async () => {
+      secureKeyValues.set("credential/slack_channel/bot_token", "xoxb-real");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "slack_channel",
+        connectionId: "any-connection-id",
+      });
+
+      // Must find the token at the manual-token path
+      expect(result.value).toBe("xoxb-real");
+      // Must report the correct key
+      expect(result.key).toBe("credential/slack_channel/bot_token");
+      // Connection ID must be irrelevant for manual-token providers
+      expect(result.key).not.toContain("any-connection-id");
+    });
+
+    test("telegram token lookup goes to credential/telegram/bot_token, not oauth path", async () => {
+      secureKeyValues.set("credential/telegram/bot_token", "tg-token");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "telegram",
+        connectionId: "any-connection-id",
+      });
+
+      expect(result.value).toBe("tg-token");
+      expect(result.key).toBe("credential/telegram/bot_token");
+      expect(result.key).not.toContain("any-connection-id");
+    });
+  });
+});

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -19,6 +19,25 @@ mock.module("../security/secure-keys.js", () => ({
   setSecureKeyAsync: mockSetSecureKeyAsync,
   getSecureKeyAsync: (account: string) =>
     Promise.resolve(secureKeyValues.get(account)),
+  getSecureKeyResultAsync: (account: string) =>
+    Promise.resolve({
+      value: secureKeyValues.get(account),
+      unreachable: false,
+    }),
+}));
+
+mock.module("../oauth/credential-token-resolver.js", () => ({
+  getConnectionAccessTokenResult: async (opts: {
+    provider: string;
+    connectionId: string;
+  }) => {
+    const key = `oauth_connection/${opts.connectionId}/access_token`;
+    return {
+      value: secureKeyValues.get(key),
+      unreachable: false,
+      key,
+    };
+  },
 }));
 
 import { eq } from "drizzle-orm";

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -11,18 +11,14 @@
  * no token refresh or recovery is attempted.
  */
 
-import {
-  isTokenExpired,
-  oauthConnectionAccessTokenPath,
-} from "@vellumai/credential-storage";
+import { isTokenExpired } from "@vellumai/credential-storage";
 
-import { manualTokenAccessCredentialKey } from "../oauth/manual-token-connection.js";
+import { getConnectionAccessTokenResult } from "../oauth/credential-token-resolver.js";
 import {
   getProvider,
   listActiveConnectionsByProvider,
   listProviders,
 } from "../oauth/oauth-store.js";
-import { getSecureKeyResultAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("credential-health");
@@ -166,15 +162,14 @@ async function checkConnection(
     missingScopes: [] as string[],
   };
 
-  // 1. Check token presence. Manual-token providers (e.g. slack_channel,
-  // telegram) store their primary token under credential/<provider>/<field>
-  // rather than oauth_connection/<id>/access_token, so resolve the correct
-  // path before looking up the token — otherwise the lookup always returns
-  // null and marks these providers as "missing_token".
-  const tokenPath =
-    manualTokenAccessCredentialKey(provider) ??
-    oauthConnectionAccessTokenPath(connectionId);
-  const tokenResult = await getSecureKeyResultAsync(tokenPath);
+  // 1. Check token presence via the centralized resolver. Manual-token
+  // providers (e.g. slack_channel, telegram) store their primary token at
+  // credential/<provider>/<field> rather than oauth_connection/<id>/access_token;
+  // the resolver handles the mapping automatically.
+  const tokenResult = await getConnectionAccessTokenResult({
+    provider,
+    connectionId,
+  });
   if (!tokenResult.value) {
     if (tokenResult.unreachable) {
       return {

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -39,6 +39,14 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => mockAccessToken,
 }));
 
+mock.module("./credential-token-resolver.js", () => ({
+  getConnectionAccessTokenResult: async () => ({
+    value: mockAccessToken,
+    unreachable: false,
+    key: "mock-key",
+  }),
+}));
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => mockConfig,
 }));

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -5,10 +5,10 @@ import {
   ServicesSchema,
 } from "../config/schemas/services.js";
 import { VellumPlatformClient } from "../platform/client.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
+import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
 import { getActiveConnection, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
 
@@ -96,10 +96,11 @@ export async function resolveOAuthConnection(
     );
   }
 
-  const accessToken = await getSecureKeyAsync(
-    `oauth_connection/${conn.id}/access_token`,
-  );
-  if (!accessToken) {
+  const tokenResult = await getConnectionAccessTokenResult({
+    provider,
+    connectionId: conn.id,
+  });
+  if (!tokenResult.value) {
     throw new Error(
       `OAuth connection for "${provider}" exists but has no access token. Re-authorize with \`assistant oauth connect ${provider}\`.`,
     );

--- a/assistant/src/oauth/credential-token-resolver.ts
+++ b/assistant/src/oauth/credential-token-resolver.ts
@@ -1,0 +1,97 @@
+/**
+ * Centralized access-token key resolution for OAuth and manual-token providers.
+ *
+ * All code that needs to read or check the presence of a provider's access
+ * token should go through {@link getConnectionAccessTokenResult} rather than
+ * inlining provider-specific path logic. This ensures that `oauth status`,
+ * `oauth ping`, credential health checks, and runtime token lookups all
+ * agree on where the access token lives.
+ *
+ * Manual-token providers (e.g. slack_channel, telegram) store their primary
+ * token under `credential/<provider>/<field>` via the generic credential
+ * store, while standard OAuth providers use `oauth_connection/<id>/access_token`.
+ */
+
+import { oauthConnectionAccessTokenPath } from "@vellumai/credential-storage";
+
+import { credentialKey } from "../security/credential-key.js";
+import {
+  getSecureKeyResultAsync,
+  type SecureKeyResult,
+} from "../security/secure-keys.js";
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface ConnectionAccessTokenResult {
+  /** The access token value, or undefined if not found / backend unreachable. */
+  value: string | undefined;
+  /** True when the credential backend is temporarily unreachable. */
+  unreachable: boolean;
+  /** The secure-store key that was resolved for this provider + connection. */
+  key: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Return the secure-store key holding the primary access token for a
+ * manual-token provider, or null for OAuth providers whose tokens live at
+ * `oauth_connection/<id>/access_token`.
+ *
+ * Manual-token providers store their tokens under `credential/<provider>/<field>`
+ * via the generic credential store, so any code that validates tokens for these
+ * providers (e.g. credential-health checks) must resolve the path through here
+ * rather than assuming the OAuth access-token path.
+ */
+export function manualTokenAccessCredentialKey(
+  provider: string,
+): string | null {
+  switch (provider) {
+    case "slack_channel":
+      return credentialKey("slack_channel", "bot_token");
+    case "telegram":
+      return credentialKey("telegram", "bot_token");
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve the secure-store key for a provider's access token.
+ *
+ * - `slack_channel` -> `credential/slack_channel/bot_token`
+ * - `telegram`      -> `credential/telegram/bot_token`
+ * - all normal OAuth -> `oauth_connection/<connectionId>/access_token`
+ */
+export function resolveAccessTokenKey(
+  provider: string,
+  connectionId: string,
+): string {
+  return (
+    manualTokenAccessCredentialKey(provider) ??
+    oauthConnectionAccessTokenPath(connectionId)
+  );
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Look up the access token for a provider/connection pair, resolving the
+ * correct secure-store key automatically.
+ *
+ * Returns the token value, whether the backend was unreachable, and the
+ * key that was used — giving callers everything they need to diagnose
+ * token-path mismatches.
+ */
+export async function getConnectionAccessTokenResult(opts: {
+  provider: string;
+  connectionId: string;
+}): Promise<ConnectionAccessTokenResult> {
+  const key = resolveAccessTokenKey(opts.provider, opts.connectionId);
+  const result: SecureKeyResult = await getSecureKeyResultAsync(key);
+  return {
+    value: result.value,
+    unreachable: result.unreachable,
+    key,
+  };
+}

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -19,33 +19,14 @@ import {
   upsertApp,
 } from "./oauth-store.js";
 
+// Re-export from the centralized resolver so existing callers that import
+// from this module continue to work without changes.
+export { manualTokenAccessCredentialKey } from "./credential-token-resolver.js";
+
 const log = getLogger("manual-token-connection");
 
 /** Sentinel client_id used for non-OAuth providers that don't have a real app. */
 const MANUAL_TOKEN_CLIENT_ID = "manual-config";
-
-/**
- * Return the secure-store key holding the primary access token for a
- * manual-token provider, or null for OAuth providers whose tokens live at
- * `oauth_connection/<id>/access_token`.
- *
- * Manual-token providers store their tokens under `credential/<provider>/<field>`
- * via the generic credential store, so any code that validates tokens for these
- * providers (e.g. credential-health checks) must resolve the path through here
- * rather than assuming the OAuth access-token path.
- */
-export function manualTokenAccessCredentialKey(
-  provider: string,
-): string | null {
-  switch (provider) {
-    case "slack_channel":
-      return credentialKey("slack_channel", "bot_token");
-    case "telegram":
-      return credentialKey("telegram", "bot_token");
-    default:
-      return null;
-  }
-}
 
 /**
  * Ensure an active oauth_connection row exists for the given manual-token

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -33,6 +33,7 @@ import {
 } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type { AvailableScopes } from "./connect-types.js";
+import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
 import { tryRevokeOAuthToken } from "./revoke.js";
 
 const log = getLogger("oauth-store");
@@ -895,10 +896,11 @@ export function listActiveConnectionsByProvider(
 export async function isProviderConnected(provider: string): Promise<boolean> {
   const conn = getActiveConnection(provider);
   if (!conn || conn.status !== "active") return false;
-  return (
-    (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))) !==
-    undefined
-  );
+  const tokenResult = await getConnectionAccessTokenResult({
+    provider,
+    connectionId: conn.id,
+  });
+  return tokenResult.value !== undefined;
 }
 
 /**

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -14,7 +14,6 @@
 import {
   isCredentialError,
   isTokenExpired,
-  oauthConnectionAccessTokenPath,
   oauthConnectionRefreshTokenPath,
   persistRefreshedTokens,
   RefreshCircuitBreaker,
@@ -22,6 +21,7 @@ import {
   type SecureKeyBackend,
 } from "@vellumai/credential-storage";
 
+import { getConnectionAccessTokenResult } from "../oauth/credential-token-resolver.js";
 import {
   getApp,
   getConnection,
@@ -321,9 +321,13 @@ export async function withValidToken<T>(
     opts && typeof opts === "object"
       ? getConnection(opts.connectionId)
       : getConnectionByProvider(service, opts);
-  let token = conn
-    ? await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))
+  const tokenResult = conn
+    ? await getConnectionAccessTokenResult({
+        provider: conn.provider,
+        connectionId: conn.id,
+      })
     : undefined;
+  let token = tokenResult?.value;
   if (!token || !conn) {
     throw new TokenExpiredError(
       service,


### PR DESCRIPTION
## Summary
- Create `credential-token-resolver.ts` with a shared helper that resolves the correct secure-store key for any provider (manual-token or OAuth)
- Wire the centralized resolver into credential health checks, OAuth connection resolution, token manager, and provider connectivity checks
- All OAuth/manual-token consumers now agree on where the access token lives, eliminating path mismatch between `oauth status`, `oauth ping`, and health checks

Part of plan: cred-health-alert.md (PR 1b of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
