### PR TITLE
mem(v2): swap Filing for Consolidation in Settings under v2 flag

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -9,7 +9,10 @@ import { reconcileCallsOnStartup } from "../calls/call-recovery.js";
 import { setRelayBroadcast } from "../calls/relay-server.js";
 import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
-import { initFeatureFlagOverrides } from "../config/assistant-feature-flags.js";
+import {
+  initFeatureFlagOverrides,
+  isAssistantFeatureFlagEnabled,
+} from "../config/assistant-feature-flags.js";
 import {
   getPlatformAssistantId,
   getRuntimeHttpHost,
@@ -1219,16 +1222,31 @@ export async function runDaemon(): Promise<void> {
       "Heartbeat service configured",
     );
 
-    const filingConfig = config.filing;
-    const filing = new FilingService();
-    filing.start();
-    log.info(
-      {
-        enabled: filingConfig.enabled,
-        intervalMs: filingConfig.intervalMs,
-      },
-      "Filing service configured",
+    // Filing yields to the memory v2 consolidation job when the flag is on —
+    // both serve the same role (periodic background memory processing) and
+    // running both is redundant. The consolidation job runs through the
+    // memory jobs worker (see `maybeEnqueueGraphMaintenanceJobs`).
+    const memoryV2Enabled = isAssistantFeatureFlagEnabled(
+      "memory-v2-enabled",
+      config,
     );
+    let filing: FilingService | null = null;
+    if (!memoryV2Enabled) {
+      const filingConfig = config.filing;
+      filing = new FilingService();
+      filing.start();
+      log.info(
+        {
+          enabled: filingConfig.enabled,
+          intervalMs: filingConfig.intervalMs,
+        },
+        "Filing service configured",
+      );
+    } else {
+      log.info(
+        "Filing service skipped — memory v2 consolidation is the active background memory job",
+      );
+    }
 
     // Retrieve the MCP manager if MCP servers were configured.
     // The manager is a singleton created during initializeProvidersAndTools().

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -21,7 +21,7 @@ export interface ShutdownDeps {
   server: DaemonServer;
   workspaceHeartbeat: WorkspaceHeartbeatService;
   heartbeat: HeartbeatService;
-  filing: FilingService;
+  filing: FilingService | null;
   runtimeHttp: RuntimeHttpServer | null;
   scheduler: { stop(): void };
   feedScheduler: { stop(): void } | null;
@@ -61,7 +61,7 @@ export function installShutdownHandlers(deps: ShutdownDeps): void {
 
     await deps.workspaceHeartbeat.stop();
     await deps.heartbeat.stop();
-    await deps.filing.stop();
+    if (deps.filing) await deps.filing.stop();
 
     // Run registered skill shutdown hooks (e.g. meet-join session teardown)
     // before stopping the server so any HTTP round-trips and SSE emissions

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -535,7 +535,7 @@ const GRAPH_CONSOLIDATE_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const GRAPH_PATTERN_SCAN_INTERVAL_MS = 24 * 60 * 60 * 1000; // 1 day
 const GRAPH_NARRATIVE_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
 
-const GRAPH_MAINTENANCE_CHECKPOINTS = {
+export const GRAPH_MAINTENANCE_CHECKPOINTS = {
   decay: "graph_maintenance:decay:last_run",
   consolidate: "graph_maintenance:consolidate:last_run",
   patternScan: "graph_maintenance:pattern_scan:last_run",

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -481,6 +481,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "filing", scopes: ["settings.read"] },
   { endpoint: "filing:POST", scopes: ["settings.write"] },
 
+  // Consolidation (memory v2 counterpart to Filing)
+  { endpoint: "consolidation", scopes: ["settings.read"] },
+  { endpoint: "consolidation:POST", scopes: ["settings.write"] },
+
   // Heartbeat (config, runs, checklist — all share the "heartbeat" policyKey)
   { endpoint: "heartbeat:GET", scopes: ["settings.read"] },
   { endpoint: "heartbeat", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/consolidation-routes.ts
+++ b/assistant/src/runtime/routes/consolidation-routes.ts
@@ -1,0 +1,115 @@
+/**
+ * Route handlers for the memory v2 consolidation job.
+ *
+ * Consolidation is the v2 counterpart to filing: an interval-based background
+ * pass that routes accumulated `memory/buffer.md` entries into concept pages.
+ * The job itself is enqueued by the memory jobs worker (see
+ * `maybeEnqueueGraphMaintenanceJobs` in `memory/jobs-worker.ts`); these routes
+ * only surface its config and provide an on-demand trigger for the Settings UI.
+ *
+ * `available` mirrors the filing route's `available` field: it reflects which
+ * background memory job is active for this instance. When `memory-v2-enabled`
+ * is off, consolidation returns `available: false` and the UI hides the row.
+ */
+
+import { z } from "zod";
+
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
+import { getMemoryCheckpoint } from "../../memory/checkpoints.js";
+import {
+  enqueueMemoryJob,
+  hasActiveJobOfType,
+} from "../../memory/jobs-store.js";
+import { GRAPH_MAINTENANCE_CHECKPOINTS } from "../../memory/jobs-worker.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+function isConsolidationAvailable(): boolean {
+  return isAssistantFeatureFlagEnabled("memory-v2-enabled", getConfig());
+}
+
+function consolidationIntervalMs(): number {
+  return getConfig().memory.v2.consolidation_interval_hours * 60 * 60 * 1000;
+}
+
+function readLastRunAt(): number | null {
+  const raw = getMemoryCheckpoint(
+    GRAPH_MAINTENANCE_CHECKPOINTS.memoryV2Consolidate,
+  );
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+// ---------------------------------------------------------------------------
+// Shared ROUTES
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "getConsolidationConfig",
+    endpoint: "consolidation/config",
+    method: "GET",
+    policyKey: "consolidation",
+    requirePolicyEnforcement: true,
+    summary: "Get consolidation config",
+    description:
+      "Return the current memory v2 consolidation schedule configuration.",
+    tags: ["consolidation"],
+    responseBody: z.object({
+      available: z.boolean(),
+      enabled: z.boolean(),
+      intervalMs: z.number(),
+      nextRunAt: z.number().nullable(),
+      lastRunAt: z.number().nullable(),
+      success: z.boolean(),
+    }),
+    handler: async (_args: RouteHandlerArgs) => {
+      const available = isConsolidationAvailable();
+      const v2Config = getConfig().memory.v2;
+      const intervalMs = consolidationIntervalMs();
+      const lastRunAt = readLastRunAt();
+      const nextRunAt = lastRunAt != null ? lastRunAt + intervalMs : null;
+      return {
+        available,
+        enabled: available && v2Config.enabled,
+        intervalMs,
+        nextRunAt,
+        lastRunAt,
+        success: true,
+      };
+    },
+  },
+  {
+    operationId: "runConsolidationNow",
+    endpoint: "consolidation/run-now",
+    method: "POST",
+    policyKey: "consolidation",
+    requirePolicyEnforcement: true,
+    summary: "Run consolidation now",
+    description:
+      "Enqueue an immediate memory v2 consolidation job. Returns once the job is queued; the job itself runs through the memory jobs worker.",
+    tags: ["consolidation"],
+    responseBody: z.object({
+      success: z.boolean(),
+      ran: z.boolean().describe("Whether a job was enqueued"),
+      jobId: z.string().nullable(),
+    }),
+    handler: async (_args: RouteHandlerArgs) => {
+      if (!isConsolidationAvailable()) {
+        throw new BadRequestError(
+          "Consolidation is not available (memory-v2-enabled is off)",
+        );
+      }
+      // Coalesce: don't pile up duplicate jobs if the worker hasn't picked up
+      // the previous one yet. The consolidation job's own lock catches the
+      // overlapping-window case but does not prevent queue depth from growing.
+      if (hasActiveJobOfType("memory_v2_consolidate")) {
+        return { success: true, ran: false, jobId: null };
+      }
+      const jobId = enqueueMemoryJob("memory_v2_consolidate", {});
+      return { success: true, ran: true, jobId };
+    },
+  },
+];

--- a/assistant/src/runtime/routes/filing-routes.ts
+++ b/assistant/src/runtime/routes/filing-routes.ts
@@ -1,16 +1,26 @@
 /**
  * Route handlers for filing management.
+ *
+ * `available` reflects whether the filing service is the active background
+ * memory job for this instance. When the `memory-v2-enabled` flag is on,
+ * filing yields to the consolidation job (see consolidation-routes.ts) and
+ * returns `available: false` so the UI can hide the row.
  */
 
 import { z } from "zod";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { FilingService } from "../../filing/filing-service.js";
 import { getLogger } from "../../util/logger.js";
-import { InternalError } from "./errors.js";
+import { BadRequestError, InternalError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("filing-routes");
+
+function isFilingAvailable(): boolean {
+  return !isAssistantFeatureFlagEnabled("memory-v2-enabled", getConfig());
+}
 
 // ---------------------------------------------------------------------------
 // Shared ROUTES
@@ -27,6 +37,7 @@ export const ROUTES: RouteDefinition[] = [
     description: "Return the current filing schedule configuration.",
     tags: ["filing"],
     responseBody: z.object({
+      available: z.boolean(),
       enabled: z.boolean(),
       intervalMs: z.number(),
       activeHoursStart: z.number().nullable(),
@@ -39,6 +50,7 @@ export const ROUTES: RouteDefinition[] = [
       const config = getConfig().filing;
       const svc = FilingService.getInstance();
       return {
+        available: isFilingAvailable(),
         enabled: config.enabled,
         intervalMs: config.intervalMs,
         activeHoursStart: config.activeHoursStart ?? null,
@@ -63,6 +75,11 @@ export const ROUTES: RouteDefinition[] = [
       ran: z.boolean().describe("Whether the filing actually ran"),
     }),
     handler: async (_args: RouteHandlerArgs) => {
+      if (!isFilingAvailable()) {
+        throw new BadRequestError(
+          "Filing is not the active background memory job (memory v2 is enabled)",
+        );
+      }
       const svc = FilingService.getInstance();
       if (!svc) {
         throw new InternalError("Filing service not available");

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -26,6 +26,7 @@ import { ROUTES as CHANNEL_READINESS_ROUTES } from "./channel-readiness-routes.j
 import { CHANNEL_ROUTES } from "./channel-route-definitions.js";
 import { ROUTES as CHANNEL_VERIFICATION_ROUTES } from "./channel-verification-routes.js";
 import { ROUTES as CLIENT_ROUTES } from "./client-routes.js";
+import { ROUTES as CONSOLIDATION_ROUTES } from "./consolidation-routes.js";
 import { ROUTES as CONTACT_ROUTES } from "./contact-routes.js";
 import { ROUTES as CONVERSATION_ANALYSIS_ROUTES } from "./conversation-analysis-routes.js";
 import { ROUTES as CONVERSATION_ATTENTION_ROUTES } from "./conversation-attention-routes.js";
@@ -125,6 +126,7 @@ export const ROUTES: RouteDefinition[] = [
   ...CONVERSATION_LIST_ROUTES,
   ...CONVERSATION_MANAGEMENT_ROUTES,
   ...CONVERSATION_MESSAGE_ROUTES,
+  ...CONSOLIDATION_ROUTES,
   ...CREDENTIAL_PROMPT_ROUTES,
   ...DEFER_ROUTES,
   ...CONVERSATION_QUERY_ROUTES,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
@@ -19,12 +19,15 @@ struct SettingsSchedulesTab: View {
     // System task state
     @State private var heartbeatConfig: HeartbeatConfigResponse?
     @State private var filingConfig: FilingConfigResponse?
+    @State private var consolidationConfig: ConsolidationConfigResponse?
     @State private var isHeartbeatRunning = false
     @State private var isFilingRunning = false
+    @State private var isConsolidationRunning = false
 
     private let scheduleClient: ScheduleClientProtocol = ScheduleClient()
     private let heartbeatClient: HeartbeatClientProtocol = HeartbeatClient()
     private let filingClient: FilingClientProtocol = FilingClient()
+    private let consolidationClient: ConsolidationClientProtocol = ConsolidationClient()
 
     // MARK: - Body
 
@@ -64,10 +67,17 @@ struct SettingsSchedulesTab: View {
             .foregroundStyle(VColor.contentDefault)
     }
 
+    private var filingAvailable: Bool { filingConfig?.available == true }
+    private var consolidationAvailable: Bool { consolidationConfig?.available == true }
+    private var hasAnySystemTask: Bool {
+        heartbeatConfig != nil || filingAvailable || consolidationAvailable
+    }
+
     private var systemTaskCount: Int {
         var count = 0
         if heartbeatConfig != nil { count += 1 }
-        if filingConfig != nil { count += 1 }
+        if filingAvailable { count += 1 }
+        if consolidationAvailable { count += 1 }
         return count
     }
 
@@ -78,7 +88,7 @@ struct SettingsSchedulesTab: View {
         if isLoading {
             ProgressView()
                 .frame(maxWidth: .infinity, minHeight: 120)
-        } else if schedules.isEmpty && heartbeatConfig == nil && filingConfig == nil {
+        } else if schedules.isEmpty && !hasAnySystemTask {
             if let error = loadError {
                 errorView(error)
             } else {
@@ -132,7 +142,7 @@ struct SettingsSchedulesTab: View {
                 }
             }
 
-            if heartbeatConfig != nil || filingConfig != nil {
+            if hasAnySystemTask {
                 systemSection
             }
         }
@@ -304,7 +314,7 @@ struct SettingsSchedulesTab: View {
                 )
             }
 
-            if let config = filingConfig {
+            if let config = filingConfig, config.available {
                 systemRow(
                     name: "Filing",
                     subtitle: filingSubtitle(config),
@@ -313,6 +323,19 @@ struct SettingsSchedulesTab: View {
                     lastRunAt: config.lastRunAt,
                     isRunning: isFilingRunning,
                     onRunNow: { runFilingNow() },
+                    onToggle: nil
+                )
+            }
+
+            if let config = consolidationConfig, config.available {
+                systemRow(
+                    name: "Consolidation",
+                    subtitle: consolidationSubtitle(config),
+                    enabled: config.enabled,
+                    nextRunAt: config.nextRunAt,
+                    lastRunAt: config.lastRunAt,
+                    isRunning: isConsolidationRunning,
+                    onRunNow: { runConsolidationNow() },
                     onToggle: nil
                 )
             }
@@ -451,8 +474,12 @@ struct SettingsSchedulesTab: View {
         } catch {
             loadError = "Failed to load schedules. \(error.localizedDescription)"
         }
-        heartbeatConfig = await heartbeatClient.fetchConfig()
-        filingConfig = await filingClient.fetchConfig()
+        async let hb = heartbeatClient.fetchConfig()
+        async let fi = filingClient.fetchConfig()
+        async let co = consolidationClient.fetchConfig()
+        heartbeatConfig = await hb
+        filingConfig = await fi
+        consolidationConfig = await co
         isLoading = false
     }
 
@@ -572,6 +599,15 @@ struct SettingsSchedulesTab: View {
         }
     }
 
+    private func runConsolidationNow() {
+        isConsolidationRunning = true
+        Task {
+            _ = await consolidationClient.runNow()
+            consolidationConfig = await consolidationClient.fetchConfig()
+            isConsolidationRunning = false
+        }
+    }
+
     // MARK: - Helpers
 
     private func modeBadgeTone(_ mode: String) -> VBadge.Tone {
@@ -604,6 +640,14 @@ struct SettingsSchedulesTab: View {
             subtitle += " (\(Int(start)):00\u{2013}\(Int(end)):00)"
         }
         return subtitle
+    }
+
+    private func consolidationSubtitle(_ config: ConsolidationConfigResponse) -> String {
+        let minutes = Int(config.intervalMs / 60_000)
+        if minutes >= 60 && minutes % 60 == 0 {
+            return "Every \(minutes / 60) hr"
+        }
+        return "Every \(minutes) min"
     }
 
     private func formatNextRun(_ ms: Int, timezone: String?) -> String? {

--- a/clients/shared/Network/ConsolidationClient.swift
+++ b/clients/shared/Network/ConsolidationClient.swift
@@ -1,0 +1,64 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ConsolidationClient")
+
+/// Focused client for memory v2 consolidation operations routed through the gateway.
+///
+/// Mirrors ``FilingClientProtocol`` — consolidation replaces filing as the
+/// active background memory job when the `memory-v2-enabled` flag is on.
+public protocol ConsolidationClientProtocol {
+    func fetchConfig() async -> ConsolidationConfigResponse?
+    func runNow() async -> ConsolidationRunNowResponse?
+}
+
+/// Gateway-backed implementation of ``ConsolidationClientProtocol``.
+public struct ConsolidationClient: ConsolidationClientProtocol {
+    nonisolated public init() {}
+
+    public func fetchConfig() async -> ConsolidationConfigResponse? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/consolidation/config", timeout: 10
+            )
+            guard response.isSuccess else {
+                log.error("fetchConfig failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            let patched = injectType("consolidation_config_response", into: response.data)
+            return try JSONDecoder().decode(ConsolidationConfigResponse.self, from: patched)
+        } catch {
+            log.error("fetchConfig error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func runNow() async -> ConsolidationRunNowResponse? {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "assistants/{assistantId}/consolidation/run-now", timeout: 30
+            )
+            guard response.isSuccess else {
+                log.error("runNow failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            let patched = injectType("consolidation_run_now_response", into: response.data)
+            return try JSONDecoder().decode(ConsolidationRunNowResponse.self, from: patched)
+        } catch {
+            log.error("runNow error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Injects the `"type"` discriminant required by `Codable` decoding of
+    /// server message types whose JSON payloads omit it over HTTP.
+    private func injectType(_ type: String, into data: Data) -> Data {
+        guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return data
+        }
+        json["type"] = type
+        return (try? JSONSerialization.data(withJSONObject: json)) ?? data
+    }
+}

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1934,6 +1934,7 @@ public struct HeartbeatConfigResponse: Codable, Sendable {
 
 public struct FilingConfigResponse: Codable, Sendable {
     public let type: String
+    public let available: Bool
     public let enabled: Bool
     public let intervalMs: Double
     public let activeHoursStart: Double?
@@ -1943,8 +1944,9 @@ public struct FilingConfigResponse: Codable, Sendable {
     public let success: Bool
     public let error: String?
 
-    public init(type: String, enabled: Bool, intervalMs: Double, activeHoursStart: Double?, activeHoursEnd: Double?, nextRunAt: Int?, lastRunAt: Int? = nil, success: Bool, error: String? = nil) {
+    public init(type: String, available: Bool = true, enabled: Bool, intervalMs: Double, activeHoursStart: Double?, activeHoursEnd: Double?, nextRunAt: Int?, lastRunAt: Int? = nil, success: Bool, error: String? = nil) {
         self.type = type
+        self.available = available
         self.enabled = enabled
         self.intervalMs = intervalMs
         self.activeHoursStart = activeHoursStart
@@ -1966,6 +1968,44 @@ public struct FilingRunNowResponse: Codable, Sendable {
         self.type = type
         self.success = success
         self.ran = ran
+        self.error = error
+    }
+}
+
+public struct ConsolidationConfigResponse: Codable, Sendable {
+    public let type: String
+    public let available: Bool
+    public let enabled: Bool
+    public let intervalMs: Double
+    public let nextRunAt: Int?
+    public let lastRunAt: Int?
+    public let success: Bool
+    public let error: String?
+
+    public init(type: String, available: Bool, enabled: Bool, intervalMs: Double, nextRunAt: Int?, lastRunAt: Int? = nil, success: Bool, error: String? = nil) {
+        self.type = type
+        self.available = available
+        self.enabled = enabled
+        self.intervalMs = intervalMs
+        self.nextRunAt = nextRunAt
+        self.lastRunAt = lastRunAt
+        self.success = success
+        self.error = error
+    }
+}
+
+public struct ConsolidationRunNowResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let ran: Bool
+    public let jobId: String?
+    public let error: String?
+
+    public init(type: String, success: Bool, ran: Bool, jobId: String? = nil, error: String? = nil) {
+        self.type = type
+        self.success = success
+        self.ran = ran
+        self.jobId = jobId
         self.error = error
     }
 }


### PR DESCRIPTION
## Summary
- Gate `FilingService` startup on `!memory-v2-enabled` so the v2 consolidation job is the sole background memory pass when v2 is on.
- Add `GET /consolidation/config` and `POST /consolidation/run-now` routes; both endpoints return an `available` field that the macOS Settings → Schedules UI uses to render exactly one of the two rows.
- Mirror the Filing client/UI wiring: new `ConsolidationClient.swift`, a `Consolidation` row in `SettingsSchedulesTab`, and parallel `async let` fetches for the three system-job configs.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
