### PR TITLE
Wire personality group selection to tone field in onboarding context

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -173,7 +173,9 @@ struct NameExchangeView: View {
         let isActive = assistantName == name
         return Button {
             assistantName = name
-            selectedGroupID = PersonalityGroup.groupForName(name)?.id
+            withAnimation(VAnimation.fast) {
+                selectedGroupID = PersonalityGroup.groupForName(name)?.id
+            }
         } label: {
             Text(name)
                 .font(VFont.labelDefault)

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -173,6 +173,7 @@ struct NameExchangeView: View {
         let isActive = assistantName == name
         return Button {
             assistantName = name
+            selectedGroupID = PersonalityGroup.groupForName(name)?.id
         } label: {
             Text(name)
                 .font(VFont.labelDefault)

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -76,7 +76,7 @@ struct PreChatOnboardingFlow: View {
         let context = PreChatOnboardingContext(
             tools: cleanTools,
             tasks: Array(state.selectedTasks).sorted(),
-            tone: "balanced",
+            tone: state.selectedGroupID ?? "grounded",
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )

--- a/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
+++ b/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
@@ -224,7 +224,7 @@ final class PreChatOnboardingTests: XCTestCase {
         let context = PreChatOnboardingContext(
             tools: Array(state.selectedTools).sorted(),
             tasks: Array(state.selectedTasks).sorted(),
-            tone: "balanced",
+            tone: "grounded",
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )
@@ -233,7 +233,7 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertNotNil(receivedContext)
         XCTAssertEqual(receivedContext?.tools, ["slack"])
         XCTAssertEqual(receivedContext?.tasks, ["writing"])
-        XCTAssertEqual(receivedContext?.tone, "balanced")
+        XCTAssertEqual(receivedContext?.tone, "grounded")
         XCTAssertEqual(receivedContext?.userName, "Alex")
         XCTAssertEqual(receivedContext?.assistantName, "Pax")
     }

--- a/clients/shared/Models/PreChatOnboardingContext.swift
+++ b/clients/shared/Models/PreChatOnboardingContext.swift
@@ -4,7 +4,7 @@
 public struct PreChatOnboardingContext: Codable, Sendable {
     public let tools: [String]       // e.g. ["slack", "linear", "figma"]
     public let tasks: [String]       // e.g. ["code-building", "writing"]
-    public let tone: String          // "casual", "professional", or "balanced"
+    public let tone: String          // "grounded", "warm", "energetic", or "poetic"
     public let userName: String?     // nil if skipped
     public let assistantName: String? // nil if kept default
 


### PR DESCRIPTION
## Summary
- Replace hardcoded tone 'balanced' with selectedGroupID (defaulting to 'grounded')
- Auto-select personality group when user taps a name chip
- Update PreChatOnboardingContext.tone doc comment with new valid values

Part of plan: personality-group-names.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
