### PR TITLE
fix(mem-v2): extract shared test fixtures for activation log store and route

### DIFF
--- a/assistant/src/memory/__tests__/fixtures/memory-v2-activation-fixtures.ts
+++ b/assistant/src/memory/__tests__/fixtures/memory-v2-activation-fixtures.ts
@@ -1,0 +1,55 @@
+import type {
+  MemoryV2ConceptRowRecord,
+  MemoryV2ConfigSnapshot,
+  MemoryV2SkillRowRecord,
+} from "../../memory-v2-activation-log-store.js";
+
+export const sampleConcepts: MemoryV2ConceptRowRecord[] = [
+  {
+    slug: "concept-a",
+    finalActivation: 0.9,
+    ownActivation: 0.7,
+    priorActivation: 0.5,
+    simUser: 0.6,
+    simAssistant: 0.4,
+    simNow: 0.3,
+    spreadContribution: 0.2,
+    source: "both",
+    status: "injected",
+  },
+  {
+    slug: "concept-b",
+    finalActivation: 0.4,
+    ownActivation: 0.3,
+    priorActivation: 0.1,
+    simUser: 0.2,
+    simAssistant: 0.1,
+    simNow: 0.05,
+    spreadContribution: 0.0,
+    source: "ann_top50",
+    status: "not_injected",
+  },
+];
+
+export const sampleSkills: MemoryV2SkillRowRecord[] = [
+  {
+    id: "skill-1",
+    activation: 0.8,
+    simUser: 0.5,
+    simAssistant: 0.4,
+    simNow: 0.3,
+    status: "injected",
+  },
+];
+
+export const sampleConfig: MemoryV2ConfigSnapshot = {
+  d: 0.85,
+  c_user: 1.0,
+  c_assistant: 0.5,
+  c_now: 0.25,
+  k: 5,
+  hops: 2,
+  top_k: 10,
+  top_k_skills: 3,
+  epsilon: 0.001,
+};

--- a/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
@@ -23,12 +23,14 @@ import { initializeDb } from "../db-init.js";
 import {
   backfillMemoryV2ActivationMessageId,
   getMemoryV2ActivationLogByMessageIds,
-  type MemoryV2ConceptRowRecord,
-  type MemoryV2ConfigSnapshot,
-  type MemoryV2SkillRowRecord,
   recordMemoryV2ActivationLog,
 } from "../memory-v2-activation-log-store.js";
 import { memoryV2ActivationLogs } from "../schema.js";
+import {
+  sampleConcepts,
+  sampleConfig,
+  sampleSkills,
+} from "./fixtures/memory-v2-activation-fixtures.js";
 
 initializeDb();
 
@@ -36,56 +38,6 @@ function resetTables(): void {
   const db = getDb();
   db.delete(memoryV2ActivationLogs).run();
 }
-
-const sampleConcepts: MemoryV2ConceptRowRecord[] = [
-  {
-    slug: "concept-a",
-    finalActivation: 0.9,
-    ownActivation: 0.7,
-    priorActivation: 0.5,
-    simUser: 0.6,
-    simAssistant: 0.4,
-    simNow: 0.3,
-    spreadContribution: 0.2,
-    source: "both",
-    status: "injected",
-  },
-  {
-    slug: "concept-b",
-    finalActivation: 0.4,
-    ownActivation: 0.3,
-    priorActivation: 0.1,
-    simUser: 0.2,
-    simAssistant: 0.1,
-    simNow: 0.05,
-    spreadContribution: 0.0,
-    source: "ann_top50",
-    status: "not_injected",
-  },
-];
-
-const sampleSkills: MemoryV2SkillRowRecord[] = [
-  {
-    id: "skill-1",
-    activation: 0.8,
-    simUser: 0.5,
-    simAssistant: 0.4,
-    simNow: 0.3,
-    status: "injected",
-  },
-];
-
-const sampleConfig: MemoryV2ConfigSnapshot = {
-  d: 0.85,
-  c_user: 1.0,
-  c_assistant: 0.5,
-  c_now: 0.25,
-  k: 5,
-  hops: 2,
-  top_k: 10,
-  top_k_skills: 3,
-  epsilon: 0.001,
-};
 
 describe("memory-v2-activation-log-store", () => {
   beforeEach(() => {

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -7,6 +7,11 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
+import {
+  sampleConcepts as sharedSampleConcepts,
+  sampleConfig,
+  sampleSkills,
+} from "../../../memory/__tests__/fixtures/memory-v2-activation-fixtures.js";
 import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import {
@@ -21,6 +26,12 @@ import {
   memoryV2ActivationLogs,
 } from "../../../memory/schema.js";
 import { ROUTES } from "../conversation-query-routes.js";
+
+// Local subset: this test only exercises a single concept row.
+const sampleConcepts: MemoryV2ConceptRowRecord[] = sharedSampleConcepts.slice(
+  0,
+  1,
+);
 
 initializeDb();
 
@@ -54,44 +65,6 @@ function seedRequestLog(messageId: string, id: string): void {
     })
     .run();
 }
-
-const sampleConcepts: MemoryV2ConceptRowRecord[] = [
-  {
-    slug: "concept-a",
-    finalActivation: 0.9,
-    ownActivation: 0.7,
-    priorActivation: 0.5,
-    simUser: 0.6,
-    simAssistant: 0.4,
-    simNow: 0.3,
-    spreadContribution: 0.2,
-    source: "both",
-    status: "injected",
-  },
-];
-
-const sampleSkills: MemoryV2SkillRowRecord[] = [
-  {
-    id: "skill-1",
-    activation: 0.8,
-    simUser: 0.5,
-    simAssistant: 0.4,
-    simNow: 0.3,
-    status: "injected",
-  },
-];
-
-const sampleConfig: MemoryV2ConfigSnapshot = {
-  d: 0.85,
-  c_user: 1.0,
-  c_assistant: 0.5,
-  c_now: 0.25,
-  k: 5,
-  hops: 2,
-  top_k: 10,
-  top_k_skills: 3,
-  epsilon: 0.001,
-};
 
 describe("GET /v1/messages/:id/llm-context — memoryV2Activation", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
Fixes a duplication gap identified during plan review for memory-v2-inspector-tab.md.

The activation-log-store and llm-context route tests each declared their own `sampleConcepts`, `sampleSkills`, and `sampleConfig` literals. `sampleConfig` was byte-identical between the two; the others largely overlapped. Extracted to `memory/__tests__/fixtures/memory-v2-activation-fixtures.ts`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
