### PR TITLE
fix: Restrict Slack active thread tracking

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -120,6 +120,10 @@ function makeOpenSocket(): WebSocket {
   } as unknown as WebSocket;
 }
 
+function flushAsyncEventEmission(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 beforeEach(() => {
   clearUserInfoCache();
   fetchMock = mock(async () => makeSlackUserResponse());
@@ -262,4 +266,117 @@ describe("SlackSocketModeClient thread tracking", () => {
       rawDb.close();
     }
   });
+
+  test.each([
+    {
+      name: "reaction",
+      seedEventId: "Ev-reaction",
+      seedEvent: {
+        type: "reaction_added",
+        user: "U-reactor",
+        reaction: "eyes",
+        item: {
+          type: "message",
+          channel: "C-thread",
+          ts: "1700000000.000500",
+        },
+        item_user: "U-author",
+        event_ts: "1700000000.000501",
+      },
+      replyThreadTs: "1700000000.000500",
+    },
+    {
+      name: "message edit",
+      seedEventId: "Ev-edit",
+      seedEvent: {
+        type: "message",
+        subtype: "message_changed",
+        channel: "C-thread",
+        channel_type: "channel",
+        message: {
+          user: "U-editor",
+          text: "edited message",
+          ts: "1700000000.000600",
+          thread_ts: "1700000000.000550",
+        },
+      },
+      replyThreadTs: "1700000000.000550",
+    },
+    {
+      name: "message delete",
+      seedEventId: "Ev-delete",
+      seedEvent: {
+        type: "message",
+        subtype: "message_deleted",
+        channel: "C-thread",
+        channel_type: "channel",
+        deleted_ts: "1700000000.000700",
+        previous_message: {
+          user: "U-author",
+          text: "deleted message",
+          ts: "1700000000.000700",
+          thread_ts: "1700000000.000650",
+        },
+      },
+      replyThreadTs: "1700000000.000650",
+    },
+  ])(
+    "does not arm active thread tracking for admitted $name events",
+    async ({ seedEventId, seedEvent, replyThreadTs }) => {
+      const { rawDb, store } = createSlackStore();
+      const emitted: NormalizedSlackEvent[] = [];
+      const client = createHarness(store, (event) => emitted.push(event));
+      const ws = makeOpenSocket();
+
+      try {
+        await Promise.all([
+          resolveSlackUser("U-reactor", "xoxb-test"),
+          resolveSlackUser("U-editor", "xoxb-test"),
+          resolveSlackUser("U-author", "xoxb-test"),
+          resolveSlackUser("U-reply", "xoxb-test"),
+        ]);
+
+        client.handleMessage(
+          JSON.stringify({
+            envelope_id: `env-${seedEventId}`,
+            type: "events_api",
+            payload: {
+              event_id: seedEventId,
+              event: seedEvent,
+            },
+          }),
+          ws,
+        );
+        await flushAsyncEventEmission();
+
+        expect(emitted).toHaveLength(1);
+        expect(emitted[0].event.source.updateId).toBe(seedEventId);
+        expect(emitted[0].threadTs).toBe(replyThreadTs);
+
+        client.handleMessage(
+          JSON.stringify({
+            envelope_id: `env-reply-${seedEventId}`,
+            type: "events_api",
+            payload: {
+              event_id: `Ev-reply-${seedEventId}`,
+              event: {
+                type: "message",
+                user: "U-reply",
+                text: "unmentioned reply should stay filtered",
+                ts: `${replyThreadTs}-reply`,
+                channel: "C-thread",
+                channel_type: "channel",
+                thread_ts: replyThreadTs,
+              },
+            },
+          }),
+          ws,
+        );
+
+        expect(emitted).toHaveLength(1);
+      } finally {
+        rawDb.close();
+      }
+    },
+  );
 });

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -692,11 +692,12 @@ export class SlackSocketModeClient {
       return;
     }
 
-    // Track threads on the inbound side so follow-up replies (without
-    // @mention) continue to be forwarded. Use the normalized thread id so
-    // top-level app mentions register their own ts as the active thread.
+    // Track threads only for real participation signals so follow-up replies
+    // continue after app mentions and admitted messages, without reactions,
+    // edits, or deletes arming unrelated threads.
     const threadTs = normalized.threadTs;
-    if (threadTs) {
+    const shouldTrackActiveThread = isAppMention || isActiveThreadReply;
+    if (shouldTrackActiveThread && threadTs) {
       this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
     }
 


### PR DESCRIPTION
## Summary
- Restrict Slack thread tracking to participation events
- Keep top-level and threaded app mention tracking intact
- Cover non-participation events not arming active threads

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
