### PR TITLE
feat(macos): multi-provider API key management for Your Own mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
@@ -1,0 +1,290 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Sheet for managing API keys across all key-required inference providers.
+///
+/// Each provider row shows its current key status (configured / not configured)
+/// and expands inline to reveal an `APIKeyTextField` for entry. Keys are
+/// validated and persisted individually via `store.saveInferenceAPIKey()`.
+///
+/// Opened from the "Manage API Keys..." button on `InferenceServiceCard`
+/// when the inference-profiles feature flag is enabled.
+@MainActor
+struct APIKeysSheet: View {
+    @ObservedObject var store: SettingsStore
+    @Binding var isPresented: Bool
+    var showToast: (String, ToastInfo.Style) -> Void
+
+    /// Provider currently expanded for key entry. Only one provider can be
+    /// expanded at a time to keep the UI focused.
+    @State private var expandedProvider: String?
+
+    /// Per-provider draft key text. Keyed by provider ID.
+    @State private var keyTexts: [String: String] = [:]
+
+    /// Per-provider error messages from validation failures.
+    @State private var errors: [String: String] = [:]
+
+    /// Per-provider saving state.
+    @State private var saving: [String: Bool] = [:]
+
+    /// Per-provider key-exists status. Loaded async on appear and after
+    /// add/remove operations.
+    @State private var keyStatuses: [String: Bool] = [:]
+
+    /// Per-provider masked key previews (e.g. "sk-ant-•••Ab1x").
+    @State private var maskedKeys: [String: String] = [:]
+
+    /// Confirmation dialog state for key removal.
+    @State private var providerToRemove: String?
+
+    // MARK: - Computed
+
+    /// Providers that require an API key, derived from the store's provider
+    /// catalog. Excludes keyless providers like Ollama.
+    private var keyRequiredProviders: [ProviderCatalogEntry] {
+        store.providerCatalog.filter { $0.apiKeyPlaceholder != nil }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            SettingsDivider()
+            providerList
+            SettingsDivider()
+            footer
+        }
+        .frame(width: 520, height: 480)
+        .background(VColor.surfaceLift)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .task { await loadAllKeyStatuses() }
+        .confirmationDialog(
+            "Remove API Key",
+            isPresented: Binding(
+                get: { providerToRemove != nil },
+                set: { if !$0 { providerToRemove = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            if let provider = providerToRemove {
+                Button("Remove", role: .destructive) {
+                    removeKey(for: provider)
+                }
+                Button("Cancel", role: .cancel) {
+                    providerToRemove = nil
+                }
+            }
+        } message: {
+            if let provider = providerToRemove {
+                Text("Remove the \(store.dynamicProviderDisplayName(provider)) API key? Profiles using this provider will stop working until a new key is added.")
+            }
+        }
+    }
+
+    // MARK: - Header / Footer
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("API Keys")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Text("Add API keys for the providers you want to use with inference profiles.")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+            VButton(
+                label: "Close",
+                iconOnly: VIcon.x.rawValue,
+                style: .ghost,
+                tintColor: VColor.contentTertiary
+            ) {
+                isPresented = false
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            VButton(label: "Done", style: .outlined) {
+                isPresented = false
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+
+    // MARK: - Provider List
+
+    private var providerList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(keyRequiredProviders, id: \.id) { provider in
+                    providerRow(provider)
+                    if provider.id != keyRequiredProviders.last?.id {
+                        SettingsDivider()
+                            .padding(.horizontal, VSpacing.lg)
+                    }
+                }
+            }
+            .padding(.vertical, VSpacing.sm)
+        }
+    }
+
+    // MARK: - Provider Row
+
+    private func providerRow(_ provider: ProviderCatalogEntry) -> some View {
+        let isConfigured = keyStatuses[provider.id] == true
+        let isExpanded = expandedProvider == provider.id
+        let isSaving = saving[provider.id] == true
+
+        return VStack(alignment: .leading, spacing: VSpacing.sm) {
+            // Header: provider name + status + action
+            HStack(spacing: VSpacing.sm) {
+                Text(provider.displayName)
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+
+                Spacer(minLength: 0)
+
+                if isConfigured {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(VIcon.check.rawValue)
+                            .resizable()
+                            .frame(width: 12, height: 12)
+                            .foregroundStyle(VColor.systemPositiveStrong)
+                        Text("Configured")
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.systemPositiveStrong)
+                    }
+                }
+
+                if isConfigured && !isExpanded {
+                    HStack(spacing: VSpacing.xs) {
+                        VButton(label: "Update", style: .ghost, size: .compact) {
+                            expandProvider(provider.id)
+                        }
+                        VButton(label: "Remove", style: .dangerGhost, size: .compact) {
+                            providerToRemove = provider.id
+                        }
+                    }
+                } else if !isConfigured && !isExpanded {
+                    VButton(label: "Add Key", style: .outlined, size: .compact) {
+                        expandProvider(provider.id)
+                    }
+                }
+            }
+
+            // Masked key preview when configured and not expanded
+            if isConfigured, !isExpanded, let masked = maskedKeys[provider.id] {
+                Text(masked)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+
+            // Expanded: key entry form
+            if isExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.sm) {
+                    APIKeyTextField(
+                        label: "\(provider.displayName) API Key",
+                        hasKey: isConfigured,
+                        text: Binding(
+                            get: { keyTexts[provider.id] ?? "" },
+                            set: { keyTexts[provider.id] = $0 }
+                        ),
+                        emptyPlaceholder: provider.apiKeyPlaceholder ?? "Enter your API key",
+                        errorMessage: errors[provider.id]
+                    )
+                    .disabled(isSaving)
+
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(
+                            label: isSaving ? "Validating..." : "Save Key",
+                            style: .primary,
+                            size: .compact,
+                            isDisabled: (keyTexts[provider.id] ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving
+                        ) {
+                            saveKey(for: provider.id)
+                        }
+                        VButton(label: "Cancel", style: .ghost, size: .compact) {
+                            collapseProvider(provider.id)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+        .animation(VAnimation.fast, value: isExpanded)
+    }
+
+    // MARK: - Actions
+
+    private func expandProvider(_ id: String) {
+        keyTexts[id] = ""
+        errors[id] = nil
+        expandedProvider = id
+    }
+
+    private func collapseProvider(_ id: String) {
+        keyTexts[id] = nil
+        errors[id] = nil
+        if expandedProvider == id {
+            expandedProvider = nil
+        }
+    }
+
+    private func saveKey(for providerId: String) {
+        let text = keyTexts[providerId] ?? ""
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        saving[providerId] = true
+        errors[providerId] = nil
+
+        store.saveInferenceAPIKey(
+            trimmed,
+            provider: providerId,
+            onSuccess: {
+                saving[providerId] = false
+                keyStatuses[providerId] = true
+                keyTexts[providerId] = nil
+                expandedProvider = nil
+                showToast("\(store.dynamicProviderDisplayName(providerId)) API key saved", .success)
+                // Refresh masked key
+                Task { maskedKeys[providerId] = await APIKeyManager.maskedKey(for: providerId) }
+            },
+            onError: { error in
+                saving[providerId] = false
+                errors[providerId] = error
+            }
+        )
+    }
+
+    private func removeKey(for providerId: String) {
+        store.clearAPIKeyForProvider(providerId)
+        keyStatuses[providerId] = false
+        maskedKeys[providerId] = nil
+        if expandedProvider == providerId {
+            expandedProvider = nil
+        }
+        showToast("\(store.dynamicProviderDisplayName(providerId)) API key removed", .success)
+    }
+
+    // MARK: - Key Status Loading
+
+    private func loadAllKeyStatuses() async {
+        for provider in keyRequiredProviders {
+            let hasKey = await APIKeyManager.hasKey(for: provider.id)
+            keyStatuses[provider.id] = hasKey
+            if hasKey {
+                maskedKeys[provider.id] = await APIKeyManager.maskedKey(for: provider.id)
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -59,6 +59,15 @@ struct InferenceServiceCard: View {
     /// subsequent dropdown pick can cancel it and avoid an out-of-order
     /// PATCH landing the older selection last.
     @State private var activeProfileTask: Task<Void, Never>?
+    /// Whether the API keys management sheet is presented.
+    @State private var showAPIKeysSheet = false
+    /// Per-provider key-exists status. Loaded async on appear and refreshed
+    /// after the API keys sheet is dismissed.
+    @State private var providerKeyStatuses: [String: Bool] = [:]
+    /// Monotonically increasing counter bumped every time the API keys
+    /// sheet is dismissed. Drives `.task(id:)` to re-fetch key statuses
+    /// without a manual onChange handler.
+    @State private var apiKeysRefreshToken: Int = 0
 
     // MARK: - Provider Helpers
 
@@ -78,6 +87,11 @@ struct InferenceServiceCard: View {
 
     private var isLoggedIn: Bool {
         authManager.isAuthenticated
+    }
+
+    /// True when at least one key-required provider has a configured API key.
+    private var hasAnyProviderKey: Bool {
+        providerKeyStatuses.values.contains(true)
     }
 
     /// True when changing inference mode/provider would invalidate the current
@@ -121,7 +135,10 @@ struct InferenceServiceCard: View {
             return false
         }
         let modeChanged = draftMode != store.inferenceMode
-        let hasNewKey = draftMode == "your-own" && !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        // When profiles are enabled, API keys are managed in the sheet —
+        // the card's Save button only covers mode changes.
+        let hasNewKey = !profilesEnabled && draftMode == "your-own"
+            && !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let providerChanged = draftProvider != initialProvider
         return modeChanged || hasNewKey || providerChanged
     }
@@ -157,34 +174,55 @@ struct InferenceServiceCard: View {
             },
             yourOwnContent: {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    if !profilesEnabled {
-                        providerPicker
-                    }
+                    if profilesEnabled && hasAnyProviderKey {
+                        // Multi-provider API key summary + full profile UI
+                        apiKeysSection
 
-                    // API Key field
-                    apiKeyField
-
-                    if profilesEnabled {
                         activeProfilePicker
                         HStack(spacing: VSpacing.md) {
                             manageProfilesButton
                             overridesBadge
                         }
-                    }
 
-                    // Action buttons
-                    ServiceCardActions(
-                        hasChanges: hasChanges,
-                        isSaving: store.apiKeySaving,
-                        onSave: { save() },
-                        savingLabel: "Validating...",
-                        onReset: {
-                            store.clearAPIKeyForProvider(effectiveProvider)
-                            providerHasKey = false
-                            apiKeyText = ""
-                        },
-                        showReset: providerHasKey
-                    )
+                        // Save button — only needed for mode changes when
+                        // profiles are enabled (API keys are managed in the
+                        // sheet, not inline on this card).
+                        ServiceCardActions(
+                            hasChanges: hasChanges,
+                            isSaving: false,
+                            onSave: { save() }
+                        )
+                    } else if profilesEnabled {
+                        // No API keys configured — show a friendly empty
+                        // state instead of profiles/overrides (which can't
+                        // do anything without provider credentials).
+                        apiKeysEmptyState
+
+                        ServiceCardActions(
+                            hasChanges: hasChanges,
+                            isSaving: false,
+                            onSave: { save() }
+                        )
+                    } else {
+                        providerPicker
+
+                        // Single-provider API key field (legacy path)
+                        apiKeyField
+
+                        // Action buttons
+                        ServiceCardActions(
+                            hasChanges: hasChanges,
+                            isSaving: store.apiKeySaving,
+                            onSave: { save() },
+                            savingLabel: "Validating...",
+                            onReset: {
+                                store.clearAPIKeyForProvider(effectiveProvider)
+                                providerHasKey = false
+                                apiKeyText = ""
+                            },
+                            showReset: providerHasKey
+                        )
+                    }
                 }
             },
             footer: {
@@ -196,6 +234,19 @@ struct InferenceServiceCard: View {
         }
         .sheet(isPresented: $showProfilesSheet) {
             InferenceProfilesSheet(store: store, isPresented: $showProfilesSheet)
+        }
+        .sheet(isPresented: $showAPIKeysSheet) {
+            APIKeysSheet(store: store, isPresented: $showAPIKeysSheet, showToast: showToast)
+        }
+        .onChange(of: showAPIKeysSheet) { _, isShowing in
+            // Refresh key statuses when the sheet is dismissed so the card
+            // summary reflects any keys added or removed in the sheet.
+            if !isShowing {
+                apiKeysRefreshToken += 1
+            }
+        }
+        .task(id: apiKeysRefreshToken) {
+            await loadProviderKeyStatuses()
         }
         .onAppear {
             draftMode = store.inferenceMode
@@ -355,11 +406,8 @@ struct InferenceServiceCard: View {
                 pendingOverrideOldProviderName = ""
             }
         } message: {
-            Text(
-                "\(pendingOverrideClears.count) task(s) are pinned to "
-                    + "\(pendingOverrideOldProviderName). Keep them as-is, or "
-                    + "update them to follow the new default?"
-            )
+            let msg = "\(pendingOverrideClears.count) task(s) are pinned to \(pendingOverrideOldProviderName). Keep them as-is, or update them to follow the new default?"
+            Text(msg)
         }
     }
 
@@ -457,6 +505,82 @@ struct InferenceServiceCard: View {
             errorMessage: store.apiKeySaveError
         )
         .disabled(store.apiKeySaving)
+    }
+
+    // MARK: - Multi-Provider API Keys Section
+
+    /// Compact summary of configured provider API keys, shown in "Your Own"
+    /// mode when the inference-profiles feature flag is enabled.
+    private var apiKeysSection: some View {
+        let configuredProviders = store.providerCatalog
+            .filter { $0.apiKeyPlaceholder != nil && providerKeyStatuses[$0.id] == true }
+
+        return VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("API Keys")
+                .font(VFont.labelDefault)
+                .foregroundStyle(VColor.contentSecondary)
+
+            if configuredProviders.isEmpty {
+                Text("No API keys configured.")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            } else {
+                // Flow of chips for each configured provider
+                HStack(spacing: VSpacing.sm) {
+                    ForEach(configuredProviders, id: \.id) { provider in
+                        HStack(spacing: VSpacing.xs) {
+                            Image(VIcon.check.rawValue)
+                                .resizable()
+                                .frame(width: 10, height: 10)
+                                .foregroundStyle(VColor.systemPositiveStrong)
+                            Text(provider.displayName)
+                                .font(VFont.labelDefault)
+                                .foregroundStyle(VColor.contentDefault)
+                        }
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.vertical, VSpacing.xxs)
+                        .background(VColor.surfaceBase.opacity(0.6))
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.chip))
+                    }
+                }
+            }
+
+            Button {
+                showAPIKeysSheet = true
+            } label: {
+                Text(configuredProviders.isEmpty ? "Add API Keys\u{2026}" : "Manage API Keys\u{2026}")
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(.secondary)
+                    .underline()
+            }
+            .buttonStyle(.plain)
+            .pointerCursor()
+        }
+    }
+
+    /// Friendly empty state shown when profiles are enabled but no provider
+    /// API keys have been configured yet. Replaces the profile picker and
+    /// overrides controls since they can't do anything without credentials.
+    private var apiKeysEmptyState: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Add an API key to get started")
+                .font(VFont.bodyMediumDefault)
+                .foregroundStyle(VColor.contentDefault)
+            Text("Configure at least one provider API key so your inference profiles have credentials to use.")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            VButton(label: "Add API Keys\u{2026}", style: .outlined) {
+                showAPIKeysSheet = true
+            }
+        }
+    }
+
+    /// Fetches the key-exists status for every key-required provider.
+    private func loadProviderKeyStatuses() async {
+        for provider in store.providerCatalog where provider.apiKeyPlaceholder != nil {
+            providerKeyStatuses[provider.id] = await APIKeyManager.hasKey(for: provider.id)
+        }
     }
 
     // MARK: - Active Profile Picker
