### PR TITLE
Simplify first greeting: replace guess matrix with tone-aware invite

### DIFF
--- a/assistant/src/__tests__/first-greeting.test.ts
+++ b/assistant/src/__tests__/first-greeting.test.ts
@@ -65,7 +65,15 @@ describe("first-greeting", () => {
 
     it("no-onboarding greeting uses two-paragraph structure", () => {
       expect(CANNED_FIRST_GREETING).toContain("\n\n");
-      expect(CANNED_FIRST_GREETING).toContain("I can ask");
+      const paragraphs = CANNED_FIRST_GREETING.split("\n\n");
+      expect(paragraphs.length).toBe(2);
+    });
+
+    it("no-onboarding greeting does not contain old self-deprecation text", () => {
+      expect(CANNED_FIRST_GREETING).not.toContain("no name, no memories");
+      expect(CANNED_FIRST_GREETING).not.toContain("Brand new");
+      expect(CANNED_FIRST_GREETING).not.toContain("I can ask");
+      expect(CANNED_FIRST_GREETING).not.toContain("get sharper");
     });
   });
 
@@ -73,333 +81,208 @@ describe("first-greeting", () => {
     const base: OnboardingGreetingContext = {
       tools: [],
       tasks: [],
-      tone: "balanced",
+      tone: "grounded",
     };
 
-    it("full dev stack: GitHub + Linear, Building + PM", () => {
+    it("grounded + name + assistantName", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tools: ["github", "linear"],
-        tasks: ["code-building", "project-management"],
-        userName: "Bob",
-        assistantName: "Pip",
+        tone: "grounded",
+        userName: "Alice",
+        assistantName: "Pax",
       });
-      expect(greeting).toContain("Hey Bob, I'm Pip.");
-      expect(greeting).toContain("You mentioned using GitHub and Linear");
-      expect(greeting).toContain(
-        "shipping code or figuring out what to ship next",
+      expect(greeting).toBe(
+        "Hey Alice, I'm Pax.\n\nWe can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
       );
-      expect(greeting).toContain("\n\n");
     });
 
-    it("PM + comms: Linear + Notion, PM + Writing", () => {
+    it("warm + name + assistantName", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tools: ["linear", "notion"],
-        tasks: ["project-management", "writing"],
-        userName: "Bob",
-        assistantName: "Pip",
+        tone: "warm",
+        userName: "Alice",
+        assistantName: "Remy",
       });
-      expect(greeting).toContain("You mentioned using Notion and Linear");
-      expect(greeting).toContain("writing a spec or pushing something forward");
+      expect(greeting).toBe(
+        "Hey Alice, I'm Remy. Good to meet you.\n\nWe can start on something specific, or just talk for a bit first — honestly that tends to work out better. Either way, I'm here.",
+      );
     });
 
-    it("writer: Notion + Google Drive, Writing only", () => {
+    it("energetic + no names", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tools: ["notion", "google-drive"],
-        tasks: ["writing"],
-        userName: "Bob",
-        assistantName: "Luna",
+        tone: "energetic",
+        assistantName: "Pax",
       });
-      expect(greeting).toContain("You mentioned using Notion and Google Drive");
-      expect(greeting).toContain("drafting something or cleaning up docs");
+      expect(greeting).toBe(
+        "Hey, I'm Pax. Let's see what you've got.\n\nWe can jump straight into whatever you've got, or take a few minutes to just talk first. What sounds right?",
+      );
     });
 
-    it("single task no tools: Building only", () => {
+    it("poetic + name + assistantName", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tasks: ["code-building"],
-        userName: "Bob",
-        assistantName: "Pip",
+        tone: "poetic",
+        userName: "Alice",
+        assistantName: "Pax",
       });
-      expect(greeting).toContain("Probably shipping something or debugging");
-      expect(greeting).not.toContain("You mentioned using");
+      expect(greeting).toBe(
+        "Hey Alice, I'm Pax.\n\nWe can start with whatever's in front of you, or just talk for a bit first. Either way.",
+      );
     });
 
-    it("single tool single task: GitHub + Building", () => {
+    it("name only (no assistantName)", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tools: ["github"],
-        tasks: ["code-building"],
-        userName: "Bob",
-        assistantName: "Pip",
+        tone: "grounded",
+        userName: "Alice",
       });
-      expect(greeting).toContain("You mentioned using GitHub");
+      expect(greeting).toBe(
+        "Hey Alice,\n\nWe can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
+      );
     });
 
