### PR TITLE
fix: Continue shrinking Slack backfill probes

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -468,6 +468,104 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     ).toEqual([{ name: "requirements.txt", mimetype: "text/plain" }]);
   });
 
+  test("high-throughput initial backfill keeps shrinking after a truncated probe and persists newest pre-mention rows", async () => {
+    const conv = createTestConversation();
+    const ts = (seconds: number, micros = 0) =>
+      `${seconds}.${String(micros).padStart(6, "0")}`;
+    const threadTs = ts(1700000000);
+    const inboundTs = ts(1700001000);
+    const fiveMinuteAfter = ts(1700000700);
+    const sixtySecondAfter = ts(1700000940);
+    const tenSecondAfter = ts(1700000990);
+    const newestPreMention = [
+      makeBackfillMessage({
+        id: ts(1700000997, 100000),
+        text: "newest context 1",
+        threadId: threadTs,
+      }),
+      makeBackfillMessage({
+        id: ts(1700000998, 200000),
+        text: "newest context 2",
+        threadId: threadTs,
+      }),
+      makeBackfillMessage({
+        id: ts(1700000999, 300000),
+        text: "newest context 3",
+        threadId: threadTs,
+      }),
+    ];
+
+    backfillThreadPageMock.mockImplementation(
+      async (_channel, _thread, opts) => {
+        if (opts?.limit === 25 && opts.before === undefined) {
+          return {
+            messages: [
+              makeBackfillMessage({
+                id: threadTs,
+                text: "thread parent",
+                threadId: undefined,
+              }),
+            ],
+            hasMore: true,
+          };
+        }
+
+        if (opts?.limit === 50 && opts.before === inboundTs) {
+          if (
+            opts.after === fiveMinuteAfter ||
+            opts.after === sixtySecondAfter
+          ) {
+            return {
+              messages: Array.from({ length: 50 }, (_, i) =>
+                makeBackfillMessage({
+                  id: ts(1700000940 + i, i),
+                  text: `truncated high-throughput ${i}`,
+                  threadId: threadTs,
+                }),
+              ),
+              hasMore: true,
+              nextCursor: "still-truncated",
+            };
+          }
+
+          if (opts.after === tenSecondAfter) {
+            return { messages: newestPreMention, hasMore: false };
+          }
+        }
+
+        return { messages: [], hasMore: false };
+      },
+    );
+
+    const result = await triggerSlackThreadBackfillIfNeeded({
+      conversationId: conv.id,
+      channelId: SLACK_CHANNEL_ID,
+      threadTs,
+      excludeChannelTs: inboundTs,
+    });
+
+    const afterAttempts = backfillThreadPageMock.mock.calls
+      .map((call) => call[2]?.after)
+      .filter((after): after is string => after !== undefined);
+    expect(afterAttempts).toContain(sixtySecondAfter);
+    expect(afterAttempts).toContain(tenSecondAfter);
+    expect(afterAttempts.indexOf(tenSecondAfter)).toBeGreaterThan(
+      afterAttempts.indexOf(sixtySecondAfter),
+    );
+
+    expect(result.reason).toBe("thread_late_join");
+    expect(result.omittedMiddle).toBe(true);
+
+    const persisted = readPersistedSlackRows(conv.id);
+    expect(
+      persisted.filter((p) => p.threadTs === threadTs).map((p) => p.content),
+    ).toEqual(["newest context 1", "newest context 2", "newest context 3"]);
+    expect(
+      persisted.some((p) => p.content.startsWith("truncated high-throughput")),
+    ).toBe(false);
+    expect(persisted.find((p) => p.channelTs === inboundTs)).toBeUndefined();
+  });
+
   test("backfill is NOT triggered when the parent is already persisted and no upper-bound gap is known", async () => {
     const conv = createTestConversation();
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1820,8 +1820,8 @@ async function fetchSlackThreadUpperAdjacentWindow(params: {
   if (truncatedBeforeUpperBound && !safePage && attempts < maxAttempts) {
     for (const windowMicros of SLACK_UPPER_ADJACENT_SHRINKING_WINDOWS_MICROS) {
       if (attempts >= maxAttempts) break;
-      const shouldExpand = await considerWindow(windowMicros);
-      if (!shouldExpand || safePage) break;
+      await considerWindow(windowMicros);
+      if (safePage) break;
     }
   }
 


### PR DESCRIPTION
## Summary
- Continue bounded Slack probe shrinking after truncated pages
- Preserve newest pre-mention context for high-throughput threads
- Add regression coverage for truncated probe retries

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
