### PR TITLE
fix: Correct Slack late-join backfill context

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2825,6 +2825,37 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(allText).not.toContain("dm context");
   });
 
+  test("slack late-join notice is model-facing and non-persisted", async () => {
+    const slackChannelCaps: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    const notice =
+      "Slack context note: this turn joined an existing thread. 3 earlier thread messages were backfilled before the current message.";
+
+    const { messages: result, blocks } = await applyRuntimeInjections(
+      [{ role: "user", content: [{ type: "text", text: "current turn" }] }],
+      {
+        channelCapabilities: slackChannelCaps,
+        slackRuntimeContextNotice: notice,
+        transportHints: [notice],
+      },
+    );
+
+    const allText = result
+      .flatMap((m) => m.content)
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join("\n");
+    expect(allText).toContain("<slack_context_notice>");
+    expect(allText).toContain(notice);
+    expect(allText).not.toContain("<transport_hints>");
+    expect(JSON.stringify(blocks)).not.toContain(notice);
+  });
+
   // ── transport_hints kept for non-slack channels ───────────────────────
   test("non-slack conversations still receive <transport_hints>", async () => {
     const { messages: result } = await applyRuntimeInjections(

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -8,8 +8,8 @@
  *
  * Tests exercise the helper {@link triggerSlackThreadBackfillIfNeeded}
  * directly against the real database (via the test-preload temp workspace).
- * Only `backfillThreadWindow` is mocked, since the contract under test is "given
- * what Slack returns, what does the daemon write to the DB".
+ * Only the Slack backfill read is mocked, since the contract under test is
+ * "given what Slack returns, what does the daemon write to the DB".
  */
 import {
   afterAll,
@@ -83,16 +83,26 @@ import {
 
 initializeDb();
 
-// Spy on backfillThreadWindow so the stub is scoped to this test file only.
-// Restoring after the file's tests run keeps cross-file leakage to zero —
-// other tests (e.g. backfill.test.ts) keep seeing the real implementation.
-const backfillThreadMock = spyOn(slackBackfill, "backfillThreadWindow");
+// Spy on backfillThreadWindowPage so the stub is scoped to this test file
+// only. Existing tests drive the message array through `backfillThreadMock`;
+// page metadata defaults to "complete" unless a test overrides the page spy.
+const backfillThreadMock = mock<typeof slackBackfill.backfillThreadWindow>(
+  async () => [],
+);
+const backfillThreadPageMock = spyOn(slackBackfill, "backfillThreadWindowPage");
+function installDefaultThreadPageMock(): void {
+  backfillThreadPageMock.mockImplementation(async (...args) => ({
+    messages: await backfillThreadMock(...args),
+    hasMore: false,
+  }));
+}
+installDefaultThreadPageMock();
 backfillThreadMock.mockResolvedValue([]);
 const backfillDmMock = spyOn(slackBackfill, "backfillDm");
 backfillDmMock.mockResolvedValue([]);
 
 afterAll(() => {
-  backfillThreadMock.mockRestore();
+  backfillThreadPageMock.mockRestore();
   backfillDmMock.mockRestore();
 });
 
@@ -308,6 +318,7 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
 
   afterEach(() => {
     backfillThreadMock.mockReset();
+    installDefaultThreadPageMock();
     _backfillTriggerCache.clear();
   });
 
@@ -370,12 +381,32 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     const conv = createTestConversation();
     const ts = (n: number) => `1234.${String(n).padStart(6, "0")}`;
 
+    backfillThreadPageMock.mockImplementation(async (...args) => {
+      const messages = await backfillThreadMock(...args);
+      const opts = args[2];
+      if (opts?.before === ts(100) && opts.cursor === undefined) {
+        return { messages, hasMore: true, nextCursor: "recent-page-2" };
+      }
+      if (opts?.limit === 25) {
+        return { messages, hasMore: true, nextCursor: "early-page-2" };
+      }
+      return { messages, hasMore: false };
+    });
     backfillThreadMock.mockImplementation(async (_channel, _thread, opts) => {
       if (opts?.limit === 25) {
         return Array.from({ length: 25 }, (_, i) =>
           makeBackfillMessage({
             id: ts(i),
             text: i === 0 ? "root context" : `early ${i}`,
+            threadId: i === 0 ? undefined : ts(0),
+          }),
+        );
+      }
+      if (opts?.cursor === undefined) {
+        return Array.from({ length: 50 }, (_, i) =>
+          makeBackfillMessage({
+            id: ts(i),
+            text: i === 0 ? "root context duplicate" : `early duplicate ${i}`,
             threadId: i === 0 ? undefined : ts(0),
           }),
         );
@@ -417,11 +448,12 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       excludeChannelTs: ts(100),
     });
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
+    expect(backfillThreadMock).toHaveBeenCalledTimes(3);
     expect(backfillThreadMock.mock.calls[0][2]?.limit).toBe(25);
     expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
     expect(backfillThreadMock.mock.calls[1][2]?.limit).toBe(50);
     expect(backfillThreadMock.mock.calls[1][2]?.before).toBe(ts(100));
+    expect(backfillThreadMock.mock.calls[2][2]?.cursor).toBe("recent-page-2");
 
     expect(result.reason).toBe("thread_late_join");
     expect(result.omittedMiddle).toBe(true);
@@ -1099,6 +1131,7 @@ function buildSlackDmRequest(
 }
 
 interface SlackInboundProcessOptions {
+  slackRuntimeContextNotice?: string;
   slackInbound?: {
     channelId: string;
     channelTs: string;
@@ -1160,6 +1193,7 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
 
   afterEach(() => {
     backfillThreadMock.mockReset();
+    installDefaultThreadPageMock();
     _backfillTriggerCache.clear();
   });
 
@@ -1180,13 +1214,18 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     ]);
 
     let capturedHints: string[] | undefined;
+    let capturedSlackNotice: string | undefined;
     const processMessage = async (
       _conversationId: string,
       _content: string,
       _attachmentIds?: string[],
-      options?: { transport?: { hints?: string[] } },
+      options?: {
+        transport?: { hints?: string[] };
+        slackRuntimeContextNotice?: string;
+      },
     ): Promise<{ messageId: string }> => {
       capturedHints = options?.transport?.hints;
+      capturedSlackNotice = options?.slackRuntimeContextNotice;
       return { messageId: "agent-result-id" };
     };
     setAdapterProcessMessage(processMessage);
@@ -1235,7 +1274,8 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
 
     expect(
       capturedHints?.some((hint) => hint.includes("joined an existing thread")),
-    ).toBe(true);
+    ).not.toBe(true);
+    expect(capturedSlackNotice).toContain("joined an existing thread");
     const contents = db.$client
       .prepare("SELECT content FROM messages")
       .all() as Array<{ content: string }>;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -488,6 +488,7 @@ export interface AgentLoopConversationContext {
   assistantId?: string;
   voiceCallControlPrompt?: string;
   transportHints?: string[];
+  slackRuntimeContextNotice?: string;
 
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
@@ -1285,6 +1286,7 @@ export async function runAgentLoopImpl(
       nowScratchpad,
       voiceCallControlPrompt: ctx.voiceCallControlPrompt ?? null,
       transportHints: ctx.transportHints ?? null,
+      slackRuntimeContextNotice: ctx.slackRuntimeContextNotice ?? null,
       isNonInteractive: !isInteractiveResolved,
       subagentStatusBlock,
       slackChronologicalMessages,
@@ -2811,6 +2813,7 @@ export async function runAgentLoopImpl(
     ctx.allowedToolNames = undefined;
     ctx.preactivatedSkillIds = undefined;
     ctx.currentTurnOverrideProfile = undefined;
+    ctx.slackRuntimeContextNotice = undefined;
     // Channel command intents (e.g. Telegram /start) are single-turn metadata.
     // Clear at turn end so they never leak into subsequent unrelated messages.
     ctx.commandIntent = undefined;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1005,6 +1005,17 @@ function injectTransportHints(message: Message, hints: string[]): Message {
   };
 }
 
+function injectSlackRuntimeContextNotice(
+  message: Message,
+  notice: string,
+): Message {
+  const block = `<slack_context_notice>\n${notice}\n</slack_context_notice>`;
+  return {
+    ...message,
+    content: [{ type: "text", text: block }, ...message.content],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Slack chronological transcript assembly
 // ---------------------------------------------------------------------------
@@ -1633,6 +1644,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<pkb>", // backward-compat: strip legacy tag from pre-rename history
   "<system_reminder>",
   "<transport_hints>",
+  "<slack_context_notice>",
   // The Slack active-thread focus block is non-persisted and injected on
   // the FINAL user turn only. Strip it here so re-assembly during compaction
   // and overflow recovery does not duplicate it across turns.
@@ -1917,6 +1929,7 @@ export interface RuntimeInjectionOptions {
   subagentStatusBlock?: string | null;
   isNonInteractive?: boolean;
   transportHints?: string[] | null;
+  slackRuntimeContextNotice?: string | null;
   /**
    * Pre-rendered Slack chronological transcript that replaces the
    * default `runMessages` history for any Slack conversation (channels
@@ -2245,6 +2258,23 @@ export async function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectChannelCapabilityContext(userTail, options.channelCapabilities),
+      ];
+    }
+  }
+
+  if (
+    mode === "full" &&
+    slackConversation &&
+    options.slackRuntimeContextNotice
+  ) {
+    const userTail = result[result.length - 1];
+    if (userTail && userTail.role === "user") {
+      result = [
+        ...result.slice(0, -1),
+        injectSlackRuntimeContextNotice(
+          userTail,
+          options.slackRuntimeContextNotice,
+        ),
       ];
     }
   }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -220,6 +220,7 @@ export class Conversation {
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ transportHints?: string[];
+  /** @internal */ slackRuntimeContextNotice?: string;
   /** @internal */ assistantId?: string;
   /** @internal */ commandIntent?: {
     type: string;
@@ -1107,6 +1108,10 @@ export class Conversation {
 
   setTransportHints(hints: string[] | undefined): void {
     this.transportHints = hints;
+  }
+
+  setSlackRuntimeContextNotice(notice: string | undefined): void {
+    this.slackRuntimeContextNotice = notice;
   }
 
   /**

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -119,6 +119,8 @@ export interface ConversationCreateOptions {
   authContext?: AuthContext;
   /** Whether this turn can block on interactive approval prompts. */
   isInteractive?: boolean;
+  /** Slack-only non-persisted notice injected into the active model turn. */
+  slackRuntimeContextNotice?: string;
   memoryScopeId?: string;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
@@ -508,7 +510,6 @@ export function requestSecretStandalone(params: {
   allowedTools?: string[];
   allowedDomains?: string[];
 }): Promise<SecretPromptResult> {
-
   const requestId = uuid();
   const config = getConfig();
   return new Promise((resolve) => {

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -564,6 +564,9 @@ export async function processMessage(
   }
 
   try {
+    conversation.setSlackRuntimeContextNotice(
+      options?.slackRuntimeContextNotice,
+    );
     await conversation.runAgentLoop(resolvedContent, messageId, onEvent, {
       isInteractive: options?.isInteractive ?? false,
       isUserMessage: true,

--- a/assistant/src/messaging/provider-types.ts
+++ b/assistant/src/messaging/provider-types.ts
@@ -41,6 +41,12 @@ export interface SearchResult {
   nextCursor?: string;
 }
 
+export interface HistoryPageResult {
+  messages: Message[];
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
 export interface SendResult {
   id: string;
   timestamp: number;

--- a/assistant/src/messaging/provider.ts
+++ b/assistant/src/messaging/provider.ts
@@ -11,6 +11,7 @@ import type {
   ConnectionInfo,
   Conversation,
   HistoryOptions,
+  HistoryPageResult,
   ListOptions,
   Message,
   SearchOptions,
@@ -60,6 +61,12 @@ export interface MessagingProvider {
     threadId: string,
     options?: HistoryOptions,
   ): Promise<Message[]>;
+  getThreadRepliesPage?(
+    connection: OAuthConnection | undefined,
+    conversationId: string,
+    threadId: string,
+    options?: HistoryOptions,
+  ): Promise<HistoryPageResult>;
   markRead?(
     connection: OAuthConnection | undefined,
     conversationId: string,

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -17,6 +17,7 @@ import type {
   ConnectionInfo,
   Conversation,
   HistoryOptions,
+  HistoryPageResult,
   ListOptions,
   Message,
   SearchOptions,
@@ -259,6 +260,19 @@ function mapSearchMatch(match: SlackSearchMatch): Message {
   };
 }
 
+async function mapSlackMessages(
+  auth: OAuthConnection | string,
+  channelId: string,
+  slackMessages: SlackMessage[],
+): Promise<Message[]> {
+  const messages: Message[] = [];
+  for (const msg of slackMessages) {
+    const name = await resolveUserName(auth, msg.user ?? "");
+    messages.push(mapMessage(msg, channelId, name));
+  }
+  return messages;
+}
+
 export const slackProvider: MessagingProvider = {
   id: "slack",
   displayName: "Slack",
@@ -422,13 +436,7 @@ export const slackProvider: MessagingProvider = {
       );
     });
 
-    const messages: Message[] = [];
-    for (const msg of resp.messages) {
-      const name = await resolveUserName(auth, msg.user ?? "");
-      messages.push(mapMessage(msg, conversationId, name));
-    }
-
-    return messages;
+    return mapSlackMessages(auth, conversationId, resp.messages);
   },
 
   async search(
@@ -486,12 +494,35 @@ export const slackProvider: MessagingProvider = {
         options?.cursor,
       );
     });
-    const messages: Message[] = [];
-    for (const msg of resp.messages) {
-      const name = await resolveUserName(auth, msg.user ?? "");
-      messages.push(mapMessage(msg, conversationId, name));
-    }
-    return messages;
+    return mapSlackMessages(auth, conversationId, resp.messages);
+  },
+
+  async getThreadRepliesPage(
+    connection: OAuthConnection | undefined,
+    conversationId: string,
+    threadId: string,
+    options?: HistoryOptions,
+  ): Promise<HistoryPageResult> {
+    let auth: OAuthConnection | string = getReadAuth(connection);
+    const resp = await runReadWithFallback(connection, async (a) => {
+      auth = a;
+      return slack.conversationReplies(
+        a,
+        conversationId,
+        threadId,
+        options?.limit ?? 50,
+        options?.before,
+        options?.after,
+        options?.inclusive,
+        options?.cursor,
+      );
+    });
+    const nextCursor = resp.response_metadata?.next_cursor || undefined;
+    return {
+      messages: await mapSlackMessages(auth, conversationId, resp.messages),
+      hasMore: Boolean(resp.has_more || nextCursor),
+      ...(nextCursor ? { nextCursor } : {}),
+    };
   },
 
   async markRead(

--- a/assistant/src/messaging/providers/slack/backfill.test.ts
+++ b/assistant/src/messaging/providers/slack/backfill.test.ts
@@ -17,7 +17,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { OAuthConnection } from "../../../oauth/connection.js";
-import type { HistoryOptions, Message } from "../../provider-types.js";
+import type {
+  HistoryOptions,
+  HistoryPageResult,
+  Message,
+} from "../../provider-types.js";
 
 // ── Module mocks ────────────────────────────────────────────────────────────
 
@@ -35,10 +39,22 @@ type GetThreadRepliesFn = (
   threadId: string,
   options?: HistoryOptions,
 ) => Promise<Message[]>;
+type GetThreadRepliesPageFn = (
+  connection: OAuthConnection | undefined,
+  conversationId: string,
+  threadId: string,
+  options?: HistoryOptions,
+) => Promise<HistoryPageResult>;
 
 const resolveConnectionMock = mock<ResolveConnectionFn>(async () => undefined);
 const getHistoryMock = mock<GetHistoryFn>(async () => []);
 const getThreadRepliesMock = mock<GetThreadRepliesFn>(async () => []);
+const getThreadRepliesPageMock = mock<GetThreadRepliesPageFn>(
+  async (...args) => ({
+    messages: await getThreadRepliesMock(...args),
+    hasMore: false,
+  }),
+);
 
 mock.module("./adapter.js", () => ({
   slackProvider: {
@@ -58,6 +74,13 @@ mock.module("./adapter.js", () => ({
       threadId: string,
       options?: HistoryOptions,
     ) => getThreadRepliesMock(connection, conversationId, threadId, options),
+    getThreadRepliesPage: (
+      connection: OAuthConnection | undefined,
+      conversationId: string,
+      threadId: string,
+      options?: HistoryOptions,
+    ) =>
+      getThreadRepliesPageMock(connection, conversationId, threadId, options),
     // Stub the rest of the MessagingProvider surface as no-ops; the backfill
     // helpers should never reach for these.
     testConnection: async () => {
@@ -75,6 +98,7 @@ import {
   backfillDm,
   backfillThread,
   backfillThreadWindow,
+  backfillThreadWindowPage,
 } from "./backfill.js";
 
 function makeMessage(overrides: Partial<Message> = {}): Message {
@@ -97,6 +121,11 @@ describe("backfillThread", () => {
     resolveConnectionMock.mockImplementation(async () => undefined);
     getThreadRepliesMock.mockReset();
     getThreadRepliesMock.mockImplementation(async () => []);
+    getThreadRepliesPageMock.mockReset();
+    getThreadRepliesPageMock.mockImplementation(async (...args) => ({
+      messages: await getThreadRepliesMock(...args),
+      hasMore: false,
+    }));
     getHistoryMock.mockReset();
     getHistoryMock.mockImplementation(async () => []);
   });
@@ -150,6 +179,30 @@ describe("backfillThread", () => {
     expect(opts).toEqual({
       limit: 50,
       cursor: "cursor-123",
+    });
+  });
+
+  test("page helper returns Slack pagination metadata", async () => {
+    const reply = makeMessage({
+      id: "1700000000.000300",
+      threadId: "1700000000.000100",
+    });
+    getThreadRepliesPageMock.mockImplementation(async () => ({
+      messages: [reply],
+      hasMore: true,
+      nextCursor: "cursor-next",
+    }));
+
+    const out = await backfillThreadWindowPage("C123", "1700000000.000100", {
+      limit: 25,
+      before: "1700000005.000100",
+    });
+
+    expect(getThreadRepliesPageMock).toHaveBeenCalledTimes(1);
+    expect(out).toEqual({
+      messages: [reply],
+      hasMore: true,
+      nextCursor: "cursor-next",
     });
   });
 
@@ -215,6 +268,11 @@ describe("backfillDm", () => {
     getHistoryMock.mockImplementation(async () => []);
     getThreadRepliesMock.mockReset();
     getThreadRepliesMock.mockImplementation(async () => []);
+    getThreadRepliesPageMock.mockReset();
+    getThreadRepliesPageMock.mockImplementation(async (...args) => ({
+      messages: await getThreadRepliesMock(...args),
+      hasMore: false,
+    }));
   });
 
   test("passes channelId through and defaults limit to 50, before undefined", async () => {

--- a/assistant/src/messaging/providers/slack/backfill.ts
+++ b/assistant/src/messaging/providers/slack/backfill.ts
@@ -23,6 +23,12 @@ const log = getLogger("slack-backfill");
 
 const DEFAULT_LIMIT = 50;
 
+export interface SlackBackfillWindowPage {
+  messages: Message[];
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
 function isChannelNotFound(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return /channel_not_found/i.test(msg);
@@ -62,15 +68,41 @@ export async function backfillThreadWindow(
     account?: string;
   },
 ): Promise<Message[]> {
+  const page = await backfillThreadWindowPage(channelId, threadTs, opts);
+  return page.messages;
+}
+
+/**
+ * Fetch a bounded Slack thread page and preserve Slack pagination metadata.
+ *
+ * This is the preferred helper for callers that need to know whether a
+ * bounded window fully covered the requested range. The older
+ * `backfillThreadWindow` wrapper intentionally returns only messages for
+ * existing consumers.
+ */
+export async function backfillThreadWindowPage(
+  channelId: string,
+  threadTs: string,
+  opts?: {
+    limit?: number;
+    after?: string;
+    before?: string;
+    cursor?: string;
+    account?: string;
+  },
+): Promise<SlackBackfillWindowPage> {
   const limit = opts?.limit ?? DEFAULT_LIMIT;
   try {
     const connection = await slackProvider.resolveConnection?.(opts?.account);
-    if (!slackProvider.getThreadReplies) {
+    if (
+      !slackProvider.getThreadRepliesPage &&
+      !slackProvider.getThreadReplies
+    ) {
       log.warn(
         { channelId, threadTs },
-        "Slack provider does not implement getThreadReplies — returning []",
+        "Slack provider does not implement thread reply reads — returning []",
       );
-      return [];
+      return { messages: [], hasMore: false };
     }
     const historyOptions = {
       limit,
@@ -78,12 +110,23 @@ export async function backfillThreadWindow(
       ...(opts?.before !== undefined ? { before: opts.before } : {}),
       ...(opts?.cursor !== undefined ? { cursor: opts.cursor } : {}),
     };
-    return await slackProvider.getThreadReplies(
-      connection,
-      channelId,
-      threadTs,
-      historyOptions,
-    );
+    if (slackProvider.getThreadRepliesPage) {
+      return await slackProvider.getThreadRepliesPage(
+        connection,
+        channelId,
+        threadTs,
+        historyOptions,
+      );
+    }
+    return {
+      messages: await slackProvider.getThreadReplies!(
+        connection,
+        channelId,
+        threadTs,
+        historyOptions,
+      ),
+      hasMore: false,
+    };
   } catch (err) {
     if (isChannelNotFound(err)) {
       throw err;
@@ -100,7 +143,7 @@ export async function backfillThreadWindow(
       },
       "Slack thread backfill failed — returning []",
     );
-    return [];
+    return { messages: [], hasMore: false };
   }
 }
 

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -44,7 +44,6 @@ export const slackMessageMetadataSchema = z.object({
   backfillReason: z
     .enum(["thread_late_join", "thread_delta", "dm_cold_start"])
     .optional(),
-  backfillOmittedCount: z.number().optional(),
   backfillOmittedMiddle: z.boolean().optional(),
   slackFiles: z.array(slackFileMetadataSchema).optional(),
 });

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -118,6 +118,8 @@ export interface RuntimeMessageConversationOptions {
   isInteractive?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
+  /** Slack-only non-persisted notice injected into the active model turn. */
+  slackRuntimeContextNotice?: string;
   /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
   onEvent?: (msg: ServerMessage) => void;
   /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -45,7 +45,8 @@ import { upsertBinding } from "../../memory/external-conversation-store.js";
 import type { Message as ProviderMessage } from "../../messaging/provider-types.js";
 import {
   backfillDm,
-  backfillThreadWindow,
+  backfillThreadWindowPage,
+  type SlackBackfillWindowPage,
 } from "../../messaging/providers/slack/backfill.js";
 import {
   mergeSlackMetadata,
@@ -673,6 +674,7 @@ export async function handleChannelInbound({
           typeof hint === "string" && hint.trim().length > 0,
       )
     : [];
+  let slackRuntimeContextNotice: string | undefined;
 
   // Inject channel-scoped permission hints for Slack channel messages
   if (sourceChannel === "slack") {
@@ -1055,7 +1057,7 @@ export async function handleChannelInbound({
           account: slackAccount,
         });
         const lateJoinNotice = buildSlackLateJoinNotice(backfillResult);
-        if (lateJoinNotice) metadataHints.push(lateJoinNotice);
+        if (lateJoinNotice) slackRuntimeContextNotice = lateJoinNotice;
       }
 
       // Wrap non-guardian inbound content in external_content boundaries so
@@ -1083,6 +1085,7 @@ export async function handleChannelInbound({
         externalChatId: conversationExternalId,
         trustCtx,
         metadataHints,
+        slackRuntimeContextNotice,
         metadataUxBrief,
         commandIntent,
         sourceLanguageCode,
@@ -1611,6 +1614,7 @@ const BACKFILL_TRIGGER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const BACKFILL_TRIGGER_CACHE_MAX = 1_000;
 const SLACK_THREAD_INITIAL_EARLY_LIMIT = 25;
 const SLACK_THREAD_INITIAL_RECENT_LIMIT = 50;
+const SLACK_THREAD_INITIAL_RECENT_MAX_PAGES = 5;
 const SLACK_THREAD_DELTA_LIMIT = 50;
 
 export interface SlackThreadBackfillResult {
@@ -1657,14 +1661,89 @@ function isBackfillRecentlyTriggered(cacheKey: string): boolean {
   return true;
 }
 
+interface SlackInitialThreadWindowsResult {
+  messages: ProviderMessage[];
+  omittedMiddle: boolean;
+}
+
+function slackPageHasMore(page: SlackBackfillWindowPage): boolean {
+  return page.hasMore || page.nextCursor !== undefined;
+}
+
+function minSlackMessageTs(messages: ProviderMessage[]): string | undefined {
+  return sortSlackProviderMessages(messages)[0]?.id;
+}
+
+function maxSlackMessageTs(messages: ProviderMessage[]): string | undefined {
+  const sorted = sortSlackProviderMessages(messages);
+  return sorted[sorted.length - 1]?.id;
+}
+
+function didInitialWindowsLeaveGap(params: {
+  early: SlackBackfillWindowPage;
+  recent: SlackBackfillWindowPage;
+  recentScanTruncated: boolean;
+}): boolean {
+  if (params.recentScanTruncated) return true;
+  if (!slackPageHasMore(params.early)) return false;
+  const earlyMax = maxSlackMessageTs(params.early.messages);
+  const recentMin = minSlackMessageTs(params.recent.messages);
+  if (!earlyMax || !recentMin) return false;
+  const compared = compareSlackTimestamps(earlyMax, recentMin);
+  return compared !== null && compared < 0;
+}
+
+async function fetchRecentSlackThreadWindow(params: {
+  channelId: string;
+  threadTs: string;
+  upperBoundTs: string;
+  account?: string;
+}): Promise<{
+  page: SlackBackfillWindowPage;
+  truncatedBeforeUpperBound: boolean;
+}> {
+  let cursor: string | undefined;
+  let lastPage: SlackBackfillWindowPage = { messages: [], hasMore: false };
+  let truncatedBeforeUpperBound = false;
+
+  for (
+    let pageIndex = 0;
+    pageIndex < SLACK_THREAD_INITIAL_RECENT_MAX_PAGES;
+    pageIndex++
+  ) {
+    const page = await backfillThreadWindowPage(
+      params.channelId,
+      params.threadTs,
+      {
+        limit: SLACK_THREAD_INITIAL_RECENT_LIMIT,
+        account: params.account,
+        before: params.upperBoundTs,
+        ...(cursor !== undefined ? { cursor } : {}),
+      },
+    );
+    if (page.messages.length > 0) {
+      lastPage = page;
+    }
+    if (!slackPageHasMore(page)) {
+      truncatedBeforeUpperBound = false;
+      break;
+    }
+    cursor = page.nextCursor;
+    truncatedBeforeUpperBound = true;
+    if (!cursor) break;
+  }
+
+  return { page: lastPage, truncatedBeforeUpperBound };
+}
+
 async function fetchInitialSlackThreadWindows(params: {
   channelId: string;
   threadTs: string;
   upperBoundTs?: string;
   account?: string;
-}): Promise<ProviderMessage[]> {
+}): Promise<SlackInitialThreadWindowsResult> {
   if (!params.upperBoundTs) {
-    const early = await backfillThreadWindow(
+    const early = await backfillThreadWindowPage(
       params.channelId,
       params.threadTs,
       {
@@ -1672,22 +1751,36 @@ async function fetchInitialSlackThreadWindows(params: {
         account: params.account,
       },
     );
-    return sortSlackProviderMessages(dedupeSlackProviderMessages(early));
+    return {
+      messages: sortSlackProviderMessages(
+        dedupeSlackProviderMessages(early.messages),
+      ),
+      omittedMiddle: slackPageHasMore(early),
+    };
   }
-  const [early, recent] = await Promise.all([
-    backfillThreadWindow(params.channelId, params.threadTs, {
+  const [early, recentResult] = await Promise.all([
+    backfillThreadWindowPage(params.channelId, params.threadTs, {
       limit: SLACK_THREAD_INITIAL_EARLY_LIMIT,
       account: params.account,
     }),
-    backfillThreadWindow(params.channelId, params.threadTs, {
-      limit: SLACK_THREAD_INITIAL_RECENT_LIMIT,
+    fetchRecentSlackThreadWindow({
+      channelId: params.channelId,
+      threadTs: params.threadTs,
       account: params.account,
-      before: params.upperBoundTs,
+      upperBoundTs: params.upperBoundTs,
     }),
   ]);
-  return sortSlackProviderMessages(
-    dedupeSlackProviderMessages([...early, ...recent]),
-  );
+  const recent = recentResult.page;
+  return {
+    messages: sortSlackProviderMessages(
+      dedupeSlackProviderMessages([...early.messages, ...recent.messages]),
+    ),
+    omittedMiddle: didInitialWindowsLeaveGap({
+      early,
+      recent,
+      recentScanTruncated: recentResult.truncatedBeforeUpperBound,
+    }),
+  };
 }
 
 function dedupeSlackProviderMessages(
@@ -1709,16 +1802,6 @@ function sortSlackProviderMessages(
     if (compared !== null) return compared;
     return left.id.localeCompare(right.id);
   });
-}
-
-function didSlackThreadBackfillOmitMiddle(params: {
-  fetched: ProviderMessage[];
-  isInitialLateJoin: boolean;
-}): boolean {
-  if (params.isInitialLateJoin) {
-    return params.fetched.length > SLACK_THREAD_INITIAL_RECENT_LIMIT;
-  }
-  return params.fetched.length >= SLACK_THREAD_DELTA_LIMIT;
 }
 
 function buildSlackLateJoinNotice(
@@ -1822,19 +1905,27 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     const reason: SlackMessageMetadata["backfillReason"] = isInitialLateJoin
       ? "thread_late_join"
       : "thread_delta";
-    const fetched = isInitialLateJoin
-      ? await fetchInitialSlackThreadWindows({
-          channelId,
-          threadTs,
-          upperBoundTs,
-          account,
-        })
-      : await backfillThreadWindow(channelId, threadTs, {
-          limit: SLACK_THREAD_DELTA_LIMIT,
-          account,
-          ...(lowerBoundTs !== undefined ? { after: lowerBoundTs } : {}),
-          ...(upperBoundTs !== undefined ? { before: upperBoundTs } : {}),
-        });
+    let omittedMiddle = false;
+    let fetched: ProviderMessage[];
+    if (isInitialLateJoin) {
+      const initial = await fetchInitialSlackThreadWindows({
+        channelId,
+        threadTs,
+        upperBoundTs,
+        account,
+      });
+      fetched = initial.messages;
+      omittedMiddle = initial.omittedMiddle;
+    } else {
+      const page = await backfillThreadWindowPage(channelId, threadTs, {
+        limit: SLACK_THREAD_DELTA_LIMIT,
+        account,
+        ...(lowerBoundTs !== undefined ? { after: lowerBoundTs } : {}),
+        ...(upperBoundTs !== undefined ? { before: upperBoundTs } : {}),
+      });
+      fetched = page.messages;
+      omittedMiddle = slackPageHasMore(page);
+    }
     if (fetched.length === 0) {
       log.debug(
         { conversationId, channelId, threadTs },
@@ -1843,10 +1934,6 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
       return emptySlackThreadBackfillResult();
     }
 
-    const omittedMiddle = didSlackThreadBackfillOmitMiddle({
-      fetched,
-      isInitialLateJoin,
-    });
     let persisted = 0;
     let firstPersistedInOmittedSegment = true;
     for (const message of fetched) {

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -74,6 +74,7 @@ export interface BackgroundProcessingParams {
   externalChatId: string;
   trustCtx: TrustContext;
   metadataHints: string[];
+  slackRuntimeContextNotice?: string;
   metadataUxBrief?: string;
   replyCallbackUrl?: string;
   assistantId?: string;
@@ -108,6 +109,7 @@ export function processChannelMessageInBackground(
     externalChatId,
     trustCtx,
     metadataHints,
+    slackRuntimeContextNotice,
     metadataUxBrief,
     replyCallbackUrl,
     assistantId,
@@ -222,6 +224,7 @@ export function processChannelMessageInBackground(
           trustContext: trustCtx,
           isInteractive: resolveRoutingState(trustCtx).promptWaitingAllowed,
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
+          ...(slackRuntimeContextNotice ? { slackRuntimeContextNotice } : {}),
           ...(slackInbound ? { slackInbound } : {}),
         },
         sourceChannel,


### PR DESCRIPTION
## Summary
- Fix late-join Slack thread windowing so recent context is actually near the mention
- Base omitted-middle signaling on pagination coverage and remove unused metadata
- Deliver the late-join notice through Slack-specific model-facing context

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
