### PR TITLE
mem(v2): tag candidate provenance (prior_state | ann_top50 | both)

### DIFF
--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -241,7 +241,9 @@ describe("selectCandidates", () => {
       nowText: "",
       config: makeConfig(),
     });
-    expect(out.size).toBe(0);
+    expect(out.candidates.size).toBe(0);
+    expect(out.fromPrior.size).toBe(0);
+    expect(out.fromAnn.size).toBe(0);
     // No turn text → no embedding call, no Qdrant call.
     expect(state.embedCalls).toHaveLength(0);
     expect(state.queryCalls).toHaveLength(0);
@@ -266,7 +268,9 @@ describe("selectCandidates", () => {
       nowText: "",
       config: makeConfig({ epsilon: 0.01 }),
     });
-    expect(out).toEqual(new Set(["alice-vscode", "carol-jazz"]));
+    expect(out.candidates).toEqual(new Set(["alice-vscode", "carol-jazz"]));
+    expect(out.fromPrior).toEqual(new Set(["alice-vscode", "carol-jazz"]));
+    expect(out.fromAnn).toEqual(new Set());
   });
 
   test("unions ANN hits with prior-state survivors", async () => {
@@ -289,7 +293,51 @@ describe("selectCandidates", () => {
       nowText: "",
       config: makeConfig(),
     });
-    expect(out).toEqual(new Set(["alice-vscode", "delta-recipe"]));
+    expect(out.candidates).toEqual(new Set(["alice-vscode", "delta-recipe"]));
+    expect(out.fromPrior).toEqual(new Set(["alice-vscode"]));
+    expect(out.fromAnn).toEqual(new Set(["alice-vscode", "delta-recipe"]));
+  });
+
+  test("tags overlap: a slug in both sources lands in fromPrior ∩ fromAnn", async () => {
+    const priorState: ActivationState = {
+      messageId: "msg-1",
+      state: {
+        "alice-vscode": 0.5, // in prior AND in ANN
+        "carol-jazz": 0.3, // prior only
+      },
+      everInjected: [],
+      currentTurn: 1,
+      updatedAt: 1,
+    };
+    stageHybridResponse([
+      { slug: "alice-vscode", denseScore: 0.7, sparseScore: 1 }, // overlap
+      { slug: "delta-recipe", denseScore: 0.4, sparseScore: 1 }, // ANN only
+    ]);
+
+    const out = await selectCandidates({
+      priorState,
+      userText: "hello",
+      assistantText: "",
+      nowText: "",
+      config: makeConfig(),
+    });
+
+    // Overlap: alice-vscode appears in both source sets.
+    const overlap = new Set(
+      [...out.fromPrior].filter((slug) => out.fromAnn.has(slug)),
+    );
+    expect(overlap).toEqual(new Set(["alice-vscode"]));
+
+    // candidates = fromPrior ∪ fromAnn.
+    const union = new Set<string>([...out.fromPrior, ...out.fromAnn]);
+    expect(out.candidates).toEqual(union);
+    expect(out.candidates).toEqual(
+      new Set(["alice-vscode", "carol-jazz", "delta-recipe"]),
+    );
+
+    // Source-set membership matches each slug's actual provenance.
+    expect(out.fromPrior).toEqual(new Set(["alice-vscode", "carol-jazz"]));
+    expect(out.fromAnn).toEqual(new Set(["alice-vscode", "delta-recipe"]));
   });
 
   test("ANN top-K limit equals 50 and runs without slug restriction", async () => {

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -70,27 +70,41 @@ export interface SelectCandidatesParams {
   config: AssistantConfig;
 }
 
+export interface SelectCandidatesResult {
+  /** Union of `fromPrior` and `fromAnn` — the per-turn candidate set. */
+  candidates: Set<string>;
+  /** Slugs carried forward from `priorState` because their activation > epsilon. */
+  fromPrior: Set<string>;
+  /** Slugs surfaced by the unrestricted ANN top-50 against the joined turn text. */
+  fromAnn: Set<string>;
+}
+
 /**
  * Build the per-turn candidate set: the union of slugs in the prior state
  * (above epsilon) and the top-50 ANN hits against the concatenated turn
  * text. The ANN call runs un-restricted (no slug filter) so it can surface
  * pages outside the active set.
  *
+ * Returns the union plus the two source sets separately so downstream
+ * telemetry can attribute each candidate to `prior_state`, `ann_top50`, or
+ * both. A slug present in both sources appears in `fromPrior ∩ fromAnn`.
+ *
  * Empty candidate sets are valid and propagate downstream — both
  * `computeOwnActivation` and `spreadActivation` short-circuit on them.
  */
 export async function selectCandidates(
   params: SelectCandidatesParams,
-): Promise<Set<string>> {
+): Promise<SelectCandidatesResult> {
   const { priorState, userText, assistantText, nowText, config } = params;
 
-  const candidates = new Set<string>();
+  const fromPrior = new Set<string>();
+  const fromAnn = new Set<string>();
 
   // (1) Carry forward prior-state slugs above epsilon.
   if (priorState) {
     const epsilon = config.memory.v2.epsilon;
     for (const [slug, activation] of Object.entries(priorState.state)) {
-      if (activation > epsilon) candidates.add(slug);
+      if (activation > epsilon) fromPrior.add(slug);
     }
   }
 
@@ -110,10 +124,12 @@ export async function selectCandidates(
       sparse,
       ANN_CANDIDATE_LIMIT,
     );
-    for (const hit of hits) candidates.add(hit.slug);
+    for (const hit of hits) fromAnn.add(hit.slug);
   }
 
-  return candidates;
+  const candidates = new Set<string>([...fromPrior, ...fromAnn]);
+
+  return { candidates, fromPrior, fromAnn };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/v2/backfill-jobs.ts
+++ b/assistant/src/memory/v2/backfill-jobs.ts
@@ -321,7 +321,7 @@ async function recomputeForConversation(
   const { userText, assistantText } = lastExchangeTexts(conversationId);
   if (!userText && !assistantText) return null;
 
-  const candidates = await selectCandidates({
+  const { candidates } = await selectCandidates({
     priorState,
     userText,
     assistantText,

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -132,7 +132,9 @@ export async function injectMemoryV2Block(
   const edgesIdx = await readEdges(workspaceDir);
 
   // (3) Candidate set: prior-state survivors above epsilon ∪ ANN top-50.
-  const candidates = await selectCandidates({
+  // `selectCandidates` also returns `fromPrior` / `fromAnn` provenance sets;
+  // they are unused here today and will be consumed by upcoming telemetry.
+  const { candidates } = await selectCandidates({
     priorState,
     userText: userMessage,
     assistantText: assistantMessage,


### PR DESCRIPTION
## Summary
- `selectCandidates` now returns `{ candidates, fromPrior, fromAnn }`
- All callers updated to destructure `candidates`
- Provenance sets used by upcoming PR 5 telemetry recorder

Part of plan: memory-v2-inspector-tab.md (PR 4 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
