### PR TITLE
fix: Clean up Slack continuity dead code

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -249,7 +249,6 @@ let mockSlackChronologicalContext: {
     sourceChannelTs: string | null;
   }>;
   messages: Message[];
-  sourceChannelTsByMessage: Array<string | null>;
   compactableStartIndex: number;
 } | null = null;
 const loadSlackChronologicalContextMock = mock(
@@ -2365,11 +2364,6 @@ describe("session-agent-loop", () => {
             "1700000030.000000",
           ][index]!,
         })),
-        sourceChannelTsByMessage: [
-          "1700000010.000000",
-          "1700000020.000000",
-          "1700000030.000000",
-        ],
         compactableStartIndex: 0,
       };
       const shouldCompactInputs: Message[][] = [];
@@ -2469,11 +2463,6 @@ describe("session-agent-loop", () => {
             "1700000030.000000",
           ][index]!,
         })),
-        sourceChannelTsByMessage: [
-          "1700000010.000000",
-          "1700000020.000000",
-          "1700000030.000000",
-        ],
         compactableStartIndex: 0,
       };
       mockEstimateTokens = 120_000;
@@ -2604,7 +2593,6 @@ describe("session-agent-loop", () => {
             sourceChannelTs: "1700000020.000000",
           },
         ],
-        sourceChannelTsByMessage: [null, "1700000020.000000"],
         compactableStartIndex: 1,
       };
 
@@ -2711,7 +2699,6 @@ describe("session-agent-loop", () => {
             sourceChannelTs: "1700000121.000000",
           },
         ],
-        sourceChannelTsByMessage: [null, "1700000121.000000"],
         compactableStartIndex: 1,
       };
 

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2990,7 +2990,6 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(renderedText).not.toContain("before watermark");
     expect(renderedText).not.toContain("legacy row before watermark");
     expect(renderedText).not.toContain("at watermark");
-    expect(result!.sourceChannelTsByMessage).toEqual([null, T2]);
     expect(result!.renderedMessages.map((entry) => entry.message)).toEqual(
       result!.messages,
     );
@@ -3116,9 +3115,12 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     expect(renderedText).toContain("reply after compaction");
     expect(renderedText).not.toContain("original root");
     expect(renderedText).not.toContain("pre-compaction 80");
-    expect(result!.sourceChannelTsByMessage[0]).toBeNull();
+    const sourceChannelTs = result!.renderedMessages.map(
+      (entry) => entry.sourceChannelTs,
+    );
+    expect(sourceChannelTs[0]).toBeNull();
     expect(
-      result!.sourceChannelTsByMessage
+      sourceChannelTs
         .slice(1)
         .every(
           (channelTs) =>

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1069,8 +1069,6 @@ export interface SlackChronologicalContext {
   readonly renderedMessages: readonly RenderedSlackTranscriptMessage[];
   /** Convenience projection of `renderedMessages[].message`. */
   readonly messages: Message[];
-  /** Convenience projection of `renderedMessages[].sourceChannelTs`. */
-  readonly sourceChannelTsByMessage: readonly (string | null)[];
   readonly compactableStartIndex: number;
 }
 
@@ -1345,18 +1343,12 @@ export function assembleSlackChronologicalContext(
     return {
       renderedMessages: withSummary,
       messages: withSummary.map((entry) => entry.message),
-      sourceChannelTsByMessage: withSummary.map(
-        (entry) => entry.sourceChannelTs,
-      ),
       compactableStartIndex: 1,
     };
   }
   return {
     renderedMessages,
     messages: renderedMessages.map((entry) => entry.message),
-    sourceChannelTsByMessage: renderedMessages.map(
-      (entry) => entry.sourceChannelTs,
-    ),
     compactableStartIndex: 0,
   };
 }

--- a/assistant/src/messaging/providers/slack/render-transcript.test.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.test.ts
@@ -292,7 +292,10 @@ describe("renderSlackTranscript — basics", () => {
       TS_14_25,
       TS_14_28,
     ]);
-    expect(out.sourceChannelTsByMessage).toEqual([TS_14_25, TS_14_28]);
+    expect(out.renderedMessages.map((entry) => entry.sourceChannelTs)).toEqual([
+      TS_14_25,
+      TS_14_28,
+    ]);
   });
 
   test("omits sender label for user-role message with null senderLabel (no displayName)", () => {

--- a/assistant/src/messaging/providers/slack/render-transcript.ts
+++ b/assistant/src/messaging/providers/slack/render-transcript.ts
@@ -63,17 +63,6 @@ export interface RenderedSlackTranscript {
   readonly renderedMessages: readonly RenderedSlackTranscriptMessage[];
   /** Convenience projection of `renderedMessages[].message`. */
   readonly messages: Message[];
-  /**
-   * Slack source timestamp represented by each rendered message.
-   * `null` means the rendered message came from a legacy row with no Slack
-   * metadata. Collapsed reaction overflow trailers carry the max source
-   * timestamp included in that trailer.
-   *
-   * Kept as a convenience projection of `renderedMessages[].sourceChannelTs`;
-   * watermark derivation should use `renderedMessages` so the message and
-   * provenance sequence cannot drift.
-   */
-  readonly sourceChannelTsByMessage: readonly (string | null)[];
 }
 
 export interface RenderedSlackTranscriptMessage {
@@ -416,7 +405,7 @@ export function renderSlackTranscriptWithProvenance(
   opts?: RenderOptions,
 ): RenderedSlackTranscript {
   if (messages.length === 0) {
-    return { renderedMessages: [], messages: [], sourceChannelTsByMessage: [] };
+    return { renderedMessages: [], messages: [] };
   }
 
   const maxReactions = Math.max(
@@ -538,7 +527,6 @@ export function renderSlackTranscriptWithProvenance(
   return {
     renderedMessages: filtered,
     messages: filtered.map((entry) => entry.message),
-    sourceChannelTsByMessage: filtered.map((entry) => entry.sourceChannelTs),
   };
 }
 


### PR DESCRIPTION
## Summary
- Remove low-risk dead Slack continuity helpers/metadata
- Keep current behavior unchanged

Fixes self-review cleanup for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
