### PR TITLE
mem(v2): expose per-text similarity breakdowns from compute functions

### DIFF
--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -208,7 +208,12 @@ async function activationEvidence(
 
   const edgesIdx = await readEdges(context.workingDir);
   const { k, hops } = context.config.memory.v2;
-  const finalActivation = spreadActivation(ownActivation, edgesIdx, k, hops);
+  const { final: finalActivation } = spreadActivation(
+    ownActivation,
+    edgesIdx,
+    k,
+    hops,
+  );
 
   const ranked = [...finalActivation.entries()]
     .sort(([slugA, valA], [slugB, valB]) => {

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -324,7 +324,8 @@ describe("computeOwnActivation", () => {
       nowText: "now",
       config: makeConfig(),
     });
-    expect(out.size).toBe(0);
+    expect(out.activation.size).toBe(0);
+    expect(out.breakdown.size).toBe(0);
     expect(state.embedCalls).toHaveLength(0);
     expect(state.queryCalls).toHaveLength(0);
   });
@@ -357,7 +358,7 @@ describe("computeOwnActivation", () => {
       }),
     });
     // Expected: 0.3*0.6 + 0.3*0.5 + 0.2*0.4 + 0.2*0.2 = 0.18+0.15+0.08+0.04 = 0.45
-    expect(out.get("alice")).toBeCloseTo(0.45, 6);
+    expect(out.activation.get("alice")).toBeCloseTo(0.45, 6);
   });
 
   test("clamps over-1.0 results down to [0, 1]", async () => {
@@ -388,7 +389,7 @@ describe("computeOwnActivation", () => {
         c_now: 0.5,
       }),
     });
-    expect(out.get("alice")).toBe(1);
+    expect(out.activation.get("alice")).toBe(1);
   });
 
   test("missing prior state defaults `prev` to 0", async () => {
@@ -410,7 +411,7 @@ describe("computeOwnActivation", () => {
       }),
     });
     // 0.3*0 + 0.3*1 + 0.2*0 + 0.2*0 = 0.3
-    expect(out.get("fresh")).toBeCloseTo(0.3, 6);
+    expect(out.activation.get("fresh")).toBeCloseTo(0.3, 6);
   });
 
   test("candidate with no sim hits resolves to 0", async () => {
@@ -426,7 +427,60 @@ describe("computeOwnActivation", () => {
       nowText: "n",
       config: makeConfig(),
     });
-    expect(out.get("ghost")).toBe(0);
+    expect(out.activation.get("ghost")).toBe(0);
+  });
+
+  test("breakdown captures `d * prev` and the raw sims for each candidate", async () => {
+    stageHybridResponse([{ slug: "alice", denseScore: 0.5 }]); // simU
+    stageHybridResponse([{ slug: "alice", denseScore: 0.4 }]); // simA
+    stageHybridResponse([{ slug: "alice", denseScore: 0.2 }]); // simN
+
+    const priorState: ActivationState = {
+      messageId: "msg-1",
+      state: { alice: 0.6 },
+      everInjected: [],
+      currentTurn: 1,
+      updatedAt: 1,
+    };
+    const d = 0.3;
+    const out = await computeOwnActivation({
+      candidates: new Set(["alice"]),
+      priorState,
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig({
+        d,
+        c_user: 0.3,
+        c_assistant: 0.2,
+        c_now: 0.2,
+      }),
+    });
+    const breakdown = out.breakdown.get("alice");
+    expect(breakdown).toBeDefined();
+    // priorContribution is `d * prev`, not the weighted sim term.
+    expect(breakdown?.priorContribution).toBeCloseTo(d * 0.6, 6);
+    // Raw sims, captured before c_user / c_assistant / c_now weighting.
+    expect(breakdown?.simUser).toBeCloseTo(0.5, 6);
+    expect(breakdown?.simAssistant).toBeCloseTo(0.4, 6);
+    expect(breakdown?.simNow).toBeCloseTo(0.2, 6);
+  });
+
+  test("breakdown defaults priorContribution to 0 when priorState is null", async () => {
+    stageHybridResponse([{ slug: "fresh", denseScore: 0.5 }]);
+    stageHybridResponse([{ slug: "fresh", denseScore: 0.5 }]);
+    stageHybridResponse([{ slug: "fresh", denseScore: 0.5 }]);
+
+    const out = await computeOwnActivation({
+      candidates: new Set(["fresh"]),
+      priorState: null,
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig({ d: 0.9 }),
+    });
+    // No prior state → prev=0 → priorContribution=0 regardless of `d`.
+    expect(out.breakdown.get("fresh")?.priorContribution).toBe(0);
   });
 });
 
