### PR TITLE
feat(config): add `source`, `label`, and `description` fields to inference profile schema

### DIFF
--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import {
   type LLMCallSite,
   LLMConfigBase,
-  type LLMConfigFragment,
   type LLMSchema,
+  type ProfileEntry,
 } from "./schemas/llm.js";
 
 /**
@@ -59,7 +59,7 @@ export function resolveCallSiteConfig(
   const site = llm.callSites?.[callSite];
   if (site != null) {
     if (site.profile != null) {
-      const profileFragment: LLMConfigFragment | undefined =
+      const profileFragment: ProfileEntry | undefined =
         llm.profiles?.[site.profile];
       if (profileFragment == null) {
         // Defensive: `LLMSchema.superRefine` already rejects unknown profile

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -34,6 +34,7 @@ export type {
   LLMConfig,
   LLMConfigBase,
   LLMConfigFragment,
+  ProfileEntry,
 } from "./schemas/llm.js";
 export { LLMCallSiteEnum, LLMSchema } from "./schemas/llm.js";
 export type { AuditLogConfig, LogFileConfig } from "./schemas/logging.js";

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -246,6 +246,17 @@ const OpenRouterDeepPartialSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Profile metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Distinguishes daemon-managed profiles (overwritten on every startup) from
+ * user-created ones (never touched by the daemon).
+ */
+export const ProfileSource = z.enum(["managed", "user"]);
+export type ProfileSource = z.infer<typeof ProfileSource>;
+
+// ---------------------------------------------------------------------------
 // Pricing overrides
 // ---------------------------------------------------------------------------
 
@@ -298,6 +309,9 @@ export const LLMConfigFragment = z.object({
   thinking: ThinkingFragmentSchema.optional(),
   contextWindow: ContextWindowDeepPartialSchema.optional(),
   openrouter: OpenRouterDeepPartialSchema.optional(),
+  source: ProfileSource.optional(),
+  label: z.string().min(1).optional(),
+  description: z.string().optional(),
 });
 export type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
 

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -309,11 +309,21 @@ export const LLMConfigFragment = z.object({
   thinking: ThinkingFragmentSchema.optional(),
   contextWindow: ContextWindowDeepPartialSchema.optional(),
   openrouter: OpenRouterDeepPartialSchema.optional(),
+});
+export type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
+
+/**
+ * A named profile entry: an `LLMConfigFragment` augmented with
+ * presentation/ownership metadata. These fields are intentionally kept off
+ * `LLMConfigFragment` so they don't leak into `LLMCallSiteConfig` or the
+ * resolver's deep-merge output.
+ */
+export const ProfileEntry = LLMConfigFragment.extend({
   source: ProfileSource.optional(),
   label: z.string().min(1).optional(),
   description: z.string().optional(),
 });
-export type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
+export type ProfileEntry = z.infer<typeof ProfileEntry>;
 
 /**
  * Per-call-site config: a fragment plus an optional `profile` reference.
@@ -332,7 +342,7 @@ export type LLMCallSiteConfig = z.infer<typeof LLMCallSiteConfig>;
 export const LLMSchema = z
   .object({
     default: LLMConfigBase.default(LLMConfigBase.parse({})),
-    profiles: z.record(z.string().min(1), LLMConfigFragment).default({}),
+    profiles: z.record(z.string().min(1), ProfileEntry).default({}),
     // Presentation-only order for named profiles. The resolver ignores this;
     // clients use it to render profile pickers consistently.
     profileOrder: z.array(z.string().min(1)).default([]),

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -25,7 +25,7 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import { LLMConfigFragment } from "../../config/schemas/llm.js";
+import { ProfileEntry } from "../../config/schemas/llm.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
 import { getConfigWatcher } from "../../daemon/config-watcher.js";
@@ -299,7 +299,7 @@ function handleReplaceInferenceProfile({
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new BadRequestError("Body must be a JSON object");
   }
-  const parsed = LLMConfigFragment.safeParse(body);
+  const parsed = ProfileEntry.safeParse(body);
   if (!parsed.success) {
     const detail = parsed.error.issues.map((issue) => issue.message).join("; ");
     throw new BadRequestError(`Invalid profile fragment: ${detail}`);


### PR DESCRIPTION
## Summary
- Add ProfileSource enum (managed | user) to LLM config schema
- Add optional source, label, and description fields to LLMConfigFragment
- These metadata fields enable declarative profile seeding (managed profiles overwritten on startup, user profiles never touched)

Part of plan: declarative-profile-seed.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
