### PR TITLE
Move Compaction Playground to Settings top navigation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -44,6 +44,32 @@ enum SettingsTab: String {
         if debugEnabled { tabs.append(.debug) }
         return tabs
     }
+
+    static func isCompactionPlaygroundVisible(
+        developerEnabled: Bool,
+        playgroundEnabled: Bool,
+        devModeEnabled: Bool
+    ) -> Bool {
+        developerEnabled && playgroundEnabled && devModeEnabled
+    }
+
+    static func sidebarTopTabs(
+        billingEnabled: Bool = false,
+        soundsEnabled: Bool = true,
+        debugEnabled: Bool = false,
+        includeCompactionPlayground: Bool = false
+    ) -> [SettingsTab] {
+        let primary = primaryTabs(
+            billingEnabled: billingEnabled,
+            soundsEnabled: soundsEnabled,
+            debugEnabled: debugEnabled
+        )
+        return includeCompactionPlayground ? [.compactionPlayground] + primary : primary
+    }
+
+    static func sidebarBottomTabs(developerEnabled: Bool) -> [SettingsTab] {
+        developerEnabled ? [.developer] : []
+    }
 }
 
 @MainActor
@@ -105,11 +131,18 @@ struct SettingsPanel: View {
             let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
             // Contacts and developer flags load asynchronously, so default
             // to false at init time — those tabs aren't visible yet.
+            // Compaction Playground is also deferred until flags load and
+            // dev mode can be evaluated by the live sidebar visibility helper.
             // Debug tab is gated to managed assistants; `AppDelegate` publishes
             // this synchronously via `isCurrentAssistantManaged` which is set
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
-            let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: soundsEnabled, debugEnabled: debugEnabled)
+            let visibleTabs = SettingsTab.sidebarTopTabs(
+                billingEnabled: canShowBilling,
+                soundsEnabled: soundsEnabled,
+                debugEnabled: debugEnabled,
+                includeCompactionPlayground: false
+            )
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else {
@@ -230,16 +263,10 @@ struct SettingsPanel: View {
         }
         .onChange(of: store.pendingSettingsTab) { _, newTab in
             if let tab = newTab {
-                // Compute visibility inline — same as onAppear. @State
-                // mutations (e.g. isBillingEnabled set in onAppear) may not
-                // have propagated to computed properties yet, so querying
-                // the flag manager directly avoids a stale billingVisible.
-                let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
-                let canShowBilling = billingEnabled && authManager.isAuthenticated && connectedOrgId != nil
-                let visibleTabs = SettingsTab.primaryTabs(billingEnabled: canShowBilling, soundsEnabled: isSoundsEnabled, debugEnabled: isDebugVisible)
-                    + (isDeveloperEnabled ? [.developer] : [])
-                if visibleTabs.contains(tab) {
-                    selectedTab = tab
+                if allVisibleTabs.contains(tab) {
+                    selectVisibleTab(tab)
+                } else {
+                    deferredDeepLinkTab = tab
                 }
                 store.pendingSettingsTab = nil
             }
@@ -250,41 +277,39 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: .navigateToSettingsTab)) { notification in
             if let tab = notification.object as? SettingsTab {
                 guard allVisibleTabs.contains(tab) else { return }
-                selectedTab = tab
+                selectVisibleTab(tab)
             }
         }
-        .onChange(of: billingVisible) { _, visible in
-            if !visible && selectedTab == .billing {
-                selectedTab = .general
-            }
+        .onChange(of: billingVisible) { _, _ in
+            ensureSelectedTabIsVisible()
         }
-        .onChange(of: isDebugVisible) { _, visible in
-            if !visible && selectedTab == .debug {
-                selectedTab = .general
-            }
+        .onChange(of: isDebugVisible) { _, _ in
+            ensureSelectedTabIsVisible()
         }
-        .onChange(of: isSoundsEnabled) { _, enabled in
-            if !enabled && selectedTab == .sounds {
-                selectedTab = .general
-            }
+        .onChange(of: isSoundsEnabled) { _, _ in
+            ensureSelectedTabIsVisible()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
+                var visibilityMayHaveChanged = false
                 if key == Self.developerFeatureFlagKey {
                     isDeveloperEnabled = enabled
-                    if !enabled && selectedTab == .developer {
-                        selectedTab = .general
-                    }
+                    visibilityMayHaveChanged = true
                 } else if key == Self.billingFeatureFlagKey {
                     isBillingEnabled = enabled
+                    visibilityMayHaveChanged = true
+                } else if key == Self.compactionPlaygroundFeatureFlagKey {
+                    isCompactionPlaygroundEnabled = enabled
+                    visibilityMayHaveChanged = true
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
                 } else if key == Self.soundsFeatureFlagKey {
                     isSoundsEnabled = enabled
-                    if !enabled && selectedTab == .sounds {
-                        selectedTab = .general
-                    }
+                    visibilityMayHaveChanged = true
+                }
+                if visibilityMayHaveChanged {
+                    consumeDeferredDeepLinkIfVisible()
                 }
             }
         }
@@ -369,14 +394,14 @@ struct SettingsPanel: View {
 
     // MARK: - Nav Sidebar
 
-    /// All currently visible tabs (primary + gated bottom tabs).
+    /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.primaryTabs(billingEnabled: billingVisible, soundsEnabled: isSoundsEnabled, debugEnabled: isDebugVisible)
-        if isDeveloperEnabled {
-            tabs.append(.developer)
-        }
-        // .archivedConversations is already included via primaryTabs()
-        return tabs
+        SettingsTab.sidebarTopTabs(
+            billingEnabled: billingVisible,
+            soundsEnabled: isSoundsEnabled,
+            debugEnabled: isDebugVisible,
+            includeCompactionPlayground: isCompactionPlaygroundVisible
+        ) + SettingsTab.sidebarBottomTabs(developerEnabled: isDeveloperEnabled)
     }
 
     private var billingVisible: Bool {
@@ -392,38 +417,54 @@ struct SettingsPanel: View {
         return AppDelegate.shared?.isCurrentAssistantManaged ?? false
     }
 
+    private var isCompactionPlaygroundVisible: Bool {
+        SettingsTab.isCompactionPlaygroundVisible(
+            developerEnabled: isDeveloperEnabled,
+            playgroundEnabled: isCompactionPlaygroundEnabled,
+            devModeEnabled: DevModeManager.shared.isDevMode
+        )
+    }
+
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(SettingsTab.primaryTabs(billingEnabled: billingVisible, soundsEnabled: isSoundsEnabled, debugEnabled: isDebugVisible), id: \.self) { tab in
+            ForEach(
+                SettingsTab.sidebarTopTabs(
+                    billingEnabled: billingVisible,
+                    soundsEnabled: isSoundsEnabled,
+                    debugEnabled: isDebugVisible,
+                    includeCompactionPlayground: isCompactionPlaygroundVisible
+                ),
+                id: \.self
+            ) { tab in
                 VNavItem(icon: tab.icon.rawValue, label: tab.rawValue, isActive: selectedTab == tab) {
-                    selectedTab = tab
+                    selectVisibleTab(tab)
                 }
             }
             Spacer(minLength: VSpacing.sm)
-            if isDeveloperEnabled {
+            if SettingsTab.sidebarBottomTabs(developerEnabled: isDeveloperEnabled).contains(.developer) {
                 VColor.surfaceBase
                     .frame(height: 1)
                     .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
                     .padding(.trailing, VSpacing.md)
                 VNavItem(icon: SettingsTab.developer.icon.rawValue, label: "Developer", isActive: selectedTab == .developer) {
-                    selectedTab = .developer
-                }
-            }
-            if isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode {
-                VColor.surfaceBase
-                    .frame(height: 1)
-                    .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
-                    .padding(.trailing, VSpacing.md)
-                VNavItem(icon: SettingsTab.compactionPlayground.icon.rawValue,
-                         label: "Compaction Playground",
-                         isActive: selectedTab == .compactionPlayground) {
-                    selectedTab = .compactionPlayground
+                    selectVisibleTab(.developer)
                 }
             }
         }
         .padding(.top, VSpacing.lg)
         .padding(.bottom, VSpacing.xl)
         .padding(.trailing, VSpacing.sm)
+    }
+
+    private func ensureSelectedTabIsVisible() {
+        if !allVisibleTabs.contains(selectedTab) {
+            selectedTab = .general
+        }
+    }
+
+    private func selectVisibleTab(_ tab: SettingsTab) {
+        selectedTab = tab
+        deferredDeepLinkTab = nil
     }
 
     // MARK: - Tab Content Router
@@ -757,12 +798,14 @@ struct SettingsPanel: View {
     /// If a deep-linked tab was deferred at init because its feature flag
     /// hadn't loaded, check whether it's now visible and navigate to it.
     private func consumeDeferredDeepLinkIfVisible() {
-        guard let deferred = deferredDeepLinkTab else { return }
-        let visibleTabs = allVisibleTabs
-        if visibleTabs.contains(deferred) {
-            selectedTab = deferred
+        guard let deferred = deferredDeepLinkTab else {
+            ensureSelectedTabIsVisible()
+            return
         }
-        deferredDeepLinkTab = nil
+        if allVisibleTabs.contains(deferred) {
+            selectVisibleTab(deferred)
+        }
+        ensureSelectedTabIsVisible()
     }
 
     private func startPermissionPolling() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -32,24 +32,32 @@ enum SettingsTab: String {
         }
     }
 
-    static func sidebarTopTabs(
-        billingEnabled: Bool = false,
-        soundsEnabled: Bool = true,
-        debugEnabled: Bool = false,
-        includeCompactionPlayground: Bool = false
-    ) -> [SettingsTab] {
+    struct SidebarVisibility {
+        var billingEnabled = false
+        var soundsEnabled = true
+        var debugEnabled = false
+        var developerEnabled = false
+        var compactionPlaygroundEnabled = false
+        var devModeEnabled = false
+
+        var showsCompactionPlayground: Bool {
+            developerEnabled && compactionPlaygroundEnabled && devModeEnabled
+        }
+    }
+
+    static func sidebarTopTabs(visibility: SidebarVisibility) -> [SettingsTab] {
         var tabs: [SettingsTab] = []
-        if includeCompactionPlayground {
+        if visibility.showsCompactionPlayground {
             tabs.append(.compactionPlayground)
         }
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
-        if soundsEnabled { tabs.append(.sounds) }
-        if billingEnabled { tabs.append(.billing) }
+        if visibility.soundsEnabled { tabs.append(.sounds) }
+        if visibility.billingEnabled { tabs.append(.billing) }
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         tabs.append(.schedules)
-        if debugEnabled { tabs.append(.debug) }
+        if visibility.debugEnabled { tabs.append(.debug) }
         return tabs
     }
 
@@ -128,12 +136,11 @@ struct SettingsPanel: View {
             // this synchronously via `isCurrentAssistantManaged` which is set
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
-            let visibleTabs = SettingsTab.sidebarTopTabs(
+            let visibleTabs = SettingsTab.sidebarTopTabs(visibility: .init(
                 billingEnabled: canShowBilling,
                 soundsEnabled: soundsEnabled,
-                debugEnabled: debugEnabled,
-                includeCompactionPlayground: false
-            )
+                debugEnabled: debugEnabled
+            ))
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else if SettingsTab.canDeferDeepLink(pending) {
@@ -274,16 +281,16 @@ struct SettingsPanel: View {
             }
         }
         .onChange(of: billingVisible) { _, _ in
-            consumeDeferredDeepLinkIfVisible()
+            reconcileSelectedTabVisibility()
         }
         .onChange(of: isDebugVisible) { _, _ in
-            consumeDeferredDeepLinkIfVisible()
+            reconcileSelectedTabVisibility()
         }
         .onChange(of: isSoundsEnabled) { _, _ in
-            consumeDeferredDeepLinkIfVisible()
+            reconcileSelectedTabVisibility()
         }
         .onChange(of: isCompactionPlaygroundVisible) { _, _ in
-            consumeDeferredDeepLinkIfVisible()
+            reconcileSelectedTabVisibility()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
@@ -305,7 +312,7 @@ struct SettingsPanel: View {
                     visibilityMayHaveChanged = true
                 }
                 if visibilityMayHaveChanged {
-                    consumeDeferredDeepLinkIfVisible()
+                    reconcileSelectedTabVisibility()
                 }
             }
         }
@@ -321,7 +328,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
-            consumeDeferredDeepLinkIfVisible()
+            reconcileSelectedTabVisibility()
         }
         .sheet(isPresented: $showingTrustRules, onDismiss: { connectionManager?.isTrustRulesSheetOpen = false }) {
             TrustRulesView(trustRuleClient: TrustRuleClient())
@@ -394,19 +401,25 @@ struct SettingsPanel: View {
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
         var tabs = visibleSidebarTopTabs
-        if isDeveloperEnabled {
+        if sidebarVisibility.developerEnabled {
             tabs.append(.developer)
         }
         return tabs
     }
 
-    private var visibleSidebarTopTabs: [SettingsTab] {
-        SettingsTab.sidebarTopTabs(
+    private var sidebarVisibility: SettingsTab.SidebarVisibility {
+        .init(
             billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
-            includeCompactionPlayground: isCompactionPlaygroundVisible
+            developerEnabled: isDeveloperEnabled,
+            compactionPlaygroundEnabled: isCompactionPlaygroundEnabled,
+            devModeEnabled: DevModeManager.shared.isDevMode
         )
+    }
+
+    private var visibleSidebarTopTabs: [SettingsTab] {
+        SettingsTab.sidebarTopTabs(visibility: sidebarVisibility)
     }
 
     private var billingVisible: Bool {
@@ -423,7 +436,7 @@ struct SettingsPanel: View {
     }
 
     private var isCompactionPlaygroundVisible: Bool {
-        isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
+        sidebarVisibility.showsCompactionPlayground
     }
 
     private var settingsNav: some View {
@@ -759,7 +772,7 @@ struct SettingsPanel: View {
                 if let soundsFlag = flags.first(where: { $0.key == Self.soundsFeatureFlagKey }) {
                     isSoundsEnabled = soundsFlag.enabled
                 }
-                consumeDeferredDeepLinkIfVisible()
+                reconcileSelectedTabVisibility()
                 return
             } catch {
                 // Fall through to local config fallback.
@@ -785,20 +798,20 @@ struct SettingsPanel: View {
         if let soundsEnabled = resolved[Self.soundsFeatureFlagKey] {
             isSoundsEnabled = soundsEnabled
         }
-        consumeDeferredDeepLinkIfVisible()
+        reconcileSelectedTabVisibility()
     }
 
-    /// If a deep-linked tab was deferred at init because its feature flag
-    /// hadn't loaded, check whether it's now visible and navigate to it.
+    private func reconcileSelectedTabVisibility() {
+        consumeDeferredDeepLinkIfVisible()
+        ensureSelectedTabIsVisible()
+    }
+
+    /// If a feature-gated deep-linked tab becomes visible, navigate to it.
     private func consumeDeferredDeepLinkIfVisible() {
-        guard let deferred = deferredDeepLinkTab else {
-            ensureSelectedTabIsVisible()
-            return
-        }
+        guard let deferred = deferredDeepLinkTab else { return }
         if allVisibleTabs.contains(deferred) {
             selectVisibleTab(deferred)
         }
-        ensureSelectedTabIsVisible()
     }
 
     private func startPermissionPolling() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -32,9 +32,17 @@ enum SettingsTab: String {
         }
     }
 
-    /// Primary tabs shown in the main nav list (excludes feature-flagged bottom tabs).
-    static func primaryTabs(billingEnabled: Bool = false, soundsEnabled: Bool = true, debugEnabled: Bool = false) -> [SettingsTab] {
-        var tabs: [SettingsTab] = [.general, .modelsAndServices, .integrations]
+    static func sidebarTopTabs(
+        billingEnabled: Bool = false,
+        soundsEnabled: Bool = true,
+        debugEnabled: Bool = false,
+        includeCompactionPlayground: Bool = false
+    ) -> [SettingsTab] {
+        var tabs: [SettingsTab] = []
+        if includeCompactionPlayground {
+            tabs.append(.compactionPlayground)
+        }
+        tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
         if soundsEnabled { tabs.append(.sounds) }
         if billingEnabled { tabs.append(.billing) }
@@ -53,22 +61,13 @@ enum SettingsTab: String {
         developerEnabled && playgroundEnabled && devModeEnabled
     }
 
-    static func sidebarTopTabs(
-        billingEnabled: Bool = false,
-        soundsEnabled: Bool = true,
-        debugEnabled: Bool = false,
-        includeCompactionPlayground: Bool = false
-    ) -> [SettingsTab] {
-        let primary = primaryTabs(
-            billingEnabled: billingEnabled,
-            soundsEnabled: soundsEnabled,
-            debugEnabled: debugEnabled
-        )
-        return includeCompactionPlayground ? [.compactionPlayground] + primary : primary
-    }
-
-    static func sidebarBottomTabs(developerEnabled: Bool) -> [SettingsTab] {
-        developerEnabled ? [.developer] : []
+    static func canDeferDeepLink(_ tab: SettingsTab) -> Bool {
+        switch tab {
+        case .developer, .compactionPlayground:
+            return true
+        default:
+            return false
+        }
     }
 }
 
@@ -145,7 +144,7 @@ struct SettingsPanel: View {
             )
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
-            } else {
+            } else if SettingsTab.canDeferDeepLink(pending) {
                 // Tab may become visible once feature flags load (e.g. .developer).
                 // Preserve it for deferred evaluation in loadFeatureFlags().
                 _deferredDeepLinkTab = State(initialValue: pending)
@@ -265,8 +264,10 @@ struct SettingsPanel: View {
             if let tab = newTab {
                 if allVisibleTabs.contains(tab) {
                     selectVisibleTab(tab)
-                } else {
+                } else if SettingsTab.canDeferDeepLink(tab) {
                     deferredDeepLinkTab = tab
+                } else {
+                    deferredDeepLinkTab = nil
                 }
                 store.pendingSettingsTab = nil
             }
@@ -281,13 +282,16 @@ struct SettingsPanel: View {
             }
         }
         .onChange(of: billingVisible) { _, _ in
-            ensureSelectedTabIsVisible()
+            consumeDeferredDeepLinkIfVisible()
         }
         .onChange(of: isDebugVisible) { _, _ in
-            ensureSelectedTabIsVisible()
+            consumeDeferredDeepLinkIfVisible()
         }
         .onChange(of: isSoundsEnabled) { _, _ in
-            ensureSelectedTabIsVisible()
+            consumeDeferredDeepLinkIfVisible()
+        }
+        .onChange(of: isCompactionPlaygroundVisible) { _, _ in
+            consumeDeferredDeepLinkIfVisible()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
@@ -325,6 +329,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
+            consumeDeferredDeepLinkIfVisible()
         }
         .sheet(isPresented: $showingTrustRules, onDismiss: { connectionManager?.isTrustRulesSheetOpen = false }) {
             TrustRulesView(trustRuleClient: TrustRuleClient())
@@ -396,12 +401,16 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
-        SettingsTab.sidebarTopTabs(
+        var tabs = SettingsTab.sidebarTopTabs(
             billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
-        ) + SettingsTab.sidebarBottomTabs(developerEnabled: isDeveloperEnabled)
+        )
+        if isDeveloperEnabled {
+            tabs.append(.developer)
+        }
+        return tabs
     }
 
     private var billingVisible: Bool {
@@ -441,7 +450,7 @@ struct SettingsPanel: View {
                 }
             }
             Spacer(minLength: VSpacing.sm)
-            if SettingsTab.sidebarBottomTabs(developerEnabled: isDeveloperEnabled).contains(.developer) {
+            if isDeveloperEnabled {
                 VColor.surfaceBase
                     .frame(height: 1)
                     .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
@@ -799,6 +808,11 @@ struct SettingsPanel: View {
     /// hadn't loaded, check whether it's now visible and navigate to it.
     private func consumeDeferredDeepLinkIfVisible() {
         guard let deferred = deferredDeepLinkTab else {
+            ensureSelectedTabIsVisible()
+            return
+        }
+        guard SettingsTab.canDeferDeepLink(deferred) else {
+            deferredDeepLinkTab = nil
             ensureSelectedTabIsVisible()
             return
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -53,22 +53,6 @@ enum SettingsTab: String {
         return tabs
     }
 
-    static func isCompactionPlaygroundVisible(
-        developerEnabled: Bool,
-        playgroundEnabled: Bool,
-        devModeEnabled: Bool
-    ) -> Bool {
-        developerEnabled && playgroundEnabled && devModeEnabled
-    }
-
-    static func canDeferDeepLink(_ tab: SettingsTab) -> Bool {
-        switch tab {
-        case .developer, .compactionPlayground:
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 @MainActor
@@ -144,7 +128,7 @@ struct SettingsPanel: View {
             )
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
-            } else if SettingsTab.canDeferDeepLink(pending) {
+            } else if Self.deferredDeepLinkTabs.contains(pending) {
                 // Tab may become visible once feature flags load (e.g. .developer).
                 // Preserve it for deferred evaluation in loadFeatureFlags().
                 _deferredDeepLinkTab = State(initialValue: pending)
@@ -188,6 +172,7 @@ struct SettingsPanel: View {
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
+    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.developer, .compactionPlayground]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -265,7 +250,7 @@ struct SettingsPanel: View {
             if let tab = newTab {
                 if allVisibleTabs.contains(tab) {
                     selectVisibleTab(tab)
-                } else if !hasLoadedFeatureFlags && SettingsTab.canDeferDeepLink(tab) {
+                } else if !hasLoadedFeatureFlags && Self.deferredDeepLinkTabs.contains(tab) {
                     deferredDeepLinkTab = tab
                 } else {
                     deferredDeepLinkTab = nil
@@ -283,16 +268,16 @@ struct SettingsPanel: View {
             }
         }
         .onChange(of: billingVisible) { _, _ in
-            reconcileSelectedTabVisibility()
+            handleSidebarVisibilityChanged()
         }
         .onChange(of: isDebugVisible) { _, _ in
-            reconcileSelectedTabVisibility()
+            handleSidebarVisibilityChanged()
         }
         .onChange(of: isSoundsEnabled) { _, _ in
-            reconcileSelectedTabVisibility()
+            handleSidebarVisibilityChanged()
         }
         .onChange(of: isCompactionPlaygroundVisible) { _, _ in
-            reconcileSelectedTabVisibility()
+            handleSidebarVisibilityChanged()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
@@ -314,7 +299,7 @@ struct SettingsPanel: View {
                     visibilityMayHaveChanged = true
                 }
                 if visibilityMayHaveChanged {
-                    reconcileSelectedTabVisibility()
+                    handleSidebarVisibilityChanged()
                 }
             }
         }
@@ -330,7 +315,7 @@ struct SettingsPanel: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
-            reconcileSelectedTabVisibility()
+            handleSidebarVisibilityChanged()
         }
         .sheet(isPresented: $showingTrustRules, onDismiss: { connectionManager?.isTrustRulesSheetOpen = false }) {
             TrustRulesView(trustRuleClient: TrustRuleClient())
@@ -432,11 +417,7 @@ struct SettingsPanel: View {
     }
 
     private var isCompactionPlaygroundVisible: Bool {
-        SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: isDeveloperEnabled,
-            playgroundEnabled: isCompactionPlaygroundEnabled,
-            devModeEnabled: DevModeManager.shared.isDevMode
-        )
+        isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
     }
 
     private var settingsNav: some View {
@@ -460,12 +441,6 @@ struct SettingsPanel: View {
         .padding(.top, VSpacing.lg)
         .padding(.bottom, VSpacing.xl)
         .padding(.trailing, VSpacing.sm)
-    }
-
-    private func ensureSelectedTabIsVisible() {
-        if !allVisibleTabs.contains(selectedTab) {
-            selectedTab = .general
-        }
     }
 
     private func selectVisibleTab(_ tab: SettingsTab) {
@@ -772,7 +747,8 @@ struct SettingsPanel: View {
                 if let soundsFlag = flags.first(where: { $0.key == Self.soundsFeatureFlagKey }) {
                     isSoundsEnabled = soundsFlag.enabled
                 }
-                finishFeatureFlagLoad()
+                handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
+                hasLoadedFeatureFlags = true
                 return
             } catch {
                 // Fall through to local config fallback.
@@ -798,26 +774,20 @@ struct SettingsPanel: View {
         if let soundsEnabled = resolved[Self.soundsFeatureFlagKey] {
             isSoundsEnabled = soundsEnabled
         }
-        finishFeatureFlagLoad()
-    }
-
-    private func finishFeatureFlagLoad() {
-        reconcileSelectedTabVisibility(clearDeferredIfHidden: true)
+        handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
         hasLoadedFeatureFlags = true
     }
 
-    private func reconcileSelectedTabVisibility(clearDeferredIfHidden: Bool = false) {
-        consumeDeferredDeepLinkIfVisible(clearIfHidden: clearDeferredIfHidden)
-        ensureSelectedTabIsVisible()
-    }
-
-    /// If a feature-gated deep-linked tab becomes visible, navigate to it.
-    private func consumeDeferredDeepLinkIfVisible(clearIfHidden: Bool = false) {
-        guard let deferred = deferredDeepLinkTab else { return }
-        if allVisibleTabs.contains(deferred) {
-            selectVisibleTab(deferred)
-        } else if clearIfHidden {
-            deferredDeepLinkTab = nil
+    private func handleSidebarVisibilityChanged(clearDeferredIfHidden: Bool = false) {
+        if let deferred = deferredDeepLinkTab {
+            if allVisibleTabs.contains(deferred) {
+                selectVisibleTab(deferred)
+            } else if clearDeferredIfHidden {
+                deferredDeepLinkTab = nil
+            }
+        }
+        if !allVisibleTabs.contains(selectedTab) {
+            selectedTab = .general
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -53,14 +53,6 @@ enum SettingsTab: String {
         return tabs
     }
 
-    static func isCompactionPlaygroundVisible(
-        developerEnabled: Bool,
-        playgroundEnabled: Bool,
-        devModeEnabled: Bool
-    ) -> Bool {
-        developerEnabled && playgroundEnabled && devModeEnabled
-    }
-
     static func canDeferDeepLink(_ tab: SettingsTab) -> Bool {
         switch tab {
         case .developer, .compactionPlayground:
@@ -401,16 +393,20 @@ struct SettingsPanel: View {
 
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
-        var tabs = SettingsTab.sidebarTopTabs(
+        var tabs = visibleSidebarTopTabs
+        if isDeveloperEnabled {
+            tabs.append(.developer)
+        }
+        return tabs
+    }
+
+    private var visibleSidebarTopTabs: [SettingsTab] {
+        SettingsTab.sidebarTopTabs(
             billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
         )
-        if isDeveloperEnabled {
-            tabs.append(.developer)
-        }
-        return tabs
     }
 
     private var billingVisible: Bool {
@@ -427,24 +423,12 @@ struct SettingsPanel: View {
     }
 
     private var isCompactionPlaygroundVisible: Bool {
-        SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: isDeveloperEnabled,
-            playgroundEnabled: isCompactionPlaygroundEnabled,
-            devModeEnabled: DevModeManager.shared.isDevMode
-        )
+        isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
     }
 
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            ForEach(
-                SettingsTab.sidebarTopTabs(
-                    billingEnabled: billingVisible,
-                    soundsEnabled: isSoundsEnabled,
-                    debugEnabled: isDebugVisible,
-                    includeCompactionPlayground: isCompactionPlaygroundVisible
-                ),
-                id: \.self
-            ) { tab in
+            ForEach(visibleSidebarTopTabs, id: \.self) { tab in
                 VNavItem(icon: tab.icon.rawValue, label: tab.rawValue, isActive: selectedTab == tab) {
                     selectVisibleTab(tab)
                 }
@@ -808,11 +792,6 @@ struct SettingsPanel: View {
     /// hadn't loaded, check whether it's now visible and navigate to it.
     private func consumeDeferredDeepLinkIfVisible() {
         guard let deferred = deferredDeepLinkTab else {
-            ensureSelectedTabIsVisible()
-            return
-        }
-        guard SettingsTab.canDeferDeepLink(deferred) else {
-            deferredDeepLinkTab = nil
             ensureSelectedTabIsVisible()
             return
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -276,30 +276,25 @@ struct SettingsPanel: View {
         .onChange(of: isSoundsEnabled) { _, _ in
             handleSidebarVisibilityChanged()
         }
+        .onChange(of: isDeveloperEnabled) { _, _ in
+            handleSidebarVisibilityChanged()
+        }
         .onChange(of: isCompactionPlaygroundVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
-                var visibilityMayHaveChanged = false
                 if key == Self.developerFeatureFlagKey {
                     isDeveloperEnabled = enabled
-                    visibilityMayHaveChanged = true
                 } else if key == Self.billingFeatureFlagKey {
                     isBillingEnabled = enabled
-                    visibilityMayHaveChanged = true
                 } else if key == Self.compactionPlaygroundFeatureFlagKey {
                     isCompactionPlaygroundEnabled = enabled
-                    visibilityMayHaveChanged = true
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
                 } else if key == Self.soundsFeatureFlagKey {
                     isSoundsEnabled = enabled
-                    visibilityMayHaveChanged = true
-                }
-                if visibilityMayHaveChanged {
-                    handleSidebarVisibilityChanged()
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -32,33 +32,33 @@ enum SettingsTab: String {
         }
     }
 
-    struct SidebarVisibility {
-        var billingEnabled = false
-        var soundsEnabled = true
-        var debugEnabled = false
-        var developerEnabled = false
-        var compactionPlaygroundEnabled = false
-        var devModeEnabled = false
-
-        var showsCompactionPlayground: Bool {
-            developerEnabled && compactionPlaygroundEnabled && devModeEnabled
-        }
-    }
-
-    static func sidebarTopTabs(visibility: SidebarVisibility) -> [SettingsTab] {
+    static func sidebarTopTabs(
+        billingEnabled: Bool = false,
+        soundsEnabled: Bool = true,
+        debugEnabled: Bool = false,
+        includeCompactionPlayground: Bool = false
+    ) -> [SettingsTab] {
         var tabs: [SettingsTab] = []
-        if visibility.showsCompactionPlayground {
+        if includeCompactionPlayground {
             tabs.append(.compactionPlayground)
         }
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
-        if visibility.soundsEnabled { tabs.append(.sounds) }
-        if visibility.billingEnabled { tabs.append(.billing) }
+        if soundsEnabled { tabs.append(.sounds) }
+        if billingEnabled { tabs.append(.billing) }
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         tabs.append(.schedules)
-        if visibility.debugEnabled { tabs.append(.debug) }
+        if debugEnabled { tabs.append(.debug) }
         return tabs
+    }
+
+    static func isCompactionPlaygroundVisible(
+        developerEnabled: Bool,
+        playgroundEnabled: Bool,
+        devModeEnabled: Bool
+    ) -> Bool {
+        developerEnabled && playgroundEnabled && devModeEnabled
     }
 
     static func canDeferDeepLink(_ tab: SettingsTab) -> Bool {
@@ -136,11 +136,12 @@ struct SettingsPanel: View {
             // this synchronously via `isCurrentAssistantManaged` which is set
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
-            let visibleTabs = SettingsTab.sidebarTopTabs(visibility: .init(
+            let visibleTabs = SettingsTab.sidebarTopTabs(
                 billingEnabled: canShowBilling,
                 soundsEnabled: soundsEnabled,
-                debugEnabled: debugEnabled
-            ))
+                debugEnabled: debugEnabled,
+                includeCompactionPlayground: false
+            )
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else if SettingsTab.canDeferDeepLink(pending) {
@@ -169,6 +170,7 @@ struct SettingsPanel: View {
     /// Deep-linked tab that wasn't visible at init (feature flags not yet loaded).
     /// Re-evaluated after loadFeatureFlags() completes.
     @State private var deferredDeepLinkTab: SettingsTab?
+    @State private var hasLoadedFeatureFlags: Bool = false
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
@@ -263,7 +265,7 @@ struct SettingsPanel: View {
             if let tab = newTab {
                 if allVisibleTabs.contains(tab) {
                     selectVisibleTab(tab)
-                } else if SettingsTab.canDeferDeepLink(tab) {
+                } else if !hasLoadedFeatureFlags && SettingsTab.canDeferDeepLink(tab) {
                     deferredDeepLinkTab = tab
                 } else {
                     deferredDeepLinkTab = nil
@@ -401,25 +403,19 @@ struct SettingsPanel: View {
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
         var tabs = visibleSidebarTopTabs
-        if sidebarVisibility.developerEnabled {
+        if isDeveloperEnabled {
             tabs.append(.developer)
         }
         return tabs
     }
 
-    private var sidebarVisibility: SettingsTab.SidebarVisibility {
-        .init(
+    private var visibleSidebarTopTabs: [SettingsTab] {
+        SettingsTab.sidebarTopTabs(
             billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
-            developerEnabled: isDeveloperEnabled,
-            compactionPlaygroundEnabled: isCompactionPlaygroundEnabled,
-            devModeEnabled: DevModeManager.shared.isDevMode
+            includeCompactionPlayground: isCompactionPlaygroundVisible
         )
-    }
-
-    private var visibleSidebarTopTabs: [SettingsTab] {
-        SettingsTab.sidebarTopTabs(visibility: sidebarVisibility)
     }
 
     private var billingVisible: Bool {
@@ -436,7 +432,11 @@ struct SettingsPanel: View {
     }
 
     private var isCompactionPlaygroundVisible: Bool {
-        sidebarVisibility.showsCompactionPlayground
+        SettingsTab.isCompactionPlaygroundVisible(
+            developerEnabled: isDeveloperEnabled,
+            playgroundEnabled: isCompactionPlaygroundEnabled,
+            devModeEnabled: DevModeManager.shared.isDevMode
+        )
     }
 
     private var settingsNav: some View {
@@ -772,7 +772,7 @@ struct SettingsPanel: View {
                 if let soundsFlag = flags.first(where: { $0.key == Self.soundsFeatureFlagKey }) {
                     isSoundsEnabled = soundsFlag.enabled
                 }
-                reconcileSelectedTabVisibility()
+                finishFeatureFlagLoad()
                 return
             } catch {
                 // Fall through to local config fallback.
@@ -798,19 +798,26 @@ struct SettingsPanel: View {
         if let soundsEnabled = resolved[Self.soundsFeatureFlagKey] {
             isSoundsEnabled = soundsEnabled
         }
-        reconcileSelectedTabVisibility()
+        finishFeatureFlagLoad()
     }
 
-    private func reconcileSelectedTabVisibility() {
-        consumeDeferredDeepLinkIfVisible()
+    private func finishFeatureFlagLoad() {
+        reconcileSelectedTabVisibility(clearDeferredIfHidden: true)
+        hasLoadedFeatureFlags = true
+    }
+
+    private func reconcileSelectedTabVisibility(clearDeferredIfHidden: Bool = false) {
+        consumeDeferredDeepLinkIfVisible(clearIfHidden: clearDeferredIfHidden)
         ensureSelectedTabIsVisible()
     }
 
     /// If a feature-gated deep-linked tab becomes visible, navigate to it.
-    private func consumeDeferredDeepLinkIfVisible() {
+    private func consumeDeferredDeepLinkIfVisible(clearIfHidden: Bool = false) {
         guard let deferred = deferredDeepLinkTab else { return }
         if allVisibleTabs.contains(deferred) {
             selectVisibleTab(deferred)
+        } else if clearIfHidden {
+            deferredDeepLinkTab = nil
         }
     }
 

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -4,15 +4,20 @@ import XCTest
 final class SettingsPanelSidebarTests: XCTestCase {
 
     func testCompactionPlaygroundPositionFollowsVisibilityGate() {
-        let cases: [(visibility: SettingsTab.SidebarVisibility, expectedVisible: Bool)] = [
-            (.init(developerEnabled: true, compactionPlaygroundEnabled: true, devModeEnabled: true), true),
-            (.init(developerEnabled: true, compactionPlaygroundEnabled: false, devModeEnabled: true), false),
-            (.init(developerEnabled: false, compactionPlaygroundEnabled: true, devModeEnabled: true), false),
-            (.init(developerEnabled: true, compactionPlaygroundEnabled: true, devModeEnabled: false), false)
+        let cases: [(developerEnabled: Bool, playgroundEnabled: Bool, devModeEnabled: Bool, expectedVisible: Bool)] = [
+            (true, true, true, true),
+            (true, false, true, false),
+            (false, true, true, false),
+            (true, true, false, false)
         ]
 
         for testCase in cases {
-            let tabs = SettingsTab.sidebarTopTabs(visibility: testCase.visibility)
+            let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
+                developerEnabled: testCase.developerEnabled,
+                playgroundEnabled: testCase.playgroundEnabled,
+                devModeEnabled: testCase.devModeEnabled
+            )
+            let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
 
             XCTAssertEqual(tabs.contains(.compactionPlayground), testCase.expectedVisible)
             if testCase.expectedVisible {
@@ -25,9 +30,7 @@ final class SettingsPanelSidebarTests: XCTestCase {
     }
 
     func testDeveloperIsNotRenderedInTopSidebarGroup() {
-        let topTabs = SettingsTab.sidebarTopTabs(
-            visibility: .init(developerEnabled: true, compactionPlaygroundEnabled: true, devModeEnabled: true)
-        )
+        let topTabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: true)
 
         XCTAssertFalse(topTabs.contains(.developer))
     }

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -3,30 +3,18 @@ import XCTest
 
 final class SettingsPanelSidebarTests: XCTestCase {
 
-    func testCompactionPlaygroundPositionFollowsVisibilityGate() {
-        let cases: [(developerEnabled: Bool, playgroundEnabled: Bool, devModeEnabled: Bool, expectedVisible: Bool)] = [
-            (true, true, true, true),
-            (true, false, true, false),
-            (false, true, true, false),
-            (true, true, false, false)
-        ]
+    func testCompactionPlaygroundAppearsBeforeGeneralWhenIncluded() {
+        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: true)
 
-        for testCase in cases {
-            let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-                developerEnabled: testCase.developerEnabled,
-                playgroundEnabled: testCase.playgroundEnabled,
-                devModeEnabled: testCase.devModeEnabled
-            )
-            let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+        XCTAssertEqual(tabs.first, .compactionPlayground)
+        XCTAssertEqual(tabs.dropFirst().first, .general)
+    }
 
-            XCTAssertEqual(tabs.contains(.compactionPlayground), testCase.expectedVisible)
-            if testCase.expectedVisible {
-                XCTAssertEqual(tabs.first, .compactionPlayground)
-                XCTAssertEqual(tabs.dropFirst().first, .general)
-            } else {
-                XCTAssertEqual(tabs.first, .general)
-            }
-        }
+    func testCompactionPlaygroundIsOmittedWhenExcluded() {
+        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: false)
+
+        XCTAssertFalse(tabs.contains(.compactionPlayground))
+        XCTAssertEqual(tabs.first, .general)
     }
 
     func testDeveloperIsNotRenderedInTopSidebarGroup() {
@@ -35,10 +23,4 @@ final class SettingsPanelSidebarTests: XCTestCase {
         XCTAssertFalse(topTabs.contains(.developer))
     }
 
-    func testDeferredDeepLinksAreLimitedToAsyncGatedTabs() {
-        XCTAssertTrue(SettingsTab.canDeferDeepLink(.developer))
-        XCTAssertTrue(SettingsTab.canDeferDeepLink(.compactionPlayground))
-        XCTAssertFalse(SettingsTab.canDeferDeepLink(.billing))
-        XCTAssertFalse(SettingsTab.canDeferDeepLink(.sounds))
-    }
 }

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -4,16 +4,15 @@ import XCTest
 final class SettingsPanelSidebarTests: XCTestCase {
 
     func testCompactionPlaygroundPositionFollowsVisibilityGate() {
-        let cases: [(developerEnabled: Bool, playgroundEnabled: Bool, devModeEnabled: Bool, expectedVisible: Bool)] = [
-            (true, true, true, true),
-            (true, false, true, false),
-            (false, true, true, false),
-            (true, true, false, false)
+        let cases: [(visibility: SettingsTab.SidebarVisibility, expectedVisible: Bool)] = [
+            (.init(developerEnabled: true, compactionPlaygroundEnabled: true, devModeEnabled: true), true),
+            (.init(developerEnabled: true, compactionPlaygroundEnabled: false, devModeEnabled: true), false),
+            (.init(developerEnabled: false, compactionPlaygroundEnabled: true, devModeEnabled: true), false),
+            (.init(developerEnabled: true, compactionPlaygroundEnabled: true, devModeEnabled: false), false)
         ]
 
         for testCase in cases {
-            let includePlayground = testCase.developerEnabled && testCase.playgroundEnabled && testCase.devModeEnabled
-            let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+            let tabs = SettingsTab.sidebarTopTabs(visibility: testCase.visibility)
 
             XCTAssertEqual(tabs.contains(.compactionPlayground), testCase.expectedVisible)
             if testCase.expectedVisible {
@@ -26,7 +25,9 @@ final class SettingsPanelSidebarTests: XCTestCase {
     }
 
     func testDeveloperIsNotRenderedInTopSidebarGroup() {
-        let topTabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: true)
+        let topTabs = SettingsTab.sidebarTopTabs(
+            visibility: .init(developerEnabled: true, compactionPlaygroundEnabled: true, devModeEnabled: true)
+        )
 
         XCTAssertFalse(topTabs.contains(.developer))
     }

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class SettingsPanelSidebarTests: XCTestCase {
+
+    func testCompactionPlaygroundAppearsFirstInTopSidebarWhenAllGatesEnabled() {
+        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
+            developerEnabled: true,
+            playgroundEnabled: true,
+            devModeEnabled: true
+        )
+
+        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+
+        XCTAssertEqual(tabs.first, .compactionPlayground)
+        XCTAssertEqual(tabs.dropFirst().first, .general)
+    }
+
+    func testCompactionPlaygroundIsOmittedWhenFeatureFlagDisabled() {
+        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
+            developerEnabled: true,
+            playgroundEnabled: false,
+            devModeEnabled: true
+        )
+
+        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+
+        XCTAssertFalse(tabs.contains(.compactionPlayground))
+        XCTAssertEqual(tabs.first, .general)
+    }
+
+    func testCompactionPlaygroundIsOmittedWhenDeveloperNavDisabled() {
+        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
+            developerEnabled: false,
+            playgroundEnabled: true,
+            devModeEnabled: true
+        )
+
+        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+
+        XCTAssertFalse(tabs.contains(.compactionPlayground))
+    }
+
+    func testCompactionPlaygroundIsOmittedWhenDevModeDisabled() {
+        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
+            developerEnabled: true,
+            playgroundEnabled: true,
+            devModeEnabled: false
+        )
+
+        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+
+        XCTAssertFalse(tabs.contains(.compactionPlayground))
+    }
+
+    func testDeveloperRemainsInBottomSidebarGroup() {
+        let topTabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: true)
+        let bottomTabs = SettingsTab.sidebarBottomTabs(developerEnabled: true)
+
+        XCTAssertFalse(topTabs.contains(.developer))
+        XCTAssertEqual(bottomTabs, [.developer])
+        XCTAssertFalse(bottomTabs.contains(.compactionPlayground))
+    }
+}

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -53,12 +53,16 @@ final class SettingsPanelSidebarTests: XCTestCase {
         XCTAssertFalse(tabs.contains(.compactionPlayground))
     }
 
-    func testDeveloperRemainsInBottomSidebarGroup() {
+    func testDeveloperIsNotRenderedInTopSidebarGroup() {
         let topTabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: true)
-        let bottomTabs = SettingsTab.sidebarBottomTabs(developerEnabled: true)
 
         XCTAssertFalse(topTabs.contains(.developer))
-        XCTAssertEqual(bottomTabs, [.developer])
-        XCTAssertFalse(bottomTabs.contains(.compactionPlayground))
+    }
+
+    func testDeferredDeepLinksAreLimitedToAsyncGatedTabs() {
+        XCTAssertTrue(SettingsTab.canDeferDeepLink(.developer))
+        XCTAssertTrue(SettingsTab.canDeferDeepLink(.compactionPlayground))
+        XCTAssertFalse(SettingsTab.canDeferDeepLink(.billing))
+        XCTAssertFalse(SettingsTab.canDeferDeepLink(.sounds))
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsPanelSidebarTests.swift
@@ -3,54 +3,26 @@ import XCTest
 
 final class SettingsPanelSidebarTests: XCTestCase {
 
-    func testCompactionPlaygroundAppearsFirstInTopSidebarWhenAllGatesEnabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: true,
-            playgroundEnabled: true,
-            devModeEnabled: true
-        )
+    func testCompactionPlaygroundPositionFollowsVisibilityGate() {
+        let cases: [(developerEnabled: Bool, playgroundEnabled: Bool, devModeEnabled: Bool, expectedVisible: Bool)] = [
+            (true, true, true, true),
+            (true, false, true, false),
+            (false, true, true, false),
+            (true, true, false, false)
+        ]
 
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
+        for testCase in cases {
+            let includePlayground = testCase.developerEnabled && testCase.playgroundEnabled && testCase.devModeEnabled
+            let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
 
-        XCTAssertEqual(tabs.first, .compactionPlayground)
-        XCTAssertEqual(tabs.dropFirst().first, .general)
-    }
-
-    func testCompactionPlaygroundIsOmittedWhenFeatureFlagDisabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: true,
-            playgroundEnabled: false,
-            devModeEnabled: true
-        )
-
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
-
-        XCTAssertFalse(tabs.contains(.compactionPlayground))
-        XCTAssertEqual(tabs.first, .general)
-    }
-
-    func testCompactionPlaygroundIsOmittedWhenDeveloperNavDisabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: false,
-            playgroundEnabled: true,
-            devModeEnabled: true
-        )
-
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
-
-        XCTAssertFalse(tabs.contains(.compactionPlayground))
-    }
-
-    func testCompactionPlaygroundIsOmittedWhenDevModeDisabled() {
-        let includePlayground = SettingsTab.isCompactionPlaygroundVisible(
-            developerEnabled: true,
-            playgroundEnabled: true,
-            devModeEnabled: false
-        )
-
-        let tabs = SettingsTab.sidebarTopTabs(includeCompactionPlayground: includePlayground)
-
-        XCTAssertFalse(tabs.contains(.compactionPlayground))
+            XCTAssertEqual(tabs.contains(.compactionPlayground), testCase.expectedVisible)
+            if testCase.expectedVisible {
+                XCTAssertEqual(tabs.first, .compactionPlayground)
+                XCTAssertEqual(tabs.dropFirst().first, .general)
+            } else {
+                XCTAssertEqual(tabs.first, .general)
+            }
+        }
     }
 
     func testDeveloperIsNotRenderedInTopSidebarGroup() {


### PR DESCRIPTION
## Summary
Moves the macOS Settings "Compaction Playground" entry from the bottom-left auxiliary section into the top-left Settings navigation above General, while preserving the existing feature-flag and developer-mode gates. Developer remains in the bottom-left auxiliary area, and hidden/deferred Settings tabs now reconcile cleanly when feature flag or dev-mode visibility changes.

## Self-review result
PASS — self-review gaps were fixed across follow-up PRs before opening this final feature branch PR.

## PRs merged into feature branch
- #28854: Move Compaction Playground to the top of Settings navigation
- #28860: fix: address settings sidebar self-review gaps
- #28866: fix: clean up settings sidebar helpers
- #28867: fix: clarify settings sidebar visibility reconciliation
- #28868: fix: make settings deep links one-shot after flag load
- #28871: fix: simplify settings sidebar navigation state
- #28875: fix: dedupe settings feature flag reconciliation

## Validation
- CI passed on each implementation/fix PR merged into the feature branch.
- `git diff --check` passed during the final fix rounds.
- Local `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsPanelSidebarTests` was blocked by existing Swift override errors outside this change (`SwiftMath/.../MTMathList.swift` and occasionally `clients/shared/DesignSystem/.../VMenuPanel.swift`) before the targeted Settings tests executed.

Part of plan: move-compaction-playground-nav.md

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
