### PR TITLE
mem(v2): inject page frontmatter alongside body

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -234,6 +234,18 @@ ref_files: []
 ---
 Carol loves jazz music — Coltrane in particular.`,
   );
+  // A page with both `edges` and `ref_files` populated so the frontmatter-
+  // injection test can assert the full canonical shape.
+  writeFileSync(
+    join(tmpWorkspace, "memory", "concepts", "frontmatter-demo.md"),
+    `---
+edges:
+  - alice-vscode
+ref_files:
+  - images/demo.jpg
+---
+Demo body content.`,
+  );
 });
 
 afterAll(() => {
@@ -539,6 +551,35 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.everInjected).toEqual([
       { slug: "alice-vscode", turn: 2 },
     ]);
+  });
+
+  test("includes the page frontmatter (edges, ref_files) in each rendered section", async () => {
+    // The frontmatter (`edges`, `ref_files`) lives on disk above the page
+    // body and is part of the page's content. Injection must reproduce both
+    // fields verbatim — bracketed by the canonical `---` delimiters — so the
+    // agent sees the page's edges and any referenced media paths alongside
+    // the prose body.
+    stageTurn([{ slug: "frontmatter-demo", denseScore: 0.9 }]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "show me the demo",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.block).not.toBeNull();
+    // Slug header is immediately followed by the frontmatter open delimiter.
+    expect(result.block).toContain("### frontmatter-demo\n---\n");
+    // Both fields render in YAML block style with their populated values.
+    expect(result.block).toContain("edges:\n  - alice-vscode");
+    expect(result.block).toContain("ref_files:\n  - images/demo.jpg");
+    // Body still renders after the closing delimiter.
+    expect(result.block).toContain("Demo body content.");
   });
 
   test("renders pages in activation-descending order", async () => {

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -43,7 +43,7 @@ import {
 } from "./activation.js";
 import { hydrate, save } from "./activation-store.js";
 import { readEdges } from "./edges.js";
-import { readPage } from "./page-store.js";
+import { readPage, renderPageContent } from "./page-store.js";
 import { getSkillCapability } from "./skill-store.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
@@ -365,13 +365,26 @@ export async function injectMemoryV2Block(
  * the missing-pages behavior.
  *
  * The block shape is the §5 layout from the design doc, with an optional
- * trailing skills subsection:
+ * trailing skills subsection. Each concept-page section reproduces the page
+ * as it lives on disk — frontmatter (`edges`, `ref_files`) plus body — so
+ * the agent sees the page's edges and any referenced media paths alongside
+ * the prose:
  *
  *   <memory>
  *   ### <slug-1>
+ *   ---
+ *   edges:
+ *     - <neighbor-slug>
+ *   ref_files:
+ *     - <path/to/asset>
+ *   ---
  *   <body-1>
  *
  *   ### <slug-2>
+ *   ---
+ *   edges: []
+ *   ref_files: []
+ *   ---
  *   <body-2>
  *
  *   ### Skills You Can Use
@@ -391,14 +404,14 @@ async function renderInjectionBlock(
   const pages = await Promise.all(
     slugs.map(async (slug) => {
       const page = await readPage(workspaceDir, slug);
-      return page ? { slug, body: page.body.trim() } : null;
+      return page ? { slug, content: renderPageContent(page).trim() } : null;
     }),
   );
 
   const sections: string[] = [];
   for (const entry of pages) {
-    if (!entry || entry.body.length === 0) continue;
-    sections.push(`### ${entry.slug}\n${entry.body}`);
+    if (!entry || entry.content.length === 0) continue;
+    sections.push(`### ${entry.slug}\n${entry.content}`);
   }
 
   // v2's skills collection is skills-only, so the activation suffix always applies.

--- a/assistant/src/memory/v2/page-store.ts
+++ b/assistant/src/memory/v2/page-store.ts
@@ -222,7 +222,7 @@ function parsePageContent(raw: string): {
  * always frontmatter + body; even pages with empty `edges` and `ref_files`
  * keep the explicit YAML keys so callers see the canonical shape on round-trip.
  */
-function renderPageContent(page: ConceptPage): string {
+export function renderPageContent(page: ConceptPage): string {
   const frontmatter = ConceptPageFrontmatterSchema.parse(page.frontmatter);
   const yamlBlock = stringifyYaml(frontmatter, { indent: 2 }).trimEnd();
   return `---\n${yamlBlock}\n---\n${page.body}`;


### PR DESCRIPTION
## Summary
- Memory v2's per-turn injection block now reproduces each concept page as it lives on disk — frontmatter (`edges`, `ref_files`) followed by body — so the agent can read each page's edges and referenced media paths inline alongside the prose.
- Reuses `renderPageContent` (the same renderer `writePage` uses) to produce the canonical `---\n...\n---\n<body>` shape, keeping the on-disk and in-context forms byte-equivalent.

## Original prompt
In memory v2, when a page is injected, the page frontmatter
\`\`\`
---
edges:
  - people/alice
ref_files:
  - images/alice.jpg
---
\`\`\`
should also be injected as part of the page
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
