### PR TITLE
feat(config): reject edits and deletes of managed inference profiles

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests that managed inference profiles ("quality-optimized", "balanced",
+ * "cost-optimized") cannot be edited via the PUT profile route or deleted
+ * via the PATCH config route.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+let savedRaw: Record<string, unknown> | null = null;
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => ({
+    llm: {
+      profiles: {
+        "quality-optimized": { provider: "anthropic", model: "claude-sonnet" },
+        balanced: { provider: "anthropic", model: "claude-sonnet" },
+        "cost-optimized": { provider: "anthropic", model: "claude-haiku" },
+        "my-custom": { provider: "openai", model: "gpt-4o" },
+      },
+    },
+  }),
+  saveRawConfig: (raw: Record<string, unknown>) => {
+    savedRaw = raw;
+  },
+  deepMergeOverwrite: (
+    target: Record<string, unknown>,
+    overrides: Record<string, unknown>,
+  ) => {
+    Object.assign(target, overrides);
+  },
+}));
+
+import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+
+const replaceRoute = ROUTES.find(
+  (r) => r.operationId === "config_llm_profiles_replace",
+)!;
+
+const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
+
+// ---------------------------------------------------------------------------
+// PUT /v1/config/llm/profiles/:name — replace inference profile
+// ---------------------------------------------------------------------------
+
+describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
+  test("rejects edits to quality-optimized with descriptive message", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "quality-optimized" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(
+      'Cannot edit managed profile "quality-optimized". Duplicate it to create a custom profile.',
+    );
+  });
+
+  test("rejects edits to balanced", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects edits to cost-optimized", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "cost-optimized" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("allows edits to a user-defined profile", () => {
+    savedRaw = null;
+    const result = replaceRoute.handler({
+      pathParams: { name: "my-custom" },
+      body: { provider: "openai", model: "gpt-4o" },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(savedRaw).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/config — managed profile deletion guard
+// ---------------------------------------------------------------------------
+
+describe("PATCH /v1/config — managed profile deletion guard", () => {
+  test("rejects deletion of quality-optimized via null with descriptive message", () => {
+    expect(() =>
+      patchRoute.handler({
+        body: { llm: { profiles: { "quality-optimized": null } } },
+      }),
+    ).toThrow('Cannot delete managed profile "quality-optimized".');
+  });
+
+  test("rejects deletion of balanced via null", () => {
+    expect(() =>
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: null } } },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects deletion of cost-optimized via null", () => {
+    expect(() =>
+      patchRoute.handler({
+        body: { llm: { profiles: { "cost-optimized": null } } },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("allows deletion of a user-defined profile via null", () => {
+    savedRaw = null;
+    const result = patchRoute.handler({
+      body: { llm: { profiles: { "my-custom": null } } },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("allows non-profile config patches", () => {
+    savedRaw = null;
+    const result = patchRoute.handler({
+      body: { someOtherKey: "value" },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("allows patches that modify a managed profile (non-null)", () => {
+    savedRaw = null;
+    const result = patchRoute.handler({
+      body: {
+        llm: {
+          profiles: { "quality-optimized": { provider: "anthropic" } },
+        },
+      },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -77,6 +77,14 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
   summary?: LlmContextSummaryResponse;
 };
 
+// TODO: Import from ../config/seed-inference-profiles.js once that module
+// exists (PR 2 of the declarative-profile-seed plan).
+const MANAGED_PROFILE_NAMES = new Set([
+  "quality-optimized",
+  "balanced",
+  "cost-optimized",
+]);
+
 const INFERENCE_PROFILE_UI_KEYS = new Set([
   "provider",
   "model",
@@ -268,6 +276,18 @@ function handleGetConfig() {
   }
 }
 
+function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
+  const llm = asMutablePlainObject(body.llm);
+  if (!llm) return;
+  const profiles = asMutablePlainObject(llm.profiles);
+  if (!profiles) return;
+  for (const name of Object.keys(profiles)) {
+    if (profiles[name] === null && MANAGED_PROFILE_NAMES.has(name)) {
+      throw new BadRequestError(`Cannot delete managed profile "${name}".`);
+    }
+  }
+}
+
 function handlePatchConfig({ body }: RouteHandlerArgs) {
   if (
     !body ||
@@ -277,6 +297,7 @@ function handlePatchConfig({ body }: RouteHandlerArgs) {
   ) {
     throw new BadRequestError("Body must be a non-empty JSON object");
   }
+  rejectManagedProfileDeletion(body as Record<string, unknown>);
   try {
     const raw = loadRawConfig();
     deepMergeOverwrite(raw, body);
@@ -298,6 +319,11 @@ function handleReplaceInferenceProfile({
   }
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new BadRequestError("Body must be a JSON object");
+  }
+  if (MANAGED_PROFILE_NAMES.has(name)) {
+    throw new BadRequestError(
+      `Cannot edit managed profile "${name}". Duplicate it to create a custom profile.`,
+    );
   }
   const parsed = ProfileEntry.safeParse(body);
   if (!parsed.success) {


### PR DESCRIPTION
## Summary
- Guard the replace-inference-profile route to reject edits to managed profiles
- Guard config PATCH to reject deletion of managed profiles
- Add tests for both rejection paths and user-profile passthrough

Part of plan: declarative-profile-seed.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
