### PR TITLE
assistant: use call-site catalog for usage labels

### DIFF
--- a/assistant/src/__tests__/llm-callsite-catalog.test.ts
+++ b/assistant/src/__tests__/llm-callsite-catalog.test.ts
@@ -1,25 +1,34 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  getLLMCallSiteLabel,
-  LLM_CALLSITE_CATALOG,
-} from "../config/llm-callsite-catalog.js";
+import { getLLMCallSiteLabel } from "../config/llm-callsite-catalog.js";
+import { CALL_SITE_CATALOG } from "../config/schemas/call-site-catalog.js";
 import { LLMCallSiteEnum } from "../config/schemas/llm.js";
 
 describe("LLM call-site catalog", () => {
-  test("has a label for every backend call-site enum value", () => {
-    const missing = LLMCallSiteEnum.options.filter(
-      (callSite) => LLM_CALLSITE_CATALOG[callSite] === undefined,
+  test("resolves every backend call-site enum value from the catalog", () => {
+    const catalogIds = new Set(CALL_SITE_CATALOG.map(({ id }) => id));
+
+    expect(LLMCallSiteEnum.options.filter((id) => !catalogIds.has(id))).toEqual(
+      [],
     );
-    expect(missing).toEqual([]);
+  });
+
+  test("returns catalog display names", () => {
+    for (const { id, displayName } of CALL_SITE_CATALOG) {
+      expect(getLLMCallSiteLabel(id)).toBe(displayName);
+    }
   });
 
   test("returns canonical user-facing labels", () => {
-    expect(getLLMCallSiteLabel("mainAgent")).toBe("Main agent");
-    expect(getLLMCallSiteLabel("memoryExtraction")).toBe("Memory extraction");
-    expect(getLLMCallSiteLabel("conversationTitle")).toBe("Conversation title");
+    expect(getLLMCallSiteLabel("mainAgent")).toBe("Main Agent");
+    expect(getLLMCallSiteLabel("memoryExtraction")).toBe("Memory Extraction");
+    expect(getLLMCallSiteLabel("conversationTitle")).toBe("Conversation Title");
     expect(getLLMCallSiteLabel("trustRuleSuggestion")).toBe(
-      "Trust rule suggestion",
+      "Trust Rule Suggestion",
     );
+  });
+
+  test("returns the raw ID for unknown call sites", () => {
+    expect(getLLMCallSiteLabel("unknownCallSite")).toBe("unknownCallSite");
   });
 });

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -910,9 +910,9 @@ describe("getUsageGroupBreakdown", () => {
 
     const groups = getUsageGroupBreakdown({ from: 0, to: 5000 }, "call_site");
     expect(groups.map((group) => group.group)).toEqual([
-      "Main agent",
+      "Main Agent",
       "Unknown Task",
-      "Conversation title",
+      "Conversation Title",
     ]);
     expect(groups.map((group) => group.groupKey)).toEqual([
       "mainAgent",
@@ -1127,12 +1127,12 @@ describe("getUsageGroupedSeries", () => {
 
     expect(buckets).toHaveLength(2);
     expect(buckets[0].groups["value:mainAgent"]).toMatchObject({
-      group: "Main agent",
+      group: "Main Agent",
       groupKey: "mainAgent",
       totalInputTokens: 100,
     });
     expect(buckets[0].groups["value:conversationTitle"]).toMatchObject({
-      group: "Conversation title",
+      group: "Conversation Title",
       groupKey: "conversationTitle",
       totalInputTokens: 200,
     });

--- a/assistant/src/__tests__/usage-cli.test.ts
+++ b/assistant/src/__tests__/usage-cli.test.ts
@@ -101,7 +101,7 @@ describe("assistant usage CLI", () => {
       breakdown: Array<{ group: string; groupKey: string | null }>;
     };
     expect(parsed.breakdown.map((row) => row.group)).toEqual([
-      "Main agent",
+      "Main Agent",
       "Unknown Task",
     ]);
     expect(parsed.breakdown.map((row) => row.groupKey)).toEqual([

--- a/assistant/src/__tests__/usage-grouped-buckets.test.ts
+++ b/assistant/src/__tests__/usage-grouped-buckets.test.ts
@@ -8,7 +8,10 @@ import {
 
 describe("usage grouped buckets", () => {
   test("uses canonical labels for call-site groups and fallbacks", () => {
-    expect(displayUsageGroup("call_site", "mainAgent")).toBe("Main agent");
+    expect(displayUsageGroup("call_site", "mainAgent")).toBe("Main Agent");
+    expect(displayUsageGroup("call_site", "unknownCallSite")).toBe(
+      "unknownCallSite",
+    );
     expect(displayUsageGroup("call_site", null)).toBe("Unknown Task");
     expect(displayUsageGroup("inference_profile", null)).toBe(
       "Default / Unset",
@@ -19,9 +22,7 @@ describe("usage grouped buckets", () => {
     expect(stableUsageSeriesGroupKey("call_site", "mainAgent")).toBe(
       "value:mainAgent",
     );
-    expect(stableUsageSeriesGroupKey("call_site", null)).toBe(
-      "null:call_site",
-    );
+    expect(stableUsageSeriesGroupKey("call_site", null)).toBe("null:call_site");
     expect(stableUsageSeriesGroupKey("inference_profile", null)).toBe(
       "null:inference_profile",
     );
@@ -64,9 +65,9 @@ describe("usage grouped buckets", () => {
     expect(buckets[0].totalEstimatedCostUsd).toBe(0.03);
     expect(buckets[0].eventCount).toBe(2);
     expect(buckets[0].groups["value:mainAgent"].totalInputTokens).toBe(100);
-    expect(
-      buckets[0].groups["value:conversationTitle"].totalInputTokens,
-    ).toBe(200);
+    expect(buckets[0].groups["value:conversationTitle"].totalInputTokens).toBe(
+      200,
+    );
   });
 
   test("keeps unset inference profiles separate from matching profile names", () => {
@@ -144,7 +145,7 @@ describe("usage grouped buckets", () => {
 
     expect(buckets).toHaveLength(1);
     expect(buckets[0].totalInputTokens).toBe(300);
-    expect(buckets[0].groups["value:mainAgent"].group).toBe("Main agent");
+    expect(buckets[0].groups["value:mainAgent"].group).toBe("Main Agent");
     expect(buckets[0].groups["null:call_site"]).toMatchObject({
       group: "Unknown Task",
       groupKey: null,

--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -356,8 +356,8 @@ describe("usage routes", () => {
       };
 
       expect(body.breakdown.map((row) => row.group)).toEqual([
-        "Main agent",
-        "Context compactor",
+        "Main Agent",
+        "Compaction Agent",
         "Unknown Task",
       ]);
       expect(body.breakdown.map((row) => row.groupKey)).toEqual([
@@ -432,12 +432,12 @@ describe("usage routes", () => {
 
       expect(body.buckets).toHaveLength(2);
       expect(body.buckets[0].groups["value:mainAgent"]).toMatchObject({
-        group: "Main agent",
+        group: "Main Agent",
         groupKey: "mainAgent",
         totalInputTokens: 850,
       });
       expect(body.buckets[0].groups["value:compactionAgent"]).toMatchObject({
-        group: "Context compactor",
+        group: "Compaction Agent",
         groupKey: "compactionAgent",
         totalInputTokens: 500,
       });

--- a/assistant/src/cli/commands/usage.ts
+++ b/assistant/src/cli/commands/usage.ts
@@ -290,8 +290,8 @@ Examples:
       "after",
       `
 Grouping dimensions:
-  call_site          Groups by user-facing task (Main agent, Memory extraction,
-                     Conversation title, etc.)
+  call_site          Groups by user-facing task (Main Agent, Memory Extraction,
+                     Conversation Title, etc.)
   inference_profile  Groups by inference profile; unset historical rows are
                      shown as Default / Unset
   provider           Groups by LLM provider (anthropic, openai, etc.)

--- a/assistant/src/config/llm-callsite-catalog.ts
+++ b/assistant/src/config/llm-callsite-catalog.ts
@@ -1,52 +1,10 @@
+import { CALL_SITE_CATALOG } from "./schemas/call-site-catalog.js";
 import type { LLMCallSite } from "./schemas/llm.js";
 
-export interface LLMCallSiteCatalogEntry {
-  label: string;
-}
-
-export const LLM_CALLSITE_CATALOG: Record<
-  LLMCallSite,
-  LLMCallSiteCatalogEntry
-> = {
-  mainAgent: { label: "Main agent" },
-  subagentSpawn: { label: "Subagent spawn" },
-  heartbeatAgent: { label: "Heartbeat agent" },
-  filingAgent: { label: "Filing agent" },
-  compactionAgent: { label: "Context compactor" },
-  analyzeConversation: { label: "Analyze conversation" },
-  callAgent: { label: "Call agent" },
-  memoryExtraction: { label: "Memory extraction" },
-  memoryConsolidation: { label: "Memory consolidation" },
-  memoryRetrieval: { label: "Memory retrieval" },
-  memoryV2Migration: { label: "Memory migration" },
-  memoryV2Sweep: { label: "Memory sweep" },
-  recall: { label: "Recall" },
-  narrativeRefinement: { label: "Narrative refinement" },
-  patternScan: { label: "Pattern scan" },
-  conversationSummarization: { label: "Conversation summarization" },
-  conversationStarters: { label: "Conversation starters" },
-  conversationTitle: { label: "Conversation title" },
-  commitMessage: { label: "Commit message" },
-  identityIntro: { label: "Identity intro" },
-  emptyStateGreeting: { label: "Empty-state greeting" },
-  notificationDecision: { label: "Notification decision" },
-  preferenceExtraction: { label: "Preference extraction" },
-  guardianQuestionCopy: { label: "Guardian question copy" },
-  approvalCopy: { label: "Approval copy" },
-  approvalConversation: { label: "Approval conversation" },
-  interactionClassifier: { label: "Interaction classifier" },
-  styleAnalyzer: { label: "Style analyzer" },
-  inviteInstructionGenerator: { label: "Invite instruction generator" },
-  skillCategoryInference: { label: "Skill category inference" },
-  meetConsentMonitor: { label: "Meet consent monitor" },
-  meetChatOpportunity: { label: "Meet chat opportunity" },
-  inference: { label: "Inference" },
-  feedEventCopy: { label: "Feed event copy" },
-  trustRuleSuggestion: { label: "Trust rule suggestion" },
-};
+const LLM_CALLSITE_LABELS = new Map<LLMCallSite, string>(
+  CALL_SITE_CATALOG.map(({ id, displayName }) => [id, displayName]),
+);
 
 export function getLLMCallSiteLabel(callSite: LLMCallSite | string): string {
-  return (
-    LLM_CALLSITE_CATALOG[callSite as LLMCallSite]?.label ?? String(callSite)
-  );
+  return LLM_CALLSITE_LABELS.get(callSite as LLMCallSite) ?? String(callSite);
 }


### PR DESCRIPTION
## Summary
- Route usage call-site labels through the authoritative call-site catalog.
- Keep compatibility helpers while removing hand-maintained duplicate labels.
- Update usage label tests to match catalog display names.

Part of plan: usage-label-metadata.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
