### PR TITLE
fix(trust-rules): address late review feedback from PR #28993

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -57,6 +57,13 @@ struct RuleEditorModal: View {
         scopeOptions.count == 1
     }
 
+    /// In edit mode, generalized options excluding the existing rule's own pattern.
+    /// Prevents offering a "Save As New" option that would duplicate the existing rule.
+    private var narrowerOptions: [ScopeOptionItem] {
+        guard let existing = existingRule else { return generalizedOptions }
+        return generalizedOptions.filter { $0.pattern != existing.pattern }
+    }
+
     /// Whether the options look like a pipeline decomposition (all "program *" patterns).
     /// Pipeline commands produce per-program wildcards that aren't useful as individual radio choices.
     private var isPipelineDecomposition: Bool {
@@ -124,12 +131,7 @@ struct RuleEditorModal: View {
     /// Whether the Save As New button should be visible.
     private var showSaveAsNew: Bool {
         guard onSaveAsNew != nil, existingRule != nil else { return false }
-        // If the LLM suggestion arrived and matches the existing pattern exactly,
-        // there's no narrower option to offer.
-        if let suggestion, let existing = existingRule, suggestion.pattern == existing.pattern {
-            return false
-        }
-        return !generalizedOptions.isEmpty
+        return !narrowerOptions.isEmpty
     }
 
     private func applySuggestionOrDefaults() {
@@ -250,14 +252,14 @@ struct RuleEditorModal: View {
                 )
 
                 // Narrower scope options for Save As New
-                if showSaveAsNew, !generalizedOptions.isEmpty {
+                if showSaveAsNew {
                     Text("Or narrow the scope:")
                         .font(VFont.labelDefault)
                         .foregroundStyle(VColor.contentSecondary)
                         .accessibilityAddTraits(.isHeader)
 
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        ForEach(Array(generalizedOptions.enumerated()), id: \.element.id) { index, option in
+                        ForEach(Array(narrowerOptions.enumerated()), id: \.element.id) { index, option in
                             patternRow(option: option, index: index)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -143,9 +143,14 @@ struct RuleEditorModal: View {
                 selectedRiskLevel = existingRule.risk.isEmpty ? "medium" : existingRule.risk
             }
             if !hasUserInteracted {
-                // In single-option mode the only Save As New choice is index 0; reset
-                // the initial default of 1 so the option isn't permanently out-of-bounds.
-                if isSingleOption { selectedPatternIndex = 0 }
+                // Default to the first narrower option so the selection isn't stale
+                // or pointing at the existing rule's own pattern.
+                if let firstNarrower = narrowerOptions.first,
+                   let idx = scopeOptions.firstIndex(where: { $0.pattern == firstNarrower.pattern }) {
+                    selectedPatternIndex = idx
+                } else if isSingleOption {
+                    selectedPatternIndex = 0
+                }
             }
             if let suggestion, !hasUserInteracted {
                 // Pre-select Save As New pattern: use LLM suggestion if it differs from existing rule

--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -259,8 +259,10 @@ struct RuleEditorModal: View {
                         .accessibilityAddTraits(.isHeader)
 
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        ForEach(Array(narrowerOptions.enumerated()), id: \.element.id) { index, option in
-                            patternRow(option: option, index: index)
+                        ForEach(narrowerOptions, id: \.id) { option in
+                            if let scopeIdx = scopeOptions.firstIndex(where: { $0.pattern == option.pattern }) {
+                                patternRow(option: option, index: isSingleOption ? scopeIdx : scopeIdx - 1)
+                            }
                         }
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/RuleEditorModal.swift
@@ -124,11 +124,9 @@ struct RuleEditorModal: View {
     /// Whether the Save As New button should be visible.
     private var showSaveAsNew: Bool {
         guard onSaveAsNew != nil, existingRule != nil else { return false }
-        // Hide while suggestion is loading — avoids flickering when the suggestion
-        // arrives and turns out to match the existing rule pattern.
-        guard let suggestion else { return false }
-        // Suppress if LLM found nothing narrower than the existing rule's pattern
-        if let existing = existingRule, suggestion.pattern == existing.pattern {
+        // If the LLM suggestion arrived and matches the existing pattern exactly,
+        // there's no narrower option to offer.
+        if let suggestion, let existing = existingRule, suggestion.pattern == existing.pattern {
             return false
         }
         return !generalizedOptions.isEmpty
@@ -234,8 +232,7 @@ struct RuleEditorModal: View {
             if let existingRule {
                 // Edit mode: show existing rule pattern as read-only
                 HStack(spacing: VSpacing.xs) {
-                    Image(systemName: "lock.fill")
-                        .font(.system(size: 10))
+                    VIconView(.lock, size: 10)
                         .foregroundStyle(VColor.contentTertiary)
                     Text(existingRule.pattern)
                         .font(VFont.bodyMediumDefault.monospaced())

--- a/gateway/src/http/routes/trust-rules.suggest.test.ts
+++ b/gateway/src/http/routes/trust-rules.suggest.test.ts
@@ -212,6 +212,31 @@ describe("POST /v1/trust-rules/suggest", () => {
     expect(callArgs.currentThreshold).toBe("medium");
   });
 
+  test("passes existingRule when provided", async () => {
+    const bodyWithExistingRule = {
+      ...VALID_BODY,
+      existingRule: {
+        id: "rule-123",
+        pattern: "bash *",
+        risk: "low",
+      },
+    };
+
+    const handler = createTrustRulesSuggestHandler();
+    const res = await handler(jsonRequest(bodyWithExistingRule));
+
+    expect(res.status).toBe(200);
+    expect(ipcSuggestTrustRuleMock).toHaveBeenCalledTimes(1);
+    const callArgs = ipcSuggestTrustRuleMock.mock.calls[0][0] as {
+      existingRule: unknown;
+    };
+    expect(callArgs.existingRule).toEqual({
+      id: "rule-123",
+      pattern: "bash *",
+      risk: "low",
+    });
+  });
+
   test("passes directoryScopeOptions when provided", async () => {
     const bodyWithDirScope = {
       ...VALID_BODY,

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -47,6 +47,13 @@ const SuggestRequestSchema = z.object({
     )
     .optional(),
   intent: z.enum(["auto_approve", "escalate"]),
+  existingRule: z
+    .object({
+      id: z.string(),
+      pattern: z.string(),
+      risk: z.string(),
+    })
+    .optional(),
 });
 
 /**

--- a/gateway/src/ipc/assistant-client.ts
+++ b/gateway/src/ipc/assistant-client.ts
@@ -324,6 +324,11 @@ export interface SuggestTrustRuleRequest {
   directoryScopeOptions?: DirectoryScopeOption[];
   currentThreshold: string; // "low" | "medium" | "high"
   intent: "auto_approve" | "escalate";
+  existingRule?: {
+    id: string;
+    pattern: string;
+    risk: string;
+  };
 }
 
 export interface SuggestTrustRuleResponse {
@@ -343,10 +348,9 @@ export interface SuggestTrustRuleResponse {
 export async function ipcSuggestTrustRule(
   params: SuggestTrustRuleRequest,
 ): Promise<SuggestTrustRuleResponse> {
-  const result = await ipcCallAssistant(
-    "suggest_trust_rule",
-    { body: params } as unknown as Record<string, unknown>,
-  );
+  const result = await ipcCallAssistant("suggest_trust_rule", {
+    body: params,
+  } as unknown as Record<string, unknown>);
   if (!result || typeof result !== "object" || Array.isArray(result)) {
     throw new Error("ipcSuggestTrustRule: unexpected response shape");
   }


### PR DESCRIPTION
## Summary
- **Gateway existingRule passthrough**: Added `existingRule` to the gateway's Zod validation schema and IPC interface type so the field is no longer silently stripped by Zod's default `strip` mode — the daemon's LLM prompt now correctly enters refinement mode when editing an existing rule.
- **Design system compliance**: Replaced `Image(systemName: "lock.fill")` with `VIconView(.lock, size: 10)` in `RuleEditorModal` to comply with the `VIcon`-only icon rule.
- **Save As New resilience**: Removed the hard gate on `suggestion != nil` from `showSaveAsNew` so users can save a narrower override rule even when the LLM suggestion request fails or times out.

## Original prompt
address the late PR feedback left on https://github.com/vellum-ai/vellum-assistant/pull/28993
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