@@ -439,7 +493,7 @@ describe("spreadActivation", () => {
     const edges: EdgesIndex = { version: 1, edges: [] };
     const own = new Map([["alice", 0.7]]);
     const out = spreadActivation(own, edges, 0.5, 2);
-    expect(out.get("alice")).toBeCloseTo(0.7, 6);
+    expect(out.final.get("alice")).toBeCloseTo(0.7, 6);
   });
 
   test("symmetric two-node ring yields symmetric activation", () => {
@@ -453,9 +507,9 @@ describe("spreadActivation", () => {
     ]);
     const out = spreadActivation(own, edges, 0.5, 2);
     // Both nodes have one neighbor, equal own-activation → equal final A.
-    expect(out.get("alice")).toBeCloseTo(out.get("bob") ?? 0, 6);
+    expect(out.final.get("alice")).toBeCloseTo(out.final.get("bob") ?? 0, 6);
     // Numerator: 0.6 + 0.5*0.6 = 0.9. Denominator: 1 + 0.5*1 = 1.5. A = 0.6.
-    expect(out.get("alice")).toBeCloseTo(0.6, 6);
+    expect(out.final.get("alice")).toBeCloseTo(0.6, 6);
   });
 
   test("asymmetric two-node ring picks up neighbor activation", () => {
@@ -470,9 +524,9 @@ describe("spreadActivation", () => {
     const out = spreadActivation(own, edges, 0.5, 2);
     // alice: numerator = 0 + 0.5*0.8 = 0.4. denominator = 1 + 0.5 = 1.5.
     //        A = 0.2666...
-    expect(out.get("alice")).toBeCloseTo(0.4 / 1.5, 6);
+    expect(out.final.get("alice")).toBeCloseTo(0.4 / 1.5, 6);
     // bob:   numerator = 0.8 + 0.5*0 = 0.8. denominator = 1.5. A = 0.5333...
-    expect(out.get("bob")).toBeCloseTo(0.8 / 1.5, 6);
+    expect(out.final.get("bob")).toBeCloseTo(0.8 / 1.5, 6);
   });
 
   test("hops=2 reaches second-degree neighbors but stops there", () => {
@@ -497,7 +551,7 @@ describe("spreadActivation", () => {
     //   numerator   = 0 + 0.5*0 + 0.25*1.0 = 0.25
     //   denominator = 1 + 0.5*1 + 0.25*1   = 1.75
     //   A = 0.25 / 1.75 ≈ 0.142857
-    expect(out.get("alice")).toBeCloseTo(0.25 / 1.75, 6);
+    expect(out.final.get("alice")).toBeCloseTo(0.25 / 1.75, 6);
   });
 
   test("output is bounded in [0, 1] for arbitrary inputs", () => {
@@ -515,7 +569,7 @@ describe("spreadActivation", () => {
       ["carol", 1.0],
     ]);
     const out = spreadActivation(own, edges, 0.99, 2);
-    for (const [, value] of out) {
+    for (const [, value] of out.final) {
       expect(value).toBeGreaterThanOrEqual(0);
       expect(value).toBeLessThanOrEqual(1);
     }
@@ -531,8 +585,8 @@ describe("spreadActivation", () => {
       ["bob", 0.9],
     ]);
     const out = spreadActivation(own, edges, 0.5, 0);
-    expect(out.get("alice")).toBeCloseTo(0.4, 6);
-    expect(out.get("bob")).toBeCloseTo(0.9, 6);
+    expect(out.final.get("alice")).toBeCloseTo(0.4, 6);
+    expect(out.final.get("bob")).toBeCloseTo(0.9, 6);
   });
 
   test("k=0 collapses to A == A_o", () => {
@@ -545,8 +599,8 @@ describe("spreadActivation", () => {
       ["bob", 0.9],
     ]);
     const out = spreadActivation(own, edges, 0, 5);
-    expect(out.get("alice")).toBeCloseTo(0.4, 6);
-    expect(out.get("bob")).toBeCloseTo(0.9, 6);
+    expect(out.final.get("alice")).toBeCloseTo(0.4, 6);
+    expect(out.final.get("bob")).toBeCloseTo(0.9, 6);
   });
 
   test("missing neighbor activation contributes 0 to the numerator", () => {
@@ -560,7 +614,7 @@ describe("spreadActivation", () => {
     const own = new Map([["alice", 0.6]]);
     const out = spreadActivation(own, edges, 0.5, 2);
     // numerator = 0.6 + 0.5*0 = 0.6. denominator = 1 + 0.5*1 = 1.5.
-    expect(out.get("alice")).toBeCloseTo(0.4, 6);
+    expect(out.final.get("alice")).toBeCloseTo(0.4, 6);
   });
 
   test("empty own-activation map returns empty result", () => {
@@ -570,7 +624,55 @@ describe("spreadActivation", () => {
       0.5,
       2,
     );
-    expect(out.size).toBe(0);
+    expect(out.final.size).toBe(0);
+    expect(out.contribution.size).toBe(0);
+  });
+
+  test("contribution equals final - own for each slug", () => {
+    const edges: EdgesIndex = {
+      version: 1,
+      edges: [["alice", "bob"]],
+    };
+    const own = new Map([
+      ["alice", 0.0],
+      ["bob", 0.8],
+    ]);
+    const out = spreadActivation(own, edges, 0.5, 2);
+    for (const [slug, finalValue] of out.final) {
+      const ownValue = own.get(slug) ?? 0;
+      expect(out.contribution.get(slug)).toBeCloseTo(finalValue - ownValue, 6);
+    }
+    // alice gained spread; bob lost some (1-hop neighbor's 0 dilutes its 0.8).
+    expect(out.contribution.get("alice")).toBeGreaterThan(0);
+    expect(out.contribution.get("bob")).toBeLessThan(0);
+  });
+
+  test("contribution is 0 for every slug when hops == 0", () => {
+    const edges: EdgesIndex = {
+      version: 1,
+      edges: [["alice", "bob"]],
+    };
+    const own = new Map([
+      ["alice", 0.4],
+      ["bob", 0.9],
+    ]);
+    const out = spreadActivation(own, edges, 0.5, 0);
+    expect(out.contribution.get("alice")).toBe(0);
+    expect(out.contribution.get("bob")).toBe(0);
+  });
+
+  test("contribution is 0 for every slug when k == 0", () => {
+    const edges: EdgesIndex = {
+      version: 1,
+      edges: [["alice", "bob"]],
+    };
+    const own = new Map([
+      ["alice", 0.4],
+      ["bob", 0.9],
+    ]);
+    const out = spreadActivation(own, edges, 0, 5);
+    expect(out.contribution.get("alice")).toBe(0);
+    expect(out.contribution.get("bob")).toBe(0);
   });
 });
 
@@ -766,7 +868,8 @@ describe("computeSkillActivation", () => {
       nowText: "n",
       config: makeConfig(),
     });
-    expect(out.size).toBe(0);
+    expect(out.activation.size).toBe(0);
+    expect(out.breakdown.size).toBe(0);
     expect(state.embedCalls).toHaveLength(0);
     expect(state.queryCalls).toHaveLength(0);
   });
@@ -790,7 +893,7 @@ describe("computeSkillActivation", () => {
       }),
     });
     // No `d · prev` term: 0.3*0.5 + 0.2*0.4 + 0.2*0.2 = 0.15 + 0.08 + 0.04 = 0.27
-    expect(out.get("example-skill-a")).toBeCloseTo(0.27, 6);
+    expect(out.activation.get("example-skill-a")).toBeCloseTo(0.27, 6);
   });
 
   test("output excludes any decay term — d coefficient is unused", async () => {
@@ -824,8 +927,8 @@ describe("computeSkillActivation", () => {
     });
 
     // Both equal `0.3*0.4 + 0.2*0.4 + 0.2*0.4 = 0.28` — d is ignored.
-    expect(withHighD.get("alpha")).toBeCloseTo(0.28, 6);
-    expect(withZeroD.get("alpha")).toBeCloseTo(0.28, 6);
+    expect(withHighD.activation.get("alpha")).toBeCloseTo(0.28, 6);
+    expect(withZeroD.activation.get("alpha")).toBeCloseTo(0.28, 6);
   });
 
   test("clamps over-1.0 results down to [0, 1]", async () => {
@@ -846,7 +949,7 @@ describe("computeSkillActivation", () => {
         c_now: 0.5,
       }),
     });
