### PR TITLE
JARVIS-643: Add durable Slack compaction watermark metadata

### DIFF
--- a/assistant/src/__tests__/db-slack-compaction-watermark-migration.test.ts
+++ b/assistant/src/__tests__/db-slack-compaction-watermark-migration.test.ts
@@ -1,0 +1,169 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../memory/db-connection.js";
+import {
+  downSlackCompactionWatermark,
+  migrateSlackCompactionWatermark,
+} from "../memory/migrations/235-slack-compaction-watermark.js";
+import * as schema from "../memory/schema.js";
+
+interface ColumnRow {
+  name: string;
+  type: string;
+  notnull: number;
+}
+
+interface ConversationCompactionRow {
+  id: string;
+  context_summary: string | null;
+  context_compacted_message_count: number;
+  context_compacted_at: number | null;
+  slack_context_compaction_watermark_ts: string | null;
+  slack_context_compaction_watermark_at: number | null;
+}
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec("PRAGMA foreign_keys = ON");
+  return drizzle(sqlite, { schema });
+}
+
+function bootstrapCheckpointsTable(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS memory_checkpoints (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+}
+
+function bootstrapLegacyConversations(raw: Database): void {
+  raw.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      context_summary TEXT,
+      context_compacted_message_count INTEGER NOT NULL DEFAULT 0,
+      context_compacted_at INTEGER
+    )
+  `);
+}
+
+function getConversationColumns(raw: Database): Map<string, ColumnRow> {
+  const columns = raw
+    .query(`PRAGMA table_info(conversations)`)
+    .all() as ColumnRow[];
+  return new Map(columns.map((column) => [column.name, column]));
+}
+
+describe("migrateSlackCompactionWatermark", () => {
+  test("adds nullable Slack watermark columns and preserves existing compaction state", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapLegacyConversations(raw);
+
+    raw
+      .query(
+        /*sql*/ `
+          INSERT INTO conversations (
+            id,
+            title,
+            created_at,
+            updated_at,
+            context_summary,
+            context_compacted_message_count,
+            context_compacted_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .run(
+        "conv-1",
+        "legacy slack thread",
+        1000,
+        2000,
+        "existing compacted summary",
+        42,
+        3000,
+      );
+
+    migrateSlackCompactionWatermark(db);
+
+    const columns = getConversationColumns(raw);
+    expect(columns.get("slack_context_compaction_watermark_ts")).toMatchObject({
+      type: "TEXT",
+      notnull: 0,
+    });
+    expect(columns.get("slack_context_compaction_watermark_at")).toMatchObject({
+      type: "INTEGER",
+      notnull: 0,
+    });
+
+    const row = raw
+      .query(
+        /*sql*/ `
+          SELECT
+            id,
+            context_summary,
+            context_compacted_message_count,
+            context_compacted_at,
+            slack_context_compaction_watermark_ts,
+            slack_context_compaction_watermark_at
+          FROM conversations
+          WHERE id = ?
+        `,
+      )
+      .get("conv-1") as ConversationCompactionRow | null;
+
+    expect(row).toEqual({
+      id: "conv-1",
+      context_summary: "existing compacted summary",
+      context_compacted_message_count: 42,
+      context_compacted_at: 3000,
+      slack_context_compaction_watermark_ts: null,
+      slack_context_compaction_watermark_at: null,
+    });
+  });
+
+  test("is idempotent when columns already exist", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapLegacyConversations(raw);
+    raw.exec(
+      `ALTER TABLE conversations ADD COLUMN slack_context_compaction_watermark_ts TEXT`,
+    );
+    raw.exec(
+      `ALTER TABLE conversations ADD COLUMN slack_context_compaction_watermark_at INTEGER`,
+    );
+
+    expect(() => migrateSlackCompactionWatermark(db)).not.toThrow();
+
+    const columns = getConversationColumns(raw);
+    expect(columns.has("slack_context_compaction_watermark_ts")).toBe(true);
+    expect(columns.has("slack_context_compaction_watermark_at")).toBe(true);
+  });
+
+  test("down migration drops Slack watermark columns and is idempotent", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    bootstrapCheckpointsTable(raw);
+    bootstrapLegacyConversations(raw);
+
+    migrateSlackCompactionWatermark(db);
+
+    downSlackCompactionWatermark(db);
+    expect(() => downSlackCompactionWatermark(db)).not.toThrow();
+
+    const columns = getConversationColumns(raw);
+    expect(columns.has("slack_context_compaction_watermark_ts")).toBe(false);
+    expect(columns.has("slack_context_compaction_watermark_at")).toBe(false);
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -174,6 +174,8 @@ export interface ConversationRow {
   contextSummary: string | null;
   contextCompactedMessageCount: number;
   contextCompactedAt: number | null;
+  slackContextCompactionWatermarkTs: string | null;
+  slackContextCompactionWatermarkAt: number | null;
   conversationType: string;
   source: string;
   memoryScopeId: string;
@@ -202,6 +204,8 @@ export const parseConversation = createRowMapper<
   contextSummary: "contextSummary",
   contextCompactedMessageCount: "contextCompactedMessageCount",
   contextCompactedAt: "contextCompactedAt",
+  slackContextCompactionWatermarkTs: "slackContextCompactionWatermarkTs",
+  slackContextCompactionWatermarkAt: "slackContextCompactionWatermarkAt",
   conversationType: "conversationType",
   source: "source",
   memoryScopeId: "memoryScopeId",
@@ -225,10 +229,7 @@ export interface MessageRow {
   metadata: string | null;
 }
 
-const parseMessage = createRowMapper<
-  typeof messages.$inferSelect,
-  MessageRow
->({
+const parseMessage = createRowMapper<typeof messages.$inferSelect, MessageRow>({
   id: "id",
   conversationId: "conversationId",
   role: "role",
@@ -295,6 +296,8 @@ export function createConversation(
     contextSummary: null as string | null,
     contextCompactedMessageCount: 0,
     contextCompactedAt: null as number | null,
+    slackContextCompactionWatermarkTs: null as string | null,
+    slackContextCompactionWatermarkAt: null as number | null,
     conversationType,
     source,
     memoryScopeId,
@@ -541,6 +544,12 @@ export function forkConversation(params: {
           : 0,
         contextCompactedAt: preserveSourceCompactionState
           ? sourceConversation.contextCompactedAt
+          : null,
+        slackContextCompactionWatermarkTs: preserveSourceCompactionState
+          ? sourceConversation.slackContextCompactionWatermarkTs
+          : null,
+        slackContextCompactionWatermarkAt: preserveSourceCompactionState
+          ? sourceConversation.slackContextCompactionWatermarkAt
           : null,
         inferenceProfile: sourceConversation.inferenceProfile,
       })
@@ -1174,6 +1183,22 @@ export function updateConversationContextWindow(
       contextSummary,
       contextCompactedMessageCount,
       contextCompactedAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    .where(eq(conversations.id, id))
+    .run();
+}
+
+export function updateConversationSlackContextWatermark(
+  id: string,
+  watermarkTs: string,
+  compactedAt: number = Date.now(),
+): void {
+  const db = getDb();
+  db.update(conversations)
+    .set({
+      slackContextCompactionWatermarkTs: watermarkTs,
+      slackContextCompactionWatermarkAt: compactedAt,
       updatedAt: Date.now(),
     })
     .where(eq(conversations.id, id))

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -157,6 +157,7 @@ import {
   migrateScheduleWakeConversationId,
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
+  migrateSlackCompactionWatermark,
   migrateStripIntegrationPrefixFromProviderKeys,
   migrateStripPlaceholderSentinelsFromMessages,
   migrateStripThinkingFromConsolidated,
@@ -395,6 +396,7 @@ export function initializeDb(): void {
     migrateActivationState,
     migrateMemoryV2ActivationLogs,
     migrateCreateDocumentConversations,
+    migrateSlackCompactionWatermark,
     function migrateBackfillAppConversationIds() {
       backfillAppConversationIds();
     },

--- a/assistant/src/memory/migrations/235-slack-compaction-watermark.ts
+++ b/assistant/src/memory/migrations/235-slack-compaction-watermark.ts
@@ -1,0 +1,44 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_slack_compaction_watermark_v1";
+
+const COLUMNS = [
+  {
+    name: "slack_context_compaction_watermark_ts",
+    definition: "slack_context_compaction_watermark_ts TEXT",
+  },
+  {
+    name: "slack_context_compaction_watermark_at",
+    definition: "slack_context_compaction_watermark_at INTEGER",
+  },
+] as const;
+
+/**
+ * Add Slack-specific compaction state to conversations.
+ *
+ * The existing context_compacted_message_count remains the generic DB-row
+ * compaction boundary. Slack threads need a source timestamp watermark because
+ * late thread mentions can arrive with historical Slack ts values independent
+ * of local insertion order.
+ */
+export function migrateSlackCompactionWatermark(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    for (const column of COLUMNS) {
+      if (tableHasColumn(database, "conversations", column.name)) {
+        continue;
+      }
+      database.run(`ALTER TABLE conversations ADD COLUMN ${column.definition}`);
+    }
+  });
+}
+
+export function downSlackCompactionWatermark(database: DrizzleDb): void {
+  for (const column of COLUMNS) {
+    if (!tableHasColumn(database, "conversations", column.name)) {
+      continue;
+    }
+    database.run(`ALTER TABLE conversations DROP COLUMN ${column.name}`);
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -187,6 +187,10 @@ export {
   migrateMemoryV2ActivationLogs,
 } from "./234-memory-v2-activation-logs.js";
 export {
+  downSlackCompactionWatermark,
+  migrateSlackCompactionWatermark,
+} from "./235-slack-compaction-watermark.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -45,6 +45,7 @@ import { downConversationHostAccess } from "./217-conversation-host-access.js";
 import { downNormalizeUserFileByPrincipal } from "./220-normalize-user-file-by-principal.js";
 import { downActivationState } from "./232-activation-state.js";
 import { downMemoryV2ActivationLogs } from "./234-memory-v2-activation-logs.js";
+import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -387,6 +388,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Create memory_v2_activation_logs table for per-turn v2 activation telemetry consumed by the LLM Context Inspector",
     down: downMemoryV2ActivationLogs,
+  },
+  {
+    key: "migration_slack_compaction_watermark_v1",
+    version: 45,
+    description:
+      "Add Slack-specific compaction watermark columns to conversations",
+    down: downSlackCompactionWatermark,
   },
 ];
 

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -21,6 +21,12 @@ export const conversations = sqliteTable(
       .notNull()
       .default(0),
     contextCompactedAt: integer("context_compacted_at"),
+    slackContextCompactionWatermarkTs: text(
+      "slack_context_compaction_watermark_ts",
+    ),
+    slackContextCompactionWatermarkAt: integer(
+      "slack_context_compaction_watermark_at",
+    ),
     conversationType: text("conversation_type").notNull().default("standard"),
     source: text("source").notNull().default("user"),
     memoryScopeId: text("memory_scope_id").notNull().default("default"),


### PR DESCRIPTION
## Summary
- Add nullable Slack compaction watermark columns and migration
- Expose conversation parsing/update helpers for Slack watermark state
- Cover migration behavior for existing conversations

Part of JARVIS-643
Part of plan: jarvis-643-slack-context-continuity.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
