### PR TITLE
Map personality tone to descriptive voice fact in relationship state

### DIFF
--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -704,6 +704,36 @@ describe("relationship-state-writer", () => {
       expect(state.facts[0]?.source).toBe("onboarding");
     });
 
+    test("tone group ID 'warm' maps to descriptive voice fact 'Warm and easy'", async () => {
+      writeOnboardingSidecar({
+        tools: [],
+        tasks: [],
+        tone: "warm",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voiceFacts = state.facts.filter(
+        (f) => f.category === "voice" && f.source === "onboarding",
+      );
+      expect(voiceFacts).toHaveLength(1);
+      expect(voiceFacts[0]!.text).toBe("Warm and easy");
+    });
+
+    test("unrecognized tone value passes through verbatim (backwards-compatible)", async () => {
+      writeOnboardingSidecar({
+        tools: [],
+        tasks: [],
+        tone: "balanced",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voiceFacts = state.facts.filter(
+        (f) => f.category === "voice" && f.source === "onboarding",
+      );
+      expect(voiceFacts).toHaveLength(1);
+      expect(voiceFacts[0]!.text).toBe("balanced");
+    });
+
     test("missing sidecar produces no onboarding-sourced facts", async () => {
       writeFile("USER.md", "- Preferred name: Alex");
       const state = (await computeRelationshipState()) as RelationshipStateLike;

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -423,6 +423,20 @@ function safeRead(path: string): string {
 }
 
 /**
+ * Map personality-group tone IDs (from onboarding) to human-readable
+ * voice descriptions displayed as relationship-state facts.
+ * Unrecognized values (e.g. legacy `"balanced"` or free-text tones from
+ * older clients) fall through via the `?? tone` fallback in
+ * `extractFacts`.
+ */
+const TONE_VOICE_MAP: Record<string, string> = {
+  grounded: "Calm and precise",
+  warm: "Warm and easy",
+  energetic: "Fast and direct",
+  poetic: "Quiet and observant",
+};
+
+/**
  * Walk the workspace prompt files and emit a flat list of inferred
  * facts. This is deliberately a simple bullet/heading parser — the TDD
  * explicitly calls out "don't try to be clever" here; the goal is to
@@ -477,7 +491,7 @@ function extractFacts(input: {
       facts.push({
         id: nextId("onboarding"),
         category: "voice",
-        text: tone,
+        text: TONE_VOICE_MAP[tone] ?? tone,
         confidence: "strong",
         source: "onboarding",
       });


### PR DESCRIPTION
## Summary
- Add TONE_VOICE_MAP to translate tone group IDs to human-readable voice descriptions
- Onboarding tone facts now read 'Calm and precise' instead of raw 'grounded'
- Backwards-compatible: unrecognized tone values pass through verbatim
- Add tests for tone mapping and legacy fallback

Part of plan: personality-group-names.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
