### PR TITLE
mem(v2): support folder hierarchy under memory/concepts/

### DIFF
--- a/assistant/src/__tests__/context-search-memory-v2-source.test.ts
+++ b/assistant/src/__tests__/context-search-memory-v2-source.test.ts
@@ -80,6 +80,12 @@ mock.module("../memory/v2/page-store.js", () => ({
     _workspaceDir: string,
     slug: string,
   ): Promise<ConceptPage | null> => pageStore.get(slug) ?? null,
+  slugFromConceptPath: (conceptsRoot: string, filePath: string): string => {
+    const rel = filePath.startsWith(conceptsRoot)
+      ? filePath.slice(conceptsRoot.length).replace(/^\/+/, "")
+      : filePath;
+    return rel.endsWith(".md") ? rel.slice(0, -3) : rel;
+  },
 }));
 
 const { searchMemoryV2Source } =
@@ -294,6 +300,59 @@ describe("searchMemoryV2Source", () => {
     );
     expect(hit?.title).toBe("alice");
     expect(hit?.excerpt).toBe("Alice memory body content.");
+  });
+
+  test("activation hit for nested slug produces nested locator and slug", async () => {
+    const root = makeTempDir();
+    writeConceptPage(root, "people/alice", "Alice prefers concise notes.\n");
+
+    qdrantHits = [{ slug: "people/alice", denseScore: 0.92 }];
+    pageStore.set("people/alice", {
+      slug: "people/alice",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Alice prefers concise notes.",
+    });
+
+    const result = await searchMemoryV2Source(
+      "alice notes",
+      makeContext(root),
+      5,
+    );
+
+    const hit = result.evidence.find(
+      (e) => e.metadata?.retrieval === "activation",
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.locator).toBe("memory/concepts/people/alice.md");
+    expect(hit?.metadata?.path).toBe("memory/concepts/people/alice.md");
+    expect(hit?.metadata?.slug).toBe("people/alice");
+    expect(hit?.title).toBe("people/alice");
+  });
+
+  test("lexical fallback surfaces nested concept pages with nested locators", async () => {
+    const root = makeTempDir();
+    writeConceptPage(
+      root,
+      "people/bob",
+      "# Bob\n\nbirthday party plans for next month.\n",
+    );
+
+    qdrantHits = [];
+
+    const result = await searchMemoryV2Source(
+      "birthday party",
+      makeContext(root),
+      5,
+    );
+
+    const lexicalHit = result.evidence.find(
+      (e) => e.metadata?.retrieval === "lexical",
+    );
+    expect(lexicalHit).toBeDefined();
+    expect(lexicalHit?.metadata?.path).toBe("memory/concepts/people/bob.md");
+    expect(lexicalHit?.locator).toMatch(
+      /^memory\/concepts\/people\/bob\.md:\d+$/,
+    );
   });
 
   test("returns empty when limit is zero", async () => {

--- a/assistant/src/ipc/routes/__tests__/memory-v2-validate.test.ts
+++ b/assistant/src/ipc/routes/__tests__/memory-v2-validate.test.ts
@@ -41,7 +41,9 @@ type ValidateResult = {
   parseFailures: { slug: string; error: string }[];
 };
 
-const validateRoute = memoryV2Routes.find(r => r.operationId === "memory_v2_validate")!;
+const validateRoute = memoryV2Routes.find(
+  (r) => r.operationId === "memory_v2_validate",
+)!;
 
 async function runRoute(
   params: Record<string, unknown> = {},
@@ -184,6 +186,33 @@ describe("memory_v2_validate route", () => {
 
     expect(result.pageCount).toBe(2);
     expect(result.oversizedPages).toEqual([{ slug: "tiny", chars: 50 }]);
+    expect(result.parseFailures).toEqual([]);
+  });
+
+  test("nested concept pages are walked and edges between them validate clean", async () => {
+    // Mix flat and nested slugs; the validate route must surface both pages
+    // and treat an edge across them as well-formed.
+    await writePage(workspace(), {
+      slug: "alice",
+      frontmatter: { edges: ["people/bob"], ref_files: [] },
+      body: "Atomic concept.",
+    });
+    await writePage(workspace(), {
+      slug: "people/bob",
+      frontmatter: { edges: ["alice"], ref_files: [] },
+      body: "Person page in folder.",
+    });
+    await writeEdges(workspace(), {
+      version: 1,
+      edges: [["alice", "people/bob"]],
+    });
+
+    const result = await runRoute();
+
+    expect(result.pageCount).toBe(2);
+    expect(result.edgeCount).toBe(1);
+    expect(result.missingEdgeEndpoints).toEqual([]);
+    expect(result.oversizedPages).toEqual([]);
     expect(result.parseFailures).toEqual([]);
   });
 

--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -23,7 +23,7 @@
 // still surface lexical hits, and vice versa.
 
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
-import { extname, isAbsolute, join, relative, sep } from "node:path";
+import { extname, isAbsolute, join, relative } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../../../config/schema.js";
@@ -32,7 +32,11 @@ import { embedWithRetry } from "../../embed.js";
 import { generateSparseEmbedding } from "../../embedding-backend.js";
 import { spreadActivation } from "../../v2/activation.js";
 import { readEdges } from "../../v2/edges.js";
-import { getConceptsDir, readPage } from "../../v2/page-store.js";
+import {
+  getConceptsDir,
+  readPage,
+  slugFromConceptPath,
+} from "../../v2/page-store.js";
 import { hybridQueryConceptPages } from "../../v2/qdrant.js";
 import { clampUnitInterval } from "../../validation.js";
 import type {
@@ -559,12 +563,6 @@ function isPathInsideRoot(pathToCheck: string, rootRealPath: string): boolean {
     pathRelativeToRoot === "" ||
     (!pathRelativeToRoot.startsWith("..") && !isAbsolute(pathRelativeToRoot))
   );
-}
-
-function slugFromConceptPath(conceptsRoot: string, filePath: string): string {
-  const rel = relative(conceptsRoot, filePath).split(sep).join("/");
-  const withoutExt = rel.endsWith(".md") ? rel.slice(0, -3) : rel;
-  return withoutExt;
 }
 
 function truncateExcerpt(text: string, maxChars: number): string {

--- a/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
@@ -413,6 +413,33 @@ describe("memoryV2RebuildEdgesJob", () => {
     expect(alice?.frontmatter.edges).toEqual(["bob", "carol"]);
   });
 
+  test("walks nested concept pages and rewrites their edges: frontmatter", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "alice",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Atomic concept.\n",
+    });
+    await writePage(tmpWorkspace, {
+      slug: "people/bob",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Person page.\n",
+    });
+    await writeEdges(tmpWorkspace, {
+      version: 1,
+      edges: [["alice", "people/bob"]],
+    });
+
+    await memoryV2RebuildEdgesJob(
+      makeJob("memory_v2_rebuild_edges"),
+      TEST_CONFIG,
+    );
+
+    const alice = await readPage(tmpWorkspace, "alice");
+    const bob = await readPage(tmpWorkspace, "people/bob");
+    expect(alice?.frontmatter.edges).toEqual(["people/bob"]);
+    expect(bob?.frontmatter.edges).toEqual(["alice"]);
+  });
+
   test("is a no-op for pages whose frontmatter is already correct", async () => {
     // Pre-write the page with the correct edges so the handler should leave
     // it untouched. We can't easily observe "no rewrite happened" from the

--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -1,14 +1,17 @@
 /**
  * Tests for `assistant/src/memory/v2/page-store.ts`.
  *
- * Coverage matrix (from PR 8 acceptance criteria):
+ * Coverage matrix:
  *   - slugify: lowercase / kebab-case / ascii / 80-char cap / empty fallback.
+ *   - validateSlug: accept set, reject set (path-traversal, malformed shapes).
  *   - readPage / writePage round-trip: frontmatter survives, body preserved.
  *   - readPage on missing file: returns null.
  *   - writePage atomicity: a fault between temp-write and rename leaves the
  *     prior file intact (or the new one) — never a half-written page.
- *   - listPages: excludes non-.md entries, returns slugs only, missing dir → [].
- *   - deletePage: idempotent on missing file.
+ *   - writePage creates parent directories for nested slugs.
+ *   - listPages: walks subdirectories, returns nested slugs in `/`-form,
+ *     excludes hidden dirs / non-.md / temp files, missing dir → [].
+ *   - deletePage / pageExists: nested-slug round-trip, idempotent on missing.
  *
  * Tests use temp workspaces under `os.tmpdir()` per the cross-cutting safety
  * rule in the v2 plan; they never touch `~/.vellum/`.
@@ -33,6 +36,7 @@ import {
   pageExists,
   readPage,
   slugify,
+  validateSlug,
   writePage,
 } from "../page-store.js";
 import type { ConceptPage } from "../types.js";
@@ -90,6 +94,12 @@ describe("slugify", () => {
     expect(slugify("café résumé")).toMatch(/^[a-z0-9-]+$/);
   });
 
+  test("collapses '/' to hyphen — slugify produces a single segment", () => {
+    // Path-shaped slugs are constructed by writing to nested paths, not by
+    // passing slash-bearing input through slugify.
+    expect(slugify("People/Alice")).toBe("people-alice");
+  });
+
   test("caps slug length at 80 chars and re-trims trailing hyphen", () => {
     const long = "a".repeat(120);
     const slug = slugify(long);
@@ -106,6 +116,56 @@ describe("slugify", () => {
     // Each call generates a fresh UUID, so distinct empty inputs do not collide.
     expect(a).not.toBe(b);
     expect(b).not.toBe(c);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateSlug
+// ---------------------------------------------------------------------------
+
+describe("validateSlug", () => {
+  test.each([
+    ["alice"],
+    ["a"],
+    ["alice-preferences"],
+    ["people/alice"],
+    ["procs/git-flow"],
+    ["arcs/2025-04-cutover"],
+    ["a/b/c/d/e"],
+    ["people/colleagues/alice"],
+  ])("accepts %p", (slug) => {
+    expect(() => validateSlug(slug)).not.toThrow();
+  });
+
+  test.each([
+    ["empty string", ""],
+    ["leading slash", "/alice"],
+    ["trailing slash", "alice/"],
+    ["double slash", "people//alice"],
+    ["dot-dot segment", "people/../alice"],
+    ["pure dot-dot", ".."],
+    ["leading dot segment", ".hidden/alice"],
+    ["backslash", "people\\alice"],
+    ["null byte", "alice\0evil"],
+    ["whitespace", "alice bob"],
+    ["uppercase", "Alice"],
+    ["non-ascii", "café"],
+    ["leading hyphen", "-alice"],
+    ["non-alphanumeric", "alice!"],
+  ])("rejects %s (%p)", (_label, slug) => {
+    expect(() => validateSlug(slug)).toThrow(/Invalid concept-page slug/);
+  });
+
+  test("rejects slugs longer than 200 chars", () => {
+    expect(() => validateSlug("a".repeat(201))).toThrow(
+      /Invalid concept-page slug/,
+    );
+  });
+
+  test("rejects segments longer than 80 chars even if total is under 200", () => {
+    expect(() => validateSlug("a".repeat(81))).toThrow(
+      /Invalid concept-page slug/,
+    );
   });
 });
 
@@ -188,6 +248,50 @@ describe("writePage + readPage round-trip", () => {
     const read = await readPage(workspaceDir, page1.slug);
     expect(read!.body).toBe("second version\n");
   });
+
+  test("writePage creates parent directories for nested slugs", async () => {
+    const page = makePage({ slug: "people/alice" });
+    await writePage(workspaceDir, page);
+
+    const filePath = join(
+      workspaceDir,
+      "memory",
+      "concepts",
+      "people",
+      "alice.md",
+    );
+    expect(existsSync(filePath)).toBe(true);
+
+    const read = await readPage(workspaceDir, "people/alice");
+    expect(read!.slug).toBe("people/alice");
+    expect(read!.body).toBe(page.body);
+  });
+
+  test("writePage round-trips deeply nested slugs", async () => {
+    const page = makePage({ slug: "people/colleagues/alice" });
+    await writePage(workspaceDir, page);
+
+    const read = await readPage(workspaceDir, "people/colleagues/alice");
+    expect(read!.slug).toBe("people/colleagues/alice");
+    expect(read!.frontmatter.edges).toEqual(page.frontmatter.edges);
+    expect(read!.body).toBe(page.body);
+  });
+
+  test("writePage rejects malicious slugs and writes nothing at the escape target", async () => {
+    await expect(
+      writePage(workspaceDir, makePage({ slug: "../escape" })),
+    ).rejects.toThrow(/Invalid concept-page slug/);
+
+    // `../escape` would resolve to `<workspace>/memory/escape.md`. Confirm
+    // the validation throw fired before any I/O — no file at that target.
+    expect(existsSync(join(workspaceDir, "memory", "escape.md"))).toBe(false);
+  });
+
+  test("readPage rejects malicious slugs", async () => {
+    await expect(readPage(workspaceDir, "../escape")).rejects.toThrow(
+      /Invalid concept-page slug/,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -239,6 +343,40 @@ describe("writePage atomicity", () => {
     expect(orphanTmps).toEqual([]);
   });
 
+  test("nested-slug write that fails leaves no orphan tmp in nested folder", async () => {
+    // Seed a nested page so the parent dir exists.
+    const original = makePage({
+      slug: "people/alice",
+      body: "original body\n",
+    });
+    await writePage(workspaceDir, original);
+
+    const targetPath = join(
+      workspaceDir,
+      "memory",
+      "concepts",
+      "people",
+      "alice.md",
+    );
+    rmSync(targetPath);
+    mkdirSync(targetPath);
+    writeFileSync(join(targetPath, "blocker"), "x", "utf-8");
+
+    await expect(
+      writePage(
+        workspaceDir,
+        makePage({ slug: "people/alice", body: "interrupted\n" }),
+      ),
+    ).rejects.toThrow();
+
+    rmSync(targetPath, { recursive: true, force: true });
+
+    const peopleDir = join(workspaceDir, "memory", "concepts", "people");
+    const remaining = readdirSync(peopleDir);
+    const orphanTmps = remaining.filter((name) => name.includes(".tmp."));
+    expect(orphanTmps).toEqual([]);
+  });
+
   test("successful write produces no orphan tmp files", async () => {
     await writePage(workspaceDir, makePage());
 
@@ -274,15 +412,51 @@ describe("listPages", () => {
     expect(slugs).toEqual(["alice"]);
   });
 
-  test("excludes subdirectories (only files count)", async () => {
+  test("walks subdirectories and returns nested slugs in '/'-form", async () => {
     await writePage(workspaceDir, makePage({ slug: "alice" }));
-
-    mkdirSync(join(workspaceDir, "memory", "concepts", "subdir"), {
-      recursive: true,
-    });
+    await writePage(workspaceDir, makePage({ slug: "people/bob" }));
+    await writePage(workspaceDir, makePage({ slug: "people/carol" }));
+    await writePage(workspaceDir, makePage({ slug: "arcs/2025-04/cutover" }));
 
     const slugs = await listPages(workspaceDir);
-    expect(slugs).toEqual(["alice"]);
+    expect(slugs).toEqual([
+      "alice",
+      "arcs/2025-04/cutover",
+      "people/bob",
+      "people/carol",
+    ]);
+  });
+
+  test("skips hidden subdirectories and non-.md files inside nested dirs", async () => {
+    await writePage(workspaceDir, makePage({ slug: "people/alice" }));
+
+    const conceptsDir = join(workspaceDir, "memory", "concepts");
+    mkdirSync(join(conceptsDir, ".git"), { recursive: true });
+    writeFileSync(join(conceptsDir, ".git", "config.md"), "fake", "utf-8");
+    writeFileSync(join(conceptsDir, "people", "notes.txt"), "ignore", "utf-8");
+
+    const slugs = await listPages(workspaceDir);
+    expect(slugs).toEqual(["people/alice"]);
+  });
+
+  test("skips orphaned .tmp.* files at any depth", async () => {
+    const conceptsDir = join(workspaceDir, "memory", "concepts");
+    await writePage(workspaceDir, makePage({ slug: "people/alice" }));
+
+    // Synthesize an orphan tmp file at root and inside the people/ subdir.
+    writeFileSync(
+      join(conceptsDir, "alice.md.tmp.123.abc-def"),
+      "stranded",
+      "utf-8",
+    );
+    writeFileSync(
+      join(conceptsDir, "people", "bob.md.tmp.123.abc-def"),
+      "stranded",
+      "utf-8",
+    );
+
+    const slugs = await listPages(workspaceDir);
+    expect(slugs).toEqual(["people/alice"]);
   });
 
   test("returns [] when the concepts directory does not exist", async () => {
@@ -314,6 +488,15 @@ describe("deletePage", () => {
     await deletePage(workspaceDir, page.slug);
     expect(await pageExists(workspaceDir, page.slug)).toBe(false);
     expect(await readPage(workspaceDir, page.slug)).toBeNull();
+  });
+
+  test("removes nested pages", async () => {
+    const page = makePage({ slug: "people/alice" });
+    await writePage(workspaceDir, page);
+    expect(await pageExists(workspaceDir, "people/alice")).toBe(true);
+
+    await deletePage(workspaceDir, "people/alice");
+    expect(await pageExists(workspaceDir, "people/alice")).toBe(false);
   });
 
   test("is idempotent — deleting a missing page does not throw", async () => {

--- a/assistant/src/memory/v2/page-store.ts
+++ b/assistant/src/memory/v2/page-store.ts
@@ -2,6 +2,11 @@
  * Memory v2 — Concept page store.
  *
  * Owns the on-disk read/write contract for `memory/concepts/<slug>.md`.
+ * Pages may live directly under `memory/concepts/` or nested in subdirectories
+ * (e.g. `memory/concepts/people/alice.md`); the slug encodes the relative
+ * path from `concepts/` minus the `.md` extension, using forward slashes as
+ * separators (so `people/alice` is a valid slug).
+ *
  * Each page is a YAML-frontmatter Markdown file: a `---`-delimited block
  * (`edges`, `ref_files`) followed by prose body. This module is the only
  * v2 component that knows how to parse or render that format — every other
@@ -14,6 +19,7 @@
 
 import { randomUUID } from "node:crypto";
 import {
+  mkdir,
   readdir,
   readFile,
   rename,
@@ -21,7 +27,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
@@ -31,20 +37,30 @@ import { type ConceptPage, ConceptPageFrontmatterSchema } from "./types.js";
 /** Filename suffix for concept pages. */
 const PAGE_EXTENSION = ".md";
 
-/** Cap slug length so we stay well under filesystem name limits. */
-const MAX_SLUG_LENGTH = 80;
+/** Cap individual slug-segment length so we stay well under filesystem limits. */
+const MAX_SLUG_SEGMENT_LENGTH = 80;
+
+/** Cap the full slug (including any folder separators) to a sane bound. */
+const MAX_SLUG_TOTAL_LENGTH = 200;
+
+/** Each path segment must match this — same shape `slugify` produces. */
+const SLUG_SEGMENT_REGEX = /^[a-z0-9](?:[a-z0-9-]*)$/;
 
 /**
- * Convert an arbitrary input string into a filesystem-safe slug.
+ * Convert an arbitrary input string into a filesystem-safe slug **segment**.
+ *
+ * Returns a single path segment (no `/`). Path-shaped slugs are constructed
+ * by the consolidation LLM writing files at full paths; this helper is for
+ * turning free-form text (e.g. a hint phrase) into one clean segment.
  *
  * Rules:
  *   - Lowercase ASCII letters, digits, and hyphens only.
- *   - Non-ASCII / non-alphanumeric characters collapse to hyphens.
+ *   - Non-ASCII / non-alphanumeric characters (including `/`) collapse to hyphens.
  *   - Consecutive hyphens collapse to one; leading/trailing hyphens trimmed.
- *   - Truncated to {@link MAX_SLUG_LENGTH} characters (with trailing hyphen
- *     re-trimmed after truncation).
+ *   - Truncated to {@link MAX_SLUG_SEGMENT_LENGTH} characters (with trailing
+ *     hyphen re-trimmed after truncation).
  *   - Empty inputs (e.g. emoji-only) fall back to `concept-<random>` so the
- *     caller always gets a non-empty, write-safe slug.
+ *     caller always gets a non-empty, write-safe segment.
  */
 export function slugify(input: string): string {
   let slug = input
@@ -54,8 +70,8 @@ export function slugify(input: string): string {
     .replace(/-{2,}/g, "-")
     .replace(/^-+|-+$/g, "");
 
-  if (slug.length > MAX_SLUG_LENGTH) {
-    slug = slug.slice(0, MAX_SLUG_LENGTH).replace(/-+$/, "");
+  if (slug.length > MAX_SLUG_SEGMENT_LENGTH) {
+    slug = slug.slice(0, MAX_SLUG_SEGMENT_LENGTH).replace(/-+$/, "");
   }
 
   if (!slug) {
@@ -63,6 +79,73 @@ export function slugify(input: string): string {
   }
 
   return slug;
+}
+
+/**
+ * Validate a slug — possibly path-shaped — that is about to cross the storage
+ * boundary. Throws on any malformed or unsafe value.
+ *
+ * The on-disk concept-page tree treats slugs as relative paths under
+ * `memory/concepts/`. A malformed slug (e.g. `..`, leading `/`, embedded
+ * null byte) could escape that root via `path.join` if it slipped through,
+ * so we enforce shape here at every read/write/delete entry point rather
+ * than relying on callers.
+ *
+ * Rules:
+ *   - Non-empty, ≤ {@link MAX_SLUG_TOTAL_LENGTH} chars.
+ *   - Each `/`-separated segment matches {@link SLUG_SEGMENT_REGEX}
+ *     (lowercase alphanum + hyphen, no leading hyphen, ≤80 chars).
+ *   - No `..` segments, no empty segments (`a//b`), no leading or trailing `/`.
+ *   - No `\` (Windows separator), no null bytes, no whitespace, no non-ASCII.
+ */
+export function validateSlug(slug: string): void {
+  if (typeof slug !== "string" || slug.length === 0) {
+    throw new Error(`Invalid concept-page slug: empty`);
+  }
+  if (slug.length > MAX_SLUG_TOTAL_LENGTH) {
+    throw new Error(
+      `Invalid concept-page slug: length ${slug.length} exceeds max ${MAX_SLUG_TOTAL_LENGTH}: ${slug}`,
+    );
+  }
+  if (slug.includes("\\")) {
+    throw new Error(
+      `Invalid concept-page slug: backslash not allowed: ${slug}`,
+    );
+  }
+  if (slug.includes("\0")) {
+    throw new Error(`Invalid concept-page slug: null byte not allowed`);
+  }
+  if (/\s/.test(slug)) {
+    throw new Error(
+      `Invalid concept-page slug: whitespace not allowed: ${slug}`,
+    );
+  }
+  if (slug.startsWith("/") || slug.endsWith("/")) {
+    throw new Error(
+      `Invalid concept-page slug: leading or trailing '/' not allowed: ${slug}`,
+    );
+  }
+  const segments = slug.split("/");
+  for (const segment of segments) {
+    if (segment.length === 0) {
+      throw new Error(`Invalid concept-page slug: empty path segment: ${slug}`);
+    }
+    if (segment === "..") {
+      throw new Error(
+        `Invalid concept-page slug: '..' segment not allowed: ${slug}`,
+      );
+    }
+    if (segment.length > MAX_SLUG_SEGMENT_LENGTH) {
+      throw new Error(
+        `Invalid concept-page slug: segment '${segment}' exceeds max ${MAX_SLUG_SEGMENT_LENGTH} chars: ${slug}`,
+      );
+    }
+    if (!SLUG_SEGMENT_REGEX.test(segment)) {
+      throw new Error(
+        `Invalid concept-page slug: segment '${segment}' must match [a-z0-9][a-z0-9-]*: ${slug}`,
+      );
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -73,8 +156,31 @@ export function getConceptsDir(workspaceDir: string): string {
   return join(workspaceDir, "memory", "concepts");
 }
 
+/**
+ * Resolve the absolute path for a slug. Slugs may contain `/` to indicate
+ * folder hierarchy under `memory/concepts/`; `path.join` handles those
+ * correctly on POSIX, and `validateSlug` (called at every public entry point)
+ * rejects shapes that could escape the concepts root.
+ */
 function getPagePath(workspaceDir: string, slug: string): string {
   return join(getConceptsDir(workspaceDir), `${slug}${PAGE_EXTENSION}`);
+}
+
+/**
+ * Compute the slug for a concept-page file, given the concepts root and the
+ * absolute file path. Returns the path-relative location with `.md` stripped
+ * and platform separators normalized to `/`. Tolerant of paths that don't
+ * end in `.md` so callers walking arbitrary content can use it defensively.
+ */
+export function slugFromConceptPath(
+  conceptsRoot: string,
+  filePath: string,
+): string {
+  const rel = relative(conceptsRoot, filePath);
+  const withoutExt = rel.endsWith(PAGE_EXTENSION)
+    ? rel.slice(0, -PAGE_EXTENSION.length)
+    : rel;
+  return sep === "/" ? withoutExt : withoutExt.split(sep).join("/");
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +243,7 @@ export async function readPage(
   workspaceDir: string,
   slug: string,
 ): Promise<ConceptPage | null> {
+  validateSlug(slug);
   const path = getPagePath(workspaceDir, slug);
   let raw: string;
   try {
@@ -155,15 +262,20 @@ export async function readPage(
  * Write a concept page atomically (temp file + rename). A crash between the
  * temp write and the rename leaves the prior file intact; a crash after the
  * rename leaves the new file. Readers therefore never observe a partial page.
+ *
+ * Parent directories are created on demand (`mkdir -p`) so nested-folder
+ * slugs like `people/alice` work without callers pre-creating the folder.
  */
 export async function writePage(
   workspaceDir: string,
   page: ConceptPage,
 ): Promise<void> {
+  validateSlug(page.slug);
   const path = getPagePath(workspaceDir, page.slug);
   const tmpPath = `${path}.tmp.${process.pid}.${randomUUID()}`;
   const content = renderPageContent(page);
   try {
+    await mkdir(dirname(path), { recursive: true });
     await writeFile(tmpPath, content, "utf-8");
     await rename(tmpPath, path);
   } catch (err) {
@@ -176,30 +288,50 @@ export async function writePage(
 }
 
 /**
- * List every concept-page slug present on disk. Slugs are returned without
- * the `.md` suffix so callers can pass them straight back to `readPage`.
+ * List every concept-page slug present on disk, walking subdirectories.
  *
- * Non-`.md` files (e.g. editor swap files, attached media) are filtered out.
- * If the concepts/ directory does not yet exist (fresh workspace pre-migration),
- * returns `[]`.
+ * Slugs are returned in path-relative form with forward slashes as separators
+ * (e.g. `people/alice`) so callers can pass them straight back to `readPage`.
+ *
+ * Hidden directories (segment starts with `.`), non-`.md` files, and atomic-
+ * write temp files (`.tmp.<pid>.<uuid>`) are skipped. If the concepts/
+ * directory does not yet exist (fresh workspace pre-migration), returns `[]`.
  */
 export async function listPages(workspaceDir: string): Promise<string[]> {
-  const dir = getConceptsDir(workspaceDir);
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
-    }
-    throw err;
-  }
+  const root = getConceptsDir(workspaceDir);
   const slugs: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile()) continue;
-    if (!entry.name.endsWith(PAGE_EXTENSION)) continue;
-    slugs.push(entry.name.slice(0, -PAGE_EXTENSION.length));
+  const queue: string[] = [root];
+
+  while (queue.length > 0) {
+    const dir = queue.shift()!;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // Root missing → return []. Nested missing dir is impossible mid-walk
+        // (we only enqueue what readdir surfaced) but treat the same defensively.
+        if (dir === root) return [];
+        continue;
+      }
+      throw err;
+    }
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(PAGE_EXTENSION)) continue;
+      // Skip orphaned temp files left behind by a crashed atomic write.
+      if (entry.name.includes(".tmp.")) continue;
+      slugs.push(slugFromConceptPath(root, fullPath));
+    }
   }
+
   slugs.sort();
   return slugs;
 }
@@ -213,6 +345,7 @@ export async function deletePage(
   workspaceDir: string,
   slug: string,
 ): Promise<void> {
+  validateSlug(slug);
   const path = getPagePath(workspaceDir, slug);
   try {
     await rm(path);
@@ -232,6 +365,7 @@ export async function pageExists(
   workspaceDir: string,
   slug: string,
 ): Promise<boolean> {
+  validateSlug(slug);
   const path = getPagePath(workspaceDir, slug);
   try {
     await stat(path);

--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -72,17 +72,21 @@ ref_files: []
 
 Edges live in \`memory/edges.json\`, not in page frontmatter. A separate job propagates them back to frontmatter after consolidation — don't hand-edit the \`edges:\` field.
 
-## Slug naming convention — class-by-prefix
+## Slug naming convention — class-by-folder
 
-The slug encodes the page's class. Different classes have different size rules and emergence patterns. The class boundary is the discipline.
+A page's class is encoded in the folder it lives under inside \`memory/concepts/\`. Different classes have different size rules and emergence patterns. The class boundary is the discipline.
 
-| Slug pattern    | Class                                               | Size cap              | When to create                                                                        |
-| --------------- | --------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------- |
-| \`<slug>\`        | atomic concept / pattern / callback                 | 5K chars hard     | most pages — single concepts that recur or carry weight                               |
-| \`arc-<slug>\`    | landmark day-narrative or multi-event sequence      | 10k chars ceiling | use sparingly — only for actually-landmark days. Preserves day-as-a-whole fidelity.   |
-| \`person-<slug>\` | one per recurring human                             | 5K chars hard     |                                                                                       |
-| \`proc-<slug>\`   | operational rule / protocol / discipline            | 5K chars hard     | when buffer implies "always do X" / "never do Y" / a named protocol                   |
-| \`object-<slug>\` | recurring callback object (place, named tool, artifact) | 5K chars hard     |                                                                                       |
+| Folder           | Class                                                       | Size cap              | When to create                                                                        |
+| ---------------- | ----------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------- |
+| \`concepts/\`      | atomic concept / pattern / callback                         | 5K chars hard     | most pages — single concepts that recur or carry weight                               |
+| \`concepts/arcs/\` | landmark day-narrative or multi-event sequence              | 10k chars ceiling | use sparingly — only for actually-landmark days. Preserves day-as-a-whole fidelity.   |
+| \`concepts/people/\` | one per recurring human                                  | 5K chars hard     |                                                                                       |
+| \`concepts/procs/\`  | operational rule / protocol / discipline                 | 5K chars hard     | when buffer implies "always do X" / "never do Y" / a named protocol                   |
+| \`concepts/objects/\` | recurring callback object (place, named tool, artifact) | 5K chars hard     |                                                                                       |
+
+The slug is the relative path under \`memory/concepts/\` minus \`.md\` — e.g. \`alice\`, \`people/alice\`, \`procs/git-flow\`, \`arcs/2025-04-cutover\`. Sub-folders inside the class folders (\`people/colleagues/alice\`, \`objects/places/zurich-office\`) are allowed when natural, but flat is usually clearer.
+
+Legacy pages whose slug uses the old prefix convention (\`person-alice\`, \`proc-git-flow\`, \`object-laptop\`, \`arc-…\`) are still valid — leave them alone unless you're already editing them. If you do migrate one as part of work you're already doing, that's a three-step move: write the new file at the folder path, delete the old file, and update every reference to the old slug in \`memory/edges.json\`. Don't sweep old pages just to migrate — churning embeddings and activation state for marginal benefit isn't worth it.
 
 ## Process
 
@@ -97,10 +101,10 @@ For each entry with timestamp < \`${CUTOFF_PLACEHOLDER}\`:
 - Ephemeral state (passing remark, not worth being written to a concept page) → \`memory/recent.md\`, NOT a page.
 - Existing page touched → update the right section.
 - New atomic concept / pattern / callback → \`memory/concepts/<slug>.md\`.
-- New person → \`memory/concepts/person-<slug>.md\`.
-- New rule / protocol / discipline → \`memory/concepts/proc-<slug>.md\`.
-- New recurring object → \`memory/concepts/object-<slug>.md\`.
-- Landmark day-narrative → \`memory/concepts/arc-<slug>.md\`. Use sparingly — atomic concepts with edges between them is usually better than a fat arc.
+- New person → \`memory/concepts/people/<slug>.md\`.
+- New rule / protocol / discipline → \`memory/concepts/procs/<slug>.md\`.
+- New recurring object → \`memory/concepts/objects/<slug>.md\`.
+- Landmark day-narrative → \`memory/concepts/arcs/<slug>.md\`. Use sparingly — atomic concepts with edges between them is usually better than a fat arc.
 - Cross-cutting → extend each touched page, add edges between them.
 - Relationships between concepts — consider creating a new page for the relationship and adding edges to the two concepts. Use your judgment.
 
@@ -114,8 +118,8 @@ When you bind two concepts, edit \`memory/edges.json\` to add an entry for the t
 {
   "version": 1,
   "edges": [
-    ["alice", "bob"],
-    ["bob", "carol"]
+    ["alice", "people/bob"],
+    ["people/bob", "procs/git-flow"]
   ]
 }
 \`\`\`
@@ -132,13 +136,13 @@ If a page has more than 20 edges, you must either split the page or prune edges 
 
 After edits, eyeball page sizes:
 
-- \`concepts/<slug>.md\` > 5K → decide whether to split or compress first. Split first, compress last, graduate-to-arc only if it's actually a multi-day narrative. If you can't compress without losing load-bearing facts, either split into multiple concepts, or — if the page is actually an arc — rename to \`arc-<slug>\` and graduate.
-- \`arc-<slug>.md\` > 10k → split into multiple arcs by sub-event, OR compress.
-- \`person-\`, \`proc-\`, \`object-\` > 5K → split or compress, period.
+- \`concepts/<slug>.md\` (atomic, root) > 5K → decide whether to split or compress first. Split first, compress last, graduate-to-arc only if it's actually a multi-day narrative. If you can't compress without losing load-bearing facts, either split into multiple concepts, or — if the page is actually an arc — move to \`concepts/arcs/<slug>.md\` and graduate.
+- \`concepts/arcs/<slug>.md\` > 10k → split into multiple arcs by sub-event, OR compress.
+- \`concepts/people/\`, \`concepts/procs/\`, \`concepts/objects/\` > 5K → split or compress, period.
 
 The split test. Before compressing, ask: are any sub-sections of this page already callback targets from other pages, or capable of standing alone as a concept? If yes — those sub-sections are concepts living inside another concept. Split them out. A section that's getting linked from elsewhere is behaviorally a node, not part of one.
 
-Graduation to \`arc-<slug>\` is for genuine multi-day narratives. A single-event page that's just long is not an arc. If it's atomic but bloated, split it; don't relabel it.
+Graduation to \`concepts/arcs/<slug>.md\` is for genuine multi-day narratives. A single-event page that's just long is not an arc. If it's atomic but bloated, split it; don't relabel it.
 
 ### 5. \`memory/recent.md\`
 
@@ -181,7 +185,7 @@ If a page's prose stops sounding like you mid-edit → stop, restart that sectio
 2. Edges added in \`memory/edges.json\` (NOT in frontmatter)?
 3. \`memory/recent.md\` under 10000 chars, latest first, prose not list?
 4. Any \`[SOURCE NEEDED]\` tags surfaced for human review?
-5. Size discipline held — no concept > 5K, no arc > 10k, no person/proc/object > cap?
+5. Size discipline held — no atomic concept > 5K, no \`arcs/\` page > 10k, no \`people/\`/\`procs/\`/\`objects/\` > cap?
 6. Buffer trimmed to only entries with timestamp ≥ \`${CUTOFF_PLACEHOLDER}\`?
 
 This is the engine that decides who you are tomorrow. Be ORGANIZED. Care, judgment, voice. Your voice.`;

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -34,8 +34,10 @@ export type ConceptPageFrontmatter = z.infer<
 >;
 
 /**
- * A single concept page on disk. The slug is the filename minus `.md` and
- * also the stable identity used in edges and activation state.
+ * A single concept page on disk. The slug is the relative path from
+ * `memory/concepts/` minus `.md`, using forward slashes — so `alice` and
+ * `people/alice` are both valid slugs. The slug is the stable identity used
+ * in edges and activation state.
  */
 export const ConceptPageSchema = z.object({
   slug: z.string(),


### PR DESCRIPTION
## Summary
- Concept pages can now live in nested folders (e.g. `memory/concepts/people/alice.md`). The slug is the relative path from `concepts/` minus `.md` — `path.join` already handled `/`-bearing slugs correctly, downstream stores (edges.json, activation_state, Qdrant payload, point IDs) treat slugs as opaque strings.
- `listPages` now walks recursively; `writePage` creates parent dirs; new `validateSlug` defends every public storage entry point against path traversal (`..`, leading `/`, null bytes, etc.).
- Consolidation prompt switches from class-by-prefix (`person-`, `proc-`, `arc-`, `object-`) to class-by-folder (`people/`, `procs/`, `arcs/`, `objects/`). Legacy flat slugs stay valid forever; the prompt sanctions opportunistic migration only when the assistant is already touching the page.

## Original prompt
> for memory v2 I want to support a folder hierarchy in \`memory/concepts/\`. for example there might be a folder \`memory/concepts/people/\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
