### PR TITLE
fix: Harden test database isolation

### DIFF
--- a/assistant/src/__tests__/db-connection-isolation.test.ts
+++ b/assistant/src/__tests__/db-connection-isolation.test.ts
@@ -1,4 +1,11 @@
-import { homedir } from "node:os";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, test } from "bun:test";
 
@@ -7,6 +14,8 @@ import { getDb, resetDb } from "../memory/db-connection.js";
 const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
 const originalAllowRealWorkspace =
   process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+const originalTestRealWorkspace = process.env.VELLUM_TEST_REAL_WORKSPACE_DIR;
+const originalHome = process.env.HOME;
 
 afterEach(() => {
   resetDb();
@@ -21,6 +30,18 @@ afterEach(() => {
   } else {
     process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS =
       originalAllowRealWorkspace;
+  }
+
+  if (originalTestRealWorkspace === undefined) {
+    delete process.env.VELLUM_TEST_REAL_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_TEST_REAL_WORKSPACE_DIR = originalTestRealWorkspace;
+  }
+
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
   }
 });
 
@@ -42,4 +63,33 @@ test("getDb refuses the real workspace during tests even when explicitly set", (
   expect(() => getDb()).toThrow(
     "Refusing to open the real assistant workspace DB during tests",
   );
+});
+
+test("getDb refuses symlink aliases to the real workspace during tests", () => {
+  resetDb();
+  const testRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vellum-db-isolation-")),
+  );
+
+  try {
+    const fakeHome = join(testRoot, "home");
+    const realWorkspace = join(fakeHome, ".vellum", "workspace");
+    const aliasParent = join(testRoot, "aliases");
+    const workspaceAlias = join(aliasParent, "workspace-link");
+
+    mkdirSync(realWorkspace, { recursive: true });
+    mkdirSync(aliasParent, { recursive: true });
+    symlinkSync(realWorkspace, workspaceAlias, "dir");
+
+    process.env.HOME = fakeHome;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceAlias;
+    process.env.VELLUM_TEST_REAL_WORKSPACE_DIR = realWorkspace;
+    delete process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+
+    expect(() => getDb()).toThrow(
+      "Refusing to open the real assistant workspace DB during tests",
+    );
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
 });

--- a/assistant/src/__tests__/db-connection-isolation.test.ts
+++ b/assistant/src/__tests__/db-connection-isolation.test.ts
@@ -1,0 +1,45 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "bun:test";
+
+import { getDb, resetDb } from "../memory/db-connection.js";
+
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+const originalAllowRealWorkspace =
+  process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+
+afterEach(() => {
+  resetDb();
+  if (originalWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+
+  if (originalAllowRealWorkspace === undefined) {
+    delete process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+  } else {
+    process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS =
+      originalAllowRealWorkspace;
+  }
+});
+
+test("getDb refuses test runs without an isolated workspace", () => {
+  resetDb();
+  delete process.env.VELLUM_WORKSPACE_DIR;
+  delete process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+
+  expect(() => getDb()).toThrow(
+    "Refusing to open the assistant DB during tests without VELLUM_WORKSPACE_DIR",
+  );
+});
+
+test("getDb refuses the real workspace during tests even when explicitly set", () => {
+  resetDb();
+  process.env.VELLUM_WORKSPACE_DIR = join(homedir(), ".vellum", "workspace");
+  delete process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+
+  expect(() => getDb()).toThrow(
+    "Refusing to open the real assistant workspace DB during tests",
+  );
+});

--- a/assistant/src/__tests__/db-connection-isolation.test.ts
+++ b/assistant/src/__tests__/db-connection-isolation.test.ts
@@ -93,3 +93,33 @@ test("getDb refuses symlink aliases to the real workspace during tests", () => {
     rmSync(testRoot, { recursive: true, force: true });
   }
 });
