### PR TITLE
LUM-1287: Collapse thinking blocks into step dropdowns

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -15,6 +15,8 @@ struct AssistantProgressView: View {
     let streamingCodePreview: String?
     let streamingCodeToolName: String?
     let decidedConfirmations: [ToolConfirmationData]
+    let thinkingContent: String?
+    let thinkingIsStreaming: Bool
     var onRehydrate: (() -> Void)?
 
     // Confirmation action callbacks (threaded from MessageListView)
@@ -60,6 +62,8 @@ struct AssistantProgressView: View {
         streamingCodePreview: String? = nil,
         streamingCodeToolName: String? = nil,
         decidedConfirmations: [ToolConfirmationData],
+        thinkingContent: String? = nil,
+        thinkingIsStreaming: Bool = false,
         onRehydrate: (() -> Void)? = nil,
         onConfirmationAllow: ((String) -> Void)? = nil,
         onConfirmationDeny: ((String) -> Void)? = nil,
@@ -78,6 +82,8 @@ struct AssistantProgressView: View {
         self.streamingCodePreview = streamingCodePreview
         self.streamingCodeToolName = streamingCodeToolName
         self.decidedConfirmations = decidedConfirmations
+        self.thinkingContent = thinkingContent
+        self.thinkingIsStreaming = thinkingIsStreaming
         self.onRehydrate = onRehydrate
         self.onConfirmationAllow = onConfirmationAllow
         self.onConfirmationDeny = onConfirmationDeny
@@ -698,9 +704,34 @@ struct AssistantProgressView: View {
         )
     }
 
+    /// Derives a `Binding<Bool>` for the thinking content row's expansion state
+    /// from the shared `ProgressCardUIState`, scoped to this card's key.
+    private var isThinkingContentExpanded: Binding<Bool> {
+        Binding(
+            get: {
+                guard let key = cardKey else { return false }
+                return progressUIState.isThinkingExpanded(for: key)
+            },
+            set: { newValue in
+                guard let key = cardKey else { return }
+                progressUIState.setThinkingExpanded(for: key, expanded: newValue)
+            }
+        )
+    }
+
     @ViewBuilder
     private func expandedContent(model: ProgressCardPresentationModel, phase: ProgressCardPhase) -> some View {
         VStack(alignment: .leading, spacing: 0) {
+            // Thinking content row — rendered before tool calls since thinking
+            // happens before tool execution. Only shown when content is provided.
+            if let content = thinkingContent, !content.isEmpty {
+                ThinkingContentRow(
+                    content: content,
+                    isStreaming: thinkingIsStreaming,
+                    isExpanded: isThinkingContentExpanded
+                )
+            }
+
             ForEach(toolCalls) { toolCall in
                 ToolCallStepDetailRow(
                     toolCall: toolCall,
@@ -1548,6 +1579,75 @@ private struct ThinkingStepRow: View {
                 }
             }
             .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm + VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs + VSpacing.xs))
+        }
+    }
+}
+
+// MARK: - Thinking Content Row
+
+/// Collapsible row that renders LLM thinking/reasoning content inside a progress
+/// card's expanded content. Follows the same visual pattern as `ToolCallStepDetailRow`
+/// by wrapping `VCollapsibleStepRow`. Renders markdown content styled to match
+/// `ThinkingBlockView` (secondary text, base code background).
+private struct ThinkingContentRow: View {
+    let content: String
+    let isStreaming: Bool
+    @Binding var isExpanded: Bool
+
+    @Environment(\.bubbleMaxWidth) private var bubbleMaxWidth
+
+    /// Cached parsed markdown segments — parsed lazily only when the row is
+    /// expanded, avoiding synchronous O(n) work while collapsed.
+    @State private var cachedSegments: [MarkdownSegment] = []
+    @State private var cachedContent: String = ""
+
+    private var rowState: VCollapsibleStepRowState {
+        isStreaming ? .running : .succeeded
+    }
+
+    private var title: String {
+        isStreaming ? "Thinking..." : "Thought process"
+    }
+
+    private func syncCacheIfExpanded() {
+        guard isExpanded, cachedContent != content else { return }
+        cachedContent = content
+        cachedSegments = parseMarkdownSegments(content)
+    }
+
+    var body: some View {
+        VCollapsibleStepRow(
+            title: title,
+            state: rowState,
+            hasDetails: true,
+            isExpanded: $isExpanded,
+            leadingAccessory: { EmptyView() },
+            trailingAccessory: { EmptyView() },
+            detailContent: { detailBody }
+        )
+        .onAppear { syncCacheIfExpanded() }
+        .onChange(of: content) { _, _ in syncCacheIfExpanded() }
+        .onChange(of: isExpanded) { _, _ in syncCacheIfExpanded() }
+    }
+
+    @ViewBuilder
+    private var detailBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Divider()
+                .padding(.horizontal, VSpacing.lg)
+
+            MarkdownSegmentView(
+                segments: cachedSegments,
+                isStreaming: isStreaming,
+                maxContentWidth: max(bubbleMaxWidth - 2 * VSpacing.sm, 0),
+                textColor: VColor.contentSecondary,
+                secondaryTextColor: VColor.contentTertiary,
+                mutedTextColor: VColor.contentTertiary,
+                tintColor: VColor.primaryBase,
+                codeTextColor: VColor.contentDefault,
+                codeBackgroundColor: VColor.surfaceBase
+            )
+            .padding(VSpacing.sm)
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -812,13 +812,13 @@ struct ChatBubble: View, Equatable {
     /// rendered alongside a bubble that contains the remaining content.
     /// This keeps the transformation at the presentation layer — the
     /// streaming pipeline and `ChatMessage` data model are unchanged.
+    ///
+    /// When tool calls are present, thinking content renders inside the
+    /// progress card (via `thinkingContentForProgressCard`) instead of
+    /// as standalone blocks — so we skip the ThinkingBlockView ForEach.
     @ViewBuilder
     private var bubbleContentWithInlineThinking: some View {
         let chunks = parseInlineThinkingTags(message.text)
-        let thinkingChunks: [String] = chunks.compactMap { chunk in
-            if case .thinking(let body) = chunk { return body }
-            return nil
-        }
         let textChunks: [String] = chunks.compactMap { chunk in
             if case .text(let body) = chunk { return body }
             return nil
@@ -829,17 +829,29 @@ struct ChatBubble: View, Equatable {
         let hasRenderedText = !joinedText.isEmpty
         let hasAttachments = !message.attachments.isEmpty
 
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { offset, content in
-                ThinkingBlockView(
-                    content: content,
-                    isStreaming: message.isStreaming,
-                    expansionKey: "\(message.id.uuidString)-inline-\(offset)",
-                    typographyGeneration: typographyGeneration
-                )
-            }
+        if !message.toolCalls.isEmpty {
+            // Thinking content renders inside the progress card via
+            // thinkingContentForProgressCard — only show the text bubble.
             if hasRenderedText || hasAttachments {
                 bubbleContent(renderingText: joinedText)
+            }
+        } else {
+            let thinkingChunks: [String] = chunks.compactMap { chunk in
+                if case .thinking(let body) = chunk { return body }
+                return nil
+            }
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { offset, content in
+                    ThinkingBlockView(
+                        content: content,
+                        isStreaming: message.isStreaming,
+                        expansionKey: "\(message.id.uuidString)-inline-\(offset)",
+                        typographyGeneration: typographyGeneration
+                    )
+                }
+                if hasRenderedText || hasAttachments {
+                    bubbleContent(renderingText: joinedText)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -292,7 +292,7 @@ extension ChatBubble {
     }
 
     @ViewBuilder
-    private func inlineToolProgress(toolIndices: [Int], isLatestGroup: Bool, hasTrailingText: Bool) -> some View {
+    private func inlineToolProgress(toolIndices: [Int], isLatestGroup: Bool, hasTrailingText: Bool, thinkingContent: String? = nil, thinkingIsStreaming: Bool = false) -> some View {
         let groupedToolCalls: [ToolCallData] = toolIndices.compactMap { idx -> ToolCallData? in
             guard idx < message.toolCalls.count else { return nil }
             return message.toolCalls[idx]
@@ -337,6 +337,8 @@ extension ChatBubble {
                     streamingCodePreview: isLatestGroup ? message.streamingCodePreview : nil,
                     streamingCodeToolName: isLatestGroup ? message.streamingCodeToolName : nil,
                     decidedConfirmations: groupConfirmations,
+                    thinkingContent: thinkingContent,
+                    thinkingIsStreaming: thinkingIsStreaming,
                     onRehydrate: onRehydrate,
                     onConfirmationAllow: onConfirmationAllow,
                     onConfirmationDeny: onConfirmationDeny,
@@ -395,6 +397,72 @@ extension ChatBubble {
             return false
         })?.stableId
 
+        // Pre-compute which thinking groups are adjacent to tool call groups
+        // so their content can be folded into the progress card instead of
+        // rendering as standalone ThinkingBlockView.
+        let foldedThinkingGroupIds: Set<String> = {
+            var ids = Set<String>()
+            for i in 0..<groups.count {
+                guard case .toolCalls = groups[i] else { continue }
+                // Check preceding group
+                if i > 0, case .thinking = groups[i - 1] {
+                    ids.insert(groups[i - 1].stableId)
+                }
+                // Check following group
+                if i + 1 < groups.count, case .thinking = groups[i + 1] {
+                    ids.insert(groups[i + 1].stableId)
+                }
+            }
+            return ids
+        }()
+
+        // Map each tool call group's stableId to the joined thinking text
+        // from its adjacent thinking group(s).
+        let toolGroupThinkingContent: [String: String] = {
+            var map: [String: String] = [:]
+            for i in 0..<groups.count {
+                guard case .toolCalls = groups[i] else { continue }
+                var parts: [String] = []
+                // Preceding thinking group
+                if i > 0, case .thinking(let thinkIndices) = groups[i - 1] {
+                    let joined = thinkIndices
+                        .compactMap { idx in
+                            idx < message.thinkingSegments.count
+                                ? message.thinkingSegments[idx]
+                                : nil
+                        }
+                        .filter { !$0.isEmpty }
+                        .joined(separator: "\n")
+                    if !joined.isEmpty { parts.append(joined) }
+                }
+                // Following thinking group
+                if i + 1 < groups.count, case .thinking(let thinkIndices) = groups[i + 1] {
+                    let joined = thinkIndices
+                        .compactMap { idx in
+                            idx < message.thinkingSegments.count
+                                ? message.thinkingSegments[idx]
+                                : nil
+                        }
+                        .filter { !$0.isEmpty }
+                        .joined(separator: "\n")
+                    if !joined.isEmpty { parts.append(joined) }
+                }
+                if !parts.isEmpty {
+                    map[groups[i].stableId] = parts.joined(separator: "\n")
+                }
+            }
+            return map
+        }()
+
+        // Determine whether thinking is currently streaming: true only when
+        // the message is streaming and the last content block is a thinking block.
+        let thinkingIsCurrentlyStreaming: Bool = {
+            guard message.isStreaming else { return false }
+            if let lastRef = message.contentOrder.last, case .thinking = lastRef {
+                return true
+            }
+            return false
+        }()
 
         // Render all content groups in order: text, tool calls, and surfaces.
         // Uses \.stableId (based on the first index in each group) so SwiftUI
@@ -432,10 +500,13 @@ extension ChatBubble {
                 }
             case .toolCalls(let indices):
                 if shouldRenderToolProgressInline {
+                    let isLatest = indices == latestToolGroup
                     inlineToolProgress(
                         toolIndices: indices,
-                        isLatestGroup: indices == latestToolGroup,
-                        hasTrailingText: cachedToolGroupsWithTrailingText.contains(group.stableId)
+                        isLatestGroup: isLatest,
+                        hasTrailingText: cachedToolGroupsWithTrailingText.contains(group.stableId),
+                        thinkingContent: toolGroupThinkingContent[group.stableId],
+                        thinkingIsStreaming: isLatest && thinkingIsCurrentlyStreaming
                     )
                     // Show images immediately when no text follows;
                     // otherwise they are deferred to render after the next text group.
@@ -456,7 +527,10 @@ extension ChatBubble {
                     InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction, onRefetch: onSurfaceRefetch)
                 }
             case .thinking(let indices):
-                if MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
+                if foldedThinkingGroupIds.contains(group.stableId) {
+                    // Thinking content is folded into the adjacent progress card
+                    EmptyView()
+                } else if MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
                     let joined = indices
                         .compactMap { i in
                             i < message.thinkingSegments.count

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -404,26 +404,27 @@ extension ChatBubble {
             var ids = Set<String>()
             for i in 0..<groups.count {
                 guard case .toolCalls = groups[i] else { continue }
-                // Check preceding group
+                // Only fold the preceding thinking group into this tool group.
+                // Each thinking group is assigned to the tool group that follows
+                // it ("think then act"), preventing duplication when a thinking
+                // group is sandwiched between two tool call groups.
                 if i > 0, case .thinking = groups[i - 1] {
                     ids.insert(groups[i - 1].stableId)
-                }
-                // Check following group
-                if i + 1 < groups.count, case .thinking = groups[i + 1] {
-                    ids.insert(groups[i + 1].stableId)
                 }
             }
             return ids
         }()
 
-        // Map each tool call group's stableId to the joined thinking text
-        // from its adjacent thinking group(s).
+        // Map each tool call group's stableId to the thinking text from its
+        // preceding thinking group. Each thinking group is assigned to the
+        // tool group that follows it ("think then act"), so we only check
+        // the preceding group. This prevents duplication when a thinking
+        // group is sandwiched between two tool call groups.
         let toolGroupThinkingContent: [String: String] = {
             var map: [String: String] = [:]
             for i in 0..<groups.count {
                 guard case .toolCalls = groups[i] else { continue }
-                var parts: [String] = []
-                // Preceding thinking group
+                // Preceding thinking group only
                 if i > 0, case .thinking(let thinkIndices) = groups[i - 1] {
                     let joined = thinkIndices
                         .compactMap { idx in
@@ -433,22 +434,9 @@ extension ChatBubble {
                         }
                         .filter { !$0.isEmpty }
                         .joined(separator: "\n")
-                    if !joined.isEmpty { parts.append(joined) }
-                }
-                // Following thinking group
-                if i + 1 < groups.count, case .thinking(let thinkIndices) = groups[i + 1] {
-                    let joined = thinkIndices
-                        .compactMap { idx in
-                            idx < message.thinkingSegments.count
-                                ? message.thinkingSegments[idx]
-                                : nil
-                        }
-                        .filter { !$0.isEmpty }
-                        .joined(separator: "\n")
-                    if !joined.isEmpty { parts.append(joined) }
-                }
-                if !parts.isEmpty {
-                    map[groups[i].stableId] = parts.joined(separator: "\n")
+                    if !joined.isEmpty {
+                        map[groups[i].stableId] = joined
+                    }
                 }
             }
             return map

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -501,12 +501,13 @@ extension ChatBubble {
             case .toolCalls(let indices):
                 if shouldRenderToolProgressInline {
                     let isLatest = indices == latestToolGroup
+                    let showThinking = MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks")
                     inlineToolProgress(
                         toolIndices: indices,
                         isLatestGroup: isLatest,
                         hasTrailingText: cachedToolGroupsWithTrailingText.contains(group.stableId),
-                        thinkingContent: toolGroupThinkingContent[group.stableId],
-                        thinkingIsStreaming: isLatest && thinkingIsCurrentlyStreaming
+                        thinkingContent: showThinking ? toolGroupThinkingContent[group.stableId] : nil,
+                        thinkingIsStreaming: showThinking && isLatest && thinkingIsCurrentlyStreaming
                     )
                     // Show images immediately when no text follows;
                     // otherwise they are deferred to render after the next text group.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -15,6 +15,35 @@ extension ChatBubble {
             || message.toolCalls.contains { $0.confirmationDecision == .denied || $0.confirmationDecision == .timedOut }
     }
 
+    /// Extracted thinking content for the progress card when the message has
+    /// both inline thinking tags and tool calls. Returns nil when thinking
+    /// should not render inside the progress card (no tags, no tool calls,
+    /// or feature flag disabled).
+    var thinkingContentForProgressCard: String? {
+        guard containsInlineThinkingTag(message.text),
+              !message.toolCalls.isEmpty,
+              MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") else {
+            return nil
+        }
+        let chunks = parseInlineThinkingTags(message.text)
+        let bodies = chunks.compactMap { chunk -> String? in
+            if case .thinking(let body) = chunk { return body }
+            return nil
+        }
+        let joined = bodies.joined(separator: "\n")
+        return joined.isEmpty ? nil : joined
+    }
+
+    /// Whether thinking content is currently streaming into the progress card.
+    /// True when the message is streaming, thinking content exists, and the
+    /// last parsed chunk is a `.thinking` case (i.e. we are mid-thought).
+    var thinkingIsStreamingForProgressCard: Bool {
+        guard message.isStreaming, thinkingContentForProgressCard != nil else { return false }
+        let chunks = parseInlineThinkingTags(message.text)
+        if case .thinking = chunks.last { return true }
+        return false
+    }
+
     @ViewBuilder
     var trailingStatus: some View {
         let inlineToolProgressRenderedInContent = shouldRenderToolProgressInline
@@ -46,6 +75,8 @@ extension ChatBubble {
                     streamingCodePreview: message.streamingCodePreview,
                     streamingCodeToolName: message.streamingCodeToolName,
                     decidedConfirmations: effectiveConfirmations,
+                    thinkingContent: thinkingContentForProgressCard,
+                    thinkingIsStreaming: thinkingIsStreamingForProgressCard,
                     onRehydrate: onRehydrate,
                     onConfirmationAllow: onConfirmationAllow,
                     onConfirmationDeny: onConfirmationDeny,

--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
@@ -43,6 +43,12 @@ struct ProgressCardUIState: Equatable, Sendable {
     /// exact regression the anchor is meant to prevent.
     var cardCompletedDates: [UUID: Date] = [:]
 
+    // MARK: - Thinking Content Expansion
+
+    /// Set of card keys (first tool call UUID) whose inline thinking content
+    /// row is currently expanded. Keyed the same way as `cardExpansionOverrides`.
+    var thinkingExpandedIds: Set<UUID> = []
+
     // MARK: - Rehydration Tracking
 
     /// Set of group IDs (first tool call UUID) for which rehydration has already
@@ -83,6 +89,11 @@ struct ProgressCardUIState: Equatable, Sendable {
     /// Returns the persisted completion timestamp for the given card, or nil if none.
     func cardCompletedAt(for cardKey: UUID) -> Date? {
         cardCompletedDates[cardKey]
+    }
+
+    /// Returns whether the thinking content row for the given card is expanded.
+    func isThinkingExpanded(for cardKey: UUID) -> Bool {
+        thinkingExpandedIds.contains(cardKey)
     }
 
     /// Whether rehydration has already been performed for the given group.
@@ -140,6 +151,15 @@ struct ProgressCardUIState: Equatable, Sendable {
         thinkingDurations.removeValue(forKey: cardKey)
     }
 
+    /// Sets the thinking content expansion state for a card.
+    mutating func setThinkingExpanded(for cardKey: UUID, expanded: Bool) {
+        if expanded {
+            thinkingExpandedIds.insert(cardKey)
+        } else {
+            thinkingExpandedIds.remove(cardKey)
+        }
+    }
+
     /// Marks a group as having been rehydrated.
     mutating func markRehydrated(groupId: UUID) {
         rehydratedGroupIds.insert(groupId)
@@ -151,6 +171,7 @@ struct ProgressCardUIState: Equatable, Sendable {
         cardExpansionOverrides.removeAll()
         thinkingDurations.removeAll()
         cardCompletedDates.removeAll()
+        thinkingExpandedIds.removeAll()
         rehydratedGroupIds.removeAll()
     }
 }


### PR DESCRIPTION
## Summary
Folds thinking blocks into progress card dropdowns so responses are less cluttered. Instead of separate "Thought process" and "Completed N steps" collapsible cards, thinking content now renders as a sub-section inside the progress card. Standalone thinking blocks are preserved for messages without tool calls.

## Self-review result
PASS — 2 gaps found and fixed (feature flag gate in interleaved path, sandwiched thinking deduplication)

## PRs merged into feature branch
- #28972: Add thinking content section to AssistantProgressView expanded content
- #28974: Fold thinking blocks into adjacent progress cards in interleaved content
- #28975: Fold inline thinking tags into progress card in non-interleaved rendering path

### Fix PRs
- #28977: Gate interleaved thinking fold behind show-thinking-blocks flag
- #28984: Deduplicate sandwiched thinking groups in interleaved content

Part of plan: collapse-thinking-into-steps.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
