### PR TITLE
fix: dedupe settings feature flag reconciliation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -276,30 +276,25 @@ struct SettingsPanel: View {
         .onChange(of: isSoundsEnabled) { _, _ in
             handleSidebarVisibilityChanged()
         }
+        .onChange(of: isDeveloperEnabled) { _, _ in
+            handleSidebarVisibilityChanged()
+        }
         .onChange(of: isCompactionPlaygroundVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
-                var visibilityMayHaveChanged = false
                 if key == Self.developerFeatureFlagKey {
                     isDeveloperEnabled = enabled
-                    visibilityMayHaveChanged = true
                 } else if key == Self.billingFeatureFlagKey {
                     isBillingEnabled = enabled
-                    visibilityMayHaveChanged = true
                 } else if key == Self.compactionPlaygroundFeatureFlagKey {
                     isCompactionPlaygroundEnabled = enabled
-                    visibilityMayHaveChanged = true
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
                 } else if key == Self.soundsFeatureFlagKey {
                     isSoundsEnabled = enabled
-                    visibilityMayHaveChanged = true
-                }
-                if visibilityMayHaveChanged {
-                    handleSidebarVisibilityChanged()
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes the remaining slop/reuse finding from plan re-review.

- Makes assistant feature-flag notifications only update local flag state.
- Lets `.onChange` handlers own sidebar visibility reconciliation.
- Adds a Developer flag observer so Developer-only visibility changes still clear hidden selections.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsPanelSidebarTests (fails before tests in existing local Swift build issues: SwiftMath public override var description and VMenuPanel canBecomeKey/canBecomeMain do not override superclass properties)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
