### PR TITLE
LUM-1287: Fold inline thinking tags into progress card in non-interleaved rendering path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -812,13 +812,13 @@ struct ChatBubble: View, Equatable {
     /// rendered alongside a bubble that contains the remaining content.
     /// This keeps the transformation at the presentation layer — the
     /// streaming pipeline and `ChatMessage` data model are unchanged.
+    ///
+    /// When tool calls are present, thinking content renders inside the
+    /// progress card (via `thinkingContentForProgressCard`) instead of
+    /// as standalone blocks — so we skip the ThinkingBlockView ForEach.
     @ViewBuilder
     private var bubbleContentWithInlineThinking: some View {
         let chunks = parseInlineThinkingTags(message.text)
-        let thinkingChunks: [String] = chunks.compactMap { chunk in
-            if case .thinking(let body) = chunk { return body }
-            return nil
-        }
         let textChunks: [String] = chunks.compactMap { chunk in
             if case .text(let body) = chunk { return body }
             return nil
@@ -829,17 +829,29 @@ struct ChatBubble: View, Equatable {
         let hasRenderedText = !joinedText.isEmpty
         let hasAttachments = !message.attachments.isEmpty
 
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { offset, content in
-                ThinkingBlockView(
-                    content: content,
-                    isStreaming: message.isStreaming,
-                    expansionKey: "\(message.id.uuidString)-inline-\(offset)",
-                    typographyGeneration: typographyGeneration
-                )
-            }
+        if !message.toolCalls.isEmpty {
+            // Thinking content renders inside the progress card via
+            // thinkingContentForProgressCard — only show the text bubble.
             if hasRenderedText || hasAttachments {
                 bubbleContent(renderingText: joinedText)
+            }
+        } else {
+            let thinkingChunks: [String] = chunks.compactMap { chunk in
+                if case .thinking(let body) = chunk { return body }
+                return nil
+            }
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { offset, content in
+                    ThinkingBlockView(
+                        content: content,
+                        isStreaming: message.isStreaming,
+                        expansionKey: "\(message.id.uuidString)-inline-\(offset)",
+                        typographyGeneration: typographyGeneration
+                    )
+                }
+                if hasRenderedText || hasAttachments {
+                    bubbleContent(renderingText: joinedText)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -15,6 +15,35 @@ extension ChatBubble {
             || message.toolCalls.contains { $0.confirmationDecision == .denied || $0.confirmationDecision == .timedOut }
     }
 
+    /// Extracted thinking content for the progress card when the message has
+    /// both inline thinking tags and tool calls. Returns nil when thinking
+    /// should not render inside the progress card (no tags, no tool calls,
+    /// or feature flag disabled).
+    var thinkingContentForProgressCard: String? {
+        guard containsInlineThinkingTag(message.text),
+              !message.toolCalls.isEmpty,
+              MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") else {
+            return nil
+        }
+        let chunks = parseInlineThinkingTags(message.text)
+        let bodies = chunks.compactMap { chunk -> String? in
+            if case .thinking(let body) = chunk { return body }
+            return nil
+        }
+        let joined = bodies.joined(separator: "\n")
+        return joined.isEmpty ? nil : joined
+    }
+
+    /// Whether thinking content is currently streaming into the progress card.
+    /// True when the message is streaming, thinking content exists, and the
+    /// last parsed chunk is a `.thinking` case (i.e. we are mid-thought).
+    var thinkingIsStreamingForProgressCard: Bool {
+        guard message.isStreaming, thinkingContentForProgressCard != nil else { return false }
+        let chunks = parseInlineThinkingTags(message.text)
+        if case .thinking = chunks.last { return true }
+        return false
+    }
+
     @ViewBuilder
     var trailingStatus: some View {
         let inlineToolProgressRenderedInContent = shouldRenderToolProgressInline
@@ -46,6 +75,8 @@ extension ChatBubble {
                     streamingCodePreview: message.streamingCodePreview,
                     streamingCodeToolName: message.streamingCodeToolName,
                     decidedConfirmations: effectiveConfirmations,
+                    thinkingContent: thinkingContentForProgressCard,
+                    thinkingIsStreaming: thinkingIsStreamingForProgressCard,
                     onRehydrate: onRehydrate,
                     onConfirmationAllow: onConfirmationAllow,
                     onConfirmationDeny: onConfirmationDeny,


### PR DESCRIPTION
## Summary
- Add thinking content extraction in ChatBubbleToolStatusView and pass to AssistantProgressView
- Suppress standalone ThinkingBlockView rendering when tool calls are present
- Preserve standalone thinking blocks for messages without tool calls (no regression)

Part of plan: collapse-thinking-into-steps.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28975" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
