### PR TITLE
fix: Track top-level Slack mentions as active threads

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -194,4 +194,72 @@ describe("SlackSocketModeClient thread tracking", () => {
       rawDb.close();
     }
   });
+
+  test("accepts unmentioned thread replies after a top-level app mention", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await Promise.all([
+        resolveSlackUser("U-mentioned", "xoxb-test"),
+        resolveSlackUser("U-reply", "xoxb-test"),
+      ]);
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-top-level-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-top-level-mention",
+            event: {
+              type: "app_mention",
+              user: "U-mentioned",
+              text: "<@U-bot> can you help here?",
+              ts: "1700000000.000300",
+              channel: "C-thread",
+            },
+          },
+        }),
+        ws,
+      );
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-top-level-mention");
+      expect(emitted[0].threadTs).toBe("1700000000.000300");
+      expect(emitted[0].event.source.threadId).toBeUndefined();
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-top-level-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-top-level-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "following up in the new thread",
+              ts: "1700000000.000400",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: "1700000000.000300",
+            },
+          },
+        }),
+        ws,
+      );
+
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1].event.source.updateId).toBe("Ev-top-level-reply");
+      expect(emitted[1].event.message.content).toBe(
+        "following up in the new thread",
+      );
+      expect(emitted[1].event.source.chatType).toBe("channel");
+      expect(emitted[1].threadTs).toBe("1700000000.000300");
+      expect(emitted[1].event.source.threadId).toBe("1700000000.000300");
+    } finally {
+      rawDb.close();
+    }
+  });
 });

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -693,9 +693,9 @@ export class SlackSocketModeClient {
     }
 
     // Track threads on the inbound side so follow-up replies (without
-    // @mention) continue to be forwarded. Any forwarded event that carries
-    // a thread_ts implies bot participation in that thread.
-    const threadTs = (event as { thread_ts?: string }).thread_ts;
+    // @mention) continue to be forwarded. Use the normalized thread id so
+    // top-level app mentions register their own ts as the active thread.
+    const threadTs = normalized.threadTs;
     if (threadTs) {
       this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
     }


### PR DESCRIPTION
## Summary
- Track normalized Slack thread ids for accepted app mentions
- Preserve unmentioned follow-up replies after top-level mentions
- Add regression coverage for top-level app mention thread tracking

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
