### PR TITLE
mem(v2): add activation telemetry table

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -110,6 +110,7 @@ import {
   migrateMemoryGraphImageRefs,
   migrateMemoryItemSupersession,
   migrateMemoryRecallLogsQueryContext,
+  migrateMemoryV2ActivationLogs,
   migrateMessagesConversationCreatedAtIndex,
   migrateMessagesFtsBackfill,
   migrateNormalizePhoneIdentities,
@@ -392,6 +393,7 @@ export function initializeDb(): void {
     migrate230AcpSessionHistory,
     migrate231RepairMemoryGraphEventDates,
     migrateActivationState,
+    migrateMemoryV2ActivationLogs,
     migrateCreateDocumentConversations,
     function migrateBackfillAppConversationIds() {
       backfillAppConversationIds();

--- a/assistant/src/memory/migrations/234-memory-v2-activation-logs.ts
+++ b/assistant/src/memory/migrations/234-memory-v2-activation-logs.ts
@@ -1,0 +1,55 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_memory_v2_activation_logs_v1";
+
+/**
+ * Create the memory_v2_activation_logs table for per-turn v2 activation
+ * telemetry.
+ *
+ * Each row captures one activation pass keyed by (conversation, turn, mode):
+ * - mode is "context-load" (initial conversation hydration) or "per-turn"
+ *   (each subsequent agent turn).
+ * - concepts_json / skills_json hold the structured activation outputs.
+ * - config_json captures the resolved config snapshot used for the pass so
+ *   the inspector can reproduce activation conditions.
+ *
+ * Indexes mirror the access patterns used by the inspector tab: lookup by
+ * message_id, by conversation_id, and ordering by created_at.
+ */
+export function migrateMemoryV2ActivationLogs(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS memory_v2_activation_logs (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        message_id TEXT,
+        turn INTEGER NOT NULL,
+        mode TEXT NOT NULL,
+        concepts_json TEXT NOT NULL,
+        skills_json TEXT NOT NULL,
+        config_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_message_id
+        ON memory_v2_activation_logs (message_id)
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_conversation_id
+        ON memory_v2_activation_logs (conversation_id)
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_memory_v2_activation_logs_created_at
+        ON memory_v2_activation_logs (created_at)
+    `);
+  });
+}
+
+export function downMemoryV2ActivationLogs(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS memory_v2_activation_logs`);
+}

--- a/assistant/src/memory/migrations/__tests__/234-memory-v2-activation-logs.test.ts
+++ b/assistant/src/memory/migrations/__tests__/234-memory-v2-activation-logs.test.ts
@@ -1,0 +1,182 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../../db-connection.js";
+import * as schema from "../../schema.js";
+import {
+  downMemoryV2ActivationLogs,
+  migrateMemoryV2ActivationLogs,
+} from "../234-memory-v2-activation-logs.js";
+
+interface TableRow {
+  name: string;
+}
+
+interface IndexRow {
+  name: string;
+}
+
+interface ColumnRow {
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapCheckpointsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+const EXPECTED_INDEXES = [
+  "idx_memory_v2_activation_logs_message_id",
+  "idx_memory_v2_activation_logs_conversation_id",
+  "idx_memory_v2_activation_logs_created_at",
+];
+
+describe("memory_v2_activation_logs migration", () => {
+  test("creates table with expected columns and indexes", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateMemoryV2ActivationLogs(db);
+
+    const tableRow = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v2_activation_logs'`,
+      )
+      .get() as TableRow | null;
+    expect(tableRow?.name).toBe("memory_v2_activation_logs");
+
+    const columns = raw
+      .query(`PRAGMA table_info(memory_v2_activation_logs)`)
+      .all() as ColumnRow[];
+    const byName = new Map(columns.map((c) => [c.name, c]));
+
+    expect(byName.get("id")?.pk).toBe(1);
+    expect(byName.get("id")?.type).toBe("TEXT");
+    expect(byName.get("conversation_id")?.notnull).toBe(1);
+    expect(byName.get("conversation_id")?.type).toBe("TEXT");
+    expect(byName.get("message_id")?.notnull).toBe(0);
+    expect(byName.get("message_id")?.type).toBe("TEXT");
+    expect(byName.get("turn")?.notnull).toBe(1);
+    expect(byName.get("turn")?.type).toBe("INTEGER");
+    expect(byName.get("mode")?.notnull).toBe(1);
+    expect(byName.get("mode")?.type).toBe("TEXT");
+    expect(byName.get("concepts_json")?.notnull).toBe(1);
+    expect(byName.get("concepts_json")?.type).toBe("TEXT");
+    expect(byName.get("skills_json")?.notnull).toBe(1);
+    expect(byName.get("skills_json")?.type).toBe("TEXT");
+    expect(byName.get("config_json")?.notnull).toBe(1);
+    expect(byName.get("config_json")?.type).toBe("TEXT");
+    expect(byName.get("created_at")?.notnull).toBe(1);
+    expect(byName.get("created_at")?.type).toBe("INTEGER");
+
+    const indexes = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='memory_v2_activation_logs'`,
+      )
+      .all() as IndexRow[];
+    const indexNames = new Set(indexes.map((r) => r.name));
+    for (const expected of EXPECTED_INDEXES) {
+      expect(indexNames.has(expected)).toBe(true);
+    }
+  });
+
+  test("re-running the migration is a no-op", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateMemoryV2ActivationLogs(db);
+
+    raw
+      .query(
+        /*sql*/ `
+        INSERT INTO memory_v2_activation_logs (
+          id,
+          conversation_id,
+          message_id,
+          turn,
+          mode,
+          concepts_json,
+          skills_json,
+          config_json,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      )
+      .run(
+        "log-1",
+        "conv-abc",
+        "msg-xyz",
+        3,
+        "per-turn",
+        "[]",
+        "[]",
+        "{}",
+        1000,
+      );
+
+    expect(() => migrateMemoryV2ActivationLogs(db)).not.toThrow();
+
+    const row = raw
+      .query(`SELECT id FROM memory_v2_activation_logs WHERE id = 'log-1'`)
+      .get() as { id: string } | null;
+    expect(row?.id).toBe("log-1");
+
+    const indexes = raw
+      .query(
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='memory_v2_activation_logs'`,
+      )
+      .all() as IndexRow[];
+    const indexNames = new Set(indexes.map((r) => r.name));
+    for (const expected of EXPECTED_INDEXES) {
+      expect(indexNames.has(expected)).toBe(true);
+    }
+  });
+
+  test("down() drops the table and is idempotent", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+
+    migrateMemoryV2ActivationLogs(db);
+
+    expect(
+      raw
+        .query(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v2_activation_logs'`,
+        )
+        .get(),
+    ).toBeTruthy();
+
+    downMemoryV2ActivationLogs(db);
+
+    expect(
+      raw
+        .query(
+          `SELECT name FROM sqlite_master WHERE type='table' AND name='memory_v2_activation_logs'`,
+        )
+        .get(),
+    ).toBeNull();
+
+    expect(() => downMemoryV2ActivationLogs(db)).not.toThrow();
+  });
+});

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -183,6 +183,10 @@ export {
 } from "./232-activation-state.js";
 export { migrateCreateDocumentConversations } from "./233-document-conversations.js";
 export {
+  downMemoryV2ActivationLogs,
+  migrateMemoryV2ActivationLogs,
+} from "./234-memory-v2-activation-logs.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -44,6 +44,7 @@ import { migrateScrubCorruptedImageAttachmentsDown } from "./206-scrub-corrupted
 import { downConversationHostAccess } from "./217-conversation-host-access.js";
 import { downNormalizeUserFileByPrincipal } from "./220-normalize-user-file-by-principal.js";
 import { downActivationState } from "./232-activation-state.js";
+import { downMemoryV2ActivationLogs } from "./234-memory-v2-activation-logs.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -379,6 +380,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     version: 43,
     description: "Create activation_state table for memory v2",
     down: downActivationState,
+  },
+  {
+    key: "migration_memory_v2_activation_logs_v1",
+    version: 44,
+    description:
+      "Create memory_v2_activation_logs table for per-turn v2 activation telemetry consumed by the LLM Context Inspector",
+    down: downMemoryV2ActivationLogs,
   },
 ];
 

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -161,6 +161,28 @@ export const memoryRecallLogs = sqliteTable(
   ],
 );
 
+export const memoryV2ActivationLogs = sqliteTable(
+  "memory_v2_activation_logs",
+  {
+    id: text("id").primaryKey(),
+    conversationId: text("conversation_id").notNull(),
+    messageId: text("message_id"),
+    turn: integer("turn").notNull(),
+    mode: text("mode").notNull(), // "context-load" | "per-turn"
+    conceptsJson: text("concepts_json").notNull(),
+    skillsJson: text("skills_json").notNull(),
+    configJson: text("config_json").notNull(),
+    createdAt: integer("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_memory_v2_activation_logs_message_id").on(table.messageId),
+    index("idx_memory_v2_activation_logs_conversation_id").on(
+      table.conversationId,
+    ),
+    index("idx_memory_v2_activation_logs_created_at").on(table.createdAt),
+  ],
+);
+
 export const llmUsageEvents = sqliteTable(
   "llm_usage_events",
   {


### PR DESCRIPTION
## Summary
- New `memory_v2_activation_logs` SQLite table for per-turn v2 telemetry
- Migration 234 with crash-recovery checkpoint, registry entry for rollback
- Unit test asserting idempotent re-run

Part of plan: memory-v2-inspector-tab.md (PR 1 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
