### PR TITLE
fix(memory): unblock background-job side-effect tools via wake-level trust

### DIFF
--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -30,3 +30,16 @@ export interface TrustContext {
   /** Chat/conversation ID the requester is interacting through. */
   requesterChatId?: string;
 }
+
+/**
+ * Trust context used by internal background jobs (memory consolidation,
+ * update bulletin, scheduled tasks) when invoking the agent loop without
+ * an inbound actor identity. The assistant is the guardian over its own
+ * internal state, so self-maintenance flows clear the side-effect
+ * approval gate. Inbound message conversations resolve trust per-actor
+ * via `resolveTrustContext()` and must not use this constant.
+ */
+export const INTERNAL_GUARDIAN_TRUST_CONTEXT = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+} as const satisfies TrustContext;

--- a/assistant/src/daemon/wake-target-adapter.ts
+++ b/assistant/src/daemon/wake-target-adapter.ts
@@ -178,6 +178,7 @@ export function conversationToWakeTarget(
     markProcessing: (on) => {
       conversation.processing = on;
     },
+    setTrustContext: (ctx) => conversation.setTrustContext(ctx),
     persistTailMessage: async (message) => {
       const turnChannelCtx = conversation.getTurnChannelContext();
       const turnInterfaceCtx = conversation.getTurnInterfaceContext();

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -56,6 +56,7 @@ import { dirname, join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../../config/types.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -159,6 +160,7 @@ export async function memoryV2ConsolidateJob(
         conversationId: conversation.id,
         hint: renderConsolidationPrompt(cutoff),
         source: WAKE_SOURCE,
+        trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       });
       wakeInvoked = result.invoked;
       failureReason = result.reason;

--- a/assistant/src/prompts/update-bulletin-job.ts
+++ b/assistant/src/prompts/update-bulletin-job.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 
 import { getConfig } from "../config/loader.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
@@ -108,6 +109,7 @@ export async function runUpdateBulletinJobIfNeeded(): Promise<void> {
       conversationId: conv.id,
       hint: updateBulletinHint(),
       source: "updates_bulletin",
+      trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
     });
 
     if (!wakeResult.invoked) {

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -402,6 +402,95 @@ describe("wakeAgentForOpportunity", () => {
     expect(processing).toBe(false);
   });
 
+  test("applies caller-supplied trustContext to the target before the agent loop runs", async () => {
+    // Background system jobs (memory consolidation, update-bulletin) need
+    // guardian trust to clear the side-effect approval gate. The wake must
+    // call setTrustContext BEFORE agentLoop.run so the per-turn snapshot
+    // captures the elevated trust.
+    const trustCalls: Array<{ ctx: unknown; before: number }> = [];
+    const runCalls: number[] = [];
+    let callOrder = 0;
+
+    const history: Message[] = [];
+    let processing = false;
+    const target: WakeTarget = {
+      conversationId: "conv-trust",
+      agentLoop: {
+        run: async (input) => {
+          runCalls.push(callOrder++);
+          return [...input];
+        },
+      },
+      getMessages: () => history,
+      pushMessage: () => {},
+      emitAgentEvent: () => {},
+      isProcessing: () => processing,
+      markProcessing: (on) => {
+        processing = on;
+      },
+      persistTailMessage: async () => {},
+      setTrustContext: (ctx) => {
+        trustCalls.push({ ctx, before: callOrder++ });
+      },
+    };
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: "conv-trust",
+        hint: "consolidate memory",
+        source: "memory_v2_consolidation",
+        trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(trustCalls).toHaveLength(1);
+    expect(trustCalls[0]!.ctx).toEqual({
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    });
+    // setTrustContext fired strictly before agentLoop.run.
+    expect(runCalls).toHaveLength(1);
+    expect(trustCalls[0]!.before).toBeLessThan(runCalls[0]!);
+  });
+
+  test("does not call setTrustContext when no trustContext is supplied", async () => {
+    const trustCalls: unknown[] = [];
+    const history: Message[] = [];
+    let processing = false;
+    const target: WakeTarget = {
+      conversationId: "conv-no-trust",
+      agentLoop: {
+        run: async (input) => [...input],
+      },
+      getMessages: () => history,
+      pushMessage: () => {},
+      emitAgentEvent: () => {},
+      isProcessing: () => processing,
+      markProcessing: (on) => {
+        processing = on;
+      },
+      persistTailMessage: async () => {},
+      setTrustContext: (ctx) => {
+        trustCalls.push(ctx);
+      },
+    };
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: "conv-no-trust",
+        hint: "x",
+        source: "t",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    // Inbound-message conversations populate trust via processMessage().
+    // Without an explicit opt-in from the caller, the wake must not
+    // overwrite whatever the conversation already holds.
+    expect(trustCalls).toHaveLength(0);
+  });
+
   test("two concurrent wakes on the same conversation are serialized", async () => {
     // Build a target whose agentLoop.run resolves only when we signal.
     const gate1 = Promise.withResolvers<void>();

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -41,6 +41,7 @@
  */
 
 import type { AgentEvent, AgentLoop } from "../agent/loop.js";
+import type { TrustContext } from "../daemon/trust-context.js";
 import { getConversationOverrideProfile } from "../memory/conversation-crud.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
@@ -137,12 +138,30 @@ export interface WakeTarget {
    * typically omit it.
    */
   onWakeProducedOutput?(source: string, hint: string, surfaceId: string): void;
+  /**
+   * Apply a trust context to the underlying conversation before the agent
+   * loop runs. Internal background jobs (memory consolidation, update
+   * bulletin) use this to declare guardian trust so side-effect tools
+   * (file_edit, file_write, bash) clear the approval gate. Inbound message
+   * conversations populate trust via `processMessage()` and don't pass
+   * `trustContext` through the wake.
+   */
+  setTrustContext?(ctx: TrustContext): void;
 }
 
 export interface WakeOptions {
   conversationId: string;
   hint: string;
   source: string;
+  /**
+   * Optional trust context to apply to the conversation before the agent
+   * loop runs. Required for internal background jobs that need elevated
+   * trust to invoke side-effect tools — without it the loop falls back to
+   * `trustClass: "unknown"` and side-effect tools are blocked. Caller
+   * should pass `{ sourceChannel: "vellum", trustClass: "guardian" }` for
+   * assistant-self-maintenance jobs.
+   */
+  trustContext?: TrustContext;
 }
 
 /**
@@ -368,6 +387,13 @@ export async function wakeAgentForOpportunity(
         "agent-wake: conversation still processing after timeout; skipping",
       );
       return { invoked: false, producedToolCalls: false, reason: "timeout" };
+    }
+
+    // Apply caller-supplied trust before the agent loop reads its per-turn
+    // snapshot. Background jobs without an inbound message use this to
+    // declare guardian trust so side-effect tools clear the approval gate.
+    if (opts.trustContext && target.setTrustContext) {
+      target.setTrustContext(opts.trustContext);
     }
 
     const baseline = target.getMessages();

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { bootstrapConversation } from "../../memory/conversation-bootstrap.js";
 import { getConversation } from "../../memory/conversation-crud.js";
 import { runScript } from "../../schedule/run-script.js";
@@ -28,10 +29,6 @@ import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("schedule-routes");
-const SCHEDULE_GUARDIAN_TRUST_CONTEXT = {
-  sourceChannel: "vellum",
-  trustClass: "guardian",
-} as const;
 
 // ---------------------------------------------------------------------------
 // Handlers (transport-agnostic)
@@ -382,7 +379,7 @@ async function handleRunScheduleNow(id: string) {
         { taskId, workingDir: process.cwd(), source: "schedule" },
         async (conversationId, message, taskRunId) => {
           const conversation = await getOrCreateConversation(conversationId, {
-            trustContext: SCHEDULE_GUARDIAN_TRUST_CONTEXT,
+            trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
           });
           conversation.taskRunId = taskRunId;
           try {
@@ -479,7 +476,7 @@ async function handleRunScheduleNow(id: string) {
       "Executing schedule manually (run now)",
     );
     const activeConversation = await getOrCreateConversation(conversationId, {
-      trustContext: SCHEDULE_GUARDIAN_TRUST_CONTEXT,
+      trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
     });
     activeConversation.taskRunId = undefined;
     await activeConversation.processMessage(


### PR DESCRIPTION
## Summary
- Memory consolidation (and the update-bulletin job) was silently failing because background conversations carry no trust context — the agent loop fell back to \`trustClass: \"unknown\"\` and every \`file_edit\`/\`file_write\`/\`bash\` call was rejected by the guardian-approval gate with \"requires guardian approval from a verified channel identity\".
- Add an optional \`trustContext\` to \`wakeAgentForOpportunity()\` and a matching \`setTrustContext\` hook on \`WakeTarget\`. The wake applies the trust to the conversation before \`agentLoop.run()\` so the per-turn snapshot picks it up. Inbound-message conversations are unaffected (they still resolve trust via \`processMessage()\`).
- Extract the duplicated \`{sourceChannel: \"vellum\", trustClass: \"guardian\"}\` literal into a shared \`INTERNAL_GUARDIAN_TRUST_CONTEXT\` in \`daemon/trust-context.ts\`; use it from memory consolidation, update bulletin, and schedule routes (which already had its own local copy).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
