### PR TITLE
fix: Remove Slack continuity stale helpers

### DIFF
--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -228,8 +228,6 @@ interface PersistedRow {
   channelTs: string | undefined;
   threadTs: string | undefined;
   displayName: string | undefined;
-  backfillReason: string | undefined;
-  backfillOmittedMiddle: boolean | undefined;
   slackFiles: Array<{ name: string; mimetype?: string }> | undefined;
 }
 
@@ -243,8 +241,6 @@ function readPersistedSlackRows(conversationId: string): PersistedRow[] {
       channelTs: undefined,
       threadTs: undefined,
       displayName: undefined,
-      backfillReason: undefined,
-      backfillOmittedMiddle: undefined,
       slackFiles: undefined,
     };
     if (!row.metadata) {
@@ -279,8 +275,6 @@ function readPersistedSlackRows(conversationId: string): PersistedRow[] {
       channelTs: slackMeta?.channelTs,
       threadTs: slackMeta?.threadTs,
       displayName: slackMeta?.displayName,
-      backfillReason: slackMeta?.backfillReason,
-      backfillOmittedMiddle: slackMeta?.backfillOmittedMiddle,
       slackFiles: slackMeta?.slackFiles?.map((file) => ({
         name: file.name,
         ...(file.mimetype ? { mimetype: file.mimetype } : {}),
@@ -366,7 +360,6 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(byChannelTs.get("1234.0")?.content).toBe("parent");
     expect(byChannelTs.get("1234.0")?.displayName).toBe("Parent User");
     expect(byChannelTs.get("1234.0")?.threadTs).toBeUndefined();
-    expect(byChannelTs.get("1234.0")?.backfillReason).toBe("thread_late_join");
 
     expect(byChannelTs.get("1234.1")?.content).toBe("first reply");
     expect(byChannelTs.get("1234.1")?.threadTs).toBe("1234.0");
@@ -462,7 +455,6 @@ describe("triggerSlackThreadBackfillIfNeeded — gap detection and persistence",
     expect(
       persisted.filter((p) => p.channelTs === ts(499960)).map((p) => p.content),
     ).toEqual(["recent 499960"]);
-    expect(persisted.some((p) => p.backfillOmittedMiddle === true)).toBe(true);
     expect(
       persisted.find((p) => p.channelTs === ts(499999))?.slackFiles,
     ).toEqual([{ name: "requirements.txt", mimetype: "text/plain" }]);

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1233,9 +1233,10 @@ function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
 }
 
 /**
- * Build a chronological Slack transcript for Slack conversations (both DMs
- * and group/channel/mpim) and project it onto the LLM-facing `Message[]`
- * shape.
+ * Compatibility projection for callers that still need the legacy
+ * `Message[] | null` shape. New runtime callers should use
+ * `assembleSlackChronologicalContext` so compaction provenance stays
+ * available with the rendered messages.
  *
  * Returns `null` when the channel is not Slack (caller should fall through
  * to the default message history). Legacy pre-upgrade rows without
@@ -1250,11 +1251,9 @@ export function assembleSlackChronologicalMessages(
   rows: SlackTranscriptInputRow[],
   capabilities: ChannelCapabilities,
 ): Message[] | null {
-  if (capabilities.channel !== "slack") {
-    return null;
-  }
-  const renderable = rows.map(rowToRenderable);
-  return renderSlackTranscript(renderable);
+  return (
+    assembleSlackChronologicalContext(rows, capabilities)?.messages ?? null
+  );
 }
 
 function maxSlackTs(values: readonly (string | null)[]): string | null {
@@ -1354,12 +1353,8 @@ export function assembleSlackChronologicalContext(
 }
 
 /**
- * Load DB rows for a Slack conversation and project them onto the
- * chronological transcript shape.
- *
- * Convenience wrapper over `getMessages` + `assembleSlackChronologicalMessages`.
- * The loader is exposed as a parameter so tests can substitute a stub. In
- * production it defaults to `getMessages` from `conversation-crud.ts`.
+ * Compatibility wrapper over `loadSlackChronologicalContext` for callers that
+ * still need only the legacy `Message[] | null` projection.
  *
  * When `trustClass` identifies an untrusted actor (guardian-scoped rows
  * must not leak into the model context), rows are passed through
@@ -1376,18 +1371,15 @@ export function loadSlackChronologicalMessages(
   options: {
     loader?: (id: string) => MessageRow[];
     trustClass?: TrustClass;
+    contextSummary?: string | null;
+    contextCompactedMessageCount?: number;
+    slackContextCompactionWatermarkTs?: string | null;
   } = {},
 ): Message[] | null {
-  if (capabilities.channel !== "slack") {
-    return null;
-  }
-  const loader = options.loader ?? defaultGetMessages;
-  const allRows = loader(conversationId);
-  const scopedRows = isUntrustedTrustClass(options.trustClass)
-    ? filterMessagesForUntrustedActor(allRows)
-    : allRows;
-  const rows = messageRowsToSlackTranscriptRows(scopedRows);
-  return assembleSlackChronologicalMessages(rows, capabilities);
+  return (
+    loadSlackChronologicalContext(conversationId, capabilities, options)
+      ?.messages ?? null
+  );
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -40,11 +40,6 @@ export const slackMessageMetadataSchema = z.object({
   reaction: slackReactionMetadataSchema.optional(),
   editedAt: z.number().optional(),
   deletedAt: z.number().optional(),
-  isBackfill: z.boolean().optional(),
-  backfillReason: z
-    .enum(["thread_late_join", "thread_delta", "dm_cold_start"])
-    .optional(),
-  backfillOmittedMiddle: z.boolean().optional(),
   slackFiles: z.array(slackFileMetadataSchema).optional(),
 });
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1043,7 +1043,7 @@ export async function handleChannelInbound({
       // the missing messages so the chronological renderer (PR 18) has the
       // full conversation. Awaited (mirrors the DM cold-start path above)
       // so the agent loop dispatched immediately afterwards observes the
-      // backfilled parent — without this, `loadSlackChronologicalMessages`
+      // backfilled parent — without this, Slack context assembly
       // can race the persist and miss thread context. Backfill is bounded
       // (parent + ~50 messages) and the agent latency is dominated by the
       // LLM call, so the added latency is negligible. Failures are
@@ -1407,8 +1407,6 @@ async function persistBackfilledSlackMessage(params: {
   conversationId: string;
   channelId: string;
   message: ProviderMessage;
-  backfillReason: SlackMessageMetadata["backfillReason"];
-  backfillOmittedMiddle?: boolean;
 }): Promise<void> {
   const { message } = params;
   const slackFiles = readSlackFilesFromProviderMetadata(message.metadata);
@@ -1419,9 +1417,6 @@ async function persistBackfilledSlackMessage(params: {
     eventKind: "message",
     ...(message.threadId ? { threadTs: message.threadId } : {}),
     ...(message.sender?.name ? { displayName: message.sender.name } : {}),
-    isBackfill: true,
-    backfillReason: params.backfillReason,
-    ...(params.backfillOmittedMiddle ? { backfillOmittedMiddle: true } : {}),
     ...(slackFiles.length > 0 ? { slackFiles } : {}),
   };
   const role = message.metadata?.isBot === true ? "assistant" : "user";
@@ -1540,7 +1535,6 @@ async function runBackfillSlackDmIfCold(params: {
           conversationId: params.conversationId,
           channelId: params.channelId,
           message,
-          backfillReason: "dm_cold_start",
         });
         seen.add(message.id);
         written++;
@@ -1636,9 +1630,11 @@ const SLACK_UPPER_ADJACENT_SHRINKING_WINDOWS_MICROS = [
 export interface SlackThreadBackfillResult {
   fetched: number;
   persisted: number;
-  reason?: SlackMessageMetadata["backfillReason"];
+  reason?: SlackBackfillReason;
   omittedMiddle: boolean;
 }
+
+type SlackBackfillReason = "thread_late_join" | "thread_delta";
 
 function emptySlackThreadBackfillResult(): SlackThreadBackfillResult {
   return { fetched: 0, persisted: 0, omittedMiddle: false };
@@ -2051,7 +2047,7 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     const isInitialLateJoin =
       lowerBoundTs === undefined &&
       threadState.storedChannelTs.size === (excludeChannelTs ? 1 : 0);
-    const reason: SlackMessageMetadata["backfillReason"] = isInitialLateJoin
+    const reason: SlackBackfillReason = isInitialLateJoin
       ? "thread_late_join"
       : "thread_delta";
     let omittedMiddle = false;
@@ -2086,7 +2082,6 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
     }
 
     let persisted = 0;
-    let firstPersistedInOmittedSegment = true;
     for (const message of fetched) {
       if (!message.id) continue;
       if (threadState.storedChannelTs.has(message.id)) continue;
@@ -2095,13 +2090,9 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
           conversationId,
           channelId,
           message,
-          backfillReason: reason,
-          backfillOmittedMiddle:
-            omittedMiddle && firstPersistedInOmittedSegment,
         });
         threadState.storedChannelTs.add(message.id);
         persisted++;
-        firstPersistedInOmittedSegment = false;
       } catch (err) {
         log.warn(
           { err, conversationId, channelId, threadTs, channelTs: message.id },


### PR DESCRIPTION
## Summary
- Remove or wrap stale Slack chronological helpers
- Clean up write-only Slack backfill diagnostics while preserving runtime notices

Fixes self-review cleanup for jarvis-643-slack-context-continuity.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
