### PR TITLE
Forward call-site and profile metadata through managed inference requests

### DIFF
--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -8,6 +8,8 @@ import { credentialKey } from "../security/credential-key.js";
 // assertions. Must be before importing the registry.
 // ---------------------------------------------------------------------------
 let lastGeminiConstructorOpts: Record<string, unknown> | null = null;
+let lastGeminiGenerateContentStreamParams: Record<string, unknown> | null =
+  null;
 
 mock.module("@google/genai", () => ({
   GoogleGenAI: class MockGoogleGenAI {
@@ -15,11 +17,14 @@ mock.module("@google/genai", () => ({
       lastGeminiConstructorOpts = opts;
     }
     models = {
-      generateContentStream: async () => ({
-        [Symbol.asyncIterator]: async function* () {
-          /* no chunks */
-        },
-      }),
+      generateContentStream: async (params: Record<string, unknown>) => {
+        lastGeminiGenerateContentStreamParams = params;
+        return {
+          [Symbol.asyncIterator]: async function* () {
+            /* no chunks */
+          },
+        };
+      },
     };
   },
   ApiError: class FakeApiError extends Error {
@@ -40,6 +45,7 @@ mock.module("@google/genai", () => ({
 let mockPlatformBaseUrl = "";
 let mockAssistantApiKey: string | null = null;
 let mockProviderKeys: Record<string, string> = {};
+let mockLlmConfig: Record<string, unknown> = {};
 
 mock.module("../config/env.js", () => ({
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
@@ -54,6 +60,14 @@ mock.module("../security/secure-keys.js", () => ({
   },
 }));
 
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    llm: mockLlmConfig,
+    services: { inference: { mode: "your-own" } },
+  }),
+}));
+
+import { LLMSchema } from "../config/schemas/llm.js";
 import type { ProvidersConfig } from "../providers/registry.js";
 import {
   getProvider,
@@ -121,6 +135,8 @@ beforeEach(() => {
   disableManagedProxy();
   mockProviderKeys = {};
   lastGeminiConstructorOpts = null;
+  lastGeminiGenerateContentStreamParams = null;
+  mockLlmConfig = LLMSchema.parse({}) as Record<string, unknown>;
 });
 
 describe("managed proxy integration — credential precedence", () => {
@@ -238,6 +254,86 @@ describe("managed proxy integration — credential precedence", () => {
         | undefined;
       expect(httpOptions).toBeDefined();
       expect(httpOptions!.baseUrl).toContain("/v1/runtime-proxy/gemini");
+    });
+
+    test("managed gemini receives attribution headers outside request JSON", async () => {
+      enableManagedProxy();
+      mockProviderKeys = {};
+      mockLlmConfig = LLMSchema.parse({
+        default: { provider: "gemini", model: "gemini-3.1-pro" },
+        profiles: {
+          "conversation-profile": {
+            model: "gemini-3.1-flash",
+            source: "user",
+          },
+        },
+        callSites: {
+          mainAgent: {},
+        },
+      }) as Record<string, unknown>;
+      await initializeProviders(makeProvidersConfig("gemini", "gemini-3.1-pro"));
+
+      const provider = getProvider("gemini");
+      const response = await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+        undefined,
+        undefined,
+        {
+          config: {
+            callSite: "mainAgent",
+            overrideProfile: "conversation-profile",
+          },
+        },
+      );
+
+      const constructorHttpOptions = lastGeminiConstructorOpts!.httpOptions as
+        | { baseUrl?: string }
+        | undefined;
+      expect(constructorHttpOptions?.baseUrl).toContain(
+        "/v1/runtime-proxy/gemini",
+      );
+      const sentConfig = lastGeminiGenerateContentStreamParams!.config as {
+        httpOptions?: { headers?: Record<string, string> };
+        usageAttributionHeaders?: Record<string, string>;
+      };
+      expect(sentConfig.httpOptions?.headers).toEqual({
+        "X-Vellum-LLM-Call-Site": "mainAgent",
+        "X-Vellum-Inference-Profile": "conversation-profile",
+        "X-Vellum-Inference-Profile-Source": "conversation",
+        "X-Vellum-Resolved-Provider": "gemini",
+        "X-Vellum-Resolved-Model": "gemini-3.1-flash",
+      });
+      expect(sentConfig.usageAttributionHeaders).toBeUndefined();
+
+      const rawRequest = response.rawRequest as {
+        config?: Record<string, unknown>;
+      };
+      expect(rawRequest.config?.usageAttributionHeaders).toBeUndefined();
+      expect(rawRequest.config?.httpOptions).toBeUndefined();
+    });
+
+    test("managed gemini omits attribution headers without callSite", async () => {
+      enableManagedProxy();
+      mockProviderKeys = {};
+      mockLlmConfig = LLMSchema.parse({
+        default: { provider: "gemini", model: "gemini-3.1-pro" },
+      }) as Record<string, unknown>;
+      await initializeProviders(makeProvidersConfig("gemini", "gemini-3.1-pro"));
+
+      const provider = getProvider("gemini");
+      await provider.sendMessage(
+        [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+        undefined,
+        undefined,
+        { config: { model: "gemini-3.1-pro" } },
+      );
+
+      const sentConfig = lastGeminiGenerateContentStreamParams!.config as {
+        httpOptions?: { headers?: Record<string, string> };
+        usageAttributionHeaders?: Record<string, string>;
+      };
+      expect(sentConfig.httpOptions?.headers).toBeUndefined();
+      expect(sentConfig.usageAttributionHeaders).toBeUndefined();
     });
   });
 

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -122,6 +122,54 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.modelIntent).toBeUndefined();
   });
 
+  test("attaches sanitized stable attribution headers when callSite is supplied", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-default",
+      },
+      profiles: {
+        "conversation-profile": {
+          model: "claude-profile",
+          source: "user",
+        },
+      },
+      callSites: {
+        memoryRetrieval: {
+          provider: "openai",
+        },
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openai", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: {
+        callSite: "memoryRetrieval",
+        overrideProfile: "conversation-profile",
+      },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.usageAttributionHeaders).toEqual({
+      "X-Vellum-LLM-Call-Site": "memoryRetrieval",
+      "X-Vellum-Inference-Profile": "conversation-profile",
+      "X-Vellum-Inference-Profile-Source": "conversation",
+      "X-Vellum-Resolved-Provider": "openai",
+      "X-Vellum-Resolved-Model": "claude-profile",
+    });
+    expect(
+      (config.usageAttributionHeaders as Record<string, string>)[
+        "X-Vellum-LLM-Call-Site-Label"
+      ],
+    ).toBeUndefined();
+  });
+
   test("falls back to llm.default when llm.callSites[id] is absent", async () => {
     setLlmConfig({
       default: {
@@ -385,6 +433,32 @@ describe("RetryProvider — no callSite (pre-resolved config passes through)", (
     expect(config.max_tokens).toBe(1234);
     expect(config.model).not.toBe("MUST-NOT-LEAK");
     expect(config.model).not.toBe("ALSO-MUST-NOT-LEAK");
+  });
+
+  test("does not forward caller-supplied attribution headers without callSite", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "MUST-NOT-LEAK" },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: {
+        model: "explicit-model",
+        usageAttributionHeaders: {
+          "X-Vellum-LLM-Call-Site": "injected",
+        },
+      },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.model).toBe("explicit-model");
+    expect(config.usageAttributionHeaders).toBeUndefined();
   });
 });
 

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -200,6 +200,39 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.callSite).toBeUndefined();
   });
 
