### PR TITLE
fix(macos): remove explicit return from Memory v2 preview ViewBuilder

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
@@ -603,7 +603,7 @@ private struct ActivationBar: View {
         )
     )
 
-    return MessageInspectorMemoryV2Tab(activation: fixture)
+    MessageInspectorMemoryV2Tab(activation: fixture)
         .frame(width: 600, height: 800)
 }
 


### PR DESCRIPTION
## Summary
- The `#Preview` for `MessageInspectorMemoryV2Tab` returned its view via an explicit `return`, which is illegal inside a `@ViewBuilder` body. Swift's CI build was failing with `error: cannot use explicit 'return' statement in the body of result builder 'ViewBuilder'` (line 606).
- Drop the `return` so the trailing `MessageInspectorMemoryV2Tab(...).frame(...)` is the implicit result of the ViewBuilder closure. The leading `let fixture = ...` declaration remains valid in modern Swift `@ViewBuilder` bodies.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25132898690/job/73663639460
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
