### PR TITLE
chore(flags): remove unused compaction-v2 flag

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -98,32 +98,3 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
     ).toBe(true);
   });
 });
-
-// ---------------------------------------------------------------------------
-// compaction-v2 flag (opt-in): ensures registry-declared defaultEnabled=false
-// is honored and that an explicit override can flip it on. Guards the rollout
-// gate for the boundary-message-based compaction pipeline introduced in
-// later PRs.
-// ---------------------------------------------------------------------------
-
-describe("compaction-v2 flag", () => {
-  test("defaults to false (disabled) when no override is set", () => {
-    const config = {} as any;
-
-    expect(isAssistantFeatureFlagEnabled("compaction-v2", config)).toBe(false);
-  });
-
-  test("returns true when explicitly overridden to true", () => {
-    _setOverridesForTesting({ "compaction-v2": true });
-    const config = {} as any;
-
-    expect(isAssistantFeatureFlagEnabled("compaction-v2", config)).toBe(true);
-  });
-
-  test("returns false when explicitly overridden to false", () => {
-    _setOverridesForTesting({ "compaction-v2": false });
-    const config = {} as any;
-
-    expect(isAssistantFeatureFlagEnabled("compaction-v2", config)).toBe(false);
-  });
-});

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -338,14 +338,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "compaction-v2",
-      "scope": "assistant",
-      "key": "compaction-v2",
-      "label": "Compaction v2",
-      "description": "Boundary-message-based compaction pipeline with forked prompt-cache-shared summarization and microcompact pre-pass. Replaces the four-tier overflow reducer and cursor-based storage.",
-      "defaultEnabled": false
-    },
-    {
       "id": "scroll-debug-overlay",
       "scope": "macos",
       "key": "scroll-debug-overlay",


### PR DESCRIPTION
## Summary
- Remove the unused compaction-v2 flag from the canonical and bundled registries
- Delete flag-specific rollout coverage that only referenced compaction-v2

Part of plan: remove-compaction-v2-flag.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
