### PR TITLE
Swift Client — Teleport Sync Cleanup

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -442,9 +442,9 @@ struct AssistantTransferSection: View {
             while Date().timeIntervalSince(start) < timeout {
                 try await Task.sleep(nanoseconds: pollInterval)
 
-                let status: PlatformMigrationClient.ImportJobStatus
+                let status: PlatformMigrationClient.JobStatus
                 do {
-                    status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+                    status = try await PlatformMigrationClient.pollJobStatus(jobId: jobId)
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -368,20 +368,15 @@ struct TeleportSection: View {
             throw TeleportError.existingPlatformAssistant(id: existingAssistant.id)
         }
 
-        // Step 3 — Upload to GCS via signed URL (with inline fallback)
+        // Step 3 — Upload to GCS via signed URL
         phase = .transferring(step: "Uploading data to cloud...")
-        let bundleKey: String?
-        do {
-            let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
-            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData, onProgress: { self.transferProgress = $0 })
-            bundleKey = uploadInfo.bundleKey
-        } catch let error as PlatformMigrationClient.PlatformMigrationError {
-            if case .signedUrlsNotAvailable = error {
-                bundleKey = nil
-            } else {
-                throw error
-            }
-        }
+        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+        try await PlatformMigrationClient.uploadToSignedUrl(
+            uploadInfo.uploadUrl,
+            bundleData: bundleData,
+            onProgress: { self.transferProgress = $0 }
+        )
+        let bundleKey = uploadInfo.bundleKey
 
         // Step 4 — Ensure managed assistant exists on platform via direct hatch
         transferProgress = nil
@@ -424,7 +419,7 @@ struct TeleportSection: View {
 
         // Step 5 — Import bundle to managed assistant
         phase = .transferring(step: "Importing data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
+        try await importBundleToManaged(bundleKey: bundleKey)
 
         // Step 5b — Inject client-resolvable vellum identity fields that
         // Django's post-hatch provisioning doesn't cover (org id, user id).
@@ -548,20 +543,15 @@ struct TeleportSection: View {
             throw TeleportError.existingPlatformAssistant(id: existingAssistant.id)
         }
 
-        // Step 3 — Upload to GCS via signed URL (with inline fallback)
+        // Step 3 — Upload to GCS via signed URL
         phase = .transferring(step: "Uploading data to cloud...")
-        let bundleKey: String?
-        do {
-            let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
-            try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData, onProgress: { self.transferProgress = $0 })
-            bundleKey = uploadInfo.bundleKey
-        } catch let error as PlatformMigrationClient.PlatformMigrationError {
-            if case .signedUrlsNotAvailable = error {
-                bundleKey = nil
-            } else {
-                throw error
-            }
-        }
+        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+        try await PlatformMigrationClient.uploadToSignedUrl(
+            uploadInfo.uploadUrl,
+            bundleData: bundleData,
+            onProgress: { self.transferProgress = $0 }
+        )
+        let bundleKey = uploadInfo.bundleKey
 
         // Step 4 — Ensure managed assistant exists on platform via direct hatch
         transferProgress = nil
@@ -603,7 +593,7 @@ struct TeleportSection: View {
 
         // Step 5 — Import bundle to managed assistant
         phase = .transferring(step: "Importing data to cloud...")
-        try await importBundleToManaged(bundleData: bundleData, bundleKey: bundleKey)
+        try await importBundleToManaged(bundleKey: bundleKey)
 
         // Step 5b — Inject client-resolvable vellum identity fields that
         // Django's post-hatch provisioning doesn't cover (org id, user id).
@@ -682,22 +672,12 @@ struct TeleportSection: View {
         return response.data
     }
 
-    /// Imports a `.vbundle` archive into the managed assistant.
+    /// Imports a `.vbundle` archive into the managed assistant via GCS.
     ///
-    /// If `bundleKey` is non-nil, triggers import from GCS (the bundle was already uploaded
-    /// via a signed URL). Otherwise, falls back to inline import by sending the raw bundle
-    /// data directly to the platform.
-    ///
-    /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
-    private func importBundleToManaged(bundleData: Data, bundleKey: String?) async throws {
-        let statusCode: Int
-        let data: Data
-
-        if let bundleKey {
-            (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: bundleKey)
-        } else {
-            (statusCode, data) = try await PlatformMigrationClient.importInline(bundleData: bundleData)
-        }
+    /// The bundle must already have been uploaded via a signed URL upstream. All endpoints
+    /// are org-scoped, so no `connectedAssistantId` swap is needed.
+    private func importBundleToManaged(bundleKey: String) async throws {
+        let (statusCode, data) = try await PlatformMigrationClient.importFromGcs(bundleKey: bundleKey)
 
         guard (200..<300).contains(statusCode) else {
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -721,9 +701,9 @@ struct TeleportSection: View {
             while Date().timeIntervalSince(start) < timeout {
                 try await Task.sleep(nanoseconds: pollInterval)
 
-                let status: PlatformMigrationClient.ImportJobStatus
+                let status: PlatformMigrationClient.JobStatus
                 do {
-                    status = try await PlatformMigrationClient.pollImportStatus(jobId: jobId)
+                    status = try await PlatformMigrationClient.pollJobStatus(jobId: jobId)
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch let error as PlatformMigrationClient.PlatformMigrationError {

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -26,8 +26,8 @@ public enum PlatformMigrationClient {
         }
     }
 
-    /// Status of an asynchronous import job returned by the polling endpoint.
-    public struct ImportJobStatus {
+    /// Status of an asynchronous migration job (import or export) returned by the unified job-status endpoint.
+    public struct JobStatus {
         public let status: String
         public let jobId: String?
         public let error: String?
@@ -207,15 +207,15 @@ public enum PlatformMigrationClient {
         return (statusCode: statusCode, data: data)
     }
 
-    /// Polls the status of an asynchronous import job.
+    /// Polls the status of an asynchronous migration job.
     ///
-    /// - Parameter jobId: The job ID returned by `importFromGcs` when it responds with 202.
-    /// - Returns: An `ImportJobStatus` with the current status, optional error, and result data.
+    /// - Parameter jobId: The job ID returned by an async migration response (export or import).
+    /// - Returns: A `JobStatus` with the current status, optional error, and result data.
     /// - Throws: `PlatformMigrationError` on auth or request failures.
-    public static func pollImportStatus(jobId: String) async throws -> ImportJobStatus {
+    public static func pollJobStatus(jobId: String) async throws -> JobStatus {
         let (baseURL, token, orgId) = try resolveAuthContext()
 
-        guard let url = URL(string: "\(baseURL)/v1/migrations/import/\(jobId)/status/") else {
+        guard let url = URL(string: "\(baseURL)/v1/migrations/jobs/\(jobId)/") else {
             throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
         }
 
@@ -227,10 +227,10 @@ public enum PlatformMigrationClient {
             request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
         }
 
-        let (data, statusCode) = try await executeWithRetry(request: request, label: "import-status")
+        let (data, statusCode) = try await executeWithRetry(request: request, label: "job-status")
 
         guard statusCode == 200 else {
-            throw PlatformMigrationError.requestFailed(statusCode: statusCode, detail: "Import status check failed")
+            throw PlatformMigrationError.requestFailed(statusCode: statusCode, detail: "Job status check failed")
         }
 
         // Parse status and error from top level, keep raw data for result
@@ -245,38 +245,7 @@ public enum PlatformMigrationClient {
             resultData = try? JSONSerialization.data(withJSONObject: result)
         }
 
-        return ImportJobStatus(status: status, jobId: jobIdValue, error: error, resultData: resultData)
-    }
-
-    /// Imports a migration bundle by sending the raw data directly to the platform.
-    ///
-    /// This is the fallback path when signed URL uploads are not available. Mirrors
-    /// the platform's `/v1/migrations/import/` octet-stream contract (the inline-import
-    /// legacy path): POST the bundle data as an octet-stream body.
-    ///
-    /// - Parameter bundleData: The raw bundle data to import.
-    /// - Returns: A tuple of the HTTP status code and raw response data.
-    /// - Throws: `PlatformMigrationError` on auth failures, or network errors from `URLSession`.
-    public static func importInline(bundleData: Data) async throws -> (statusCode: Int, data: Data) {
-        let (baseURL, token, orgId) = try resolveAuthContext()
-
-        guard let url = URL(string: "\(baseURL)/v1/migrations/import/") else {
-            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 3600
-        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
-        if let orgId {
-            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
-        }
-        request.httpBody = bundleData
-
-        let (data, statusCode) = try await executeWithRetry(request: request, label: "import-inline")
-
-        return (statusCode: statusCode, data: data)
+        return JobStatus(status: status, jobId: jobIdValue, error: error, resultData: resultData)
     }
 
     // MARK: - Internals

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -83,7 +83,7 @@ public enum PlatformMigrationClient {
         let (data, statusCode) = try await executeWithRetry(
             request: request,
             label: "upload-url",
-            nonRetryableStatusCodes: [503, 404]
+            nonRetryableStatusCodes: [404]
         )
 
         if statusCode == 503 || statusCode == 404 {

--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+// MARK: - URLProtocol stub for unified job-status calls
+
+private final class JobStatusURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+@MainActor
+final class PlatformMigrationClientPollJobStatusTests: XCTestCase {
+    private var previousToken: String?
+
+    override func setUp() {
+        super.setUp()
+        JobStatusURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(JobStatusURLProtocol.self)
+        // Save any existing token so we can restore it in tearDown, preventing
+        // a test-abort from leaving a bogus token in the real credential store.
+        previousToken = SessionTokenManager.getToken()
+        // Provide a token so network-path tests reach the stub handler rather than
+        // short-circuiting with notAuthenticated before any request is made.
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(JobStatusURLProtocol.self)
+        JobStatusURLProtocol.requestHandler = nil
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+        super.tearDown()
+    }
+
+    private func stubOK(body: String) {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+    }
+
+    func testPollJobStatusUsesUnifiedJobsPath() async throws {
+        let observed = ObservedRequest()
+        JobStatusURLProtocol.requestHandler = { request in
+            observed.url = request.url
+            observed.method = request.httpMethod
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"status":"pending"}"#.utf8))
+        }
+
+        _ = try await PlatformMigrationClient.pollJobStatus(jobId: "test-job-id")
+
+        let url = try XCTUnwrap(observed.url)
+        XCTAssertTrue(
+            url.absoluteString.hasSuffix("/v1/migrations/jobs/test-job-id/"),
+            "Expected URL to end with unified jobs path; got \(url.absoluteString)"
+        )
+        XCTAssertEqual(observed.method, "GET")
+    }
+
+    func testPollJobStatusDecodesPending() async throws {
+        stubOK(body: #"{"status":"pending","job_id":"job-1"}"#)
+        let status = try await PlatformMigrationClient.pollJobStatus(jobId: "job-1")
+        XCTAssertEqual(status.status, "pending")
+        XCTAssertEqual(status.jobId, "job-1")
+        XCTAssertNil(status.error)
+        XCTAssertNil(status.resultData)
+    }
+
+    func testPollJobStatusDecodesProcessing() async throws {
+        stubOK(body: #"{"status":"processing","job_id":"job-2"}"#)
+        let status = try await PlatformMigrationClient.pollJobStatus(jobId: "job-2")
+        XCTAssertEqual(status.status, "processing")
+        XCTAssertEqual(status.jobId, "job-2")
+        XCTAssertNil(status.error)
+        XCTAssertNil(status.resultData)
+    }
+
+    func testPollJobStatusDecodesComplete() async throws {
+        stubOK(body: #"{"status":"complete","job_id":"job-3","result":{"foo":"bar"}}"#)
+        let status = try await PlatformMigrationClient.pollJobStatus(jobId: "job-3")
+        XCTAssertEqual(status.status, "complete")
+        XCTAssertEqual(status.jobId, "job-3")
+        XCTAssertNotNil(status.resultData, "Expected resultData to be re-serialized when result is present")
+    }
+
+    func testPollJobStatusDecodesFailed() async throws {
+        stubOK(body: #"{"status":"failed","job_id":"job-4","error":"boom"}"#)
+        let status = try await PlatformMigrationClient.pollJobStatus(jobId: "job-4")
+        XCTAssertEqual(status.status, "failed")
+        XCTAssertEqual(status.error, "boom")
+    }
+
+    func testPollJobStatusThrowsOnNon200() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"not found"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.pollJobStatus(jobId: "missing-job")
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 404)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}
+
+// Captures observed request fields from the stub closure without violating
+// `@Sendable` constraints on the URLProtocol handler.
+private final class ObservedRequest: @unchecked Sendable {
+    var url: URL?
+    var method: String?
+}


### PR DESCRIPTION
## Summary

Cuts the Swift client over to the unified migration job-status endpoint and to GCS-only import. PR #28852 (vellum-assistant) and #5213 (platform) deleted the legacy sync teleport routes (`POST /v1/migrations/import/` and `POST /v1/migrations/import/{jobId}/status/`); without this PR the next macOS build would 404 on import-status polling and on the inline-import fallback in production.

## Self-review result

PASS — 4 review passes (external feedback, plan faithfulness, repo integration, slop & reuse) all returned no gaps.

External feedback during the milestone PR review:
- Devin posted one advisory inline finding noting that `signedUrlsNotAvailable` is no longer caught specifically — Devin's own framing said "this is likely intentional (removing the fallback is the purpose of this PR)". Confirmed intentional in [a thread reply](https://github.com/vellum-ai/vellum-assistant/pull/28989#issuecomment-4356000668) and resolved.

## PRs merged into feature branch

- #28989: chore(macos): cut over Swift teleport client to unified job-status + GCS-only import

### Fix PRs

None — the only review feedback was advisory and required no code changes.

## Verification checklist

- [x] `xcodebuild` builds the macOS target cleanly (CI: 8 of 8 checks passed on the milestone PR).
- [x] `grep -rn "pollImportStatus\|importInline\|ImportJobStatus" clients` returns zero hits.
- [x] New `PlatformMigrationClientTests` file added covering the unified poll path (URL/method, four-status decoding, 404 → `requestFailed`).
- [ ] **Manual macOS smoke test in dev environment** before merging this PR into `main`: teleport from a self-hosted assistant to a platform-managed assistant via the macOS UI; observe the import phase polling completes via the new `/v1/migrations/jobs/{jobId}/` path. (Plan explicitly calls this out as required pre-merge if reviewers can run it locally.)

## Out of scope (intentional non-goals)

- `requestUploadUrl()` → `requestSignedUrl({operation:"upload"})` migration (queued for a separate "Mixed Cleanup" phase).
- CLI/Django/vembda/runtime/OpenAPI/heyapi changes (already cut over upstream in #28852 + #5213).
- Test coverage for `pollJobStatus` siblings.

Part of plan: swift-teleport-sync-cleanup.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
