### PR TITLE
fix(macos): restore Save button in profiles-enabled inference card states

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -154,6 +154,11 @@ struct InferenceServiceCard: View {
                         if profilesEnabled {
                             activeProfilePicker
                             secondaryActionsRow
+                            ServiceCardActions(
+                                hasChanges: hasChanges,
+                                isSaving: false,
+                                onSave: { save() }
+                            )
                         } else {
                             managedProviderPicker
                             ServiceCardActions(
@@ -173,8 +178,18 @@ struct InferenceServiceCard: View {
                         apiKeysSection
                         activeProfilePicker
                         secondaryActionsRow
+                        ServiceCardActions(
+                            hasChanges: hasChanges,
+                            isSaving: false,
+                            onSave: { save() }
+                        )
                     } else if profilesEnabled {
                         apiKeysEmptyState
+                        ServiceCardActions(
+                            hasChanges: hasChanges,
+                            isSaving: false,
+                            onSave: { save() }
+                        )
                     } else {
                         providerPicker
                         apiKeyField


### PR DESCRIPTION
## Summary
- Restore `ServiceCardActions` in all three profiles-enabled branches so mode/provider changes can be persisted
- Caught by Devin review on #28964: without the Save button, toggling Managed/Your Own with the inference-profiles flag enabled only changed local state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
