### PR TITLE
feat(config): declarative inference profile seeding on startup

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -1,0 +1,111 @@
+import { loadRawConfig, saveRawConfig } from "./loader.js";
+import type { ProfileEntry } from "./schemas/llm.js";
+
+/**
+ * Declarative seed data for daemon-managed inference profiles.
+ *
+ * These profiles are overwritten on every startup so upstream model
+ * updates propagate automatically. User-created profiles (keyed by
+ * different names) are never touched.
+ */
+export const MANAGED_PROFILE_SEED_DATA: Record<string, ProfileEntry> = {
+  "quality-optimized": {
+    source: "managed",
+    label: "Quality",
+    description: "Best results with the most capable model",
+    provider: "anthropic",
+    model: "claude-opus-4-7",
+    maxTokens: 32000,
+    effort: "max",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  balanced: {
+    source: "managed",
+    label: "Balanced",
+    description: "Good balance of quality and speed",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  "cost-optimized": {
+    source: "managed",
+    label: "Speed",
+    description: "Fastest responses at lower cost",
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+  },
+};
+
+export const MANAGED_PROFILE_NAMES = new Set(
+  Object.keys(MANAGED_PROFILE_SEED_DATA),
+);
+
+/**
+ * Seed managed inference profiles into the workspace config.
+ *
+ * Called on every daemon startup after workspace migrations and before
+ * the first `loadConfig()`. Managed profiles are overwritten entirely
+ * (replace, not merge) so upstream model/effort changes propagate.
+ * User-created profiles are never touched; pre-existing profiles
+ * without a `source` field get `source: "user"` backfilled.
+ *
+ * No-op when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set (same guard
+ * as migration 052) because the platform-provided default-config overlay
+ * is the authoritative source for profile seeds.
+ */
+export function seedInferenceProfiles(): void {
+  if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+  const config = loadRawConfig();
+
+  if (config.llm == null || typeof config.llm !== "object") {
+    config.llm = {};
+  }
+  const llm = config.llm as Record<string, unknown>;
+
+  if (llm.profiles == null || typeof llm.profiles !== "object") {
+    llm.profiles = {};
+  }
+  const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+
+  for (const [name, seed] of Object.entries(MANAGED_PROFILE_SEED_DATA)) {
+    profiles[name] = { ...seed };
+  }
+
+  // Reset to "balanced" when the current value references a missing profile
+  if (
+    typeof llm.activeProfile !== "string" ||
+    !(llm.activeProfile in profiles)
+  ) {
+    llm.activeProfile = "balanced";
+  }
+
+  const profileOrder = Array.isArray(llm.profileOrder)
+    ? (llm.profileOrder as string[])
+    : [];
+  const orderSet = new Set(profileOrder);
+  for (const name of MANAGED_PROFILE_NAMES) {
+    if (!orderSet.has(name)) {
+      profileOrder.push(name);
+    }
+  }
+  llm.profileOrder = profileOrder;
+
+  for (const [name, profile] of Object.entries(profiles)) {
+    if (MANAGED_PROFILE_NAMES.has(name)) continue;
+    if (
+      profile != null &&
+      typeof profile === "object" &&
+      !("source" in profile)
+    ) {
+      profile.source = "user";
+    }
+  }
+
+  saveRawConfig(config);
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -19,6 +19,7 @@ import {
 } from "../config/env.js";
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
+import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import {
@@ -455,6 +456,20 @@ export async function runDaemon(): Promise<void> {
         log.warn({ err }, "Call recovery failed — continuing startup");
       }
     } // end if (dbReady)
+
+    // Seed managed inference profiles into the workspace config. Runs
+    // after workspace migrations (which may have created the initial
+    // profile slots) and before mergeDefaultWorkspaceConfig / loadConfig
+    // so the profiles are on disk for the first config load.
+    try {
+      seedInferenceProfiles();
+      log.info("Inference profile seeding complete");
+    } catch (err) {
+      log.warn(
+        { err },
+        "Inference profile seeding failed — continuing startup",
+      );
+    }
 
     // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
     // into the workspace config file before the first loadConfig() call so


### PR DESCRIPTION
## Summary
- Create seed-inference-profiles.ts with declarative managed profile definitions
- Seed three canonical profiles (quality-optimized, balanced, cost-optimized) on every startup
- Managed profiles are always overwritten; user-created profiles are never touched
- Backfill source: user on pre-existing profiles without a source field
- Wire into daemon lifecycle after workspace migrations, before config load

Part of plan: declarative-profile-seed.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
