### PR TITLE
Add task and profile breakdowns to macOS usage dashboard

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -309,7 +309,7 @@ struct UsageTabContent: View {
     @State private var hoveredConversationGroupId: String?
 
     private var allFailed: Bool {
-        store.totalsState.isFailed && store.dailyState.isFailed && store.breakdownState.isFailed
+        store.totalsState.isFailed && store.seriesState.isFailed && store.breakdownState.isFailed
     }
 
     var body: some View {
@@ -351,7 +351,7 @@ struct UsageTabContent: View {
             }
         }
         .onChange(of: store.needsRefresh) {
-            let hasIdle = store.totalsState == .idle || store.dailyState == .idle || store.breakdownState == .idle
+            let hasIdle = store.totalsState == .idle || store.seriesState == .idle || store.breakdownState == .idle
             if hasIdle {
                 refreshTask?.cancel()
                 refreshTask = Task {
@@ -429,8 +429,16 @@ struct UsageTabContent: View {
     @ViewBuilder
     func dailySection(store: UsageDashboardStore) -> some View {
         let isHourly = store.isHourlyGranularity
-        SettingsCard(title: isHourly ? "Hourly Trend" : "Daily Trend") {
-            switch store.dailyState {
+        SettingsCard(title: "Inference Usage") {
+            HStack(alignment: .center, spacing: VSpacing.md) {
+                Text(isHourly ? "Hourly Trend by \(store.selectedGroupBy.displayName)" : "Daily Trend by \(store.selectedGroupBy.displayName)")
+                    .font(VFont.bodySmallEmphasised)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer()
+                groupByPicker(store: store)
+            }
+
+            switch store.seriesState {
             case .idle, .loading:
                 HStack(alignment: .bottom, spacing: VSpacing.xs) {
                     ForEach(0..<7, id: \.self) { index in
@@ -442,15 +450,15 @@ struct UsageTabContent: View {
                 }
                 .frame(height: barChartHeight)
                 .accessibilityHidden(true)
-            case .loaded(let daily):
-                if daily.buckets.isEmpty {
+            case .loaded(let series):
+                if series.buckets.isEmpty {
                     VEmptyState(
                         title: isHourly ? "No hourly data" : "No daily data",
                         subtitle: "No usage recorded in this time range",
                         icon: "calendar"
                     )
                 } else {
-                    trendBarChart(daily.buckets, isHourly: isHourly)
+                    trendBarChart(series.buckets, isHourly: isHourly)
                 }
             case .failed(let message):
                 errorRow(message) { refreshTask?.cancel(); refreshTask = Task { await store.refresh() } }
@@ -461,9 +469,17 @@ struct UsageTabContent: View {
     private let barChartHeight: CGFloat = 140
     private let maxBarWidth: CGFloat = 40
     private let hourlyBarWidth: CGFloat = 28
+    private let stackColors: [Color] = [
+        VColor.systemPositiveStrong,
+        VColor.systemInfoStrong,
+        VColor.systemMidStrong,
+        VColor.contentSecondary,
+        VColor.systemNegativeStrong,
+        VColor.contentTertiary,
+    ]
 
     @ViewBuilder
-    private func trendBarChart(_ buckets: [UsageDayBucket], isHourly: Bool) -> some View {
+    private func trendBarChart(_ buckets: [UsageSeriesBucket], isHourly: Bool) -> some View {
         let sorted = buckets.sorted { lhs, rhs in
             if lhs.date != rhs.date { return lhs.date < rhs.date }
             // Same local-time string (DST fall-back duplicates). The bucketId
@@ -477,6 +493,7 @@ struct UsageTabContent: View {
         }
         let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
         let barWidth = isHourly ? hourlyBarWidth : maxBarWidth
+        let legend = orderedSeriesGroups(from: buckets)
 
         ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -485,9 +502,7 @@ struct UsageTabContent: View {
                         let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
                         VStack(spacing: VSpacing.xxs) {
                             Spacer(minLength: 0)
-                            RoundedRectangle(cornerRadius: VRadius.xs)
-                                .fill(VColor.systemPositiveStrong)
-                                .frame(width: barWidth, height: max(2, barChartHeight * fraction))
+                            stackedBar(bucket: bucket, legend: legend, width: barWidth, height: max(2, barChartHeight * fraction))
                         }
                     }
                 }
@@ -507,14 +522,85 @@ struct UsageTabContent: View {
                         .lineLimit(1)
                     }
                 }
+
+                if !legend.isEmpty {
+                    seriesLegend(legend)
+                }
             }
         }
+    }
+
+    @ViewBuilder
+    private func stackedBar(bucket: UsageSeriesBucket, legend: [UsageSeriesLegendItem], width: CGFloat, height: CGFloat) -> some View {
+        let nonEmptyGroups = legend.compactMap { item -> (UsageSeriesLegendItem, UsageSeriesGroupValue)? in
+            guard let value = bucket.groups[item.seriesKey], value.totalEstimatedCostUsd > 0 else { return nil }
+            return (item, value)
+        }
+
+        if nonEmptyGroups.isEmpty {
+            RoundedRectangle(cornerRadius: VRadius.xs)
+                .fill(VColor.systemPositiveStrong)
+                .frame(width: width, height: height)
+        } else {
+            VStack(spacing: 0) {
+                ForEach(nonEmptyGroups.reversed(), id: \.0.seriesKey) { item, value in
+                    Rectangle()
+                        .fill(color(for: item.colorIndex))
+                        .frame(
+                            width: width,
+                            height: max(2, height * value.totalEstimatedCostUsd / max(bucket.totalEstimatedCostUsd, 0.000_001))
+                        )
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xs))
+        }
+    }
+
+    @ViewBuilder
+    private func seriesLegend(_ items: [UsageSeriesLegendItem]) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            ForEach(items.prefix(6), id: \.seriesKey) { item in
+                HStack(spacing: VSpacing.xxs) {
+                    Circle()
+                        .fill(color(for: item.colorIndex))
+                        .frame(width: 7, height: 7)
+                    Text(item.label)
+                        .font(VFont.labelSmall)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(.top, VSpacing.xs)
+    }
+
+    private func orderedSeriesGroups(from buckets: [UsageSeriesBucket]) -> [UsageSeriesLegendItem] {
+        var totals: [String: (label: String, cost: Double)] = [:]
+        for bucket in buckets {
+            for (seriesKey, value) in bucket.groups {
+                let current = totals[seriesKey] ?? (value.group, 0)
+                totals[seriesKey] = (current.label, current.cost + value.totalEstimatedCostUsd)
+            }
+        }
+        return totals
+            .sorted { lhs, rhs in
+                if lhs.value.cost != rhs.value.cost { return lhs.value.cost > rhs.value.cost }
+                return lhs.value.label < rhs.value.label
+            }
+            .enumerated()
+            .map { index, element in
+                UsageSeriesLegendItem(seriesKey: element.key, label: element.value.label, colorIndex: index)
+            }
+    }
+
+    private func color(for index: Int) -> Color {
+        stackColors[index % stackColors.count]
     }
 
     /// The daemon emits `displayLabel` already formatted in the requested
     /// timezone. We fall back to the raw `date` string for responses from
     /// older daemons that don't include the label.
-    private func formatBucketLabel(_ bucket: UsageDayBucket) -> String {
+    private func formatBucketLabel(_ bucket: UsageSeriesBucket) -> String {
         bucket.displayLabel ?? bucket.date
     }
 
@@ -533,8 +619,6 @@ struct UsageTabContent: View {
     @ViewBuilder
     func breakdownSection(store: UsageDashboardStore) -> some View {
         SettingsCard(title: "Breakdown") {
-            groupByPicker(store: store)
-
             switch store.breakdownState {
             case .idle, .loading:
                 VStack(spacing: 0) {
@@ -585,7 +669,7 @@ struct UsageTabContent: View {
                     breakdownTask = Task { await store.selectGroupBy(newDimension) }
                 }
             ),
-            options: UsageGroupByDimension.allCases.map { ($0.rawValue.capitalized, $0) },
+            options: UsageGroupByDimension.dashboardOptions.map { ($0.displayName, $0) },
             maxWidth: 140
         )
     }
@@ -737,4 +821,10 @@ struct UsageTabContent: View {
     private func formatCount(_ count: Int) -> String {
         UsageFormatting.formatCount(count)
     }
+}
+
+private struct UsageSeriesLegendItem: Equatable {
+    let seriesKey: String
+    let label: String
+    let colorIndex: Int
 }

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
@@ -60,7 +60,7 @@ public struct CallSiteOverride: Identifiable, Equatable, Hashable {
     public let id: String
 
     /// User-facing label shown in the override picker
-    /// (e.g. `"Memory · Retrieval"`).
+    /// (e.g. `"Memory retrieval"`).
     public let displayName: String
 
     /// Logical grouping for sectioning in the picker.
@@ -115,19 +115,23 @@ public enum CallSiteCatalog {
         CallSiteOverride(id: "subagentSpawn", displayName: "Subagent spawn", domain: .agentLoop),
         CallSiteOverride(id: "heartbeatAgent", displayName: "Heartbeat agent", domain: .agentLoop),
         CallSiteOverride(id: "filingAgent", displayName: "Filing agent", domain: .agentLoop),
+        CallSiteOverride(id: "compactionAgent", displayName: "Context compactor", domain: .agentLoop),
         CallSiteOverride(id: "analyzeConversation", displayName: "Analyze conversation", domain: .agentLoop),
         CallSiteOverride(id: "callAgent", displayName: "Call agent", domain: .agentLoop),
         // Memory
-        CallSiteOverride(id: "memoryExtraction", displayName: "Memory · Extraction", domain: .memory),
-        CallSiteOverride(id: "memoryConsolidation", displayName: "Memory · Consolidation", domain: .memory),
-        CallSiteOverride(id: "memoryRetrieval", displayName: "Memory · Retrieval", domain: .memory),
+        CallSiteOverride(id: "memoryExtraction", displayName: "Memory extraction", domain: .memory),
+        CallSiteOverride(id: "memoryConsolidation", displayName: "Memory consolidation", domain: .memory),
+        CallSiteOverride(id: "memoryRetrieval", displayName: "Memory retrieval", domain: .memory),
+        CallSiteOverride(id: "memoryV2Migration", displayName: "Memory migration", domain: .memory),
+        CallSiteOverride(id: "memoryV2Sweep", displayName: "Memory sweep", domain: .memory),
+        CallSiteOverride(id: "recall", displayName: "Recall", domain: .memory),
         CallSiteOverride(id: "narrativeRefinement", displayName: "Narrative refinement", domain: .memory),
         CallSiteOverride(id: "patternScan", displayName: "Pattern scan", domain: .memory),
         CallSiteOverride(id: "conversationSummarization", displayName: "Conversation summarization", domain: .memory),
         CallSiteOverride(id: "conversationStarters", displayName: "Conversation starters", domain: .memory),
         // Workspace
         CallSiteOverride(id: "conversationTitle", displayName: "Conversation title", domain: .workspace),
-        CallSiteOverride(id: "commitMessage", displayName: "Commit message generator", domain: .workspace),
+        CallSiteOverride(id: "commitMessage", displayName: "Commit message", domain: .workspace),
         // UI
         CallSiteOverride(id: "identityIntro", displayName: "Identity intro", domain: .ui),
         CallSiteOverride(id: "emptyStateGreeting", displayName: "Empty-state greeting", domain: .ui),
@@ -136,16 +140,19 @@ public enum CallSiteCatalog {
         CallSiteOverride(id: "preferenceExtraction", displayName: "Preference extraction", domain: .notifications),
         // Voice
         CallSiteOverride(id: "guardianQuestionCopy", displayName: "Guardian question copy", domain: .voice),
-        CallSiteOverride(id: "watchCommentary", displayName: "Watch commentary", domain: .voice),
-        CallSiteOverride(id: "watchSummary", displayName: "Watch summary", domain: .voice),
         // Utility
+        CallSiteOverride(id: "approvalCopy", displayName: "Approval copy", domain: .utility),
+        CallSiteOverride(id: "approvalConversation", displayName: "Approval conversation", domain: .utility),
         CallSiteOverride(id: "interactionClassifier", displayName: "Interaction classifier", domain: .utility),
         CallSiteOverride(id: "styleAnalyzer", displayName: "Style analyzer", domain: .utility),
         CallSiteOverride(id: "inviteInstructionGenerator", displayName: "Invite instruction generator", domain: .utility),
         CallSiteOverride(id: "skillCategoryInference", displayName: "Skill category inference", domain: .utility),
+        CallSiteOverride(id: "inference", displayName: "Inference", domain: .utility),
+        CallSiteOverride(id: "feedEventCopy", displayName: "Feed event copy", domain: .utility),
+        CallSiteOverride(id: "trustRuleSuggestion", displayName: "Trust rule suggestion", domain: .utility),
         // Skills
-        CallSiteOverride(id: "meetConsentMonitor", displayName: "Meet · Consent monitor", domain: .skills),
-        CallSiteOverride(id: "meetChatOpportunity", displayName: "Meet · Chat opportunity", domain: .skills),
+        CallSiteOverride(id: "meetConsentMonitor", displayName: "Meet consent monitor", domain: .skills),
+        CallSiteOverride(id: "meetChatOpportunity", displayName: "Meet chat opportunity", domain: .skills),
     ]
 
     /// Lookup table from call-site ID to its catalog entry. Constructed

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -384,7 +384,7 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
                 "callSites": [
                     "memoryRetrieval": ["profile": "fast"],
                     "mainAgent": ["profile": "fast"],
-                    "watchSummary": ["provider": "openai"],
+                    "trustRuleSuggestion": ["provider": "openai"],
                 ]
             ]
         ])

--- a/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
@@ -38,6 +38,15 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         return nil
     }
 
+    private func callSitesPatch(at index: Int) -> [String: Any]? {
+        guard mockSettingsClient.patchConfigCalls.indices.contains(index),
+              let llm = mockSettingsClient.patchConfigCalls[index]["llm"] as? [String: Any],
+              let sites = llm["callSites"] as? [String: Any] else {
+            return nil
+        }
+        return sites
+    }
+
     /// Waits for the background `Task` started by a store helper to flush
     /// its patch into the mock client.
     private func waitForPatchCount(_ expected: Int, timeout: TimeInterval = 2.0) {
@@ -51,13 +60,13 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
     // MARK: - Catalog
 
     func testCatalogCoversEveryCallSite() {
-        // The catalog enumerates 28 sites grouped across 8 domains
+        // The catalog enumerates every backend LLM call site grouped across 8 domains
         // (agent loop, memory, workspace, UI, notifications, voice,
         // utility, skills). If this count drifts, the catalog and the
         // backend `LLMCallSiteEnum` have diverged.
-        XCTAssertEqual(CallSiteCatalog.all.count, 28)
-        XCTAssertEqual(CallSiteCatalog.byId.count, 28)
-        XCTAssertEqual(CallSiteCatalog.validIds.count, 28)
+        XCTAssertEqual(CallSiteCatalog.all.count, 35)
+        XCTAssertEqual(CallSiteCatalog.byId.count, 35)
+        XCTAssertEqual(CallSiteCatalog.validIds.count, 35)
     }
 
     func testCatalogHasUniqueIdsAndNonEmptyDisplayNames() {
@@ -113,7 +122,7 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
 
         // An entry that has no override in the config must surface as
         // "no override" with all fields nil.
-        let untouched = store.callSiteOverrides.first(where: { $0.id == "watchSummary" })
+        let untouched = store.callSiteOverrides.first(where: { $0.id == "trustRuleSuggestion" })
         XCTAssertNil(untouched?.provider)
         XCTAssertNil(untouched?.model)
         XCTAssertNil(untouched?.profile)
@@ -286,7 +295,7 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
 
     // MARK: - Batch update
 
-    func testSetCallSiteOverridesBatchEmitsAllEntriesInOnePatch() {
+    func testSetCallSiteOverridesBatchClearsThenSetsProvidedEntries() {
         let updates: [CallSiteOverride] = [
             CallSiteOverride(
                 id: "memoryRetrieval",
@@ -302,37 +311,35 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
                 profile: "fast"
             ),
             CallSiteOverride(
-                id: "watchSummary",
-                displayName: "Watch summary",
-                domain: .voice
+                id: "trustRuleSuggestion",
+                displayName: "Trust rule suggestion",
+                domain: .utility
             ), // no overrides — should emit explicit nulls to clear
         ]
 
         _ = store.setCallSiteOverrides(updates)
-        waitForPatchCount(1)
+        waitForPatchCount(2)
 
-        let sites = lastCallSitesPatch()
-        XCTAssertNotNil(sites)
-        // Batch PATCH must include every catalog entry: the three caller-
-        // provided entries plus null-clears for every other catalog ID, so
-        // the daemon's view stays aligned with the local cache (which
-        // resets all omitted entries to nil).
-        XCTAssertEqual(sites?.count, CallSiteCatalog.all.count)
+        let clearSites = callSitesPatch(at: 0)
+        XCTAssertEqual(clearSites?.count, CallSiteCatalog.all.count)
+        XCTAssertTrue(clearSites?["memoryRetrieval"] is NSNull)
+        XCTAssertTrue(clearSites?["mainAgent"] is NSNull)
+        XCTAssertTrue(clearSites?["trustRuleSuggestion"] is NSNull)
 
-        let memory = sites?["memoryRetrieval"] as? [String: Any]
+        let setSites = callSitesPatch(at: 1)
+        XCTAssertEqual(Set(setSites?.keys.map { String($0) } ?? []), ["memoryRetrieval", "mainAgent"])
+
+        let memory = setSites?["memoryRetrieval"] as? [String: Any]
         XCTAssertEqual(memory?["provider"] as? String, "openai")
         XCTAssertEqual(memory?["model"] as? String, "gpt-4.1")
-        XCTAssertTrue(memory?["profile"] is NSNull)
+        XCTAssertNil(memory?["profile"])
 
-        let main = sites?["mainAgent"] as? [String: Any]
-        XCTAssertTrue(main?["provider"] is NSNull)
-        XCTAssertTrue(main?["model"] is NSNull)
+        let main = setSites?["mainAgent"] as? [String: Any]
+        XCTAssertNil(main?["provider"])
+        XCTAssertNil(main?["model"])
         XCTAssertEqual(main?["profile"] as? String, "fast")
 
-        let watch = sites?["watchSummary"] as? [String: Any]
-        XCTAssertTrue(watch?["provider"] is NSNull)
-        XCTAssertTrue(watch?["model"] is NSNull)
-        XCTAssertTrue(watch?["profile"] is NSNull)
+        XCTAssertNil(setSites?["trustRuleSuggestion"])
     }
 
     /// Regression for Devin's review on PR #26128 (`SettingsStore.swift:3174`):
@@ -360,7 +367,7 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
 
         // Must not crash.
         _ = store.setCallSiteOverrides(duplicates)
-        waitForPatchCount(1)
+        waitForPatchCount(2)
 
         // Last-write-wins in the local cache.
         let memory = store.callSiteOverrides.first(where: { $0.id == "memoryRetrieval" })
@@ -373,7 +380,7 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         let memoryEntry = sites?["memoryRetrieval"] as? [String: Any]
         XCTAssertEqual(memoryEntry?["provider"] as? String, "anthropic")
         XCTAssertEqual(memoryEntry?["model"] as? String, "claude-haiku-4")
-        XCTAssertTrue(memoryEntry?["profile"] is NSNull)
+        XCTAssertNil(memoryEntry?["profile"])
     }
 
     /// Regression for Codex P1 + Devin on PR #26128: prior to the fix,
@@ -393,41 +400,39 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         // Now batch-update a SINGLE entry that is neither of the above.
         let updates: [CallSiteOverride] = [
             CallSiteOverride(
-                id: "watchSummary",
-                displayName: "Watch summary",
-                domain: .voice,
+                id: "trustRuleSuggestion",
+                displayName: "Trust rule suggestion",
+                domain: .utility,
                 provider: "openai"
             ),
         ]
         _ = store.setCallSiteOverrides(updates)
-        waitForPatchCount(3)
+        waitForPatchCount(4)
 
-        let sites = lastCallSitesPatch()
-        XCTAssertNotNil(sites)
+        let clearSites = callSitesPatch(at: 2)
+        XCTAssertNotNil(clearSites)
+        XCTAssertEqual(
+            Set(clearSites?.keys.map { String($0) } ?? []),
+            CallSiteCatalog.validIds,
+            "Batch clear PATCH must cover every catalog entry to keep remote/local aligned"
+        )
 
         // The PATCH must include the new entry verbatim.
-        let watch = sites?["watchSummary"] as? [String: Any]
-        XCTAssertEqual(watch?["provider"] as? String, "openai")
-        XCTAssertTrue(watch?["model"] is NSNull)
-        XCTAssertTrue(watch?["profile"] is NSNull)
+        let setSites = callSitesPatch(at: 3)
+        let trustRule = setSites?["trustRuleSuggestion"] as? [String: Any]
+        XCTAssertEqual(trustRule?["provider"] as? String, "openai")
+        XCTAssertNil(trustRule?["model"])
+        XCTAssertNil(trustRule?["profile"])
 
         // And it must include null-clears for the two pre-populated entries
         // so the daemon's view matches the (now-cleared) local cache. The
         // whole entry is nulled (not just provider/model/profile leaves) per
         // PR #26128 cycle 2 fix — clears any other leaves the entry may have.
-        XCTAssertNotNil(sites?["memoryRetrieval"], "PATCH must include null-clear for memoryRetrieval")
-        XCTAssertTrue(sites?["memoryRetrieval"] is NSNull)
+        XCTAssertNotNil(clearSites?["memoryRetrieval"], "PATCH must include null-clear for memoryRetrieval")
+        XCTAssertTrue(clearSites?["memoryRetrieval"] is NSNull)
 
-        XCTAssertNotNil(sites?["commitMessage"], "PATCH must include null-clear for commitMessage")
-        XCTAssertTrue(sites?["commitMessage"] is NSNull)
-
-        // Stronger invariant: the set of IDs PATCHed must equal the full
-        // catalog. Anything less re-creates the divergence bug.
-        XCTAssertEqual(
-            Set(sites?.keys.map { String($0) } ?? []),
-            CallSiteCatalog.validIds,
-            "Batch PATCH must cover every catalog entry to keep remote/local aligned"
-        )
+        XCTAssertNotNil(clearSites?["commitMessage"], "PATCH must include null-clear for commitMessage")
+        XCTAssertTrue(clearSites?["commitMessage"] is NSNull)
 
         // Local cache also reflects the cleared state for the omitted entries.
         let cachedMemory = store.callSiteOverrides.first(where: { $0.id == "memoryRetrieval" })
@@ -440,9 +445,9 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
     func testSetCallSiteOverridesUpdatesLocalCacheInCatalogOrder() {
         let updates: [CallSiteOverride] = [
             CallSiteOverride(
-                id: "watchSummary",
-                displayName: "Watch summary",
-                domain: .voice,
+                id: "trustRuleSuggestion",
+                displayName: "Trust rule suggestion",
+                domain: .utility,
                 provider: "openai"
             ),
             CallSiteOverride(
@@ -457,8 +462,8 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         // Local cache must follow CallSiteCatalog.all order, regardless
         // of the order the caller passed in.
         let mainIndex = store.callSiteOverrides.firstIndex(where: { $0.id == "mainAgent" }) ?? -1
-        let watchIndex = store.callSiteOverrides.firstIndex(where: { $0.id == "watchSummary" }) ?? -1
-        XCTAssertLessThan(mainIndex, watchIndex,
+        let trustRuleIndex = store.callSiteOverrides.firstIndex(where: { $0.id == "trustRuleSuggestion" }) ?? -1
+        XCTAssertLessThan(mainIndex, trustRuleIndex,
                           "callSiteOverrides must preserve CallSiteCatalog order")
         XCTAssertEqual(store.overridesCount, 2)
     }
@@ -480,12 +485,11 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         ]
 
         _ = store.setCallSiteOverrides(updates)
-        waitForPatchCount(1)
+        waitForPatchCount(2)
 
         let sites = lastCallSitesPatch()
-        // The PATCH covers every catalog entry (valid input + null-clears
-        // for everything else). Unknown IDs from the input must NOT appear.
-        XCTAssertEqual(sites?.count, CallSiteCatalog.all.count)
+        // The set PATCH includes only valid entries with non-empty overrides.
+        XCTAssertEqual(sites?.count, 1)
         XCTAssertNotNil(sites?["memoryRetrieval"])
         XCTAssertNil(sites?["totallyMadeUpId"], "Unknown call-site IDs must be filtered out of the patch")
 

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -21,9 +21,10 @@ struct UsageTabContentEmptyTests {
 
         #expect(store.totalsState == .idle)
         #expect(store.dailyState == .idle)
+        #expect(store.seriesState == .idle)
         #expect(store.breakdownState == .idle)
         #expect(store.selectedRange == .last7Days)
-        #expect(store.selectedGroupBy == .model)
+        #expect(store.selectedGroupBy == .callSite)
     }
 
     @Test @MainActor
@@ -53,6 +54,12 @@ struct UsageTabContentEmptyTests {
             #expect(daily.buckets.isEmpty)
         } else {
             Issue.record("Expected .loaded for daily with empty buckets")
+        }
+
+        if case .loaded(let series) = store.seriesState {
+            #expect(series.buckets.isEmpty)
+        } else {
+            Issue.record("Expected .loaded for series with empty buckets")
         }
 
         if case .loaded(let breakdown) = store.breakdownState {
@@ -85,6 +92,12 @@ struct UsageTabContentLoadingTests {
             #expect(msg.contains("daily"))
         } else {
             Issue.record("Expected .failed for daily")
+        }
+
+        if case .failed(let msg) = store.seriesState {
+            #expect(msg.contains("series"))
+        } else {
+            Issue.record("Expected .failed for series")
         }
 
         if case .failed(let msg) = store.breakdownState {
@@ -185,15 +198,17 @@ struct UsageTabContentPopulatedTests {
         let store = UsageDashboardStore()
         store.updateClient(client)
 
-        // Default is .model
-        #expect(store.selectedGroupBy == .model)
+        // Default is .callSite (shown as Task)
+        #expect(store.selectedGroupBy == .callSite)
 
         await store.selectGroupBy(.provider)
         #expect(store.selectedGroupBy == .provider)
+        #expect(client.lastSeriesGroupBy == "provider")
         #expect(client.lastBreakdownGroupBy == "provider")
 
         await store.selectGroupBy(.actor)
         #expect(store.selectedGroupBy == .actor)
+        #expect(client.lastSeriesGroupBy == "actor")
         #expect(client.lastBreakdownGroupBy == "actor")
     }
 
@@ -216,6 +231,7 @@ struct UsageTabContentPopulatedTests {
         #expect(store.selectedRange == .last30Days)
         #expect(client.lastTotalsFrom != nil)
         #expect(client.lastDailyFrom != nil)
+        #expect(client.lastSeriesFrom != nil)
         #expect(client.lastBreakdownFrom != nil)
     }
 }
@@ -372,7 +388,7 @@ struct UsageTabContentConversationRowInteractivityTests {
         client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [Self.modelEntry])
         let store = UsageDashboardStore()
         store.updateClient(client)
-        // Default groupBy is .model — do not switch it.
+        await store.selectGroupBy(.model)
 
         var captured: [String] = []
         let tab = UsageTabContent(
@@ -484,7 +500,7 @@ struct UsageTabContentViewEmptyTests {
 
         // Section headers
         #expect(joined.contains("Totals"))
-        #expect(joined.contains("Daily Trend"))
+        #expect(joined.contains("Inference Usage"))
         #expect(joined.contains("Breakdown"))
         #expect(joined.contains(UsageFormatting.directInputTokensLabel))
         #expect(joined.contains("Cache Created"))
@@ -546,7 +562,7 @@ struct UsageTabContentViewPopulatedTests {
 
         // Section headers
         #expect(joined.contains("Totals"))
-        #expect(joined.contains("Daily Trend"))
+        #expect(joined.contains("Inference Usage"))
         #expect(joined.contains("Breakdown"))
 
         // Formatted cost: verify the formatted cost appears
@@ -608,6 +624,63 @@ struct UsageTabContentViewPopulatedTests {
         #expect(store.selectedGroupBy == .provider)
         #expect(joined.contains("anthropic"))
     }
+
+    @Test @MainActor
+    func tabRendersTaskSeriesAndProfileSelection() async {
+        let client = MockPanelClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 100, totalOutputTokens: 50,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.03, eventCount: 2,
+            pricedEventCount: 2, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedSeries = UsageSeriesResponse(buckets: [
+            UsageSeriesBucket(
+                date: "2026-03-04",
+                displayLabel: "Mar 4",
+                totalInputTokens: 100,
+                totalOutputTokens: 50,
+                totalEstimatedCostUsd: 0.03,
+                eventCount: 2,
+                groups: [
+                    "value:mainAgent": UsageSeriesGroupValue(
+                        group: "Main agent",
+                        groupKey: "mainAgent",
+                        totalInputTokens: 100,
+                        totalOutputTokens: 50,
+                        totalEstimatedCostUsd: 0.03,
+                        eventCount: 2
+                    )
+                ]
+            )
+        ])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
+            UsageGroupBreakdownEntry(
+                group: "Main agent",
+                groupKey: "mainAgent",
+                totalInputTokens: 100,
+                totalOutputTokens: 50,
+                totalEstimatedCostUsd: 0.03,
+                eventCount: 2
+            )
+        ])
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.refresh()
+
+        let joined = collectTabContent(store: store)
+        #expect(client.lastSeriesGroupBy == "call_site")
+        #expect(client.lastBreakdownGroupBy == "call_site")
+        #expect(joined.contains("Inference Usage"))
+        #expect(joined.contains("Daily Trend by Task"))
+        #expect(joined.contains("Main agent"))
+
+        await store.selectGroupBy(.inferenceProfile)
+        #expect(client.lastSeriesGroupBy == "inference_profile")
+        #expect(client.lastBreakdownGroupBy == "inference_profile")
+    }
 }
 
 @Suite("UsageTabContent — View Rendering: Failed State")
@@ -629,7 +702,7 @@ struct UsageTabContentViewFailedTests {
 
         // Section headers should still render even in failed state
         #expect(joined.contains("Totals"))
-        #expect(joined.contains("Daily Trend"))
+        #expect(joined.contains("Inference Usage"))
         #expect(joined.contains("Breakdown"))
     }
 }
@@ -640,10 +713,13 @@ struct UsageTabContentViewFailedTests {
 private final class MockPanelClient: UsageClientProtocol {
     var stubbedTotals: UsageTotalsResponse?
     var stubbedDaily: UsageDailyResponse?
+    var stubbedSeries: UsageSeriesResponse?
     var stubbedBreakdown: UsageBreakdownResponse?
 
     var lastTotalsFrom: Int?
     var lastDailyFrom: Int?
+    var lastSeriesFrom: Int?
+    var lastSeriesGroupBy: String?
     var lastBreakdownFrom: Int?
     var lastBreakdownGroupBy: String?
 
@@ -655,6 +731,31 @@ private final class MockPanelClient: UsageClientProtocol {
     func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse? {
         lastDailyFrom = from
         return stubbedDaily
+    }
+
+    func fetchUsageSeries(from: Int, to: Int, granularity: String, groupBy: String, tz: String) async -> UsageSeriesResponse? {
+        lastSeriesFrom = from
+        lastSeriesGroupBy = groupBy
+        if let stubbedSeries {
+            return stubbedSeries
+        }
+        guard let daily = stubbedDaily else {
+            return nil
+        }
+        return UsageSeriesResponse(
+            buckets: daily.buckets.map { bucket in
+                UsageSeriesBucket(
+                    bucketId: bucket.bucketId,
+                    date: bucket.date,
+                    displayLabel: bucket.displayLabel,
+                    totalInputTokens: bucket.totalInputTokens,
+                    totalOutputTokens: bucket.totalOutputTokens,
+                    totalEstimatedCostUsd: bucket.totalEstimatedCostUsd,
+                    eventCount: bucket.eventCount,
+                    groups: [:]
+                )
+            }
+        )
     }
 
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -8,7 +8,9 @@ import Testing
 private final class MockUsageClient: UsageClientProtocol {
     var stubbedTotals: UsageTotalsResponse?
     var stubbedDaily: UsageDailyResponse?
+    var stubbedSeries: UsageSeriesResponse?
     var stubbedBreakdown: UsageBreakdownResponse?
+    var simulateMissingSeriesEndpoint = false
 
     var lastTotalsFrom: Int?
     var lastTotalsTo: Int?
@@ -16,6 +18,11 @@ private final class MockUsageClient: UsageClientProtocol {
     var lastDailyTo: Int?
     var lastDailyTz: String?
     var lastDailyGranularity: String?
+    var lastSeriesFrom: Int?
+    var lastSeriesTo: Int?
+    var lastSeriesTz: String?
+    var lastSeriesGranularity: String?
+    var lastSeriesGroupBy: String?
     var lastBreakdownFrom: Int?
     var lastBreakdownTo: Int?
     var lastBreakdownGroupBy: String?
@@ -32,6 +39,37 @@ private final class MockUsageClient: UsageClientProtocol {
         lastDailyGranularity = granularity
         lastDailyTz = tz
         return stubbedDaily
+    }
+
+    func fetchUsageSeries(from: Int, to: Int, granularity: String, groupBy: String, tz: String) async -> UsageSeriesResponse? {
+        lastSeriesFrom = from
+        lastSeriesTo = to
+        lastSeriesGranularity = granularity
+        lastSeriesGroupBy = groupBy
+        lastSeriesTz = tz
+        if simulateMissingSeriesEndpoint {
+            return nil
+        }
+        if let stubbedSeries {
+            return stubbedSeries
+        }
+        guard let daily = stubbedDaily else {
+            return nil
+        }
+        return UsageSeriesResponse(
+            buckets: daily.buckets.map { bucket in
+                UsageSeriesBucket(
+                    bucketId: bucket.bucketId,
+                    date: bucket.date,
+                    displayLabel: bucket.displayLabel,
+                    totalInputTokens: bucket.totalInputTokens,
+                    totalOutputTokens: bucket.totalOutputTokens,
+                    totalEstimatedCostUsd: bucket.totalEstimatedCostUsd,
+                    eventCount: bucket.eventCount,
+                    groups: [:]
+                )
+            }
+        )
     }
 
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
@@ -140,6 +178,62 @@ struct UsageDashboardStoreDecodingTests {
     }
 
     @Test
+    func decodeBreakdownResponseWithGroupKey() throws {
+        let json = """
+        {
+            "breakdown": [
+                {
+                    "group": "Main agent",
+                    "groupKey": "mainAgent",
+                    "totalInputTokens": 800,
+                    "totalOutputTokens": 400,
+                    "totalEstimatedCostUsd": 0.04,
+                    "eventCount": 5
+                }
+            ]
+        }
+        """
+        let decoded = try JSONDecoder().decode(UsageBreakdownResponse.self, from: Data(json.utf8))
+        #expect(decoded.breakdown[0].group == "Main agent")
+        #expect(decoded.breakdown[0].groupKey == "mainAgent")
+    }
+
+    @Test
+    func decodeSeriesResponseWithGroups() throws {
+        let json = """
+        {
+            "buckets": [
+                {
+                    "bucketId": "2026-03-01",
+                    "date": "2026-03-01",
+                    "displayLabel": "Mar 1",
+                    "totalInputTokens": 800,
+                    "totalOutputTokens": 400,
+                    "totalEstimatedCostUsd": 0.04,
+                    "eventCount": 5,
+                    "groups": {
+                        "value:mainAgent": {
+                            "group": "Main agent",
+                            "groupKey": "mainAgent",
+                            "totalInputTokens": 500,
+                            "totalOutputTokens": 250,
+                            "totalEstimatedCostUsd": 0.03,
+                            "eventCount": 3
+                        }
+                    }
+                }
+            ]
+        }
+        """
+        let decoded = try JSONDecoder().decode(UsageSeriesResponse.self, from: Data(json.utf8))
+        #expect(decoded.buckets.count == 1)
+        #expect(decoded.buckets[0].bucketId == "2026-03-01")
+        #expect(decoded.buckets[0].displayLabel == "Mar 1")
+        #expect(decoded.buckets[0].groups["value:mainAgent"]?.group == "Main agent")
+        #expect(decoded.buckets[0].groups["value:mainAgent"]?.groupKey == "mainAgent")
+    }
+
+    @Test
     func decodeBreakdownResponseDefaultsMissingCacheFieldsToZero() throws {
         let json = """
         {
@@ -194,6 +288,7 @@ struct UsageDashboardStoreLoadingTests {
         store.updateClient(client)
         #expect(store.totalsState == .idle)
         #expect(store.dailyState == .idle)
+        #expect(store.seriesState == .idle)
         #expect(store.breakdownState == .idle)
 
         await store.refresh()
@@ -210,6 +305,13 @@ struct UsageDashboardStoreLoadingTests {
             #expect(daily.buckets[0].date == "2026-03-05")
         } else {
             Issue.record("Expected .loaded state for daily")
+        }
+
+        if case .loaded(let series) = store.seriesState {
+            #expect(series.buckets.count == 1)
+            #expect(series.buckets[0].date == "2026-03-05")
+        } else {
+            Issue.record("Expected .loaded state for series")
         }
 
         if case .loaded(let breakdown) = store.breakdownState {
@@ -241,6 +343,12 @@ struct UsageDashboardStoreLoadingTests {
             #expect(msg.contains("daily"))
         } else {
             Issue.record("Expected .failed state for daily")
+        }
+
+        if case .failed(let msg) = store.seriesState {
+            #expect(msg.contains("series"))
+        } else {
+            Issue.record("Expected .failed state for series")
         }
 
         if case .failed(let msg) = store.breakdownState {
@@ -307,9 +415,10 @@ struct UsageDashboardStoreGroupTests {
 
         // Initial refresh to populate all states
         await store.refresh()
-        #expect(client.lastBreakdownGroupBy == "model")
+        #expect(client.lastSeriesGroupBy == "call_site")
+        #expect(client.lastBreakdownGroupBy == "call_site")
 
-        // Now change group-by — should only re-fetch breakdown
+        // Now change group-by — should re-fetch the grouped series and breakdown.
         client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
             UsageGroupBreakdownEntry(
                 group: "provider-x",
@@ -324,6 +433,7 @@ struct UsageDashboardStoreGroupTests {
         await store.selectGroupBy(.provider)
 
         #expect(store.selectedGroupBy == .provider)
+        #expect(client.lastSeriesGroupBy == "provider")
         #expect(client.lastBreakdownGroupBy == "provider")
 
         if case .loaded(let breakdown) = store.breakdownState {
@@ -344,7 +454,50 @@ struct UsageDashboardStoreGroupTests {
         store.updateClient(client)
         await store.selectGroupBy(.actor)
 
+        #expect(client.lastSeriesGroupBy == "actor")
         #expect(client.lastBreakdownGroupBy == "actor")
+    }
+
+    @Test @MainActor
+    func taskAndProfileGroupByPassExpectedParamsToSeriesAndBreakdown() async {
+        let client = MockUsageClient()
+        client.stubbedSeries = UsageSeriesResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+
+        await store.selectGroupBy(.callSite)
+        #expect(store.selectedGroupBy == .callSite)
+        #expect(client.lastSeriesGroupBy == "call_site")
+        #expect(client.lastBreakdownGroupBy == "call_site")
+
+        await store.selectGroupBy(.inferenceProfile)
+        #expect(store.selectedGroupBy == .inferenceProfile)
+        #expect(client.lastSeriesGroupBy == "inference_profile")
+        #expect(client.lastBreakdownGroupBy == "inference_profile")
+    }
+
+    @Test @MainActor
+    func taskDefaultFallsBackToModelForOlderAssistants() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 0, totalOutputTokens: 0,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0, eventCount: 0,
+            pricedEventCount: 0, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.simulateMissingSeriesEndpoint = true
+        client.stubbedBreakdown = nil
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.refresh()
+
+        #expect(store.selectedGroupBy == .model)
+        #expect(client.lastSeriesGroupBy == "model")
+        #expect(client.lastBreakdownGroupBy == "model")
     }
 }
 
@@ -358,6 +511,7 @@ private final class DelayedMockUsageClient: UsageClientProtocol {
     /// Tests pop and resume them in whatever order they want.
     var totalsContinuations: [CheckedContinuation<UsageTotalsResponse?, Never>] = []
     var dailyContinuations: [CheckedContinuation<UsageDailyResponse?, Never>] = []
+    var seriesContinuations: [CheckedContinuation<UsageSeriesResponse?, Never>] = []
     var breakdownContinuations: [CheckedContinuation<UsageBreakdownResponse?, Never>] = []
 
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
@@ -369,6 +523,12 @@ private final class DelayedMockUsageClient: UsageClientProtocol {
     func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse? {
         await withCheckedContinuation { continuation in
             dailyContinuations.append(continuation)
+        }
+    }
+
+    func fetchUsageSeries(from: Int, to: Int, granularity: String, groupBy: String, tz: String) async -> UsageSeriesResponse? {
+        await withCheckedContinuation { continuation in
+            seriesContinuations.append(continuation)
         }
     }
 
@@ -395,6 +555,10 @@ struct UsageDashboardStoreRaceTests {
 
     private static func makeDaily() -> UsageDailyResponse {
         UsageDailyResponse(buckets: [])
+    }
+
+    private static func makeSeries() -> UsageSeriesResponse {
+        UsageSeriesResponse(buckets: [])
     }
 
     private static func makeBreakdown(group: String) -> UsageBreakdownResponse {
@@ -436,6 +600,7 @@ struct UsageDashboardStoreRaceTests {
         await Self.yieldUntil {
             client.totalsContinuations.count >= 2
             && client.dailyContinuations.count >= 2
+            && client.seriesContinuations.count >= 2
             && client.breakdownContinuations.count >= 2
         }
 
@@ -443,6 +608,7 @@ struct UsageDashboardStoreRaceTests {
         #expect(client.totalsContinuations.count == 2)
         client.totalsContinuations[1].resume(returning: Self.makeTotals(inputTokens: 999))
         client.dailyContinuations[1].resume(returning: Self.makeDaily())
+        client.seriesContinuations[1].resume(returning: Self.makeSeries())
         client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "latest"))
         await secondRefresh.value
 
@@ -456,6 +622,7 @@ struct UsageDashboardStoreRaceTests {
         // Now complete the FIRST (stale) request — it should NOT overwrite the store
         client.totalsContinuations[0].resume(returning: Self.makeTotals(inputTokens: 111))
         client.dailyContinuations[0].resume(returning: Self.makeDaily())
+        client.seriesContinuations[0].resume(returning: Self.makeSeries())
         client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "stale"))
         await firstRefresh.value
 
@@ -484,14 +651,19 @@ struct UsageDashboardStoreRaceTests {
         await Self.yieldUntil {
             client.totalsContinuations.count >= 1
             && client.dailyContinuations.count >= 1
+            && client.seriesContinuations.count >= 1
             && client.breakdownContinuations.count >= 1
         }
 
         // While refresh() is in flight, user changes group-by dimension
         let groupByTask = Task { @MainActor in await store.selectGroupBy(.provider) }
-        await Self.yieldUntil { client.breakdownContinuations.count >= 2 }
+        await Self.yieldUntil {
+            client.seriesContinuations.count >= 2
+            && client.breakdownContinuations.count >= 2
+        }
 
         // Complete selectGroupBy's breakdown first (the newer request)
+        client.seriesContinuations[1].resume(returning: Self.makeSeries())
         client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "provider-fresh"))
         await groupByTask.value
 
@@ -505,6 +677,7 @@ struct UsageDashboardStoreRaceTests {
         // because selectGroupBy() incremented breakdownGeneration
         client.totalsContinuations[0].resume(returning: Self.makeTotals(inputTokens: 42))
         client.dailyContinuations[0].resume(returning: Self.makeDaily())
+        client.seriesContinuations[0].resume(returning: Self.makeSeries())
         client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "model-stale"))
         await refreshTask.value
 
@@ -532,14 +705,21 @@ struct UsageDashboardStoreRaceTests {
 
         // Launch first selectGroupBy
         let first = Task { @MainActor in await store.selectGroupBy(.model) }
-        await Self.yieldUntil { client.breakdownContinuations.count >= 1 }
+        await Self.yieldUntil {
+            client.seriesContinuations.count >= 1
+            && client.breakdownContinuations.count >= 1
+        }
 
         // Launch second selectGroupBy before the first completes
         let second = Task { @MainActor in await store.selectGroupBy(.provider) }
-        await Self.yieldUntil { client.breakdownContinuations.count >= 2 }
+        await Self.yieldUntil {
+            client.seriesContinuations.count >= 2
+            && client.breakdownContinuations.count >= 2
+        }
 
         // Complete the second (latest) request first
         #expect(client.breakdownContinuations.count == 2)
+        client.seriesContinuations[1].resume(returning: Self.makeSeries())
         client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "provider-result"))
         await second.value
 
@@ -550,6 +730,7 @@ struct UsageDashboardStoreRaceTests {
         }
 
         // Complete the first (stale) request — should be discarded
+        client.seriesContinuations[0].resume(returning: Self.makeSeries())
         client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "model-stale"))
         await first.value
 

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -359,6 +359,22 @@ struct UsageDashboardStoreLoadingTests {
     }
 
     @Test @MainActor
+    func needsRefreshTracksVisibleDashboardSectionsOnly() {
+        let store = UsageDashboardStore()
+        store.totalsState = .loaded(UsageTotalsResponse(
+            totalInputTokens: 0, totalOutputTokens: 0,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0, eventCount: 0,
+            pricedEventCount: 0, unpricedEventCount: 0
+        ))
+        store.dailyState = .failed("Legacy daily endpoint failed")
+        store.seriesState = .loaded(UsageSeriesResponse(buckets: []))
+        store.breakdownState = .loaded(UsageBreakdownResponse(breakdown: []))
+
+        #expect(store.needsRefresh == false)
+    }
+
+    @Test @MainActor
     func selectRangeChangesRangeAndRefreshes() async {
         let client = MockUsageClient()
         client.stubbedTotals = UsageTotalsResponse(
@@ -478,6 +494,16 @@ struct UsageDashboardStoreGroupTests {
         #expect(client.lastBreakdownGroupBy == "inference_profile")
     }
 
+    @Test
+    func dashboardPickerOptionsMatchGroupedSeriesSupport() {
+        #expect(UsageGroupByDimension.dashboardOptions == [
+            .callSite,
+            .inferenceProfile,
+            .model,
+            .provider,
+        ])
+    }
+
     @Test @MainActor
     func taskDefaultFallsBackToModelForOlderAssistants() async {
         let client = MockUsageClient()
@@ -557,8 +583,29 @@ struct UsageDashboardStoreRaceTests {
         UsageDailyResponse(buckets: [])
     }
 
-    private static func makeSeries() -> UsageSeriesResponse {
-        UsageSeriesResponse(buckets: [])
+    private static func makeSeries(group: String? = nil) -> UsageSeriesResponse {
+        guard let group else {
+            return UsageSeriesResponse(buckets: [])
+        }
+
+        return UsageSeriesResponse(buckets: [
+            UsageSeriesBucket(
+                date: "2026-03-01",
+                totalInputTokens: 0,
+                totalOutputTokens: 0,
+                totalEstimatedCostUsd: 0,
+                eventCount: 0,
+                groups: [
+                    group: UsageSeriesGroupValue(
+                        group: group,
+                        totalInputTokens: 0,
+                        totalOutputTokens: 0,
+                        totalEstimatedCostUsd: 0,
+                        eventCount: 0
+                    )
+                ]
+            )
+        ])
     }
 
     private static func makeBreakdown(group: String) -> UsageBreakdownResponse {
@@ -663,9 +710,15 @@ struct UsageDashboardStoreRaceTests {
         }
 
         // Complete selectGroupBy's breakdown first (the newer request)
-        client.seriesContinuations[1].resume(returning: Self.makeSeries())
+        client.seriesContinuations[1].resume(returning: Self.makeSeries(group: "provider-fresh"))
         client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "provider-fresh"))
         await groupByTask.value
+
+        if case .loaded(let series) = store.seriesState {
+            #expect(series.buckets[0].groups.keys.contains("provider-fresh"))
+        } else {
+            Issue.record("Expected series to be loaded after selectGroupBy completes")
+        }
 
         if case .loaded(let breakdown) = store.breakdownState {
             #expect(breakdown.breakdown[0].group == "provider-fresh")
@@ -677,7 +730,7 @@ struct UsageDashboardStoreRaceTests {
         // because selectGroupBy() incremented breakdownGeneration
         client.totalsContinuations[0].resume(returning: Self.makeTotals(inputTokens: 42))
         client.dailyContinuations[0].resume(returning: Self.makeDaily())
-        client.seriesContinuations[0].resume(returning: Self.makeSeries())
+        client.seriesContinuations[0].resume(returning: Self.makeSeries(group: "model-stale"))
         client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "model-stale"))
         await refreshTask.value
 
@@ -689,6 +742,13 @@ struct UsageDashboardStoreRaceTests {
         }
 
         // Breakdown must still be the selectGroupBy result, not overwritten by refresh()
+        if case .loaded(let series) = store.seriesState {
+            #expect(series.buckets[0].groups.keys.contains("provider-fresh"),
+                    "refresh() must not overwrite series set by concurrent selectGroupBy()")
+        } else {
+            Issue.record("Series was overwritten by stale refresh()")
+        }
+
         if case .loaded(let breakdown) = store.breakdownState {
             #expect(breakdown.breakdown[0].group == "provider-fresh",
                     "refresh() must not overwrite breakdown set by concurrent selectGroupBy()")

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -6,6 +6,7 @@ import Foundation
 public protocol UsageClientProtocol {
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse?
     func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse?
+    func fetchUsageSeries(from: Int, to: Int, granularity: String, groupBy: String, tz: String) async -> UsageSeriesResponse?
     func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
 }
 
@@ -33,6 +34,15 @@ public struct UsageClient: UsageClientProtocol {
         let encodedTz = tz.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? tz
         let result: (UsageDailyResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
             path: "assistants/{assistantId}/usage/daily?from=\(from)&to=\(to)&granularity=\(granularity)&tz=\(encodedTz)", timeout: 10
+        )
+        return result?.0
+    }
+
+    public func fetchUsageSeries(from: Int, to: Int, granularity: String = "daily", groupBy: String, tz: String) async -> UsageSeriesResponse? {
+        let encodedGroupBy = groupBy.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? groupBy
+        let encodedTz = tz.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? tz
+        let result: (UsageSeriesResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
+            path: "assistants/{assistantId}/usage/series?from=\(from)&to=\(to)&granularity=\(granularity)&groupBy=\(encodedGroupBy)&tz=\(encodedTz)", timeout: 10
         )
         return result?.0
     }
@@ -105,10 +115,31 @@ public enum UsageLoadingState<T: Equatable>: Equatable {
 
 /// The dimension to group usage breakdown by.
 public enum UsageGroupByDimension: String, CaseIterable, Sendable {
+    case callSite = "call_site"
+    case inferenceProfile = "inference_profile"
     case actor
     case provider
     case model
     case conversation
+
+    public static let dashboardOptions: [UsageGroupByDimension] = [
+        .callSite,
+        .inferenceProfile,
+        .model,
+        .provider,
+        .conversation,
+    ]
+
+    public var displayName: String {
+        switch self {
+        case .callSite: return "Task"
+        case .inferenceProfile: return "Profile"
+        case .actor: return "Actor (Legacy)"
+        case .provider: return "Provider"
+        case .model: return "Model"
+        case .conversation: return "Conversation"
+        }
+    }
 }
 
 // MARK: - Formatting Helpers
@@ -166,8 +197,9 @@ public final class UsageDashboardStore {
     public var selectedRange: UsageTimeRange = .last7Days
     public var totalsState: UsageLoadingState<UsageTotalsResponse> = .idle
     public var dailyState: UsageLoadingState<UsageDailyResponse> = .idle
+    public var seriesState: UsageLoadingState<UsageSeriesResponse> = .idle
     public var breakdownState: UsageLoadingState<UsageBreakdownResponse> = .idle
-    public var selectedGroupBy: UsageGroupByDimension = .model
+    public var selectedGroupBy: UsageGroupByDimension = .callSite
 
     /// Whether the current daily data uses hourly granularity (true when range is "Today").
     public var isHourlyGranularity: Bool { selectedRange == .today }
@@ -217,6 +249,7 @@ public final class UsageDashboardStore {
         breakdownGeneration &+= 1
         totalsState = .idle
         dailyState = .idle
+        seriesState = .idle
         breakdownState = .idle
     }
 
@@ -225,6 +258,7 @@ public final class UsageDashboardStore {
     public var needsRefresh: Bool {
         totalsState == .idle || totalsState.isFailed ||
         dailyState == .idle || dailyState.isFailed ||
+        seriesState == .idle || seriesState.isFailed ||
         breakdownState == .idle || breakdownState.isFailed
     }
 
@@ -243,20 +277,42 @@ public final class UsageDashboardStore {
 
         totalsState = .loading
         dailyState = .loading
+        seriesState = .loading
         breakdownState = .loading
 
         let granularity = isHourlyGranularity ? "hourly" : "daily"
+        let groupBy = selectedGroupBy
         async let totalsResult = client.fetchUsageTotals(from: range.from, to: range.to)
         async let dailyResult = client.fetchUsageDaily(
             from: range.from, to: range.to, granularity: granularity, tz: tzIdentifier
         )
+        async let seriesResult = client.fetchUsageSeries(
+            from: range.from, to: range.to, granularity: granularity, groupBy: groupBy.rawValue, tz: tzIdentifier
+        )
         async let breakdownResult = client.fetchUsageBreakdown(
-            from: range.from, to: range.to, groupBy: selectedGroupBy.rawValue
+            from: range.from, to: range.to, groupBy: groupBy.rawValue
         )
 
         let totals = await totalsResult
         let daily = await dailyResult
-        let breakdown = await breakdownResult
+        var series = await seriesResult
+        var breakdown = await breakdownResult
+
+        if groupBy == .callSite && (series == nil || breakdown == nil) {
+            selectedGroupBy = .model
+            async let modelSeriesResult = client.fetchUsageSeries(
+                from: range.from, to: range.to, granularity: granularity, groupBy: UsageGroupByDimension.model.rawValue, tz: tzIdentifier
+            )
+            async let modelBreakdownResult = client.fetchUsageBreakdown(
+                from: range.from, to: range.to, groupBy: UsageGroupByDimension.model.rawValue
+            )
+            series = await modelSeriesResult
+            breakdown = await modelBreakdownResult
+        }
+
+        if series == nil, let daily {
+            series = UsageSeriesResponse(daily: daily)
+        }
 
         if capturedRefreshGen == refreshGeneration {
             if let totals {
@@ -269,6 +325,12 @@ public final class UsageDashboardStore {
                 dailyState = .loaded(daily)
             } else {
                 dailyState = .failed("Failed to load daily usage")
+            }
+
+            if let series {
+                seriesState = .loaded(series)
+            } else {
+                seriesState = .failed("Failed to load usage series")
             }
         }
 
@@ -294,18 +356,77 @@ public final class UsageDashboardStore {
         let capturedGeneration = breakdownGeneration
 
         let range = selectedRange.epochMillisRange(timeZone: resolvedTimezone)
+        let granularity = isHourlyGranularity ? "hourly" : "daily"
         breakdownState = .loading
+        seriesState = .loading
 
-        let result = await client.fetchUsageBreakdown(
+        async let seriesResult = client.fetchUsageSeries(
+            from: range.from,
+            to: range.to,
+            granularity: granularity,
+            groupBy: dimension.rawValue,
+            tz: resolvedTimezoneIdentifier
+        )
+        async let breakdownResult = client.fetchUsageBreakdown(
             from: range.from, to: range.to, groupBy: dimension.rawValue
         )
 
+        var series = await seriesResult
+        var result = await breakdownResult
+
+        if dimension == .callSite && (series == nil || result == nil) {
+            selectedGroupBy = .model
+            async let modelSeriesResult = client.fetchUsageSeries(
+                from: range.from,
+                to: range.to,
+                granularity: granularity,
+                groupBy: UsageGroupByDimension.model.rawValue,
+                tz: resolvedTimezoneIdentifier
+            )
+            async let modelBreakdownResult = client.fetchUsageBreakdown(
+                from: range.from,
+                to: range.to,
+                groupBy: UsageGroupByDimension.model.rawValue
+            )
+            series = await modelSeriesResult
+            result = await modelBreakdownResult
+        }
+
+        if series == nil, case .loaded(let daily) = dailyState {
+            series = UsageSeriesResponse(daily: daily)
+        }
+
         guard capturedGeneration == breakdownGeneration else { return }
+
+        if let series {
+            seriesState = .loaded(series)
+        } else {
+            seriesState = .failed("Failed to load usage series")
+        }
 
         if let result {
             breakdownState = .loaded(result)
         } else {
             breakdownState = .failed("Failed to load usage breakdown")
         }
+    }
+}
+
+private extension UsageSeriesResponse {
+    init(daily: UsageDailyResponse) {
+        self.init(
+            buckets: daily.buckets.map { bucket in
+                UsageSeriesBucket(
+                    bucketId: bucket.bucketId,
+                    date: bucket.date,
+                    displayLabel: bucket.displayLabel,
+                    totalInputTokens: bucket.totalInputTokens,
+                    totalOutputTokens: bucket.totalOutputTokens,
+                    totalEstimatedCostUsd: bucket.totalEstimatedCostUsd,
+                    eventCount: bucket.eventCount,
+                    groups: [:]
+                )
+            }
+        )
     }
 }

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -127,7 +127,6 @@ public enum UsageGroupByDimension: String, CaseIterable, Sendable {
         .inferenceProfile,
         .model,
         .provider,
-        .conversation,
     ]
 
     public var displayName: String {
@@ -257,7 +256,6 @@ public final class UsageDashboardStore {
     /// on first appearance or after a partial/total failure.
     public var needsRefresh: Bool {
         totalsState == .idle || totalsState.isFailed ||
-        dailyState == .idle || dailyState.isFailed ||
         seriesState == .idle || seriesState.isFailed ||
         breakdownState == .idle || breakdownState.isFailed
     }
@@ -297,9 +295,10 @@ public final class UsageDashboardStore {
         let daily = await dailyResult
         var series = await seriesResult
         var breakdown = await breakdownResult
+        var didFallbackToModel = false
 
         if groupBy == .callSite && (series == nil || breakdown == nil) {
-            selectedGroupBy = .model
+            didFallbackToModel = true
             async let modelSeriesResult = client.fetchUsageSeries(
                 from: range.from, to: range.to, granularity: granularity, groupBy: UsageGroupByDimension.model.rawValue, tz: tzIdentifier
             )
@@ -327,14 +326,19 @@ public final class UsageDashboardStore {
                 dailyState = .failed("Failed to load daily usage")
             }
 
+        }
+
+        if capturedBreakdownGen == breakdownGeneration {
+            if didFallbackToModel && selectedGroupBy == groupBy {
+                selectedGroupBy = .model
+            }
+
             if let series {
                 seriesState = .loaded(series)
             } else {
                 seriesState = .failed("Failed to load usage series")
             }
-        }
 
-        if capturedBreakdownGen == breakdownGeneration {
             if let breakdown {
                 breakdownState = .loaded(breakdown)
             } else {
@@ -373,9 +377,10 @@ public final class UsageDashboardStore {
 
         var series = await seriesResult
         var result = await breakdownResult
+        var didFallbackToModel = false
 
         if dimension == .callSite && (series == nil || result == nil) {
-            selectedGroupBy = .model
+            didFallbackToModel = true
             async let modelSeriesResult = client.fetchUsageSeries(
                 from: range.from,
                 to: range.to,
@@ -397,6 +402,10 @@ public final class UsageDashboardStore {
         }
 
         guard capturedGeneration == breakdownGeneration else { return }
+
+        if didFallbackToModel && selectedGroupBy == dimension {
+            selectedGroupBy = .model
+        }
 
         if let series {
             seriesState = .loaded(series)

--- a/clients/shared/Network/UsageModels.swift
+++ b/clients/shared/Network/UsageModels.swift
@@ -109,6 +109,7 @@ public struct UsageDailyResponse: Decodable, Equatable, Sendable {
 public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
     public let group: String
     public let groupId: String?
+    public let groupKey: String?
     public let totalInputTokens: Int
     public let totalOutputTokens: Int
     public let totalCacheCreationTokens: Int
@@ -119,6 +120,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
     public init(
         group: String,
         groupId: String? = nil,
+        groupKey: String? = nil,
         totalInputTokens: Int,
         totalOutputTokens: Int,
         totalCacheCreationTokens: Int = 0,
@@ -128,6 +130,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
     ) {
         self.group = group
         self.groupId = groupId
+        self.groupKey = groupKey
         self.totalInputTokens = totalInputTokens
         self.totalOutputTokens = totalOutputTokens
         self.totalCacheCreationTokens = totalCacheCreationTokens
@@ -139,6 +142,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case group
         case groupId
+        case groupKey
         case totalInputTokens
         case totalOutputTokens
         case totalCacheCreationTokens
@@ -151,6 +155,7 @@ public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         group = try container.decode(String.self, forKey: .group)
         groupId = try container.decodeIfPresent(String.self, forKey: .groupId)
+        groupKey = try container.decodeIfPresent(String.self, forKey: .groupKey)
         totalInputTokens = try container.decode(Int.self, forKey: .totalInputTokens)
         totalOutputTokens = try container.decode(Int.self, forKey: .totalOutputTokens)
         totalCacheCreationTokens = try container.decodeIfPresent(Int.self, forKey: .totalCacheCreationTokens) ?? 0
@@ -166,5 +171,97 @@ public struct UsageBreakdownResponse: Decodable, Equatable, Sendable {
 
     public init(breakdown: [UsageGroupBreakdownEntry]) {
         self.breakdown = breakdown
+    }
+}
+
+/// A single grouped value inside a usage series bucket from `GET /v1/usage/series`.
+public struct UsageSeriesGroupValue: Decodable, Equatable, Sendable {
+    public let group: String
+    public let groupKey: String?
+    public let totalInputTokens: Int
+    public let totalOutputTokens: Int
+    public let totalEstimatedCostUsd: Double
+    public let eventCount: Int
+
+    public init(
+        group: String,
+        groupKey: String? = nil,
+        totalInputTokens: Int,
+        totalOutputTokens: Int,
+        totalEstimatedCostUsd: Double,
+        eventCount: Int
+    ) {
+        self.group = group
+        self.groupKey = groupKey
+        self.totalInputTokens = totalInputTokens
+        self.totalOutputTokens = totalOutputTokens
+        self.totalEstimatedCostUsd = totalEstimatedCostUsd
+        self.eventCount = eventCount
+    }
+}
+
+/// A grouped time-series bucket from `GET /v1/usage/series`.
+public struct UsageSeriesBucket: Decodable, Equatable, Sendable, Identifiable {
+    public let bucketId: String
+    public let date: String
+    public let displayLabel: String?
+    public let totalInputTokens: Int
+    public let totalOutputTokens: Int
+    public let totalEstimatedCostUsd: Double
+    public let eventCount: Int
+    public let groups: [String: UsageSeriesGroupValue]
+
+    public var id: String { bucketId }
+
+    public init(
+        bucketId: String? = nil,
+        date: String,
+        displayLabel: String? = nil,
+        totalInputTokens: Int,
+        totalOutputTokens: Int,
+        totalEstimatedCostUsd: Double,
+        eventCount: Int,
+        groups: [String: UsageSeriesGroupValue] = [:]
+    ) {
+        self.bucketId = bucketId ?? date
+        self.date = date
+        self.displayLabel = displayLabel
+        self.totalInputTokens = totalInputTokens
+        self.totalOutputTokens = totalOutputTokens
+        self.totalEstimatedCostUsd = totalEstimatedCostUsd
+        self.eventCount = eventCount
+        self.groups = groups
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case bucketId
+        case date
+        case displayLabel
+        case totalInputTokens
+        case totalOutputTokens
+        case totalEstimatedCostUsd
+        case eventCount
+        case groups
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        date = try container.decode(String.self, forKey: .date)
+        bucketId = try container.decodeIfPresent(String.self, forKey: .bucketId) ?? date
+        displayLabel = try container.decodeIfPresent(String.self, forKey: .displayLabel)
+        totalInputTokens = try container.decode(Int.self, forKey: .totalInputTokens)
+        totalOutputTokens = try container.decode(Int.self, forKey: .totalOutputTokens)
+        totalEstimatedCostUsd = try container.decode(Double.self, forKey: .totalEstimatedCostUsd)
+        eventCount = try container.decode(Int.self, forKey: .eventCount)
+        groups = try container.decodeIfPresent([String: UsageSeriesGroupValue].self, forKey: .groups) ?? [:]
+    }
+}
+
+/// Response wrapper for `GET /v1/usage/series`.
+public struct UsageSeriesResponse: Decodable, Equatable, Sendable {
+    public let buckets: [UsageSeriesBucket]
+
+    public init(buckets: [UsageSeriesBucket]) {
+        self.buckets = buckets
     }
 }


### PR DESCRIPTION
## Summary
- adds Task/Profile usage dimensions to the macOS usage dashboard, backed by call_site and inference_profile
- adds /usage/series decoding/store support and stacked inference usage bars controlled by one picker
- updates the call-site override catalog to match the backend task catalog

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter UsageDashboardStoreTests --filter UsageDashboardPanelTests --filter SettingsStoreCallSiteOverrideTests --filter SettingsStoreInferenceProfilesTests
- clients/macos ./build.sh lint (per worker report; passed with unrelated existing strict-concurrency warnings)

Apple refs checked (2026-04-29): SwiftUI accessibility/environment guidance and HIG patterns via clients/AGENTS.md guidance; no new Apple API adoption beyond existing SwiftUI controls.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