+  test("omits profile source attribution header when no profile is applied", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openai",
+        model: "gpt-default",
+      },
+      callSites: {
+        memoryRetrieval: {
+          provider: "openai",
+        },
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openai", (options) => {
+        seen = options;
+      }),
+      { forwardUsageAttributionHeaders: true },
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "memoryRetrieval" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.usageAttributionHeaders).toEqual({
+      "X-Vellum-LLM-Call-Site": "memoryRetrieval",
+      "X-Vellum-Resolved-Provider": "openai",
+      "X-Vellum-Resolved-Model": "gpt-default",
+    });
+  });
+
   test("falls back to llm.default when llm.callSites[id] is absent", async () => {
     setLlmConfig({
       default: {

--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -122,7 +122,7 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.modelIntent).toBeUndefined();
   });
 
-  test("attaches sanitized stable attribution headers when callSite is supplied", async () => {
+  test("attaches sanitized stable attribution headers only when enabled", async () => {
     setLlmConfig({
       default: {
         provider: "anthropic",
@@ -146,6 +146,7 @@ describe("RetryProvider — callSite resolution", () => {
       makeProvider("openai", (options) => {
         seen = options;
       }),
+      { forwardUsageAttributionHeaders: true },
     );
 
     await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
@@ -168,6 +169,35 @@ describe("RetryProvider — callSite resolution", () => {
         "X-Vellum-LLM-Call-Site-Label"
       ],
     ).toBeUndefined();
+  });
+
+  test("omits attribution headers by default for direct provider transports", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openai",
+        model: "gpt-default",
+      },
+      callSites: {
+        memoryRetrieval: {
+          provider: "openai",
+        },
+      },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openai", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "memoryRetrieval" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.usageAttributionHeaders).toBeUndefined();
+    expect(config.callSite).toBeUndefined();
   });
 
   test("falls back to llm.default when llm.callSites[id] is absent", async () => {

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -866,6 +866,7 @@ export class AnthropicProvider implements Provider {
         output_config,
         cacheTtl: _cacheTtl,
         max_tokens: callerMaxTokens,
+        usageAttributionHeaders,
         ...restConfig
       } = (config ?? {}) as Record<string, unknown> & {
         // "xhigh" is an intermediate tier between "high" and "max" supported
@@ -877,6 +878,7 @@ export class AnthropicProvider implements Provider {
         effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
         speed?: "standard" | "fast";
         output_config?: Record<string, unknown>;
+        usageAttributionHeaders?: Record<string, string>;
       };
       // Haiku does not support the effort / output_config parameter,
       // extended cache TTL betas, 1M context, or 64K output tokens.
@@ -1140,7 +1142,12 @@ export class AnthropicProvider implements Provider {
                 betas,
               } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
                 Anthropic.Beta.Messages.MessageCreateParamsStreaming,
-              { signal: timeoutSignal },
+              {
+                signal: timeoutSignal,
+                ...(usageAttributionHeaders
+                  ? { headers: usageAttributionHeaders }
+                  : {}),
+              },
             ) as unknown as UnifiedStream)
           : betas.length > 0
             ? (this.client.beta.messages.stream(
@@ -1149,10 +1156,18 @@ export class AnthropicProvider implements Provider {
                   betas,
                 } as Anthropic.Beta.Messages.MessageCreateParamsNonStreaming &
                   Anthropic.Beta.Messages.MessageCreateParamsStreaming,
-                { signal: timeoutSignal },
+                {
+                  signal: timeoutSignal,
+                  ...(usageAttributionHeaders
+                    ? { headers: usageAttributionHeaders }
+                    : {}),
+                },
               ) as unknown as UnifiedStream)
             : (this.client.messages.stream(params, {
                 signal: timeoutSignal,
+                ...(usageAttributionHeaders
+                  ? { headers: usageAttributionHeaders }
+                  : {}),
               }) as unknown as UnifiedStream);
 
         // Buffer streaming text until it's clear the accumulated text isn't

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -207,11 +207,7 @@ export class GeminiProvider implements Provider {
         createStreamTimeout(this.streamTimeoutMs, signal);
       geminiConfig.abortSignal = timeoutSignal;
       if (usageAttributionHeaders) {
-        (
-          geminiConfig as genai.GenerateContentConfig & {
-            httpOptions?: { headers?: Record<string, string> };
-          }
-        ).httpOptions = { headers: usageAttributionHeaders };
+        geminiConfig.httpOptions = { headers: usageAttributionHeaders };
       }
 
       // Accumulate from streaming chunks

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -34,6 +34,16 @@ function isGemini3Model(model: string): boolean {
   return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
 }
 
+function stripGeminiHttpOptions(
+  config: genai.GenerateContentConfig,
+): genai.GenerateContentConfig {
+  const { httpOptions: _httpOptions, ...rest } =
+    config as genai.GenerateContentConfig & {
+      httpOptions?: unknown;
+    };
+  return rest;
+}
+
 /**
  * Detect Gemini's context-overflow signals on an `ApiError`. Gemini surfaces
  * this condition via its "RESOURCE_EXHAUSTED" category. The Gemini SDK's
@@ -162,6 +172,9 @@ export class GeminiProvider implements Provider {
     const configObj = config as Record<string, unknown> | undefined;
     const maxTokens = configObj?.max_tokens as number | undefined;
     const modelOverride = configObj?.model as string | undefined;
+    const usageAttributionHeaders = configObj?.usageAttributionHeaders as
+      | Record<string, string>
+      | undefined;
     const activeModel = modelOverride ?? this.model;
 
     try {
@@ -193,6 +206,13 @@ export class GeminiProvider implements Provider {
       const { signal: timeoutSignal, cleanup: cleanupTimeout } =
         createStreamTimeout(this.streamTimeoutMs, signal);
       geminiConfig.abortSignal = timeoutSignal;
+      if (usageAttributionHeaders) {
+        (
+          geminiConfig as genai.GenerateContentConfig & {
+            httpOptions?: { headers?: Record<string, string> };
+          }
+        ).httpOptions = { headers: usageAttributionHeaders };
+      }
 
       // Accumulate from streaming chunks
       let fullText = "";
@@ -296,7 +316,7 @@ export class GeminiProvider implements Provider {
       const rawRequest = {
         model: activeModel,
         contents: geminiContents,
-        config: geminiConfig,
+        config: stripGeminiHttpOptions(geminiConfig),
       };
       const rawResponse = {
         model: responseModel,

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -139,6 +139,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const maxTokens = configObj?.max_tokens as number | undefined;
     const modelOverride = configObj?.model as string | undefined;
     const effort = configObj?.effort as string | undefined;
+    const usageAttributionHeaders = configObj?.usageAttributionHeaders as
+      | Record<string, string>
+      | undefined;
 
     try {
       const openaiMessages = this.toOpenAIMessages(messages, systemPrompt);
@@ -196,6 +199,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
       try {
         const stream = await this.client.chat.completions.create(params, {
           signal: timeoutSignal,
+          ...(usageAttributionHeaders
+            ? { headers: usageAttributionHeaders }
+            : {}),
         });
 
         for await (const chunk of stream) {

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -130,6 +130,9 @@ export class OpenAIResponsesProvider implements Provider {
     const modelOverride = configObj?.model as string | undefined;
     const effort = configObj?.effort as string | undefined;
     const verbosity = configObj?.verbosity as string | undefined;
+    const usageAttributionHeaders = configObj?.usageAttributionHeaders as
+      | Record<string, string>
+      | undefined;
 
     try {
       const input = this.toResponsesInput(messages);
@@ -222,11 +225,14 @@ export class OpenAIResponsesProvider implements Provider {
         const responsesApi = this.client.responses as unknown as {
           stream(
             p: Record<string, unknown>,
-            o: { signal: AbortSignal },
+            o: { signal: AbortSignal; headers?: Record<string, string> },
           ): AsyncIterable<ResponsesStreamEvent>;
         };
         const stream = responsesApi.stream(params, {
           signal: timeoutSignal,
+          ...(usageAttributionHeaders
+            ? { headers: usageAttributionHeaders }
+            : {}),
         });
 
         for await (const event of stream) {

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -163,6 +163,10 @@ export async function initializeProviders(
             ? { baseURL: anthropicCreds.baseURL }
             : {}),
         }),
+        {
+          forwardUsageAttributionHeaders:
+            anthropicCreds.source === "managed-proxy",
+        },
       ),
     );
     routingSources.set("anthropic", anthropicCreds.source);
@@ -180,6 +184,10 @@ export async function initializeProviders(
           streamTimeoutMs,
           ...(openaiCreds.baseURL ? { baseURL: openaiCreds.baseURL } : {}),
         }),
+        {
+          forwardUsageAttributionHeaders:
+            openaiCreds.source === "managed-proxy",
+        },
       ),
     );
     routingSources.set("openai", openaiCreds.source);
@@ -198,6 +206,10 @@ export async function initializeProviders(
             ? { managedBaseUrl: geminiCreds.baseURL }
             : {}),
         }),
+        {
+          forwardUsageAttributionHeaders:
+            geminiCreds.source === "managed-proxy",
+        },
       ),
     );
     routingSources.set("gemini", geminiCreds.source);

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,5 +1,9 @@
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
+import {
+  resolveUsageAttribution,
+  sanitizeUsageMetadataValue,
+} from "../usage/attribution.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -23,6 +27,14 @@ import {
 } from "./types.js";
 
 const log = getLogger("retry");
+
+const USAGE_ATTRIBUTION_HEADER_NAMES = {
+  callSite: "X-Vellum-LLM-Call-Site",
+  inferenceProfile: "X-Vellum-Inference-Profile",
+  inferenceProfileSource: "X-Vellum-Inference-Profile-Source",
+  resolvedProvider: "X-Vellum-Resolved-Provider",
+  resolvedModel: "X-Vellum-Resolved-Model",
+} as const;
 
 /** Providers that support the `effort` config (extended thinking / reasoning). */
 const EFFORT_SUPPORTED_PROVIDERS = new Set([
@@ -124,6 +136,10 @@ function normalizeSendMessageOptions(
 
   const nextConfig: Record<string, unknown> = { ...config };
 
+  // Internal metadata must be derived here, not accepted from callers, and it
+  // must never leak into provider JSON request bodies.
+  delete nextConfig.usageAttributionHeaders;
+
   // `overrideProfile` is a routing/resolution-time concern (consumed by the
   // resolver below and `CallSiteRoutingProvider`'s provider selection); it is
   // not a wire-format field. Strip unconditionally so it never leaks into
@@ -132,6 +148,10 @@ function normalizeSendMessageOptions(
 
   if (config.callSite !== undefined) {
     const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {
+      overrideProfile: config.overrideProfile,
+    });
+    const attribution = resolveUsageAttribution({
+      callSite: config.callSite,
       overrideProfile: config.overrideProfile,
     });
 
@@ -143,6 +163,16 @@ function normalizeSendMessageOptions(
     // Routing key is consumed by the resolver above and must not leak
     // downstream as a wire-format field.
     delete nextConfig.callSite;
+    const usageAttributionHeaders = buildUsageAttributionHeaders({
+      callSite: attribution.callSite,
+      appliedProfile: attribution.appliedProfile,
+      profileSource: attribution.profileSource,
+      resolvedProvider: attribution.resolvedProvider,
+      resolvedModel: attribution.resolvedModel,
+    });
+    if (Object.keys(usageAttributionHeaders).length > 0) {
+      nextConfig.usageAttributionHeaders = usageAttributionHeaders;
+    }
 
     // Apply resolved values, letting per-call explicit fields win where set.
     nextConfig.model = explicitModel ?? resolved.model;
@@ -272,6 +302,53 @@ function normalizeSendMessageOptions(
     ...options,
     config: nextConfig,
   };
+}
+
+function buildUsageAttributionHeaders(input: {
+  callSite: string | null;
+  appliedProfile: string | null;
+  profileSource: string;
+  resolvedProvider: string;
+  resolvedModel: string;
+}): Record<string, string> {
+  const headers: Record<string, string> = {};
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.callSite,
+    input.callSite,
+  );
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.inferenceProfile,
+    input.appliedProfile,
+  );
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.inferenceProfileSource,
+    input.profileSource,
+  );
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.resolvedProvider,
+    input.resolvedProvider,
+  );
+  addSanitizedHeader(
+    headers,
+    USAGE_ATTRIBUTION_HEADER_NAMES.resolvedModel,
+    input.resolvedModel,
+  );
+  return headers;
+}
+
+function addSanitizedHeader(
+  headers: Record<string, string>,
+  name: string,
+  value: unknown,
+): void {
+  const sanitized = sanitizeUsageMetadataValue(value);
+  if (sanitized != null) {
+    headers[name] = sanitized;
+  }
 }
 
 /**

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -325,11 +325,13 @@ function buildUsageAttributionHeaders(input: {
     USAGE_ATTRIBUTION_HEADER_NAMES.inferenceProfile,
     input.appliedProfile,
   );
-  addSanitizedHeader(
-    headers,
-    USAGE_ATTRIBUTION_HEADER_NAMES.inferenceProfileSource,
-    input.profileSource,
-  );
+  if (input.appliedProfile) {
+    addSanitizedHeader(
+      headers,
+      USAGE_ATTRIBUTION_HEADER_NAMES.inferenceProfileSource,
+      input.profileSource,
+    );
+  }
   addSanitizedHeader(
     headers,
     USAGE_ATTRIBUTION_HEADER_NAMES.resolvedProvider,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -130,6 +130,7 @@ function isRetryableError(error: unknown): boolean {
 function normalizeSendMessageOptions(
   providerName: string,
   options?: SendMessageOptions,
+  normalizeOptions: { forwardUsageAttributionHeaders?: boolean } = {},
 ): SendMessageOptions | undefined {
   const config = options?.config;
   if (!config) return options;
@@ -163,15 +164,17 @@ function normalizeSendMessageOptions(
     // Routing key is consumed by the resolver above and must not leak
     // downstream as a wire-format field.
     delete nextConfig.callSite;
-    const usageAttributionHeaders = buildUsageAttributionHeaders({
-      callSite: attribution.callSite,
-      appliedProfile: attribution.appliedProfile,
-      profileSource: attribution.profileSource,
-      resolvedProvider: attribution.resolvedProvider,
-      resolvedModel: attribution.resolvedModel,
-    });
-    if (Object.keys(usageAttributionHeaders).length > 0) {
-      nextConfig.usageAttributionHeaders = usageAttributionHeaders;
+    if (normalizeOptions.forwardUsageAttributionHeaders === true) {
+      const usageAttributionHeaders = buildUsageAttributionHeaders({
+        callSite: attribution.callSite,
+        appliedProfile: attribution.appliedProfile,
+        profileSource: attribution.profileSource,
+        resolvedProvider: attribution.resolvedProvider,
+        resolvedModel: attribution.resolvedModel,
+      });
+      if (Object.keys(usageAttributionHeaders).length > 0) {
+        nextConfig.usageAttributionHeaders = usageAttributionHeaders;
+      }
     }
 
     // Apply resolved values, letting per-call explicit fields win where set.
@@ -366,7 +369,10 @@ export class RetryProvider implements Provider {
     return this.inner.tokenEstimationProvider;
   }
 
-  constructor(private readonly inner: Provider) {
+  constructor(
+    private readonly inner: Provider,
+    private readonly options: { forwardUsageAttributionHeaders?: boolean } = {},
+  ) {
     this.name = inner.name;
   }
 
@@ -379,7 +385,10 @@ export class RetryProvider implements Provider {
     let lastError: unknown;
     let didRetry = false;
 
-    const normalizedOptions = normalizeSendMessageOptions(this.name, options);
+    const normalizedOptions = normalizeSendMessageOptions(this.name, options, {
+      forwardUsageAttributionHeaders:
+        this.options.forwardUsageAttributionHeaders === true,
+    });
 
     for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
       try {

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -156,6 +156,12 @@ export interface SendMessageConfig {
    * silently fall through.
    */
   overrideProfile?: string;
+  /**
+   * Internal per-request HTTP headers for usage attribution. Provider clients
+   * may pass these through SDK request options, but must never include this
+   * object in provider JSON request bodies.
+   */
+  usageAttributionHeaders?: Record<string, string>;
   effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
   speed?: "standard" | "fast";
   verbosity?: "low" | "medium" | "high";

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -157,9 +157,10 @@ export interface SendMessageConfig {
    */
   overrideProfile?: string;
   /**
-   * Internal per-request HTTP headers for usage attribution. Provider clients
-   * may pass these through SDK request options, but must never include this
-   * object in provider JSON request bodies.
+   * Internal per-request HTTP headers for managed-proxy usage attribution.
+   * Provider clients may pass these through SDK request options only when the
+   * transport is Vellum-managed, and must never include this object in provider
+   * JSON request bodies.
    */
   usageAttributionHeaders?: Record<string, string>;
   effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";


### PR DESCRIPTION
## Summary
- Resolves and attaches sanitized usage attribution headers in provider retry normalization.
- Threads attribution headers through provider transports without leaking them into request JSON.
- Adds managed proxy and retry coverage for header behavior.

Part of plan: per-task-usage-attribution.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
