### PR TITLE
fix: add missing poetic voice block test

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -345,6 +345,21 @@ describe("buildSystemPrompt", () => {
       expect(voiceIdx).toBeLessThan(bootstrapBodyIdx);
     });
 
+    test("prepends poetic voice block when tone is 'poetic'", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# First run\n\nWelcome aboard.",
+      );
+      const result = buildSystemPrompt({
+        onboardingContext: {
+          tools: [],
+          tasks: [],
+          tone: "poetic",
+        },
+      });
+      expect(result).toContain("## Voice\nThoughtful and unhurried");
+    });
+
     test("prepends grounded voice block when tone is 'grounded'", () => {
       writeFileSync(
         join(TEST_DIR, "BOOTSTRAP.md"),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for greeting-bootstrap-personality.md.

**Gap:** Missing poetic voice block test
**What was expected:** Tests for all four voice block tones
**What was found:** system-prompt.test.ts tested warm, grounded, energetic but not poetic
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
