### PR TITLE
fix(macos): eliminate 2s+ main-thread hang in bundledAppIcon during app quit (LUM-1301)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -807,9 +807,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         // the quit sequence so the new version launches after termination.
         updateManager.installDeferredUpdateIfAvailable()
 
-        // Restore the Vellum logo so the pinned dock tile caches the
-        // correct icon instead of whatever avatar was showing at quit time.
-        AvatarAppearanceManager.shared.restoreBundleIcon()
+        // Clear the runtime icon override so the dock tile reverts to the
+        // bundle icon. applicationIconImage is an in-process property that
+        // dies with the process; the Dock independently resolves the bundle
+        // icon for pinned tiles on process exit. Setting nil is Apple's
+        // documented API to restore the original icon and avoids the 2s+
+        // NSWorkspace.icon(forFile:) filesystem read that restoreBundleIcon()
+        // would trigger if the static had never been accessed (LUM-1301).
+        //
+        // Reference: https://developer.apple.com/documentation/appkit/nsapplication/applicationiconimage
+        NSApplication.shared.applicationIconImage = nil
 
         if let monitor = hotKeyMonitor {
             NSEvent.removeMonitor(monitor)

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -104,6 +104,14 @@ final class AvatarAppearanceManager {
     @ObservationIgnored private var identityLoadTask: Task<Void, Never>?
 
     func start() {
+        // Pre-load the bundle icon on a background thread so the
+        // dispatch_once doesn't block the main thread if updateDockIcon()
+        // falls through to restoreBundleIcon() during resetForDisconnect,
+        // clearCustomAvatar, or an authoritative 404 response.
+        // NSWorkspace.icon(forFile:) is documented as thread-safe.
+        // Reference: https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
+        Task.detached { _ = Self.bundledAppIcon }
+
         identityLoadTask = Task {
             let info = await IdentityInfo.loadAsync()
             guard !Task.isCancelled else { return }


### PR DESCRIPTION
Eliminates a 2s+ main-thread hang during app quit caused by `NSWorkspace.shared.icon(forFile:)` firing its `dispatch_once` for the first time inside `applicationWillTerminate`. Replaces the unnecessary filesystem I/O with `applicationIconImage = nil` (Apple's documented restore API) and pre-loads the static off the main thread for the live-app fallback path.

## Prompt / plan

Sentry reported a 2s+ app hang (VELLUM-ASSISTANT-MACOS-QX) in `AvatarAppearanceManager.bundledAppIcon` during quit. The `private static let bundledAppIcon` uses `NSWorkspace.shared.icon(forFile:)` which performs filesystem/metadata reads. If the user had an avatar for the entire session, this static was never accessed until `applicationWillTerminate` called `restoreBundleIcon()` — triggering the expensive I/O on the main thread during the time-critical shutdown path.

**Two-part fix:**

1. **`applicationWillTerminate`**: Replace `restoreBundleIcon()` with `applicationIconImage = nil`. `applicationIconImage` is an in-process property that dies with the process. The Dock independently resolves the bundle icon for pinned tiles on process exit. `nil` is [Apple's documented API](https://developer.apple.com/documentation/appkit/nsapplication/applicationiconimage) to restore the original icon. The activation-policy bug that `bundledAppIcon` works around (blank squircle after `.accessory`/`.regular` transitions) only applies while the app is running — not during termination.

2. **`start()`**: Pre-load `bundledAppIcon` off the main thread via `Task.detached`. [`NSWorkspace.icon(forFile:)`](https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)) is documented as thread-safe. This ensures the `updateDockIcon()` fallback path (`resetForDisconnect`, `clearCustomAvatar`, authoritative 404) doesn't block the main thread either.

**Why not just a warmup?** A warmup alone races app quit — if the app quits before the background task completes, `dispatch_once` still blocks the main thread. The real fix is removing the unnecessary I/O from the quit path entirely.

**Alternatives not taken:**
- `NSImage(named: "AppIcon")` from asset catalog — may not include system-resolved representations; naming conflicts possible with `NSApplicationIcon`
- Removing `bundledAppIcon` entirely — still needed for `updateDockIcon()` fallback while app is running (activation-policy bug is relevant there)
- Skip `restoreBundleIcon()` during quit without setting `nil` — works but `nil` is a zero-cost belt-and-suspenders hint to AppKit

**Root cause analysis:**
1. *How did the code get into this state?* PR #23279 added `restoreBundleIcon()` to `applicationWillTerminate` to ensure the pinned dock tile caches the correct icon. It used `NSWorkspace.icon(forFile:)` because `nil` was unreliable after activation-policy transitions.
2. *What decisions led to it?* The fix correctly addressed the running-app case but over-applied the same approach to `applicationWillTerminate` where the constraints are different (no more policy transitions, process about to exit).
3. *Warning signs missed?* The `static let` lazy initialization pattern means the I/O cost is deferred to first access — which could be any code path, including quit.
4. *Prevention?* Avoid filesystem I/O in `applicationWillTerminate`. Any work done there must be instant or best-effort.

Apple refs checked (2026-04-30):
- [`applicationIconImage`](https://developer.apple.com/documentation/appkit/nsapplication/applicationiconimage) — "To restore your app's original icon, set this property to nil"
- [`NSWorkspace.icon(forFile:)`](https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)) — thread-safe
- [`NSDockTile`](https://developer.apple.com/documentation/appkit/nsdocktile) — defaults to `applicationIconImage`
- [`NSDockTilePlugIn`](https://developer.apple.com/documentation/appkit/nsdocktileplugin) — required for persistent custom dock tiles (not used)

## Test plan

- CI (no macOS build in CI — user verifies Xcode build locally)
- Code review: two files changed, minimal diff, no logic changes beyond the quit path and warmup

---

- Requested by: @ashleeradka
- Session: https://app.devin.ai/sessions/d4a0014bd98f4e738bcf6d31f756b55f
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
