### PR TITLE
Add LLM usage attribution snapshot helpers

### DIFF
--- a/assistant/src/__tests__/usage-attribution.test.ts
+++ b/assistant/src/__tests__/usage-attribution.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockLlmConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llm: mockLlmConfig }),
+}));
+
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  type LLMCallSite,
+  type LLMConfig,
+  LLMSchema,
+} from "../config/schemas/llm.js";
+import {
+  resolveUsageAttribution,
+  sanitizeUsageMetadataValue,
+} from "../usage/attribution.js";
+
+function setLlmConfig(raw: unknown): void {
+  mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;
+}
+
+function expectResolvedProviderModelMatchesResolver(
+  callSite: LLMCallSite,
+  overrideProfile?: string,
+): void {
+  const snapshot = resolveUsageAttribution({
+    callSite,
+    ...(overrideProfile != null ? { overrideProfile } : {}),
+  });
+  const resolved = resolveCallSiteConfig(
+    callSite,
+    mockLlmConfig as LLMConfig,
+    {
+      ...(overrideProfile != null ? { overrideProfile } : {}),
+    },
+  );
+
+  expect(snapshot.resolvedProvider).toBe(resolved.provider);
+  expect(snapshot.resolvedModel).toBe(resolved.model);
+}
+
+beforeEach(() => {
+  mockLlmConfig = LLMSchema.parse({}) as Record<string, unknown>;
+});
+
+describe("resolveUsageAttribution", () => {
+  test("resolves default-only attribution", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+    });
+
+    const snapshot = resolveUsageAttribution({ callSite: "mainAgent" });
+
+    expect(snapshot).toMatchObject({
+      callSite: "mainAgent",
+      activeProfile: null,
+      overrideProfile: null,
+      callSiteProfile: null,
+      appliedProfile: null,
+      profileSource: "default",
+      resolvedProvider: "anthropic",
+      resolvedModel: "claude-opus-4-7",
+    });
+    expectResolvedProviderModelMatchesResolver("mainAgent");
+  });
+
+  test("resolves workspace active profile attribution", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        balanced: { provider: "openai", model: "gpt-5.4" },
+      },
+      activeProfile: "balanced",
+    });
+
+    const snapshot = resolveUsageAttribution({ callSite: "mainAgent" });
+
+    expect(snapshot).toMatchObject({
+      activeProfile: "balanced",
+      overrideProfile: null,
+      callSiteProfile: null,
+      appliedProfile: "balanced",
+      profileSource: "active",
+      resolvedProvider: "openai",
+      resolvedModel: "gpt-5.4",
+    });
+    expectResolvedProviderModelMatchesResolver("mainAgent");
+  });
+
+  test("resolves per-conversation override profile attribution", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        active: { provider: "openai", model: "gpt-5.4" },
+        pinned: { provider: "gemini", model: "gemini-3-pro" },
+      },
+      activeProfile: "active",
+    });
+
+    const snapshot = resolveUsageAttribution({
+      callSite: "mainAgent",
+      overrideProfile: "pinned",
+    });
+
+    expect(snapshot).toMatchObject({
+      activeProfile: "active",
+      overrideProfile: "pinned",
+      callSiteProfile: null,
+      appliedProfile: "pinned",
+      profileSource: "conversation",
+      resolvedProvider: "gemini",
+      resolvedModel: "gemini-3-pro",
+    });
+    expectResolvedProviderModelMatchesResolver("mainAgent", "pinned");
+  });
+
+  test("resolves call-site profile attribution over conversation override", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        active: { provider: "openai", model: "gpt-5.4" },
+        pinned: { provider: "gemini", model: "gemini-3-pro" },
+        site: {
+          provider: "fireworks",
+          model: "accounts/fireworks/models/kimi-k2",
+        },
+      },
+      activeProfile: "active",
+      callSites: {
+        memoryRetrieval: { profile: "site" },
+      },
+    });
+
+    const snapshot = resolveUsageAttribution({
+      callSite: "memoryRetrieval",
+      overrideProfile: "pinned",
+    });
+
+    expect(snapshot).toMatchObject({
+      activeProfile: "active",
+      overrideProfile: "pinned",
+      callSiteProfile: "site",
+      appliedProfile: "site",
+      profileSource: "call_site",
+      resolvedProvider: "fireworks",
+      resolvedModel: "accounts/fireworks/models/kimi-k2",
+    });
+    expectResolvedProviderModelMatchesResolver("memoryRetrieval", "pinned");
+  });
+
+  test("uses explicit call-site provider and model overrides in resolved metadata", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        active: { provider: "openai", model: "gpt-5.4" },
+      },
+      activeProfile: "active",
+      callSites: {
+        memoryRetrieval: {
+          provider: "ollama",
+          model: "llama3.2",
+        },
+      },
+    });
+
+    const snapshot = resolveUsageAttribution({
+      callSite: "memoryRetrieval",
+    });
+
+    expect(snapshot).toMatchObject({
+      activeProfile: "active",
+      callSiteProfile: null,
+      appliedProfile: "active",
+      profileSource: "active",
+      resolvedProvider: "ollama",
+      resolvedModel: "llama3.2",
+    });
+    expectResolvedProviderModelMatchesResolver("memoryRetrieval");
+  });
+
+  test("falls back when a runtime override profile is missing", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        active: { provider: "openai", model: "gpt-5.4" },
+      },
+      activeProfile: "active",
+    });
+
+    const snapshot = resolveUsageAttribution({
+      callSite: "mainAgent",
+      overrideProfile: "deleted",
+    });
+
+    expect(snapshot).toMatchObject({
+      activeProfile: "active",
+      overrideProfile: "deleted",
+      appliedProfile: "active",
+      profileSource: "active",
+      resolvedProvider: "openai",
+      resolvedModel: "gpt-5.4",
+    });
+    expectResolvedProviderModelMatchesResolver("mainAgent", "deleted");
+  });
+});
+
+describe("sanitizeUsageMetadataValue", () => {
+  test("trims, drops empty values, caps long values, and rejects controls", () => {
+    expect(sanitizeUsageMetadataValue("  profile-1  ")).toBe("profile-1");
+    expect(sanitizeUsageMetadataValue("   ")).toBeNull();
+    expect(sanitizeUsageMetadataValue(`profile\n1`)).toBeNull();
+    expect(sanitizeUsageMetadataValue("profile\u00851")).toBeNull();
+    expect(sanitizeUsageMetadataValue("x".repeat(200))).toHaveLength(128);
+  });
+});

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -1,0 +1,144 @@
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import { getConfig } from "../config/loader.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
+import { safeStringSlice } from "../util/unicode.js";
+
+const MAX_METADATA_VALUE_LENGTH = 128;
+
+export type UsageAttributionProfileSource =
+  | "call_site"
+  | "conversation"
+  | "active"
+  | "default"
+  | "unknown";
+
+export interface UsageAttributionInput {
+  callSite: LLMCallSite | null;
+  overrideProfile?: string | null;
+}
+
+export interface UsageAttributionSnapshot {
+  callSite: LLMCallSite | null;
+  activeProfile: string | null;
+  overrideProfile: string | null;
+  callSiteProfile: string | null;
+  appliedProfile: string | null;
+  profileSource: UsageAttributionProfileSource;
+  resolvedProvider: string;
+  resolvedModel: string;
+}
+
+/**
+ * Sanitizes values before they are copied into external metadata surfaces.
+ * Empty strings and control-character-bearing strings are dropped, and long
+ * values are capped so later forwarding cannot create unbounded headers.
+ */
+export function sanitizeUsageMetadataValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (containsControlCharacter(trimmed)) return null;
+
+  return safeStringSlice(trimmed, 0, MAX_METADATA_VALUE_LENGTH);
+}
+
+export function resolveUsageAttribution(
+  input: UsageAttributionInput,
+): UsageAttributionSnapshot {
+  const llm = getConfig().llm;
+  const callSite = input.callSite;
+  const overrideProfile = normalizeProfileId(input.overrideProfile);
+
+  if (callSite == null) {
+    return {
+      callSite: null,
+      activeProfile: normalizeProfileId(llm.activeProfile),
+      overrideProfile,
+      callSiteProfile: null,
+      appliedProfile: null,
+      profileSource: "unknown",
+      resolvedProvider: llm.default.provider,
+      resolvedModel: llm.default.model,
+    };
+  }
+
+  const resolved = resolveCallSiteConfig(callSite, llm, {
+    ...(overrideProfile != null ? { overrideProfile } : {}),
+  });
+  const activeProfile = normalizeProfileId(llm.activeProfile);
+  const callSiteProfile = normalizeProfileId(llm.callSites?.[callSite]?.profile);
+  const profile = resolveAppliedProfile({
+    profiles: llm.profiles ?? {},
+    activeProfile,
+    overrideProfile,
+    callSiteProfile,
+  });
+
+  return {
+    callSite,
+    activeProfile,
+    overrideProfile,
+    callSiteProfile,
+    appliedProfile: profile.appliedProfile,
+    profileSource: profile.profileSource,
+    resolvedProvider: resolved.provider,
+    resolvedModel: resolved.model,
+  };
+}
+
+function resolveAppliedProfile(input: {
+  profiles: Record<string, unknown>;
+  activeProfile: string | null;
+  overrideProfile: string | null;
+  callSiteProfile: string | null;
+}): Pick<UsageAttributionSnapshot, "appliedProfile" | "profileSource"> {
+  if (
+    input.callSiteProfile != null &&
+    input.profiles[input.callSiteProfile] != null
+  ) {
+    return {
+      appliedProfile: input.callSiteProfile,
+      profileSource: "call_site",
+    };
+  }
+
+  if (
+    input.overrideProfile != null &&
+    input.profiles[input.overrideProfile] != null
+  ) {
+    return {
+      appliedProfile: input.overrideProfile,
+      profileSource: "conversation",
+    };
+  }
+
+  if (
+    input.activeProfile != null &&
+    input.profiles[input.activeProfile] != null
+  ) {
+    return {
+      appliedProfile: input.activeProfile,
+      profileSource: "active",
+    };
+  }
+
+  return {
+    appliedProfile: null,
+    profileSource: "default",
+  };
+}
+
+function normalizeProfileId(value: string | null | undefined): string | null {
+  return value ?? null;
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/assistant/src/usage/types.ts
+++ b/assistant/src/usage/types.ts
@@ -1,5 +1,11 @@
 import type { UsageActor } from "./actors.js";
 
+export type {
+  UsageAttributionInput,
+  UsageAttributionProfileSource,
+  UsageAttributionSnapshot,
+} from "./attribution.js";
+
 /**
  * Anthropic prompt caching exposes write-tier detail so callers can price
  * 5-minute and 1-hour cache writes differently.


### PR DESCRIPTION
## Summary
- Adds usage attribution snapshot resolution for LLM call sites and inference profiles.
- Adds safe metadata value sanitization for later managed forwarding.
- Covers resolver precedence with focused tests.

Part of plan: per-task-usage-attribution.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
