### PR TITLE
mem(v2): persist activation telemetry per turn

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -164,6 +164,30 @@ mock.module("../skill-store.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Activation-log store mock
+// ---------------------------------------------------------------------------
+//
+// The real `recordMemoryV2ActivationLog` writes to the singleton
+// `getDb()` — but this test uses an isolated in-memory database, so we mock
+// the writer to capture calls in-process. `recordCalls` is the captured log
+// array; `recordShouldThrow` makes the next call throw to verify the caller
+// swallows the failure.
+
+const telemetryState = {
+  recordCalls: [] as Array<Record<string, unknown>>,
+  recordShouldThrow: false,
+};
+
+mock.module("../../memory-v2-activation-log-store.js", () => ({
+  recordMemoryV2ActivationLog: (params: Record<string, unknown>) => {
+    if (telemetryState.recordShouldThrow) {
+      throw new Error("simulated telemetry write failure");
+    }
+    telemetryState.recordCalls.push(params);
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // Workspace + DB setup
 // ---------------------------------------------------------------------------
 
@@ -322,6 +346,8 @@ function resetState(): void {
   state.queryResponses.sparse.length = 0;
   skillState.topSkillIds.length = 0;
   skillState.entries.clear();
+  telemetryState.recordCalls.length = 0;
+  telemetryState.recordShouldThrow = false;
   // The qdrant module caches its client; the cached client may be a
   // MockQdrantClient instance from a sibling test file. Reset to force a
   // fresh `new QdrantClient()` against this file's mock.
@@ -878,5 +904,109 @@ describe("injectMemoryV2Block", () => {
     expect(result.block).toContain("### alice-vscode");
     expect(result.block).not.toContain("### Skills You Can Use");
     expect(result.block).not.toContain("example-skill-a");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Activation-log telemetry
+  // ---------------------------------------------------------------------------
+
+  test("writes one activation-log row per turn with concept rows partitioned and sorted", async () => {
+    // Turn 1: seed alice as injected so turn 2 has an `in_context` candidate.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Alice's editor",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+    expect(telemetryState.recordCalls.length).toBe(1);
+
+    // Turn 2: alice carries forward (now `in_context`); carol is freshly
+    // surfaced (`injected`); bob would be a candidate only if it carried
+    // forward, but with no prior bob entry it doesn't appear here.
+    stageTurn([
+      { slug: "alice-vscode", denseScore: 0.6 },
+      { slug: "carol-jazz", denseScore: 0.95 },
+    ]);
+    await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 2,
+      userMessage: "Carol's music",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-2",
+      config: makeConfig(),
+    });
+
+    expect(telemetryState.recordCalls.length).toBe(2);
+    const row = telemetryState.recordCalls[1] as {
+      conversationId: string;
+      turn: number;
+      mode: string;
+      concepts: Array<{
+        slug: string;
+        finalActivation: number;
+        status: string;
+        source: string;
+      }>;
+      skills: unknown[];
+      config: { top_k: number };
+    };
+    expect(row.conversationId).toBe("conv-1");
+    expect(row.turn).toBe(2);
+    expect(row.mode).toBe("per-turn");
+    expect(row.config.top_k).toBe(20);
+
+    // The candidate set is the union of fromPrior (alice) and fromAnn
+    // (alice + carol) → two concept rows.
+    expect(row.concepts.length).toBe(2);
+    const slugs = row.concepts.map((c) => c.slug);
+    expect(new Set(slugs)).toEqual(new Set(["alice-vscode", "carol-jazz"]));
+
+    // Sorted descending by finalActivation.
+    for (let i = 1; i < row.concepts.length; i++) {
+      expect(row.concepts[i - 1]!.finalActivation).toBeGreaterThanOrEqual(
+        row.concepts[i]!.finalActivation,
+      );
+    }
+
+    const byslug = new Map(row.concepts.map((c) => [c.slug, c]));
+    // Alice was attached on turn 1 → status `in_context` on turn 2.
+    expect(byslug.get("alice-vscode")!.status).toBe("in_context");
+    // Carol is freshly injected on turn 2.
+    expect(byslug.get("carol-jazz")!.status).toBe("injected");
+  });
+
+  test("telemetry write failure is non-fatal — injection still returns a normal result", async () => {
+    telemetryState.recordShouldThrow = true;
+
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Alice's editor",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    // No row captured (the throw aborted the push), but the caller still
+    // produced a regular block + toInject result and persisted state.
+    expect(telemetryState.recordCalls.length).toBe(0);
+    expect(result.toInject).toEqual(["alice-vscode"]);
+    expect(result.block).not.toBeNull();
+    expect(result.block).toContain("### alice-vscode");
+
+    const persisted = await hydrate(db, "conv-1");
+    expect(persisted!.everInjected).toEqual([
+      { slug: "alice-vscode", turn: 1 },
+    ]);
   });
 });

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -24,8 +24,14 @@
 // cached prefix bytes-identical across turns.
 
 import type { AssistantConfig } from "../../config/types.js";
+import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import type { DrizzleDb } from "../db-connection.js";
+import {
+  type MemoryV2ConceptRowRecord,
+  type MemoryV2SkillRowRecord,
+  recordMemoryV2ActivationLog,
+} from "../memory-v2-activation-log-store.js";
 import {
   computeOwnActivation,
   computeSkillActivation,
@@ -40,6 +46,8 @@ import { readEdges } from "./edges.js";
 import { readPage } from "./page-store.js";
 import { getSkillCapability } from "./skill-store.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
+
+const log = getLogger("memory-v2-injection");
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -132,9 +140,9 @@ export async function injectMemoryV2Block(
   const edgesIdx = await readEdges(workspaceDir);
 
   // (3) Candidate set: prior-state survivors above epsilon ∪ ANN top-50.
-  // `selectCandidates` also returns `fromPrior` / `fromAnn` provenance sets;
-  // they are unused here today and will be consumed by upcoming telemetry.
-  const { candidates } = await selectCandidates({
+  // `selectCandidates` also returns `fromPrior` / `fromAnn` provenance sets so
+  // telemetry can attribute each candidate back to its source.
+  const { candidates, fromPrior, fromAnn } = await selectCandidates({
     priorState,
     userText: userMessage,
     assistantText: assistantMessage,
@@ -143,23 +151,20 @@ export async function injectMemoryV2Block(
   });
 
   // (4) Own activation: A_o = d·prev + c_user·sim_u + c_a·sim_a + c_now·sim_n.
-  const { activation: ownActivation } = await computeOwnActivation({
-    candidates,
-    priorState,
-    userText: userMessage,
-    assistantText: assistantMessage,
-    nowText,
-    config,
-  });
+  const { activation: ownActivation, breakdown: ownBreakdown } =
+    await computeOwnActivation({
+      candidates,
+      priorState,
+      userText: userMessage,
+      assistantText: assistantMessage,
+      nowText,
+      config,
+    });
 
   // (5) Spreading activation across the edge graph (k, hops from config).
   const { k, hops, top_k, epsilon } = config.memory.v2;
-  const { final: finalActivation } = spreadActivation(
-    ownActivation,
-    edgesIdx,
-    k,
-    hops,
-  );
+  const { final: finalActivation, contribution: spreadContribution } =
+    spreadActivation(ownActivation, edgesIdx, k, hops);
 
   // (6) Pick top-K by activation. Per-turn turns subtract everInjected for the
   // injection delta (cache-stable append-only); context-load renders the
@@ -188,13 +193,14 @@ export async function injectMemoryV2Block(
     config,
     topK: config.memory.v2.top_k_skills,
   });
-  const { activation: skillActivation } = await computeSkillActivation({
-    candidates: skillCandidates,
-    userText: userMessage,
-    assistantText: assistantMessage,
-    nowText,
-    config,
-  });
+  const { activation: skillActivation, breakdown: skillBreakdown } =
+    await computeSkillActivation({
+      candidates: skillCandidates,
+      userText: userMessage,
+      assistantText: assistantMessage,
+      nowText,
+      config,
+    });
   const { topNow: topSkillIds } = selectSkillInjections({
     A: skillActivation,
     topK: config.memory.v2.top_k_skills,
@@ -234,6 +240,80 @@ export async function injectMemoryV2Block(
   };
 
   await save(database, conversationId, nextActivationState);
+
+  // Record per-turn activation telemetry. This runs *before* the cache-stable
+  // empty-block return so we capture diagnostics even on no-op turns. Failures
+  // are warn-logged and never block memory injection.
+  const toInjectSet = new Set(toInject);
+  const topSkillIdSet = new Set(topSkillIds);
+  const conceptRows: MemoryV2ConceptRowRecord[] = [...candidates].map(
+    (slug) => {
+      const breakdown = ownBreakdown.get(slug);
+      const inPrior = fromPrior.has(slug);
+      const inAnn = fromAnn.has(slug);
+      const status: MemoryV2ConceptRowRecord["status"] = everInjectedSet.has(
+        slug,
+      )
+        ? "in_context"
+        : toInjectSet.has(slug)
+          ? "injected"
+          : "not_injected";
+      return {
+        slug,
+        finalActivation: finalActivation.get(slug) ?? 0,
+        ownActivation: ownActivation.get(slug) ?? 0,
+        priorActivation: breakdown?.priorContribution ?? 0,
+        simUser: breakdown?.simUser ?? 0,
+        simAssistant: breakdown?.simAssistant ?? 0,
+        simNow: breakdown?.simNow ?? 0,
+        spreadContribution: spreadContribution.get(slug) ?? 0,
+        source:
+          inPrior && inAnn ? "both" : inPrior ? "prior_state" : "ann_top50",
+        status,
+      };
+    },
+  );
+  conceptRows.sort((a, b) => b.finalActivation - a.finalActivation);
+
+  const skillRows: MemoryV2SkillRowRecord[] = [...skillCandidates].map((id) => {
+    const breakdown = skillBreakdown.get(id);
+    return {
+      id,
+      activation: skillActivation.get(id) ?? 0,
+      simUser: breakdown?.simUser ?? 0,
+      simAssistant: breakdown?.simAssistant ?? 0,
+      simNow: breakdown?.simNow ?? 0,
+      status: topSkillIdSet.has(id) ? "injected" : "not_injected",
+    };
+  });
+  skillRows.sort((a, b) => b.activation - a.activation);
+
+  const v2Cfg = config.memory.v2;
+  try {
+    recordMemoryV2ActivationLog({
+      conversationId,
+      turn: currentTurn,
+      mode,
+      concepts: conceptRows,
+      skills: skillRows,
+      config: {
+        d: v2Cfg.d,
+        c_user: v2Cfg.c_user,
+        c_assistant: v2Cfg.c_assistant,
+        c_now: v2Cfg.c_now,
+        k: v2Cfg.k,
+        hops: v2Cfg.hops,
+        top_k: v2Cfg.top_k,
+        top_k_skills: v2Cfg.top_k_skills,
+        epsilon: v2Cfg.epsilon,
+      },
+    });
+  } catch (err) {
+    log.warn(
+      { err, conversationId, turn: currentTurn },
+      "Failed to record memory v2 activation telemetry — continuing",
+    );
+  }
 
   // (7) Cache-stable empty path: nothing to render AND no ranked skills.
   if (slugsToRender.length === 0 && topSkillIds.length === 0) {


### PR DESCRIPTION
## Summary
- Record per-turn activation telemetry to `memory_v2_activation_logs` after each `injectMemoryV2Block` call
- Concept rows tagged with provenance (`prior_state`/`ann_top50`/`both`) and status (`in_context`/`injected`/`not_injected`)
- Failures are warn-logged and never block memory injection

Part of plan: memory-v2-inspector-tab.md (PR 5 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
