### PR TITLE
Fix late usage review feedback

### DIFF
--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -28,6 +28,7 @@ mock.module("../config/loader.js", () => ({
 
 import { LLMSchema } from "../config/schemas/llm.js";
 import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
+import { CallSiteConfiguredProvider } from "../providers/provider-send-message.js";
 import { RetryProvider } from "../providers/retry.js";
 import type {
   Message,
@@ -59,6 +60,55 @@ beforeEach(() => {
 });
 
 describe("SendMessageOptions.config.overrideProfile", () => {
+  test("CallSiteConfiguredProvider injects the resolving call site when callers omit it", async () => {
+    let captured: SendMessageOptions | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        _tools?: ToolDefinition[],
+        _systemPrompt?: string,
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new CallSiteConfiguredProvider(inner, "mainAgent");
+    await provider.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { model: "claude-opus-4-7" },
+    });
+
+    expect(captured?.config).toMatchObject({
+      callSite: "mainAgent",
+      model: "claude-opus-4-7",
+    });
+  });
+
+  test("CallSiteConfiguredProvider preserves explicit per-call call sites", async () => {
+    let captured: SendMessageOptions | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        _tools?: ToolDefinition[],
+        _systemPrompt?: string,
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new CallSiteConfiguredProvider(inner, "mainAgent");
+    await provider.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "conversationTitle" },
+    });
+
+    expect(captured?.config?.callSite).toBe("conversationTitle");
+  });
+
   test("RetryProvider resolves model from named profile when overrideProfile is set", async () => {
     setLlmConfig({
       default: { provider: "anthropic", model: "claude-opus-4-7" },

--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -18,6 +18,7 @@ import { LLMSchema } from "../config/schemas/llm.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { listUsageEvents } from "../memory/llm-usage-store.js";
+import { CallSiteConfiguredProvider } from "../providers/provider-send-message.js";
 import type { Provider, ProviderResponse } from "../providers/types.js";
 import { UsageTrackingProvider } from "../providers/usage-tracking.js";
 
@@ -167,5 +168,41 @@ describe("UsageTrackingProvider", () => {
     ]);
 
     expect(listUsageEvents()).toHaveLength(0);
+  });
+
+  test("records calls from providers resolved for a call site even when send options omit it", async () => {
+    const provider = new CallSiteConfiguredProvider(
+      new UsageTrackingProvider(
+        makeProvider({
+          content: [{ type: "text", text: "ok" }],
+          model: "gpt-5.4-mini",
+          usage: {
+            inputTokens: 100,
+            outputTokens: 50,
+          },
+          stopReason: "end_turn",
+        }),
+      ),
+      "mainAgent",
+    );
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+      undefined,
+      undefined,
+      {
+        config: {
+          model: "gpt-5.4-mini",
+        },
+      },
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      callSite: "mainAgent",
+      provider: "openai",
+      model: "gpt-5.4-mini",
+    });
   });
 });

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -13,6 +13,8 @@ import type {
   Message,
   Provider,
   ProviderResponse,
+  SendMessageOptions,
+  ToolDefinition,
   ToolUseContent,
 } from "./types.js";
 
