### PR TITLE
fix(macos): unbreak DiskPressureMonitor default-arg compile errors

### DIFF
--- a/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
+++ b/clients/macos/vellum-assistant/App/DiskPressureMonitor.swift
@@ -37,7 +37,7 @@ final class DiskPressureMonitor {
     @ObservationIgnored private var activeAssistantObserver: NSObjectProtocol?
 
     init(
-        fetchUsageFraction: @escaping UsageFractionFetcher = { Self.defaultUsageFraction() },
+        fetchUsageFraction: @escaping UsageFractionFetcher = { DiskPressureMonitor.defaultUsageFraction() },
         activeAssistantIdProvider: @escaping ActiveAssistantIdProvider = {
             LockfileAssistant.loadActiveAssistantId()
         },
@@ -162,7 +162,7 @@ final class DiskPressureMonitor {
     /// iCloud cache) that macOS reclaims under pressure, so the banner agrees
     /// with the user's perceived free space rather than the strict raw-FS
     /// reading from `statfs(2)`.
-    static func defaultUsageFraction() -> Double? {
+    nonisolated static func defaultUsageFraction() -> Double? {
         let url = VellumPaths.current.homeDirectory
         guard let values = try? url.resourceValues(forKeys: [
             .volumeTotalCapacityKey,


### PR DESCRIPTION
## Summary
- Replace \`Self.defaultUsageFraction()\` with \`DiskPressureMonitor.defaultUsageFraction()\` in the \`fetchUsageFraction\` default argument — covariant \`Self\` is not allowed in default-argument expressions.
- Mark \`defaultUsageFraction()\` \`nonisolated\` so the \`@Sendable\` \`UsageFractionFetcher\` closure can call it without crossing actor isolation. The function only reads \`VellumPaths.current\` and Foundation URL APIs — no main-actor state.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25131615322/job/73659113339
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
