### PR TITLE
polish(macos): API keys sheet button consistency and layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
@@ -144,32 +144,28 @@ struct APIKeysSheet: View {
         let isSaving = saving[provider.id] == true
 
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
-            // Header: provider name + status + action
+            // Header: provider name + masked key + actions
             HStack(spacing: VSpacing.sm) {
-                Text(provider.displayName)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentDefault)
-
-                Spacer(minLength: 0)
-
-                if isConfigured {
-                    HStack(spacing: VSpacing.xs) {
-                        Image(VIcon.check.rawValue)
-                            .resizable()
-                            .frame(width: 12, height: 12)
-                            .foregroundStyle(VColor.systemPositiveStrong)
-                        Text("Configured")
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    Text(provider.displayName)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                    if isConfigured, !isExpanded, let masked = maskedKeys[provider.id] {
+                        Text(masked)
                             .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.systemPositiveStrong)
+                            .foregroundStyle(VColor.contentTertiary)
                     }
                 }
 
+                Spacer(minLength: 0)
+
                 if isConfigured && !isExpanded {
-                    HStack(spacing: VSpacing.xs) {
-                        VButton(label: "Update", style: .ghost, size: .compact) {
+                    HStack(spacing: VSpacing.sm) {
+                        VTag("Connected", color: VColor.systemPositiveStrong, icon: .check)
+                        VButton(label: "Update", style: .outlined, size: .compact) {
                             expandProvider(provider.id)
                         }
-                        VButton(label: "Remove", style: .dangerGhost, size: .compact) {
+                        VButton(label: "Remove", style: .dangerOutline, size: .compact) {
                             providerToRemove = provider.id
                         }
                     }
@@ -178,13 +174,6 @@ struct APIKeysSheet: View {
                         expandProvider(provider.id)
                     }
                 }
-            }
-
-            // Masked key preview when configured and not expanded
-            if isConfigured, !isExpanded, let masked = maskedKeys[provider.id] {
-                Text(masked)
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
             }
 
             // Expanded: key entry form


### PR DESCRIPTION
## Summary
- Replace bare text buttons (Update, Remove, Configured) with proper `VButton` and `VTag` design system components for consistent styling, hit targets, and hover states
- Move masked key preview inline under the provider name to save vertical space

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