+
+test("getDb refuses missing children under symlink aliases to the real workspace", () => {
+  resetDb();
+  const testRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vellum-db-isolation-")),
+  );
+
+  try {
+    const fakeHome = join(testRoot, "home");
+    const realWorkspace = join(fakeHome, ".vellum", "workspace");
+    const aliasParent = join(testRoot, "aliases");
+    const workspaceLink = join(aliasParent, "workspace-link");
+    const missingChild = join(workspaceLink, "new-test-workspace");
+
+    mkdirSync(realWorkspace, { recursive: true });
+    mkdirSync(aliasParent, { recursive: true });
+    symlinkSync(realWorkspace, workspaceLink, "dir");
+
+    process.env.HOME = fakeHome;
+    process.env.VELLUM_WORKSPACE_DIR = missingChild;
+    process.env.VELLUM_TEST_REAL_WORKSPACE_DIR = realWorkspace;
+    delete process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+
+    expect(() => getDb()).toThrow(
+      "Refusing to open the real assistant workspace DB during tests",
+    );
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { join, resolve, sep } from "node:path";
 import { Database } from "bun:sqlite";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -9,8 +11,44 @@ export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
 
 let db: DrizzleDb | null = null;
 
+function assertTestDbIsIsolated(): void {
+  if (
+    process.env.NODE_ENV !== "test" ||
+    process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS === "1"
+  ) {
+    return;
+  }
+
+  const workspaceDir = process.env.VELLUM_WORKSPACE_DIR?.trim();
+  if (!workspaceDir) {
+    throw new Error(
+      [
+        "Refusing to open the assistant DB during tests without VELLUM_WORKSPACE_DIR.",
+        "Run assistant tests from the assistant package so the test preload can isolate state:",
+        "  cd assistant && bun test src/path/to/file.test.ts",
+      ].join("\n"),
+    );
+  }
+
+  const resolvedWorkspaceDir = resolve(workspaceDir);
+  const realWorkspaceDir = resolve(join(homedir(), ".vellum", "workspace"));
+  if (
+    resolvedWorkspaceDir === realWorkspaceDir ||
+    resolvedWorkspaceDir.startsWith(realWorkspaceDir + sep)
+  ) {
+    throw new Error(
+      [
+        "Refusing to open the real assistant workspace DB during tests.",
+        `VELLUM_WORKSPACE_DIR resolved to ${resolvedWorkspaceDir}.`,
+        "Use a temp workspace for tests instead.",
+      ].join("\n"),
+    );
+  }
+}
+
 export function getDb(): DrizzleDb {
   if (!db) {
+    assertTestDbIsIsolated();
     ensureDataDir();
     const sqlite = new Database(getDbPath());
     sqlite.exec("PRAGMA journal_mode=WAL");

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -1,6 +1,6 @@
 import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { Database } from "bun:sqlite";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -12,11 +12,22 @@ export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
 
 let db: DrizzleDb | null = null;
 
-function canonicalizeExistingPath(path: string): string {
-  try {
-    return realpathSync(path);
-  } catch {
-    return resolve(path);
+function canonicalizePathThroughExistingParent(path: string): string {
+  const resolvedPath = resolve(path);
+  const pendingSegments: string[] = [];
+  let currentPath = resolvedPath;
+
+  while (true) {
+    try {
+      return resolve(realpathSync(currentPath), ...pendingSegments.reverse());
+    } catch {
+      const parentPath = dirname(currentPath);
+      if (parentPath === currentPath) {
+        return resolvedPath;
+      }
+      pendingSegments.push(basename(currentPath));
+      currentPath = parentPath;
+    }
   }
 }
 
@@ -39,8 +50,9 @@ function assertTestDbIsIsolated(): void {
     );
   }
 
-  const resolvedWorkspaceDir = canonicalizeExistingPath(workspaceDir);
-  const realWorkspaceDir = canonicalizeExistingPath(
+  const resolvedWorkspaceDir =
+    canonicalizePathThroughExistingParent(workspaceDir);
+  const realWorkspaceDir = canonicalizePathThroughExistingParent(
     process.env.VELLUM_TEST_REAL_WORKSPACE_DIR?.trim() ||
       join(homedir(), ".vellum", "workspace"),
   );

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { Database } from "bun:sqlite";
@@ -10,6 +11,14 @@ import * as schema from "./schema.js";
 export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
 
 let db: DrizzleDb | null = null;
+
+function canonicalizeExistingPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
 
 function assertTestDbIsIsolated(): void {
   if (
@@ -30,8 +39,11 @@ function assertTestDbIsIsolated(): void {
     );
   }
 
-  const resolvedWorkspaceDir = resolve(workspaceDir);
-  const realWorkspaceDir = resolve(join(homedir(), ".vellum", "workspace"));
+  const resolvedWorkspaceDir = canonicalizeExistingPath(workspaceDir);
+  const realWorkspaceDir = canonicalizeExistingPath(
+    process.env.VELLUM_TEST_REAL_WORKSPACE_DIR?.trim() ||
+      join(homedir(), ".vellum", "workspace"),
+  );
   if (
     resolvedWorkspaceDir === realWorkspaceDir ||
     resolvedWorkspaceDir.startsWith(realWorkspaceDir + sep)

--- a/gateway/src/__tests__/db-connection-isolation.test.ts
+++ b/gateway/src/__tests__/db-connection-isolation.test.ts
@@ -98,6 +98,36 @@ test("initGatewayDb refuses symlink aliases to the real security dir during test
   }
 });
 
+test("initGatewayDb refuses missing children under symlink aliases to the real security dir", async () => {
+  resetGatewayDb();
+  const testRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vellum-gateway-db-isolation-")),
+  );
+
+  try {
+    const fakeHome = join(testRoot, "home");
+    const realSecurityDir = join(fakeHome, ".vellum", "protected");
+    const aliasParent = join(testRoot, "aliases");
+    const securityLink = join(aliasParent, "gateway-security-link");
+    const missingChild = join(securityLink, "new-security-dir");
+
+    mkdirSync(realSecurityDir, { recursive: true });
+    mkdirSync(aliasParent, { recursive: true });
+    symlinkSync(realSecurityDir, securityLink, "dir");
+
+    process.env.HOME = fakeHome;
+    process.env.GATEWAY_SECURITY_DIR = missingChild;
+    process.env.VELLUM_TEST_REAL_GATEWAY_SECURITY_DIR = realSecurityDir;
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+
+    await expect(initGatewayDb()).rejects.toThrow(
+      "Refusing to open the real gateway security DB during tests",
+    );
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("initGatewayDb does not migrate legacy gateway DBs during tests", async () => {
   resetGatewayDb();
   const testRoot = realpathSync(

--- a/gateway/src/__tests__/db-connection-isolation.test.ts
+++ b/gateway/src/__tests__/db-connection-isolation.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, expect, test } from "bun:test";
-import { homedir } from "node:os";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
@@ -7,6 +16,9 @@ import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
 const originalSecurityDir = process.env.GATEWAY_SECURITY_DIR;
 const originalAllowRealSecurity =
   process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+const originalTestRealSecurity =
+  process.env.VELLUM_TEST_REAL_GATEWAY_SECURITY_DIR;
+const originalHome = process.env.HOME;
 
 afterEach(() => {
   resetGatewayDb();
@@ -21,6 +33,19 @@ afterEach(() => {
   } else {
     process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS =
       originalAllowRealSecurity;
+  }
+
+  if (originalTestRealSecurity === undefined) {
+    delete process.env.VELLUM_TEST_REAL_GATEWAY_SECURITY_DIR;
+  } else {
+    process.env.VELLUM_TEST_REAL_GATEWAY_SECURITY_DIR =
+      originalTestRealSecurity;
+  }
+
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
   }
 });
 
@@ -42,4 +67,61 @@ test("initGatewayDb refuses the real security dir during tests even when explici
   await expect(initGatewayDb()).rejects.toThrow(
     "Refusing to open the real gateway security DB during tests",
   );
+});
+
+test("initGatewayDb refuses symlink aliases to the real security dir during tests", async () => {
+  resetGatewayDb();
+  const testRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vellum-gateway-db-isolation-")),
+  );
+
+  try {
+    const fakeHome = join(testRoot, "home");
+    const realSecurityDir = join(fakeHome, ".vellum", "protected");
+    const aliasParent = join(testRoot, "aliases");
+    const securityAlias = join(aliasParent, "gateway-security-link");
+
+    mkdirSync(realSecurityDir, { recursive: true });
+    mkdirSync(aliasParent, { recursive: true });
+    symlinkSync(realSecurityDir, securityAlias, "dir");
+
+    process.env.HOME = fakeHome;
+    process.env.GATEWAY_SECURITY_DIR = securityAlias;
+    process.env.VELLUM_TEST_REAL_GATEWAY_SECURITY_DIR = realSecurityDir;
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+
+    await expect(initGatewayDb()).rejects.toThrow(
+      "Refusing to open the real gateway security DB during tests",
+    );
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("initGatewayDb does not migrate legacy gateway DBs during tests", async () => {
+  resetGatewayDb();
+  const testRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vellum-gateway-db-isolation-")),
+  );
+
+  try {
+    const fakeHome = join(testRoot, "home");
+    const legacyDir = join(fakeHome, ".vellum", "data");
+    const legacyDb = join(legacyDir, "gateway.sqlite");
+    const securityDir = join(testRoot, "gateway-security");
+
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(legacyDb, "legacy gateway db");
+
+    process.env.HOME = fakeHome;
+    process.env.GATEWAY_SECURITY_DIR = securityDir;
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+
+    await initGatewayDb();
+
+    expect(existsSync(legacyDb)).toBe(true);
+    expect(existsSync(join(securityDir, "gateway.sqlite"))).toBe(true);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
 });

--- a/gateway/src/__tests__/db-connection-isolation.test.ts
+++ b/gateway/src/__tests__/db-connection-isolation.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { initGatewayDb, resetGatewayDb } from "../db/connection.js";
+
+const originalSecurityDir = process.env.GATEWAY_SECURITY_DIR;
+const originalAllowRealSecurity =
+  process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+
+afterEach(() => {
+  resetGatewayDb();
+  if (originalSecurityDir === undefined) {
+    delete process.env.GATEWAY_SECURITY_DIR;
+  } else {
+    process.env.GATEWAY_SECURITY_DIR = originalSecurityDir;
+  }
+
+  if (originalAllowRealSecurity === undefined) {
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+  } else {
+    process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS =
+      originalAllowRealSecurity;
+  }
+});
+
+test("initGatewayDb refuses test runs without an isolated security dir", async () => {
+  resetGatewayDb();
+  delete process.env.GATEWAY_SECURITY_DIR;
+  delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+
+  await expect(initGatewayDb()).rejects.toThrow(
+    "Refusing to open the gateway DB during tests without GATEWAY_SECURITY_DIR",
+  );
+});
+
+test("initGatewayDb refuses the real security dir during tests even when explicitly set", async () => {
+  resetGatewayDb();
+  process.env.GATEWAY_SECURITY_DIR = join(homedir(), ".vellum", "protected");
+  delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+
+  await expect(initGatewayDb()).rejects.toThrow(
+    "Refusing to open the real gateway security DB during tests",
+  );
+});

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -1,7 +1,8 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { existsSync, mkdirSync, renameSync } from "node:fs";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve, sep } from "node:path";
 import { getGatewaySecurityDir, getLegacyRootDir } from "../paths.js";
 import * as schema from "./schema.js";
 import { seedTrustRulesFromRegistry } from "./seed-trust-rules.js";
@@ -71,6 +72,41 @@ async function pushSchemaNoPrompt(
 
 let db: GatewayDb | null = null;
 
+function assertTestDbIsIsolated(): void {
+  if (
+    process.env.NODE_ENV !== "test" ||
+    process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS === "1"
+  ) {
+    return;
+  }
+
+  const securityDir = process.env.GATEWAY_SECURITY_DIR?.trim();
+  if (!securityDir) {
+    throw new Error(
+      [
+        "Refusing to open the gateway DB during tests without GATEWAY_SECURITY_DIR.",
+        "Run gateway tests from the gateway package so the test preload can isolate state:",
+        "  cd gateway && bun test src/path/to/file.test.ts",
+      ].join("\n"),
+    );
+  }
+
+  const resolvedSecurityDir = resolve(securityDir);
+  const realSecurityDir = resolve(join(homedir(), ".vellum", "protected"));
+  if (
+    resolvedSecurityDir === realSecurityDir ||
+    resolvedSecurityDir.startsWith(realSecurityDir + sep)
+  ) {
+    throw new Error(
+      [
+        "Refusing to open the real gateway security DB during tests.",
+        `GATEWAY_SECURITY_DIR resolved to ${resolvedSecurityDir}.`,
+        "Use a temp gateway security directory for tests instead.",
+      ].join("\n"),
+    );
+  }
+}
+
 /**
  * One-time migration: move gateway.sqlite from the legacy path
  * (~/.vellum/data/gateway.sqlite) to the new PVC-backed path
@@ -100,6 +136,7 @@ function migrateLegacyDb(newPath: string): void {
 }
 
 function getDbPath(): string {
+  assertTestDbIsIsolated();
   const securityDir = getGatewaySecurityDir();
   if (!existsSync(securityDir)) {
     mkdirSync(securityDir, { recursive: true });

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
-import { existsSync, mkdirSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, realpathSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { getGatewaySecurityDir, getLegacyRootDir } from "../paths.js";
@@ -72,6 +72,14 @@ async function pushSchemaNoPrompt(
 
 let db: GatewayDb | null = null;
 
+function canonicalizeExistingPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
 function assertTestDbIsIsolated(): void {
   if (
     process.env.NODE_ENV !== "test" ||
@@ -91,8 +99,11 @@ function assertTestDbIsIsolated(): void {
     );
   }
 
-  const resolvedSecurityDir = resolve(securityDir);
-  const realSecurityDir = resolve(join(homedir(), ".vellum", "protected"));
+  const resolvedSecurityDir = canonicalizeExistingPath(securityDir);
+  const realSecurityDir = canonicalizeExistingPath(
+    process.env.VELLUM_TEST_REAL_GATEWAY_SECURITY_DIR?.trim() ||
+      join(homedir(), ".vellum", "protected"),
+  );
   if (
     resolvedSecurityDir === realSecurityDir ||
     resolvedSecurityDir.startsWith(realSecurityDir + sep)
@@ -142,7 +153,9 @@ function getDbPath(): string {
     mkdirSync(securityDir, { recursive: true });
   }
   const dbPath = join(securityDir, "gateway.sqlite");
-  migrateLegacyDb(dbPath);
+  if (process.env.NODE_ENV !== "test") {
+    migrateLegacyDb(dbPath);
+  }
   return dbPath;
 }
 

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { existsSync, mkdirSync, realpathSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { getGatewaySecurityDir, getLegacyRootDir } from "../paths.js";
 import * as schema from "./schema.js";
 import { seedTrustRulesFromRegistry } from "./seed-trust-rules.js";
@@ -72,11 +72,22 @@ async function pushSchemaNoPrompt(
 
 let db: GatewayDb | null = null;
 
-function canonicalizeExistingPath(path: string): string {
-  try {
-    return realpathSync(path);
-  } catch {
-    return resolve(path);
+function canonicalizePathThroughExistingParent(path: string): string {
+  const resolvedPath = resolve(path);
+  const pendingSegments: string[] = [];
+  let currentPath = resolvedPath;
+
+  while (true) {
+    try {
+      return resolve(realpathSync(currentPath), ...pendingSegments.reverse());
+    } catch {
+      const parentPath = dirname(currentPath);
+      if (parentPath === currentPath) {
+        return resolvedPath;
+      }
+      pendingSegments.push(basename(currentPath));
+      currentPath = parentPath;
+    }
   }
 }
 
@@ -99,8 +110,9 @@ function assertTestDbIsIsolated(): void {
     );
   }
 
-  const resolvedSecurityDir = canonicalizeExistingPath(securityDir);
-  const realSecurityDir = canonicalizeExistingPath(
+  const resolvedSecurityDir =
+    canonicalizePathThroughExistingParent(securityDir);
+  const realSecurityDir = canonicalizePathThroughExistingParent(
     process.env.VELLUM_TEST_REAL_GATEWAY_SECURITY_DIR?.trim() ||
       join(homedir(), ".vellum", "protected"),
   );

--- a/test-preload.ts
+++ b/test-preload.ts
@@ -9,17 +9,49 @@
  *
  * This preload is registered in the root bunfig.toml. It checks whether the
  * current working directory is the repo root (by looking for this file) and
- * only throws in that case. Sub-packages without their own bunfig.toml
- * (e.g. cli/, packages/*) may inherit this preload but will pass through
- * safely since their cwd differs from the repo root.
+ * only throws in that case. Bun may still continue running sibling test files
+ * after reporting a preload error, so the root case first redirects persistent
+ * state to a temp workspace/security dir before throwing. Sub-packages without
+ * their own bunfig.toml (e.g. cli/, packages/*) may inherit this preload but
+ * will pass through safely since their cwd differs from the repo root.
  */
 
-import { existsSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterAll } from "bun:test";
 
 const isRepoRoot = existsSync(join(process.cwd(), "test-preload.ts"));
 
 if (isRepoRoot) {
+  const testRoot = realpathSync(
+    mkdtempSync(join(tmpdir(), "vellum-root-test-")),
+  );
+  const workspaceDir = join(testRoot, "workspace");
+  const gatewaySecurityDir = join(testRoot, "gateway-security");
+
+  mkdirSync(workspaceDir, { recursive: true });
+  mkdirSync(gatewaySecurityDir, { recursive: true });
+
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  process.env.GATEWAY_SECURITY_DIR = gatewaySecurityDir;
+  delete process.env.CES_CREDENTIAL_URL;
+  delete process.env.CES_SERVICE_TOKEN;
+
+  afterAll(() => {
+    try {
+      rmSync(testRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
   throw new Error(
     [
       "Do not run `bun test` from the repo root.",


### PR DESCRIPTION
## Summary
- Redirect root-level Bun test continuation into temp assistant and gateway state directories before throwing
- Refuse to open real assistant or gateway SQLite storage from test processes
- Add focused regression tests for assistant and gateway DB isolation

## Original prompt
$do put this up in a PR from a git worktree and automerge after review
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
