### PR TITLE
fix: Persist Slack watermarks for all compactions

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2444,6 +2444,122 @@ describe("session-agent-loop", () => {
       expect(firstInjectionOptions.slackChronologicalMessages).toBeNull();
     });
 
+    test("overflow reducer Slack compaction persists watermark from rendered context", async () => {
+      const renderedSlackMessages: Message[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "first rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "second rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "retained Slack row" }],
+        },
+      ];
+      mockSlackChronologicalContext = {
+        messages: renderedSlackMessages,
+        renderedMessages: renderedSlackMessages.map((message, index) => ({
+          message,
+          sourceChannelTs: [
+            "1700000010.000000",
+            "1700000020.000000",
+            "1700000030.000000",
+          ][index]!,
+        })),
+        sourceChannelTsByMessage: [
+          "1700000010.000000",
+          "1700000020.000000",
+          "1700000030.000000",
+        ],
+        compactableStartIndex: 0,
+      };
+      mockEstimateTokens = 120_000;
+      mockReducerStepFn = (_msgs: Message[]) => ({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "summary" }],
+          },
+          renderedSlackMessages[2]!,
+        ],
+        tier: "forced_compaction",
+        state: {
+          appliedTiers: ["forced_compaction"],
+          injectionMode: "full",
+          exhausted: false,
+        },
+        estimatedTokens: 5_000,
+        compactionResult: {
+          compacted: true,
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "summary" }],
+            },
+            renderedSlackMessages[2]!,
+          ],
+          compactedPersistedMessages: 2,
+          previousEstimatedInputTokens: 120_000,
+          estimatedInputTokens: 5_000,
+          maxInputTokens: 100_000,
+          thresholdTokens: 80_000,
+          compactedMessages: 2,
+          summaryCalls: 1,
+          summaryInputTokens: 100,
+          summaryOutputTokens: 20,
+          summaryModel: "mock-model",
+          summaryText: "summary",
+          summaryFailed: false,
+        },
+      });
+
+      const ctx = makeCtx({
+        channelCapabilities: {
+          channel: "slack",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "channel",
+        },
+        trustContext: {
+          sourceChannel: "slack",
+          trustClass: "guardian",
+        } as AgentLoopConversationContext["trustContext"],
+        getTurnChannelContext: () => ({
+          userMessageChannel: "slack" as const,
+          assistantMessageChannel: "slack" as const,
+        }),
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async () => ({ compacted: false }),
+        } as unknown as AgentLoopConversationContext["contextWindowManager"],
+      });
+
+      await runAgentLoopImpl(ctx, "next reply", "user-msg-overflow", () => {});
+
+      expect(getSlackCompactionWatermarkForPrefixMock).toHaveBeenCalledWith(
+        mockSlackChronologicalContext,
+        2,
+      );
+      expect(updateConversationSlackContextWatermarkMock).toHaveBeenCalledWith(
+        "test-conv",
+        "1700000020.000000",
+        expect.any(Number),
+      );
+      const reinjectionOptions = applyRuntimeInjectionsMock.mock.calls.find(
+        (call) => {
+          const options = call[1] as {
+            slackChronologicalMessages?: Message[] | null;
+          };
+          return options.slackChronologicalMessages === null;
+        },
+      )?.[1] as { slackChronologicalMessages?: Message[] | null } | undefined;
+      expect(reinjectionOptions?.slackChronologicalMessages).toBeNull();
+    });
+
     test("next inbound Slack turn injects the watermark-filtered chronological context", async () => {
       mockConversationRow = {
         ...mockConversationRow,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -782,27 +782,37 @@ export async function runAgentLoopImpl(
     let shouldInjectWorkspace = isFirstMessage;
     let compactedThisTurn = false;
     const isSlackConversation = ctx.channelCapabilities?.channel === "slack";
+    let currentSlackContextSummary =
+      turnStartConversation?.contextSummary ?? null;
+    let currentSlackContextCompactedMessageCount =
+      turnStartConversation?.contextCompactedMessageCount ?? 0;
+    let currentSlackContextCompactionWatermarkTs =
+      turnStartConversation?.slackContextCompactionWatermarkTs ?? null;
+    const loadCurrentSlackChronologicalContext =
+      (): SlackChronologicalContext | null => {
+        if (!isSlackConversation) return null;
+        return loadSlackChronologicalContext(
+          ctx.conversationId,
+          ctx.channelCapabilities!,
+          {
+            trustClass: ctx.trustContext?.trustClass,
+            contextSummary: currentSlackContextSummary,
+            contextCompactedMessageCount:
+              currentSlackContextCompactedMessageCount,
+            slackContextCompactionWatermarkTs:
+              currentSlackContextCompactionWatermarkTs,
+          },
+        );
+      };
     let slackChronologicalContext: SlackChronologicalContext | null =
-      isSlackConversation
-        ? loadSlackChronologicalContext(
-            ctx.conversationId,
-            ctx.channelCapabilities!,
-            {
-              trustClass: ctx.trustContext?.trustClass,
-              contextSummary: turnStartConversation?.contextSummary,
-              contextCompactedMessageCount:
-                turnStartConversation?.contextCompactedMessageCount,
-              slackContextCompactionWatermarkTs:
-                turnStartConversation?.slackContextCompactionWatermarkTs,
-            },
-          )
-        : null;
+      loadCurrentSlackChronologicalContext();
     const messagesForStartOfTurnCompaction =
       slackChronologicalContext?.messages ?? ctx.messages;
     const applySuccessfulCompaction = (
       result: Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>,
-      provenanceContext: SlackChronologicalContext | null = null,
     ) => {
+      const provenanceContext =
+        slackChronologicalContext ?? loadCurrentSlackChronologicalContext();
       const slackWatermarkTs = getSlackCompactionWatermarkForPrefix(
         provenanceContext,
         result.compactedMessages,
@@ -810,7 +820,11 @@ export async function runAgentLoopImpl(
       applyCompactionResult(ctx, result, onEvent, reqId, {
         slackContextCompactionWatermarkTs: slackWatermarkTs,
       });
+      currentSlackContextSummary = result.summaryText;
+      currentSlackContextCompactedMessageCount =
+        ctx.contextCompactedMessageCount;
       if (slackWatermarkTs) {
+        currentSlackContextCompactionWatermarkTs = slackWatermarkTs;
         slackChronologicalContext = null;
       }
     };
@@ -881,7 +895,7 @@ export async function runAgentLoopImpl(
       await trackCompactionOutcome(ctx, compacted.summaryFailed, onEvent);
     }
     if (compacted?.compacted) {
-      applySuccessfulCompaction(compacted, slackChronologicalContext);
+      applySuccessfulCompaction(compacted);
       shouldInjectWorkspace = true;
       if (compacted.compactedPersistedMessages > 0) {
         compactedThisTurn = true;


### PR DESCRIPTION
## Summary
- Thread Slack provenance through non-start compaction paths
- Preserve watermark filtering after overflow/recovery compactions
- Add regression coverage for Slack watermark persistence outside start-of-turn compaction

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
