### PR TITLE
test(host-browser): deflake cloud e2e timeout test

### DIFF
--- a/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
+++ b/assistant/src/__tests__/host-browser-e2e-cloud.test.ts
@@ -301,10 +301,14 @@ describe("host_browser cloud-hosted e2e round-trip", () => {
 
     const proxy = HostBrowserProxy.instance;
 
-    const result = await proxy.request(
-      { cdpMethod: "Browser.getVersion", timeout_seconds: 0.05 },
+    const resultPromise = proxy.request(
+      { cdpMethod: "Browser.getVersion", timeout_seconds: 0.5 },
       "conv-timeout",
     );
+
+    await waitFor(() => mockExt.receivedRequests().length === 1);
+
+    const result = await resultPromise;
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("timed out");


### PR DESCRIPTION
## Summary
- `host_browser cloud-hosted e2e round-trip > timeout` flaked in CI when the proxy's 50ms timer fired before the WebSocket loopback delivered the request to the mock extension, leaving `mockExt.receivedRequests()` empty.
- Hold the proxy promise without awaiting, `waitFor` the mock extension to record the request, then await the result. Bump the timeout from 0.05s to 0.5s for headroom.
- Verified locally: all 7 tests pass over 3 consecutive runs.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25131243605/job/73657756450
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
