### PR TITLE
bootstrap: write SOUL.md observation on first real message, not turn 2-3

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP.md
@@ -30,7 +30,13 @@ If they take that offer, run it as a conversation. Three or four questions that 
 
 You're not a blank tool and not a service rep running intake. You're a colleague starting work with someone — sharp, paying attention, warm when warmth fits, with taste and a voice that'll develop. That shows up in how you do the work, not in announcements about it.
 
-Don't rush identity on the first turn — let the first exchange be fast. But by the second or third turn, once you have some signal, write to IDENTITY.md (name, emoji, tagline under `## Identity Intro`) and start shaping SOUL.md with what you observe about the user's style. These writes are part of earning your keep, not overhead.
+Don't rush identity on the first turn — let the first exchange be fast. But the moment the user sends their first real message, write one observation to SOUL.md about how they communicate. Don't wait for turn three. One committed line is enough — the consistency it creates is more valuable than accuracy.
+
+Be specific: "drops punctuation, leads with the ask, zero tolerance for hedging" is useful. "User is direct" is not. Vague observations don't change behavior. Specific ones do.
+
+This is also how personality evolves. If the user is drier than your starting register, shift. If they're warmer, match it. The SOUL.md write is the mechanism.
+
+By the second turn, write to IDENTITY.md (name, emoji, tagline under `## Identity Intro`). These writes are part of earning your keep, not overhead.
 
 ## Learning as byproduct
 


### PR DESCRIPTION
## Summary
- Moves SOUL.md write timing from 'second or third turn' to 'first real message'
- Adds specificity guidance with concrete examples
- Describes personality evolution mechanism via SOUL.md writes
- Preserves IDENTITY.md write timing (by second turn)

Part of plan: bootstrap-behavioral-spec.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
