### PR TITLE
fix: auto-select first name on group pill tap, use defaultGroupID constant

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -134,8 +134,10 @@ struct NameExchangeView: View {
             withAnimation(VAnimation.fast) {
                 if isActive {
                     selectedGroupID = nil
+                    assistantName = ""
                 } else {
                     selectedGroupID = group.id
+                    assistantName = group.names.first ?? ""
                 }
             }
         } label: {

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -76,7 +76,7 @@ struct PreChatOnboardingFlow: View {
         let context = PreChatOnboardingContext(
             tools: cleanTools,
             tasks: Array(state.selectedTasks).sorted(),
-            tone: state.selectedGroupID ?? "grounded",
+            tone: state.selectedGroupID ?? PersonalityGroup.defaultGroupID,
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for personality-group-names.md.

**Gap 1:** Tapping a group pill now auto-selects the first name in that group
**Gap 2:** Uses PersonalityGroup.defaultGroupID constant instead of hardcoded string
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