@@ -594,18 +718,20 @@ struct InferenceServiceCard: View {
             initialProvider = draftProvider
         }
 
-        // Persist API key if entered and in your-own mode.
-        // saveAPIKey / saveInferenceAPIKey is async (validates with the provider before storing).
-        // The key text is kept until validation succeeds so the user can retry.
-        let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if draftMode == "your-own" && !trimmedKey.isEmpty {
-            let keyTextBinding = $apiKeyText
-            let displayName = providerDisplayName
-            store.saveInferenceAPIKey(trimmedKey, provider: effectiveProvider, onSuccess: { [self] in
-                providerHasKey = true
-                keyTextBinding.wrappedValue = ""
-                showToast("\(displayName) API key saved", .success)
-            })
+        // Persist API key if entered and in your-own mode (legacy single-key
+        // path). When profiles are enabled, keys are managed in the API Keys
+        // sheet — not inline on this card.
+        if !profilesEnabled {
+            let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if draftMode == "your-own" && !trimmedKey.isEmpty {
+                let keyTextBinding = $apiKeyText
+                let displayName = providerDisplayName
+                store.saveInferenceAPIKey(trimmedKey, provider: effectiveProvider, onSuccess: { [self] in
+                    providerHasKey = true
+                    keyTextBinding.wrappedValue = ""
+                    showToast("\(displayName) API key saved", .success)
+                })
+            }
         }
 
         // Persist provider in a single PATCH when it changed (or when the


### PR DESCRIPTION
## Summary
- Add `APIKeysSheet` — a dedicated management sheet for per-provider API keys, with inline entry, async validation, masked previews, and remove actions
- Update `InferenceServiceCard` to show configured provider chips and "Manage API Keys..." link when profiles are enabled, replacing the single API key field
- Hide Active Profile, Manage Profiles, and model overrides behind a friendly empty state when no API keys are configured yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
