### PR TITLE
bootstrap: enforce file_edit for structured writes, not remember

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -44,6 +44,8 @@ SOUL.md captures communication style. Be specific: "lowercase, drops punctuation
 
 The current contents of all three files are in your system prompt — use that exact text as `old_string`.
 
+Use `file_edit` for any structured write (IDENTITY.md, SOUL.md, user profile). Don't use `remember` as a substitute — `remember` goes to the knowledge base, not to the files the platform tracks. Names, emoji, and tagline all go in IDENTITY.md via `file_edit`.
+
 ## Next steps, when they come up
 
 If finishing the current task naturally points to something bigger — connecting an inbox, working inside Slack, drafting in their voice — mention it then. As the obvious next move, not an upsell. They take it or leave it.


### PR DESCRIPTION
## Summary
- Adds file_edit discipline guidance to Learning as byproduct section
- Clarifies that file_edit (not remember) is for IDENTITY.md, SOUL.md, and user profile writes
- remember is for the knowledge base only

Part of plan: bootstrap-behavioral-spec.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
