### PR TITLE
polish(macos): profile editor layout and managed profile viewing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -25,7 +25,10 @@ import VellumAssistantShared
 struct InferenceProfileEditor: View {
     @ObservedObject var store: SettingsStore
     @Binding var profile: InferenceProfile
+    var isReadOnly: Bool = false
+    var isCreating: Bool = false
     let onSave: () -> Void
+    var onSaveAs: (() -> Void)?
     let onCancel: () -> Void
 
     /// Effort ladder mirrors the daemon's `EffortLevel` schema. Includes
@@ -97,7 +100,7 @@ struct InferenceProfileEditor: View {
     var body: some View {
         let visibility = parameterVisibility
         VStack(alignment: .leading, spacing: 0) {
-            toolbar
+            editorHeader
             SettingsDivider()
             ScrollView {
                 VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -125,6 +128,9 @@ struct InferenceProfileEditor: View {
                 }
                 .padding(VSpacing.lg)
             }
+            .disabled(isReadOnly)
+            SettingsDivider()
+            editorFooter
         }
         .frame(minWidth: 480, minHeight: 600)
         .background(VColor.surfaceLift)
@@ -134,27 +140,60 @@ struct InferenceProfileEditor: View {
 
     // MARK: - Toolbar
 
-    private var toolbar: some View {
-        HStack(spacing: VSpacing.md) {
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                Text("Edit Inference Profile")
-                    .font(VFont.titleSmall)
-                    .foregroundStyle(VColor.contentDefault)
-                if profile.isManaged {
-                    Text("Managed profile")
-                        .font(VFont.bodySmallDefault)
-                        .foregroundStyle(.secondary)
-                }
+    private var editorHeader: some View {
+        HStack(spacing: VSpacing.sm) {
+            Text(editorTitle)
+                .font(VFont.titleSmall)
+                .foregroundStyle(VColor.contentDefault)
+            if isReadOnly {
+                VBadge(label: "Managed", tone: .neutral, emphasis: .subtle)
             }
             Spacer(minLength: 0)
-            VButton(label: "Cancel", style: .ghost) {
+            VButton(
+                label: "Close",
+                iconOnly: VIcon.x.rawValue,
+                style: .ghost,
+                tintColor: VColor.contentTertiary
+            ) {
                 onCancel()
-            }
-            VButton(label: "Save", style: .primary, isDisabled: !canSave) {
-                saveVisibleProfile()
             }
         }
         .padding(VSpacing.lg)
+    }
+
+    private var editorFooter: some View {
+        HStack(spacing: VSpacing.sm) {
+            Spacer(minLength: 0)
+            if isReadOnly {
+                VButton(label: "Close", style: .outlined) {
+                    onCancel()
+                }
+                if let onSaveAs {
+                    VButton(label: "Save As New", style: .primary) {
+                        onSaveAs()
+                    }
+                }
+            } else {
+                VButton(label: "Cancel", style: .outlined) {
+                    onCancel()
+                }
+                VButton(label: confirmLabel, style: .primary, isDisabled: !canSave) {
+                    saveVisibleProfile()
+                }
+            }
+        }
+        .padding(VSpacing.lg)
+    }
+
+    private var editorTitle: String {
+        if isReadOnly {
+            return profile.displayName
+        }
+        return isCreating ? "New Profile" : "Edit Profile"
+    }
+
+    private var confirmLabel: String {
+        isCreating ? "Create" : "Save"
     }
 
     // MARK: - Fields

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -58,6 +58,7 @@ struct InferenceProfilesSheet: View {
         case create
         case edit(name: String)
         case duplicate(name: String)
+        case view(name: String)
     }
 
     /// Conflict surface for a blocked delete. Mirrors
@@ -117,18 +118,13 @@ struct InferenceProfilesSheet: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer(minLength: 0)
-            HStack(spacing: VSpacing.sm) {
-                VButton(label: "+ New Profile", style: .primary) {
-                    beginCreate()
-                }
-                VButton(
-                    label: "Close",
-                    iconOnly: VIcon.x.rawValue,
-                    style: .ghost,
-                    tintColor: VColor.contentTertiary
-                ) {
-                    isPresented = false
-                }
+            VButton(
+                label: "Close",
+                iconOnly: VIcon.x.rawValue,
+                style: .ghost,
+                tintColor: VColor.contentTertiary
+            ) {
+                isPresented = false
             }
         }
         .padding(VSpacing.lg)
@@ -136,6 +132,9 @@ struct InferenceProfilesSheet: View {
 
     private var footer: some View {
         HStack {
+            VButton(label: "+ New Profile", style: .primary) {
+                beginCreate()
+            }
             if let actionError {
                 Text(actionError)
                     .font(VFont.bodySmallDefault)
@@ -182,8 +181,11 @@ struct InferenceProfilesSheet: View {
                             )
                         )
                         .contextMenu {
-                            Button("Edit") { beginEdit(profile.name) }
-                                .disabled(profile.isManaged)
+                            if profile.isManaged {
+                                Button("View") { beginView(profile.name) }
+                            } else {
+                                Button("Edit") { beginEdit(profile.name) }
+                            }
                             Button("Duplicate") { beginDuplicate(profile.name) }
                             Divider()
                             Button("Delete", role: .destructive) {
@@ -258,10 +260,13 @@ struct InferenceProfilesSheet: View {
                     .foregroundStyle(VColor.contentSecondary)
             }
             Spacer(minLength: 0)
-            VButton(label: "Edit", style: .ghost, isDisabled: profile.isManaged) {
-                beginEdit(profile.name)
+            VButton(label: profile.isManaged ? "View" : "Edit", style: .ghost) {
+                if profile.isManaged {
+                    beginView(profile.name)
+                } else {
+                    beginEdit(profile.name)
+                }
             }
-            .help(profile.isManaged ? "Managed profiles are read-only. Duplicate to customize." : "")
         }
         .padding(.vertical, VSpacing.xs)
         .contentShape(Rectangle())
@@ -280,12 +285,37 @@ struct InferenceProfilesSheet: View {
     // MARK: - Editor Sheet
 
     private var editorSheet: some View {
-        InferenceProfileEditor(
+        let isViewMode: Bool = {
+            if case .view = editorState { return true }
+            return false
+        }()
+        let isCreateMode: Bool = {
+            switch editorState {
+            case .create, .duplicate: return true
+            default: return false
+            }
+        }()
+
+        return InferenceProfileEditor(
             store: store,
             profile: $editorDraft,
+            isReadOnly: isViewMode,
+            isCreating: isCreateMode,
             onSave: {
                 Task { await commitEditor() }
             },
+            onSaveAs: isViewMode ? {
+                // Transition from view mode to a duplicate-style create:
+                // clear the managed source, generate a unique name, and
+                // open a fresh editable editor.
+                guard let originalName = editorOriginalName else { return }
+                editorState = nil
+                // Defer so the sheet dismissal animation completes before
+                // the new sheet presents.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    beginDuplicate(originalName)
+                }
+            } : nil,
             onCancel: {
                 editorState = nil
             }
@@ -408,6 +438,14 @@ struct InferenceProfilesSheet: View {
         editorDraft = InferenceProfile(name: uniqueName)
         editorOriginalName = nil
         editorState = .create
+    }
+
+    private func beginView(_ name: String) {
+        actionError = nil
+        guard let existing = store.profiles.first(where: { $0.name == name }) else { return }
+        editorDraft = existing
+        editorOriginalName = name
+        editorState = .view(name: name)
     }
 
     private func beginEdit(_ name: String) {
@@ -675,6 +713,8 @@ extension InferenceProfilesSheet.EditorState: Identifiable {
             return "edit:\(name)"
         case .duplicate(let name):
             return "duplicate:\(name)"
+        case .view(let name):
+            return "view:\(name)"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Move editor actions (Save/Cancel) from header to footer for consistent modal layout; header now shows title + Managed badge + X close
- Add read-only viewing for managed profiles: click "View" to inspect all settings, "Save As New" to duplicate as an editable user profile
- Contextual confirm button: "Create" when making a new profile, "Save" when editing an existing one; move "+ New Profile" to profiles sheet footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
