### PR TITLE
mem(v2): add Swift types for activation payload

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -631,6 +631,7 @@ struct MessageInspectorViewState {
     private(set) var loadState: MessageInspectorLoadState = .loading
     private(set) var logs: [LLMRequestLogEntry] = []
     private(set) var memoryRecall: MemoryRecallData?
+    private(set) var memoryV2Activation: MemoryV2ActivationData?
     private(set) var selectedLogID: String?
     private(set) var selectedDetailTab: MessageInspectorDetailTab = .overview
     private(set) var selectedRawPane: RawPayloadPane = .response
@@ -668,6 +669,7 @@ struct MessageInspectorViewState {
             let orderedLogs = Self.ordered(response.logs)
             logs = orderedLogs
             memoryRecall = response.memoryRecall
+            memoryV2Activation = response.memoryV2Activation
 
             guard !orderedLogs.isEmpty else {
                 loadState = .empty
@@ -686,11 +688,13 @@ struct MessageInspectorViewState {
         case .empty:
             logs = []
             memoryRecall = nil
+            memoryV2Activation = nil
             loadState = .empty
             selectedLogID = nil
         case .failed:
             logs = []
             memoryRecall = nil
+            memoryV2Activation = nil
             loadState = .failed
             selectedLogID = nil
         }

--- a/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageInspectorViewTests.swift
@@ -122,8 +122,17 @@ final class MessageInspectorViewTests: XCTestCase {
         XCTAssertEqual(tab.label, "Memory")
     }
 
-    private func makeResponse(logs: [LLMRequestLogEntry], memoryRecall: MemoryRecallData? = nil) -> LLMContextResponse {
-        LLMContextResponse(messageId: "message-1", logs: logs, memoryRecall: memoryRecall)
+    private func makeResponse(
+        logs: [LLMRequestLogEntry],
+        memoryRecall: MemoryRecallData? = nil,
+        memoryV2Activation: MemoryV2ActivationData? = nil
+    ) -> LLMContextResponse {
+        LLMContextResponse(
+            messageId: "message-1",
+            logs: logs,
+            memoryRecall: memoryRecall,
+            memoryV2Activation: memoryV2Activation
+        )
     }
 
     private func makeLog(

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -518,6 +518,58 @@ public struct MemoryRecallData: Codable, Sendable, Equatable {
     public let queryContext: String?
 }
 
+public struct MemoryV2ActivationData: Codable, Sendable, Equatable {
+    public let turn: Int
+    public let mode: String // "context-load" | "per-turn"
+    public let concepts: [MemoryV2ConceptRow]
+    public let skills: [MemoryV2SkillRow]
+    public let config: MemoryV2Config
+}
+
+public struct MemoryV2ConceptRow: Codable, Sendable, Equatable, Identifiable {
+    public var id: String { slug }
+    public let slug: String
+    public let finalActivation: Double
+    public let ownActivation: Double
+    public let priorActivation: Double
+    public let simUser: Double
+    public let simAssistant: Double
+    public let simNow: Double
+    public let spreadContribution: Double
+    public let source: String  // "prior_state" | "ann_top50" | "both"
+    public let status: String  // "in_context" | "injected" | "not_injected"
+}
+
+public struct MemoryV2SkillRow: Codable, Sendable, Equatable, Identifiable {
+    public let id: String
+    public let activation: Double
+    public let simUser: Double
+    public let simAssistant: Double
+    public let simNow: Double
+    public let status: String  // "injected" | "not_injected"
+}
+
+public struct MemoryV2Config: Codable, Sendable, Equatable {
+    public let d: Double
+    public let cUser: Double
+    public let cAssistant: Double
+    public let cNow: Double
+    public let k: Double
+    public let hops: Int
+    public let topK: Int
+    public let topKSkills: Int
+    public let epsilon: Double
+
+    enum CodingKeys: String, CodingKey {
+        case d, k, hops, epsilon
+        case cUser = "c_user"
+        case cAssistant = "c_assistant"
+        case cNow = "c_now"
+        case topK = "top_k"
+        case topKSkills = "top_k_skills"
+    }
+}
+
 /// A single LLM request/response log entry returned by the context endpoint.
 /// `requestPayload` and `responsePayload` are nil in the initial response and
 /// fetched on demand via the dedicated payload endpoint.
@@ -543,6 +595,7 @@ public struct LLMContextResponse: Codable, Sendable {
     public let messageId: String
     public let logs: [LLMRequestLogEntry]
     public let memoryRecall: MemoryRecallData?
+    public let memoryV2Activation: MemoryV2ActivationData?
 }
 
 /// Explicit outcome for an LLM context fetch.


### PR DESCRIPTION
## Summary
- New `MemoryV2ActivationData`, `MemoryV2ConceptRow`, `MemoryV2SkillRow`, `MemoryV2Config` types in `LLMContextClient.swift`
- `LLMContextResponse.memoryV2Activation` is optional for backwards compat
- Plumbed through `LLMContextFetchResult` and `MessageInspectorViewState` (no UI rendering yet — that lands in PR 9/10)

Part of plan: memory-v2-inspector-tab.md (PR 8 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28815" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
