### PR TITLE
Declarative inference profile seeding

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -2601,6 +2601,76 @@ paths:
                 - requestId
                 - decision
               additionalProperties: false
+  /v1/consolidation/config:
+    get:
+      operationId: consolidation_config_get
+      summary: Get consolidation config
+      description: Return the current memory v2 consolidation schedule configuration.
+      tags:
+        - consolidation
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                  enabled:
+                    type: boolean
+                  intervalMs:
+                    type: number
+                  nextRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  lastRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  success:
+                    type: boolean
+                required:
+                  - available
+                  - enabled
+                  - intervalMs
+                  - nextRunAt
+                  - lastRunAt
+                  - success
+                additionalProperties: false
+  /v1/consolidation/run-now:
+    post:
+      operationId: consolidation_runnow_post
+      summary: Run consolidation now
+      description:
+        Enqueue an immediate memory v2 consolidation job. Returns once the job is queued; the job itself runs
+        through the memory jobs worker.
+      tags:
+        - consolidation
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  ran:
+                    type: boolean
+                    description: Whether a job was enqueued
+                  jobId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - success
+                  - ran
+                  - jobId
+                additionalProperties: false
   /v1/contact-channels/{contactChannelId}:
     patch:
       operationId: contactchannels_by_contactChannelId_patch
@@ -4473,6 +4543,8 @@ paths:
               schema:
                 type: object
                 properties:
+                  available:
+                    type: boolean
                   enabled:
                     type: boolean
                   intervalMs:
@@ -4496,6 +4568,7 @@ paths:
                   success:
                     type: boolean
                 required:
+                  - available
                   - enabled
                   - intervalMs
                   - activeHoursStart

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests that managed inference profiles ("quality-optimized", "balanced",
+ * "cost-optimized") cannot be edited via the PUT profile route or deleted
+ * via the PATCH config route.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "./helpers/mock-logger.js";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+let savedRaw: Record<string, unknown> | null = null;
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => ({
+    llm: {
+      profiles: {
+        "quality-optimized": { provider: "anthropic", model: "claude-sonnet" },
+        balanced: { provider: "anthropic", model: "claude-sonnet" },
+        "cost-optimized": { provider: "anthropic", model: "claude-haiku" },
+        "my-custom": { provider: "openai", model: "gpt-4o" },
+      },
+    },
+  }),
+  saveRawConfig: (raw: Record<string, unknown>) => {
+    savedRaw = raw;
+  },
+  deepMergeOverwrite: (
+    target: Record<string, unknown>,
+    overrides: Record<string, unknown>,
+  ) => {
+    Object.assign(target, overrides);
+  },
+}));
+
+import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+
+const replaceRoute = ROUTES.find(
+  (r) => r.operationId === "config_llm_profiles_replace",
+)!;
+
+const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
+
+// ---------------------------------------------------------------------------
+// PUT /v1/config/llm/profiles/:name — replace inference profile
+// ---------------------------------------------------------------------------
+
+describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
+  test("rejects edits to quality-optimized with descriptive message", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "quality-optimized" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(
+      'Cannot edit managed profile "quality-optimized". Duplicate it to create a custom profile.',
+    );
+  });
+
+  test("rejects edits to balanced", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "balanced" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects edits to cost-optimized", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "cost-optimized" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("allows edits to a user-defined profile", () => {
+    savedRaw = null;
+    const result = replaceRoute.handler({
+      pathParams: { name: "my-custom" },
+      body: { provider: "openai", model: "gpt-4o" },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(savedRaw).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /v1/config — managed profile deletion guard
+// ---------------------------------------------------------------------------
+
+describe("PATCH /v1/config — managed profile deletion guard", () => {
+  test("rejects deletion of quality-optimized via null with descriptive message", () => {
+    expect(() =>
+      patchRoute.handler({
+        body: { llm: { profiles: { "quality-optimized": null } } },
+      }),
+    ).toThrow('Cannot delete managed profile "quality-optimized".');
+  });
+
+  test("rejects deletion of balanced via null", () => {
+    expect(() =>
+      patchRoute.handler({
+        body: { llm: { profiles: { balanced: null } } },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects deletion of cost-optimized via null", () => {
+    expect(() =>
+      patchRoute.handler({
+        body: { llm: { profiles: { "cost-optimized": null } } },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("allows deletion of a user-defined profile via null", () => {
+    savedRaw = null;
+    const result = patchRoute.handler({
+      body: { llm: { profiles: { "my-custom": null } } },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("allows non-profile config patches", () => {
+    savedRaw = null;
+    const result = patchRoute.handler({
+      body: { someOtherKey: "value" },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("allows patches that modify a managed profile (non-null)", () => {
+    savedRaw = null;
+    const result = patchRoute.handler({
+      body: {
+        llm: {
+          profiles: { "quality-optimized": { provider: "anthropic" } },
+        },
+      },
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -146,4 +146,12 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
     });
     expect(result).toEqual({ ok: true });
   });
+
+  test("rejects nulling the entire profiles map", () => {
+    expect(() =>
+      patchRoute.handler({
+        body: { llm: { profiles: null } },
+      }),
+    ).toThrow("Cannot null llm.profiles");
+  });
 });

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import {
   type LLMCallSite,
   LLMConfigBase,
-  type LLMConfigFragment,
   type LLMSchema,
+  type ProfileEntry,
 } from "./schemas/llm.js";
 
 /**
@@ -59,7 +59,7 @@ export function resolveCallSiteConfig(
   const site = llm.callSites?.[callSite];
   if (site != null) {
     if (site.profile != null) {
-      const profileFragment: LLMConfigFragment | undefined =
+      const profileFragment: ProfileEntry | undefined =
         llm.profiles?.[site.profile];
       if (profileFragment == null) {
         // Defensive: `LLMSchema.superRefine` already rejects unknown profile

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -34,6 +34,7 @@ export type {
   LLMConfig,
   LLMConfigBase,
   LLMConfigFragment,
+  ProfileEntry,
 } from "./schemas/llm.js";
 export { LLMCallSiteEnum, LLMSchema } from "./schemas/llm.js";
 export type { AuditLogConfig, LogFileConfig } from "./schemas/logging.js";

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -246,6 +246,17 @@ const OpenRouterDeepPartialSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Profile metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Distinguishes daemon-managed profiles (overwritten on every startup) from
+ * user-created ones (never touched by the daemon).
+ */
+export const ProfileSource = z.enum(["managed", "user"]);
+export type ProfileSource = z.infer<typeof ProfileSource>;
+
+// ---------------------------------------------------------------------------
 // Pricing overrides
 // ---------------------------------------------------------------------------
 
@@ -302,6 +313,19 @@ export const LLMConfigFragment = z.object({
 export type LLMConfigFragment = z.infer<typeof LLMConfigFragment>;
 
 /**
+ * A named profile entry: an `LLMConfigFragment` augmented with
+ * presentation/ownership metadata. These fields are intentionally kept off
+ * `LLMConfigFragment` so they don't leak into `LLMCallSiteConfig` or the
+ * resolver's deep-merge output.
+ */
+export const ProfileEntry = LLMConfigFragment.extend({
+  source: ProfileSource.optional(),
+  label: z.string().min(1).optional(),
+  description: z.string().optional(),
+});
+export type ProfileEntry = z.infer<typeof ProfileEntry>;
+
+/**
  * Per-call-site config: a fragment plus an optional `profile` reference.
  * The resolver merges in the named profile (if any) before applying
  * call-site-level overrides.
@@ -318,7 +342,7 @@ export type LLMCallSiteConfig = z.infer<typeof LLMCallSiteConfig>;
 export const LLMSchema = z
   .object({
     default: LLMConfigBase.default(LLMConfigBase.parse({})),
-    profiles: z.record(z.string().min(1), LLMConfigFragment).default({}),
+    profiles: z.record(z.string().min(1), ProfileEntry).default({}),
     // Presentation-only order for named profiles. The resolver ignores this;
     // clients use it to render profile pickers consistently.
     profileOrder: z.array(z.string().min(1)).default([]),

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -1,0 +1,111 @@
+import { loadRawConfig, saveRawConfig } from "./loader.js";
+import type { ProfileEntry } from "./schemas/llm.js";
+
+/**
+ * Declarative seed data for daemon-managed inference profiles.
+ *
+ * These profiles are overwritten on every startup so upstream model
+ * updates propagate automatically. User-created profiles (keyed by
+ * different names) are never touched.
+ */
+export const MANAGED_PROFILE_SEED_DATA: Record<string, ProfileEntry> = {
+  "quality-optimized": {
+    source: "managed",
+    label: "Quality",
+    description: "Best results with the most capable model",
+    provider: "anthropic",
+    model: "claude-opus-4-7",
+    maxTokens: 32000,
+    effort: "max",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  balanced: {
+    source: "managed",
+    label: "Balanced",
+    description: "Good balance of quality and speed",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+  },
+  "cost-optimized": {
+    source: "managed",
+    label: "Speed",
+    description: "Fastest responses at lower cost",
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+  },
+};
+
+export const MANAGED_PROFILE_NAMES = new Set(
+  Object.keys(MANAGED_PROFILE_SEED_DATA),
+);
+
+/**
+ * Seed managed inference profiles into the workspace config.
+ *
+ * Called on every daemon startup after workspace migrations and before
+ * the first `loadConfig()`. Managed profiles are overwritten entirely
+ * (replace, not merge) so upstream model/effort changes propagate.
+ * User-created profiles are never touched; pre-existing profiles
+ * without a `source` field get `source: "user"` backfilled.
+ *
+ * No-op when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set (same guard
+ * as migration 052) because the platform-provided default-config overlay
+ * is the authoritative source for profile seeds.
+ */
+export function seedInferenceProfiles(): void {
+  if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+  const config = loadRawConfig();
+
+  if (config.llm == null || typeof config.llm !== "object") {
+    config.llm = {};
+  }
+  const llm = config.llm as Record<string, unknown>;
+
+  if (llm.profiles == null || typeof llm.profiles !== "object") {
+    llm.profiles = {};
+  }
+  const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+
+  for (const [name, seed] of Object.entries(MANAGED_PROFILE_SEED_DATA)) {
+    profiles[name] = { ...seed };
+  }
+
+  // Reset to "balanced" when the current value references a missing profile
+  if (
+    typeof llm.activeProfile !== "string" ||
+    !(llm.activeProfile in profiles)
+  ) {
+    llm.activeProfile = "balanced";
+  }
+
+  const profileOrder = Array.isArray(llm.profileOrder)
+    ? (llm.profileOrder as string[])
+    : [];
+  const orderSet = new Set(profileOrder);
+  for (const name of MANAGED_PROFILE_NAMES) {
+    if (!orderSet.has(name)) {
+      profileOrder.push(name);
+    }
+  }
+  llm.profileOrder = profileOrder;
+
+  for (const [name, profile] of Object.entries(profiles)) {
+    if (MANAGED_PROFILE_NAMES.has(name)) continue;
+    if (
+      profile != null &&
+      typeof profile === "object" &&
+      !("source" in profile)
+    ) {
+      profile.source = "user";
+    }
+  }
+
+  saveRawConfig(config);
+}

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -19,6 +19,7 @@ import {
 } from "../config/env.js";
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
+import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import {
@@ -455,6 +456,20 @@ export async function runDaemon(): Promise<void> {
         log.warn({ err }, "Call recovery failed — continuing startup");
       }
     } // end if (dbReady)
+
+    // Seed managed inference profiles into the workspace config. Runs
+    // after workspace migrations (which may have created the initial
+    // profile slots) and before mergeDefaultWorkspaceConfig / loadConfig
+    // so the profiles are on disk for the first config load.
+    try {
+      seedInferenceProfiles();
+      log.info("Inference profile seeding complete");
+    } catch (err) {
+      log.warn(
+        { err },
+        "Inference profile seeding failed — continuing startup",
+      );
+    }
 
     // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
     // into the workspace config file before the first loadConfig() call so

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -78,13 +78,7 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
   summary?: LlmContextSummaryResponse;
 };
 
-// TODO: Import from ../config/seed-inference-profiles.js once that module
-// exists (PR 2 of the declarative-profile-seed plan).
-const MANAGED_PROFILE_NAMES = new Set([
-  "quality-optimized",
-  "balanced",
-  "cost-optimized",
-]);
+import { MANAGED_PROFILE_NAMES } from "../../config/seed-inference-profiles.js";
 
 const INFERENCE_PROFILE_UI_KEYS = new Set([
   "provider",

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -25,7 +25,7 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import { LLMConfigFragment } from "../../config/schemas/llm.js";
+import { ProfileEntry } from "../../config/schemas/llm.js";
 import { VALID_MEMORY_EMBEDDING_PROVIDERS } from "../../config/schemas/memory-storage.js";
 import { VALID_INFERENCE_PROVIDERS } from "../../config/schemas/services.js";
 import { getConfigWatcher } from "../../daemon/config-watcher.js";
@@ -299,7 +299,7 @@ function handleReplaceInferenceProfile({
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new BadRequestError("Body must be a JSON object");
   }
-  const parsed = LLMConfigFragment.safeParse(body);
+  const parsed = ProfileEntry.safeParse(body);
   if (!parsed.success) {
     const detail = parsed.error.issues.map((issue) => issue.message).join("; ");
     throw new BadRequestError(`Invalid profile fragment: ${detail}`);

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -274,6 +274,11 @@ function handleGetConfig() {
 function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
   const llm = asMutablePlainObject(body.llm);
   if (!llm) return;
+  if ("profiles" in llm && llm.profiles === null) {
+    throw new BadRequestError(
+      "Cannot null llm.profiles — managed profiles would be deleted.",
+    );
+  }
   const profiles = asMutablePlainObject(llm.profiles);
   if (!profiles) return;
   for (const name of Object.keys(profiles)) {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -77,6 +77,14 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
   summary?: LlmContextSummaryResponse;
 };
 
+// TODO: Import from ../config/seed-inference-profiles.js once that module
+// exists (PR 2 of the declarative-profile-seed plan).
+const MANAGED_PROFILE_NAMES = new Set([
+  "quality-optimized",
+  "balanced",
+  "cost-optimized",
+]);
+
 const INFERENCE_PROFILE_UI_KEYS = new Set([
   "provider",
   "model",
@@ -268,6 +276,18 @@ function handleGetConfig() {
   }
 }
 
+function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
+  const llm = asMutablePlainObject(body.llm);
+  if (!llm) return;
+  const profiles = asMutablePlainObject(llm.profiles);
+  if (!profiles) return;
+  for (const name of Object.keys(profiles)) {
+    if (profiles[name] === null && MANAGED_PROFILE_NAMES.has(name)) {
+      throw new BadRequestError(`Cannot delete managed profile "${name}".`);
+    }
+  }
+}
+
 function handlePatchConfig({ body }: RouteHandlerArgs) {
   if (
     !body ||
@@ -277,6 +297,7 @@ function handlePatchConfig({ body }: RouteHandlerArgs) {
   ) {
     throw new BadRequestError("Body must be a non-empty JSON object");
   }
+  rejectManagedProfileDeletion(body as Record<string, unknown>);
   try {
     const raw = loadRawConfig();
     deepMergeOverwrite(raw, body);
@@ -298,6 +319,11 @@ function handleReplaceInferenceProfile({
   }
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new BadRequestError("Body must be a JSON object");
+  }
+  if (MANAGED_PROFILE_NAMES.has(name)) {
+    throw new BadRequestError(
+      `Cannot edit managed profile "${name}". Duplicate it to create a custom profile.`,
+    );
   }
   const parsed = ProfileEntry.safeParse(body);
   if (!parsed.success) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -54,25 +54,29 @@ struct ChatProfilePicker: View {
     /// conversation falls back to `activeProfile`.
     let onSelect: (String?) -> Void
 
-    /// Pill label: the override profile when set, otherwise
+    /// Pill label: the override profile's display name when set, otherwise
     /// "Default (`<activeProfile>`)". Internal so tests can assert on it
     /// without spinning up a SwiftUI host.
-    static func label(current: String?, activeProfile: String) -> String {
-        if let current { return current }
-        return "Default (\(activeProfile))"
+    static func label(current: String?, profiles: [InferenceProfile], activeProfile: String) -> String {
+        if let current {
+            return profiles.first(where: { $0.name == current })?.displayName ?? current
+        }
+        let activeDisplay = profiles.first(where: { $0.name == activeProfile })?.displayName ?? activeProfile
+        return "Default (\(activeDisplay))"
     }
 
     var body: some View {
+        let pillLabel = Self.label(current: current, profiles: profiles, activeProfile: activeProfile)
         #if os(macOS)
         ComposerPillMenu(
             isEnabled: isEnabled,
             accessibilityLabel: "Inference profile",
-            accessibilityValue: Self.label(current: current, activeProfile: activeProfile),
+            accessibilityValue: pillLabel,
             tooltip: "Inference profile for this conversation"
         ) {
             VIconView(.sparkles, size: 14)
                 .foregroundStyle(VColor.contentSecondary)
-            Text(Self.label(current: current, activeProfile: activeProfile))
+            Text(pillLabel)
                 .font(VFont.labelDefault)
                 .foregroundStyle(VColor.contentSecondary)
                 .lineLimit(1)
@@ -80,7 +84,7 @@ struct ChatProfilePicker: View {
             ForEach(profiles) { profile in
                 VMenuItem(
                     icon: VIcon.sparkles.rawValue,
-                    label: profile.name,
+                    label: profile.displayName,
                     isActive: current == profile.name,
                     size: .regular
                 ) {
@@ -96,7 +100,7 @@ struct ChatProfilePicker: View {
             }
             VMenuItem(
                 icon: VIcon.rotateCcw.rawValue,
-                label: "Reset to default (\(activeProfile))",
+                label: "Reset to default (\(profiles.first { $0.name == activeProfile }?.displayName ?? activeProfile))",
                 isActive: current == nil,
                 size: .regular
             ) {

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -27,6 +27,19 @@ public struct InferenceProfile: Hashable, Identifiable {
     /// stable `id` for `Identifiable` conformance.
     public var name: String
 
+    /// Origin of the profile. `"managed"` indicates a daemon-seeded profile
+    /// that should be read-only in the UI. User-created profiles have `nil`.
+    public var source: String?
+
+    /// Human-readable label for pickers and list rows (e.g. "Quality").
+    /// Falls back to `name` when absent — see `displayName`.
+    public var label: String?
+
+    /// Longer description surfaced as secondary text in the profiles list.
+    /// Named `profileDescription` because `description` collides with
+    /// Swift's `CustomStringConvertible.description`.
+    public var profileDescription: String?
+
     public var provider: String?
     public var model: String?
     public var maxTokens: Int?
@@ -53,8 +66,23 @@ public struct InferenceProfile: Hashable, Identifiable {
 
     public var id: String { name }
 
+    /// Whether this profile was seeded by the daemon and should be
+    /// treated as read-only in the UI. Users can duplicate a managed
+    /// profile to create a customizable variant.
+    public var isManaged: Bool { source == "managed" }
+
+    /// Label for pickers and list rows. Prefers the explicit `label`
+    /// (e.g. "Quality") and falls back to `name`.
+    public var displayName: String { label ?? name }
+
+    /// Optional secondary text for list row subtitles.
+    public var subtitle: String? { profileDescription }
+
     public init(
         name: String,
+        source: String? = nil,
+        label: String? = nil,
+        profileDescription: String? = nil,
         provider: String? = nil,
         model: String? = nil,
         maxTokens: Int? = nil,
@@ -66,6 +94,9 @@ public struct InferenceProfile: Hashable, Identifiable {
         thinkingStreamThinking: Bool? = nil
     ) {
         self.name = name
+        self.source = source
+        self.label = label
+        self.profileDescription = profileDescription
         self.provider = provider
         self.model = model
         self.maxTokens = maxTokens
@@ -82,6 +113,9 @@ public struct InferenceProfile: Hashable, Identifiable {
     /// produce an explicit `null`, pass `.explicitNull` directly.
     public init(
         name: String,
+        source: String? = nil,
+        label: String? = nil,
+        profileDescription: String? = nil,
         provider: String? = nil,
         model: String? = nil,
         maxTokens: Int? = nil,
@@ -94,6 +128,9 @@ public struct InferenceProfile: Hashable, Identifiable {
     ) {
         self.init(
             name: name,
+            source: source,
+            label: label,
+            profileDescription: profileDescription,
             provider: provider,
             model: model,
             maxTokens: maxTokens,
@@ -114,6 +151,9 @@ public struct InferenceProfile: Hashable, Identifiable {
     /// survive a save.
     public init(name: String, json: [String: Any]) {
         self.name = name
+        self.source = (json["source"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        self.label = (json["label"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        self.profileDescription = (json["description"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.provider = (json["provider"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.model = (json["model"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.maxTokens = json["maxTokens"] as? Int
@@ -153,6 +193,9 @@ public struct InferenceProfile: Hashable, Identifiable {
     /// distinction between "absent" and "null".
     public func toJSON() -> [String: Any] {
         var result: [String: Any] = [:]
+        if let source { result["source"] = source }
+        if let label { result["label"] = label }
+        if let profileDescription { result["description"] = profileDescription }
         if let provider { result["provider"] = provider }
         if let model { result["model"] = model }
         if let maxTokens { result["maxTokens"] = maxTokens }
@@ -234,12 +277,3 @@ public enum TemperatureValue: Hashable {
     }
 }
 
-/// The three first-class profile names the daemon seeds into every
-/// workspace (see migration 052 in `assistant/src/workspace/migrations/`).
-/// The macOS UI uses this set only to render a "Built-in" badge —
-/// deletion and editing remain allowed for these profiles.
-public let builtInInferenceProfileNames: Set<String> = [
-    "quality-optimized",
-    "balanced",
-    "cost-optimized",
-]

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -140,8 +140,8 @@ struct InferenceProfileEditor: View {
                 Text("Edit Inference Profile")
                     .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentDefault)
-                if builtInInferenceProfileNames.contains(profile.name) {
-                    Text("Built-in profile")
+                if profile.isManaged {
+                    Text("Managed profile")
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(.secondary)
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -3,9 +3,9 @@ import UniformTypeIdentifiers
 import VellumAssistantShared
 
 /// Management sheet for the user's inference profiles. Lists every entry in
-/// `store.profiles`, surfaces a "Built-in" badge for the canonical profiles
-/// seeded by workspace migration 052, and exposes Edit / Duplicate / Delete
-/// per row plus a `+ New profile` toolbar action.
+/// `store.profiles`, surfaces a "Managed" badge for profiles with
+/// `source == "managed"`, and exposes Edit / Duplicate / Delete per row
+/// plus a `+ New profile` toolbar action.
 ///
 /// State ownership:
 /// - The list mirrors `store.profiles` directly. Edits route through
@@ -19,10 +19,8 @@ import VellumAssistantShared
 ///   The user can re-target every conflicting reference to a replacement
 ///   profile, which retries the delete after the patches land.
 ///
-/// Built-in profiles are *not* protected — the badge is informational only.
-/// Users can edit, duplicate, or delete a built-in profile. Re-running the
-/// seed migration is idempotent and skips entries the user has touched, so
-/// deleted built-ins stay deleted across daemon restarts.
+/// Managed profiles are read-only — Edit and Delete are disabled.
+/// Users can duplicate a managed profile to create a customizable variant.
 @MainActor
 struct InferenceProfilesSheet: View {
     @ObservedObject var store: SettingsStore
@@ -185,11 +183,13 @@ struct InferenceProfilesSheet: View {
                         )
                         .contextMenu {
                             Button("Edit") { beginEdit(profile.name) }
+                                .disabled(profile.isManaged)
                             Button("Duplicate") { beginDuplicate(profile.name) }
                             Divider()
                             Button("Delete", role: .destructive) {
                                 Task { await attemptDelete(profile.name) }
                             }
+                            .disabled(profile.isManaged)
                         }
                 }
             }
@@ -213,9 +213,9 @@ struct InferenceProfilesSheet: View {
         .padding(VSpacing.xl)
     }
 
-    /// Single row: name + optional badge on the leading column, summary on
-    /// the trailing column. Tapping opens the editor; the context menu
-    /// surfaces Duplicate and Delete in addition.
+    /// Single row: display name + optional badge on the leading column,
+    /// summary on the trailing column. Managed profiles disable Edit and
+    /// Delete but keep Duplicate available.
     private func profileRow(_ profile: InferenceProfile) -> some View {
         HStack(alignment: .center, spacing: VSpacing.md) {
             VIconView(.gripVertical, size: 14)
@@ -223,13 +223,13 @@ struct InferenceProfilesSheet: View {
                 .frame(width: 18, height: 28)
                 .contentShape(Rectangle())
                 .help("Drag to reorder")
-                .accessibilityLabel("Reorder \(profile.name)")
+                .accessibilityLabel("Reorder \(profile.displayName)")
                 .pointerCursor()
                 .onDrag {
                     draggingProfileName = profile.name
                     return NSItemProvider(object: profile.name as NSString)
                 } preview: {
-                    Text(profile.name)
+                    Text(profile.displayName)
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentDefault)
                         .lineLimit(1)
@@ -241,21 +241,27 @@ struct InferenceProfilesSheet: View {
                 }
             VStack(alignment: .leading, spacing: VSpacing.xxs) {
                 HStack(spacing: VSpacing.xs) {
-                    Text(profile.name)
+                    Text(profile.displayName)
                         .font(VFont.bodyMediumEmphasised)
                         .foregroundStyle(VColor.contentDefault)
-                    if builtInInferenceProfileNames.contains(profile.name) {
-                        VBadge(label: "Built-in", tone: .neutral, emphasis: .subtle)
+                    if profile.isManaged {
+                        VBadge(label: "Managed", tone: .neutral, emphasis: .subtle)
                     }
+                }
+                if let subtitle = profile.subtitle {
+                    Text(subtitle)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentSecondary)
                 }
                 Text(InferenceProfilesSheet.summary(for: profile, store: store))
                     .font(VFont.bodySmallDefault)
                     .foregroundStyle(VColor.contentSecondary)
             }
             Spacer(minLength: 0)
-            VButton(label: "Edit", style: .ghost) {
+            VButton(label: "Edit", style: .ghost, isDisabled: profile.isManaged) {
                 beginEdit(profile.name)
             }
+            .help(profile.isManaged ? "Managed profiles are read-only. Duplicate to customize." : "")
         }
         .padding(.vertical, VSpacing.xs)
         .contentShape(Rectangle())
@@ -417,6 +423,9 @@ struct InferenceProfilesSheet: View {
         guard let source = store.profiles.first(where: { $0.name == name }) else { return }
         var copy = source
         copy.name = uniqueProfileName(prefix: "\(name)-copy")
+        // Clear the managed source so the duplicate is treated as a
+        // user-created profile and is fully editable.
+        copy.source = nil
         editorDraft = copy
         editorOriginalName = nil
         editorState = .duplicate(name: name)
@@ -429,6 +438,16 @@ struct InferenceProfilesSheet: View {
         // Refuse to commit empty or whitespace-only names — the daemon
         // would accept them but the row would render unusably.
         guard !name.isEmpty else { return }
+
+        // Defense-in-depth: the UI disables Edit for managed profiles, but
+        // guard here in case the method is reached through an unexpected
+        // path. The daemon also rejects writes to managed profiles.
+        if let originalName,
+           let existing = store.profiles.first(where: { $0.name == originalName }),
+           existing.isManaged {
+            actionError = "Managed profiles are read-only. Duplicate to customize."
+            return
+        }
 
         // Profile saves are upserts keyed by name, so committing under a
         // name that already belongs to a different profile would silently
@@ -517,6 +536,8 @@ struct InferenceProfilesSheet: View {
             blockedState = .active(profileName: name, activeProfile: active)
         case .blockedByCallSites(let ids):
             blockedState = .callSites(profileName: name, callSiteIds: ids)
+        case .blockedByManaged:
+            actionError = "Managed profiles are read-only. Duplicate to customize."
         case .failed:
             actionError = "Couldn't delete \"\(name)\". Please try again."
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -3408,6 +3408,10 @@ public final class SettingsStore: ObservableObject {
         /// affordance.
         case blockedByCallSites([String])
 
+        /// Deletion blocked because the profile is managed (source ==
+        /// "managed"). Managed profiles are read-only.
+        case blockedByManaged
+
         /// Reference checks passed but the daemon PATCH failed — typically
         /// a transient connectivity issue. The caller should surface a
         /// retry affordance; the next config sync will reconcile the
@@ -3425,6 +3429,9 @@ public final class SettingsStore: ObservableObject {
     /// treats as deletion.
     @discardableResult
     func deleteProfile(name: String) async -> DeleteProfileResult {
+        if profiles.first(where: { $0.name == name })?.isManaged == true {
+            return .blockedByManaged
+        }
         if activeProfile == name {
             return .blockedByActive(activeProfile)
         }

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -9,23 +9,44 @@ final class ChatProfilePickerTests: XCTestCase {
     // MARK: - Label
 
     func testLabelShowsDefaultWhenOverrideIsNil() {
+        let profiles = [InferenceProfile(name: "balanced")]
         XCTAssertEqual(
-            ChatProfilePicker.label(current: nil, activeProfile: "balanced"),
+            ChatProfilePicker.label(current: nil, profiles: profiles, activeProfile: "balanced"),
             "Default (balanced)"
         )
     }
 
     func testLabelShowsProfileNameWhenOverrideIsSet() {
+        let profiles = [
+            InferenceProfile(name: "quality-optimized"),
+            InferenceProfile(name: "balanced"),
+        ]
         XCTAssertEqual(
-            ChatProfilePicker.label(current: "quality-optimized", activeProfile: "balanced"),
+            ChatProfilePicker.label(current: "quality-optimized", profiles: profiles, activeProfile: "balanced"),
             "quality-optimized"
         )
     }
 
     func testLabelReflectsActiveProfileChange() {
+        let profiles = [InferenceProfile(name: "cost-optimized")]
         XCTAssertEqual(
-            ChatProfilePicker.label(current: nil, activeProfile: "cost-optimized"),
+            ChatProfilePicker.label(current: nil, profiles: profiles, activeProfile: "cost-optimized"),
             "Default (cost-optimized)"
+        )
+    }
+
+    func testLabelShowsDisplayNameWhenLabelIsSet() {
+        let profiles = [
+            InferenceProfile(name: "quality-optimized", label: "Quality"),
+            InferenceProfile(name: "balanced", label: "Balanced"),
+        ]
+        XCTAssertEqual(
+            ChatProfilePicker.label(current: "quality-optimized", profiles: profiles, activeProfile: "balanced"),
+            "Quality"
+        )
+        XCTAssertEqual(
+            ChatProfilePicker.label(current: nil, profiles: profiles, activeProfile: "balanced"),
+            "Default (Balanced)"
         )
     }
 

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
@@ -153,13 +153,47 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertEqual(profile.id, "balanced")
     }
 
-    // MARK: - Built-in profile names
+    // MARK: - Source, label, description
 
-    func testBuiltInProfileNamesIsExactlyTheMigrationSeededTrio() {
-        XCTAssertEqual(
-            builtInInferenceProfileNames,
-            ["quality-optimized", "balanced", "cost-optimized"]
-        )
+    func testSourceLabelDescriptionRoundTrip() {
+        let json: [String: Any] = [
+            "source": "managed",
+            "label": "Quality",
+            "description": "Highest quality output",
+            "provider": "anthropic",
+        ]
+        let profile = InferenceProfile(name: "quality-optimized", json: json)
+        XCTAssertEqual(profile.source, "managed")
+        XCTAssertEqual(profile.label, "Quality")
+        XCTAssertEqual(profile.profileDescription, "Highest quality output")
+        XCTAssertTrue(profile.isManaged)
+        XCTAssertEqual(profile.displayName, "Quality")
+        XCTAssertEqual(profile.subtitle, "Highest quality output")
+
+        let reEncoded = profile.toJSON()
+        XCTAssertEqual(reEncoded["source"] as? String, "managed")
+        XCTAssertEqual(reEncoded["label"] as? String, "Quality")
+        XCTAssertEqual(reEncoded["description"] as? String, "Highest quality output")
+    }
+
+    func testIsManagedFalseWhenSourceIsNil() {
+        let profile = InferenceProfile(name: "custom")
+        XCTAssertFalse(profile.isManaged)
+    }
+
+    func testIsManagedFalseWhenSourceIsNotManaged() {
+        let profile = InferenceProfile(name: "custom", source: "user")
+        XCTAssertFalse(profile.isManaged)
+    }
+
+    func testDisplayNameFallsBackToNameWhenLabelIsNil() {
+        let profile = InferenceProfile(name: "my-profile")
+        XCTAssertEqual(profile.displayName, "my-profile")
+    }
+
+    func testSubtitleIsNilWhenDescriptionIsNil() {
+        let profile = InferenceProfile(name: "simple")
+        XCTAssertNil(profile.subtitle)
     }
 
     // MARK: - Temperature: explicit null vs unset

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
@@ -73,11 +73,11 @@ final class InferenceProfilesSheetTests: XCTestCase {
         XCTAssertNotNil(sheet.body)
     }
 
-    // MARK: - Built-in detection
+    // MARK: - Managed detection
 
-    /// The badge wiring uses `builtInInferenceProfileNames.contains`, so
-    /// the row's badge presence should match the constant exactly.
-    func testBuiltInProfilesShowBadgeAndCustomDoesNot() {
+    /// Managed profiles (source == "managed") show a "Managed" badge;
+    /// user-created profiles without a source do not.
+    func testManagedProfilesShowBadgeAndCustomDoesNot() {
         seedBuiltInsAndCustom(includeCustom: true)
         XCTAssertEqual(store.profiles.count, 4)
 
@@ -87,18 +87,18 @@ final class InferenceProfilesSheetTests: XCTestCase {
         XCTAssertTrue(names.contains("cost-optimized"))
         XCTAssertTrue(names.contains("experimental"))
 
-        // The badge predicate is defined as a top-level constant so the
-        // row can stay declarative. Verify it directly here so the
-        // contract doesn't drift.
+        // Managed profiles have source == "managed" from the payload.
         for name in ["quality-optimized", "balanced", "cost-optimized"] {
+            let profile = store.profiles.first(where: { $0.name == name })
             XCTAssertTrue(
-                builtInInferenceProfileNames.contains(name),
-                "\(name) must render with a Built-in badge"
+                profile?.isManaged == true,
+                "\(name) must render with a Managed badge"
             )
         }
+        let custom = store.profiles.first(where: { $0.name == "experimental" })
         XCTAssertFalse(
-            builtInInferenceProfileNames.contains("experimental"),
-            "Custom profiles must not render the Built-in badge"
+            custom?.isManaged == true,
+            "Custom profiles must not render the Managed badge"
         )
     }
 
@@ -245,15 +245,12 @@ final class InferenceProfilesSheetTests: XCTestCase {
         XCTAssertFalse(store.profiles.contains(where: { $0.name == "experimental" }))
     }
 
-    /// Built-in profiles remain deletable when nothing references them —
-    /// the badge is informational, not a guard. This protects the
-    /// invariant called out in the plan: "Built-ins render with the badge
-    /// but remain editable and deletable when not referenced."
-    func testBuiltInProfileIsDeletableWhenNotReferenced() async {
+    /// Managed profiles cannot be deleted — `deleteProfile` returns
+    /// `.blockedByManaged` regardless of reference state.
+    func testManagedProfileIsNotDeletable() async {
         seedBuiltInsAndCustom()
-        // Make a non-built-in the active profile so the built-in target
-        // isn't blocked by the active-profile check. Use a fresh custom
-        // entry to avoid colliding with the seeded set.
+        // Make a non-managed profile the active profile so the managed
+        // target isn't also blocked by the active-profile check.
         let custom = InferenceProfile(
             name: "alt",
             provider: "anthropic",
@@ -264,11 +261,11 @@ final class InferenceProfilesSheetTests: XCTestCase {
         let switched = await store.setActiveProfile("alt")
         XCTAssertTrue(switched)
 
-        // Now delete a built-in. No call-site override references it, so
-        // the result must be .deleted.
+        // Attempting to delete a managed profile must return
+        // `.blockedByManaged`.
         let result = await store.deleteProfile(name: "quality-optimized")
-        XCTAssertEqual(result, .deleted)
-        XCTAssertFalse(store.profiles.contains(where: { $0.name == "quality-optimized" }))
+        XCTAssertEqual(result, .blockedByManaged)
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "quality-optimized" }))
     }
 
     // MARK: - "+ New profile" flow

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsTestFixture.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsTestFixture.swift
@@ -76,13 +76,16 @@ enum SettingsTestFixture {
         ),
     ]
 
-    // MARK: - Built-in profile payloads
+    // MARK: - Managed profile payloads
 
-    /// Mirrors the daemon's migration-052 seed: the three canonical
-    /// built-in inference profiles (quality-optimized, balanced,
-    /// cost-optimized).
+    /// Mirrors the daemon's declarative profile seed: the three canonical
+    /// managed inference profiles (quality-optimized, balanced,
+    /// cost-optimized) with `source: "managed"`.
     static let builtInProfilesPayload: [String: Any] = [
         "quality-optimized": [
+            "source": "managed",
+            "label": "Quality",
+            "description": "Highest quality output",
             "provider": "anthropic",
             "model": "claude-opus-4-7",
             "maxTokens": 32000,
@@ -90,6 +93,9 @@ enum SettingsTestFixture {
             "thinking": ["enabled": true, "streamThinking": true],
         ],
         "balanced": [
+            "source": "managed",
+            "label": "Balanced",
+            "description": "Good balance of quality and speed",
             "provider": "anthropic",
             "model": "claude-sonnet-4-6",
             "maxTokens": 16000,
@@ -97,6 +103,9 @@ enum SettingsTestFixture {
             "thinking": ["enabled": true, "streamThinking": true],
         ],
         "cost-optimized": [
+            "source": "managed",
+            "label": "Fast",
+            "description": "Optimized for speed and cost",
             "provider": "anthropic",
             "model": "claude-haiku-4-5-20251001",
             "maxTokens": 8192,


### PR DESCRIPTION
## Summary
Move inference profile seeding from one-shot workspace migration 052 to a declarative seed-on-startup pattern. Managed profiles are overwritten on every startup; user-created profiles are never touched.

- Add `source` (`managed` | `user`), `label`, and `description` metadata fields to profile schema via a new `ProfileEntry` wrapper
- Create `seed-inference-profiles.ts` with declarative managed profile definitions, called on every daemon startup
- Guard daemon routes to reject edits/deletes of managed profiles
- Surface `source`, `label`, and `description` in the macOS client: managed profiles show a badge and are read-only (Edit/Delete disabled), user profiles remain fully editable
- Profile pickers show `displayName` (label when available, falling back to name)

## PRs merged into feature branch
- #28803: Add `source`, `label`, and `description` fields to inference profile schema
- #28820: Declarative inference profile seeding on startup
- #28819: Reject edits and deletes of managed inference profiles
- #28836: Show profile labels and enforce managed profile read-only in UI

Part of plan: declarative-profile-seed.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