-    expect(out.get("loud-skill")).toBe(1);
+    expect(out.activation.get("loud-skill")).toBe(1);
   });
 
   test("candidate with no sim hits resolves to 0", async () => {
@@ -861,7 +964,30 @@ describe("computeSkillActivation", () => {
       nowText: "n",
       config: makeConfig(),
     });
-    expect(out.get("ghost-skill")).toBe(0);
+    expect(out.activation.get("ghost-skill")).toBe(0);
+  });
+
+  test("breakdown captures the raw sims for each candidate", async () => {
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.5 }]); // simU
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.4 }]); // simA
+    stageSkillHybridResponse([{ id: "example-skill-a", denseScore: 0.2 }]); // simN
+
+    const out = await computeSkillActivation({
+      candidates: new Set(["example-skill-a"]),
+      userText: "u",
+      assistantText: "a",
+      nowText: "n",
+      config: makeConfig({
+        c_user: 0.3,
+        c_assistant: 0.2,
+        c_now: 0.2,
+      }),
+    });
+    const breakdown = out.breakdown.get("example-skill-a");
+    expect(breakdown).toBeDefined();
+    expect(breakdown?.simUser).toBeCloseTo(0.5, 6);
+    expect(breakdown?.simAssistant).toBeCloseTo(0.4, 6);
+    expect(breakdown?.simNow).toBeCloseTo(0.2, 6);
   });
 
   test("uses the dedicated skills collection and never queries concept pages", async () => {

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -150,7 +150,10 @@ mock.module("../activation.js", () => ({
   // injection logic introspects. Stub them to empty so the test stays focused
   // on the wiring, not the pipeline internals (covered in activation.test.ts).
   selectSkillCandidates: async () => new Set<string>(),
-  computeSkillActivation: async () => new Map<string, number>(),
+  computeSkillActivation: async () => ({
+    activation: new Map<string, number>(),
+    breakdown: new Map(),
+  }),
   selectSkillInjections: ({ topK }: { topK: number }) => ({
     topNow: skillState.topSkillIds.slice(0, topK),
   }),

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -130,23 +130,49 @@ export interface ComputeOwnActivationParams {
 }
 
 /**
+ * Per-slug breakdown of the own-activation inputs, captured before any
+ * coefficient weighting is applied. Surfaced for telemetry / inspector views
+ * so the UI can show how each term contributed to the final value.
+ */
+export interface OwnActivationBreakdown {
+  /** `d * prev(slug)` — the decayed prior-turn activation contribution. */
+  priorContribution: number;
+  /** Raw `sim(user, slug)` similarity, before `c_user` weighting. */
+  simUser: number;
+  /** Raw `sim(assistant, slug)` similarity, before `c_assistant` weighting. */
+  simAssistant: number;
+  /** Raw `sim(now, slug)` similarity, before `c_now` weighting. */
+  simNow: number;
+}
+
+export interface ComputeOwnActivationResult {
+  /** Final clamped own-activation value per slug. */
+  activation: Map<string, number>;
+  /** Per-slug breakdown of the inputs that fed into `activation`. */
+  breakdown: Map<string, OwnActivationBreakdown>;
+}
+
+/**
  * Apply the own-activation formula
  *   A_o(n) = d · prev(n) + c_user · sim_u + c_assistant · sim_a + c_now · sim_n
  * over the candidate set. Returns a sparse map keyed by slug; slugs whose
  * computed value rounds to 0 are still included so callers can see the
- * candidate set explicitly.
+ * candidate set explicitly. Also returns a per-slug breakdown of the raw
+ * inputs (decayed prior + raw sims) so callers can render contribution
+ * diagnostics without re-running the math.
  *
  * The three `simBatch` calls run concurrently — they hit independent named
  * vectors and embed independent query texts.
  */
 export async function computeOwnActivation(
   params: ComputeOwnActivationParams,
-): Promise<Map<string, number>> {
+): Promise<ComputeOwnActivationResult> {
   const { candidates, priorState, userText, assistantText, nowText, config } =
     params;
 
-  const result = new Map<string, number>();
-  if (candidates.size === 0) return result;
+  const activation = new Map<string, number>();
+  const breakdown = new Map<string, OwnActivationBreakdown>();
+  if (candidates.size === 0) return { activation, breakdown };
 
   const { d, c_user, c_assistant, c_now } = config.memory.v2;
   const slugList = [...candidates];
@@ -159,20 +185,38 @@ export async function computeOwnActivation(
 
   for (const slug of slugList) {
     const prev = priorState?.state[slug] ?? 0;
-    const value =
-      d * prev +
-      c_user * (simUser.get(slug) ?? 0) +
-      c_assistant * (simAssistant.get(slug) ?? 0) +
-      c_now * (simNow.get(slug) ?? 0);
-    result.set(slug, clampUnitInterval(value));
+    const simU = simUser.get(slug) ?? 0;
+    const simA = simAssistant.get(slug) ?? 0;
+    const simN = simNow.get(slug) ?? 0;
+    const value = d * prev + c_user * simU + c_assistant * simA + c_now * simN;
+    activation.set(slug, clampUnitInterval(value));
+    breakdown.set(slug, {
+      priorContribution: d * prev,
+      simUser: simU,
+      simAssistant: simA,
+      simNow: simN,
+    });
   }
 
-  return result;
+  return { activation, breakdown };
 }
 
 // ---------------------------------------------------------------------------
 // Spreading activation
 // ---------------------------------------------------------------------------
+
+export interface SpreadActivationResult {
+  /** Final activation value per slug after spreading. */
+  final: Map<string, number>;
+  /**
+   * Per-slug spread delta: `final[slug] - own[slug]`. Captures how much
+   * the spread step nudged each node above (or below) its own activation —
+   * useful for inspector views that want to show graph contributions
+   * separate from raw sim contributions. Always 0 when `hops == 0` or
+   * `k == 0` because both short-circuit to `final == own`.
+   */
+  contribution: Map<string, number>;
+}
 
 /**
  * Apply 2-hop spreading activation with neighborhood normalization:
@@ -197,16 +241,18 @@ export function spreadActivation(
   edgesIdx: EdgesIndex,
   k: number,
   hops: number,
-): Map<string, number> {
-  const result = new Map<string, number>();
-  if (ownActivation.size === 0) return result;
+): SpreadActivationResult {
+  const final = new Map<string, number>();
+  const contribution = new Map<string, number>();
+  if (ownActivation.size === 0) return { final, contribution };
 
   // Short-circuit: with no spread the formula collapses to A == A_o.
   if (hops <= 0 || k <= 0) {
     for (const [slug, ownValue] of ownActivation) {
-      result.set(slug, clampUnitInterval(ownValue));
+      final.set(slug, clampUnitInterval(ownValue));
+      contribution.set(slug, 0);
     }
-    return result;
+    return { final, contribution };
   }
 
   const adjacency = buildAdjacency(edgesIdx);
@@ -235,10 +281,12 @@ export function spreadActivation(
       denominator += kPow * ringCounts[r];
     }
 
-    result.set(slug, clampUnitInterval(numerator / denominator));
+    const finalValue = clampUnitInterval(numerator / denominator);
+    final.set(slug, finalValue);
+    contribution.set(slug, finalValue - ownValue);
   }
 
-  return result;
+  return { final, contribution };
 }
 
 // ---------------------------------------------------------------------------
@@ -411,23 +459,47 @@ export interface ComputeSkillActivationParams {
 }
 
 /**
+ * Per-skill breakdown of the raw similarity inputs, captured before any
+ * coefficient weighting. Skills have no decay term, so the breakdown is just
+ * the three raw sims. Surfaced for telemetry / inspector views.
+ */
+export interface SkillActivationBreakdown {
+  /** Raw `sim(user, skill)` similarity, before `c_user` weighting. */
+  simUser: number;
+  /** Raw `sim(assistant, skill)` similarity, before `c_assistant` weighting. */
+  simAssistant: number;
+  /** Raw `sim(now, skill)` similarity, before `c_now` weighting. */
+  simNow: number;
+}
+
+export interface ComputeSkillActivationResult {
+  /** Final clamped skill-activation value per id. */
+  activation: Map<string, number>;
+  /** Per-skill breakdown of the raw sim inputs that fed into `activation`. */
+  breakdown: Map<string, SkillActivationBreakdown>;
+}
+
+/**
  * Apply the skill-side activation formula (no decay carry-over, no spread):
  *   A_skill(s) = clamp01(c_user · sim_u + c_assistant · sim_a + c_now · sim_n)
  *
  * Reuses the activation coefficients from `config.memory.v2`. The three
  * `simSkillBatch` calls run concurrently — they hit independent named
- * vectors and embed independent query texts.
+ * vectors and embed independent query texts. Returns a per-skill breakdown
+ * of the raw sims alongside the activation map so callers can render
+ * contribution diagnostics without re-running the math.
  *
  * Empty candidates short-circuits to an empty map without touching the
  * embedding backend or Qdrant.
  */
 export async function computeSkillActivation(
   params: ComputeSkillActivationParams,
-): Promise<Map<string, number>> {
+): Promise<ComputeSkillActivationResult> {
   const { candidates, userText, assistantText, nowText, config } = params;
 
-  const result = new Map<string, number>();
-  if (candidates.size === 0) return result;
+  const activation = new Map<string, number>();
+  const breakdown = new Map<string, SkillActivationBreakdown>();
+  if (candidates.size === 0) return { activation, breakdown };
 
   const { c_user, c_assistant, c_now } = config.memory.v2;
   const idList = [...candidates];
@@ -439,14 +511,15 @@ export async function computeSkillActivation(
   ]);
 
   for (const id of idList) {
-    const value =
-      c_user * (simUser.get(id) ?? 0) +
-      c_assistant * (simAssistant.get(id) ?? 0) +
-      c_now * (simNow.get(id) ?? 0);
-    result.set(id, clampUnitInterval(value));
+    const simU = simUser.get(id) ?? 0;
+    const simA = simAssistant.get(id) ?? 0;
+    const simN = simNow.get(id) ?? 0;
+    const value = c_user * simU + c_assistant * simA + c_now * simN;
+    activation.set(id, clampUnitInterval(value));
+    breakdown.set(id, { simUser: simU, simAssistant: simA, simNow: simN });
   }
 
-  return result;
+  return { activation, breakdown };
 }
 
 export interface SelectSkillInjectionsParams {

--- a/assistant/src/memory/v2/backfill-jobs.ts
+++ b/assistant/src/memory/v2/backfill-jobs.ts
@@ -328,7 +328,7 @@ async function recomputeForConversation(
     nowText,
     config,
   });
-  const ownActivation = await computeOwnActivation({
+  const { activation: ownActivation } = await computeOwnActivation({
     candidates,
     priorState,
     userText,
@@ -336,7 +336,7 @@ async function recomputeForConversation(
     nowText,
     config,
   });
-  const spread = spreadActivation(
+  const { final: spread } = spreadActivation(
     ownActivation,
     edgesIdx,
     config.memory.v2.k,

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -141,7 +141,7 @@ export async function injectMemoryV2Block(
   });
 
   // (4) Own activation: A_o = d·prev + c_user·sim_u + c_a·sim_a + c_now·sim_n.
-  const ownActivation = await computeOwnActivation({
+  const { activation: ownActivation } = await computeOwnActivation({
     candidates,
     priorState,
     userText: userMessage,
@@ -152,7 +152,12 @@ export async function injectMemoryV2Block(
 
   // (5) Spreading activation across the edge graph (k, hops from config).
   const { k, hops, top_k, epsilon } = config.memory.v2;
-  const finalActivation = spreadActivation(ownActivation, edgesIdx, k, hops);
+  const { final: finalActivation } = spreadActivation(
+    ownActivation,
+    edgesIdx,
+    k,
+    hops,
+  );
 
   // (6) Pick top-K by activation. Per-turn turns subtract everInjected for the
   // injection delta (cache-stable append-only); context-load renders the
@@ -181,7 +186,7 @@ export async function injectMemoryV2Block(
     config,
     topK: config.memory.v2.top_k_skills,
   });
-  const skillActivation = await computeSkillActivation({
+  const { activation: skillActivation } = await computeSkillActivation({
     candidates: skillCandidates,
     userText: userMessage,
     assistantText: assistantMessage,


### PR DESCRIPTION
## Summary
- `computeOwnActivation` / `computeSkillActivation` now return `{ activation, breakdown }`
- `spreadActivation` now returns `{ final, contribution }` exposing per-slug spread delta
- injection.ts updated to destructure new shapes; no behavior change

Part of plan: memory-v2-inspector-tab.md (PR 3 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
