### PR TITLE
mem(v2): backfill messageId on activation logs at turn end

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -26,6 +26,7 @@ import {
   recordRequestLog,
 } from "../memory/llm-request-log-store.js";
 import { backfillMemoryRecallLogMessageId } from "../memory/memory-recall-log-store.js";
+import { backfillMemoryV2ActivationMessageId } from "../memory/memory-v2-activation-log-store.js";
 import { getThreadTs } from "../memory/slack-thread-store.js";
 import {
   type SlackMessageMetadata,
@@ -935,6 +936,18 @@ export async function handleMessageComplete(
     deps.rlog.warn(
       { err },
       "Failed to backfill message_id on memory recall log (non-fatal)",
+    );
+  }
+
+  try {
+    backfillMemoryV2ActivationMessageId(
+      deps.ctx.conversationId,
+      assistantMsg.id,
+    );
+  } catch (err) {
+    deps.rlog.warn(
+      { err },
+      "Failed to backfill memory v2 activation log messageId (non-fatal)",
     );
   }
 


### PR DESCRIPTION
## Summary
- Backfill `message_id` on `memory_v2_activation_logs` rows alongside existing `llm_request_logs` backfill
- Failure is warn-logged and non-fatal

Part of plan: memory-v2-inspector-tab.md (PR 6 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
