### PR TITLE
mem(v2): mode-gate concept status in activation telemetry

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -982,6 +982,118 @@ describe("injectMemoryV2Block", () => {
     expect(byslug.get("carol-jazz")!.status).toBe("injected");
   });
 
+  test("context-load mode marks every rendered slug as `injected`, never `in_context`", async () => {
+    // Turn 1 (per-turn): seed alice as injected so the next turn's prior
+    // `everInjected` includes her — the same setup the per-turn telemetry
+    // test uses, so the difference between modes is unambiguous.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Alice's editor",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+    expect(telemetryState.recordCalls.length).toBe(1);
+
+    // Turn 2 in context-load mode (post-compaction or fresh load). Alice
+    // carries forward AND ranks high again; carol is a brand-new candidate.
+    // Both end up in `topNow` (and therefore in `slugsToRender` since
+    // context-load renders the full top-K). The status field must reflect
+    // that they were physically rendered into the new user message on this
+    // turn — `injected` for both — rather than reading `in_context` for
+    // alice based on stale prior `everInjected` state.
+    stageTurn([
+      { slug: "alice-vscode", denseScore: 0.6 },
+      { slug: "carol-jazz", denseScore: 0.95 },
+    ]);
+    await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 2,
+      userMessage: "Reload context",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-2",
+      mode: "context-load",
+      config: makeConfig(),
+    });
+
+    expect(telemetryState.recordCalls.length).toBe(2);
+    const row = telemetryState.recordCalls[1] as {
+      mode: string;
+      concepts: Array<{ slug: string; status: string }>;
+    };
+    expect(row.mode).toBe("context-load");
+
+    const byslug = new Map(row.concepts.map((c) => [c.slug, c]));
+    // Both rendered slugs read as `injected` — alice especially, even though
+    // she's in prior `everInjected`, because context-load actually rendered
+    // her into the fresh user message on this turn.
+    expect(byslug.get("alice-vscode")!.status).toBe("injected");
+    expect(byslug.get("carol-jazz")!.status).toBe("injected");
+
+    // No slug reads as `in_context` in context-load mode — the cache was
+    // wiped, so there is no prior cached attachment to reference.
+    for (const concept of row.concepts) {
+      expect(concept.status).not.toBe("in_context");
+    }
+  });
+
+  test("context-load mode marks candidates outside `slugsToRender` as `not_injected`", async () => {
+    // Turn 1 (per-turn): seed both alice and bob with positive activation
+    // so they survive into turn 2's prior-state candidate pool.
+    stageTurn([
+      { slug: "alice-vscode", denseScore: 0.9 },
+      { slug: "bob-coffee", denseScore: 0.8 },
+    ]);
+    await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "Alice's editor and Bob's coffee",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    // Turn 2 (context-load) with `top_k: 1`: alice and bob both carry
+    // forward as candidates, but only the top-ranked slug is rendered.
+    // Whichever slug doesn't make the cut must read as `not_injected`.
+    stageTurn([
+      { slug: "alice-vscode", denseScore: 0.95 },
+      { slug: "bob-coffee", denseScore: 0.05 },
+    ]);
+    await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 2,
+      userMessage: "Reload context",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-2",
+      mode: "context-load",
+      config: makeConfig({ top_k: 1 }),
+    });
+
+    expect(telemetryState.recordCalls.length).toBe(2);
+    const row = telemetryState.recordCalls[1] as {
+      mode: string;
+      concepts: Array<{ slug: string; status: string }>;
+    };
+    expect(row.mode).toBe("context-load");
+
+    const byslug = new Map(row.concepts.map((c) => [c.slug, c]));
+    // Alice ranked first → she is in `slugsToRender` → `injected`.
+    expect(byslug.get("alice-vscode")!.status).toBe("injected");
+    // Bob was a candidate but didn't make `top_k: 1` → `not_injected`.
+    expect(byslug.get("bob-coffee")!.status).toBe("not_injected");
+  });
+
   test("telemetry write failure is non-fatal — injection still returns a normal result", async () => {
     telemetryState.recordShouldThrow = true;
 

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -245,19 +245,31 @@ export async function injectMemoryV2Block(
   // empty-block return so we capture diagnostics even on no-op turns. Failures
   // are warn-logged and never block memory injection.
   const toInjectSet = new Set(toInject);
+  const renderedSet = new Set(slugsToRender);
   const topSkillIdSet = new Set(topSkillIds);
   const conceptRows: MemoryV2ConceptRowRecord[] = [...candidates].map(
     (slug) => {
       const breakdown = ownBreakdown.get(slug);
       const inPrior = fromPrior.has(slug);
       const inAnn = fromAnn.has(slug);
-      const status: MemoryV2ConceptRowRecord["status"] = everInjectedSet.has(
-        slug,
-      )
-        ? "in_context"
-        : toInjectSet.has(slug)
-          ? "injected"
-          : "not_injected";
+      // Status reflects what was rendered for *this* turn:
+      //   - context-load: cache was wiped (turn 1 / post-compaction), so
+      //     `slugsToRender = topNow` and every rendered slug is freshly
+      //     injected on this turn. `in_context` is unreachable because there
+      //     is no prior cached attachment for the inspector to point at.
+      //   - per-turn: cached attachments from prior turns are still on the
+      //     user message, so prior-everInjected slugs are `in_context` and
+      //     the delta (`toInject`) is `injected`.
+      let status: MemoryV2ConceptRowRecord["status"];
+      if (mode === "context-load") {
+        status = renderedSet.has(slug) ? "injected" : "not_injected";
+      } else if (everInjectedSet.has(slug)) {
+        status = "in_context";
+      } else if (toInjectSet.has(slug)) {
+        status = "injected";
+      } else {
+        status = "not_injected";
+      }
       return {
         slug,
         finalActivation: finalActivation.get(slug) ?? 0,


### PR DESCRIPTION
## Summary
- Status field on `memory_v2_activation_logs` concept rows now reflects what was actually rendered for the turn
- In `context-load` mode (turn 1 / post-compaction), every slug in `slugsToRender` reads as `injected`; `in_context` is unreachable since the cache was wiped
- In `per-turn` mode, behavior is unchanged: `in_context` for prior-attached slugs, `injected` for the delta

## Original prompt
the followups in parallel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