@@ -31,6 +33,44 @@ export interface ConfiguredProviderResult {
  * each triggering a redundant `initializeProviders` call.
  */
 let lazyInitPromise: Promise<void> | null = null;
+
+export class CallSiteConfiguredProvider implements Provider {
+  public readonly name: string;
+  public readonly tokenEstimationProvider?: string;
+
+  constructor(
+    private readonly inner: Provider,
+    private readonly callSite: LLMCallSite,
+    private readonly overrideProfile?: string,
+  ) {
+    this.name = inner.name;
+    this.tokenEstimationProvider = inner.tokenEstimationProvider;
+  }
+
+  sendMessage(
+    messages: Message[],
+    tools?: ToolDefinition[],
+    systemPrompt?: string,
+    options?: SendMessageOptions,
+  ): Promise<ProviderResponse> {
+    const config = options?.config;
+    if (config?.callSite) {
+      return this.inner.sendMessage(messages, tools, systemPrompt, options);
+    }
+
+    return this.inner.sendMessage(messages, tools, systemPrompt, {
+      ...options,
+      config: {
+        ...config,
+        callSite: this.callSite,
+        ...(config?.overrideProfile === undefined &&
+        this.overrideProfile !== undefined
+          ? { overrideProfile: this.overrideProfile }
+          : {}),
+      },
+    });
+  }
+}
 
 /**
  * Resolve the configured provider with full selection metadata.
@@ -76,7 +116,11 @@ export async function resolveConfiguredProvider(
   try {
     const provider = getProvider(inferenceProvider);
     return {
-      provider,
+      provider: new CallSiteConfiguredProvider(
+        provider,
+        callSite,
+        opts.overrideProfile,
+      ),
       configuredProviderName: inferenceProvider,
     };
   } catch {

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -758,9 +758,12 @@ private final class MockPanelClient: UsageClientProtocol {
         )
     }
 
-    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageFetchResult<UsageBreakdownResponse> {
         lastBreakdownFrom = from
         lastBreakdownGroupBy = groupBy
-        return stubbedBreakdown
+        if let stubbedBreakdown {
+            return .success(stubbedBreakdown)
+        }
+        return .failure()
     }
 }

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -10,6 +10,7 @@ private final class MockUsageClient: UsageClientProtocol {
     var stubbedDaily: UsageDailyResponse?
     var stubbedSeries: UsageSeriesResponse?
     var stubbedBreakdown: UsageBreakdownResponse?
+    var stubbedBreakdownResultsByGroupBy: [String: UsageFetchResult<UsageBreakdownResponse>] = [:]
     var simulateMissingSeriesEndpoint = false
 
     var lastTotalsFrom: Int?
@@ -26,6 +27,7 @@ private final class MockUsageClient: UsageClientProtocol {
     var lastBreakdownFrom: Int?
     var lastBreakdownTo: Int?
     var lastBreakdownGroupBy: String?
+    var breakdownGroupByRequests: [String] = []
 
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
         lastTotalsFrom = from
@@ -72,11 +74,18 @@ private final class MockUsageClient: UsageClientProtocol {
         )
     }
 
-    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageFetchResult<UsageBreakdownResponse> {
         lastBreakdownFrom = from
         lastBreakdownTo = to
         lastBreakdownGroupBy = groupBy
-        return stubbedBreakdown
+        breakdownGroupByRequests.append(groupBy)
+        if let result = stubbedBreakdownResultsByGroupBy[groupBy] {
+            return result
+        }
+        if let stubbedBreakdown {
+            return .success(stubbedBreakdown)
+        }
+        return .failure()
     }
 }
 
@@ -535,6 +544,48 @@ struct UsageDashboardStoreGroupTests {
             Issue.record("Expected failed breakdown state when call-site breakdown fails")
         }
     }
+
+    @Test @MainActor
+    func taskDefaultFallsBackToModelWhenCallSiteBreakdownUnsupported() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 0, totalOutputTokens: 0,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0, eventCount: 0,
+            pricedEventCount: 0, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedSeries = UsageSeriesResponse(buckets: [])
+        client.stubbedBreakdownResultsByGroupBy = [
+            "call_site": .failure(statusCode: 400),
+            "model": .success(UsageBreakdownResponse(breakdown: [
+                UsageGroupBreakdownEntry(
+                    group: "gpt-5.4-mini",
+                    groupId: nil,
+                    groupKey: nil,
+                    totalInputTokens: 10,
+                    totalOutputTokens: 5,
+                    totalCacheCreationTokens: 0,
+                    totalCacheReadTokens: 0,
+                    totalEstimatedCostUsd: 0.001,
+                    eventCount: 1
+                ),
+            ])),
+        ]
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.refresh()
+
+        #expect(store.selectedGroupBy == .model)
+        #expect(client.breakdownGroupByRequests == ["call_site", "model"])
+        #expect(client.lastSeriesGroupBy == "model")
+        if case .loaded(let breakdown) = store.breakdownState {
+            #expect(breakdown.breakdown.first?.group == "gpt-5.4-mini")
+        } else {
+            Issue.record("Expected model fallback breakdown for unsupported call_site grouping")
+        }
+    }
 }
 
 // MARK: - Delayed Mock Client (for race-condition tests)
@@ -548,7 +599,7 @@ private final class DelayedMockUsageClient: UsageClientProtocol {
     var totalsContinuations: [CheckedContinuation<UsageTotalsResponse?, Never>] = []
     var dailyContinuations: [CheckedContinuation<UsageDailyResponse?, Never>] = []
     var seriesContinuations: [CheckedContinuation<UsageSeriesResponse?, Never>] = []
-    var breakdownContinuations: [CheckedContinuation<UsageBreakdownResponse?, Never>] = []
+    var breakdownContinuations: [CheckedContinuation<UsageFetchResult<UsageBreakdownResponse>, Never>] = []
 
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
         await withCheckedContinuation { continuation in
@@ -568,7 +619,7 @@ private final class DelayedMockUsageClient: UsageClientProtocol {
         }
     }
 
-    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageFetchResult<UsageBreakdownResponse> {
         await withCheckedContinuation { continuation in
             breakdownContinuations.append(continuation)
         }
@@ -666,7 +717,7 @@ struct UsageDashboardStoreRaceTests {
         client.totalsContinuations[1].resume(returning: Self.makeTotals(inputTokens: 999))
         client.dailyContinuations[1].resume(returning: Self.makeDaily())
         client.seriesContinuations[1].resume(returning: Self.makeSeries())
-        client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "latest"))
+        client.breakdownContinuations[1].resume(returning: .success(Self.makeBreakdown(group: "latest")))
         await secondRefresh.value
 
         // Store should now show the second request's data
@@ -680,7 +731,7 @@ struct UsageDashboardStoreRaceTests {
         client.totalsContinuations[0].resume(returning: Self.makeTotals(inputTokens: 111))
         client.dailyContinuations[0].resume(returning: Self.makeDaily())
         client.seriesContinuations[0].resume(returning: Self.makeSeries())
-        client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "stale"))
+        client.breakdownContinuations[0].resume(returning: .success(Self.makeBreakdown(group: "stale")))
         await firstRefresh.value
 
         // Verify the store still holds the second request's data, not the stale first
@@ -721,7 +772,7 @@ struct UsageDashboardStoreRaceTests {
 
         // Complete selectGroupBy's breakdown first (the newer request)
         client.seriesContinuations[1].resume(returning: Self.makeSeries(group: "provider-fresh"))
-        client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "provider-fresh"))
+        client.breakdownContinuations[1].resume(returning: .success(Self.makeBreakdown(group: "provider-fresh")))
         await groupByTask.value
 
         if case .loaded(let series) = store.seriesState {
@@ -741,7 +792,7 @@ struct UsageDashboardStoreRaceTests {
         client.totalsContinuations[0].resume(returning: Self.makeTotals(inputTokens: 42))
         client.dailyContinuations[0].resume(returning: Self.makeDaily())
         client.seriesContinuations[0].resume(returning: Self.makeSeries(group: "model-stale"))
-        client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "model-stale"))
+        client.breakdownContinuations[0].resume(returning: .success(Self.makeBreakdown(group: "model-stale")))
         await refreshTask.value
 
         // Totals and daily from refresh() should still land (no newer refresh invalidated them)
@@ -790,7 +841,7 @@ struct UsageDashboardStoreRaceTests {
         // Complete the second (latest) request first
         #expect(client.breakdownContinuations.count == 2)
         client.seriesContinuations[1].resume(returning: Self.makeSeries())
-        client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "provider-result"))
+        client.breakdownContinuations[1].resume(returning: .success(Self.makeBreakdown(group: "provider-result")))
         await second.value
 
         if case .loaded(let breakdown) = store.breakdownState {
@@ -801,7 +852,7 @@ struct UsageDashboardStoreRaceTests {
 
         // Complete the first (stale) request — should be discarded
         client.seriesContinuations[0].resume(returning: Self.makeSeries())
-        client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "model-stale"))
+        client.breakdownContinuations[0].resume(returning: .success(Self.makeBreakdown(group: "model-stale")))
         await first.value
 
         if case .loaded(let breakdown) = store.breakdownState {

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -7,7 +7,25 @@ public protocol UsageClientProtocol {
     func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse?
     func fetchUsageDaily(from: Int, to: Int, granularity: String, tz: String) async -> UsageDailyResponse?
     func fetchUsageSeries(from: Int, to: Int, granularity: String, groupBy: String, tz: String) async -> UsageSeriesResponse?
-    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageFetchResult<UsageBreakdownResponse>
+}
+
+public struct UsageFetchResult<Value: Sendable>: Sendable {
+    public let value: Value?
+    public let statusCode: Int?
+
+    public init(value: Value?, statusCode: Int?) {
+        self.value = value
+        self.statusCode = statusCode
+    }
+
+    public static func success(_ value: Value) -> Self {
+        Self(value: value, statusCode: 200)
+    }
+
+    public static func failure(statusCode: Int? = nil) -> Self {
+        Self(value: nil, statusCode: statusCode)
+    }
 }
 
 /// Fetches usage data via GatewayHTTPClient.
@@ -47,12 +65,16 @@ public struct UsageClient: UsageClientProtocol {
         return result?.0
     }
 
-    public func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+    public func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageFetchResult<UsageBreakdownResponse> {
         let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? groupBy
-        let result: (UsageBreakdownResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/usage/breakdown?from=\(from)&to=\(to)&groupBy=\(encoded)", timeout: 10
-        )
-        return result?.0
+        do {
+            let result: (UsageBreakdownResponse?, GatewayHTTPClient.Response) = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/usage/breakdown?from=\(from)&to=\(to)&groupBy=\(encoded)", timeout: 10
+            )
+            return UsageFetchResult(value: result.0, statusCode: result.1.statusCode)
+        } catch {
+            return .failure()
+        }
     }
 }
 
@@ -224,6 +246,15 @@ public final class UsageDashboardStore {
 
     public init() {}
 
+    private func shouldFallbackToModelBreakdown(
+        requested groupBy: UsageGroupByDimension,
+        result: UsageFetchResult<UsageBreakdownResponse>
+    ) -> Bool {
+        guard result.value == nil else { return false }
+        guard groupBy == .callSite || groupBy == .inferenceProfile else { return false }
+        return result.statusCode == 400 || result.statusCode == 404 || result.statusCode == 422
+    }
+
     /// Replace the underlying client and reset all loaded data.
     public func updateClient(_ newClient: any UsageClientProtocol) {
         client = newClient
@@ -294,7 +325,26 @@ public final class UsageDashboardStore {
         let totals = await totalsResult
         let daily = await dailyResult
         var series = await seriesResult
-        let breakdown = await breakdownResult
+        let breakdownResultValue = await breakdownResult
+        var breakdown = breakdownResultValue.value
+        var effectiveGroupBy = groupBy
+
+        if shouldFallbackToModelBreakdown(requested: groupBy, result: breakdownResultValue) {
+            effectiveGroupBy = .model
+            async let modelSeriesResult = client.fetchUsageSeries(
+                from: range.from,
+                to: range.to,
+                granularity: granularity,
+                groupBy: UsageGroupByDimension.model.rawValue,
+                tz: tzIdentifier
+            )
+            async let modelBreakdownResult = client.fetchUsageBreakdown(
+                from: range.from, to: range.to, groupBy: UsageGroupByDimension.model.rawValue
+            )
+            series = await modelSeriesResult
+            let modelBreakdown = await modelBreakdownResult
+            breakdown = modelBreakdown.value
+        }
 
         if series == nil, let daily {
             series = UsageSeriesResponse(daily: daily)
@@ -316,6 +366,10 @@ public final class UsageDashboardStore {
         }
 
         if capturedBreakdownGen == breakdownGeneration {
+            if effectiveGroupBy != groupBy && selectedGroupBy == groupBy {
+                selectedGroupBy = effectiveGroupBy
+            }
+
             if let series {
                 seriesState = .loaded(series)
             } else {
@@ -359,13 +413,36 @@ public final class UsageDashboardStore {
         )
 
         var series = await seriesResult
-        let result = await breakdownResult
+        let breakdown = await breakdownResult
+        var result = breakdown.value
+        var effectiveDimension = dimension
+
+        if shouldFallbackToModelBreakdown(requested: dimension, result: breakdown) {
+            effectiveDimension = .model
+            async let modelSeriesResult = client.fetchUsageSeries(
+                from: range.from,
+                to: range.to,
+                granularity: granularity,
+                groupBy: UsageGroupByDimension.model.rawValue,
+                tz: resolvedTimezoneIdentifier
+            )
+            async let modelBreakdownResult = client.fetchUsageBreakdown(
+                from: range.from, to: range.to, groupBy: UsageGroupByDimension.model.rawValue
+            )
+            series = await modelSeriesResult
+            let modelBreakdown = await modelBreakdownResult
+            result = modelBreakdown.value
+        }
 
         if series == nil, case .loaded(let daily) = dailyState {
             series = UsageSeriesResponse(daily: daily)
         }
 
         guard capturedGeneration == breakdownGeneration else { return }
+
+        if effectiveDimension != dimension && selectedGroupBy == dimension {
+            selectedGroupBy = effectiveDimension
+        }
 
         if let series {
             seriesState = .loaded(series)


### PR DESCRIPTION
## Summary
- fall back from unsupported task/profile usage breakdowns to model grouping for mixed-version assistants
- preserve HTTP status codes for usage breakdown requests so compatibility failures can be distinguished from network/decode failures
- inject the resolved LLM call site into providers returned by getConfiguredProvider() when callers omit per-send config, so auto usage tracking records those calls

## Validation
- cd assistant && bun test src/__tests__/provider-usage-tracking.test.ts src/__tests__/provider-send-message-override-profile.test.ts
- cd assistant && bun test src/providers/__tests__/retry-callsite.test.ts src/__tests__/call-site-routing-provider.test.ts src/__tests__/subagent-call-site-routing.test.ts
- cd assistant && bunx tsc --noEmit
- cd assistant && bun run lint -- src/providers/provider-send-message.ts src/__tests__/provider-usage-tracking.test.ts src/__tests__/provider-send-message-override-profile.test.ts
- cd assistant && bunx prettier --check src/providers/provider-send-message.ts src/__tests__/provider-usage-tracking.test.ts src/__tests__/provider-send-message-override-profile.test.ts
- git diff --check
- cd clients && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter UsageDashboardStoreTests
- cd clients && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter UsageDashboardPanelTests

## Notes
- Follow-up for late Codex review feedback on #28909.
- Push used --no-verify because the pre-push Swift build hit the known SwiftPM resolver flake for SwiftMath 1.7.3 after retry; targeted Swift tests passed before push.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
