### PR TITLE
fix(credentials): distinguish unreachable backend from missing tokens

### DIFF
--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // ── Mutable state for mocks ──────────────────────────────────────────
 
 const secureKeyValues = new Map<string, string>();
+const unreachableKeys = new Set<string>();
 
 let mockProviders: Array<{
   provider: string;
@@ -36,6 +37,10 @@ let mockFetchThrows = false;
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: secureKeyValues.get(account),
+    unreachable: unreachableKeys.has(account),
+  }),
   setSecureKeyAsync: async () => {},
   deleteSecureKeyAsync: async () => "deleted",
   listSecureKeysAsync: async () => [],
@@ -140,11 +145,16 @@ function setToken(connectionId: string, token = "mock-token") {
   secureKeyValues.set(`oauth_connection/${connectionId}/access_token`, token);
 }
 
+function markUnreachable(key: string) {
+  unreachableKeys.add(key);
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("credential-health-service", () => {
   beforeEach(() => {
     secureKeyValues.clear();
+    unreachableKeys.clear();
     mockProviders = [];
     mockConnections = new Map();
     mockFetchResponse = { ok: true, status: 200 };
@@ -189,6 +199,30 @@ describe("credential-health-service", () => {
     expect(report.results[0]!.status).toBe("missing_token");
     expect(report.results[0]!.canAutoRecover).toBe(false);
     expect(report.unhealthy).toHaveLength(1);
+  });
+
+  test("returns unreachable when credential backend is unreachable", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1");
+    // Don't set token, but mark the path as unreachable
+    markUnreachable("oauth_connection/conn-1/access_token");
+
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0]!.status).toBe("unreachable");
+    expect(report.results[0]!.canAutoRecover).toBe(true);
+    expect(report.unhealthy).toHaveLength(1);
+  });
+
+  test("returns missing_token (not unreachable) when backend is reachable but token absent", async () => {
+    addProvider("google");
+    addConnection("google", "conn-1");
+    // Don't set token, don't mark unreachable — genuinely missing
+
+    const report = await checkAllCredentials();
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0]!.status).toBe("missing_token");
+    expect(report.results[0]!.canAutoRecover).toBe(false);
   });
 
   test("returns expired when token is past expiresAt without refresh token", async () => {
@@ -388,6 +422,40 @@ describe("credential-health-service", () => {
 
       const report = await checkAllCredentials();
       expect(report.results[0]!.status).toBe("healthy");
+    });
+
+    test("slack_channel returns unreachable when credential backend is down", async () => {
+      addProvider("slack_channel", {
+        pingUrl: "https://slack.com/api/auth.test",
+      });
+      addConnection("slack_channel", "conn-slack", {
+        expiresAt: null,
+        hasRefreshToken: false,
+        grantedScopes: [],
+      });
+      // Don't set token, mark the manual-token path as unreachable
+      markUnreachable("credential/slack_channel/bot_token");
+
+      const report = await checkAllCredentials();
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]!.status).toBe("unreachable");
+      expect(report.results[0]!.canAutoRecover).toBe(true);
+    });
+
+    test("telegram returns unreachable when credential backend is down", async () => {
+      addProvider("telegram");
+      addConnection("telegram", "conn-tg", {
+        expiresAt: null,
+        hasRefreshToken: false,
+        grantedScopes: [],
+      });
+      // Don't set token, mark the manual-token path as unreachable
+      markUnreachable("credential/telegram/bot_token");
+
+      const report = await checkAllCredentials();
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]!.status).toBe("unreachable");
+      expect(report.results[0]!.canAutoRecover).toBe(true);
     });
   });
 

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -61,6 +61,10 @@ mock.module("../security/secure-keys.js", () => {
   };
   return {
     getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
+    getSecureKeyResultAsync: async (account: string) => ({
+      value: storedKeys.get(account),
+      unreachable: false,
+    }),
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -195,6 +195,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/integrations/slack/share.ts", // Slack share routes credential lookup
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
+      "oauth/credential-token-resolver.ts", // centralized access-token key resolution for OAuth and manual-token providers
       "oauth/connection-resolver.ts", // resolve OAuthConnection from oauth-store (access_token lookup)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "runtime/routes/migration-routes.ts", // migration import credential restore

--- a/assistant/src/__tests__/credential-token-resolver.test.ts
+++ b/assistant/src/__tests__/credential-token-resolver.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mutable state for mocks ──────────────────────────────────────────
+
+const secureKeyValues = new Map<string, string>();
+const unreachableKeys = new Set<string>();
+
+// ── Module mocks ─────────────────────────────────────────────────────
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: secureKeyValues.get(account),
+    unreachable: unreachableKeys.has(account),
+  }),
+  setSecureKeyAsync: async () => {},
+  deleteSecureKeyAsync: async () => "deleted",
+  listSecureKeysAsync: async () => [],
+  getProviderKeyAsync: async () => undefined,
+  getMaskedProviderKey: () => undefined,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  }),
+}));
+
+// ── Import under test ────────────────────────────────────────────────
+
+const { resolveAccessTokenKey, getConnectionAccessTokenResult } =
+  await import("../oauth/credential-token-resolver.js");
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("credential-token-resolver", () => {
+  beforeEach(() => {
+    secureKeyValues.clear();
+    unreachableKeys.clear();
+  });
+
+  describe("resolveAccessTokenKey", () => {
+    test("slack_channel resolves to credential/slack_channel/bot_token", () => {
+      expect(resolveAccessTokenKey("slack_channel", "conn-123")).toBe(
+        "credential/slack_channel/bot_token",
+      );
+    });
+
+    test("telegram resolves to credential/telegram/bot_token", () => {
+      expect(resolveAccessTokenKey("telegram", "conn-456")).toBe(
+        "credential/telegram/bot_token",
+      );
+    });
+
+    test("standard OAuth provider resolves to oauth_connection/<id>/access_token", () => {
+      expect(resolveAccessTokenKey("google", "conn-789")).toBe(
+        "oauth_connection/conn-789/access_token",
+      );
+    });
+
+    test("unknown provider resolves to oauth_connection/<id>/access_token", () => {
+      expect(resolveAccessTokenKey("github", "conn-abc")).toBe(
+        "oauth_connection/conn-abc/access_token",
+      );
+    });
+  });
+
+  describe("getConnectionAccessTokenResult", () => {
+    test("returns token value and key for slack_channel using bot_token path", async () => {
+      secureKeyValues.set("credential/slack_channel/bot_token", "xoxb-valid");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "slack_channel",
+        connectionId: "conn-slack",
+      });
+
+      expect(result.value).toBe("xoxb-valid");
+      expect(result.unreachable).toBe(false);
+      expect(result.key).toBe("credential/slack_channel/bot_token");
+    });
+
+    test("returns undefined for slack_channel when bot_token is absent even if oauth path is set", async () => {
+      // Simulate the bug scenario: OAuth access-token path is populated but
+      // the manual-token path is not. The resolver must NOT fall through to
+      // the OAuth path for manual-token providers.
+      secureKeyValues.set(
+        "oauth_connection/conn-slack/access_token",
+        "should-be-ignored",
+      );
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "slack_channel",
+        connectionId: "conn-slack",
+      });
+
+      expect(result.value).toBeUndefined();
+      expect(result.key).toBe("credential/slack_channel/bot_token");
+    });
+
+    test("returns token for standard OAuth provider via connection path", async () => {
+      secureKeyValues.set(
+        "oauth_connection/conn-google/access_token",
+        "ya29.token",
+      );
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "google",
+        connectionId: "conn-google",
+      });
+
+      expect(result.value).toBe("ya29.token");
+      expect(result.unreachable).toBe(false);
+      expect(result.key).toBe("oauth_connection/conn-google/access_token");
+    });
+
+    test("returns unreachable when credential backend is down", async () => {
+      unreachableKeys.add("credential/telegram/bot_token");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "telegram",
+        connectionId: "conn-tg",
+      });
+
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(true);
+      expect(result.key).toBe("credential/telegram/bot_token");
+    });
+
+    test("returns undefined (not unreachable) when token is genuinely missing", async () => {
+      const result = await getConnectionAccessTokenResult({
+        provider: "google",
+        connectionId: "conn-missing",
+      });
+
+      expect(result.value).toBeUndefined();
+      expect(result.unreachable).toBe(false);
+      expect(result.key).toBe("oauth_connection/conn-missing/access_token");
+    });
+  });
+
+  describe("regression: oauth ping slack_channel uses bot_token", () => {
+    // The root cause of false credential health alerts was that some code paths
+    // looked up tokens at oauth_connection/<id>/access_token for ALL providers,
+    // while manual-token providers (slack_channel, telegram) actually store
+    // their tokens at credential/<provider>/bot_token. The centralized resolver
+    // ensures ALL consumers agree on the path.
+
+    test("slack_channel token lookup goes to credential/slack_channel/bot_token, not oauth path", async () => {
+      secureKeyValues.set("credential/slack_channel/bot_token", "xoxb-real");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "slack_channel",
+        connectionId: "any-connection-id",
+      });
+
+      // Must find the token at the manual-token path
+      expect(result.value).toBe("xoxb-real");
+      // Must report the correct key
+      expect(result.key).toBe("credential/slack_channel/bot_token");
+      // Connection ID must be irrelevant for manual-token providers
+      expect(result.key).not.toContain("any-connection-id");
+    });
+
+    test("telegram token lookup goes to credential/telegram/bot_token, not oauth path", async () => {
+      secureKeyValues.set("credential/telegram/bot_token", "tg-token");
+
+      const result = await getConnectionAccessTokenResult({
+        provider: "telegram",
+        connectionId: "any-connection-id",
+      });
+
+      expect(result.value).toBe("tg-token");
+      expect(result.key).toBe("credential/telegram/bot_token");
+      expect(result.key).not.toContain("any-connection-id");
+    });
+  });
+});

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -90,14 +90,72 @@ mock.module("../memory/conversation-crud.js", () => ({
   },
 }));
 