-    it("many hats: 4 selections", () => {
+    it("assistantName only (no userName)", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tasks: ["code-building", "writing", "research", "project-management"],
-        userName: "Bob",
-        assistantName: "Pip",
+        tone: "grounded",
+        assistantName: "Pax",
       });
-      expect(greeting).toContain("wear a lot of hats");
-      expect(greeting).toContain("Where should we start?");
+      expect(greeting).toBe(
+        "Hey, I'm Pax.\n\nWe can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
+      );
     });
 
-    it("many hats: 6 selections", () => {
+    it("no name, no assistantName, no tone returns CANNED_FIRST_GREETING", () => {
       const greeting = getCannedFirstGreeting({
-        ...base,
-        tasks: [
-          "code-building",
-          "writing",
-          "research",
-          "project-management",
-          "scheduling",
-          "personal",
-        ],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain("wear a lot of hats");
-    });
-
-    it("no tasks with tools: no-signal branch", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tools: ["gmail", "linear"],
+        tools: [],
         tasks: [],
-        userName: "Bob",
-        assistantName: "Pip",
+        tone: "",
       });
-      expect(greeting).toContain("What's on your plate?");
-      expect(greeting).toContain("I can ask you a few questions");
+      expect(greeting).toBe(CANNED_FIRST_GREETING);
     });
 
-    it("missing name uses Hey comma opener", () => {
+    it("unknown tone falls back to grounded defaults", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tasks: ["code-building"],
-        assistantName: "Pip",
+        tone: "mysterious-future-tone",
+        userName: "Alice",
+        assistantName: "Pax",
       });
-      expect(greeting).toStartWith("Hey, I'm Pip.");
-    });
-
-    it("3-selection falls back to highest-priority single template", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tasks: ["writing", "research", "scheduling"],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain("drafting something or cleaning up docs");
-    });
-
-    it("unlisted 2-combo falls back to highest-priority single", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tasks: ["research", "personal"],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain(
-        "digging into a topic or making sense of something",
+      expect(greeting).toBe(
+        "Hey Alice, I'm Pax.\n\nWe can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
       );
     });
 
