### PR TITLE
JARVIS-643: Preserve long Slack thread anchors during backfill

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -70,7 +70,10 @@ import {
   _backfillTriggerCache,
   triggerSlackThreadBackfillIfNeeded,
 } from "../runtime/routes/inbound-message-handler.js";
-import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
+import {
+  handleChannelInbound,
+  setAdapterProcessMessage,
+} from "./helpers/channel-test-adapter.js";
 
 initializeDb();
 
@@ -190,6 +193,9 @@ interface PersistedRow {
   channelTs: string | undefined;
   threadTs: string | undefined;
   displayName: string | undefined;
+  backfillReason: string | undefined;
+  backfillOmittedMiddle: boolean | undefined;
+  slackFiles: Array<{ name: string; mimetype?: string }> | undefined;
 }
 
 function readPersistedSlackRows(conversationId: string): PersistedRow[] {
@@ -202,6 +208,9 @@ function readPersistedSlackRows(conversationId: string): PersistedRow[] {
       channelTs: undefined,
       threadTs: undefined,
       displayName: undefined,
+      backfillReason: undefined,
+      backfillOmittedMiddle: undefined,
+      slackFiles: undefined,
     };
     if (!row.metadata) {
       out.push(blank);
@@ -235,6 +244,12 @@ function readPersistedSlackRows(conversationId: string): PersistedRow[] {
       channelTs: slackMeta?.channelTs,
       threadTs: slackMeta?.threadTs,
       displayName: slackMeta?.displayName,
+      backfillReason: slackMeta?.backfillReason,
+      backfillOmittedMiddle: slackMeta?.backfillOmittedMiddle,
+      slackFiles: slackMeta?.slackFiles?.map((file) => ({
+        name: file.name,
+        ...(file.mimetype ? { mimetype: file.mimetype } : {}),
+      })),
     });
   }
   return out;
@@ -315,6 +330,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(byChannelTs.get("1234.0")?.content).toBe("parent");
     expect(byChannelTs.get("1234.0")?.displayName).toBe("Parent User");
     expect(byChannelTs.get("1234.0")?.threadTs).toBeUndefined();
+    expect(byChannelTs.get("1234.0")?.backfillReason).toBe("thread_late_join");
 
     expect(byChannelTs.get("1234.1")?.content).toBe("first reply");
     expect(byChannelTs.get("1234.1")?.threadTs).toBe("1234.0");
@@ -323,6 +339,84 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(byChannelTs.get("1234.2")?.content).toBe("second reply");
     expect(byChannelTs.get("1234.2")?.threadTs).toBe("1234.0");
     expect(byChannelTs.get("1234.2")?.displayName).toBe("Reply Two");
