### PR TITLE
fix: Align Slack watermark provenance basis

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2560,6 +2560,157 @@ describe("session-agent-loop", () => {
       expect(reinjectionOptions?.slackChronologicalMessages).toBeNull();
     });
 
+    test("mid-loop Slack compaction does not persist watermark from mismatched loaded context", async () => {
+      const renderedSlackMessages: Message[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "first rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "second rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "retained Slack row" }],
+        },
+      ];
+      mockSlackChronologicalContext = {
+        messages: renderedSlackMessages,
+        renderedMessages: renderedSlackMessages.map((message, index) => ({
+          message,
+          sourceChannelTs: [
+            "1700000010.000000",
+            "1700000020.000000",
+            "1700000030.000000",
+          ][index]!,
+        })),
+        sourceChannelTsByMessage: [
+          "1700000010.000000",
+          "1700000020.000000",
+          "1700000030.000000",
+        ],
+        compactableStartIndex: 0,
+      };
+
+      const rawMidLoopBasis: Message[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "fresh DB basis user row" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "partial assistant response" }],
+        },
+      ];
+      const maybeCompactInputs: Message[][] = [];
+      let runCount = 0;
+      const agentLoopRun: AgentLoopRun = async (
+        messages,
+        _onEvent,
+        _signal,
+        _reqId,
+        onCheckpoint,
+      ) => {
+        runCount++;
+        if (runCount === 1) {
+          mockEstimateTokens = 90_000;
+          const decision = await onCheckpoint?.({
+            turnIndex: 0,
+            toolCount: 1,
+            hasToolUse: true,
+            history: messages,
+          });
+          mockEstimateTokens = 1000;
+          if (decision === "yield") {
+            return rawMidLoopBasis;
+          }
+        }
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "final response" }],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        channelCapabilities: {
+          channel: "slack",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "channel",
+        },
+        trustContext: {
+          sourceChannel: "slack",
+          trustClass: "guardian",
+        } as AgentLoopConversationContext["trustContext"],
+        getTurnChannelContext: () => ({
+          userMessageChannel: "slack" as const,
+          assistantMessageChannel: "slack" as const,
+        }),
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
+          maybeCompact: async (messages: Message[]) => {
+            maybeCompactInputs.push(messages);
+            if (messages === renderedSlackMessages) {
+              return {
+                compacted: false,
+                messages,
+                compactedPersistedMessages: 0,
+                previousEstimatedInputTokens: 1000,
+                estimatedInputTokens: 1000,
+                maxInputTokens: 100_000,
+                thresholdTokens: 80_000,
+                compactedMessages: 0,
+                summaryCalls: 0,
+                summaryInputTokens: 0,
+                summaryOutputTokens: 0,
+                summaryModel: "",
+                summaryText: "",
+              };
+            }
+            return {
+              compacted: true,
+              messages: [
+                {
+                  role: "user",
+                  content: [{ type: "text", text: "summary" }],
+                },
+              ],
+              compactedPersistedMessages: 2,
+              previousEstimatedInputTokens: 90_000,
+              estimatedInputTokens: 5_000,
+              maxInputTokens: 100_000,
+              thresholdTokens: 80_000,
+              compactedMessages: 2,
+              summaryCalls: 1,
+              summaryInputTokens: 100,
+              summaryOutputTokens: 20,
+              summaryModel: "mock-model",
+              summaryText: "summary",
+              summaryFailed: false,
+            };
+          },
+        } as unknown as AgentLoopConversationContext["contextWindowManager"],
+      });
+
+      await runAgentLoopImpl(ctx, "next reply", "user-msg-mid-loop", () => {});
+
+      expect(maybeCompactInputs[0]).toBe(renderedSlackMessages);
+      expect(maybeCompactInputs[1]).toBe(rawMidLoopBasis);
+      expect(getSlackCompactionWatermarkForPrefixMock).toHaveBeenCalledWith(
+        null,
+        2,
+      );
+      expect(
+        updateConversationSlackContextWatermarkMock,
+      ).not.toHaveBeenCalled();
+    });
+
     test("next inbound Slack turn injects the watermark-filtered chronological context", async () => {
       mockConversationRow = {
         ...mockConversationRow,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -808,11 +808,37 @@ export async function runAgentLoopImpl(
       loadCurrentSlackChronologicalContext();
     const messagesForStartOfTurnCompaction =
       slackChronologicalContext?.messages ?? ctx.messages;
+    const getSlackProvenanceContextForCompactionBasis = (
+      messages: Message[],
+      compactedMessages: number,
+    ): SlackChronologicalContext | null => {
+      if (!isSlackConversation || compactedMessages <= 0) return null;
+      const context = slackChronologicalContext;
+      if (!context) return null;
+      const end = Math.min(
+        context.renderedMessages.length,
+        context.compactableStartIndex + compactedMessages,
+      );
+      if (end <= context.compactableStartIndex || messages.length < end) {
+        return null;
+      }
+      for (let index = 0; index < end; index++) {
+        if (messages[index] !== context.messages[index]) {
+          return null;
+        }
+      }
+      return context;
+    };
     const applySuccessfulCompaction = (
       result: Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>,
+      compactedBasis?: Message[],
     ) => {
-      const provenanceContext =
-        slackChronologicalContext ?? loadCurrentSlackChronologicalContext();
+      const provenanceContext = compactedBasis
+        ? getSlackProvenanceContextForCompactionBasis(
+            compactedBasis,
+            result.compactedMessages,
+          )
+        : null;
       const slackWatermarkTs = getSlackCompactionWatermarkForPrefix(
         provenanceContext,
         result.compactedMessages,
@@ -825,8 +851,8 @@ export async function runAgentLoopImpl(
         ctx.contextCompactedMessageCount;
       if (slackWatermarkTs) {
         currentSlackContextCompactionWatermarkTs = slackWatermarkTs;
-        slackChronologicalContext = null;
       }
+      slackChronologicalContext = null;
     };
 
     const compactCheck = ctx.contextWindowManager.shouldCompact(
@@ -895,7 +921,7 @@ export async function runAgentLoopImpl(
       await trackCompactionOutcome(ctx, compacted.summaryFailed, onEvent);
     }
     if (compacted?.compacted) {
-      applySuccessfulCompaction(compacted);
+      applySuccessfulCompaction(compacted, messagesForStartOfTurnCompaction);
       shouldInjectWorkspace = true;
       if (compacted.compactedPersistedMessages > 0) {
         compactedThisTurn = true;
@@ -1490,8 +1516,10 @@ export async function runAgentLoopImpl(
       // injection reassembly, token re-estimation). Registered plugins that
       // wrap the `overflowReduce` slot see each iteration through their own
       // middleware `next` callback.
+      const messagesForPreflightOverflowReduction =
+        slackChronologicalContext?.messages ?? ctx.messages;
       const overflowArgs: OverflowReduceArgs = {
-        messages: ctx.messages,
+        messages: messagesForPreflightOverflowReduction,
         runMessages,
         systemPrompt: ctx.systemPrompt,
         providerName: estimationProviderName,
@@ -1568,7 +1596,7 @@ export async function runAgentLoopImpl(
             reqId,
           );
         },
-        onCompactionResult: async (result) => {
+        onCompactionResult: async (result, compactedBasis) => {
           // Track circuit-breaker state whenever the reducer invoked
           // compaction. The reducer's forced_compaction tier uses
           // force:true, so it bypasses the open-circuit check, but we
@@ -1582,7 +1610,7 @@ export async function runAgentLoopImpl(
             await trackCompactionOutcome(ctx, result.summaryFailed, onEvent);
           }
           if (result.compacted) {
-            applySuccessfulCompaction(result);
+            applySuccessfulCompaction(result, compactedBasis);
             shouldInjectWorkspace = true;
           }
         },
@@ -1909,7 +1937,7 @@ export async function runAgentLoopImpl(
         );
       }
       if (midLoopCompact.compacted) {
-        applySuccessfulCompaction(midLoopCompact);
+        applySuccessfulCompaction(midLoopCompact, rawHistory);
         reducerCompacted = true;
         shouldInjectWorkspace = true;
       }
@@ -2120,8 +2148,9 @@ export async function runAgentLoopImpl(
           "assistant_turn",
           reqId,
         );
+        const convergenceCompactionBasis = ctx.messages;
         const step = await reduceContextOverflow(
-          ctx.messages,
+          convergenceCompactionBasis,
           {
             providerName: estimationProviderName,
             systemPrompt: ctx.systemPrompt,
@@ -2155,7 +2184,10 @@ export async function runAgentLoopImpl(
         }
 
         if (step.compactionResult?.compacted) {
-          applySuccessfulCompaction(step.compactionResult);
+          applySuccessfulCompaction(
+            step.compactionResult,
+            convergenceCompactionBasis,
+          );
           shouldInjectWorkspace = true;
           reducerCompacted = true;
         }
@@ -2316,7 +2348,7 @@ export async function runAgentLoopImpl(
             );
           }
           if (emergencyCompact?.compacted) {
-            applySuccessfulCompaction(emergencyCompact);
+            applySuccessfulCompaction(emergencyCompact, ctx.messages);
             reducerCompacted = true;
             shouldInjectWorkspace = true;
           }

--- a/assistant/src/plugins/defaults/overflow-reduce.ts
+++ b/assistant/src/plugins/defaults/overflow-reduce.ts
@@ -74,8 +74,9 @@ export const defaultOverflowReduceMiddleware: Middleware<
     attempts++;
     args.emitActivityState();
 
+    const basisMessages = messages;
     const step = await reduceContextOverflow(
-      messages,
+      basisMessages,
       {
         providerName: args.providerName,
         systemPrompt: args.systemPrompt,
@@ -101,7 +102,7 @@ export const defaultOverflowReduceMiddleware: Middleware<
     // Let the orchestrator apply compaction side effects (circuit-breaker
     // tracking, event emission, ctx mutation) before we re-inject.
     if (step.compactionResult) {
-      await args.onCompactionResult(step.compactionResult);
+      await args.onCompactionResult(step.compactionResult, basisMessages);
       if (stepCompacted) {
         reducerCompacted = true;
       }

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -401,6 +401,7 @@ export interface OverflowReduceArgs {
    */
   readonly onCompactionResult: (
     result: ContextWindowResult,
+    compactedBasis?: Message[],
   ) => void | Promise<void>;
   /**
    * Invoked after each step to rebuild `runMessages` from the step's


### PR DESCRIPTION
## Summary
- Ensure Slack watermark provenance matches the compacted message basis
- Avoid writing watermarks from mismatched DB snapshots
- Add regression coverage for mismatched provenance handling

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
