### PR TITLE
fix(macos): show profile labels in active picker, fix override accordion resize

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
@@ -368,7 +368,8 @@ struct CallSiteOverrideRow: View {
         }
         var parts: [String] = []
         if let profile = draft.profile {
-            parts.append("Profile: \(profile)")
+            let display = profiles.first(where: { $0.name == profile })?.displayName ?? profile
+            parts.append(display)
         } else if let provider = draft.provider, let model = draft.model {
             parts.append("\(providerDisplayName(provider)) \u{00B7} \(modelDisplayName(provider, model))")
         } else if let model = draft.model {

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
@@ -124,6 +124,8 @@ struct CallSiteOverrideRow: View {
             }
         }
         .padding(.vertical, VSpacing.xs)
+        .animation(VAnimation.fast, value: isExpanded)
+        .animation(VAnimation.fast, value: isOverrideOn)
         .onAppear {
             // Expand rows that are already configured so the user sees their
             // current settings without an extra click.

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverrideRow.swift
@@ -283,7 +283,7 @@ struct CallSiteOverrideRow: View {
                         }
                     }
                 ),
-                options: profiles.map { (label: $0.name, value: $0.name) }
+                options: profiles.map { (label: $0.displayName, value: $0.name) }
                     + [(label: Self.customLabel, value: Self.customSentinel)]
             )
         }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -484,7 +484,7 @@ struct InferenceServiceCard: View {
             VDropdown(
                 placeholder: "Select a profile\u{2026}",
                 selection: activeProfileBinding,
-                options: store.profiles.map { (label: $0.name, value: $0.name) }
+                options: store.profiles.map { (label: $0.displayName, value: $0.name) }
             )
         }
     }


### PR DESCRIPTION
## Summary
- Show profile `displayName` (label) instead of raw name in the Active Profile dropdown so managed profiles display "Quality", "Balanced", "Speed" instead of "quality-optimized", "balanced", "cost-optimized"
- Fix Per-Task Model Overrides accordion not resizing until scroll by adding `.animation()` modifiers tied to `isExpanded` and `isOverrideOn` state changes

## Original prompt
1. In the "Active Profile" dropdown, show the profile's label instead of name as the dropdown option and selected value
2. When expanding/collapsing the accordion for a task in the "Per-Task Model Overrides" modal, the section should auto-adjust size without requiring a scroll
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
