### PR TITLE
fix: Mark Slack DMs with chat type

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -267,6 +267,45 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
+  test("emits direct messages with im chat type for assistant backfill", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await resolveSlackUser("U-dm", "xoxb-test");
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-dm",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-dm",
+            event: {
+              type: "message",
+              user: "U-dm",
+              text: "hello from dm",
+              ts: "1700000000.000500",
+              channel: "D-direct",
+              channel_type: "im",
+            },
+          },
+        }),
+        ws,
+      );
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-dm");
+      expect(emitted[0].event.source.chatType).toBe("im");
+      expect(emitted[0].event.message.conversationExternalId).toBe("D-direct");
+      expect(emitted[0].threadTs).toBeUndefined();
+      expect(emitted[0].event.source.threadId).toBeUndefined();
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test.each([
     {
       name: "reaction",

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -492,7 +492,9 @@ describe("DM threading", () => {
     const result = normalizeSlackDirectMessage(event, "evt-dm-1", config);
 
     expect(result).not.toBeNull();
+    expect(result!.event.source.chatType).toBe("im");
     expect(result!.threadTs).toBeUndefined();
+    expect(result!.event.source.threadId).toBeUndefined();
   });
 
   it("threaded DM preserves threadTs", () => {
@@ -501,7 +503,9 @@ describe("DM threading", () => {
     const result = normalizeSlackDirectMessage(event, "evt-dm-2", config);
 
     expect(result).not.toBeNull();
+    expect(result!.event.source.chatType).toBe("im");
     expect(result!.threadTs).toBe("1700000000.000050");
+    expect(result!.event.source.threadId).toBe("1700000000.000050");
   });
 });
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -396,6 +396,7 @@ export function normalizeSlackDirectMessage(
       source: {
         updateId: eventId,
         messageId: event.ts,
+        chatType: "im",
         ...(event.thread_ts ? { threadId: event.thread_ts } : {}),
       },
       raw: event as unknown as Record<string, unknown>,


### PR DESCRIPTION
## Summary
- Add chatType=im to normalized Slack DM source metadata
- Cover the Socket Mode DM metadata path used by cold-start backfill

Fixes self-review gap for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
