### PR TITLE
fix: Keep newest Slack backfill windows

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -377,16 +377,14 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(byChannelTs.get("1234.2")?.displayName).toBe("Reply Two");
   });
 
-  test("initial late-join backfill preserves early and recent anchors without loading the middle", async () => {
+  test("initial late-join backfill keeps the newest bounded page before the inbound mention", async () => {
     const conv = createTestConversation();
-    const ts = (n: number) => `1234.${String(n).padStart(6, "0")}`;
+    const ts = (n: number) => `1700000000.${String(n).padStart(6, "0")}`;
+    const inboundTs = ts(500000);
 
     backfillThreadPageMock.mockImplementation(async (...args) => {
       const messages = await backfillThreadMock(...args);
       const opts = args[2];
-      if (opts?.before === ts(100) && opts.cursor === undefined) {
-        return { messages, hasMore: true, nextCursor: "recent-page-2" };
-      }
       if (opts?.limit === 25) {
         return { messages, hasMore: true, nextCursor: "early-page-2" };
       }
@@ -402,58 +400,52 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
           }),
         );
       }
-      if (opts?.cursor === undefined) {
-        return Array.from({ length: 50 }, (_, i) =>
-          makeBackfillMessage({
-            id: ts(i),
-            text: i === 0 ? "root context duplicate" : `early duplicate ${i}`,
-            threadId: i === 0 ? undefined : ts(0),
+      if (opts?.before === inboundTs && opts.after !== undefined) {
+        return [
+          ...Array.from({ length: 50 }, (_, i) => {
+            const n = 499950 + i;
+            return makeBackfillMessage({
+              id: ts(n),
+              text: n === 499999 ? "newest file share" : `recent ${n}`,
+              threadId: ts(0),
+              ...(n === 499999
+                ? {
+                    metadata: {
+                      slackFiles: [
+                        {
+                          id: "F123",
+                          name: "requirements.txt",
+                          mimetype: "text/plain",
+                        },
+                      ],
+                    },
+                  }
+                : {}),
+            });
           }),
-        );
-      }
-      return [
-        ...Array.from({ length: 50 }, (_, i) => {
-          const n = i + 50;
-          return makeBackfillMessage({
-            id: ts(n),
-            text: n === 99 ? "recent file share" : `recent ${n}`,
+          makeBackfillMessage({
+            id: ts(499960),
+            text: "duplicate recent row",
             threadId: ts(0),
-            ...(n === 99
-              ? {
-                  metadata: {
-                    slackFiles: [
-                      {
-                        id: "F123",
-                        name: "requirements.txt",
-                        mimetype: "text/plain",
-                      },
-                    ],
-                  },
-                }
-              : {}),
-          });
-        }),
-        makeBackfillMessage({
-          id: ts(60),
-          text: "duplicate recent row",
-          threadId: ts(0),
-        }),
-      ];
+          }),
+        ];
+      }
+      return [];
     });
 
     const result = await triggerSlackThreadBackfillIfNeeded({
       conversationId: conv.id,
       channelId: SLACK_CHANNEL_ID,
       threadTs: ts(0),
-      excludeChannelTs: ts(100),
+      excludeChannelTs: inboundTs,
     });
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(3);
+    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
     expect(backfillThreadMock.mock.calls[0][2]?.limit).toBe(25);
     expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
     expect(backfillThreadMock.mock.calls[1][2]?.limit).toBe(50);
-    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe(ts(100));
-    expect(backfillThreadMock.mock.calls[2][2]?.cursor).toBe("recent-page-2");
+    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe(inboundTs);
+    expect(backfillThreadMock.mock.calls[1][2]?.after).toBeDefined();
 
     expect(result.reason).toBe("thread_late_join");
     expect(result.omittedMiddle).toBe(true);
@@ -463,17 +455,17 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(persisted.find((p) => p.channelTs === ts(0))?.content).toBe(
       "root context",
     );
-    expect(persisted.find((p) => p.channelTs === ts(30))).toBeUndefined();
-    expect(persisted.find((p) => p.channelTs === ts(99))?.content).toBe(
-      "recent file share",
+    expect(persisted.find((p) => p.channelTs === ts(250000))).toBeUndefined();
+    expect(persisted.find((p) => p.channelTs === ts(499999))?.content).toBe(
+      "newest file share",
     );
     expect(
-      persisted.filter((p) => p.channelTs === ts(60)).map((p) => p.content),
-    ).toEqual(["recent 60"]);
+      persisted.filter((p) => p.channelTs === ts(499960)).map((p) => p.content),
+    ).toEqual(["recent 499960"]);
     expect(persisted.some((p) => p.backfillOmittedMiddle === true)).toBe(true);
-    expect(persisted.find((p) => p.channelTs === ts(99))?.slackFiles).toEqual([
-      { name: "requirements.txt", mimetype: "text/plain" },
-    ]);
+    expect(
+      persisted.find((p) => p.channelTs === ts(499999))?.slackFiles,
+    ).toEqual([{ name: "requirements.txt", mimetype: "text/plain" }]);
   });
 
   test("backfill is NOT triggered when the parent is already persisted and no upper-bound gap is known", async () => {
@@ -541,6 +533,68 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       "unseen earlier reply",
     );
     expect(persisted.find((p) => p.channelTs === "1234.5")).toBeUndefined();
+  });
+
+  test("multi-page delta backfill keeps the newest rows before the inbound mention", async () => {
+    const conv = createTestConversation();
+    const parentTs = "1699990000.000000";
+    const inboundTs = "1700000000.500000";
+    const ts = (n: number) => `1700000000.${String(n).padStart(6, "0")}`;
+
+    seedSlackRow(conv.id, parentTs, undefined, "parent already here");
+
+    backfillThreadPageMock.mockImplementation(async (...args) => {
+      const messages = await backfillThreadMock(...args);
+      const opts = args[2];
+      if (opts?.limit === 1) {
+        return { messages, hasMore: messages.length > 0 };
+      }
+      return { messages, hasMore: false };
+    });
+    backfillThreadMock.mockImplementation(async (_channel, _thread, opts) => {
+      if (opts?.limit === 1) {
+        return [
+          makeBackfillMessage({
+            id: ts(100000),
+            text: "omitted earlier delta",
+            threadId: parentTs,
+          }),
+        ];
+      }
+      if (opts?.before === inboundTs && opts.after !== parentTs) {
+        return Array.from({ length: 50 }, (_, i) => {
+          const n = 499950 + i;
+          return makeBackfillMessage({
+            id: ts(n),
+            text: `newest delta ${n}`,
+            threadId: parentTs,
+          });
+        });
+      }
+      return [];
+    });
+
+    const result = await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs: parentTs,
+      excludeChannelTs: inboundTs,
+    });
+
+    expect(result.reason).toBe("thread_delta");
+    expect(result.omittedMiddle).toBe(true);
+    expect(backfillThreadMock.mock.calls[0][2]?.before).toBe(inboundTs);
+    expect(backfillThreadMock.mock.calls[0][2]?.after).not.toBe(parentTs);
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(persisted.find((p) => p.channelTs === parentTs)?.content).toBe(
+      "parent already here",
+    );
+    expect(persisted.find((p) => p.channelTs === ts(100000))).toBeUndefined();
+    expect(persisted.find((p) => p.channelTs === ts(499999))?.content).toBe(
+      "newest delta 499999",
+    );
+    expect(persisted.find((p) => p.channelTs === inboundTs)).toBeUndefined();
   });
 
   test("file-bearing backfill renders a Slack file marker without binary hydration", async () => {
@@ -747,11 +801,16 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       excludeChannelTs: "1234.6",
     });
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(4);
-    expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
-    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("1234.5");
-    expect(backfillThreadMock.mock.calls[2][2]?.before).toBeUndefined();
-    expect(backfillThreadMock.mock.calls[3][2]?.before).toBe("1234.6");
+    expect(
+      backfillThreadMock.mock.calls.some(
+        (call) => call[2]?.before === "1234.5",
+      ),
+    ).toBe(true);
+    expect(
+      backfillThreadMock.mock.calls.some(
+        (call) => call[2]?.before === "1234.6",
+      ),
+    ).toBe(true);
   });
 
   test("rapid consecutive replies can fetch a newer gap even when the prior inbound reply was only excluded", async () => {
@@ -813,13 +872,19 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
       excludeChannelTs: "1234.6",
     });
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(3);
+    expect(backfillThreadMock.mock.calls.length).toBeGreaterThanOrEqual(3);
     expect(backfillThreadMock.mock.calls[0][2]?.after).toBeUndefined();
     expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
