### PR TITLE
Add personality group pill selector to name exchange screen

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -7,9 +7,10 @@ struct NameExchangeView: View {
 
     @Binding var userName: String
     @Binding var assistantName: String
+    @Binding var selectedGroupID: String?
 
-    /// Stable subset of the name pool to display as quick-tap pills. The caller
-    /// is responsible for sampling so the pills don't reshuffle across re-renders.
+    /// Names to display as quick-tap pills, ordered by the caller based on
+    /// the currently selected personality group.
     let displayedAssistantNames: [String]
 
     var onBack: (() -> Void)?
@@ -21,25 +22,7 @@ struct NameExchangeView: View {
     @State private var showHeader = false
     @State private var showContent = false
     @State private var hoveredSuggestion: String?
-
-    /// Curated pool of short, evocative names for the assistant. The quick-tap
-    /// suggestion pills show a random sample of `suggestionCount` names drawn
-    /// from this pool per onboarding session.
-    static let assistantNamePool = [
-        "Pax", "Atlas", "Sage", "Nova", "Kit",
-        "Echo", "Luna", "Juno", "Ada", "Iris",
-        "Milo", "Remy", "Wren", "Lark", "Vesper",
-        "Onyx", "Vela", "Cleo", "Quill", "Rune",
-        "Orion", "Ember", "Ziggy", "Bodhi", "Pip",
-    ]
-
-    /// Number of suggestion pills shown at a time.
-    static let suggestionCount = 5
-
-    /// Returns `suggestionCount` unique random names drawn from the pool.
-    static func sampleAssistantNames() -> [String] {
-        Array(assistantNamePool.shuffled().prefix(suggestionCount))
-    }
+    @State private var hoveredGroup: String?
 
     /// Usernames that are clearly not real names and should not be pre-filled.
     private static let usernameBlacklist: Set<String> = ["admin", "user", "root", "guest"]
@@ -83,7 +66,7 @@ struct NameExchangeView: View {
                     text: $userName
                 )
 
-                // "Call me..." field + suggestion pills
+                // "Call me..." field + group pills + suggestion pills
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     VTextField(
                         "What should I go by?",
@@ -91,8 +74,15 @@ struct NameExchangeView: View {
                         text: $assistantName
                     )
 
-                    // Suggestion pills
+                    // Personality group pills
                     HStack(spacing: VSpacing.xs) {
+                        ForEach(PersonalityGroup.allGroups, id: \.id) { group in
+                            groupPill(group)
+                        }
+                    }
+
+                    // Name suggestion pills (flow layout for wrapping)
+                    WrappingHStack(hSpacing: VSpacing.xs, vSpacing: VSpacing.xs) {
                         ForEach(displayedAssistantNames, id: \.self) { suggestion in
                             suggestionPill(suggestion)
                         }
@@ -136,6 +126,48 @@ struct NameExchangeView: View {
     }
 
     // MARK: - Subviews
+
+    private func groupPill(_ group: PersonalityGroup) -> some View {
+        let isActive = selectedGroupID == group.id
+        let isHovered = hoveredGroup == group.id
+        return Button {
+            withAnimation(VAnimation.fast) {
+                if isActive {
+                    selectedGroupID = nil
+                } else {
+                    selectedGroupID = group.id
+                }
+            }
+        } label: {
+            VStack(spacing: 2) {
+                Text(group.label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(isActive ? VColor.contentInset : VColor.contentDefault)
+                Text(group.descriptor)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(isActive ? VColor.contentInset.opacity(0.8) : VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.pill)
+                    .fill(isActive ? VColor.primaryBase : (isHovered ? VColor.surfaceBase : VColor.surfaceLift))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.pill)
+                            .stroke(isActive ? VColor.primaryBase : VColor.borderElement, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor(onHover: { hovering in
+            withAnimation(VAnimation.fast) {
+                hoveredGroup = hovering ? group.id : nil
+            }
+        })
+        .accessibilityLabel("\(group.label), \(group.descriptor)")
+        .accessibilityValue(isActive ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
 
     private func suggestionPill(_ name: String) -> some View {
         let isActive = assistantName == name
@@ -200,5 +232,59 @@ struct NameExchangeView: View {
         }
 
         return ""
+    }
+}
+
+// MARK: - Wrapping horizontal layout
+
+private struct WrappingHStack: Layout {
+    var hSpacing: CGFloat
+    var vSpacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        guard !rows.isEmpty else { return .zero }
+        let height = rows.enumerated().reduce(CGFloat.zero) { acc, pair in
+            let rowHeight = pair.element.map { $0.size.height }.max() ?? 0
+            return acc + rowHeight + (pair.offset > 0 ? vSpacing : 0)
+        }
+        return CGSize(width: proposal.width ?? 0, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            let rowHeight = row.map { $0.size.height }.max() ?? 0
+            var x = bounds.minX
+            for item in row {
+                item.subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(item.size))
+                x += item.size.width + hSpacing
+            }
+            y += rowHeight + vSpacing
+        }
+    }
+
+    private struct LayoutItem {
+        let subview: LayoutSubview
+        let size: CGSize
+    }
+
+    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[LayoutItem]] {
+        let maxWidth = proposal.width ?? .infinity
+        var rows: [[LayoutItem]] = [[]]
+        var currentRowWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let needed = currentRowWidth > 0 ? size.width + hSpacing : size.width
+            if currentRowWidth + needed > maxWidth, !rows[rows.count - 1].isEmpty {
+                rows.append([])
+                currentRowWidth = 0
+            }
+            rows[rows.count - 1].append(LayoutItem(subview: subview, size: size))
+            currentRowWidth += currentRowWidth > 0 ? size.width + hSpacing : size.width
+        }
+        return rows
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -42,6 +42,7 @@ struct PreChatOnboardingFlow: View {
                 NameExchangeView(
                     userName: $state.userName,
                     assistantName: $state.assistantName,
+                    selectedGroupID: $state.selectedGroupID,
                     displayedAssistantNames: state.displayedAssistantNames,
                     onBack: { advanceTo(1) },
                     onComplete: { finish() },

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
@@ -15,11 +15,23 @@ final class PreChatOnboardingState {
     var assistantName: String
     var skippedAll: Bool = false
 
-    /// Random subset of `NameExchangeView.assistantNamePool` displayed as
-    /// quick-tap suggestion pills. Sampled once per state instance so the pills
-    /// remain stable across re-renders and back-navigation within a session.
-    /// Not persisted to UserDefaults — a fresh sample is drawn on each run.
-    let displayedAssistantNames: [String]
+    /// The currently selected personality group ID, or `nil` for no selection.
+    var selectedGroupID: String?
+
+    /// Assistant names to display as quick-tap pills, ordered by group
+    /// relevance. When a group is selected its names appear first, followed
+    /// by names from the remaining groups. When no group is selected all
+    /// names from every group are shown.
+    var displayedAssistantNames: [String] {
+        guard let selectedID = selectedGroupID,
+              let group = PersonalityGroup.allGroups.first(where: { $0.id == selectedID }) else {
+            return PersonalityGroup.allNames
+        }
+        let rest = PersonalityGroup.allGroups
+            .filter { $0.id != selectedID }
+            .flatMap(\.names)
+        return group.names + rest
+    }
 
     // MARK: - Persistence Keys
 
@@ -29,18 +41,18 @@ final class PreChatOnboardingState {
     private static let tasksKey = "\(prefix)selectedTasks"
     private static let userNameKey = "\(prefix)userName"
     private static let assistantNameKey = "\(prefix)assistantName"
+    private static let selectedGroupIDKey = "\(prefix)selectedGroupID"
 
     private static let allKeys: [String] = [
         screenKey, toolsKey, tasksKey,
         userNameKey, assistantNameKey,
+        selectedGroupIDKey,
     ]
 
     // MARK: - Init (restore from UserDefaults)
 
     init() {
-        let sampled = NameExchangeView.sampleAssistantNames()
-        self.displayedAssistantNames = sampled
-        self.assistantName = sampled.first ?? "Pax"
+        self.assistantName = ""
         self.userName = ""
 
         let defaults = UserDefaults.standard
@@ -64,6 +76,8 @@ final class PreChatOnboardingState {
            !name.hasPrefix("vellum-") {
             assistantName = name
         }
+
+        selectedGroupID = defaults.string(forKey: Self.selectedGroupIDKey)
     }
 
     // MARK: - Persist
@@ -75,6 +89,7 @@ final class PreChatOnboardingState {
         defaults.set(Array(selectedTasks), forKey: Self.tasksKey)
         defaults.set(userName, forKey: Self.userNameKey)
         defaults.set(assistantName, forKey: Self.assistantNameKey)
+        defaults.set(selectedGroupID, forKey: Self.selectedGroupIDKey)
     }
 
     // MARK: - Clear

--- a/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
+++ b/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
@@ -84,51 +84,46 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(decoded.assistantName, original.assistantName)
     }
 
-    // MARK: - Assistant Name Pool / Sampling
+    // MARK: - PersonalityGroup Name Pool
 
-    func testAssistantNamePoolHasExpectedSize() {
-        // The pool must be large enough that five random draws still leave
-        // meaningful variety; 25 is the product-spec target.
-        XCTAssertEqual(NameExchangeView.assistantNamePool.count, 25)
+    func testAllNamesHasUniqueEntries() {
+        let allNames = PersonalityGroup.allNames
+        XCTAssertEqual(Set(allNames).count, allNames.count, "All names across groups must be unique")
     }
 
-    func testAssistantNamePoolHasUniqueEntries() {
-        let pool = NameExchangeView.assistantNamePool
-        XCTAssertEqual(Set(pool).count, pool.count, "Pool entries must be unique")
-    }
-
-    func testSampleAssistantNamesReturnsFiveUniqueNamesFromPool() {
-        let sample = NameExchangeView.sampleAssistantNames()
-        let pool = Set(NameExchangeView.assistantNamePool)
-
-        XCTAssertEqual(sample.count, NameExchangeView.suggestionCount)
-        XCTAssertEqual(Set(sample).count, sample.count, "Sampled names must be unique")
-        for name in sample {
-            XCTAssertTrue(pool.contains(name), "Sampled name '\(name)' must come from the pool")
-        }
-    }
-
-    func testStateDisplayedNamesMatchSampleContract() {
+    func testStateDisplayedNamesMatchAllNamesWhenNoGroupSelected() {
+        PreChatOnboardingState.clearPersistedState()
         let state = PreChatOnboardingState()
-        let pool = Set(NameExchangeView.assistantNamePool)
 
-        XCTAssertEqual(state.displayedAssistantNames.count, NameExchangeView.suggestionCount)
-        XCTAssertEqual(Set(state.displayedAssistantNames).count, state.displayedAssistantNames.count)
-        for name in state.displayedAssistantNames {
-            XCTAssertTrue(pool.contains(name))
-        }
+        XCTAssertNil(state.selectedGroupID)
+        XCTAssertEqual(state.displayedAssistantNames, PersonalityGroup.allNames)
     }
 
-    func testDefaultAssistantNameIsFromDisplayedSample() {
-        // On a fresh state (no persisted assistantName), the initial pre-fill
-        // should be one of the displayed suggestion pills so the active pill
-        // matches the text field out of the box.
+    func testStateDisplayedNamesPrioritizesSelectedGroup() {
+        PreChatOnboardingState.clearPersistedState()
+        let state = PreChatOnboardingState()
+        state.selectedGroupID = "warm"
+
+        let warmGroup = PersonalityGroup.allGroups.first { $0.id == "warm" }!
+        let displayed = state.displayedAssistantNames
+
+        // Selected group's names should come first
+        let prefix = Array(displayed.prefix(warmGroup.names.count))
+        XCTAssertEqual(prefix, warmGroup.names)
+
+        // All names should still be present
+        XCTAssertEqual(Set(displayed), Set(PersonalityGroup.allNames))
+    }
+
+    func testDefaultAssistantNameIsEmptyOnFreshState() {
+        // On a fresh state (no persisted assistantName), the initial value
+        // should be empty so the user must make a deliberate choice.
         PreChatOnboardingState.clearPersistedState()
         let state = PreChatOnboardingState()
 
         XCTAssertTrue(
-            state.displayedAssistantNames.contains(state.assistantName),
-            "Initial assistantName '\(state.assistantName)' should be one of the displayed suggestions"
+            state.assistantName.isEmpty,
+            "Initial assistantName should be empty, got '\(state.assistantName)'"
         )
     }
 
@@ -159,6 +154,7 @@ final class PreChatOnboardingTests: XCTestCase {
         state1.selectedTasks = ["code-building"]
         state1.userName = "TestUser"
         state1.assistantName = "TestAssistant"
+        state1.selectedGroupID = "warm"
         state1.persist()
 
         // Create a new instance — it should restore from UserDefaults
@@ -169,6 +165,7 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(state2.selectedTasks, ["code-building"])
         XCTAssertEqual(state2.userName, "TestUser")
         XCTAssertEqual(state2.assistantName, "TestAssistant")
+        XCTAssertEqual(state2.selectedGroupID, "warm")
     }
 
     func testClearPersistedStateResetsToDefaults() {


### PR DESCRIPTION
## Summary
- Add personality group pill row (grounded/warm/energetic/poetic) above name chips in NameExchangeView
- Replace random 5-name sampling with group-aware name display (selected group first, then others)
- Add selectedGroupID state with UserDefaults persistence to PreChatOnboardingState
- Remove old assistantNamePool/suggestionCount/sampleAssistantNames in favor of PersonalityGroup model

Part of plan: personality-group-names.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
