### PR TITLE
mem(v2): expose Memory v2 tab in inspector when data is present

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -294,9 +294,15 @@ struct MessageInspectorView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    private var visibleTabs: [MessageInspectorDetailTab] {
+        MessageInspectorDetailTab.allCases.filter { tab in
+            tab != .memoryV2 || viewState.memoryV2Activation != nil
+        }
+    }
+
     private var detailTabBar: some View {
         VTabs(
-            items: MessageInspectorDetailTab.allCases.map { (label: $0.label, tag: $0) },
+            items: visibleTabs.map { (label: $0.label, tag: $0) },
             selection: Binding(
                 get: { viewState.selectedDetailTab },
                 set: { viewState.selectDetailTab($0) }
@@ -311,6 +317,8 @@ struct MessageInspectorView: View {
             MessageInspectorOverviewTab(entry: entry)
         case .memory:
             MessageInspectorMemoryTab(memoryRecall: viewState.memoryRecall)
+        case .memoryV2:
+            MessageInspectorMemoryV2Tab(activation: viewState.memoryV2Activation)
         case .prompt:
             MessageInspectorPromptTab(entry: entry)
         case .response:
@@ -606,6 +614,7 @@ enum RawPayloadPane: String, CaseIterable {
 enum MessageInspectorDetailTab: String, CaseIterable {
     case overview
     case memory
+    case memoryV2
     case prompt
     case response
     case raw
@@ -616,6 +625,8 @@ enum MessageInspectorDetailTab: String, CaseIterable {
             return "Overview"
         case .memory:
             return "Memory"
+        case .memoryV2:
+            return "Memory v2"
         case .prompt:
             return "Prompt"
         case .response:
@@ -674,17 +685,16 @@ struct MessageInspectorViewState {
             guard !orderedLogs.isEmpty else {
                 loadState = .empty
                 selectedLogID = nil
+                resetSelectedTabIfMemoryV2Unavailable()
                 return
             }
 
             loadState = .loaded
 
-            if let selectedLogID,
-               orderedLogs.contains(where: { $0.id == selectedLogID }) {
-                return
+            if selectedLogID == nil
+               || !orderedLogs.contains(where: { $0.id == selectedLogID }) {
+                selectedLogID = orderedLogs.last?.id
             }
-
-            selectedLogID = orderedLogs.last?.id
         case .empty:
             logs = []
             memoryRecall = nil
@@ -697,6 +707,14 @@ struct MessageInspectorViewState {
             memoryV2Activation = nil
             loadState = .failed
             selectedLogID = nil
+        }
+
+        resetSelectedTabIfMemoryV2Unavailable()
+    }
+
+    private mutating func resetSelectedTabIfMemoryV2Unavailable() {
+        if selectedDetailTab == .memoryV2 && memoryV2Activation == nil {
+            selectedDetailTab = .overview
         }
     }
 


### PR DESCRIPTION
## Summary
- New `memoryV2` case in `MessageInspectorDetailTab` enum (between Memory and Prompt)
- Tab bar filters `.memoryV2` out when `memoryV2Activation` is `nil`, so the tab appears only when v2 ran for the turn
- Selected tab resets to `.overview` when switching to a turn without v2 data
- Renders `MessageInspectorMemoryV2Tab` with the activation payload

Part of plan: memory-v2-inspector-tab.md (PR 10 of 10)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
