### PR TITLE
Personality group name selection for onboarding

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -298,4 +298,108 @@ describe("first-greeting", () => {
       expect(greeting).not.toContain("\n\n\n");
     });
   });
+
+  describe("tone-specific greetings", () => {
+    const base: OnboardingGreetingContext = {
+      tools: ["github", "linear"],
+      tasks: ["code-building"],
+      tone: "balanced",
+      userName: "Bob",
+      assistantName: "Pip",
+    };
+
+    it("grounded tone produces direct, calm intro", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "grounded" });
+      expect(greeting).toContain("Bob.");
+      expect(greeting).toContain(
+        "I'm Pip. Brand new, and I'll get sharper the more we work together.",
+      );
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("warm tone uses casual phrasing", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "warm" });
+      expect(greeting).toContain("Hey Bob!");
+      expect(greeting).toContain("hang out");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("energetic tone is punchy", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "energetic" });
+      expect(greeting).toContain("Bob!");
+      expect(greeting).toContain("let's get into it");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("poetic tone is softer", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "poetic" });
+      expect(greeting).toContain("Hello, Bob.");
+      expect(greeting).toContain("grow alongside you");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("balanced tone falls back to generic intro", () => {
+      const greeting = getCannedFirstGreeting({ ...base, tone: "balanced" });
+      expect(greeting).toContain("Hey Bob, I'm Pip.");
+      expect(greeting).toContain("I'll get sharper");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("unknown tone string falls back to generic intro", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "mysterious-future-tone",
+      });
+      expect(greeting).toContain("Hey Bob, I'm Pip.");
+      expect(greeting).toContain("I'll get sharper");
+      expect(greeting.split("\n\n").length).toBe(2);
+    });
+
+    it("each tone produces a distinct intro line", () => {
+      const tones = ["grounded", "warm", "energetic", "poetic"];
+      const intros = tones.map((tone) => {
+        const greeting = getCannedFirstGreeting({ ...base, tone });
+        return greeting.split("\n\n")[0];
+      });
+      const unique = new Set(intros);
+      expect(unique.size).toBe(tones.length);
+    });
+
+    it("warm tone without user name uses Hey!", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "warm",
+        userName: undefined,
+      });
+      expect(greeting).toStartWith("Hey! I'm Pip");
+    });
+
+    it("poetic tone without user name uses Hello.", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "poetic",
+        userName: undefined,
+      });
+      expect(greeting).toStartWith("Hello. I'm Pip");
+    });
+
+    it("grounded tone without user name omits greeting prefix", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "grounded",
+        userName: undefined,
+      });
+      expect(greeting).toStartWith("I'm Pip.");
+    });
+
+    it("tone-specific intro falls back to generic when no assistantName", () => {
+      const greeting = getCannedFirstGreeting({
+        ...base,
+        tone: "warm",
+        assistantName: undefined,
+      });
+      expect(greeting).toContain("Hey Bob,");
+      expect(greeting).toContain("brand new");
+    });
+  });
 });

