### PR TITLE
fix: drop stale references to deleted sync helpers in comments

### DIFF
--- a/cli/src/lib/job-polling.ts
+++ b/cli/src/lib/job-polling.ts
@@ -107,7 +107,7 @@ function isTransientPollError(err: unknown): boolean {
  *
  * Transient errors raised by `poll()` (5xx, network hiccups, rate-limits) are
  * retried up to `maxTransientErrors` times before the last error propagates,
- * matching the pre-rewrite `platformPollExportStatus` loop's behavior so a
+ * matching the pre-rewrite migration-export polling loop's behavior so a
  * single flaky poll doesn't abort a migration that may still be running.
  */
 export async function pollJobUntilDone(

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -250,9 +250,9 @@ public enum PlatformMigrationClient {
 
     /// Imports a migration bundle by sending the raw data directly to the platform.
     ///
-    /// This is the fallback path when signed URL uploads are not available. It matches
-    /// the CLI's `platformImportBundle()` function: POST to `/v1/migrations/import/`
-    /// with the bundle data as an octet-stream body.
+    /// This is the fallback path when signed URL uploads are not available. Mirrors
+    /// the platform's `/v1/migrations/import/` octet-stream contract (the inline-import
+    /// legacy path): POST the bundle data as an octet-stream body.
     ///
     /// - Parameter bundleData: The raw bundle data to import.
     /// - Returns: A tuple of the HTTP status code and raw response data.


### PR DESCRIPTION
## Summary
Two comments still named symbols deleted in plan PR 4 (#28844):
- `cli/src/lib/job-polling.ts:110` referenced `platformPollExportStatus`
- `clients/shared/Network/PlatformMigrationClient.swift:254` referenced `platformImportBundle()`

Both reworded to describe behavior/contract directly without naming the deleted CLI helpers.

Part of plan: teleport-sync-deprecation.md (self-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
