### PR TITLE
mem(v2): add activation log store

### DIFF
--- a/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import {
+  backfillMemoryV2ActivationMessageId,
+  getMemoryV2ActivationLogByMessageIds,
+  type MemoryV2ConceptRowRecord,
+  type MemoryV2ConfigSnapshot,
+  type MemoryV2SkillRowRecord,
+  recordMemoryV2ActivationLog,
+} from "../memory-v2-activation-log-store.js";
+import { memoryV2ActivationLogs } from "../schema.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.delete(memoryV2ActivationLogs).run();
+}
+
+const sampleConcepts: MemoryV2ConceptRowRecord[] = [
+  {
+    slug: "concept-a",
+    finalActivation: 0.9,
+    ownActivation: 0.7,
+    priorActivation: 0.5,
+    simUser: 0.6,
+    simAssistant: 0.4,
+    simNow: 0.3,
+    spreadContribution: 0.2,
+    source: "both",
+    status: "injected",
+  },
+  {
+    slug: "concept-b",
+    finalActivation: 0.4,
+    ownActivation: 0.3,
+    priorActivation: 0.1,
+    simUser: 0.2,
+    simAssistant: 0.1,
+    simNow: 0.05,
+    spreadContribution: 0.0,
+    source: "ann_top50",
+    status: "not_injected",
+  },
+];
+
+const sampleSkills: MemoryV2SkillRowRecord[] = [
+  {
+    id: "skill-1",
+    activation: 0.8,
+    simUser: 0.5,
+    simAssistant: 0.4,
+    simNow: 0.3,
+    status: "injected",
+  },
+];
+
+const sampleConfig: MemoryV2ConfigSnapshot = {
+  d: 0.85,
+  c_user: 1.0,
+  c_assistant: 0.5,
+  c_now: 0.25,
+  k: 5,
+  hops: 2,
+  top_k: 10,
+  top_k_skills: 3,
+  epsilon: 0.001,
+};
+
+describe("memory-v2-activation-log-store", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("round-trip: record → backfill messageId → query by messageId", () => {
+    const conversationId = "conv-1";
+    const messageId = "msg-1";
+
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: 3,
+      mode: "per-turn",
+      concepts: sampleConcepts,
+      skills: sampleSkills,
+      config: sampleConfig,
+    });
+
+    backfillMemoryV2ActivationMessageId(conversationId, messageId);
+
+    const result = getMemoryV2ActivationLogByMessageIds([messageId]);
+    expect(result).not.toBeNull();
+    expect(result!.conversationId).toBe(conversationId);
+    expect(result!.turn).toBe(3);
+    expect(result!.mode).toBe("per-turn");
+    expect(result!.concepts).toEqual(sampleConcepts);
+    expect(result!.skills).toEqual(sampleSkills);
+    expect(result!.config).toEqual(sampleConfig);
+  });
+
+  test("returns null for empty messageIds array", () => {
+    const result = getMemoryV2ActivationLogByMessageIds([]);
+    expect(result).toBeNull();
+  });
+
+  test("backfill only updates rows with NULL messageId", () => {
+    const conversationId = "conv-2";
+
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: 1,
+      mode: "context-load",
+      concepts: sampleConcepts,
+      skills: sampleSkills,
+      config: sampleConfig,
+    });
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: 2,
+      mode: "per-turn",
+      concepts: sampleConcepts,
+      skills: sampleSkills,
+      config: sampleConfig,
+    });
+
+    // First backfill: both rows should now have msg-a.
+    backfillMemoryV2ActivationMessageId(conversationId, "msg-a");
+
+    const db = getDb();
+    const afterFirstBackfill = db.select().from(memoryV2ActivationLogs).all();
+    expect(afterFirstBackfill).toHaveLength(2);
+    for (const row of afterFirstBackfill) {
+      expect(row.messageId).toBe("msg-a");
+    }
+
+    // Record a third row (messageId is NULL initially).
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: 3,
+      mode: "per-turn",
+      concepts: sampleConcepts,
+      skills: sampleSkills,
+      config: sampleConfig,
+    });
+
+    // Second backfill with msg-b should only set the third row,
+    // and must not overwrite the first two rows already set to msg-a.
+    backfillMemoryV2ActivationMessageId(conversationId, "msg-b");
+
+    const afterSecondBackfill = db.select().from(memoryV2ActivationLogs).all();
+    const byTurn = new Map(afterSecondBackfill.map((r) => [r.turn, r]));
+    expect(byTurn.get(1)!.messageId).toBe("msg-a");
+    expect(byTurn.get(2)!.messageId).toBe("msg-a");
+    expect(byTurn.get(3)!.messageId).toBe("msg-b");
+  });
+});

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -1,0 +1,115 @@
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "./db-connection.js";
+import { memoryV2ActivationLogs } from "./schema.js";
+
+export interface MemoryV2ConceptRowRecord {
+  slug: string;
+  finalActivation: number;
+  ownActivation: number;
+  priorActivation: number;
+  simUser: number;
+  simAssistant: number;
+  simNow: number;
+  spreadContribution: number;
+  source: "prior_state" | "ann_top50" | "both";
+  status: "in_context" | "injected" | "not_injected";
+}
+
+export interface MemoryV2SkillRowRecord {
+  id: string;
+  activation: number;
+  simUser: number;
+  simAssistant: number;
+  simNow: number;
+  status: "injected" | "not_injected";
+}
+
+export interface MemoryV2ConfigSnapshot {
+  d: number;
+  c_user: number;
+  c_assistant: number;
+  c_now: number;
+  k: number;
+  hops: number;
+  top_k: number;
+  top_k_skills: number;
+  epsilon: number;
+}
+
+export interface RecordMemoryV2ActivationLogParams {
+  conversationId: string;
+  turn: number;
+  mode: "context-load" | "per-turn";
+  concepts: MemoryV2ConceptRowRecord[];
+  skills: MemoryV2SkillRowRecord[];
+  config: MemoryV2ConfigSnapshot;
+}
+
+export function recordMemoryV2ActivationLog(
+  params: RecordMemoryV2ActivationLogParams,
+): void {
+  const db = getDb();
+  db.insert(memoryV2ActivationLogs)
+    .values({
+      id: uuid(),
+      conversationId: params.conversationId,
+      messageId: null,
+      turn: params.turn,
+      mode: params.mode,
+      conceptsJson: JSON.stringify(params.concepts),
+      skillsJson: JSON.stringify(params.skills),
+      configJson: JSON.stringify(params.config),
+      createdAt: Date.now(),
+    })
+    .run();
+}
+
+export function backfillMemoryV2ActivationMessageId(
+  conversationId: string,
+  messageId: string,
+): void {
+  const db = getDb();
+  db.update(memoryV2ActivationLogs)
+    .set({ messageId })
+    .where(
+      and(
+        eq(memoryV2ActivationLogs.conversationId, conversationId),
+        isNull(memoryV2ActivationLogs.messageId),
+      ),
+    )
+    .run();
+}
+
+export interface MemoryV2ActivationLog {
+  conversationId: string;
+  turn: number;
+  mode: "context-load" | "per-turn";
+  concepts: MemoryV2ConceptRowRecord[];
+  skills: MemoryV2SkillRowRecord[];
+  config: MemoryV2ConfigSnapshot;
+}
+
+export function getMemoryV2ActivationLogByMessageIds(
+  messageIds: string[],
+): MemoryV2ActivationLog | null {
+  if (messageIds.length === 0) return null;
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(memoryV2ActivationLogs)
+    .where(inArray(memoryV2ActivationLogs.messageId, messageIds))
+    .orderBy(desc(memoryV2ActivationLogs.createdAt))
+    .all();
+  if (rows.length === 0) return null;
+  const row = rows[0]!;
+  return {
+    conversationId: row.conversationId,
+    turn: row.turn,
+    mode: row.mode as "context-load" | "per-turn",
+    concepts: JSON.parse(row.conceptsJson) as MemoryV2ConceptRowRecord[],
+    skills: JSON.parse(row.skillsJson) as MemoryV2SkillRowRecord[],
+    config: JSON.parse(row.configJson) as MemoryV2ConfigSnapshot,
+  };
+}


### PR DESCRIPTION
## Summary
- New `memory-v2-activation-log-store.ts` with insert / fetch / backfill helpers
- JSON columns serialized at write, parsed at read
- Test covers round-trip, empty-input early-out, and backfill no-overwrite invariant

Part of plan: memory-v2-inspector-tab.md (PR 2 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
