### PR TITLE
Vary first greeting voice based on personality tone

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -298,4 +298,108 @@ describe("first-greeting", () => {
       expect(greeting).not.toContain("\n\n\n");
     });
   });
+
+  describe("tone-specific greetings", () => {
+    const base: OnboardingGreetingContext = {
+      tools: ["github", "linear"],
+      tasks: ["code-building"],
+      tone: "balanced",
+      userName: "Bob",
+      assistantName: "Pip",
+    };
+
+    it("grounded tone produces direct, calm intro", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "grounded" });
+      expect(greeting).toContain("Bob.");
+      expect(greeting).toContain(
+        "I'm Pip. Brand new, and I'll get sharper the more we work together.",
+      );
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("warm tone uses casual phrasing", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "warm" });
+      expect(greeting).toContain("Hey Bob!");
+      expect(greeting).toContain("hang out");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("energetic tone is punchy", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "energetic" });
+      expect(greeting).toContain("Bob!");
+      expect(greeting).toContain("let's get into it");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("poetic tone is softer", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "poetic" });
+      expect(greeting).toContain("Hello, Bob.");
+      expect(greeting).toContain("grow alongside you");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("balanced tone falls back to generic intro", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "balanced" });
+      expect(greeting).toContain("Hey Bob, I'm Pip.");
+      expect(greeting).toContain("I'll get sharper");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("unknown tone string falls back to generic intro", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "mysterious-future-tone",
+      });
+      expect(greeting).toContain("Hey Bob, I'm Pip.");
+      expect(greeting).toContain("I'll get sharper");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("each tone produces a distinct intro line", () => {
+      const tones = ["grounded", "warm", "energetic", "poetic"];
+      const intros = tones.map((tone) => {
+        const greeting = getCannedFirstGreeting({ ...base, tone });
+        return greeting.split("\n\n")[0];
+      });
+      const unique = new Set(intros);
+      expect(unique.size).toBe(tones.length);
+    });
+
+    it("warm tone without user name uses Hey!", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "warm",
+        userName: undefined,
+      });
+      expect(greeting).toStartWith("Hey! I'm Pip");
+    });
+
+    it("poetic tone without user name uses Hello.", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "poetic",
+        userName: undefined,
+      });
+      expect(greeting).toStartWith("Hello. I'm Pip");
+    });
+
+    it("grounded tone without user name omits greeting prefix", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "grounded",
+        userName: undefined,
+      });
+      expect(greeting).toStartWith("I'm Pip.");
+    });
+
+    it("tone-specific intro falls back to generic when no assistantName", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "warm",
+        assistantName: undefined,
+      });
+      expect(greeting).toContain("Hey Bob,");
+      expect(greeting).toContain("brand new");
+    });
+  });
 });

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -136,7 +136,46 @@ function highestPriorityTask(tasks: string[]): string | undefined {
   return tasks[0];
 }
 
-function buildIntroLine(userName?: string, assistantName?: string): string {
+const TONE_INTROS: Record<
+  string,
+  {
+    greeting: (userName?: string) => string;
+    selfIntro: (assistantName: string) => string;
+  }
+> = {
+  grounded: {
+    greeting: (u) => (u ? `${u}.` : ""),
+    selfIntro: (n) =>
+      `I'm ${n}. Brand new, and I'll get sharper the more we work together.`,
+  },
+  warm: {
+    greeting: (u) => (u ? `Hey ${u}!` : "Hey!"),
+    selfIntro: (n) =>
+      `I'm ${n} — brand new, but I'll get better the more we hang out.`,
+  },
+  energetic: {
+    greeting: (u) => (u ? `${u}!` : "Hey!"),
+    selfIntro: (n) => `I'm ${n}. Fresh start — let's get into it.`,
+  },
+  poetic: {
+    greeting: (u) => (u ? `Hello, ${u}.` : "Hello."),
+    selfIntro: (n) => `I'm ${n}. Still quite new — I'll grow alongside you.`,
+  },
+};
+
+function buildIntroLine(
+  userName?: string,
+  assistantName?: string,
+  tone?: string,
+): string {
+  const toneEntry = tone ? TONE_INTROS[tone] : undefined;
+
+  if (toneEntry && assistantName) {
+    const greetPart = toneEntry.greeting(userName);
+    const selfPart = toneEntry.selfIntro(assistantName);
+    return greetPart ? `${greetPart} ${selfPart}` : selfPart;
+  }
+
   const namepart = userName ? `Hey ${userName},` : "Hey,";
   const who = assistantName
     ? `I'm ${assistantName}. Brand new, and I'll get sharper the more we work together.`
@@ -199,7 +238,11 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
     return CANNED_FIRST_GREETING;
   }
 
-  const intro = buildIntroLine(hasName ? userName : undefined, assistantName);
+  const intro = buildIntroLine(
+    hasName ? userName : undefined,
+    assistantName,
+    ctx.tone,
+  );
 
   let secondParagraph: string;
 


### PR DESCRIPTION
## Summary
- Add TONE_INTROS map with distinct greeting and self-intro patterns per personality tone
- Update buildIntroLine() and buildPersonalizedGreeting() to use tone-specific phrasing
- Backwards-compatible: unrecognized tones (including legacy 'balanced') fall back to generic intro
- Add tests for all four tones plus legacy fallback

Part of plan: personality-group-names.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
