### PR TITLE
mem(v2): disable v1 PKB filing when memory v2 is on

### DIFF
--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -21,6 +21,9 @@ let mockConfig = {
     activeHoursStart: null as number | null,
     activeHoursEnd: null as number | null,
   },
+  memory: {
+    v2: { enabled: false },
+  },
 };
 
 mock.module("../config/loader.js", () => ({
@@ -30,6 +33,9 @@ mock.module("../config/loader.js", () => ({
   saveRawConfig: () => {},
   invalidateConfigCache: () => {},
 }));
+
+const { _setOverridesForTesting } =
+  await import("../config/assistant-feature-flags.js");
 
 // Mock conversation store
 const createdConversations: Array<{ title: string; conversationType: string }> =
@@ -123,6 +129,7 @@ describe("FilingService", () => {
     } catch {
       // best-effort
     }
+    _setOverridesForTesting({});
   });
 
   beforeEach(() => {
@@ -151,6 +158,9 @@ describe("FilingService", () => {
         speed: "standard",
         activeHoursStart: null,
         activeHoursEnd: null,
+      },
+      memory: {
+        v2: { enabled: false },
       },
     };
 
@@ -318,6 +328,43 @@ describe("FilingService", () => {
       expect(content).not.toContain("Pick 3 random topic files");
       expect(content).not.toContain("Part 2");
       expect(content).toContain("focused on the buffer");
+    });
+  });
+
+  describe("memory v2 gate", () => {
+    test("start() does not schedule timers when v2 flag and config are both on", () => {
+      _setOverridesForTesting({ "memory-v2-enabled": true });
+      mockConfig.memory.v2.enabled = true;
+
+      const service = createService();
+      service.start();
+
+      expect(service.nextRunAt).toBeNull();
+      expect(service.nextCompactionAt).toBeNull();
+    });
+
+    test("start() schedules timers when only the flag is on", () => {
+      _setOverridesForTesting({ "memory-v2-enabled": true });
+      mockConfig.memory.v2.enabled = false;
+
+      const service = createService();
+      service.start();
+
+      expect(service.nextRunAt).not.toBeNull();
+      expect(service.nextCompactionAt).not.toBeNull();
+      service.stop();
+    });
+
+    test("start() schedules timers when only the config is on", () => {
+      _setOverridesForTesting({ "memory-v2-enabled": false });
+      mockConfig.memory.v2.enabled = true;
+
+      const service = createService();
+      service.start();
+
+      expect(service.nextRunAt).not.toBeNull();
+      expect(service.nextCompactionAt).not.toBeNull();
+      service.stop();
     });
   });
 

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { processMessage } from "../daemon/process-message.js";
@@ -108,7 +109,18 @@ export class FilingService {
   }
 
   start(): void {
-    const config = getConfig().filing;
+    const fullConfig = getConfig();
+    if (
+      isAssistantFeatureFlagEnabled("memory-v2-enabled", fullConfig) &&
+      fullConfig.memory.v2.enabled
+    ) {
+      log.info("Filing service disabled — memory v2 is active");
+      this._nextRunAt = null;
+      this._nextCompactionAt = null;
+      return;
+    }
+
+    const config = fullConfig.filing;
 
     if (config.enabled && !this.timer) {
       log.info({ intervalMs: config.intervalMs }, "Filing service started");


### PR DESCRIPTION
## Summary
- Gate `FilingService.start()` on the existing v2 double-check (`memory-v2-enabled` flag AND `memory.v2.enabled` config). When both are on, both timers are skipped and `nextRunAt`/`nextCompactionAt` stay null.
- Mirrors the same predicate already used to schedule v2 consolidation in `maybeEnqueueGraphMaintenanceJobs` (`assistant/src/memory/jobs-worker.ts`).
- HTTP-route forced runs (`runOnce({ force: true })`) intentionally still work — `force` is the existing escape hatch and matches how `config.enabled` and active-hours are handled today.

## Original prompt
When the memory v2 flag is on, the old filing job should be disabled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
