### PR TITLE
fix: clean up settings sidebar helpers

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -53,14 +53,6 @@ enum SettingsTab: String {
         return tabs
     }
 
-    static func isCompactionPlaygroundVisible(
-        developerEnabled: Bool,
-        playgroundEnabled: Bool,
-        devModeEnabled: Bool
-    ) -> Bool {
-        developerEnabled && playgroundEnabled && devModeEnabled
-    }
-
     static func canDeferDeepLink(_ tab: SettingsTab) -> Bool {
         switch tab {
         case .developer, .compactionPlayground:
@@ -401,16 +393,20 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.sidebarTopTabs(
+        var tabs = visibleSidebarTopTabs
+        if isDeveloperEnabled {
+            tabs.append(.developer)
+        }
+        return tabs
+    }
+
+    private var visibleSidebarTopTabs: [SettingsTab] {
+        SettingsTab.sidebarTopTabs(
             billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
         )
-        if isDeveloperEnabled {
-            tabs.append(.developer)
-        }
-        return tabs
     }
 
     private var billingVisible: Bool {
@@ -427,24 +423,12 @@ struct SettingsPanel: View {
     }
 
     private var isCompactionPlaygroundVisible: Bool {
-        SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: isDeveloperEnabled,
-            playgroundEnabled: isCompactionPlaygroundEnabled,
-            devModeEnabled: DevModeManager.shared.isDevMode
-        )
+        isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
     }
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(
-                SettingsTab.sidebarTopTabs(
-                    billingEnabled: billingVisible,
-                    soundsEnabled: isSoundsEnabled,
-                    debugEnabled: isDebugVisible,
-                    includeCompactionPlayground: isCompactionPlaygroundVisible
-                ),
-                id: \.self
-            ) { tab in
+            ForEach(visibleSidebarTopTabs, id: \.self) { tab in
                 VNavItem(icon: tab.icon.rawValue, label: tab.rawValue, isActive: selectedTab == tab) {
                     selectVisibleTab(tab)
                 }
@@ -808,11 +792,6 @@ struct SettingsPanel: View {
     /// hadn't loaded, check whether it's now visible and navigate to it.
     private func consumeDeferredDeepLinkIfVisible() {
         guard let deferred = deferredDeepLinkTab else {
-            ensureSelectedTabIsVisible()
-            return
-        }
-        guard SettingsTab.canDeferDeepLink(deferred) else {
-            deferredDeepLinkTab = nil
             ensureSelectedTabIsVisible()
             return
         }

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -3,54 +3,26 @@ import XCTest
 
 final class SettingsPanelSidebarTests: XCTestCase {
 
-    func testCompactionPlaygroundAppearsFirstInTopSidebarWhenAllGatesEnabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: true,
-            playgroundEnabled: true,
-            devModeEnabled: true
-        )
+    func testCompactionPlaygroundPositionFollowsVisibilityGate() {
+        let cases: [(developerEnabled: Bool, playgroundEnabled: Bool, devModeEnabled: Bool, expectedVisible: Bool)] = [
+            (true, true, true, true),
+            (true, false, true, false),
+            (false, true, true, false),
+            (true, true, false, false)
+        ]
 
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+        for testCase in cases {
+            let includePlayground = testCase.developerEnabled && testCase.playgroundEnabled && testCase.devModeEnabled
+            let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
 
-        XCTAssertEqual(tabs.first, .compactionPlayground)
-        XCTAssertEqual(tabs.dropFirst().first, .general)
-    }
-
-    func testCompactionPlaygroundIsOmittedWhenFeatureFlagDisabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: true,
-            playgroundEnabled: false,
-            devModeEnabled: true
-        )
-
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
-
-        XCTAssertFalse(tabs.contains(.compactionPlayground))
-        XCTAssertEqual(tabs.first, .general)
-    }
-
-    func testCompactionPlaygroundIsOmittedWhenDeveloperNavDisabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: false,
-            playgroundEnabled: true,
-            devModeEnabled: true
-        )
-
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
-
-        XCTAssertFalse(tabs.contains(.compactionPlayground))
-    }
-
-    func testCompactionPlaygroundIsOmittedWhenDevModeDisabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: true,
-            playgroundEnabled: true,
-            devModeEnabled: false
-        )
-
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
-
-        XCTAssertFalse(tabs.contains(.compactionPlayground))
+            XCTAssertEqual(tabs.contains(.compactionPlayground), testCase.expectedVisible)
+            if testCase.expectedVisible {
+                XCTAssertEqual(tabs.first, .compactionPlayground)
+                XCTAssertEqual(tabs.dropFirst().first, .general)
+            } else {
+                XCTAssertEqual(tabs.first, .general)
+            }
+        }
     }
 
     func testDeveloperIsNotRenderedInTopSidebarGroup() {


### PR DESCRIPTION
## Summary
Fixes the remaining slop/reuse gap identified during plan re-review for move-compaction-playground-nav.md.

- Reuses a single visible top-sidebar tab list for rendering and visible-tab bookkeeping.
- Inlines the one-line Compaction Playground visibility predicate into SettingsPanel.
- Removes a redundant deferred-deep-link guard and tightens the sidebar tests around the remaining helper behavior.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsPanelSidebarTests (fails before tests in existing SwiftMath dependency: public override var description does not override a superclass property)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