-// Mock logger
+// Mock logger — capture warn calls for unreachable-credential assertions
+const loggerWarnCalls: Array<Record<string, unknown>> = [];
 mock.module("../util/logger.js", () => ({
   getLogger: () => ({
     info: () => {},
     debug: () => {},
-    warn: () => {},
+    warn: (...args: unknown[]) => {
+      if (args.length > 0 && typeof args[0] === "object" && args[0] !== null) {
+        loggerWarnCalls.push(args[0] as Record<string, unknown>);
+      }
+    },
     error: () => {},
   }),
+}));
+
+// ── Credential health mock ──────────────────────────────────────────
+//
+// HeartbeatService dynamically imports `checkAllCredentials` inside
+// `runCredentialHealthCheck`, so `mock.module` intercepts it. Tests
+// mutate `mockCredentialHealthReport` to drive different scenarios.
+import type {
+  CredentialHealthReport,
+  CredentialHealthResult,
+  CredentialHealthStatus,
+} from "../credential-health/credential-health-service.js";
+
+let mockCredentialHealthReport: CredentialHealthReport | null = null;
+let mockCheckAllCredentialsFail = false;
+
+mock.module("../credential-health/credential-health-service.js", () => ({
+  checkAllCredentials: async () => {
+    if (mockCheckAllCredentialsFail) {
+      throw new Error("CES unreachable");
+    }
+    return (
+      mockCredentialHealthReport ?? {
+        checkedAt: Date.now(),
+        results: [],
+        unhealthy: [],
+      }
+    );
+  },
+}));
+
+// ── Notification signal mock ────────────────────────────────────────
+//
+// `notifyUnhealthyCredentials` dynamically imports `emitNotificationSignal`.
+// Track calls so tests can assert which credentials were notified about.
+const emittedNotificationSignals: Array<{
+  sourceContextId: string;
+  dedupeKey: string;
+  contextPayload: Record<string, unknown>;
+}> = [];
+
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (opts: {
+    sourceContextId: string;
+    dedupeKey: string;
+    contextPayload: Record<string, unknown>;
+  }) => {
+    emittedNotificationSignals.push({
+      sourceContextId: opts.sourceContextId,
+      dedupeKey: opts.dedupeKey,
+      contextPayload: opts.contextPayload,
+    });
+  },
 }));
 
 // Mock conversation title service
