### PR TITLE
Add PersonalityGroup data model and tone type

### DIFF
--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -5,6 +5,7 @@ import { getWorkspacePromptPath } from "../util/platform.js";
 export interface OnboardingGreetingContext {
   tools: string[];
   tasks: string[];
+  /** Valid values: "grounded" | "warm" | "energetic" | "poetic" */
   tone: string;
   userName?: string;
   assistantName?: string;

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -1,3 +1,5 @@
+export type Tone = "grounded" | "warm" | "energetic" | "poetic";
+
 export interface OnboardingContext {
   tools: string[];
   tasks: string[];

--- a/clients/shared/Models/PersonalityGroup.swift
+++ b/clients/shared/Models/PersonalityGroup.swift
@@ -1,0 +1,48 @@
+/// A personality cluster that groups assistant names by communication style.
+public struct PersonalityGroup: Sendable {
+    public let id: String
+    public let label: String
+    public let descriptor: String
+    public let names: [String]
+
+    /// The four built-in personality groups.
+    public static let allGroups: [PersonalityGroup] = [
+        PersonalityGroup(
+            id: "grounded",
+            label: "Grounded",
+            descriptor: "Calm and precise",
+            names: ["Pax", "Sage", "Atlas", "Orion", "Rune", "Quill"]
+        ),
+        PersonalityGroup(
+            id: "warm",
+            label: "Warm",
+            descriptor: "Warm and easy",
+            names: ["Kit", "Pip", "Remy", "Wren", "Lark", "Milo", "Cleo"]
+        ),
+        PersonalityGroup(
+            id: "energetic",
+            label: "Energetic",
+            descriptor: "Fast and direct",
+            names: ["Nova", "Ember", "Ziggy", "Bodhi", "Vela", "Onyx"]
+        ),
+        PersonalityGroup(
+            id: "poetic",
+            label: "Poetic",
+            descriptor: "Quiet and observant",
+            names: ["Luna", "Iris", "Vesper", "Echo", "Juno", "Ada"]
+        ),
+    ]
+
+    /// The default personality group identifier.
+    public static let defaultGroupID = "grounded"
+
+    /// All assistant names across every personality group.
+    public static var allNames: [String] {
+        allGroups.flatMap(\.names)
+    }
+
+    /// Returns the personality group that contains the given name, or `nil`.
+    public static func groupForName(_ name: String) -> PersonalityGroup? {
+        allGroups.first { $0.names.contains(name) }
+    }
+}


### PR DESCRIPTION
## Summary
- Add PersonalityGroup Swift model with four personality clusters (grounded/warm/energetic/poetic) and name assignments
- Add Tone type alias to TypeScript onboarding-context
- Document new tone values on OnboardingGreetingContext interface

Part of plan: personality-group-names.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
