### PR TITLE
fix: Keep Slack compaction provenance aligned

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2549,6 +2549,157 @@ describe("session-agent-loop", () => {
       expect(reinjectionOptions?.slackChronologicalMessages).toBeNull();
     });
 
+    test("same-turn Slack compaction updates watermark from projected provenance", async () => {
+      const renderedSlackMessages: Message[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "first rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "second rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "third rendered Slack row" }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "retained Slack row" }],
+        },
+      ];
+      mockSlackChronologicalContext = {
+        messages: renderedSlackMessages,
+        renderedMessages: renderedSlackMessages.map((message, index) => ({
+          message,
+          sourceChannelTs: [
+            "1700000010.000000",
+            "1700000020.000000",
+            "1700000030.000000",
+            "1700000040.000000",
+          ][index]!,
+        })),
+        compactableStartIndex: 0,
+      };
+
+      const firstSummaryMessage: Message = {
+        role: "user",
+        content: [{ type: "text", text: "first summary" }],
+      };
+      const firstCompactedMessages: Message[] = [
+        firstSummaryMessage,
+        renderedSlackMessages[2]!,
+        renderedSlackMessages[3]!,
+      ];
+      const secondSummaryMessage: Message = {
+        role: "user",
+        content: [{ type: "text", text: "second summary" }],
+      };
+      const secondCompactedMessages: Message[] = [
+        secondSummaryMessage,
+        renderedSlackMessages[3]!,
+      ];
+      const reducerInputs: Message[][] = [];
+      mockEstimateTokens = 120_000;
+      mockReducerStepFn = (msgs: Message[]) => {
+        reducerInputs.push(msgs);
+        mockEstimateTokens = 1000;
+        return {
+          messages: secondCompactedMessages,
+          tier: "forced_compaction",
+          state: {
+            appliedTiers: ["forced_compaction"],
+            injectionMode: "full",
+            exhausted: false,
+          },
+          estimatedTokens: 5_000,
+          compactionResult: {
+            compacted: true,
+            messages: secondCompactedMessages,
+            compactedPersistedMessages: 1,
+            previousEstimatedInputTokens: 120_000,
+            estimatedInputTokens: 5_000,
+            maxInputTokens: 100_000,
+            thresholdTokens: 80_000,
+            compactedMessages: 1,
+            summaryCalls: 1,
+            summaryInputTokens: 100,
+            summaryOutputTokens: 20,
+            summaryModel: "mock-model",
+            summaryText: "second summary",
+            summaryFailed: false,
+          },
+        };
+      };
+
+      const ctx = makeCtx({
+        channelCapabilities: {
+          channel: "slack",
+          dashboardCapable: false,
+          supportsDynamicUi: false,
+          supportsVoiceInput: false,
+          chatType: "channel",
+        },
+        trustContext: {
+          sourceChannel: "slack",
+          trustClass: "guardian",
+        } as AgentLoopConversationContext["trustContext"],
+        getTurnChannelContext: () => ({
+          userMessageChannel: "slack" as const,
+          assistantMessageChannel: "slack" as const,
+        }),
+        contextWindowManager: {
+          shouldCompact: () => ({ needed: true, estimatedTokens: 120_000 }),
+          maybeCompact: async (messages: Message[]) => {
+            expect(messages).toBe(renderedSlackMessages);
+            return {
+              compacted: true,
+              messages: firstCompactedMessages,
+              compactedPersistedMessages: 2,
+              previousEstimatedInputTokens: 120_000,
+              estimatedInputTokens: 60_000,
+              maxInputTokens: 100_000,
+              thresholdTokens: 80_000,
+              compactedMessages: 2,
+              summaryCalls: 1,
+              summaryInputTokens: 100,
+              summaryOutputTokens: 20,
+              summaryModel: "mock-model",
+              summaryText: "first summary",
+              summaryFailed: false,
+            };
+          },
+        } as unknown as AgentLoopConversationContext["contextWindowManager"],
+      });
+
+      await runAgentLoopImpl(ctx, "next reply", "user-msg-repeat", () => {});
+
+      expect(reducerInputs[0]).toBe(firstCompactedMessages);
+      expect(getSlackCompactionWatermarkForPrefixMock.mock.calls).toEqual([
+        [mockSlackChronologicalContext, 2],
+        [
+          {
+            renderedMessages: [
+              {
+                message: firstSummaryMessage,
+                sourceChannelTs: null,
+              },
+              mockSlackChronologicalContext.renderedMessages[2],
+              mockSlackChronologicalContext.renderedMessages[3],
+            ],
+            messages: firstCompactedMessages,
+            compactableStartIndex: 1,
+          },
+          1,
+        ],
+      ]);
+      expect(updateConversationSlackContextWatermarkMock.mock.calls).toEqual([
+        ["test-conv", "1700000020.000000", expect.any(Number)],
+        ["test-conv", "1700000030.000000", expect.any(Number)],
+      ]);
+      expect(loadSlackChronologicalContextMock).toHaveBeenCalledTimes(1);
+    });
+
     test("mid-loop Slack compaction does not persist watermark from mismatched loaded context", async () => {
       const renderedSlackMessages: Message[] = [
         {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -781,6 +781,7 @@ export async function runAgentLoopImpl(
     const isFirstMessage = ctx.messages.length === 1;
     let shouldInjectWorkspace = isFirstMessage;
     let compactedThisTurn = false;
+    let slackCompactedThisTurn = false;
     const isSlackConversation = ctx.channelCapabilities?.channel === "slack";
     let currentSlackContextSummary =
       turnStartConversation?.contextSummary ?? null;
@@ -815,19 +816,66 @@ export async function runAgentLoopImpl(
       if (!isSlackConversation || compactedMessages <= 0) return null;
       const context = slackChronologicalContext;
       if (!context) return null;
-      const end = Math.min(
-        context.renderedMessages.length,
-        context.compactableStartIndex + compactedMessages,
-      );
-      if (end <= context.compactableStartIndex || messages.length < end) {
+      if (messages !== context.messages) return null;
+      const end = context.compactableStartIndex + compactedMessages;
+      if (
+        end <= context.compactableStartIndex ||
+        end > context.renderedMessages.length ||
+        context.renderedMessages.length !== context.messages.length
+      ) {
         return null;
       }
-      for (let index = 0; index < end; index++) {
-        if (messages[index] !== context.messages[index]) {
+      return context;
+    };
+    const projectSlackProvenanceAfterCompaction = (
+      context: SlackChronologicalContext | null,
+      compactedBasis: Message[] | undefined,
+      result: Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>,
+    ): SlackChronologicalContext | null => {
+      if (
+        !isSlackConversation ||
+        !context ||
+        !compactedBasis ||
+        compactedBasis !== context.messages ||
+        result.compactedMessages <= 0 ||
+        result.messages.length === 0 ||
+        context.renderedMessages.length !== context.messages.length
+      ) {
+        return null;
+      }
+
+      const keptStart =
+        context.compactableStartIndex + result.compactedMessages;
+      if (keptStart > context.renderedMessages.length) {
+        return null;
+      }
+
+      const retainedRenderedMessages =
+        context.renderedMessages.slice(keptStart);
+      const retainedResultMessages = result.messages.slice(1);
+      if (retainedResultMessages.length !== retainedRenderedMessages.length) {
+        return null;
+      }
+      for (let index = 0; index < retainedResultMessages.length; index++) {
+        if (
+          retainedResultMessages[index] !==
+          retainedRenderedMessages[index]!.message
+        ) {
           return null;
         }
       }
-      return context;
+
+      return {
+        renderedMessages: [
+          {
+            message: result.messages[0]!,
+            sourceChannelTs: null,
+          },
+          ...retainedRenderedMessages,
+        ],
+        messages: result.messages,
+        compactableStartIndex: 1,
+      };
     };
     const applySuccessfulCompaction = (
       result: Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>,
@@ -852,7 +900,14 @@ export async function runAgentLoopImpl(
       if (slackWatermarkTs) {
         currentSlackContextCompactionWatermarkTs = slackWatermarkTs;
       }
-      slackChronologicalContext = null;
+      if (isSlackConversation) {
+        slackCompactedThisTurn = true;
+      }
+      slackChronologicalContext = projectSlackProvenanceAfterCompaction(
+        provenanceContext,
+        compactedBasis,
+        result,
+      );
     };
 
     const compactCheck = ctx.contextWindowManager.shouldCompact(
@@ -1290,7 +1345,7 @@ export async function runAgentLoopImpl(
     const slackConversationForInjection = isSlackConversation
       ? (getConversation(ctx.conversationId) ?? turnStartConversation)
       : turnStartConversation;
-    if (isSlackConversation && !compactedThisTurn) {
+    if (isSlackConversation && !slackCompactedThisTurn) {
       slackChronologicalContext ??= loadSlackChronologicalContext(
         ctx.conversationId,
         ctx.channelCapabilities!,


### PR DESCRIPTION
## Summary
- Keep Slack compaction provenance aligned across repeated same-turn compactions
- Avoid unsafe watermark writes from stale provenance
- Cover the repeated-compaction edge case

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
