### PR TITLE
fix: address settings sidebar self-review gaps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -32,9 +32,17 @@ enum SettingsTab: String {
         }
     }
 
-    /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
-    static func primaryTabs(billingEnabled: Bool = false, soundsEnabled: Bool = true, debugEnabled: Bool = false) -> [SettingsTab] {
-        var tabs: [SettingsTab] = [.general, .modelsAndServices, .integrations]
+    static func sidebarTopTabs(
+        billingEnabled: Bool = false,
+        soundsEnabled: Bool = true,
+        debugEnabled: Bool = false,
+        includeCompactionPlayground: Bool = false
+    ) -> [SettingsTab] {
+        var tabs: [SettingsTab] = []
+        if includeCompactionPlayground {
+            tabs.append(.compactionPlayground)
+        }
+        tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
         if soundsEnabled { tabs.append(.sounds) }
         if billingEnabled { tabs.append(.billing) }
@@ -53,22 +61,13 @@ enum SettingsTab: String {
         developerEnabled && playgroundEnabled && devModeEnabled
     }
 
-    static func sidebarTopTabs(
-        billingEnabled: Bool = false,
-        soundsEnabled: Bool = true,
-        debugEnabled: Bool = false,
-        includeCompactionPlayground: Bool = false
-    ) -> [SettingsTab] {
-        let primary = primaryTabs(
-            billingEnabled: billingEnabled,
-            soundsEnabled: soundsEnabled,
-            debugEnabled: debugEnabled
-        )
-        return includeCompactionPlayground ? [.compactionPlayground] + primary : primary
-    }
-
-    static func sidebarBottomTabs(developerEnabled: Bool) -> [SettingsTab] {
-        developerEnabled ? [.developer] : []
+    static func canDeferDeepLink(_ tab: SettingsTab) -> Bool {
+        switch tab {
+        case .developer, .compactionPlayground:
+            return true
+        default:
+            return false
+        }
     }
 }
 
@@ -145,7 +144,7 @@ struct SettingsPanel: View {
             )
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
-            } else {
+            } else if SettingsTab.canDeferDeepLink(pending) {
                 // Tab may become visible once feature flags load (e.g. .developer).
                 // Preserve it for deferred evaluation in loadFeatureFlags().
                 _deferredDeepLinkTab = State(initialValue: pending)
@@ -265,8 +264,10 @@ struct SettingsPanel: View {
             if let tab = newTab {
                 if allVisibleTabs.contains(tab) {
                     selectVisibleTab(tab)
-                } else {
+                } else if SettingsTab.canDeferDeepLink(tab) {
                     deferredDeepLinkTab = tab
+                } else {
+                    deferredDeepLinkTab = nil
                 }
                 store.pendingSettingsTab = nil
             }
@@ -281,13 +282,16 @@ struct SettingsPanel: View {
             }
         }
         .onChange(of: billingVisible) { _, _ in
-            ensureSelectedTabIsVisible()
+            consumeDeferredDeepLinkIfVisible()
         }
         .onChange(of: isDebugVisible) { _, _ in
-            ensureSelectedTabIsVisible()
+            consumeDeferredDeepLinkIfVisible()
         }
         .onChange(of: isSoundsEnabled) { _, _ in
-            ensureSelectedTabIsVisible()
+            consumeDeferredDeepLinkIfVisible()
+        }
+        .onChange(of: isCompactionPlaygroundVisible) { _, _ in
+            consumeDeferredDeepLinkIfVisible()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
@@ -325,6 +329,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
+            consumeDeferredDeepLinkIfVisible()
         }
         .sheet(isPresented: $showingTrustRules, onDismiss: { connectionManager?.isTrustRulesSheetOpen = false }) {
             TrustRulesView(trustRuleClient: TrustRuleClient())
@@ -396,12 +401,16 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
-        SettingsTab.sidebarTopTabs(
+        var tabs = SettingsTab.sidebarTopTabs(
             billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
-        ) + SettingsTab.sidebarBottomTabs(developerEnabled: isDeveloperEnabled)
+        )
+        if isDeveloperEnabled {
+            tabs.append(.developer)
+        }
+        return tabs
     }
 
     private var billingVisible: Bool {
@@ -441,7 +450,7 @@ struct SettingsPanel: View {
                 }
             }
             Spacer(minLength: VSpacing.sm)
-            if SettingsTab.sidebarBottomTabs(developerEnabled: isDeveloperEnabled).contains(.developer) {
+            if isDeveloperEnabled {
                 VColor.surfaceBase
                     .frame(height: 1)
                     .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
@@ -799,6 +808,11 @@ struct SettingsPanel: View {
     /// hadn't loaded, check whether it's now visible and navigate to it.
     private func consumeDeferredDeepLinkIfVisible() {
         guard let deferred = deferredDeepLinkTab else {
+            ensureSelectedTabIsVisible()
+            return
+        }
+        guard SettingsTab.canDeferDeepLink(deferred) else {
+            deferredDeepLinkTab = nil
             ensureSelectedTabIsVisible()
             return
         }

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -53,12 +53,16 @@ final class SettingsPanelSidebarTests: XCTestCase {
         XCTAssertFalse(tabs.contains(.compactionPlayground))
     }
 
-    func testDeveloperRemainsInBottomSidebarGroup() {
+    func testDeveloperIsNotRenderedInTopSidebarGroup() {
         let topTabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: true)
-        let bottomTabs = SettingsTab.sidebarBottomTabs(developerEnabled: true)
 
         XCTAssertFalse(topTabs.contains(.developer))
-        XCTAssertEqual(bottomTabs, [.developer])
-        XCTAssertFalse(bottomTabs.contains(.compactionPlayground))
+    }
+
+    func testDeferredDeepLinksAreLimitedToAsyncGatedTabs() {
+        XCTAssertTrue(SettingsTab.canDeferDeepLink(.developer))
+        XCTAssertTrue(SettingsTab.canDeferDeepLink(.compactionPlayground))
+        XCTAssertFalse(SettingsTab.canDeferDeepLink(.billing))
+        XCTAssertFalse(SettingsTab.canDeferDeepLink(.sounds))
     }
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for move-compaction-playground-nav.md.

- Simplifies the Settings sidebar tab helpers so the top list owns the Compaction Playground insertion directly.
- Repairs selection and deferred deep links when Compaction Playground visibility changes via dev mode or feature flags.
- Restricts deferred Settings deep links to the async-gated Developer and Compaction Playground tabs so hidden Billing or Sounds links do not linger.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsPanelSidebarTests (fails before tests in existing SwiftMath dependency: public override var description does not override a superclass property)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
