### PR TITLE
Prepend tone-calibrated voice block to BOOTSTRAP.md system prompt injection

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -322,6 +322,104 @@ describe("buildSystemPrompt", () => {
     });
   });
 
+  describe("BOOTSTRAP.md voice block injection", () => {
+    test("prepends warm voice block before BOOTSTRAP.md content when tone is 'warm'", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nWelcome aboard.",
+      );
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: [],
+          tasks: [],
+          tone: "warm",
+        },
+      });
+      expect(result).toContain("## Voice\nFriendly and easy");
+      // Voice block should appear inside the First-Run Ritual section, before the BOOTSTRAP.md body
+      const ritualIdx = result.indexOf("# First-Run Ritual");
+      const voiceIdx = result.indexOf("## Voice\nFriendly and easy");
+      const bootstrapBodyIdx = result.indexOf("# First run\n\nWelcome aboard.");
+      expect(ritualIdx).toBeGreaterThan(-1);
+      expect(voiceIdx).toBeGreaterThan(ritualIdx);
+      expect(voiceIdx).toBeLessThan(bootstrapBodyIdx);
+    });
+
+    test("prepends grounded voice block when tone is 'grounded'", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nWelcome aboard.",
+      );
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: [],
+          tasks: [],
+          tone: "grounded",
+        },
+      });
+      expect(result).toContain("## Voice\nCalm, direct, precise");
+    });
+
+    test("does not inject voice block when tone is missing", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nWelcome aboard.",
+      );
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: [],
+          tasks: [],
+          tone: "",
+        },
+      });
+      expect(result).not.toContain("## Voice");
+    });
+
+    test("does not inject voice block when tone is unrecognized", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nWelcome aboard.",
+      );
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: [],
+          tasks: [],
+          tone: "robotic",
+        },
+      });
+      expect(result).not.toContain("## Voice");
+    });
+
+    test("does not inject voice block when onboardingContext is absent", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nWelcome aboard.",
+      );
+      const result = buildSystemPrompt();
+      expect(result).not.toContain("## Voice");
+    });
+
+    test("voice block appears inside First-Run Ritual section before BOOTSTRAP.md body", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Onboarding\n\nStep 1: Do stuff.",
+      );
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: [],
+          tasks: [],
+          tone: "energetic",
+        },
+      });
+      const ritualIdx = result.indexOf("# First-Run Ritual");
+      const voiceIdx = result.indexOf("## Voice\nFast and generative");
+      const bodyIdx = result.indexOf("# Onboarding\n\nStep 1: Do stuff.");
+      expect(ritualIdx).toBeGreaterThan(-1);
+      expect(voiceIdx).toBeGreaterThan(ritualIdx);
+      expect(bodyIdx).toBeGreaterThan(voiceIdx);
+    });
+  });
+
   describe("app-builder tool ownership guidance", () => {
     test("iteration guidance does not mention app_update for HTML changes", () => {
       const result = buildSystemPrompt();

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -24,6 +24,16 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
 
 export { SYSTEM_PROMPT_CACHE_BOUNDARY };
 
+const BOOTSTRAP_VOICE_BLOCKS: Record<string, string> = {
+  grounded:
+    "## Voice\nCalm, direct, precise. No filler. Lead with the thing, explain if needed. Opinions stated plainly.",
+  warm: "## Voice\nFriendly and easy. Match their energy quickly. Warmth comes through in word choice, not in announcements.",
+  energetic:
+    "## Voice\nFast and generative. Lean into momentum. Enthusiasm is in the pace, not the exclamations.",
+  poetic:
+    "## Voice\nThoughtful and unhurried. Notice things. Word choice matters. Don't rush to close — sometimes the observation is the value.",
+};
+
 const log = getLogger("system-prompt");
 
 const PROMPT_FILES = ["SOUL.md", "IDENTITY.md"] as const;
@@ -307,10 +317,17 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
       "{{USER_PERSONA_FILE}}",
       `${userSlug}.md`,
     );
+    let bootstrapContent = bootstrapWithSlug;
+    const voiceBlock = options?.onboardingContext?.tone
+      ? BOOTSTRAP_VOICE_BLOCKS[options.onboardingContext.tone]
+      : undefined;
+    if (voiceBlock) {
+      bootstrapContent = voiceBlock + "\n\n" + bootstrapContent;
+    }
     dynamicParts.push(
       "# First-Run Ritual\n\n" +
         "BOOTSTRAP.md is present — this is your first conversation. Follow its instructions.\n\n" +
-        bootstrapWithSlug,
+        bootstrapContent,
     );
 
     if (options?.onboardingContext) {


### PR DESCRIPTION
## Summary
- Add BOOTSTRAP_VOICE_BLOCKS map with tone-specific voice directives
- Prepend matching voice block to BOOTSTRAP.md content in system prompt when onboarding tone is present
- Add tests for voice block injection and absence

Part of plan: greeting-bootstrap-personality.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
