### PR TITLE
fix: Make Slack compaction boundaries reliable

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2335,6 +2335,102 @@ describe("session-agent-loop", () => {
   });
 
   describe("Slack compaction watermarks", () => {
+    test("start-of-turn Slack compaction derives and persists watermark from rendered context", async () => {
+      const renderedSlackMessages: Message[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "first rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "second rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "retained Slack row" }],
+        },
+      ];
+      mockSlackChronologicalContext = {
+        messages: renderedSlackMessages,
+        sourceChannelTsByMessage: [
+          "1700000010.000000",
+          "1700000020.000000",
+          "1700000030.000000",
+        ],
+        compactableStartIndex: 0,
+      };
+      const shouldCompactInputs: Message[][] = [];
+      const maybeCompactInputs: Message[][] = [];
+
+      const ctx = makeCtx({
+        channelCapabilities: {
+          channel: "slack",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "channel",
+        },
+        trustContext: {
+          sourceChannel: "slack",
+          trustClass: "guardian",
+        } as AgentLoopConversationContext["trustContext"],
+        getTurnChannelContext: () => ({
+          userMessageChannel: "slack" as const,
+          assistantMessageChannel: "slack" as const,
+        }),
+        contextWindowManager: {
+          shouldCompact: (messages: Message[]) => {
+            shouldCompactInputs.push(messages);
+            return { needed: true, estimatedTokens: 95_000 };
+          },
+          maybeCompact: async (messages: Message[]) => {
+            maybeCompactInputs.push(messages);
+            return {
+              compacted: true,
+              messages: [
+                {
+                  role: "user",
+                  content: [{ type: "text", text: "summary" }],
+                },
+                messages[2]!,
+              ],
+              compactedPersistedMessages: 2,
+              previousEstimatedInputTokens: 95_000,
+              estimatedInputTokens: 5_000,
+              maxInputTokens: 100_000,
+              thresholdTokens: 80_000,
+              compactedMessages: 2,
+              summaryCalls: 1,
+              summaryInputTokens: 100,
+              summaryOutputTokens: 20,
+              summaryModel: "mock-model",
+              summaryText: "summary",
+              summaryFailed: false,
+            };
+          },
+        } as unknown as AgentLoopConversationContext["contextWindowManager"],
+      });
+
+      await runAgentLoopImpl(ctx, "next reply", "user-msg-start", () => {});
+
+      expect(shouldCompactInputs[0]).toBe(renderedSlackMessages);
+      expect(maybeCompactInputs[0]).toBe(renderedSlackMessages);
+      expect(getSlackCompactionWatermarkForPrefixMock).toHaveBeenCalledWith(
+        mockSlackChronologicalContext,
+        2,
+      );
+      expect(updateConversationSlackContextWatermarkMock).toHaveBeenCalledWith(
+        "test-conv",
+        "1700000020.000000",
+        expect.any(Number),
+      );
+      const firstInjectionOptions = applyRuntimeInjectionsMock.mock
+        .calls[0]![1] as {
+        slackChronologicalMessages?: Message[] | null;
+      };
+      expect(firstInjectionOptions.slackChronologicalMessages).toBeNull();
+    });
+
     test("next inbound Slack turn injects the watermark-filtered chronological context", async () => {
       mockConversationRow = {
         ...mockConversationRow,

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2922,6 +2922,11 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         }),
       }),
       userRow({
+        id: "legacy-before-watermark",
+        createdAt: 1700000008_000,
+        text: "legacy row before watermark",
+      }),
+      userRow({
         id: "at-watermark",
         createdAt: 1700000045_000,
         text: "at watermark",
@@ -2952,9 +2957,70 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(renderedText).toContain("compacted Slack history");
     expect(renderedText).toContain("after watermark");
     expect(renderedText).not.toContain("before watermark");
+    expect(renderedText).not.toContain("legacy row before watermark");
     expect(renderedText).not.toContain("at watermark");
     expect(result!.sourceChannelTsByMessage).toEqual([null, T2]);
     expect(getSlackCompactionWatermarkForPrefix(result, 1)).toBe(T2);
+  });
+
+  test("active-thread focus filters pre-watermark and legacy compacted rows", () => {
+    const caps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    const rows: MessageRow[] = [
+      userRow({
+        id: "thread-root",
+        createdAt: 1700000000_000,
+        text: "compacted root",
+        slackMeta: buildSlackMeta({
+          channelTs: T0,
+          threadTs: T0,
+          displayName: "alice",
+        }),
+      }),
+      userRow({
+        id: "legacy-old",
+        createdAt: 1700000005_000,
+        text: "legacy compacted row",
+      }),
+      userRow({
+        id: "reply-before",
+        createdAt: 1700000008_000,
+        text: "compacted reply",
+        slackMeta: buildSlackMeta({
+          channelTs: T0_REPLY1,
+          threadTs: T0,
+          displayName: "bob",
+        }),
+      }),
+      userRow({
+        id: "reply-after",
+        createdAt: 1700000025_000,
+        text: "live reply",
+        slackMeta: buildSlackMeta({
+          channelTs: T0_REPLY2,
+          threadTs: T0,
+          displayName: "carol",
+        }),
+      }),
+    ];
+
+    const result = loadSlackActiveThreadFocusBlock("conv-1", caps, {
+      loader: () => rows,
+      trustClass: "guardian",
+      contextCompactedMessageCount: 3,
+      slackContextCompactionWatermarkTs: T1,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!).toContain("live reply");
+    expect(result!).not.toContain("compacted root");
+    expect(result!).not.toContain("compacted reply");
+    expect(result!).not.toContain("legacy compacted row");
   });
 
   test("long Slack thread stays compacted after a later reply", () => {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -780,19 +780,42 @@ export async function runAgentLoopImpl(
     const isFirstMessage = ctx.messages.length === 1;
     let shouldInjectWorkspace = isFirstMessage;
     let compactedThisTurn = false;
-    let slackChronologicalContext: SlackChronologicalContext | null = null;
+    const isSlackConversation = ctx.channelCapabilities?.channel === "slack";
+    let slackChronologicalContext: SlackChronologicalContext | null =
+      isSlackConversation
+        ? loadSlackChronologicalContext(
+            ctx.conversationId,
+            ctx.channelCapabilities!,
+            {
+              trustClass: ctx.trustContext?.trustClass,
+              contextSummary: turnStartConversation?.contextSummary,
+              contextCompactedMessageCount:
+                turnStartConversation?.contextCompactedMessageCount,
+              slackContextCompactionWatermarkTs:
+                turnStartConversation?.slackContextCompactionWatermarkTs,
+            },
+          )
+        : null;
+    const messagesForStartOfTurnCompaction =
+      slackChronologicalContext?.messages ?? ctx.messages;
     const applySuccessfulCompaction = (
       result: Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>,
     ) => {
+      const slackWatermarkTs = getSlackCompactionWatermarkForPrefix(
+        slackChronologicalContext,
+        result.compactedMessages,
+      );
       applyCompactionResult(ctx, result, onEvent, reqId, {
-        slackContextCompactionWatermarkTs: getSlackCompactionWatermarkForPrefix(
-          slackChronologicalContext,
-          result.compactedMessages,
-        ),
+        slackContextCompactionWatermarkTs: slackWatermarkTs,
       });
+      if (slackWatermarkTs) {
+        slackChronologicalContext = null;
+      }
     };
 
-    const compactCheck = ctx.contextWindowManager.shouldCompact(ctx.messages);
+    const compactCheck = ctx.contextWindowManager.shouldCompact(
+      messagesForStartOfTurnCompaction,
+    );
     // Skip auto-compaction while the circuit breaker is open. Force paths
     // and user-initiated /compact bypass this check.
     const autoCompactAllowed = !(await isCompactionCircuitOpen(ctx));
@@ -815,7 +838,7 @@ export async function runAgentLoopImpl(
           (args) =>
             defaultCompactionTerminal(args, buildPluginTurnContext(ctx, reqId)),
           {
-            messages: ctx.messages,
+            messages: messagesForStartOfTurnCompaction,
             signal: abortController.signal,
             options: {
               lastCompactedAt: ctx.contextCompactedAt ?? undefined,
@@ -1222,21 +1245,23 @@ export async function runAgentLoopImpl(
     // model sees one channel-wide view instead of the gateway's per-turn
     // hints. DMs render as a flat sequence (no thread tags), channels
     // include sibling threads.
-    const isSlackConversation = ctx.channelCapabilities?.channel === "slack";
-    slackChronologicalContext = isSlackConversation
-      ? loadSlackChronologicalContext(
-          ctx.conversationId,
-          ctx.channelCapabilities!,
-          {
-            trustClass: ctx.trustContext?.trustClass,
-            contextSummary: turnStartConversation?.contextSummary,
-            contextCompactedMessageCount:
-              turnStartConversation?.contextCompactedMessageCount,
-            slackContextCompactionWatermarkTs:
-              turnStartConversation?.slackContextCompactionWatermarkTs,
-          },
-        )
-      : null;
+    const slackConversationForInjection = isSlackConversation
+      ? (getConversation(ctx.conversationId) ?? turnStartConversation)
+      : turnStartConversation;
+    if (isSlackConversation && !compactedThisTurn) {
+      slackChronologicalContext ??= loadSlackChronologicalContext(
+        ctx.conversationId,
+        ctx.channelCapabilities!,
+        {
+          trustClass: ctx.trustContext?.trustClass,
+          contextSummary: slackConversationForInjection?.contextSummary,
+          contextCompactedMessageCount:
+            slackConversationForInjection?.contextCompactedMessageCount,
+          slackContextCompactionWatermarkTs:
+            slackConversationForInjection?.slackContextCompactionWatermarkTs,
+        },
+      );
+    }
     const slackChronologicalMessages =
       slackChronologicalContext?.messages ?? null;
 
@@ -1251,7 +1276,13 @@ export async function runAgentLoopImpl(
       ? loadSlackActiveThreadFocusBlock(
           ctx.conversationId,
           ctx.channelCapabilities!,
-          { trustClass: ctx.trustContext?.trustClass },
+          {
+            trustClass: ctx.trustContext?.trustClass,
+            contextCompactedMessageCount:
+              slackConversationForInjection?.contextCompactedMessageCount,
+            slackContextCompactionWatermarkTs:
+              slackConversationForInjection?.slackContextCompactionWatermarkTs,
+          },
         )
       : null;
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -22,10 +22,13 @@ import {
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import {
+  compareSlackTs,
   extractTagLineTexts,
   isReactionTagLine,
+  isSlackTsAfter,
   type RenderableSlackMessage,
   renderSlackTranscript,
+  renderSlackTranscriptWithProvenance,
 } from "../messaging/providers/slack/render-transcript.js";
 import { getInjectors } from "../plugins/registry.js";
 import type {
@@ -1056,6 +1059,22 @@ export interface SlackChronologicalContext {
   readonly compactableStartIndex: number;
 }
 
+interface SlackBoundaryOptions {
+  readonly contextCompactedMessageCount?: number;
+  readonly slackContextCompactionWatermarkTs?: string | null;
+}
+
+function messageRowsToSlackTranscriptRows(
+  rows: MessageRow[],
+): SlackTranscriptInputRow[] {
+  return rows.map((row) => ({
+    role: row.role === "assistant" ? "assistant" : "user",
+    content: row.content,
+    createdAt: row.createdAt,
+    metadata: row.metadata,
+  }));
+}
+
 /**
  * Extract the user-facing plain text from an already-parsed `ContentBlock[]`.
  * Only `text` blocks contribute to the rendered transcript line. Tool-use /
@@ -1225,42 +1244,6 @@ export function assembleSlackChronologicalMessages(
   return renderSlackTranscript(renderable);
 }
 
-function slackTranscriptSortKey(msg: RenderableSlackMessage): number {
-  if (msg.metadata) {
-    const n = Number.parseFloat(msg.metadata.channelTs);
-    if (Number.isFinite(n)) return n;
-  }
-  return msg.createdAt / 1000;
-}
-
-function sortedSlackSourceChannelTs(
-  rows: RenderableSlackMessage[],
-): Array<string | null> {
-  const indexed = rows.map((row, index) => ({
-    row,
-    index,
-    key: slackTranscriptSortKey(row),
-  }));
-  indexed.sort((a, b) => {
-    if (a.key !== b.key) return a.key - b.key;
-    return a.index - b.index;
-  });
-  return indexed.map(({ row }) => row.metadata?.channelTs ?? null);
-}
-
-function compareSlackTs(a: string, b: string): number {
-  const aNum = Number.parseFloat(a);
-  const bNum = Number.parseFloat(b);
-  if (Number.isFinite(aNum) && Number.isFinite(bNum) && aNum !== bNum) {
-    return aNum - bNum;
-  }
-  return a.localeCompare(b);
-}
-
-function isSlackTsAfter(ts: string, watermarkTs: string): boolean {
-  return compareSlackTs(ts, watermarkTs) > 0;
-}
-
 function maxSlackTs(values: readonly (string | null)[]): string | null {
   let max: string | null = null;
   for (const value of values) {
@@ -1270,6 +1253,38 @@ function maxSlackTs(values: readonly (string | null)[]): string | null {
     }
   }
   return max;
+}
+
+function legacyRowIsAfterWatermark(
+  row: SlackTranscriptInputRow,
+  watermarkTs: string,
+): boolean {
+  return compareSlackTs(String(row.createdAt / 1000), watermarkTs) > 0;
+}
+
+function filterRowsAfterSlackCompactionBoundary(
+  rows: SlackTranscriptInputRow[],
+  options: SlackBoundaryOptions,
+): SlackTranscriptInputRow[] {
+  const fallbackCount = Math.max(
+    0,
+    Math.floor(options.contextCompactedMessageCount ?? 0),
+  );
+  const watermarkTs = options.slackContextCompactionWatermarkTs ?? null;
+  if (watermarkTs === null) {
+    return fallbackCount > 0 ? rows.slice(fallbackCount) : rows;
+  }
+
+  return rows.filter((row, index) => {
+    const meta = rowToRenderable(row).metadata;
+    if (meta) {
+      return isSlackTsAfter(meta.channelTs, watermarkTs);
+    }
+    if (index < fallbackCount) {
+      return false;
+    }
+    return legacyRowIsAfterWatermark(row, watermarkTs);
+  });
 }
 
 export function getSlackCompactionWatermarkForPrefix(
@@ -1297,19 +1312,21 @@ export function assembleSlackChronologicalContext(
     return null;
   }
   const renderable = rows.map(rowToRenderable);
-  const rendered = renderSlackTranscript(renderable);
-  const sourceChannelTsByMessage = sortedSlackSourceChannelTs(renderable);
+  const rendered = renderSlackTranscriptWithProvenance(renderable);
   const contextSummary = options.contextSummary?.trim();
   if (contextSummary) {
     return {
-      messages: [createContextSummaryMessage(contextSummary), ...rendered],
-      sourceChannelTsByMessage: [null, ...sourceChannelTsByMessage],
+      messages: [
+        createContextSummaryMessage(contextSummary),
+        ...rendered.messages,
+      ],
+      sourceChannelTsByMessage: [null, ...rendered.sourceChannelTsByMessage],
       compactableStartIndex: 1,
     };
   }
   return {
-    messages: rendered,
-    sourceChannelTsByMessage,
+    messages: rendered.messages,
+    sourceChannelTsByMessage: rendered.sourceChannelTsByMessage,
     compactableStartIndex: 0,
   };
 }
@@ -1347,13 +1364,7 @@ export function loadSlackChronologicalMessages(
   const scopedRows = isUntrustedTrustClass(options.trustClass)
     ? filterMessagesForUntrustedActor(allRows)
     : allRows;
-  // Coerce MessageRow.role (string) to the structural row's stricter union.
-  const rows: SlackTranscriptInputRow[] = scopedRows.map((row) => ({
-    role: row.role === "assistant" ? "assistant" : "user",
-    content: row.content,
-    createdAt: row.createdAt,
-    metadata: row.metadata,
-  }));
+  const rows = messageRowsToSlackTranscriptRows(scopedRows);
   return assembleSlackChronologicalMessages(rows, capabilities);
 }
 
@@ -1387,28 +1398,10 @@ export function loadSlackChronologicalContext(
   const scopedRows = isUntrustedTrustClass(options.trustClass)
     ? filterMessagesForUntrustedActor(allRows)
     : allRows;
-  const fallbackCount =
-    options.slackContextCompactionWatermarkTs == null
-      ? Math.max(0, Math.floor(options.contextCompactedMessageCount ?? 0))
-      : 0;
-  const rowsAfterCount =
-    fallbackCount > 0 ? scopedRows.slice(fallbackCount) : scopedRows;
-  const rows: SlackTranscriptInputRow[] = rowsAfterCount
-    .map(
-      (row): SlackTranscriptInputRow => ({
-        role: row.role === "assistant" ? "assistant" : "user",
-        content: row.content,
-        createdAt: row.createdAt,
-        metadata: row.metadata,
-      }),
-    )
-    .filter((row) => {
-      const watermarkTs = options.slackContextCompactionWatermarkTs;
-      if (watermarkTs == null) return true;
-      const meta = rowToRenderable(row).metadata;
-      if (!meta) return true;
-      return isSlackTsAfter(meta.channelTs, watermarkTs);
-    });
+  const rows = filterRowsAfterSlackCompactionBoundary(
+    messageRowsToSlackTranscriptRows(scopedRows),
+    options,
+  );
   return assembleSlackChronologicalContext(rows, capabilities, {
     contextSummary: isUntrustedTrustClass(options.trustClass)
       ? null
@@ -1580,6 +1573,8 @@ export function loadSlackActiveThreadFocusBlock(
   options: {
     loader?: (id: string) => MessageRow[];
     trustClass?: TrustClass;
+    contextCompactedMessageCount?: number;
+    slackContextCompactionWatermarkTs?: string | null;
   } = {},
 ): string | null {
   if (capabilities.channel !== "slack") return null;
@@ -1589,12 +1584,10 @@ export function loadSlackActiveThreadFocusBlock(
   const scopedRows = isUntrustedTrustClass(options.trustClass)
     ? filterMessagesForUntrustedActor(allRows)
     : allRows;
-  const rows: SlackTranscriptInputRow[] = scopedRows.map((row) => ({
-    role: row.role === "assistant" ? "assistant" : "user",
-    content: row.content,
-    createdAt: row.createdAt,
-    metadata: row.metadata,
-  }));
+  const rows = filterRowsAfterSlackCompactionBoundary(
+    messageRowsToSlackTranscriptRows(scopedRows),
+    options,
+  );
   return assembleSlackActiveThreadFocusBlock(rows, capabilities);
 }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -43,7 +43,10 @@ import {
 } from "../events/tool-profiling-listener.js";
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
-import { getConversationOriginChannel } from "../memory/conversation-crud.js";
+import {
+  getConversation,
+  getConversationOriginChannel,
+} from "../memory/conversation-crud.js";
 import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
@@ -92,7 +95,11 @@ import {
 } from "./conversation-process.js";
 import type { QueueDrainReason } from "./conversation-queue-manager.js";
 import { MessageQueue } from "./conversation-queue-manager.js";
-import type { ChannelCapabilities } from "./conversation-runtime-assembly.js";
+import {
+  type ChannelCapabilities,
+  getSlackCompactionWatermarkForPrefix,
+  loadSlackChronologicalContext,
+} from "./conversation-runtime-assembly.js";
 import type { SkillProjectionCache } from "./conversation-skill-tools.js";
 import {
   createSurfaceMutex,
@@ -1049,8 +1056,26 @@ export class Conversation {
   }
 
   async forceCompact(): Promise<ContextWindowResult> {
+    const conversationRow = getConversation(this.conversationId);
+    const slackChronologicalContext =
+      this.channelCapabilities?.channel === "slack"
+        ? loadSlackChronologicalContext(
+            this.conversationId,
+            this.channelCapabilities,
+            {
+              trustClass: this.trustContext?.trustClass,
+              contextSummary: conversationRow?.contextSummary,
+              contextCompactedMessageCount:
+                conversationRow?.contextCompactedMessageCount,
+              slackContextCompactionWatermarkTs:
+                conversationRow?.slackContextCompactionWatermarkTs,
+            },
+          )
+        : null;
+    const messagesToCompact =
+      slackChronologicalContext?.messages ?? this.messages;
     const result = await this.contextWindowManager.maybeCompact(
-      this.messages,
+      messagesToCompact,
       this.abortController?.signal ?? undefined,
       {
         force: true,
@@ -1072,7 +1097,12 @@ export class Conversation {
       );
     }
     if (result.compacted) {
-      applyCompactionResult(this, result, this.sendToClient, null);
+      applyCompactionResult(this, result, this.sendToClient, null, {
+        slackContextCompactionWatermarkTs: getSlackCompactionWatermarkForPrefix(
+          slackChronologicalContext,
+          result.compactedMessages,
+        ),
+      });
     }
     return result;
   }

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -16,6 +16,7 @@ import {
   parentAlias,
   type RenderableSlackMessage,
   renderSlackTranscript,
+  renderSlackTranscriptWithProvenance,
 } from "./render-transcript.js";
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -266,6 +267,25 @@ describe("renderSlackTranscript — basics", () => {
         "[11/14/23 14:26 @bob]: [attached file: diagram.png, image/png]",
       ),
     ]);
+  });
+
+  test("provenance follows the rendered sequence after orphan filtering", () => {
+    const out = renderSlackTranscriptWithProvenance([
+      userMsg(TS_14_25, "@alice", "kept"),
+      {
+        ...userMsg(TS_14_26, null, "", { role: "assistant" }),
+        contentBlocks: [
+          { type: "tool_use", id: "tool-1", name: "lookup", input: {} },
+        ],
+      },
+      userMsg(TS_14_28, "@bob", "also kept"),
+    ]);
+
+    expect(extractTagLineTexts(out.messages)).toEqual([
+      "[11/14/23 14:25 @alice]: kept",
+      "[11/14/23 14:28 @bob]: also kept",
+    ]);
+    expect(out.sourceChannelTsByMessage).toEqual([TS_14_25, TS_14_28]);
   });
 
   test("omits sender label for user-role message with null senderLabel (no displayName)", () => {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -58,6 +58,22 @@ export interface RenderOptions {
 
 const DEFAULT_MAX_REACTIONS = 5;
 
+export interface RenderedSlackTranscript {
+  readonly messages: Message[];
+  /**
+   * Slack source timestamp represented by each rendered message.
+   * `null` means the rendered message came from a legacy row with no Slack
+   * metadata. Collapsed reaction overflow trailers carry the max source
+   * timestamp included in that trailer.
+   */
+  readonly sourceChannelTsByMessage: readonly (string | null)[];
+}
+
+interface RenderedSlackEntry {
+  readonly message: Message;
+  readonly sourceChannelTs: string | null;
+}
+
 /**
  * Replayable Anthropic content-block types that we preserve verbatim from a
  * persisted row when rendering the Slack chronological transcript.
@@ -184,6 +200,25 @@ function sortKey(msg: RenderableSlackMessage): number {
   }
   // createdAt is epoch ms; convert to seconds for like-with-like comparison.
   return msg.createdAt / 1000;
+}
+
+export function compareSlackTs(a: string, b: string): number {
+  const aNum = Number.parseFloat(a);
+  const bNum = Number.parseFloat(b);
+  if (Number.isFinite(aNum) && Number.isFinite(bNum) && aNum !== bNum) {
+    return aNum - bNum;
+  }
+  return a.localeCompare(b);
+}
+
+export function isSlackTsAfter(ts: string, watermarkTs: string): boolean {
+  return compareSlackTs(ts, watermarkTs) > 0;
+}
+
+function maxNullableSlackTs(a: string | null, b: string | null): string | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return compareSlackTs(a, b) >= 0 ? a : b;
 }
 
 /**
@@ -366,7 +401,16 @@ export function renderSlackTranscript(
   messages: RenderableSlackMessage[],
   opts?: RenderOptions,
 ): Message[] {
-  if (messages.length === 0) return [];
+  return renderSlackTranscriptWithProvenance(messages, opts).messages;
+}
+
+export function renderSlackTranscriptWithProvenance(
+  messages: RenderableSlackMessage[],
+  opts?: RenderOptions,
+): RenderedSlackTranscript {
+  if (messages.length === 0) {
+    return { messages: [], sourceChannelTsByMessage: [] };
+  }
 
   const maxReactions = Math.max(
     1,
@@ -388,23 +432,37 @@ export function renderSlackTranscript(
   // reaches an event that is not an overflowing reaction for that target.
   const overflowAccumulator = new Map<
     string,
-    { excess: number; role: "user" | "assistant" }
+    {
+      excess: number;
+      role: "user" | "assistant";
+      sourceChannelTs: string | null;
+    }
   >();
 
   const trailerMessage = (
     target: string,
-    acc: { excess: number; role: "user" | "assistant" },
-  ): Message => ({
-    role: acc.role,
-    content: [
-      {
-        type: "text" as const,
-        text: `[…and ${acc.excess} more ${acc.excess === 1 ? "reaction" : "reactions"} to ${parentAlias(target)}]`,
-      },
-    ],
+    acc: {
+      excess: number;
+      role: "user" | "assistant";
+      sourceChannelTs: string | null;
+    },
+  ): RenderedSlackEntry => ({
+    message: {
+      role: acc.role,
+      content: [
+        {
+          type: "text" as const,
+          text: `[…and ${acc.excess} more ${acc.excess === 1 ? "reaction" : "reactions"} to ${parentAlias(target)}]`,
+        },
+      ],
+    },
+    sourceChannelTs: acc.sourceChannelTs,
   });
 
-  const flushOverflowExcept = (out: Message[], keepTarget: string | null) => {
+  const flushOverflowExcept = (
+    out: RenderedSlackEntry[],
+    keepTarget: string | null,
+  ) => {
     for (const target of Array.from(overflowAccumulator.keys())) {
       if (target === keepTarget) continue;
       const acc = overflowAccumulator.get(target)!;
@@ -413,7 +471,7 @@ export function renderSlackTranscript(
     }
   };
 
-  const out: Message[] = [];
+  const out: RenderedSlackEntry[] = [];
   for (const m of sorted) {
     const meta = m.metadata;
     if (meta?.eventKind === "reaction" && meta.reaction) {
@@ -427,8 +485,11 @@ export function renderSlackTranscript(
         const line = renderReaction(m);
         if (line !== null) {
           out.push({
-            role: m.role,
-            content: [{ type: "text" as const, text: line }],
+            message: {
+              role: m.role,
+              content: [{ type: "text" as const, text: line }],
+            },
+            sourceChannelTs: meta.channelTs,
           });
         }
       } else {
@@ -438,8 +499,13 @@ export function renderSlackTranscript(
         const acc = overflowAccumulator.get(target) ?? {
           excess: 0,
           role: m.role,
+          sourceChannelTs: null,
         };
         acc.excess += 1;
+        acc.sourceChannelTs = maxNullableSlackTs(
+          acc.sourceChannelTs,
+          meta.channelTs,
+        );
         overflowAccumulator.set(target, acc);
       }
       continue;
@@ -450,15 +516,22 @@ export function renderSlackTranscript(
     const blocks = buildMessageContentBlocks(m, tagLine);
     if (blocks.length === 0) continue;
     out.push({
-      role: m.role,
-      content: blocks,
+      message: {
+        role: m.role,
+        content: blocks,
+      },
+      sourceChannelTs: meta?.channelTs ?? null,
     });
   }
 
   // End of the walk: flush any still-open overflow windows.
   flushOverflowExcept(out, null);
 
-  return filterOrphanToolPairs(out);
+  const filtered = filterOrphanToolPairs(out);
+  return {
+    messages: filtered.map((entry) => entry.message),
+    sourceChannelTsByMessage: filtered.map((entry) => entry.sourceChannelTs),
+  };
 }
 
 /**
@@ -483,18 +556,21 @@ export function renderSlackTranscript(
  * emitted as `{role, content: []}` — empty-content messages are also
  * rejected by the provider.
  */
-function filterOrphanToolPairs(messages: Message[]): Message[] {
+function filterOrphanToolPairs(
+  entries: RenderedSlackEntry[],
+): RenderedSlackEntry[] {
   const produced = new Set<string>();
   const consumed = new Set<string>();
-  for (const msg of messages) {
+  for (const { message: msg } of entries) {
     for (const b of msg.content) {
       if (b.type === "tool_use") produced.add(b.id);
       else if (b.type === "tool_result" || b.type === "web_search_tool_result")
         consumed.add(b.tool_use_id);
     }
   }
-  const out: Message[] = [];
-  for (const msg of messages) {
+  const out: RenderedSlackEntry[] = [];
+  for (const entry of entries) {
+    const msg = entry.message;
     const kept: ContentBlock[] = [];
     for (const b of msg.content) {
       if (b.type === "tool_use" && !consumed.has(b.id)) continue;
@@ -505,7 +581,12 @@ function filterOrphanToolPairs(messages: Message[]): Message[] {
         continue;
       kept.push(b);
     }
-    if (kept.length > 0) out.push({ role: msg.role, content: kept });
+    if (kept.length > 0) {
+      out.push({
+        message: { role: msg.role, content: kept },
+        sourceChannelTs: entry.sourceChannelTs,
+      });
+    }
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- Derive Slack compaction watermarks from rendered transcript provenance
- Persist watermarks for start-of-turn and forced Slack compaction paths
- Filter active-thread and legacy rows consistently across the watermark boundary

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
