### PR TITLE
fix(macos): use purgeable-aware free space for disk-pressure banner

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -118,7 +118,6 @@ extension AppDelegate {
         let assistant = loadAssistantFromLockfile()
 
         configureDaemonTransport(for: assistant)
-        services.diskPressureMonitor.refreshForCurrentAssistant()
 
         // Set recovery credentials for automatic 401 re-bootstrap
         connectionManager.recoveryPlatform = "macos"
@@ -150,7 +149,6 @@ extension AppDelegate {
         // Rebind the menu bar icon observer after transport reconfiguration
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()
-        rebindDiskPressureConnectionObserver()
 
         // Observe the managed-assistant-gone signal (health check 404) once
         // per setup so a retired/deleted platform assistant no longer leaves
@@ -192,7 +190,6 @@ extension AppDelegate {
                 log.info("setupGatewayConnectionManager: skipping connect() — isConnected=\(self.connectionManager.isConnected), isConnecting=\(self.connectionManager.isConnecting)")
             }
             if connectionManager.isConnected {
-                services.diskPressureMonitor.connectionStateChanged(isConnected: true)
                 setupAmbientAgent()
                 refreshAppsCache()
                 refreshSkillsCache()
@@ -203,17 +200,6 @@ extension AppDelegate {
     }
 
     // MARK: - SSE Event Subscription
-
-    func rebindDiskPressureConnectionObserver() {
-        diskPressureConnectionTask?.cancel()
-        diskPressureConnectionTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            for await isConnected in self.connectionManager.isConnectedStream {
-                guard !Task.isCancelled else { break }
-                self.services.diskPressureMonitor.connectionStateChanged(isConnected: isConnected)
-            }
-        }
-    }
 
     /// Subscribe to the event stream and dispatch events to their handlers.
     /// Each event type is handled in a single switch statement.

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -156,7 +156,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// (e.g. the async batch STT fallback completing after the user already sent).
     var voiceTranscriptionConsumed = false
     var connectionStatusTask: Task<Void, Never>?
-    var diskPressureConnectionTask: Task<Void, Never>?
     var quickInputAttachmentCancellable: AnyCancellable?
     var avatarChangeObserver: NSObjectProtocol?
     /// Cached circular avatar image for the menu bar icon. Invalidated only
@@ -835,7 +834,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         tearDownSleepWakeHandlers()
         NSApp.dockTile.badgeLabel = nil
         connectionStatusTask?.cancel()
-        diskPressureConnectionTask?.cancel()
         services.diskPressureMonitor.stop()
         statusDotLayer?.removeAllAnimations()
         statusDotLayer?.removeFromSuperlayer()

--- a/clients/macos/vellum-assistant/App/AppServices.swift
+++ b/clients/macos/vellum-assistant/App/AppServices.swift
@@ -28,11 +28,7 @@ public final class AppServices {
     public init() {
         let connectionManager = GatewayConnectionManager()
         self.connectionManager = connectionManager
-        diskPressureMonitor = DiskPressureMonitor(
-            isConnectedProvider: { [weak connectionManager] in
-                connectionManager?.isConnected ?? false
-            }
-        )
+        diskPressureMonitor = DiskPressureMonitor()
     }
 
     /// Reconfigure the connection for a new assistant.

--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -15,17 +15,15 @@ struct DiskPressureAlert: Equatable, Sendable {
 @MainActor
 @Observable
 final class DiskPressureMonitor {
-    typealias HealthzFetcher = @Sendable () async throws -> DaemonHealthz?
+    typealias UsageFractionFetcher = @Sendable () -> Double?
     typealias ActiveAssistantIdProvider = @MainActor () -> String?
-    typealias ConnectedProvider = @MainActor () -> Bool
 
     static let triggerUsageFraction = 0.85
     /// Keep the banner visible until usage drops comfortably below the trigger.
     static let resolveUsageFraction = 0.80
 
-    private let fetchHealthz: HealthzFetcher
+    private let fetchUsageFraction: UsageFractionFetcher
     private let activeAssistantIdProvider: ActiveAssistantIdProvider
-    private let isConnectedProvider: ConnectedProvider
     private let notificationCenter: NotificationCenter
     private let cadenceNanoseconds: UInt64
 
@@ -34,38 +32,26 @@ final class DiskPressureMonitor {
     @ObservationIgnored private var activeAssistantId: String?
     @ObservationIgnored private var alertCycle = 0
     @ObservationIgnored private var started = false
-    @ObservationIgnored private var refreshTask: Task<Void, Never>?
     @ObservationIgnored private var cadenceTask: Task<Void, Never>?
     @ObservationIgnored private var appActivationObserver: NSObjectProtocol?
     @ObservationIgnored private var activeAssistantObserver: NSObjectProtocol?
 
     init(
-        fetchHealthz: @escaping HealthzFetcher = {
-            let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
-                timeout: 10
-            ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
-            return decoded
-        },
+        fetchUsageFraction: @escaping UsageFractionFetcher = { Self.defaultUsageFraction() },
         activeAssistantIdProvider: @escaping ActiveAssistantIdProvider = {
             LockfileAssistant.loadActiveAssistantId()
-        },
-        isConnectedProvider: @escaping ConnectedProvider = {
-            AppDelegate.shared?.connectionManager.isConnected ?? false
         },
         notificationCenter: NotificationCenter = .default,
         cadenceNanoseconds: UInt64 = 60_000_000_000
     ) {
-        self.fetchHealthz = fetchHealthz
+        self.fetchUsageFraction = fetchUsageFraction
         self.activeAssistantIdProvider = activeAssistantIdProvider
-        self.isConnectedProvider = isConnectedProvider
         self.notificationCenter = notificationCenter
         self.cadenceNanoseconds = cadenceNanoseconds
         self.activeAssistantId = activeAssistantIdProvider()
     }
 
     deinit {
-        refreshTask?.cancel()
         cadenceTask?.cancel()
         if let appActivationObserver {
             notificationCenter.removeObserver(appActivationObserver)
@@ -107,12 +93,12 @@ final class DiskPressureMonitor {
                 self.refreshForCurrentAssistant()
             }
         }
+
+        refreshForCurrentAssistant()
     }
 
     func stop() {
         started = false
-        refreshTask?.cancel()
-        refreshTask = nil
         cadenceTask?.cancel()
         cadenceTask = nil
         clearAlert()
@@ -127,67 +113,15 @@ final class DiskPressureMonitor {
         }
     }
 
-    func connectionStateChanged(isConnected: Bool) {
-        if isConnected {
-            refreshForCurrentAssistant()
-        } else {
-            refreshTask?.cancel()
-            refreshTask = nil
-            clearAlert()
-        }
-    }
-
     func refreshForCurrentAssistant() {
         let assistantId = activeAssistantIdProvider()
+        applyUsageFraction(fetchUsageFraction(), assistantId: assistantId)
+    }
+
+    func applyUsageFraction(_ usageFraction: Double?, assistantId: String?) {
         updateActiveAssistant(assistantId)
 
-        guard isConnectedProvider(), assistantId != nil else {
-            refreshTask?.cancel()
-            refreshTask = nil
-            clearAlert()
-            return
-        }
-
-        refreshTask?.cancel()
-        refreshTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            await self.fetchAndApplyHealthz(for: assistantId)
-        }
-    }
-
-    func applyHealthz(_ healthz: DaemonHealthz?, assistantId: String?) {
-        updateActiveAssistant(assistantId)
-
-        guard let assistantId, let disk = healthz?.disk else {
-            clearAlert()
-            return
-        }
-
-        applyDiskInfo(disk, assistantId: assistantId)
-    }
-
-    private func fetchAndApplyHealthz(for assistantId: String?) async {
-        do {
-            let healthz = try await fetchHealthz()
-            guard !Task.isCancelled else { return }
-            applyHealthz(healthz, assistantId: assistantId)
-        } catch {
-            guard !Task.isCancelled else { return }
-            log.debug("Disk-pressure healthz refresh failed: \(error.localizedDescription, privacy: .public)")
-            applyHealthz(nil, assistantId: assistantId)
-        }
-    }
-
-    private func updateActiveAssistant(_ assistantId: String?) {
-        guard activeAssistantId != assistantId else { return }
-        activeAssistantId = assistantId
-        refreshTask?.cancel()
-        refreshTask = nil
-        clearAlert()
-    }
-
-    private func applyDiskInfo(_ disk: DaemonHealthz.DiskInfo, assistantId: String) {
-        guard let usageFraction = Self.usageFraction(for: disk) else {
+        guard let assistantId, let usageFraction, usageFraction.isFinite else {
             clearAlert()
             return
         }
@@ -210,16 +144,42 @@ final class DiskPressureMonitor {
         }
     }
 
+    private func updateActiveAssistant(_ assistantId: String?) {
+        guard activeAssistantId != assistantId else { return }
+        activeAssistantId = assistantId
+        clearAlert()
+    }
+
     private func clearAlert() {
         guard alert != nil else { return }
         alert = nil
     }
 
-    static func usageFraction(for disk: DaemonHealthz.DiskInfo) -> Double? {
-        guard disk.totalMb > 0, disk.usedMb.isFinite, disk.totalMb.isFinite else {
+    /// Reads the home volume's usage fraction using
+    /// `volumeAvailableCapacityForImportantUsageKey`, the Apple-recommended
+    /// signal that matches what System Settings → Storage and Finder show.
+    /// Accounts for purgeable space (Time Machine local snapshots, evictable
+    /// iCloud cache) that macOS reclaims under pressure, so the banner agrees
+    /// with the user's perceived free space rather than the strict raw-FS
+    /// reading from `statfs(2)`.
+    static func defaultUsageFraction() -> Double? {
+        let url = VellumPaths.current.homeDirectory
+        guard let values = try? url.resourceValues(forKeys: [
+            .volumeTotalCapacityKey,
+            .volumeAvailableCapacityForImportantUsageKey,
+        ]),
+              let total = values.volumeTotalCapacity,
+              total > 0,
+              let importantAvailable = values.volumeAvailableCapacityForImportantUsage
+        else {
+            log.debug("Disk-pressure: failed to read volume capacity for home directory")
             return nil
         }
-        return disk.usedMb / disk.totalMb
+        let totalBytes = Double(total)
+        let availableBytes = Double(importantAvailable)
+        guard totalBytes.isFinite, availableBytes.isFinite, totalBytes > 0 else { return nil }
+        let usedBytes = max(0.0, totalBytes - availableBytes)
+        return min(1.0, usedBytes / totalBytes)
     }
 
     static func displayPercent(forUsageFraction usageFraction: Double) -> Int {

--- a/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
+++ b/clients/macos/vellum-assistantTests/DiskPressureMonitorTests.swift
@@ -6,7 +6,7 @@ final class DiskPressureMonitorTests: XCTestCase {
     func testPressureTriggersAtEightyFivePercent() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 85, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.85, assistantId: "assistant-a")
 
         XCTAssertEqual(monitor.alert?.assistantId, "assistant-a")
         XCTAssertEqual(monitor.alert?.displayPercent, 85)
@@ -16,7 +16,7 @@ final class DiskPressureMonitorTests: XCTestCase {
     func testPressureDoesNotTriggerBelowEightyFivePercent() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 84.9, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.849, assistantId: "assistant-a")
 
         XCTAssertNil(monitor.alert)
     }
@@ -24,14 +24,14 @@ final class DiskPressureMonitorTests: XCTestCase {
     func testPressureResolvesOnlyBelowEightyPercent() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.95, assistantId: "assistant-a")
         let initialAlertId = monitor.alert?.id
-        monitor.applyHealthz(healthz(usedMb: 80, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.80, assistantId: "assistant-a")
 
         XCTAssertEqual(monitor.alert?.id, initialAlertId)
         XCTAssertEqual(monitor.alert?.displayPercent, 80)
 
-        monitor.applyHealthz(healthz(usedMb: 79.9, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.799, assistantId: "assistant-a")
 
         XCTAssertNil(monitor.alert)
     }
@@ -39,11 +39,11 @@ final class DiskPressureMonitorTests: XCTestCase {
     func testNewAlertCycleUsesStableNewId() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.95, assistantId: "assistant-a")
         XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:1")
 
-        monitor.applyHealthz(healthz(usedMb: 70, totalMb: 100), assistantId: "assistant-a")
-        monitor.applyHealthz(healthz(usedMb: 91, totalMb: 100), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.70, assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.91, assistantId: "assistant-a")
 
         XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-a:2")
     }
@@ -51,53 +51,46 @@ final class DiskPressureMonitorTests: XCTestCase {
     func testAssistantSwitchClearsStaleAlertAndScopesNextId() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-b")
+        monitor.applyUsageFraction(0.95, assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.95, assistantId: "assistant-b")
 
         XCTAssertEqual(monitor.alert?.assistantId, "assistant-b")
         XCTAssertEqual(monitor.alert?.id, "disk-pressure:assistant-b:2")
     }
 
-    func testUnreachableOrMissingDiskMetricsClearsAlert() {
+    func testNilUsageFractionClearsAlert() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
-        monitor.applyHealthz(nil, assistantId: "assistant-a")
-        XCTAssertNil(monitor.alert)
+        monitor.applyUsageFraction(0.95, assistantId: "assistant-a")
+        monitor.applyUsageFraction(nil, assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
-        monitor.applyHealthz(DaemonHealthz(status: "ok"), assistantId: "assistant-a")
         XCTAssertNil(monitor.alert)
     }
 
-    func testInvalidDiskTotalClearsAlert() {
+    func testNilAssistantIdClearsAlert() {
         let monitor = makeMonitor(assistantId: "assistant-a")
 
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 100), assistantId: "assistant-a")
-        monitor.applyHealthz(healthz(usedMb: 95, totalMb: 0), assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.95, assistantId: "assistant-a")
+        monitor.applyUsageFraction(0.95, assistantId: nil)
+
+        XCTAssertNil(monitor.alert)
+    }
+
+    func testNonFiniteUsageFractionClearsAlert() {
+        let monitor = makeMonitor(assistantId: "assistant-a")
+
+        monitor.applyUsageFraction(0.95, assistantId: "assistant-a")
+        monitor.applyUsageFraction(.nan, assistantId: "assistant-a")
 
         XCTAssertNil(monitor.alert)
     }
 
     private func makeMonitor(assistantId: String) -> DiskPressureMonitor {
         DiskPressureMonitor(
-            fetchHealthz: { nil },
+            fetchUsageFraction: { nil },
             activeAssistantIdProvider: { assistantId },
-            isConnectedProvider: { true },
             notificationCenter: NotificationCenter(),
             cadenceNanoseconds: 1_000_000_000
-        )
-    }
-
-    private func healthz(usedMb: Double, totalMb: Double) -> DaemonHealthz {
-        DaemonHealthz(
-            status: "ok",
-            disk: DaemonHealthz.DiskInfo(
-                path: "/workspace",
-                totalMb: totalMb,
-                usedMb: usedMb,
-                freeMb: max(totalMb - usedMb, 0)
-            )
         )
     }
 }


### PR DESCRIPTION
## Summary
- macOS disk-pressure banner now reads `volumeAvailableCapacityForImportantUsageKey` (the API System Settings/Finder use) instead of the daemon's strict `statfs(2)` reading. Time Machine local snapshots and evictable iCloud cache no longer count against you.
- Drops the daemon health-poll path entirely for this banner: no more 60s HTTP ticks, no connection-state coupling. The Settings → Storage panel still reads daemon healthz (raw-FS) on user action — that's the right signal there.
- Trims the now-dead plumbing: `connectionStateChanged()`, `rebindDiskPressureConnectionObserver()`, `diskPressureConnectionTask`, and the redundant `refreshForCurrentAssistant()` in `setupGatewayConnectionManager`.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