@@ -202,6 +260,10 @@ describe("HeartbeatService", () => {
     createdConversations.length = 0;
     conversationIdCounter = 0;
     mockGuardianPersona = null;
+    mockCredentialHealthReport = null;
+    mockCheckAllCredentialsFail = false;
+    emittedNotificationSignals.length = 0;
+    loggerWarnCalls.length = 0;
 
     // Default processMessage mock: capture calls for assertions.
     setTestProcessMessage(async (...args: unknown[]) => {
@@ -770,6 +832,226 @@ describe("HeartbeatService", () => {
       ]);
 
       expect(prompt).toContain("google, slack");
+    });
+  });
+
+  describe("transient credential health suppression", () => {
+    function makeUnhealthyResult(
+      overrides: Partial<CredentialHealthResult> = {},
+    ): CredentialHealthResult {
+      return {
+        connectionId: overrides.connectionId ?? "conn-1",
+        provider: overrides.provider ?? "google",
+        accountInfo: overrides.accountInfo ?? "user@example.com",
+        status: overrides.status ?? ("missing_token" as CredentialHealthStatus),
+        details: overrides.details ?? "Token not found",
+        missingScopes: overrides.missingScopes ?? [],
+        canAutoRecover: overrides.canAutoRecover ?? false,
+      };
+    }
+
+    test("unreachable credentials do not trigger notifications", async () => {
+      mockCredentialHealthReport = {
+        checkedAt: Date.now(),
+        results: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+        unhealthy: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+      };
+
+      const service = createService();
+      await service.runOnce();
+
+      // No notification signals should have been emitted for unreachable
+      expect(emittedNotificationSignals).toHaveLength(0);
+    });
+
+    test("unreachable credentials do not block provider tools in heartbeat prompt", async () => {
+      mockCredentialHealthReport = {
+        checkedAt: Date.now(),
+        results: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+        unhealthy: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+      };
+
+      const service = createService();
+      await service.runOnce();
+
+      // The prompt should NOT contain <credential-status> since unreachable
+      // is not a hard failure and should not tell the LLM to skip providers
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].content).not.toContain(
+        "<credential-status>",
+      );
+    });
+
+    test("unreachable credentials log a warning", async () => {
+      mockCredentialHealthReport = {
+        checkedAt: Date.now(),
+        results: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+        unhealthy: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+      };
+
+      const service = createService();
+      await service.runOnce();
+
+      // Logger warn should have been called with unreachableCount
+      const unreachableWarns = loggerWarnCalls.filter(
+        (call) => "unreachableCount" in call,
+      );
+      expect(unreachableWarns).toHaveLength(1);
+      expect(unreachableWarns[0].unreachableCount).toBe(1);
+    });
+
+    test("missing_token still notifies and blocks provider tools", async () => {
+      mockCredentialHealthReport = {
+        checkedAt: Date.now(),
+        results: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "missing_token",
+            details: "Token not found in keychain",
+          }),
+        ],
+        unhealthy: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "missing_token",
+            details: "Token not found in keychain",
+          }),
+        ],
+      };
+
+      const service = createService();
+      await service.runOnce();
+
+      // Should have emitted a notification for missing_token
+      expect(emittedNotificationSignals).toHaveLength(1);
+      expect(emittedNotificationSignals[0].contextPayload.status).toBe(
+        "missing_token",
+      );
+      expect(emittedNotificationSignals[0].contextPayload.provider).toBe(
+        "google",
+      );
+
+      // Prompt should include <credential-status> blocking google
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].content).toContain("<credential-status>");
+      expect(processMessageCalls[0].content).toContain("google");
+    });
+
+    test("mixed report notifies only actionable failures, not unreachable", async () => {
+      mockCredentialHealthReport = {
+        checkedAt: Date.now(),
+        results: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+          makeUnhealthyResult({
+            connectionId: "conn-slack",
+            provider: "slack",
+            status: "revoked",
+            details: "Token was revoked by user",
+          }),
+          makeUnhealthyResult({
+            connectionId: "conn-github",
+            provider: "github",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+        unhealthy: [
+          makeUnhealthyResult({
+            connectionId: "conn-google",
+            provider: "google",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+          makeUnhealthyResult({
+            connectionId: "conn-slack",
+            provider: "slack",
+            status: "revoked",
+            details: "Token was revoked by user",
+          }),
+          makeUnhealthyResult({
+            connectionId: "conn-github",
+            provider: "github",
+            status: "unreachable",
+            details: "CES backend unavailable",
+          }),
+        ],
+      };
+
+      const service = createService();
+      await service.runOnce();
+
+      // Only the revoked credential should trigger a notification
+      expect(emittedNotificationSignals).toHaveLength(1);
+      expect(emittedNotificationSignals[0].contextPayload.provider).toBe(
+        "slack",
+      );
+      expect(emittedNotificationSignals[0].contextPayload.status).toBe(
+        "revoked",
+      );
+
+      // Only slack (revoked = hard failure) should appear in credential-status
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].content).toContain("<credential-status>");
+      expect(processMessageCalls[0].content).toContain("slack");
+      // google and github are unreachable — should NOT be in credential-status
+      expect(processMessageCalls[0].content).not.toContain("google");
+      expect(processMessageCalls[0].content).not.toContain("github");
+
+      // Should have logged a warning about the 2 unreachable credentials
+      const unreachableWarns = loggerWarnCalls.filter(
+        (call) => "unreachableCount" in call,
+      );
+      expect(unreachableWarns).toHaveLength(1);
+      expect(unreachableWarns[0].unreachableCount).toBe(2);
     });
   });
 });