+  });
+
+  test("initial late-join backfill preserves early and recent anchors without loading the middle", async () => {
+    const conv = createTestConversation();
+    const ts = (n: number) => `1234.${String(n).padStart(6, "0")}`;
+
+    backfillThreadMock.mockImplementation(async (_channel, _thread, opts) => {
+      if (opts?.limit === 25) {
+        return Array.from({ length: 25 }, (_, i) =>
+          makeBackfillMessage({
+            id: ts(i),
+            text: i === 0 ? "root context" : `early ${i}`,
+            threadId: i === 0 ? undefined : ts(0),
+          }),
+        );
+      }
+      return [
+        ...Array.from({ length: 50 }, (_, i) => {
+          const n = i + 50;
+          return makeBackfillMessage({
+            id: ts(n),
+            text: n === 99 ? "recent file share" : `recent ${n}`,
+            threadId: ts(0),
+            ...(n === 99
+              ? {
+                  metadata: {
+                    slackFiles: [
+                      {
+                        id: "F123",
+                        name: "requirements.txt",
+                        mimetype: "text/plain",
+                      },
+                    ],
+                  },
+                }
+              : {}),
+          });
+        }),
+        makeBackfillMessage({
+          id: ts(60),
+          text: "duplicate recent row",
+          threadId: ts(0),
+        }),
+      ];
+    });
+
+    const result = await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: ts(0),
+      excludeChannelTs: ts(100),
+    });
+
+    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
+    expect(backfillThreadMock.mock.calls[0][2]?.limit).toBe(25);
+    expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
+    expect(backfillThreadMock.mock.calls[1][2]?.limit).toBe(50);
+    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe(ts(100));
+
+    expect(result.reason).toBe("thread_late_join");
+    expect(result.omittedMiddle).toBe(true);
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.length).toBe(75);
+    expect(persisted.find((p) => p.channelTs === ts(0))?.content).toBe(
+      "root context",
+    );
+    expect(persisted.find((p) => p.channelTs === ts(30))).toBeUndefined();
+    expect(persisted.find((p) => p.channelTs === ts(99))?.content).toBe(
+      "recent file share",
+    );
+    expect(
+      persisted.filter((p) => p.channelTs === ts(60)).map((p) => p.content),
+    ).toEqual(["recent 60"]);
+    expect(persisted.some((p) => p.backfillOmittedMiddle === true)).toBe(true);
+    expect(persisted.find((p) => p.channelTs === ts(99))?.slackFiles).toEqual([
+      { name: "requirements.txt", mimetype: "text/plain" },
+    ]);
   });
 
   test("backfill is NOT triggered when the parent is already persisted and no upper-bound gap is known", async () => {
@@ -552,15 +646,26 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       excludeChannelTs: "1234.6",
     });
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
-    expect(backfillThreadMock.mock.calls[0][2]?.before).toBe("1234.5");
-    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("1234.6");
+    expect(backfillThreadMock).toHaveBeenCalledTimes(4);
+    expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
+    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("1234.5");
+    expect(backfillThreadMock.mock.calls[2][2]?.before).toBeUndefined();
+    expect(backfillThreadMock.mock.calls[3][2]?.before).toBe("1234.6");
   });
 
   test("rapid consecutive replies can fetch a newer gap even when the prior inbound reply was only excluded", async () => {
     const conv = createTestConversation();
 
     backfillThreadMock.mockImplementation(async (_channel, _thread, opts) => {
+      if (opts?.limit === 25) {
+        return [
+          makeBackfillMessage({
+            id: "1234.0",
+            text: "parent",
+            threadId: undefined,
+          }),
+        ];
+      }
       if (opts?.before === "1234.5") {
         return [
           makeBackfillMessage({
@@ -607,11 +712,13 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       excludeChannelTs: "1234.6",
     });
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
+    expect(backfillThreadMock).toHaveBeenCalledTimes(3);
     expect(backfillThreadMock.mock.calls[0][2]?.after).toBeUndefined();
-    expect(backfillThreadMock.mock.calls[0][2]?.before).toBe("1234.5");
-    expect(backfillThreadMock.mock.calls[1][2]?.after).toBe("1234.4");
-    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("1234.6");
+    expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
+    expect(backfillThreadMock.mock.calls[1][2]?.after).toBeUndefined();
+    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("1234.5");
+    expect(backfillThreadMock.mock.calls[2][2]?.after).toBe("1234.4");
+    expect(backfillThreadMock.mock.calls[2][2]?.before).toBe("1234.6");
 
     const persisted = readPersistedSlackRows(conv.id);
     expect(persisted.map((p) => p.channelTs).sort()).toEqual([
@@ -837,6 +944,7 @@ function resetHttpState(): void {
   _backfillTriggerCache.clear();
   backfillThreadMock.mockReset();
   backfillThreadMock.mockImplementation(async () => []);
+  setAdapterProcessMessage(undefined);
 }
 
 function seedHttpActiveMember(): void {
@@ -914,9 +1022,17 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
       }),
     ]);
 
-    const processMessage = async (): Promise<{ messageId: string }> => {
+    let capturedHints: string[] | undefined;
+    const processMessage = async (
+      _conversationId: string,
+      _content: string,
+      _attachmentIds?: string[],
+      options?: { transport?: { hints?: string[] } },
+    ): Promise<{ messageId: string }> => {
+      capturedHints = options?.transport?.hints;
       return { messageId: "agent-result-id" };
     };
+    setAdapterProcessMessage(processMessage);
 
     const req = buildThreadReplyRequest("1234.0", "1234.3");
     const resp = await handleChannelInbound(
@@ -933,7 +1049,7 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     // void-promise has time to write to the DB before we assert.
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(1);
+    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
     const [calledChannel, calledThread] = backfillThreadMock.mock.calls[0];
     expect(calledChannel).toBe(HTTP_SLACK_CHANNEL_ID);
     expect(calledThread).toBe("1234.0");
@@ -959,6 +1075,16 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
 
     expect(channelTimestamps.has("1234.0")).toBe(true);
     expect(channelTimestamps.has("1234.1")).toBe(true);
+
+    expect(
+      capturedHints?.some((hint) => hint.includes("joined an existing thread")),
+    ).toBe(true);
+    const contents = db.$client
+      .prepare("SELECT content FROM messages")
+      .all() as Array<{ content: string }>;
+    expect(
+      contents.some((row) => row.content.includes("Slack context note")),
+    ).toBe(false);
   });
 
   test("second thread reply within the TTL window can fetch a newer bounded gap", async () => {
@@ -986,9 +1112,10 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     expect(r2.status).toBe(200);
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
-    expect(backfillThreadMock.mock.calls[0][2]?.before).toBe("5678.1");
-    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("5678.2");
+    expect(backfillThreadMock).toHaveBeenCalledTimes(3);
+    expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
+    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("5678.1");
+    expect(backfillThreadMock.mock.calls[2][2]?.before).toBe("5678.2");
   });
 
   test("backfill error from the HTTP path does not crash the request", async () => {

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -199,6 +199,20 @@ function mapConversation(conv: SlackConversation): Conversation {
   };
 }
 
+function mapSlackFiles(
+  files: SlackMessage["files"],
+): Array<{ id?: string; name: string; mimetype?: string }> | undefined {
+  if (!files || files.length === 0) return undefined;
+  const mapped = files
+    .map((file) => ({
+      ...(file.id ? { id: file.id } : {}),
+      name: file.name,
+      ...(file.mimetype ? { mimetype: file.mimetype } : {}),
+    }))
+    .filter((file) => file.name.length > 0);
+  return mapped.length > 0 ? mapped : undefined;
+}
+
 function mapMessage(
   msg: SlackMessage,
   channelId: string,
@@ -209,6 +223,7 @@ function mapMessage(
   // avoid rehydrating assistant/bot replies as user turns.
   const isBot =
     msg.subtype === "bot_message" || (msg.bot_id != null && !msg.user);
+  const slackFiles = mapSlackFiles(msg.files);
   return {
     id: msg.ts,
     conversationId: channelId,
@@ -220,7 +235,14 @@ function mapMessage(
     platform: "slack",
     reactions: msg.reactions?.map((r) => ({ name: r.name, count: r.count })),
     hasAttachments: (msg.files?.length ?? 0) > 0,
-    ...(isBot ? { metadata: { isBot: true } } : {}),
+    ...(isBot || slackFiles
+      ? {
+          metadata: {
+            ...(isBot ? { isBot: true } : {}),
+            ...(slackFiles ? { slackFiles } : {}),
+          },
+        }
+      : {}),
   };
 }
 

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -24,6 +24,12 @@ const slackReactionMetadataSchema = z.object({
   op: z.enum(["added", "removed"]),
 });
 
+const slackFileMetadataSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  mimetype: z.string().optional(),
+});
+
 export const slackMessageMetadataSchema = z.object({
   source: z.literal("slack"),
   channelId: z.string(),
@@ -34,9 +40,17 @@ export const slackMessageMetadataSchema = z.object({
   reaction: slackReactionMetadataSchema.optional(),
   editedAt: z.number().optional(),
   deletedAt: z.number().optional(),
+  isBackfill: z.boolean().optional(),
+  backfillReason: z
+    .enum(["thread_late_join", "thread_delta", "dm_cold_start"])
+    .optional(),
+  backfillOmittedCount: z.number().optional(),
+  backfillOmittedMiddle: z.boolean().optional(),
+  slackFiles: z.array(slackFileMetadataSchema).optional(),
 });
 
 export type SlackReactionMetadata = z.infer<typeof slackReactionMetadataSchema>;
+export type SlackFileMetadata = z.infer<typeof slackFileMetadataSchema>;
 export type SlackMessageMetadata = z.infer<typeof slackMessageMetadataSchema>;
 
 /**

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -44,6 +44,7 @@ function userMsg(
     deletedAt?: number;
     role?: "user" | "assistant";
     createdAt?: number;
+    slackFiles?: Array<{ name: string; mimetype?: string }>;
   } = {},
 ): RenderableSlackMessage {
   return {
@@ -59,6 +60,7 @@ function userMsg(
       eventKind: "message",
       editedAt: opts.editedAt,
       deletedAt: opts.deletedAt,
+      slackFiles: opts.slackFiles,
     },
   };
 }
@@ -240,6 +242,28 @@ describe("renderSlackTranscript — basics", () => {
       userMsg(TS_14_25, null, "yo 👋", { role: "assistant" }),
     ]);
     expect(out).toEqual([textMsg("assistant", "yo 👋")]);
+  });
+
+  test("backfilled Slack file metadata renders as concise attachment markers", () => {
+    const out = renderSlackTranscript([
+      userMsg(TS_14_25, "@alice", "shared the draft", {
+        slackFiles: [{ name: "requirements.txt", mimetype: "text/plain" }],
+      }),
+      userMsg(TS_14_26, "@bob", "", {
+        slackFiles: [{ name: "diagram.png", mimetype: "image/png" }],
+      }),
+    ]);
+
+    expect(out).toEqual([
+      textMsg(
+        "user",
+        "[11/14/23 14:25 @alice]: shared the draft [attached file: requirements.txt, text/plain]",
+      ),
+      textMsg(
+        "user",
+        "[11/14/23 14:26 @bob]: [attached file: diagram.png, image/png]",
+      ),
+    ]);
   });
 
   test("omits sender label for user-role message with null senderLabel (no displayName)", () => {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -146,6 +146,30 @@ function formatEpochMs(ms: number): string {
   return `${mo}/${da}/${yy} ${hh}:${mm}`;
 }
 
+function renderSlackFileMarkers(
+  files: SlackMessageMetadata["slackFiles"],
+): string {
+  if (!files || files.length === 0) return "";
+  return files
+    .map((file) => {
+      const name = file.name.replace(/\s+/g, " ").trim();
+      const mime = file.mimetype?.replace(/\s+/g, " ").trim();
+      return mime
+        ? `[attached file: ${name}, ${mime}]`
+        : `[attached file: ${name}]`;
+    })
+    .join(" ");
+}
+
+function appendSlackFileMarkers(
+  content: string,
+  files: SlackMessageMetadata["slackFiles"],
+): string {
+  const markers = renderSlackFileMarkers(files);
+  if (!markers) return content;
+  return content.length > 0 ? `${content} ${markers}` : markers;
+}
+
 /**
  * Sort key for chronological ordering.
  *
@@ -197,7 +221,7 @@ function sortKey(msg: RenderableSlackMessage): number {
 function renderMessage(msg: RenderableSlackMessage): string {
   if (msg.role === "assistant") {
     if (msg.metadata?.deletedAt !== undefined) return "[deleted]";
-    return msg.content;
+    return appendSlackFileMarkers(msg.content, msg.metadata?.slackFiles);
   }
 
   const meta = msg.metadata;
@@ -222,7 +246,7 @@ function renderMessage(msg: RenderableSlackMessage): string {
   if (meta.editedAt !== undefined) {
     head += `, edited ${formatEpochMs(meta.editedAt)}`;
   }
-  head += `]: ${msg.content}`;
+  head += `]: ${appendSlackFileMarkers(msg.content, meta.slackFiles)}`;
   return head;
 }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -50,6 +50,7 @@ import {
 import {
   mergeSlackMetadata,
   readSlackMetadata,
+  type SlackFileMetadata,
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "../../messaging/providers/slack/message-metadata.js";
@@ -1046,13 +1047,15 @@ export async function handleChannelInbound({
       // LLM call, so the added latency is negligible. Failures are
       // swallowed inside the helper so they never block dispatch.
       if (slackThreadTs) {
-        await triggerSlackThreadBackfillIfNeeded({
+        const backfillResult = await triggerSlackThreadBackfillIfNeeded({
           conversationId: result.conversationId,
           channelId: conversationExternalId,
           threadTs: slackThreadTs,
           excludeChannelTs: slackInbound?.channelTs,
           account: slackAccount,
         });
+        const lateJoinNotice = buildSlackLateJoinNotice(backfillResult);
+        if (lateJoinNotice) metadataHints.push(lateJoinNotice);
       }
 
       // Wrap non-guardian inbound content in external_content boundaries so
@@ -1401,8 +1404,11 @@ async function persistBackfilledSlackMessage(params: {
   conversationId: string;
   channelId: string;
   message: ProviderMessage;
+  backfillReason: SlackMessageMetadata["backfillReason"];
+  backfillOmittedMiddle?: boolean;
 }): Promise<void> {
   const { message } = params;
+  const slackFiles = readSlackFilesFromProviderMetadata(message.metadata);
   const slackMeta: SlackMessageMetadata = {
     source: "slack",
     channelId: params.channelId,
@@ -1410,11 +1416,41 @@ async function persistBackfilledSlackMessage(params: {
     eventKind: "message",
     ...(message.threadId ? { threadTs: message.threadId } : {}),
     ...(message.sender?.name ? { displayName: message.sender.name } : {}),
+    isBackfill: true,
+    backfillReason: params.backfillReason,
+    ...(params.backfillOmittedMiddle ? { backfillOmittedMiddle: true } : {}),
+    ...(slackFiles.length > 0 ? { slackFiles } : {}),
   };
   const role = message.metadata?.isBot === true ? "assistant" : "user";
   await addMessage(params.conversationId, role, message.text ?? "", {
     slackMeta: writeSlackMetadata(slackMeta),
   });
+}
+
+function readSlackFilesFromProviderMetadata(
+  metadata: Record<string, unknown> | undefined,
+): SlackFileMetadata[] {
+  const raw = metadata?.slackFiles;
+  if (!Array.isArray(raw)) return [];
+  const files: SlackFileMetadata[] = [];
+  for (const item of raw) {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) {
+      continue;
+    }
+    const record = item as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    if (!name) continue;
+    files.push({
+      ...(typeof record.id === "string" && record.id.length > 0
+        ? { id: record.id }
+        : {}),
+      name,
+      ...(typeof record.mimetype === "string" && record.mimetype.length > 0
+        ? { mimetype: record.mimetype }
+        : {}),
+    });
+  }
+  return files;
 }
 
 /**
@@ -1501,6 +1537,7 @@ async function runBackfillSlackDmIfCold(params: {
           conversationId: params.conversationId,
           channelId: params.channelId,
           message,
+          backfillReason: "dm_cold_start",
         });
         seen.add(message.id);
         written++;
@@ -1572,6 +1609,20 @@ export const _backfillTriggerCache = new Map<string, number>();
 
 const BACKFILL_TRIGGER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const BACKFILL_TRIGGER_CACHE_MAX = 1_000;
+const SLACK_THREAD_INITIAL_EARLY_LIMIT = 25;
+const SLACK_THREAD_INITIAL_RECENT_LIMIT = 50;
+const SLACK_THREAD_DELTA_LIMIT = 50;
+
+export interface SlackThreadBackfillResult {
+  fetched: number;
+  persisted: number;
+  reason?: SlackMessageMetadata["backfillReason"];
+  omittedMiddle: boolean;
+}
+
+function emptySlackThreadBackfillResult(): SlackThreadBackfillResult {
+  return { fetched: 0, persisted: 0, omittedMiddle: false };
+}
 
 function pruneBackfillCacheIfNeeded(): void {
   if (_backfillTriggerCache.size < BACKFILL_TRIGGER_CACHE_MAX) return;
@@ -1604,6 +1655,82 @@ function isBackfillRecentlyTriggered(cacheKey: string): boolean {
     return false;
   }
   return true;
+}
+
+async function fetchInitialSlackThreadWindows(params: {
+  channelId: string;
+  threadTs: string;
+  upperBoundTs?: string;
+  account?: string;
+}): Promise<ProviderMessage[]> {
+  if (!params.upperBoundTs) {
+    const early = await backfillThreadWindow(
+      params.channelId,
+      params.threadTs,
+      {
+        limit: SLACK_THREAD_INITIAL_EARLY_LIMIT,
+        account: params.account,
+      },
+    );
+    return sortSlackProviderMessages(dedupeSlackProviderMessages(early));
+  }
+  const [early, recent] = await Promise.all([
+    backfillThreadWindow(params.channelId, params.threadTs, {
+      limit: SLACK_THREAD_INITIAL_EARLY_LIMIT,
+      account: params.account,
+    }),
+    backfillThreadWindow(params.channelId, params.threadTs, {
+      limit: SLACK_THREAD_INITIAL_RECENT_LIMIT,
+      account: params.account,
+      before: params.upperBoundTs,
+    }),
+  ]);
+  return sortSlackProviderMessages(
+    dedupeSlackProviderMessages([...early, ...recent]),
+  );
+}
+
+function dedupeSlackProviderMessages(
+  messages: ProviderMessage[],
+): ProviderMessage[] {
+  const byTs = new Map<string, ProviderMessage>();
+  for (const message of messages) {
+    if (!message.id || byTs.has(message.id)) continue;
+    byTs.set(message.id, message);
+  }
+  return [...byTs.values()];
+}
+
+function sortSlackProviderMessages(
+  messages: ProviderMessage[],
+): ProviderMessage[] {
+  return [...messages].sort((left, right) => {
+    const compared = compareSlackTimestamps(left.id, right.id);
+    if (compared !== null) return compared;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function didSlackThreadBackfillOmitMiddle(params: {
+  fetched: ProviderMessage[];
+  isInitialLateJoin: boolean;
+}): boolean {
+  if (params.isInitialLateJoin) {
+    return params.fetched.length > SLACK_THREAD_INITIAL_RECENT_LIMIT;
+  }
+  return params.fetched.length >= SLACK_THREAD_DELTA_LIMIT;
+}
+
+function buildSlackLateJoinNotice(
+  result: SlackThreadBackfillResult,
+): string | null {
+  if (result.reason !== "thread_late_join" || result.persisted === 0) {
+    return null;
+  }
+  const omitted = result.omittedMiddle
+    ? " Some middle thread messages were intentionally omitted from this turn's hydrated context to keep latency bounded."
+    : "";
+  return `Slack context note: this turn joined an existing thread. ${result.persisted} earlier thread message${result.persisted === 1 ? " was" : "s were"} backfilled before the current message.${omitted}`;
 }
 
 /**
@@ -1648,7 +1775,7 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
    * resolver falls back to the default-active connection.
    */
   account?: string;
-}): Promise<void> {
+}): Promise<SlackThreadBackfillResult> {
   const { conversationId, channelId, threadTs, excludeChannelTs, account } =
     params;
 
@@ -1667,17 +1794,17 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     if (upperBoundTs && lowerBoundTs) {
       const lowerVsUpper = compareSlackTimestamps(lowerBoundTs, upperBoundTs);
       if (lowerVsUpper !== null && lowerVsUpper >= 0) {
-        return;
+        return emptySlackThreadBackfillResult();
       }
     } else if (!upperBoundTs && lowerBoundTs) {
-      return;
+      return emptySlackThreadBackfillResult();
     }
 
     const cacheKey = `${conversationId}:${threadTs}:${
       lowerBoundTs ?? "none"
     }:${upperBoundTs ?? "unbounded"}`;
     if (isBackfillRecentlyTriggered(cacheKey)) {
-      return;
+      return emptySlackThreadBackfillResult();
     }
 
     // Mark the trigger before issuing the network call. Doing this first
@@ -1689,20 +1816,39 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     _backfillTriggerCache.set(cacheKey, Date.now());
     pruneBackfillCacheIfNeeded();
 
-    const fetched = await backfillThreadWindow(channelId, threadTs, {
-      account,
-      ...(lowerBoundTs !== undefined ? { after: lowerBoundTs } : {}),
-      ...(upperBoundTs !== undefined ? { before: upperBoundTs } : {}),
-    });
+    const isInitialLateJoin =
+      lowerBoundTs === undefined &&
+      threadState.storedChannelTs.size === (excludeChannelTs ? 1 : 0);
+    const reason: SlackMessageMetadata["backfillReason"] = isInitialLateJoin
+      ? "thread_late_join"
+      : "thread_delta";
+    const fetched = isInitialLateJoin
+      ? await fetchInitialSlackThreadWindows({
+          channelId,
+          threadTs,
+          upperBoundTs,
+          account,
+        })
+      : await backfillThreadWindow(channelId, threadTs, {
+          limit: SLACK_THREAD_DELTA_LIMIT,
+          account,
+          ...(lowerBoundTs !== undefined ? { after: lowerBoundTs } : {}),
+          ...(upperBoundTs !== undefined ? { before: upperBoundTs } : {}),
+        });
     if (fetched.length === 0) {
       log.debug(
         { conversationId, channelId, threadTs },
         "Slack thread backfill returned no messages",
       );
-      return;
+      return emptySlackThreadBackfillResult();
     }
 
+    const omittedMiddle = didSlackThreadBackfillOmitMiddle({
+      fetched,
+      isInitialLateJoin,
+    });
     let persisted = 0;
+    let firstPersistedInOmittedSegment = true;
     for (const message of fetched) {
       if (!message.id) continue;
       if (threadState.storedChannelTs.has(message.id)) continue;
@@ -1711,9 +1857,13 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
           conversationId,
           channelId,
           message,
+          backfillReason: reason,
+          backfillOmittedMiddle:
+            omittedMiddle && firstPersistedInOmittedSegment,
         });
         threadState.storedChannelTs.add(message.id);
         persisted++;
+        firstPersistedInOmittedSegment = false;
       } catch (err) {
         log.warn(
           { err, conversationId, channelId, threadTs, channelTs: message.id },
@@ -1729,9 +1879,16 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
         threadTs,
         persisted,
         fetched: fetched.length,
+        omittedMiddle,
       },
       "Slack thread backfill persisted ancestor messages",
     );
+    return {
+      fetched: fetched.length,
+      persisted,
+      reason,
+      omittedMiddle,
+    };
   } catch (err) {
     // `channel_not_found` almost always means the resolved connection is
     // pointing at the wrong Slack workspace (a real config bug), so log it
@@ -1749,5 +1906,6 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     } else {
       log.warn(payload, "Slack thread backfill failed; proceeding without it");
     }
+    return emptySlackThreadBackfillResult();
   }
 }


### PR DESCRIPTION
## Summary
- Preserve early and recent context for initial Slack late-join backfills
- Add lightweight backfill metadata and Slack file markers
- Cover long-thread anchor, file-marker, and dedupe behavior

Part of JARVIS-643
Part of plan: jarvis-643-slack-context-continuity.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
