### PR TITLE
fix(mem-v2): replace personal slugs in preview + scope counts to concepts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
@@ -97,11 +97,11 @@ struct MessageInspectorMemoryV2TabModel: Equatable {
                 )
             }
 
+        // Concept-only partition: skills lack `in_context`, so summing them in would
+        // make the three chips asymmetric. Skills are surfaced in their own card.
         let inContext = conceptRows.filter { $0.status == "in_context" }.count
         let injected = conceptRows.filter { $0.status == "injected" }.count
-            + skillRows.filter { $0.status == "injected" }.count
         let notInjected = conceptRows.filter { $0.status == "not_injected" }.count
-            + skillRows.filter { $0.status == "not_injected" }.count
 
         let config = ConfigVM(
             d: formatActivation(activation.config.d),
@@ -536,7 +536,7 @@ private struct ActivationBar: View {
         mode: "per-turn",
         concepts: [
             MemoryV2ConceptRow(
-                slug: "user_assistant_name",
+                slug: "user-prefers-dark-mode",
                 finalActivation: 0.842,
                 ownActivation: 0.512,
                 priorActivation: 0.220,
@@ -548,7 +548,7 @@ private struct ActivationBar: View {
                 status: "injected"
             ),
             MemoryV2ConceptRow(
-                slug: "project_persona_journal_systems",
+                slug: "project-onboarding-notes",
                 finalActivation: 0.610,
                 ownActivation: 0.430,
                 priorActivation: 0.150,
@@ -560,7 +560,7 @@ private struct ActivationBar: View {
                 status: "in_context"
             ),
             MemoryV2ConceptRow(
-                slug: "feedback_use_rg",
+                slug: "feedback-prefer-tdd",
                 finalActivation: 0.180,
                 ownActivation: 0.140,
                 priorActivation: 0.030,
@@ -574,7 +574,7 @@ private struct ActivationBar: View {
         ],
         skills: [
             MemoryV2SkillRow(
-                id: "meet-join",
+                id: "meeting-bot",
                 activation: 0.720,
                 simUser: 0.510,
                 simAssistant: 0.420,


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for memory-v2-inspector-tab.md.

- SwiftUI preview fixture replaced personal memory slugs with generic placeholders per CLAUDE.md.
- Counts-pill row (in context / injected / not injected) now scoped to concept rows only so the three chips partition a single set; skills already have their own section.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
