### PR TITLE
fix(macos): public memberwise inits for MemoryV2 shared types

### DIFF
--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -524,6 +524,20 @@ public struct MemoryV2ActivationData: Codable, Sendable, Equatable {
     public let concepts: [MemoryV2ConceptRow]
     public let skills: [MemoryV2SkillRow]
     public let config: MemoryV2Config
+
+    public init(
+        turn: Int,
+        mode: String,
+        concepts: [MemoryV2ConceptRow],
+        skills: [MemoryV2SkillRow],
+        config: MemoryV2Config
+    ) {
+        self.turn = turn
+        self.mode = mode
+        self.concepts = concepts
+        self.skills = skills
+        self.config = config
+    }
 }
 
 public struct MemoryV2ConceptRow: Codable, Sendable, Equatable, Identifiable {
@@ -538,6 +552,30 @@ public struct MemoryV2ConceptRow: Codable, Sendable, Equatable, Identifiable {
     public let spreadContribution: Double
     public let source: String  // "prior_state" | "ann_top50" | "both"
     public let status: String  // "in_context" | "injected" | "not_injected"
+
+    public init(
+        slug: String,
+        finalActivation: Double,
+        ownActivation: Double,
+        priorActivation: Double,
+        simUser: Double,
+        simAssistant: Double,
+        simNow: Double,
+        spreadContribution: Double,
+        source: String,
+        status: String
+    ) {
+        self.slug = slug
+        self.finalActivation = finalActivation
+        self.ownActivation = ownActivation
+        self.priorActivation = priorActivation
+        self.simUser = simUser
+        self.simAssistant = simAssistant
+        self.simNow = simNow
+        self.spreadContribution = spreadContribution
+        self.source = source
+        self.status = status
+    }
 }
 
 public struct MemoryV2SkillRow: Codable, Sendable, Equatable, Identifiable {
@@ -547,6 +585,22 @@ public struct MemoryV2SkillRow: Codable, Sendable, Equatable, Identifiable {
     public let simAssistant: Double
     public let simNow: Double
     public let status: String  // "injected" | "not_injected"
+
+    public init(
+        id: String,
+        activation: Double,
+        simUser: Double,
+        simAssistant: Double,
+        simNow: Double,
+        status: String
+    ) {
+        self.id = id
+        self.activation = activation
+        self.simUser = simUser
+        self.simAssistant = simAssistant
+        self.simNow = simNow
+        self.status = status
+    }
 }
 
 public struct MemoryV2Config: Codable, Sendable, Equatable {
@@ -567,6 +621,28 @@ public struct MemoryV2Config: Codable, Sendable, Equatable {
         case cNow = "c_now"
         case topK = "top_k"
         case topKSkills = "top_k_skills"
+    }
+
+    public init(
+        d: Double,
+        cUser: Double,
+        cAssistant: Double,
+        cNow: Double,
+        k: Double,
+        hops: Int,
+        topK: Int,
+        topKSkills: Int,
+        epsilon: Double
+    ) {
+        self.d = d
+        self.cUser = cUser
+        self.cAssistant = cAssistant
+        self.cNow = cNow
+        self.k = k
+        self.hops = hops
+        self.topK = topK
+        self.topKSkills = topKSkills
+        self.epsilon = epsilon
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds public memberwise initializers to `MemoryV2ActivationData`, `MemoryV2ConceptRow`, `MemoryV2SkillRow`, and `MemoryV2Config` in `clients/shared/Network/LLMContextClient.swift`.
- Without explicit public inits, Swift only synthesizes the memberwise init at internal access. The macOS `MessageInspectorMemoryV2Tab` preview lives in a different module, so it could only see `init(from:)` and the build failed with "extra arguments" / "missing argument for parameter 'from'".
- Fixes the macOS Tests job: https://github.com/vellum-ai/vellum-assistant/actions/runs/25133535151/job/73665831153

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25133535151/job/73665831153
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