-    expect(backfillThreadMock.mock.calls[1][2]?.after).toBeUndefined();
-    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("1234.5");
-    expect(backfillThreadMock.mock.calls[2][2]?.after).toBe("1234.4");
-    expect(backfillThreadMock.mock.calls[2][2]?.before).toBe("1234.6");
+    expect(
+      backfillThreadMock.mock.calls.some(
+        (call) => call[2]?.before === "1234.5",
+      ),
+    ).toBe(true);
+    expect(
+      backfillThreadMock.mock.calls.some(
+        (call) => call[2]?.before === "1234.6",
+      ),
+    ).toBe(true);
 
     const persisted = readPersistedSlackRows(conv.id);
     expect(persisted.map((p) => p.channelTs).sort()).toEqual([
@@ -1245,7 +1310,7 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     // void-promise has time to write to the DB before we assert.
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(2);
+    expect(backfillThreadMock.mock.calls.length).toBeGreaterThanOrEqual(2);
     const [calledChannel, calledThread] = backfillThreadMock.mock.calls[0];
     expect(calledChannel).toBe(HTTP_SLACK_CHANNEL_ID);
     expect(calledThread).toBe("1234.0");
@@ -1479,10 +1544,17 @@ describe("handleChannelInbound — Slack thread backfill wiring", () => {
     expect(r2.status).toBe(200);
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(backfillThreadMock).toHaveBeenCalledTimes(3);
     expect(backfillThreadMock.mock.calls[0][2]?.before).toBeUndefined();
-    expect(backfillThreadMock.mock.calls[1][2]?.before).toBe("5678.1");
-    expect(backfillThreadMock.mock.calls[2][2]?.before).toBe("5678.2");
+    expect(
+      backfillThreadMock.mock.calls.some(
+        (call) => call[2]?.before === "5678.1",
+      ),
+    ).toBe(true);
+    expect(
+      backfillThreadMock.mock.calls.some(
+        (call) => call[2]?.before === "5678.2",
+      ),
+    ).toBe(true);
   });
 
   test("backfill error from the HTTP path does not crash the request", async () => {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1616,6 +1616,22 @@ const SLACK_THREAD_INITIAL_EARLY_LIMIT = 25;
 const SLACK_THREAD_INITIAL_RECENT_LIMIT = 50;
 const SLACK_THREAD_INITIAL_RECENT_MAX_PAGES = 5;
 const SLACK_THREAD_DELTA_LIMIT = 50;
+const SLACK_THREAD_UPPER_ADJACENT_MAX_ATTEMPTS = 5;
+const MICROS_PER_SECOND = 1_000_000n;
+const SLACK_UPPER_ADJACENT_EXPANDING_WINDOWS_MICROS = [
+  5n * 60n * MICROS_PER_SECOND,
+  60n * 60n * MICROS_PER_SECOND,
+  24n * 60n * 60n * MICROS_PER_SECOND,
+  7n * 24n * 60n * 60n * MICROS_PER_SECOND,
+  30n * 24n * 60n * 60n * MICROS_PER_SECOND,
+];
+const SLACK_UPPER_ADJACENT_SHRINKING_WINDOWS_MICROS = [
+  60n * MICROS_PER_SECOND,
+  10n * MICROS_PER_SECOND,
+  MICROS_PER_SECOND,
+  100_000n,
+  1_000n,
+];
 
 export interface SlackThreadBackfillResult {
   fetched: number;
@@ -1666,6 +1682,12 @@ interface SlackInitialThreadWindowsResult {
   omittedMiddle: boolean;
 }
 
+interface SlackUpperAdjacentWindowResult {
+  messages: ProviderMessage[];
+  omittedEarlierContent: boolean;
+  truncatedBeforeUpperBound: boolean;
+}
+
 function slackPageHasMore(page: SlackBackfillWindowPage): boolean {
   return page.hasMore || page.nextCursor !== undefined;
 }
@@ -1677,6 +1699,19 @@ function minSlackMessageTs(messages: ProviderMessage[]): string | undefined {
 function maxSlackMessageTs(messages: ProviderMessage[]): string | undefined {
   const sorted = sortSlackProviderMessages(messages);
   return sorted[sorted.length - 1]?.id;
+}
+
+function slackTimestampToMicros(ts: string | undefined): bigint | null {
+  const parsed = parseSlackTimestamp(ts);
+  if (!parsed) return null;
+  return parsed.seconds * MICROS_PER_SECOND + parsed.micros;
+}
+
+function slackTimestampFromMicros(totalMicros: bigint): string | undefined {
+  if (totalMicros < 0n) return undefined;
+  const seconds = totalMicros / MICROS_PER_SECOND;
+  const micros = totalMicros % MICROS_PER_SECOND;
+  return `${seconds.toString()}.${micros.toString().padStart(6, "0")}`;
 }
 
 function didInitialWindowsLeaveGap(params: {
@@ -1693,47 +1728,154 @@ function didInitialWindowsLeaveGap(params: {
   return compared !== null && compared < 0;
 }
 
-async function fetchRecentSlackThreadWindow(params: {
+async function fetchSlackThreadUpperAdjacentWindow(params: {
   channelId: string;
   threadTs: string;
   upperBoundTs: string;
+  lowerBoundTs?: string;
+  limit: number;
   account?: string;
-}): Promise<{
-  page: SlackBackfillWindowPage;
-  truncatedBeforeUpperBound: boolean;
-}> {
-  let cursor: string | undefined;
-  let lastPage: SlackBackfillWindowPage = { messages: [], hasMore: false };
-  let truncatedBeforeUpperBound = false;
-
-  for (
-    let pageIndex = 0;
-    pageIndex < SLACK_THREAD_INITIAL_RECENT_MAX_PAGES;
-    pageIndex++
-  ) {
+  maxAttempts?: number;
+}): Promise<SlackUpperAdjacentWindowResult> {
+  // Slack returns bounded conversations.replies pages earliest-first. To keep
+  // the context closest to the inbound mention, narrow by timestamp instead
+  // of cursoring forward from the oldest page in the bounded range.
+  const upperMicros = slackTimestampToMicros(params.upperBoundTs);
+  if (upperMicros === null) {
     const page = await backfillThreadWindowPage(
       params.channelId,
       params.threadTs,
       {
-        limit: SLACK_THREAD_INITIAL_RECENT_LIMIT,
+        limit: params.limit,
         account: params.account,
         before: params.upperBoundTs,
-        ...(cursor !== undefined ? { cursor } : {}),
+        ...(params.lowerBoundTs !== undefined
+          ? { after: params.lowerBoundTs }
+          : {}),
       },
     );
-    if (page.messages.length > 0) {
-      lastPage = page;
-    }
-    if (!slackPageHasMore(page)) {
-      truncatedBeforeUpperBound = false;
-      break;
-    }
-    cursor = page.nextCursor;
-    truncatedBeforeUpperBound = true;
-    if (!cursor) break;
+    return {
+      messages: page.messages,
+      omittedEarlierContent: slackPageHasMore(page),
+      truncatedBeforeUpperBound: slackPageHasMore(page),
+    };
   }
 
-  return { page: lastPage, truncatedBeforeUpperBound };
+  const lowerMicros = slackTimestampToMicros(params.lowerBoundTs);
+  const maxAttempts =
+    params.maxAttempts ?? SLACK_THREAD_UPPER_ADJACENT_MAX_ATTEMPTS;
+  let attempts = 0;
+  let safePage: SlackBackfillWindowPage | undefined;
+  let safeAfterTs: string | undefined;
+  let truncatedBeforeUpperBound = false;
+
+  const fetchWindow = async (
+    windowMicros: bigint,
+  ): Promise<{
+    page: SlackBackfillWindowPage;
+    after?: string;
+    reachedLowerBound: boolean;
+  }> => {
+    let candidateMicros = upperMicros - windowMicros;
+    let reachedLowerBound = false;
+    if (lowerMicros !== null && candidateMicros <= lowerMicros) {
+      candidateMicros = lowerMicros;
+      reachedLowerBound = true;
+    }
+    const after = reachedLowerBound
+      ? params.lowerBoundTs
+      : slackTimestampFromMicros(candidateMicros);
+    const page = await backfillThreadWindowPage(
+      params.channelId,
+      params.threadTs,
+      {
+        limit: params.limit,
+        account: params.account,
+        before: params.upperBoundTs,
+        ...(after !== undefined ? { after } : {}),
+      },
+    );
+    attempts++;
+    return { page, after, reachedLowerBound };
+  };
+
+  const considerWindow = async (windowMicros: bigint): Promise<boolean> => {
+    const { page, after, reachedLowerBound } = await fetchWindow(windowMicros);
+    if (slackPageHasMore(page)) {
+      truncatedBeforeUpperBound = true;
+      return false;
+    }
+
+    safePage = page;
+    safeAfterTs = after;
+    return page.messages.length < params.limit && !reachedLowerBound;
+  };
+
+  for (const windowMicros of SLACK_UPPER_ADJACENT_EXPANDING_WINDOWS_MICROS) {
+    if (attempts >= maxAttempts) break;
+    const shouldExpand = await considerWindow(windowMicros);
+    if (!shouldExpand) break;
+  }
+
+  if (truncatedBeforeUpperBound && !safePage && attempts < maxAttempts) {
+    for (const windowMicros of SLACK_UPPER_ADJACENT_SHRINKING_WINDOWS_MICROS) {
+      if (attempts >= maxAttempts) break;
+      const shouldExpand = await considerWindow(windowMicros);
+      if (!shouldExpand || safePage) break;
+    }
+  }
+
+  if (!safePage && attempts < maxAttempts) {
+    const after = slackTimestampFromMicros(upperMicros - 2n);
+    const page = await backfillThreadWindowPage(
+      params.channelId,
+      params.threadTs,
+      {
+        limit: params.limit,
+        account: params.account,
+        before: params.upperBoundTs,
+        ...(after !== undefined ? { after } : {}),
+      },
+    );
+    safePage = page;
+    safeAfterTs = after;
+    truncatedBeforeUpperBound =
+      truncatedBeforeUpperBound || slackPageHasMore(page);
+  }
+  if (!safePage) {
+    return {
+      messages: [],
+      omittedEarlierContent: true,
+      truncatedBeforeUpperBound: true,
+    };
+  }
+
+  let omittedEarlierContent = truncatedBeforeUpperBound;
+  if (
+    !omittedEarlierContent &&
+    params.lowerBoundTs !== undefined &&
+    safeAfterTs !== undefined &&
+    compareSlackTimestamps(params.lowerBoundTs, safeAfterTs) === -1
+  ) {
+    const coverageProbe = await backfillThreadWindowPage(
+      params.channelId,
+      params.threadTs,
+      {
+        limit: 1,
+        account: params.account,
+        after: params.lowerBoundTs,
+        before: safeAfterTs,
+      },
+    );
+    omittedEarlierContent =
+      coverageProbe.messages.length > 0 || slackPageHasMore(coverageProbe);
+  }
+
+  return {
+    messages: safePage.messages,
+    omittedEarlierContent,
+    truncatedBeforeUpperBound,
+  };
 }
 
 async function fetchInitialSlackThreadWindows(params: {
@@ -1763,23 +1905,30 @@ async function fetchInitialSlackThreadWindows(params: {
       limit: SLACK_THREAD_INITIAL_EARLY_LIMIT,
       account: params.account,
     }),
-    fetchRecentSlackThreadWindow({
+    fetchSlackThreadUpperAdjacentWindow({
       channelId: params.channelId,
       threadTs: params.threadTs,
       account: params.account,
       upperBoundTs: params.upperBoundTs,
+      limit: SLACK_THREAD_INITIAL_RECENT_LIMIT,
+      maxAttempts: SLACK_THREAD_INITIAL_RECENT_MAX_PAGES,
     }),
   ]);
-  const recent = recentResult.page;
+  const recent: SlackBackfillWindowPage = {
+    messages: recentResult.messages,
+    hasMore: recentResult.truncatedBeforeUpperBound,
+  };
   return {
     messages: sortSlackProviderMessages(
       dedupeSlackProviderMessages([...early.messages, ...recent.messages]),
     ),
-    omittedMiddle: didInitialWindowsLeaveGap({
-      early,
-      recent,
-      recentScanTruncated: recentResult.truncatedBeforeUpperBound,
-    }),
+    omittedMiddle:
+      recentResult.omittedEarlierContent ||
+      didInitialWindowsLeaveGap({
+        early,
+        recent,
+        recentScanTruncated: recentResult.truncatedBeforeUpperBound,
+      }),
   };
 }
 
@@ -1917,14 +2066,16 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
       fetched = initial.messages;
       omittedMiddle = initial.omittedMiddle;
     } else {
-      const page = await backfillThreadWindowPage(channelId, threadTs, {
+      const window = await fetchSlackThreadUpperAdjacentWindow({
+        channelId,
+        threadTs,
         limit: SLACK_THREAD_DELTA_LIMIT,
         account,
-        ...(lowerBoundTs !== undefined ? { after: lowerBoundTs } : {}),
-        ...(upperBoundTs !== undefined ? { before: upperBoundTs } : {}),
+        ...(lowerBoundTs !== undefined ? { lowerBoundTs } : {}),
+        upperBoundTs: upperBoundTs ?? threadTs,
       });
-      fetched = page.messages;
-      omittedMiddle = slackPageHasMore(page);
+      fetched = window.messages;
+      omittedMiddle = window.omittedEarlierContent;
     }
     if (fetched.length === 0) {
       log.debug(


### PR DESCRIPTION
## Summary
- Ensure bounded Slack thread backfill keeps messages nearest the inbound mention
- Share the upper-bound-adjacent window logic across initial and delta backfill
- Cover multi-page late-join and delta windows

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
