### PR TITLE
fix(macos): allowlist FlexFrame entries for MessageInspectorMemoryV2Tab

### DIFF
--- a/clients/scripts/flexframe-allowlist.txt
+++ b/clients/scripts/flexframe-allowlist.txt
@@ -59,6 +59,8 @@ clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift|.fr
 clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift|.frame(maxWidth: .infinity, alignment: .topLeading)
 clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift|.frame(maxWidth: .infinity, alignment: .topLeading)
 clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryTab.swift|.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift|.frame(maxWidth: .infinity, alignment: .topLeading)
+clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift|.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 clients/macos/vellum-assistant/Features/Chat/MessageInspectorOverviewTab.swift|.frame(maxWidth: .infinity, alignment: .topLeading)
 clients/macos/vellum-assistant/Features/Chat/MessageInspectorOverviewTab.swift|.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 clients/macos/vellum-assistant/Features/Chat/MessageInspectorPayloadView.swift|.frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- Add the two `.frame(maxWidth:/maxHeight:)` lines in `MessageInspectorMemoryV2Tab.swift` (added in #28818) to `clients/scripts/flexframe-allowlist.txt`.
- Matches the pattern every sibling `MessageInspector*` tab already uses (root fill-parent + ScrollView inner top-leading), and the tab is rendered eagerly via `switch` in `MessageInspectorView` — no lazy container above it, so it fits the documented allowlist case for detail-panel surfaces.
- Unblocks `FlexFrame Lint` on `main` (failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/25132345340/job/73661684426).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25132345340/job/73661684426
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
