### PR TITLE
fix: gate interleaved thinking fold behind show-thinking-blocks flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -501,12 +501,13 @@ extension ChatBubble {
             case .toolCalls(let indices):
                 if shouldRenderToolProgressInline {
                     let isLatest = indices == latestToolGroup
+                    let showThinking = MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks")
                     inlineToolProgress(
                         toolIndices: indices,
                         isLatestGroup: isLatest,
                         hasTrailingText: cachedToolGroupsWithTrailingText.contains(group.stableId),
-                        thinkingContent: toolGroupThinkingContent[group.stableId],
-                        thinkingIsStreaming: isLatest && thinkingIsCurrentlyStreaming
+                        thinkingContent: showThinking ? toolGroupThinkingContent[group.stableId] : nil,
+                        thinkingIsStreaming: showThinking && isLatest && thinkingIsCurrentlyStreaming
                     )
                     // Show images immediately when no text follows;
                     // otherwise they are deferred to render after the next text group.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for collapse-thinking-into-steps.md.

**Gap:** Missing show-thinking-blocks feature flag check in interleaved path
**What was expected:** Both code paths should gate thinking content behind the feature flag
**What was found:** Interleaved path unconditionally folded thinking into progress cards
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
