### PR TITLE
JARVIS-643: Add bounded Slack thread reply windowing

### DIFF
--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -66,6 +66,8 @@ export interface HistoryOptions {
   limit?: number;
   before?: string;
   after?: string;
+  cursor?: string;
+  inclusive?: boolean;
 }
 
 export interface SearchOptions {

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -395,6 +395,8 @@ export const slackProvider: MessagingProvider = {
         options?.limit ?? 50,
         options?.before,
         options?.after,
+        options?.cursor,
+        options?.inclusive,
       );
     });
 
@@ -456,6 +458,10 @@ export const slackProvider: MessagingProvider = {
         conversationId,
         threadId,
         options?.limit ?? 50,
+        options?.before,
+        options?.after,
+        options?.inclusive,
+        options?.cursor,
       );
     });
     const messages: Message[] = [];

--- a/assistant/src/messaging/providers/slack/backfill.test.ts
+++ b/assistant/src/messaging/providers/slack/backfill.test.ts
@@ -17,7 +17,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { OAuthConnection } from "../../../oauth/connection.js";
-import type { Message } from "../../provider-types.js";
+import type { HistoryOptions, Message } from "../../provider-types.js";
 
 // ── Module mocks ────────────────────────────────────────────────────────────
 
@@ -27,13 +27,13 @@ type ResolveConnectionFn = (
 type GetHistoryFn = (
   connection: OAuthConnection | undefined,
   conversationId: string,
-  options?: { limit?: number; before?: string; after?: string },
+  options?: HistoryOptions,
 ) => Promise<Message[]>;
 type GetThreadRepliesFn = (
   connection: OAuthConnection | undefined,
   conversationId: string,
   threadId: string,
-  options?: { limit?: number },
+  options?: HistoryOptions,
 ) => Promise<Message[]>;
 
 const resolveConnectionMock = mock<ResolveConnectionFn>(async () => undefined);
@@ -50,13 +50,13 @@ mock.module("./adapter.js", () => ({
     getHistory: (
       connection: OAuthConnection | undefined,
       conversationId: string,
-      options?: { limit?: number; before?: string; after?: string },
+      options?: HistoryOptions,
     ) => getHistoryMock(connection, conversationId, options),
     getThreadReplies: (
       connection: OAuthConnection | undefined,
       conversationId: string,
       threadId: string,
-      options?: { limit?: number },
+      options?: HistoryOptions,
     ) => getThreadRepliesMock(connection, conversationId, threadId, options),
     // Stub the rest of the MessagingProvider surface as no-ops; the backfill
     // helpers should never reach for these.
@@ -71,7 +71,11 @@ mock.module("./adapter.js", () => ({
   },
 }));
 
-import { backfillDm, backfillThread } from "./backfill.js";
+import {
+  backfillDm,
+  backfillThread,
+  backfillThreadWindow,
+} from "./backfill.js";
 
 function makeMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -120,6 +124,33 @@ describe("backfillThread", () => {
     await backfillThread("C123", "1700000000.000100", { limit: 10 });
     const [, , , opts] = getThreadRepliesMock.mock.calls[0];
     expect(opts).toEqual({ limit: 10 });
+  });
+
+  test("forwards explicit before/after window through window helper", async () => {
+    await backfillThreadWindow("C123", "1700000000.000100", {
+      limit: 10,
+      after: "1700000000.000100",
+      before: "1700000005.000100",
+    });
+
+    const [, , , opts] = getThreadRepliesMock.mock.calls[0];
+    expect(opts).toEqual({
+      limit: 10,
+      after: "1700000000.000100",
+      before: "1700000005.000100",
+    });
+  });
+
+  test("forwards cursor through window helper", async () => {
+    await backfillThreadWindow("C123", "1700000000.000100", {
+      cursor: "cursor-123",
+    });
+
+    const [, , , opts] = getThreadRepliesMock.mock.calls[0];
+    expect(opts).toEqual({
+      limit: 50,
+      cursor: "cursor-123",
+    });
   });
 
   test("returns [] when getThreadReplies throws (generic Slack API error)", async () => {

--- a/assistant/src/messaging/providers/slack/backfill.ts
+++ b/assistant/src/messaging/providers/slack/backfill.ts
@@ -41,6 +41,27 @@ export async function backfillThread(
   threadTs: string,
   opts?: { limit?: number; account?: string },
 ): Promise<Message[]> {
+  return backfillThreadWindow(channelId, threadTs, opts);
+}
+
+/**
+ * Fetch a bounded window of messages in a Slack thread.
+ *
+ * `after` and `before` are passed through to Slack as `oldest` and `latest`;
+ * callers can also pass a Slack pagination cursor when continuing a bounded
+ * scan. Returns `[]` on transient errors; rethrows `channel_not_found`.
+ */
+export async function backfillThreadWindow(
+  channelId: string,
+  threadTs: string,
+  opts?: {
+    limit?: number;
+    after?: string;
+    before?: string;
+    cursor?: string;
+    account?: string;
+  },
+): Promise<Message[]> {
   const limit = opts?.limit ?? DEFAULT_LIMIT;
   try {
     const connection = await slackProvider.resolveConnection?.(opts?.account);
@@ -51,18 +72,32 @@ export async function backfillThread(
       );
       return [];
     }
+    const historyOptions = {
+      limit,
+      ...(opts?.after !== undefined ? { after: opts.after } : {}),
+      ...(opts?.before !== undefined ? { before: opts.before } : {}),
+      ...(opts?.cursor !== undefined ? { cursor: opts.cursor } : {}),
+    };
     return await slackProvider.getThreadReplies(
       connection,
       channelId,
       threadTs,
-      { limit },
+      historyOptions,
     );
   } catch (err) {
     if (isChannelNotFound(err)) {
       throw err;
     }
     log.warn(
-      { channelId, threadTs, account: opts?.account, err },
+      {
+        channelId,
+        threadTs,
+        after: opts?.after,
+        before: opts?.before,
+        cursor: opts?.cursor,
+        account: opts?.account,
+        err,
+      },
       "Slack thread backfill failed — returning []",
     );
     return [];

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -310,6 +310,7 @@ export async function conversationHistory(
   latest?: string,
   oldest?: string,
   cursor?: string,
+  inclusive?: boolean,
 ): Promise<SlackConversationHistoryResponse> {
   return request<SlackConversationHistoryResponse>(
     connectionOrToken,
@@ -320,6 +321,7 @@ export async function conversationHistory(
       latest,
       oldest,
       cursor,
+      inclusive: inclusive === undefined ? undefined : String(inclusive),
     },
   );
 }
@@ -329,6 +331,10 @@ export async function conversationReplies(
   channel: string,
   ts: string,
   limit = 50,
+  latest?: string,
+  oldest?: string,
+  inclusive?: boolean,
+  cursor?: string,
 ): Promise<SlackConversationRepliesResponse> {
   return request<SlackConversationRepliesResponse>(
     connectionOrToken,
@@ -337,6 +343,10 @@ export async function conversationReplies(
       channel,
       ts,
       limit: String(limit),
+      latest,
+      oldest,
+      inclusive: inclusive === undefined ? undefined : String(inclusive),
+      cursor,
     },
   );
 }

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -59,6 +59,7 @@ export interface SlackConversationHistoryResponse extends SlackApiResponse {
 export interface SlackConversationRepliesResponse extends SlackApiResponse {
   messages: SlackMessage[];
   has_more: boolean;
+  response_metadata?: { next_cursor?: string };
 }
 
 export interface SlackUser {


### PR DESCRIPTION
## Summary
- Add Slack-compatible reply windowing options and pass-through plumbing
- Add bounded backfill helper while preserving existing backfill behavior
- Cover forwarding and error behavior in focused tests

Part of JARVIS-643
Part of plan: jarvis-643-slack-context-continuity.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