-    it("uses capital I throughout", () => {
+    it("two-paragraph structure preserved", () => {
       const greeting = getCannedFirstGreeting({
         ...base,
-        tasks: ["code-building"],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain("I'm Pip");
-      expect(greeting).toContain("I'll get sharper");
-      expect(greeting).toContain("Am I on the right track");
-    });
-
-    it("two-paragraph structure with blank line", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tasks: ["code-building"],
-        userName: "Bob",
-        assistantName: "Pip",
+        tone: "grounded",
+        userName: "Alice",
+        assistantName: "Pax",
       });
       const paragraphs = greeting.split("\n\n");
       expect(paragraphs.length).toBe(2);
-    });
-
-    it("picks relevant tools for guess, not arbitrary selection order", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tools: [
-          "notion",
-          "linear",
-          "gmail",
-          "google-calendar",
-          "github",
-          "apple-notes",
-        ],
-        tasks: ["code-building", "project-management"],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain("You mentioned using GitHub and Linear");
-      expect(greeting).not.toContain("Apple Notes");
-      expect(greeting).not.toContain("Notion");
-    });
-
-    it("falls back to no-tool prefix when no relevant tools match", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tools: ["notion", "apple-notes"],
-        tasks: ["code-building"],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain("Probably shipping something or debugging");
-      expect(greeting).not.toContain("You mentioned using");
-    });
-
-    it("life admin guess uses verb phrase", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tools: ["gmail", "google-calendar"],
-        tasks: ["personal"],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain(
-        "You mentioned using Gmail and Google Calendar",
-      );
-      expect(greeting).toContain("juggling travel, bills, or household stuff");
-    });
-
-    it("uses personalized greeting when assistantName present but no user name/tasks/tools", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain("I'm Pip");
-      expect(greeting).not.toContain("no name, no memories");
-    });
-
-    it("falls back to no-signal branch for unknown task types", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tasks: ["future-task-type"],
-        userName: "Bob",
-        assistantName: "Pip",
-      });
-      expect(greeting).toContain("What's on your plate?");
-      expect(greeting).not.toContain("\n\n\n");
     });
   });
 
   describe("tone-specific greetings", () => {
     const base: OnboardingGreetingContext = {
-      tools: ["github", "linear"],
-      tasks: ["code-building"],
-      tone: "balanced",
+      tools: [],
+      tasks: [],
+      tone: "grounded",
       userName: "Bob",
-      assistantName: "Pip",
+      assistantName: "Pax",
     };
 
-    it("grounded tone produces direct, calm intro", () => {
+    it("grounded intro close is empty, invite is grounded", () => {
       const greeting = getCannedFirstGreeting({ ...base, tone: "grounded" });
-      expect(greeting).toContain("Bob.");
-      expect(greeting).toContain(
-        "I'm Pip. Brand new, and I'll get sharper the more we work together.",
+      const [intro, invite] = greeting.split("\n\n");
+      expect(intro).toBe("Hey Bob, I'm Pax.");
+      expect(invite).toBe(
+        "We can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
       );
-      expect(greeting.split("\n\n").length).toBe(2);
     });
 
-    it("warm tone uses casual phrasing", () => {
+    it("warm intro close is 'Good to meet you.', invite is warm", () => {
       const greeting = getCannedFirstGreeting({ ...base, tone: "warm" });
-      expect(greeting).toContain("Hey Bob!");
-      expect(greeting).toContain("hang out");
-      expect(greeting.split("\n\n").length).toBe(2);
+      const [intro, invite] = greeting.split("\n\n");
+      expect(intro).toBe("Hey Bob, I'm Pax. Good to meet you.");
+      expect(invite).toBe(
+        "We can start on something specific, or just talk for a bit first — honestly that tends to work out better. Either way, I'm here.",
+      );
     });
 
-    it("energetic tone is punchy", () => {
+    it("energetic intro close is 'Let's see what you've got.', invite is energetic", () => {
       const greeting = getCannedFirstGreeting({ ...base, tone: "energetic" });
-      expect(greeting).toContain("Bob!");
-      expect(greeting).toContain("let's get into it");
-      expect(greeting.split("\n\n").length).toBe(2);
+      const [intro, invite] = greeting.split("\n\n");
+      expect(intro).toBe("Hey Bob, I'm Pax. Let's see what you've got.");
+      expect(invite).toBe(
+        "We can jump straight into whatever you've got, or take a few minutes to just talk first. What sounds right?",
+      );
     });
 
-    it("poetic tone is softer", () => {
+    it("poetic intro close is empty, invite is poetic", () => {
       const greeting = getCannedFirstGreeting({ ...base, tone: "poetic" });
-      expect(greeting).toContain("Hello, Bob.");
-      expect(greeting).toContain("grow alongside you");
-      expect(greeting.split("\n\n").length).toBe(2);
+      const [intro, invite] = greeting.split("\n\n");
+      expect(intro).toBe("Hey Bob, I'm Pax.");
+      expect(invite).toBe(
+        "We can start with whatever's in front of you, or just talk for a bit first. Either way.",
+      );
     });
 
-    it("balanced tone falls back to generic intro", () => {
-      const greeting = getCannedFirstGreeting({ ...base, tone: "balanced" });
-      expect(greeting).toContain("Hey Bob, I'm Pip.");
-      expect(greeting).toContain("I'll get sharper");
-      expect(greeting.split("\n\n").length).toBe(2);
-    });
-
-    it("unknown tone string falls back to generic intro", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tone: "mysterious-future-tone",
-      });
-      expect(greeting).toContain("Hey Bob, I'm Pip.");
-      expect(greeting).toContain("I'll get sharper");
-      expect(greeting.split("\n\n").length).toBe(2);
-    });
-
-    it("each tone produces a distinct intro line", () => {
+    it("each tone produces a distinct full greeting", () => {
       const tones = ["grounded", "warm", "energetic", "poetic"];
-      const intros = tones.map((tone) => {
-        const greeting = getCannedFirstGreeting({ ...base, tone });
-        return greeting.split("\n\n")[0];
+      const greetings = tones.map((tone) => {
+        return getCannedFirstGreeting({ ...base, tone });
       });
-      const unique = new Set(intros);
+      const unique = new Set(greetings);
       expect(unique.size).toBe(tones.length);
     });
 
-    it("warm tone without user name uses Hey!", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
-        tone: "warm",
-        userName: undefined,
+    it("each tone produces distinct invite text", () => {
+      const tones = ["grounded", "warm", "energetic", "poetic"];
+      const invites = tones.map((tone) => {
+        const greeting = getCannedFirstGreeting({ ...base, tone });
+        return greeting.split("\n\n")[1];
       });
-      expect(greeting).toStartWith("Hey! I'm Pip");
+      const unique = new Set(invites);
+      expect(unique.size).toBe(tones.length);
     });
+  });
 
-    it("poetic tone without user name uses Hello.", () => {
+  describe("tasks and tools fields are ignored", () => {
+    it("tasks do not appear in output", () => {
       const greeting = getCannedFirstGreeting({
-        ...base,
-        tone: "poetic",
-        userName: undefined,
-      });
-      expect(greeting).toStartWith("Hello. I'm Pip");
-    });
-
-    it("grounded tone without user name omits greeting prefix", () => {
-      const greeting = getCannedFirstGreeting({
-        ...base,
+        tools: ["github", "linear"],
+        tasks: ["code-building", "project-management"],
         tone: "grounded",
-        userName: undefined,
+        userName: "Alice",
+        assistantName: "Pax",
       });
-      expect(greeting).toStartWith("I'm Pip.");
+      expect(greeting).not.toContain("GitHub");
+      expect(greeting).not.toContain("Linear");
+      expect(greeting).not.toContain("code");
+      expect(greeting).not.toContain("shipping");
+      expect(greeting).not.toContain("You mentioned using");
+      expect(greeting).not.toContain("wear a lot of hats");
+      expect(greeting).not.toContain("Am I on the right track");
     });
 
-    it("tone-specific intro falls back to generic when no assistantName", () => {
+    it("tools do not appear in output", () => {
       const greeting = getCannedFirstGreeting({
-        ...base,
+        tools: ["gmail", "google-calendar", "slack", "notion"],
+        tasks: ["scheduling", "personal", "writing", "research"],
         tone: "warm",
-        assistantName: undefined,
+        userName: "Bob",
+        assistantName: "Remy",
       });
-      expect(greeting).toContain("Hey Bob,");
-      expect(greeting).toContain("brand new");
+      expect(greeting).not.toContain("Gmail");
+      expect(greeting).not.toContain("Google Calendar");
+      expect(greeting).not.toContain("Slack");
+      expect(greeting).not.toContain("Notion");
+      expect(greeting).not.toContain("scheduling");
+      expect(greeting).not.toContain("personal");
     });
   });
 });

--- a/assistant/src/daemon/first-greeting.ts
+++ b/assistant/src/daemon/first-greeting.ts
@@ -2,6 +2,8 @@ import { existsSync } from "node:fs";
 
 import { getWorkspacePromptPath } from "../util/platform.js";
 
+type Tone = "grounded" | "warm" | "energetic" | "poetic";
+
 export interface OnboardingGreetingContext {
   tools: string[];
   tasks: string[];
@@ -12,9 +14,9 @@ export interface OnboardingGreetingContext {
 }
 
 export const CANNED_FIRST_GREETING = [
-  "Hey — brand new, no name, no memories, no idea who you are yet. I'll get sharper the more we work together.",
+  "Hey,",
   "",
-  "What can I do for you? Or I can ask you some questions to get started.",
+  "We can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
 ].join("\n");
 
 /**
@@ -46,217 +48,57 @@ export function getCannedFirstGreeting(
   return CANNED_FIRST_GREETING;
 }
 
-const TOOL_LABELS: Record<string, string> = {
-  gmail: "Gmail",
-  outlook: "Outlook",
-  "google-calendar": "Google Calendar",
-  slack: "Slack",
-  notion: "Notion",
-  linear: "Linear",
-  jira: "Jira",
-  github: "GitHub",
-  figma: "Figma",
-  "google-drive": "Google Drive",
-  excel: "Excel",
-  "apple-notes": "Apple Notes",
-};
-
-const TASK_PRIORITY: string[] = [
-  "code-building",
-  "project-management",
-  "writing",
-  "research",
-  "scheduling",
-  "personal",
-];
-
-interface Guess {
-  text: string;
-  preferredTools: string[];
-}
-
-const SINGLE_GUESSES: Record<string, Guess> = {
-  "code-building": {
-    text: "shipping something or debugging",
-    preferredTools: ["github", "linear", "jira"],
-  },
-  writing: {
-    text: "drafting something or cleaning up docs",
-    preferredTools: ["notion", "google-drive", "apple-notes"],
-  },
-  research: {
-    text: "digging into a topic or making sense of something",
-    preferredTools: ["notion", "google-drive"],
-  },
-  "project-management": {
-    text: "planning the week, writing a spec, or pushing something forward",
-    preferredTools: ["notion", "linear", "google-drive"],
-  },
-  scheduling: {
-    text: "planning the week or prepping for meetings",
-    preferredTools: ["google-calendar", "outlook", "linear"],
-  },
-  personal: {
-    text: "juggling travel, bills, or household stuff",
-    preferredTools: ["gmail", "google-calendar", "apple-notes"],
-  },
-};
-
-const COMBO_GUESSES: Record<string, Guess> = {
-  "code-building+project-management": {
-    text: "shipping code or figuring out what to ship next",
-    preferredTools: ["github", "linear", "jira"],
-  },
-  "code-building+writing": {
-    text: "shipping code or writing something up",
-    preferredTools: ["github", "linear", "jira"],
-  },
-  "project-management+writing": {
-    text: "writing a spec or pushing something forward",
-    preferredTools: ["notion", "linear", "google-drive"],
-  },
-  "research+writing": {
-    text: "drafting something or digging into a topic",
-    preferredTools: ["notion", "google-drive"],
-  },
-  "project-management+scheduling": {
-    text: "planning the week or prepping for something",
-    preferredTools: ["google-calendar", "outlook", "linear"],
-  },
-};
-
-function comboKey(a: string, b: string): string {
-  return [a, b].sort().join("+");
-}
-
-function highestPriorityTask(tasks: string[]): string | undefined {
-  for (const t of TASK_PRIORITY) {
-    if (tasks.includes(t)) return t;
-  }
-  return tasks[0];
-}
-
-const TONE_INTROS: Record<
-  string,
-  {
-    greeting: (userName?: string) => string;
-    selfIntro: (assistantName: string) => string;
-  }
-> = {
-  grounded: {
-    greeting: (u) => (u ? `${u}.` : ""),
-    selfIntro: (n) =>
-      `I'm ${n}. Brand new, and I'll get sharper the more we work together.`,
-  },
-  warm: {
-    greeting: (u) => (u ? `Hey ${u}!` : "Hey!"),
-    selfIntro: (n) =>
-      `I'm ${n} — brand new, but I'll get better the more we hang out.`,
-  },
-  energetic: {
-    greeting: (u) => (u ? `${u}!` : "Hey!"),
-    selfIntro: (n) => `I'm ${n}. Fresh start — let's get into it.`,
-  },
-  poetic: {
-    greeting: (u) => (u ? `Hello, ${u}.` : "Hello."),
-    selfIntro: (n) => `I'm ${n}. Still quite new — I'll grow alongside you.`,
-  },
+const TONE_INTRO_CLOSE: Record<Tone, string> = {
+  grounded: "",
+  warm: "Good to meet you.",
+  energetic: "Let's see what you've got.",
+  poetic: "",
 };
 
 function buildIntroLine(
-  userName?: string,
-  assistantName?: string,
-  tone?: string,
+  name?: string,
+  assistant?: string,
+  tone: Tone = "grounded",
 ): string {
-  const toneEntry = tone ? TONE_INTROS[tone] : undefined;
-
-  if (toneEntry && assistantName) {
-    const greetPart = toneEntry.greeting(userName);
-    const selfPart = toneEntry.selfIntro(assistantName);
-    return greetPart ? `${greetPart} ${selfPart}` : selfPart;
-  }
-
-  const namepart = userName ? `Hey ${userName},` : "Hey,";
-  const who = assistantName
-    ? `I'm ${assistantName}. Brand new, and I'll get sharper the more we work together.`
-    : "brand new, and I'll get sharper the more we work together.";
-  return `${namepart} ${who}`;
+  const greeting = name ? `Hey ${name},` : "Hey,";
+  const who = assistant ? `I'm ${assistant}.` : "";
+  const close = TONE_INTRO_CLOSE[tone];
+  return [greeting, who, close].filter(Boolean).join(" ");
 }
 
-function pickRelevantTools(
-  preferredTools: string[],
-  userTools: string[],
-): string[] {
-  const userSet = new Set(userTools);
-  const matched: string[] = [];
-  for (const t of preferredTools) {
-    if (userSet.has(t)) {
-      matched.push(TOOL_LABELS[t] ?? t);
-      if (matched.length === 2) break;
-    }
-  }
-  return matched;
+const TONE_INVITE: Record<Tone, string> = {
+  grounded:
+    "We can get into whatever you've got, or just talk first — that tends to go better. Up to you.",
+  warm: "We can start on something specific, or just talk for a bit first — honestly that tends to work out better. Either way, I'm here.",
+  energetic:
+    "We can jump straight into whatever you've got, or take a few minutes to just talk first. What sounds right?",
+  poetic:
+    "We can start with whatever's in front of you, or just talk for a bit first. Either way.",
+};
+
+function buildInvite(tone: Tone = "grounded"): string {
+  return TONE_INVITE[tone];
 }
 
-function buildSpecificGuess(tasks: string[], tools: string[]): string {
-  let guess: Guess | undefined;
+const VALID_TONES = new Set<string>([
+  "grounded",
+  "warm",
+  "energetic",
+  "poetic",
+]);
 
-  if (tasks.length === 2) {
-    guess = COMBO_GUESSES[comboKey(tasks[0], tasks[1])];
-  }
-
-  if (!guess) {
-    const top = highestPriorityTask(tasks);
-    guess = top ? SINGLE_GUESSES[top] : undefined;
-  }
-
-  if (!guess) return "";
-
-  const relevant = pickRelevantTools(guess.preferredTools, tools);
-
-  if (relevant.length === 2) {
-    return `You mentioned using ${relevant[0]} and ${relevant[1]} — probably ${guess.text}? Am I on the right track, or something else on your mind?`;
-  }
-  if (relevant.length === 1) {
-    return `You mentioned using ${relevant[0]} — probably ${guess.text}? Am I on the right track, or something else on your mind?`;
-  }
-
-  return `Probably ${guess.text}? Am I on the right track, or something else on your mind?`;
+function resolveTone(raw?: string): Tone {
+  return raw && VALID_TONES.has(raw) ? (raw as Tone) : "grounded";
 }
 
 function buildPersonalizedGreeting(ctx: OnboardingGreetingContext): string {
-  const userName = ctx.userName?.trim();
-  const assistantName = ctx.assistantName?.trim();
+  const name = ctx.userName?.trim();
+  const assistant = ctx.assistantName?.trim();
+  const tone = resolveTone(ctx.tone);
 
-  const hasName = userName && userName.length > 0;
-  const hasTasks = ctx.tasks.length > 0;
-  const hasTools = ctx.tools.length > 0;
+  if (!name && !assistant) return CANNED_FIRST_GREETING;
 
-  const hasAssistantName = assistantName && assistantName.length > 0;
-
-  if (!hasName && !hasTasks && !hasTools && !hasAssistantName) {
-    return CANNED_FIRST_GREETING;
-  }
-
-  const intro = buildIntroLine(
-    hasName ? userName : undefined,
-    assistantName,
-    ctx.tone,
-  );
-
-  let secondParagraph: string;
-
-  if (ctx.tasks.length >= 4) {
-    secondParagraph =
-      "Looks like you wear a lot of hats. Where should we start?";
-  } else if (ctx.tasks.length === 0) {
-    secondParagraph =
-      "What's on your plate? Or if it's easier, I can ask you a few questions to get oriented.";
-  } else {
-    secondParagraph =
-      buildSpecificGuess(ctx.tasks, ctx.tools) ||
-      "What's on your plate? Or if it's easier, I can ask you a few questions to get oriented.";
-  }
-
-  return [intro, "", secondParagraph].join("\n");
+  const intro = buildIntroLine(name, assistant, tone);
+  const invite = buildInvite(tone);
+  return [intro, "", invite].join("\n");
 }


### PR DESCRIPTION
## Summary
- Remove combo/guess matrix (TOOL_LABELS, TASK_PRIORITY, SINGLE_GUESSES, COMBO_GUESSES, buildSpecificGuess, pickRelevantTools, etc.)
- Replace with clean buildIntroLine + buildInvite pattern with tone-aware variants
- Update CANNED_FIRST_GREETING to use grounded invite pattern
- Rewrite tests for new behavior

Part of plan: greeting-bootstrap-personality.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
