### PR TITLE
refactor(macos): inline profile editor instead of nested sheet

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -132,7 +132,6 @@ struct InferenceProfileEditor: View {
             SettingsDivider()
             editorFooter
         }
-        .frame(minWidth: 480, minHeight: 600)
         .background(VColor.surfaceLift)
         .onAppear { syncMaxTokensFromBinding() }
         .onChange(of: profile.maxTokens) { _, _ in syncMaxTokensFromBinding() }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -73,25 +73,23 @@ struct InferenceProfilesSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-            SettingsDivider()
-            profilesList
-            SettingsDivider()
-            footer
+            if editorState != nil {
+                editorInline
+            } else {
+                header
+                SettingsDivider()
+                profilesList
+                SettingsDivider()
+                footer
+            }
         }
-        .frame(width: 560, height: 540)
+        .frame(width: 560, height: 600)
         .background(VColor.surfaceLift)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .sheet(item: $editorState) { _ in
-            editorSheet
-        }
         .sheet(item: $blockedState) { _ in
             blockedDeleteSheet
         }
         .onChange(of: editorState) { _, newValue in
-            // Clear the draft when the editor dismisses so the next
-            // session starts from a clean slate. Re-seeding happens in
-            // `beginCreate` / `beginEdit` / `beginDuplicate`.
             if newValue == nil {
                 editorDraft = InferenceProfile(name: "")
                 editorOriginalName = nil
@@ -102,6 +100,7 @@ struct InferenceProfilesSheet: View {
                 replacementSelection = ""
             }
         }
+        .animation(VAnimation.fast, value: editorState != nil)
     }
 
     // MARK: - Header / Footer
@@ -282,9 +281,9 @@ struct InferenceProfilesSheet: View {
         }
     }
 
-    // MARK: - Editor Sheet
+    // MARK: - Inline Editor
 
-    private var editorSheet: some View {
+    private var editorInline: some View {
         let isViewMode: Bool = {
             if case .view = editorState { return true }
             return false
@@ -305,16 +304,8 @@ struct InferenceProfilesSheet: View {
                 Task { await commitEditor() }
             },
             onSaveAs: isViewMode ? {
-                // Transition from view mode to a duplicate-style create:
-                // clear the managed source, generate a unique name, and
-                // open a fresh editable editor.
                 guard let originalName = editorOriginalName else { return }
-                editorState = nil
-                // Defer so the sheet dismissal animation completes before
-                // the new sheet presents.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    beginDuplicate(originalName)
-                }
+                beginDuplicate(originalName)
             } : nil,
             onCancel: {
                 editorState = nil


### PR DESCRIPTION
## Summary
- Replace `.sheet(item: $editorState)` with inline conditional rendering — editor swaps in place of the list within the same modal, eliminating the sheet-within-sheet stacking problem
- Remove `DispatchQueue.main.asyncAfter` delay from "Save As New" flow since the transition is now an inline view swap instead of a sheet dismiss+present
- Remove fixed `minWidth`/`minHeight` from `InferenceProfileEditor` — it now inherits size from the parent sheet frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