--- a/assistant/src/__tests__/manual-token-reconciliation.test.ts
+++ b/assistant/src/__tests__/manual-token-reconciliation.test.ts
@@ -1,0 +1,334 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SecureKeyResult } from "../security/secure-keys.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let secureKeyResults: Record<string, SecureKeyResult> = {};
+let connectionStore: Record<
+  string,
+  { id: string; provider: string; accountInfo?: string | null }
+> = {};
+let deletedConnectionIds: string[] = [];
+let createdConnections: Array<{ provider: string; accountInfo?: string }> = [];
+const warnings: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be registered before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    warn: (msg: string) => warnings.push(msg),
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyResultAsync: async (account: string): Promise<SecureKeyResult> =>
+    secureKeyResults[account] ?? { value: undefined, unreachable: false },
+  // Keep getSecureKeyAsync available for any transitive imports
+  getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
+    const result = secureKeyResults[account] ?? {
+      value: undefined,
+      unreachable: false,
+    };
+    return result.value;
+  },
+}));
+
+mock.module("../oauth/oauth-store.js", () => ({
+  getConnectionByProvider: (provider: string) =>
+    connectionStore[provider] ?? undefined,
+  deleteConnection: (id: string) => {
+    deletedConnectionIds.push(id);
+    // Remove from store
+    for (const [key, val] of Object.entries(connectionStore)) {
+      if (val.id === id) {
+        delete connectionStore[key];
+        break;
+      }
+    }
+  },
+  createConnection: (params: {
+    oauthAppId: string;
+    provider: string;
+    accountInfo?: string;
+    grantedScopes: string[];
+    hasRefreshToken: boolean;
+  }) => {
+    createdConnections.push({
+      provider: params.provider,
+      accountInfo: params.accountInfo,
+    });
+    connectionStore[params.provider] = {
+      id: `conn-${params.provider}`,
+      provider: params.provider,
+      accountInfo: params.accountInfo ?? null,
+    };
+    return { id: `conn-${params.provider}` };
+  },
+  updateConnection: () => {},
+  upsertApp: async (_provider: string, _clientId: string) => ({
+    id: "app-1",
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { backfillManualTokenConnections, syncManualTokenConnection } =
+  await import("../oauth/manual-token-connection.js");
+import { credentialKey } from "../security/credential-key.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setCredentialResult(
+  service: string,
+  field: string,
+  result: SecureKeyResult,
+): void {
+  secureKeyResults[credentialKey(service, field)] = result;
+}
+
+function seedConnection(
+  provider: string,
+  opts?: { accountInfo?: string },
+): void {
+  connectionStore[provider] = {
+    id: `conn-${provider}`,
+    provider,
+    accountInfo: opts?.accountInfo ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("syncManualTokenConnection", () => {
+  beforeEach(() => {
+    secureKeyResults = {};
+    connectionStore = {};
+    deletedConnectionIds = [];
+    createdConnections = [];
+    warnings.length = 0;
+  });
+
+  // ---- Slack: reachable backend, missing tokens -> removes row ----
+
+  test("removes slack_channel connection when bot token is missing and backend is reachable", async () => {
+    seedConnection("slack_channel");
+    setCredentialResult("slack_channel", "bot_token", {
+      value: undefined,
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: "xapp-valid",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toContain("conn-slack_channel");
+    expect(connectionStore["slack_channel"]).toBeUndefined();
+  });
+
+  test("removes slack_channel connection when app token is missing and backend is reachable", async () => {
+    seedConnection("slack_channel");
+    setCredentialResult("slack_channel", "bot_token", {
+      value: "xoxb-valid",
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toContain("conn-slack_channel");
+    expect(connectionStore["slack_channel"]).toBeUndefined();
+  });
+
+  // ---- Telegram: reachable backend, missing tokens -> removes row ----
+
+  test("removes telegram connection when bot token is missing and backend is reachable", async () => {
+    seedConnection("telegram");
+    setCredentialResult("telegram", "bot_token", {
+      value: undefined,
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: "secret-valid",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(deletedConnectionIds).toContain("conn-telegram");
+    expect(connectionStore["telegram"]).toBeUndefined();
+  });
+
+  test("removes telegram connection when webhook secret is missing and backend is reachable", async () => {
+    seedConnection("telegram");
+    setCredentialResult("telegram", "bot_token", {
+      value: "bot-token-valid",
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: undefined,
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(deletedConnectionIds).toContain("conn-telegram");
+    expect(connectionStore["telegram"]).toBeUndefined();
+  });
+
+  // ---- Unreachable backend -> leaves rows untouched ----
+
+  test("leaves slack_channel connection untouched when backend is unreachable", async () => {
+    seedConnection("slack_channel");
+    setCredentialResult("slack_channel", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(createdConnections).toEqual([]);
+    expect(connectionStore["slack_channel"]).toBeDefined();
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("slack_channel");
+    expect(warnings[0]).toContain("unreachable");
+  });
+
+  test("leaves telegram connection untouched when backend is unreachable", async () => {
+    seedConnection("telegram");
+    setCredentialResult("telegram", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(createdConnections).toEqual([]);
+    expect(connectionStore["telegram"]).toBeDefined();
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain("telegram");
+    expect(warnings[0]).toContain("unreachable");
+  });
+
+  test("leaves slack_channel connection untouched when only one credential read is unreachable", async () => {
+    seedConnection("slack_channel");
+    // bot_token is readable but app_token backend is unreachable
+    setCredentialResult("slack_channel", "bot_token", {
+      value: "xoxb-valid",
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(connectionStore["slack_channel"]).toBeDefined();
+  });
+
+  // ---- Reachable backend, all tokens present -> ensures connection ----
+
+  test("creates slack_channel connection when all tokens are present", async () => {
+    setCredentialResult("slack_channel", "bot_token", {
+      value: "xoxb-valid",
+      unreachable: false,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: "xapp-valid",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("slack_channel");
+
+    expect(createdConnections).toEqual([
+      { provider: "slack_channel", accountInfo: undefined },
+    ]);
+  });
+
+  test("creates telegram connection when all tokens are present", async () => {
+    setCredentialResult("telegram", "bot_token", {
+      value: "bot-token",
+      unreachable: false,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: "webhook-secret",
+      unreachable: false,
+    });
+
+    await syncManualTokenConnection("telegram");
+
+    expect(createdConnections).toEqual([
+      { provider: "telegram", accountInfo: undefined },
+    ]);
+  });
+});
+
+describe("backfillManualTokenConnections", () => {
+  beforeEach(() => {
+    secureKeyResults = {};
+    connectionStore = {};
+    deletedConnectionIds = [];
+    createdConnections = [];
+    warnings.length = 0;
+  });
+
+  test("propagates non-destructive behavior — unreachable backend leaves all rows untouched", async () => {
+    seedConnection("telegram");
+    seedConnection("slack_channel");
+
+    // All credential reads return unreachable
+    setCredentialResult("telegram", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("telegram", "webhook_secret", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("slack_channel", "bot_token", {
+      value: undefined,
+      unreachable: true,
+    });
+    setCredentialResult("slack_channel", "app_token", {
+      value: undefined,
+      unreachable: true,
+    });
+
+    await backfillManualTokenConnections();
+
+    expect(deletedConnectionIds).toEqual([]);
+    expect(connectionStore["telegram"]).toBeDefined();
+    expect(connectionStore["slack_channel"]).toBeDefined();
+    expect(warnings.length).toBe(2);
+  });
+});

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -19,6 +19,25 @@ mock.module("../security/secure-keys.js", () => ({
   setSecureKeyAsync: mockSetSecureKeyAsync,
   getSecureKeyAsync: (account: string) =>
     Promise.resolve(secureKeyValues.get(account)),
+  getSecureKeyResultAsync: (account: string) =>
+    Promise.resolve({
+      value: secureKeyValues.get(account),
+      unreachable: false,
+    }),
+}));
+
+mock.module("../oauth/credential-token-resolver.js", () => ({
+  getConnectionAccessTokenResult: async (opts: {
+    provider: string;
+    connectionId: string;
+  }) => {
+    const key = `oauth_connection/${opts.connectionId}/access_token`;
+    return {
+      value: secureKeyValues.get(key),
+      unreachable: false,
+      key,
+    };
+  },
 }));
 
 import { eq } from "drizzle-orm";

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -61,6 +61,10 @@ mock.module("../security/secure-keys.js", () => {
   };
   return {
     getSecureKeyAsync: async (key: string) => storedKeys.get(key) ?? undefined,
+    getSecureKeyResultAsync: async (account: string) => ({
+      value: storedKeys.get(account),
+      unreachable: false,
+    }),
     setSecureKeyAsync: async (key: string, value: string) =>
       syncSet(key, value),
     deleteSecureKeyAsync: async (key: string) => syncDelete(key),

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -11,18 +11,14 @@
  * no token refresh or recovery is attempted.
  */
 
-import {
-  isTokenExpired,
-  oauthConnectionAccessTokenPath,
-} from "@vellumai/credential-storage";
+import { isTokenExpired } from "@vellumai/credential-storage";
 
-import { manualTokenAccessCredentialKey } from "../oauth/manual-token-connection.js";
+import { getConnectionAccessTokenResult } from "../oauth/credential-token-resolver.js";
 import {
   getProvider,
   listActiveConnectionsByProvider,
   listProviders,
 } from "../oauth/oauth-store.js";
-import { getSecureKeyResultAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("credential-health");
@@ -166,15 +162,14 @@ async function checkConnection(
     missingScopes: [] as string[],
   };
 
-  // 1. Check token presence. Manual-token providers (e.g. slack_channel,
-  // telegram) store their primary token under credential/<provider>/<field>
-  // rather than oauth_connection/<id>/access_token, so resolve the correct
-  // path before looking up the token — otherwise the lookup always returns
-  // null and marks these providers as "missing_token".
-  const tokenPath =
-    manualTokenAccessCredentialKey(provider) ??
-    oauthConnectionAccessTokenPath(connectionId);
-  const tokenResult = await getSecureKeyResultAsync(tokenPath);
+  // 1. Check token presence via the centralized resolver. Manual-token
+  // providers (e.g. slack_channel, telegram) store their primary token at
+  // credential/<provider>/<field> rather than oauth_connection/<id>/access_token;
+  // the resolver handles the mapping automatically.
+  const tokenResult = await getConnectionAccessTokenResult({
+    provider,
+    connectionId,
+  });
   if (!tokenResult.value) {
     if (tokenResult.unreachable) {
       return {

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -22,7 +22,7 @@ import {
   listActiveConnectionsByProvider,
   listProviders,
 } from "../oauth/oauth-store.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getSecureKeyResultAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("credential-health");
@@ -40,6 +40,7 @@ export type CredentialHealthStatus =
   | "expiring"
   | "expired"
   | "missing_token"
+  | "unreachable"
   | "missing_scopes"
   | "revoked"
   | "ping_failed";
@@ -173,8 +174,16 @@ async function checkConnection(
   const tokenPath =
     manualTokenAccessCredentialKey(provider) ??
     oauthConnectionAccessTokenPath(connectionId);
-  const token = await getSecureKeyAsync(tokenPath);
-  if (!token) {
+  const tokenResult = await getSecureKeyResultAsync(tokenPath);
+  if (!tokenResult.value) {
+    if (tokenResult.unreachable) {
+      return {
+        ...base,
+        status: "unreachable",
+        details: `Credential backend is temporarily unreachable for ${provider}. Token status unknown.`,
+        canAutoRecover: true,
+      };
+    }
     return {
       ...base,
       status: "missing_token",
@@ -182,6 +191,7 @@ async function checkConnection(
       canAutoRecover: false,
     };
   }
+  const token = tokenResult.value;
 
   // 2. Check token expiry
   if (isTokenExpired(expiresAt)) {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -274,11 +274,25 @@ export class HeartbeatService {
         await import("../credential-health/credential-health-service.js");
       const report = await checkAllCredentials();
       if (report.unhealthy.length > 0) {
-        await this.notifyUnhealthyCredentials(report.unhealthy);
-        // Only block providers for hard-failure statuses — expiring and ping_failed
-        // are transient/still-usable and should not disable provider tools.
-        // missing_scopes is a hard failure because required scopes are absent and
-        // provider tools will predictably fail.
+        // Filter out unreachable results — CES wake/startup blips should not
+        // produce user-facing credential alerts. Only actionable failures notify.
+        const notifiable = report.unhealthy.filter(
+          (r) => r.status !== "unreachable",
+        );
+        const unreachableCount = report.unhealthy.length - notifiable.length;
+        if (unreachableCount > 0) {
+          log.warn(
+            { unreachableCount },
+            "Credential backend unreachable — skipping health alerts for affected providers",
+          );
+        }
+        if (notifiable.length > 0) {
+          await this.notifyUnhealthyCredentials(notifiable);
+        }
+        // Only block providers for hard-failure statuses — expiring, ping_failed,
+        // and unreachable are transient/still-usable and should not disable
+        // provider tools. missing_scopes is a hard failure because required
+        // scopes are absent and provider tools will predictably fail.
         const hardFailureStatuses = new Set([
           "revoked",
           "missing_token",

--- a/assistant/src/oauth/connection-resolver.test.ts
+++ b/assistant/src/oauth/connection-resolver.test.ts
@@ -39,6 +39,14 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => mockAccessToken,
 }));
 
+mock.module("./credential-token-resolver.js", () => ({
+  getConnectionAccessTokenResult: async () => ({
+    value: mockAccessToken,
+    unreachable: false,
+    key: "mock-key",
+  }),
+}));
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => mockConfig,
 }));

--- a/assistant/src/oauth/connection-resolver.ts
+++ b/assistant/src/oauth/connection-resolver.ts
@@ -5,10 +5,10 @@ import {
   ServicesSchema,
 } from "../config/schemas/services.js";
 import { VellumPlatformClient } from "../platform/client.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { BYOOAuthConnection } from "./byo-connection.js";
 import type { OAuthConnection } from "./connection.js";
+import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
 import { getActiveConnection, getProvider } from "./oauth-store.js";
 import { PlatformOAuthConnection } from "./platform-connection.js";
 
@@ -96,10 +96,11 @@ export async function resolveOAuthConnection(
     );
   }
 
-  const accessToken = await getSecureKeyAsync(
-    `oauth_connection/${conn.id}/access_token`,
-  );
-  if (!accessToken) {
+  const tokenResult = await getConnectionAccessTokenResult({
+    provider,
+    connectionId: conn.id,
+  });
+  if (!tokenResult.value) {
     throw new Error(
       `OAuth connection for "${provider}" exists but has no access token. Re-authorize with \`assistant oauth connect ${provider}\`.`,
     );

--- a/assistant/src/oauth/credential-token-resolver.ts
+++ b/assistant/src/oauth/credential-token-resolver.ts
@@ -1,0 +1,97 @@
+/**
+ * Centralized access-token key resolution for OAuth and manual-token providers.
+ *
+ * All code that needs to read or check the presence of a provider's access
+ * token should go through {@link getConnectionAccessTokenResult} rather than
+ * inlining provider-specific path logic. This ensures that `oauth status`,
+ * `oauth ping`, credential health checks, and runtime token lookups all
+ * agree on where the access token lives.
+ *
+ * Manual-token providers (e.g. slack_channel, telegram) store their primary
+ * token under `credential/<provider>/<field>` via the generic credential
+ * store, while standard OAuth providers use `oauth_connection/<id>/access_token`.
+ */
+
+import { oauthConnectionAccessTokenPath } from "@vellumai/credential-storage";
+
+import { credentialKey } from "../security/credential-key.js";
+import {
+  getSecureKeyResultAsync,
+  type SecureKeyResult,
+} from "../security/secure-keys.js";
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface ConnectionAccessTokenResult {
+  /** The access token value, or undefined if not found / backend unreachable. */
+  value: string | undefined;
+  /** True when the credential backend is temporarily unreachable. */
+  unreachable: boolean;
+  /** The secure-store key that was resolved for this provider + connection. */
+  key: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Return the secure-store key holding the primary access token for a
+ * manual-token provider, or null for OAuth providers whose tokens live at
+ * `oauth_connection/<id>/access_token`.
+ *
+ * Manual-token providers store their tokens under `credential/<provider>/<field>`
+ * via the generic credential store, so any code that validates tokens for these
+ * providers (e.g. credential-health checks) must resolve the path through here
+ * rather than assuming the OAuth access-token path.
+ */
+export function manualTokenAccessCredentialKey(
+  provider: string,
+): string | null {
+  switch (provider) {
+    case "slack_channel":
+      return credentialKey("slack_channel", "bot_token");
+    case "telegram":
+      return credentialKey("telegram", "bot_token");
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve the secure-store key for a provider's access token.
+ *
+ * - `slack_channel` -> `credential/slack_channel/bot_token`
+ * - `telegram`      -> `credential/telegram/bot_token`
+ * - all normal OAuth -> `oauth_connection/<connectionId>/access_token`
+ */
+export function resolveAccessTokenKey(
+  provider: string,
+  connectionId: string,
+): string {
+  return (
+    manualTokenAccessCredentialKey(provider) ??
+    oauthConnectionAccessTokenPath(connectionId)
+  );
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Look up the access token for a provider/connection pair, resolving the
+ * correct secure-store key automatically.
+ *
+ * Returns the token value, whether the backend was unreachable, and the
+ * key that was used — giving callers everything they need to diagnose
+ * token-path mismatches.
+ */
+export async function getConnectionAccessTokenResult(opts: {
+  provider: string;
+  connectionId: string;
+}): Promise<ConnectionAccessTokenResult> {
+  const key = resolveAccessTokenKey(opts.provider, opts.connectionId);
+  const result: SecureKeyResult = await getSecureKeyResultAsync(key);
+  return {
+    value: result.value,
+    unreachable: result.unreachable,
+    key,
+  };
+}

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -9,7 +9,8 @@
  */
 
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getSecureKeyResultAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
 import {
   createConnection,
   deleteConnection,
@@ -17,6 +18,8 @@ import {
   updateConnection,
   upsertApp,
 } from "./oauth-store.js";
+
+const log = getLogger("manual-token-connection");
 
 /** Sentinel client_id used for non-OAuth providers that don't have a real app. */
 const MANUAL_TOKEN_CLIENT_ID = "manual-config";
@@ -101,13 +104,19 @@ export async function syncManualTokenConnection(
 ): Promise<void> {
   switch (provider) {
     case "telegram": {
-      const hasBotToken = !!(await getSecureKeyAsync(
+      const botTokenResult = await getSecureKeyResultAsync(
         credentialKey("telegram", "bot_token"),
-      ));
-      const hasWebhookSecret = !!(await getSecureKeyAsync(
+      );
+      const webhookSecretResult = await getSecureKeyResultAsync(
         credentialKey("telegram", "webhook_secret"),
-      ));
-      if (hasBotToken && hasWebhookSecret) {
+      );
+      if (botTokenResult.unreachable || webhookSecretResult.unreachable) {
+        log.warn(
+          "Skipping telegram manual-token reconciliation — credential backend unreachable",
+        );
+        return;
+      }
+      if (botTokenResult.value && webhookSecretResult.value) {
         await ensureManualTokenConnection(provider, accountInfo);
       } else {
         removeManualTokenConnection(provider);
@@ -116,13 +125,19 @@ export async function syncManualTokenConnection(
     }
 
     case "slack_channel": {
-      const hasBotToken = !!(await getSecureKeyAsync(
+      const botTokenResult = await getSecureKeyResultAsync(
         credentialKey("slack_channel", "bot_token"),
-      ));
-      const hasAppToken = !!(await getSecureKeyAsync(
+      );
+      const appTokenResult = await getSecureKeyResultAsync(
         credentialKey("slack_channel", "app_token"),
-      ));
-      if (hasBotToken && hasAppToken) {
+      );
+      if (botTokenResult.unreachable || appTokenResult.unreachable) {
+        log.warn(
+          "Skipping slack_channel manual-token reconciliation — credential backend unreachable",
+        );
+        return;
+      }
+      if (botTokenResult.value && appTokenResult.value) {
         await ensureManualTokenConnection(provider, accountInfo);
       } else {
         removeManualTokenConnection(provider);

--- a/assistant/src/oauth/manual-token-connection.ts
+++ b/assistant/src/oauth/manual-token-connection.ts
@@ -19,33 +19,14 @@ import {
   upsertApp,
 } from "./oauth-store.js";
 
+// Re-export from the centralized resolver so existing callers that import
+// from this module continue to work without changes.
+export { manualTokenAccessCredentialKey } from "./credential-token-resolver.js";
+
 const log = getLogger("manual-token-connection");
 
 /** Sentinel client_id used for non-OAuth providers that don't have a real app. */
 const MANUAL_TOKEN_CLIENT_ID = "manual-config";
-
-/**
- * Return the secure-store key holding the primary access token for a
- * manual-token provider, or null for OAuth providers whose tokens live at
- * `oauth_connection/<id>/access_token`.
- *
- * Manual-token providers store their tokens under `credential/<provider>/<field>`
- * via the generic credential store, so any code that validates tokens for these
- * providers (e.g. credential-health checks) must resolve the path through here
- * rather than assuming the OAuth access-token path.
- */
-export function manualTokenAccessCredentialKey(
-  provider: string,
-): string | null {
-  switch (provider) {
-    case "slack_channel":
-      return credentialKey("slack_channel", "bot_token");
-    case "telegram":
-      return credentialKey("telegram", "bot_token");
-    default:
-      return null;
-  }
-}
 
 /**
  * Ensure an active oauth_connection row exists for the given manual-token

--- a/assistant/src/oauth/oauth-store.ts
+++ b/assistant/src/oauth/oauth-store.ts
@@ -33,6 +33,7 @@ import {
 } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import type { AvailableScopes } from "./connect-types.js";
+import { getConnectionAccessTokenResult } from "./credential-token-resolver.js";
 import { tryRevokeOAuthToken } from "./revoke.js";
 
 const log = getLogger("oauth-store");
@@ -895,10 +896,11 @@ export function listActiveConnectionsByProvider(
 export async function isProviderConnected(provider: string): Promise<boolean> {
   const conn = getActiveConnection(provider);
   if (!conn || conn.status !== "active") return false;
-  return (
-    (await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))) !==
-    undefined
-  );
+  const tokenResult = await getConnectionAccessTokenResult({
+    provider,
+    connectionId: conn.id,
+  });
+  return tokenResult.value !== undefined;
 }
 
 /**

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -451,6 +451,8 @@ export async function setSecureKeyAsync(
         { account, backend: backend.name },
         "Credential backend set failed",
       );
+    } else {
+      log.info({ account, backend: backend.name }, "Credential stored");
     }
     updateCesHttpReachability(backend, !ok);
     return ok;
@@ -468,6 +470,9 @@ export async function deleteSecureKeyAsync(
   return withCredentialTimeout(async () => {
     const backend = await resolveBackendAsync();
     const result = await backend.delete(account);
+    if (result === "deleted") {
+      log.info({ account, backend: backend.name }, "Credential deleted");
+    }
     updateCesHttpReachability(backend, result === "error");
     return result;
   }, "error");
@@ -485,21 +490,31 @@ export async function bulkSetSecureKeysAsync(
   return withCredentialTimeout(
     async () => {
       const backend = await resolveBackendAsync();
+      let results: Array<{ account: string; ok: boolean }>;
       if (backend.bulkSet) {
-        const results = await backend.bulkSet(credentials);
+        results = await backend.bulkSet(credentials);
         const anyFailed = results.some((r) => !r.ok);
         updateCesHttpReachability(backend, anyFailed);
-        return results;
+      } else {
+        // Fallback: loop individual sets
+        results = [];
+        let anyFailed = false;
+        for (const { account, value } of credentials) {
+          const ok = await backend.set(account, value);
+          if (!ok) anyFailed = true;
+          results.push({ account, ok });
+        }
+        updateCesHttpReachability(backend, anyFailed);
       }
-      // Fallback: loop individual sets
-      const results = [];
-      let anyFailed = false;
-      for (const { account, value } of credentials) {
-        const ok = await backend.set(account, value);
-        if (!ok) anyFailed = true;
-        results.push({ account, ok });
+      const succeeded = results.filter((r) => r.ok).length;
+      const failed = results.filter((r) => !r.ok).length;
+      if (succeeded > 0 || failed > 0) {
+        const level = succeeded > 0 ? "info" : "warn";
+        log[level](
+          { succeeded, failed, backend: backend.name },
+          "Bulk credential store completed",
+        );
       }
-      updateCesHttpReachability(backend, anyFailed);
       return results;
     },
     credentials.map((c) => ({ account: c.account, ok: false })),

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -14,7 +14,6 @@
 import {
   isCredentialError,
   isTokenExpired,
-  oauthConnectionAccessTokenPath,
   oauthConnectionRefreshTokenPath,
   persistRefreshedTokens,
   RefreshCircuitBreaker,
@@ -22,6 +21,7 @@ import {
   type SecureKeyBackend,
 } from "@vellumai/credential-storage";
 
+import { getConnectionAccessTokenResult } from "../oauth/credential-token-resolver.js";
 import {
   getApp,
   getConnection,
@@ -321,9 +321,13 @@ export async function withValidToken<T>(
     opts && typeof opts === "object"
       ? getConnection(opts.connectionId)
       : getConnectionByProvider(service, opts);
-  let token = conn
-    ? await getSecureKeyAsync(oauthConnectionAccessTokenPath(conn.id))
+  const tokenResult = conn
+    ? await getConnectionAccessTokenResult({
+        provider: conn.provider,
+        connectionId: conn.id,
+      })
     : undefined;
+  let token = tokenResult?.value;
   if (!token || !conn) {
     throw new TokenExpiredError(
       service,


### PR DESCRIPTION
## Summary
Fixes false `missing_token` credential health alerts caused by conflating "credential backend unreachable" with "token genuinely absent." Also prevents destructive manual-token reconciliation during CES unavailability and centralizes token-path resolution across all OAuth consumers.

## Self-review result
PASS — both plan faithfulness and repo integration reviews found no gaps.

## PRs merged into feature branch
- #28779: fix(credential-health): distinguish backend-unreachable from missing token
- #28781: fix(heartbeat): suppress transient credential health alerts
- #28780: fix(oauth): prevent manual-token reconciliation from deleting rows when backend is unreachable
- #28788: refactor(oauth): centralize access-token key resolution across OAuth and manual-token providers
- #28778: feat(secure-keys): audit credential writes and deletes

Closes JARVIS-581

Part of plan: cred-health-alert.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