--- a/assistant/src/__tests__/prechat-onboarding-contract.test.ts
+++ b/assistant/src/__tests__/prechat-onboarding-contract.test.ts
@@ -101,7 +101,7 @@ describe("pre-chat onboarding contract", () => {
       const context = {
         tools: ["slack", "linear"],
         tasks: ["code-building", "writing"],
-        tone: "balanced",
+        tone: "grounded",
         userName: "Alex",
         assistantName: "Pax",
       };
@@ -128,7 +128,7 @@ describe("pre-chat onboarding contract", () => {
       const context: OnboardingContext = {
         tools: ["figma"],
         tasks: ["design"],
-        tone: "casual",
+        tone: "energetic",
       };
 
       expect(context.userName).toBeUndefined();
@@ -146,7 +146,7 @@ describe("pre-chat onboarding contract", () => {
       const context = {
         tools: ["slack", "linear"],
         tasks: ["code-building"],
-        tone: "professional",
+        tone: "warm",
         userName: "Alex",
         assistantName: "Nova",
       };
@@ -163,7 +163,7 @@ describe("pre-chat onboarding contract", () => {
       expect(dynamic).toContain('"linear"');
       expect(dynamic).toContain('"tasks"');
       expect(dynamic).toContain('"code-building"');
-      expect(dynamic).toContain('"tone": "professional"');
+      expect(dynamic).toContain('"tone": "warm"');
       expect(dynamic).toContain('"userName": "Alex"');
       expect(dynamic).toContain('"assistantName": "Nova"');
       expect(dynamic).toContain("```json");
@@ -177,7 +177,7 @@ describe("pre-chat onboarding contract", () => {
       const context = {
         tools: ["slack"],
         tasks: ["writing"],
-        tone: "casual",
+        tone: "poetic",
         userName: "Alex",
       };
 
@@ -198,7 +198,7 @@ describe("pre-chat onboarding contract", () => {
       const context = {
         tools: ["figma"],
         tasks: ["design"],
-        tone: "balanced",
+        tone: "grounded",
       };
 
       const result = buildSystemPrompt({
@@ -226,6 +226,30 @@ describe("pre-chat onboarding contract", () => {
       expect(dynamic).not.toContain("## Pre-chat Onboarding Context");
     });
 
+    test("accepts all four personality tones", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nOnboarding.",
+      );
+
+      const tones = ["grounded", "warm", "energetic", "poetic"] as const;
+
+      for (const tone of tones) {
+        const context = {
+          tools: ["slack"],
+          tasks: ["writing"],
+          tone,
+          userName: "Alex",
+        };
+
+        const result = buildSystemPrompt({ onboardingContext: context });
+        const dynamic = dynamicBlock(result);
+
+        expect(dynamic).toContain("## Pre-chat Onboarding Context");
+        expect(dynamic).toContain(`"tone": "${tone}"`);
+      }
+    });
+
     test("serializes onboarding context as pretty-printed JSON", () => {
       writeFileSync(
         join(TEST_DIR, "BOOTSTRAP.md"),
@@ -235,7 +259,7 @@ describe("pre-chat onboarding contract", () => {
       const context = {
         tools: ["notion"],
         tasks: ["project-management"],
-        tone: "balanced",
+        tone: "warm",
         userName: "Jane",
         assistantName: "Kit",
       };

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -5,6 +5,7 @@ import { getWorkspacePromptPath } from "../util/platform.js";
 export interface OnboardingGreetingContext {
   tools: string[];
   tasks: string[];
+  /** Valid values: "grounded" | "warm" | "energetic" | "poetic" */
   tone: string;
   userName?: string;
   assistantName?: string;

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -136,7 +136,46 @@ function highestPriorityTask(tasks: string[]): string | undefined {
   return tasks[0];
 }
 
-function buildIntroLine(userName?: string, assistantName?: string): string {
+const TONE_INTROS: Record<
+  string,
+  {
+    greeting: (userName?: string) => string;
+    selfIntro: (assistantName: string) => string;
+  }
+> = {
+  grounded: {
+    greeting: (u) => (u ? `${u}.` : ""),
+    selfIntro: (n) =>
+      `I'm ${n}. Brand new, and I'll get sharper the more we work together.`,
+  },
+  warm: {
+    greeting: (u) => (u ? `Hey ${u}!` : "Hey!"),
+    selfIntro: (n) =>
+      `I'm ${n} — brand new, but I'll get better the more we hang out.`,
+  },
+  energetic: {
+    greeting: (u) => (u ? `${u}!` : "Hey!"),
+    selfIntro: (n) => `I'm ${n}. Fresh start — let's get into it.`,
+  },
+  poetic: {
+    greeting: (u) => (u ? `Hello, ${u}.` : "Hello."),
+    selfIntro: (n) => `I'm ${n}. Still quite new — I'll grow alongside you.`,
+  },
+};
+
+function buildIntroLine(
+  userName?: string,
+  assistantName?: string,
+  tone?: string,
+): string {
+  const toneEntry = tone ? TONE_INTROS[tone] : undefined;
+
+  if (toneEntry && assistantName) {
+    const greetPart = toneEntry.greeting(userName);
+    const selfPart = toneEntry.selfIntro(assistantName);
+    return greetPart ? `${greetPart} ${selfPart}` : selfPart;
+  }
+
   const namepart = userName ? `Hey ${userName},` : "Hey,";
   const who = assistantName
     ? `I'm ${assistantName}. Brand new, and I'll get sharper the more we work together.`
@@ -199,7 +238,11 @@ function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
     return CANNED_FIRST_GREETING;
   }
 
-  const intro = buildIntroLine(hasName ? userName : undefined, assistantName);
+  const intro = buildIntroLine(
+    hasName ? userName : undefined,
+    assistantName,
+    ctx.tone,
+  );
 
   let secondParagraph: string;
 

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -704,6 +704,36 @@ describe("relationship-state-writer", () => {
       expect(state.facts[0]?.source).toBe("onboarding");
     });
 
+    test("tone group ID 'warm' maps to descriptive voice fact 'Warm and easy'", async () => {
+      writeOnboardingSidecar({
+        tools: [],
+        tasks: [],
+        tone: "warm",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voiceFacts = state.facts.filter(
+        (f) => f.category === "voice" && f.source === "onboarding",
+      );
+      expect(voiceFacts).toHaveLength(1);
+      expect(voiceFacts[0]!.text).toBe("Warm and easy");
+    });
+
+    test("unrecognized tone value passes through verbatim (backwards-compatible)", async () => {
+      writeOnboardingSidecar({
+        tools: [],
+        tasks: [],
+        tone: "balanced",
+      });
+
+      const state = (await computeRelationshipState()) as RelationshipStateLike;
+      const voiceFacts = state.facts.filter(
+        (f) => f.category === "voice" && f.source === "onboarding",
+      );
+      expect(voiceFacts).toHaveLength(1);
+      expect(voiceFacts[0]!.text).toBe("balanced");
+    });
+
     test("missing sidecar produces no onboarding-sourced facts", async () => {
       writeFile("USER.md", "- Preferred name: Alex");
       const state = (await computeRelationshipState()) as RelationshipStateLike;

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -423,6 +423,20 @@ function safeRead(path: string): string {
 }
 
 /**
+ * Map personality-group tone IDs (from onboarding) to human-readable
+ * voice descriptions displayed as relationship-state facts.
+ * Unrecognized values (e.g. legacy `"balanced"` or free-text tones from
+ * older clients) fall through via the `?? tone` fallback in
+ * `extractFacts`.
+ */
+const TONE_VOICE_MAP: Record<string, string> = {
+  grounded: "Calm and precise",
+  warm: "Warm and easy",
+  energetic: "Fast and direct",
+  poetic: "Quiet and observant",
+};
+
+/**
  * Walk the workspace prompt files and emit a flat list of inferred
  * facts. This is deliberately a simple bullet/heading parser — the TDD
  * explicitly calls out "don't try to be clever" here; the goal is to
@@ -477,7 +491,7 @@ function extractFacts(input: {
       facts.push({
         id: nextId("onboarding"),
         category: "voice",
-        text: tone,
+        text: TONE_VOICE_MAP[tone] ?? tone,
         confidence: "strong",
         source: "onboarding",
       });

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -1,3 +1,5 @@
+export type Tone = "grounded" | "warm" | "energetic" | "poetic";
+
 export interface OnboardingContext {
   tools: string[];
   tasks: string[];

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -1,5 +1,3 @@
-export type Tone = "grounded" | "warm" | "energetic" | "poetic";
-
 export interface OnboardingContext {
   tools: string[];
   tasks: string[];

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -149,8 +149,7 @@ struct NameExchangeView: View {
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(isActive ? VColor.contentInset.opacity(0.8) : VColor.contentTertiary)
             }
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
             .background(
                 RoundedRectangle(cornerRadius: VRadius.pill)
                     .fill(isActive ? VColor.primaryBase : (isHovered ? VColor.surfaceBase : VColor.surfaceLift))
@@ -182,8 +181,7 @@ struct NameExchangeView: View {
             Text(name)
                 .font(VFont.labelDefault)
                 .foregroundStyle(isActive ? VColor.contentInset : VColor.contentSecondary)
-                .padding(.horizontal, VSpacing.sm)
-                .padding(.vertical, VSpacing.xs)
+                .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.pill)
                         .fill(isActive ? VColor.primaryBase : (hoveredSuggestion == name ? VColor.surfaceBase : VColor.surfaceLift))

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -134,8 +134,10 @@ struct NameExchangeView: View {
             withAnimation(VAnimation.fast) {
                 if isActive {
                     selectedGroupID = nil
+                    assistantName = ""
                 } else {
                     selectedGroupID = group.id
+                    assistantName = group.names.first ?? ""
                 }
             }
         } label: {

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -173,6 +173,9 @@ struct NameExchangeView: View {
         let isActive = assistantName == name
         return Button {
             assistantName = name
+            withAnimation(VAnimation.fast) {
+                selectedGroupID = PersonalityGroup.groupForName(name)?.id
+            }
         } label: {
             Text(name)
                 .font(VFont.labelDefault)

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -55,18 +55,39 @@ struct NameExchangeView: View {
             }
             .opacity(showHeader ? 1 : 0)
             .offset(y: showHeader ? 0 : 8)
-            .padding(.bottom, VSpacing.xxl)
+            .padding(.bottom, VSpacing.sm)
+
+            Text("You can change these any time.")
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+                .multilineTextAlignment(.center)
+                .opacity(showHeader ? 1 : 0)
+                .offset(y: showHeader ? 0 : 8)
+                .padding(.horizontal, VSpacing.xxl)
+                .padding(.bottom, VSpacing.xl)
 
             // Form content
             VStack(spacing: VSpacing.lg) {
-                // "I'll call you..." field
                 VTextField(
-                    "What's your name?",
+                    "Your name",
                     placeholder: "Your name",
                     text: $userName
                 )
 
-                // "Call me..." field + group pills + suggestion pills
+                // Personality group grid
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    Text("Pick a vibe")
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+
+                    LazyVGrid(columns: [GridItem(.flexible(), spacing: VSpacing.sm), GridItem(.flexible(), spacing: VSpacing.sm)], spacing: VSpacing.sm) {
+                        ForEach(PersonalityGroup.allGroups, id: \.id) { group in
+                            vibeCard(group)
+                        }
+                    }
+                }
+
+                // Assistant name + suggestions
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     VTextField(
                         "What should I go by?",
@@ -74,14 +95,11 @@ struct NameExchangeView: View {
                         text: $assistantName
                     )
 
-                    // Personality group pills
-                    HStack(spacing: VSpacing.xs) {
-                        ForEach(PersonalityGroup.allGroups, id: \.id) { group in
-                            groupPill(group)
-                        }
-                    }
+                    Text(selectedGroupID != nil ? "Suggestions" : "A few to try")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .textCase(.uppercase)
 
-                    // Name suggestion pills (flow layout for wrapping)
                     WrappingHStack(hSpacing: VSpacing.xs, vSpacing: VSpacing.xs) {
                         ForEach(displayedAssistantNames, id: \.self) { suggestion in
                             suggestionPill(suggestion)
@@ -89,11 +107,6 @@ struct NameExchangeView: View {
                     }
                 }
 
-                // Helper note
-                Text("You can always change these later.")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
             }
             .padding(.horizontal, VSpacing.xxl)
             .opacity(showContent ? 1 : 0)
@@ -127,7 +140,14 @@ struct NameExchangeView: View {
 
     // MARK: - Subviews
 
-    private func groupPill(_ group: PersonalityGroup) -> some View {
+    private static let vibeTaglines: [String: String] = [
+        "grounded": "Measured. No filler.",
+        "warm": "Friendly and casual.",
+        "energetic": "Brief. To the point.",
+        "poetic": "Listens, then replies.",
+    ]
+
+    private func vibeCard(_ group: PersonalityGroup) -> some View {
         let isActive = selectedGroupID == group.id
         let isHovered = hoveredGroup == group.id
         return Button {
@@ -141,21 +161,22 @@ struct NameExchangeView: View {
                 }
             }
         } label: {
-            VStack(spacing: 2) {
-                Text(group.label)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(isActive ? VColor.contentInset : VColor.contentDefault)
+            VStack(alignment: .leading, spacing: 2) {
                 Text(group.descriptor)
+                    .font(VFont.bodyMediumEmphasised)
+                    .foregroundStyle(isActive ? VColor.contentInset : VColor.contentDefault)
+                Text(Self.vibeTaglines[group.id] ?? "")
                     .font(VFont.bodySmallDefault)
-                    .foregroundStyle(isActive ? VColor.contentInset.opacity(0.8) : VColor.contentTertiary)
+                    .foregroundStyle(isActive ? VColor.contentInset.opacity(0.62) : VColor.contentSecondary)
             }
-            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(EdgeInsets(top: VSpacing.md, leading: VSpacing.md, bottom: VSpacing.md, trailing: VSpacing.md))
             .background(
-                RoundedRectangle(cornerRadius: VRadius.pill)
+                RoundedRectangle(cornerRadius: VRadius.lg)
                     .fill(isActive ? VColor.primaryBase : (isHovered ? VColor.surfaceBase : VColor.surfaceLift))
                     .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.pill)
-                            .stroke(isActive ? VColor.primaryBase : VColor.borderElement, lineWidth: 1)
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(isActive ? VColor.primaryBase : VColor.borderElement, lineWidth: 0.5)
                     )
             )
         }
@@ -179,9 +200,9 @@ struct NameExchangeView: View {
             }
         } label: {
             Text(name)
-                .font(VFont.labelDefault)
-                .foregroundStyle(isActive ? VColor.contentInset : VColor.contentSecondary)
-                .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+                .font(VFont.menuCompact)
+                .foregroundStyle(isActive ? VColor.contentInset : VColor.contentDefault)
+                .padding(EdgeInsets(top: VSpacing.xs + 1, leading: VSpacing.md, bottom: VSpacing.xs + 1, trailing: VSpacing.md))
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.pill)
                         .fill(isActive ? VColor.primaryBase : (hoveredSuggestion == name ? VColor.surfaceBase : VColor.surfaceLift))

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/NameExchangeView.swift
@@ -7,9 +7,10 @@ struct NameExchangeView: View {
 
     @Binding var userName: String
     @Binding var assistantName: String
+    @Binding var selectedGroupID: String?
 
-    /// Stable subset of the name pool to display as quick-tap pills. The caller
-    /// is responsible for sampling so the pills don't reshuffle across re-renders.
+    /// Names to display as quick-tap pills, ordered by the caller based on
+    /// the currently selected personality group.
     let displayedAssistantNames: [String]
 
     var onBack: (() -> Void)?
@@ -21,25 +22,7 @@ struct NameExchangeView: View {
     @State private var showHeader = false
     @State private var showContent = false
     @State private var hoveredSuggestion: String?
-
-    /// Curated pool of short, evocative names for the assistant. The quick-tap
-    /// suggestion pills show a random sample of `suggestionCount` names drawn
-    /// from this pool per onboarding session.
-    static let assistantNamePool = [
-        "Pax", "Atlas", "Sage", "Nova", "Kit",
-        "Echo", "Luna", "Juno", "Ada", "Iris",
-        "Milo", "Remy", "Wren", "Lark", "Vesper",
-        "Onyx", "Vela", "Cleo", "Quill", "Rune",
-        "Orion", "Ember", "Ziggy", "Bodhi", "Pip",
-    ]
-
-    /// Number of suggestion pills shown at a time.
-    static let suggestionCount = 5
-
-    /// Returns `suggestionCount` unique random names drawn from the pool.
-    static func sampleAssistantNames() -> [String] {
-        Array(assistantNamePool.shuffled().prefix(suggestionCount))
-    }
+    @State private var hoveredGroup: String?
 
     /// Usernames that are clearly not real names and should not be pre-filled.
     private static let usernameBlacklist: Set<String> = ["admin", "user", "root", "guest"]
@@ -83,7 +66,7 @@ struct NameExchangeView: View {
                     text: $userName
                 )
 
-                // "Call me..." field + suggestion pills
+                // "Call me..." field + group pills + suggestion pills
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     VTextField(
                         "What should I go by?",
@@ -91,8 +74,15 @@ struct NameExchangeView: View {
                         text: $assistantName
                     )
 
-                    // Suggestion pills
+                    // Personality group pills
                     HStack(spacing: VSpacing.xs) {
+                        ForEach(PersonalityGroup.allGroups, id: \.id) { group in
+                            groupPill(group)
+                        }
+                    }
+
+                    // Name suggestion pills (flow layout for wrapping)
+                    WrappingHStack(hSpacing: VSpacing.xs, vSpacing: VSpacing.xs) {
                         ForEach(displayedAssistantNames, id: \.self) { suggestion in
                             suggestionPill(suggestion)
                         }
@@ -136,6 +126,48 @@ struct NameExchangeView: View {
     }
 
     // MARK: - Subviews
+
+    private func groupPill(_ group: PersonalityGroup) -> some View {
+        let isActive = selectedGroupID == group.id
+        let isHovered = hoveredGroup == group.id
+        return Button {
+            withAnimation(VAnimation.fast) {
+                if isActive {
+                    selectedGroupID = nil
+                } else {
+                    selectedGroupID = group.id
+                }
+            }
+        } label: {
+            VStack(spacing: 2) {
+                Text(group.label)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(isActive ? VColor.contentInset : VColor.contentDefault)
+                Text(group.descriptor)
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(isActive ? VColor.contentInset.opacity(0.8) : VColor.contentTertiary)
+            }
+            .padding(.horizontal, VSpacing.sm)
+            .padding(.vertical, VSpacing.xs)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.pill)
+                    .fill(isActive ? VColor.primaryBase : (isHovered ? VColor.surfaceBase : VColor.surfaceLift))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.pill)
+                            .stroke(isActive ? VColor.primaryBase : VColor.borderElement, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor(onHover: { hovering in
+            withAnimation(VAnimation.fast) {
+                hoveredGroup = hovering ? group.id : nil
+            }
+        })
+        .accessibilityLabel("\(group.label), \(group.descriptor)")
+        .accessibilityValue(isActive ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
 
     private func suggestionPill(_ name: String) -> some View {
         let isActive = assistantName == name
@@ -200,5 +232,59 @@ struct NameExchangeView: View {
         }
 
         return ""
+    }
+}
+
+// MARK: - Wrapping horizontal layout
+
+private struct WrappingHStack: Layout {
+    var hSpacing: CGFloat
+    var vSpacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        guard !rows.isEmpty else { return .zero }
+        let height = rows.enumerated().reduce(CGFloat.zero) { acc, pair in
+            let rowHeight = pair.element.map { $0.size.height }.max() ?? 0
+            return acc + rowHeight + (pair.offset > 0 ? vSpacing : 0)
+        }
+        return CGSize(width: proposal.width ?? 0, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            let rowHeight = row.map { $0.size.height }.max() ?? 0
+            var x = bounds.minX
+            for item in row {
+                item.subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(item.size))
+                x += item.size.width + hSpacing
+            }
+            y += rowHeight + vSpacing
+        }
+    }
+
+    private struct LayoutItem {
+        let subview: LayoutSubview
+        let size: CGSize
+    }
+
+    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[LayoutItem]] {
+        let maxWidth = proposal.width ?? .infinity
+        var rows: [[LayoutItem]] = [[]]
+        var currentRowWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let needed = currentRowWidth > 0 ? size.width + hSpacing : size.width
+            if currentRowWidth + needed > maxWidth, !rows[rows.count - 1].isEmpty {
+                rows.append([])
+                currentRowWidth = 0
+            }
+            rows[rows.count - 1].append(LayoutItem(subview: subview, size: size))
+            currentRowWidth += currentRowWidth > 0 ? size.width + hSpacing : size.width
+        }
+        return rows
     }
 }

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -76,7 +76,7 @@ struct PreChatOnboardingFlow: View {
         let context = PreChatOnboardingContext(
             tools: cleanTools,
             tasks: Array(state.selectedTasks).sorted(),
-            tone: state.selectedGroupID ?? "grounded",
+            tone: state.selectedGroupID ?? PersonalityGroup.defaultGroupID,
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -42,6 +42,7 @@ struct PreChatOnboardingFlow: View {
                 NameExchangeView(
                     userName: $state.userName,
                     assistantName: $state.assistantName,
+                    selectedGroupID: $state.selectedGroupID,
                     displayedAssistantNames: state.displayedAssistantNames,
                     onBack: { advanceTo(1) },
                     onComplete: { finish() },

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingFlow.swift
@@ -76,7 +76,7 @@ struct PreChatOnboardingFlow: View {
         let context = PreChatOnboardingContext(
             tools: cleanTools,
             tasks: Array(state.selectedTasks).sorted(),
-            tone: "balanced",
+            tone: state.selectedGroupID ?? "grounded",
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
@@ -15,11 +15,23 @@ final class PreChatOnboardingState {
     var assistantName: String
     var skippedAll: Bool = false
 
-    /// Random subset of `NameExchangeView.assistantNamePool` displayed as
-    /// quick-tap suggestion pills. Sampled once per state instance so the pills
-    /// remain stable across re-renders and back-navigation within a session.
-    /// Not persisted to UserDefaults — a fresh sample is drawn on each run.
-    let displayedAssistantNames: [String]
+    /// The currently selected personality group ID, or `nil` for no selection.
+    var selectedGroupID: String?
+
+    /// Assistant names to display as quick-tap pills, ordered by group
+    /// relevance. When a group is selected its names appear first, followed
+    /// by names from the remaining groups. When no group is selected all
+    /// names from every group are shown.
+    var displayedAssistantNames: [String] {
+        guard let selectedID = selectedGroupID,
+              let group = PersonalityGroup.allGroups.first(where: { $0.id == selectedID }) else {
+            return PersonalityGroup.allNames
+        }
+        let rest = PersonalityGroup.allGroups
+            .filter { $0.id != selectedID }
+            .flatMap(\.names)
+        return group.names + rest
+    }
 
     // MARK: - Persistence Keys
 
@@ -29,18 +41,18 @@ final class PreChatOnboardingState {
     private static let tasksKey = "\(prefix)selectedTasks"
     private static let userNameKey = "\(prefix)userName"
     private static let assistantNameKey = "\(prefix)assistantName"
+    private static let selectedGroupIDKey = "\(prefix)selectedGroupID"
 
     private static let allKeys: [String] = [
         screenKey, toolsKey, tasksKey,
         userNameKey, assistantNameKey,
+        selectedGroupIDKey,
     ]
 
     // MARK: - Init (restore from UserDefaults)
 
     init() {
-        let sampled = NameExchangeView.sampleAssistantNames()
-        self.displayedAssistantNames = sampled
-        self.assistantName = sampled.first ?? "Pax"
+        self.assistantName = ""
         self.userName = ""
 
         let defaults = UserDefaults.standard
@@ -64,6 +76,8 @@ final class PreChatOnboardingState {
            !name.hasPrefix("vellum-") {
             assistantName = name
         }
+
+        selectedGroupID = defaults.string(forKey: Self.selectedGroupIDKey)
     }
 
     // MARK: - Persist
@@ -75,6 +89,7 @@ final class PreChatOnboardingState {
         defaults.set(Array(selectedTasks), forKey: Self.tasksKey)
         defaults.set(userName, forKey: Self.userNameKey)
         defaults.set(assistantName, forKey: Self.assistantNameKey)
+        defaults.set(selectedGroupID, forKey: Self.selectedGroupIDKey)
     }
 
     // MARK: - Clear

--- a/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/PreChat/PreChatOnboardingState.swift
@@ -18,19 +18,17 @@ final class PreChatOnboardingState {
     /// The currently selected personality group ID, or `nil` for no selection.
     var selectedGroupID: String?
 
-    /// Assistant names to display as quick-tap pills, ordered by group
-    /// relevance. When a group is selected its names appear first, followed
-    /// by names from the remaining groups. When no group is selected all
-    /// names from every group are shown.
+    /// A representative sample shown when no personality group is selected.
+    static let tasterNames = ["Penn", "Sage", "Wren", "Milo", "Nova", "Ember", "Luna", "Iris"]
+
+    /// Names to show as quick-tap pills. When a group is selected, shows only
+    /// that group's names. Otherwise shows a curated taster sample.
     var displayedAssistantNames: [String] {
         guard let selectedID = selectedGroupID,
               let group = PersonalityGroup.allGroups.first(where: { $0.id == selectedID }) else {
-            return PersonalityGroup.allNames
+            return Self.tasterNames
         }
-        let rest = PersonalityGroup.allGroups
-            .filter { $0.id != selectedID }
-            .flatMap(\.names)
-        return group.names + rest
+        return group.names
     }
 
     // MARK: - Persistence Keys

--- a/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
+++ b/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
@@ -84,51 +84,46 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(decoded.assistantName, original.assistantName)
     }
 
-    // MARK: - Assistant Name Pool / Sampling
+    // MARK: - PersonalityGroup Name Pool
 
-    func testAssistantNamePoolHasExpectedSize() {
-        // The pool must be large enough that five random draws still leave
-        // meaningful variety; 25 is the product-spec target.
-        XCTAssertEqual(NameExchangeView.assistantNamePool.count, 25)
+    func testAllNamesHasUniqueEntries() {
+        let allNames = PersonalityGroup.allNames
+        XCTAssertEqual(Set(allNames).count, allNames.count, "All names across groups must be unique")
     }
 
-    func testAssistantNamePoolHasUniqueEntries() {
-        let pool = NameExchangeView.assistantNamePool
-        XCTAssertEqual(Set(pool).count, pool.count, "Pool entries must be unique")
-    }
-
-    func testSampleAssistantNamesReturnsFiveUniqueNamesFromPool() {
-        let sample = NameExchangeView.sampleAssistantNames()
-        let pool = Set(NameExchangeView.assistantNamePool)
-
-        XCTAssertEqual(sample.count, NameExchangeView.suggestionCount)
-        XCTAssertEqual(Set(sample).count, sample.count, "Sampled names must be unique")
-        for name in sample {
-            XCTAssertTrue(pool.contains(name), "Sampled name '\(name)' must come from the pool")
-        }
-    }
-
-    func testStateDisplayedNamesMatchSampleContract() {
+    func testStateDisplayedNamesMatchAllNamesWhenNoGroupSelected() {
+        PreChatOnboardingState.clearPersistedState()
         let state = PreChatOnboardingState()
-        let pool = Set(NameExchangeView.assistantNamePool)
 
-        XCTAssertEqual(state.displayedAssistantNames.count, NameExchangeView.suggestionCount)
-        XCTAssertEqual(Set(state.displayedAssistantNames).count, state.displayedAssistantNames.count)
-        for name in state.displayedAssistantNames {
-            XCTAssertTrue(pool.contains(name))
-        }
+        XCTAssertNil(state.selectedGroupID)
+        XCTAssertEqual(state.displayedAssistantNames, PersonalityGroup.allNames)
     }
 
-    func testDefaultAssistantNameIsFromDisplayedSample() {
-        // On a fresh state (no persisted assistantName), the initial pre-fill
-        // should be one of the displayed suggestion pills so the active pill
-        // matches the text field out of the box.
+    func testStateDisplayedNamesPrioritizesSelectedGroup() {
+        PreChatOnboardingState.clearPersistedState()
+        let state = PreChatOnboardingState()
+        state.selectedGroupID = "warm"
+
+        let warmGroup = PersonalityGroup.allGroups.first { $0.id == "warm" }!
+        let displayed = state.displayedAssistantNames
+
+        // Selected group's names should come first
+        let prefix = Array(displayed.prefix(warmGroup.names.count))
+        XCTAssertEqual(prefix, warmGroup.names)
+
+        // All names should still be present
+        XCTAssertEqual(Set(displayed), Set(PersonalityGroup.allNames))
+    }
+
+    func testDefaultAssistantNameIsEmptyOnFreshState() {
+        // On a fresh state (no persisted assistantName), the initial value
+        // should be empty so the user must make a deliberate choice.
         PreChatOnboardingState.clearPersistedState()
         let state = PreChatOnboardingState()
 
         XCTAssertTrue(
-            state.displayedAssistantNames.contains(state.assistantName),
-            "Initial assistantName '\(state.assistantName)' should be one of the displayed suggestions"
+            state.assistantName.isEmpty,
+            "Initial assistantName should be empty, got '\(state.assistantName)'"
         )
     }
 
@@ -159,6 +154,7 @@ final class PreChatOnboardingTests: XCTestCase {
         state1.selectedTasks = ["code-building"]
         state1.userName = "TestUser"
         state1.assistantName = "TestAssistant"
+        state1.selectedGroupID = "warm"
         state1.persist()
 
         // Create a new instance — it should restore from UserDefaults
@@ -169,6 +165,7 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(state2.selectedTasks, ["code-building"])
         XCTAssertEqual(state2.userName, "TestUser")
         XCTAssertEqual(state2.assistantName, "TestAssistant")
+        XCTAssertEqual(state2.selectedGroupID, "warm")
     }
 
     func testClearPersistedStateResetsToDefaults() {

--- a/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
+++ b/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
@@ -224,7 +224,7 @@ final class PreChatOnboardingTests: XCTestCase {
         let context = PreChatOnboardingContext(
             tools: Array(state.selectedTools).sorted(),
             tasks: Array(state.selectedTasks).sorted(),
-            tone: "balanced",
+            tone: "grounded",
             userName: state.userName.isEmpty ? nil : state.userName,
             assistantName: state.assistantName.isEmpty ? nil : state.assistantName
         )
@@ -233,7 +233,7 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertNotNil(receivedContext)
         XCTAssertEqual(receivedContext?.tools, ["slack"])
         XCTAssertEqual(receivedContext?.tasks, ["writing"])
-        XCTAssertEqual(receivedContext?.tone, "balanced")
+        XCTAssertEqual(receivedContext?.tone, "grounded")
         XCTAssertEqual(receivedContext?.userName, "Alex")
         XCTAssertEqual(receivedContext?.assistantName, "Pax")
     }

--- a/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
+++ b/clients/macos/vellum-assistantTests/PreChatOnboardingTests.swift
@@ -91,28 +91,21 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(Set(allNames).count, allNames.count, "All names across groups must be unique")
     }
 
-    func testStateDisplayedNamesMatchAllNamesWhenNoGroupSelected() {
+    func testStateDisplayedNamesShowsTasterWhenNoGroupSelected() {
         PreChatOnboardingState.clearPersistedState()
         let state = PreChatOnboardingState()
 
         XCTAssertNil(state.selectedGroupID)
-        XCTAssertEqual(state.displayedAssistantNames, PersonalityGroup.allNames)
+        XCTAssertEqual(state.displayedAssistantNames, PreChatOnboardingState.tasterNames)
     }
 
-    func testStateDisplayedNamesPrioritizesSelectedGroup() {
+    func testStateDisplayedNamesFiltersToSelectedGroup() {
         PreChatOnboardingState.clearPersistedState()
         let state = PreChatOnboardingState()
         state.selectedGroupID = "warm"
 
         let warmGroup = PersonalityGroup.allGroups.first { $0.id == "warm" }!
-        let displayed = state.displayedAssistantNames
-
-        // Selected group's names should come first
-        let prefix = Array(displayed.prefix(warmGroup.names.count))
-        XCTAssertEqual(prefix, warmGroup.names)
-
-        // All names should still be present
-        XCTAssertEqual(Set(displayed), Set(PersonalityGroup.allNames))
+        XCTAssertEqual(state.displayedAssistantNames, warmGroup.names)
     }
 
     func testDefaultAssistantNameIsEmptyOnFreshState() {
@@ -219,7 +212,7 @@ final class PreChatOnboardingTests: XCTestCase {
         state.selectedTools = ["slack"]
         state.selectedTasks = ["writing"]
         state.userName = "Alex"
-        state.assistantName = "Pax"
+        state.assistantName = "Penn"
 
         let context = PreChatOnboardingContext(
             tools: Array(state.selectedTools).sorted(),
@@ -235,7 +228,7 @@ final class PreChatOnboardingTests: XCTestCase {
         XCTAssertEqual(receivedContext?.tasks, ["writing"])
         XCTAssertEqual(receivedContext?.tone, "grounded")
         XCTAssertEqual(receivedContext?.userName, "Alex")
-        XCTAssertEqual(receivedContext?.assistantName, "Pax")
+        XCTAssertEqual(receivedContext?.assistantName, "Penn")
     }
 
     // MARK: - Identity Cache Seeding

--- a/clients/shared/Models/PersonalityGroup.swift
+++ b/clients/shared/Models/PersonalityGroup.swift
@@ -1,0 +1,48 @@
+/// A personality cluster that groups assistant names by communication style.
+public struct PersonalityGroup: Sendable {
+    public let id: String
+    public let label: String
+    public let descriptor: String
+    public let names: [String]
+
+    /// The four built-in personality groups.
+    public static let allGroups: [PersonalityGroup] = [
+        PersonalityGroup(
+            id: "grounded",
+            label: "Grounded",
+            descriptor: "Calm and precise",
+            names: ["Pax", "Sage", "Atlas", "Orion", "Rune", "Quill"]
+        ),
+        PersonalityGroup(
+            id: "warm",
+            label: "Warm",
+            descriptor: "Warm and easy",
+            names: ["Kit", "Pip", "Remy", "Wren", "Lark", "Milo", "Cleo"]
+        ),
+        PersonalityGroup(
+            id: "energetic",
+            label: "Energetic",
+            descriptor: "Fast and direct",
+            names: ["Nova", "Ember", "Ziggy", "Bodhi", "Vela", "Onyx"]
+        ),
+        PersonalityGroup(
+            id: "poetic",
+            label: "Poetic",
+            descriptor: "Quiet and observant",
+            names: ["Luna", "Iris", "Vesper", "Echo", "Juno", "Ada"]
+        ),
+    ]
+
+    /// The default personality group identifier.
+    public static let defaultGroupID = "grounded"
+
+    /// All assistant names across every personality group.
+    public static var allNames: [String] {
+        allGroups.flatMap(\.names)
+    }
+
+    /// Returns the personality group that contains the given name, or `nil`.
+    public static func groupForName(_ name: String) -> PersonalityGroup? {
+        allGroups.first { $0.names.contains(name) }
+    }
+}

--- a/clients/shared/Models/PersonalityGroup.swift
+++ b/clients/shared/Models/PersonalityGroup.swift
@@ -11,25 +11,25 @@ public struct PersonalityGroup: Sendable {
             id: "grounded",
             label: "Grounded",
             descriptor: "Calm and precise",
-            names: ["Pax", "Sage", "Atlas", "Orion", "Rune", "Quill"]
+            names: ["Penn", "Sage", "Atlas", "Orion", "Reed", "Quill"]
         ),
         PersonalityGroup(
             id: "warm",
             label: "Warm",
             descriptor: "Warm and easy",
-            names: ["Kit", "Pip", "Remy", "Wren", "Lark", "Milo", "Cleo"]
+            names: ["Kit", "Remy", "Wren", "Milo", "Fenn", "Cleo"]
         ),
         PersonalityGroup(
             id: "energetic",
             label: "Energetic",
             descriptor: "Fast and direct",
-            names: ["Nova", "Ember", "Ziggy", "Bodhi", "Vela", "Onyx"]
+            names: ["Nova", "Ember", "Cade", "Lark", "Vela", "Ziggy"]
         ),
         PersonalityGroup(
             id: "poetic",
             label: "Poetic",
             descriptor: "Quiet and observant",
-            names: ["Luna", "Iris", "Vesper", "Echo", "Juno", "Ada"]
+            names: ["Luna", "Iris", "Vesper", "Lyra", "Juno", "Ada"]
         ),
     ]
 

--- a/clients/shared/Models/PreChatOnboardingContext.swift
+++ b/clients/shared/Models/PreChatOnboardingContext.swift
@@ -4,7 +4,7 @@
 public struct PreChatOnboardingContext: Codable, Sendable {
     public let tools: [String]       // e.g. ["slack", "linear", "figma"]
     public let tasks: [String]       // e.g. ["code-building", "writing"]
-    public let tone: String          // "casual", "professional", or "balanced"
+    public let tone: String          // "grounded", "warm", "energetic", or "poetic"
     public let userName: String?     // nil if skipped
     public let assistantName: String? // nil if kept default
 


### PR DESCRIPTION
## Summary
Replace the flat name-chip picker on the onboarding name screen with a two-tier personality-group → name selection. The user picks a personality cluster (grounded / warm / energetic / poetic) via pill buttons; the name chips filter to that group's names. The selected group sets the `tone` field on `PreChatOnboardingContext`, which flows into the first greeting and relationship-state facts.

## Self-review result
PASS — 2 gaps found and fixed across 1 fix PR (auto-select first name on group pill tap, use defaultGroupID constant)

## PRs merged into feature branch
- #28797: Add PersonalityGroup data model and tone type
- #28810: Add personality group pill selector to name exchange screen
- #28804: Vary first greeting voice based on personality tone
- #28806: Map personality tone to descriptive voice fact in relationship state
- #28814: Wire personality group selection to tone field in onboarding context
- #28823: Update prechat onboarding contract test for personality tone values

### Fix PRs
- #28833: fix: auto-select first name on group pill tap, use defaultGroupID constant

Part of plan: personality-group-names.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
