### PR TITLE
assistant: document call-site metadata source of truth

### DIFF
--- a/assistant/src/config/llm-callsite-catalog.ts
+++ b/assistant/src/config/llm-callsite-catalog.ts
@@ -1,6 +1,8 @@
 import { CALL_SITE_CATALOG } from "./schemas/call-site-catalog.js";
 import type { LLMCallSite } from "./schemas/llm.js";
 
+// Compatibility wrapper for existing usage display imports. Do not define
+// labels here; call-site display metadata belongs in CALL_SITE_CATALOG.
 const LLM_CALLSITE_LABELS = new Map<LLMCallSite, string>(
   CALL_SITE_CATALOG.map(({ id, displayName }) => [id, displayName]),
 );

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -29,56 +29,243 @@ export interface CallSiteEntry {
  * is a compile error — no runtime drift guard needed.
  */
 type CatalogRecord = {
-  [K in LLMCallSite]: { id: K; displayName: string; description: string; domain: CallSiteDomainId };
+  [K in LLMCallSite]: {
+    id: K;
+    displayName: string;
+    description: string;
+    domain: CallSiteDomainId;
+  };
 };
 
 const CATALOG_RECORD: CatalogRecord = {
   // agentLoop
-  mainAgent: { id: "mainAgent", displayName: "Main Agent", description: "The primary conversation agent that handles user messages.", domain: "agentLoop" },
-  subagentSpawn: { id: "subagentSpawn", displayName: "Subagent Spawn", description: "Spawns a subagent to handle a delegated subtask.", domain: "agentLoop" },
-  heartbeatAgent: { id: "heartbeatAgent", displayName: "Heartbeat Agent", description: "Runs background tasks and proactive checks on a schedule.", domain: "agentLoop" },
-  filingAgent: { id: "filingAgent", displayName: "Filing Agent", description: "Files memories and updates the knowledge base after conversations.", domain: "agentLoop" },
-  compactionAgent: { id: "compactionAgent", displayName: "Compaction Agent", description: "Compacts conversation history to stay within context limits.", domain: "agentLoop" },
-  analyzeConversation: { id: "analyzeConversation", displayName: "Analyze Conversation", description: "Analyzes conversation content for summaries and insights.", domain: "agentLoop" },
-  callAgent: { id: "callAgent", displayName: "Call Agent", description: "Handles voice call conversations.", domain: "agentLoop" },
+  mainAgent: {
+    id: "mainAgent",
+    displayName: "Main Agent",
+    description: "The primary conversation agent that handles user messages.",
+    domain: "agentLoop",
+  },
+  subagentSpawn: {
+    id: "subagentSpawn",
+    displayName: "Subagent Spawn",
+    description: "Spawns a subagent to handle a delegated subtask.",
+    domain: "agentLoop",
+  },
+  heartbeatAgent: {
+    id: "heartbeatAgent",
+    displayName: "Heartbeat Agent",
+    description: "Runs background tasks and proactive checks on a schedule.",
+    domain: "agentLoop",
+  },
+  filingAgent: {
+    id: "filingAgent",
+    displayName: "Filing Agent",
+    description:
+      "Files memories and updates the knowledge base after conversations.",
+    domain: "agentLoop",
+  },
+  compactionAgent: {
+    id: "compactionAgent",
+    displayName: "Compaction Agent",
+    description: "Compacts conversation history to stay within context limits.",
+    domain: "agentLoop",
+  },
+  analyzeConversation: {
+    id: "analyzeConversation",
+    displayName: "Analyze Conversation",
+    description: "Analyzes conversation content for summaries and insights.",
+    domain: "agentLoop",
+  },
+  callAgent: {
+    id: "callAgent",
+    displayName: "Call Agent",
+    description: "Handles voice call conversations.",
+    domain: "agentLoop",
+  },
 
   // memory
-  memoryExtraction: { id: "memoryExtraction", displayName: "Memory Extraction", description: "Extracts memorable facts from conversation turns.", domain: "memory" },
-  memoryConsolidation: { id: "memoryConsolidation", displayName: "Memory Consolidation", description: "Merges and deduplicates related memories.", domain: "memory" },
-  memoryRetrieval: { id: "memoryRetrieval", displayName: "Memory Retrieval", description: "Retrieves relevant memories to augment the agent context.", domain: "memory" },
-  memoryV2Migration: { id: "memoryV2Migration", displayName: "Memory V2 Migration", description: "One-time migration of memories to the V2 storage format.", domain: "memory" },
-  memoryV2Sweep: { id: "memoryV2Sweep", displayName: "Memory V2 Sweep", description: "Background sweep pass for V2 memory maintenance.", domain: "memory" },
-  recall: { id: "recall", displayName: "Recall", description: "Searches memory to answer a specific question during a turn.", domain: "memory" },
-  narrativeRefinement: { id: "narrativeRefinement", displayName: "Narrative Refinement", description: "Refines the autobiographical narrative stored in memory.", domain: "memory" },
-  patternScan: { id: "patternScan", displayName: "Pattern Scan", description: "Scans memories for recurring behavioral patterns.", domain: "memory" },
+  memoryExtraction: {
+    id: "memoryExtraction",
+    displayName: "Memory Extraction",
+    description: "Extracts memorable facts from conversation turns.",
+    domain: "memory",
+  },
+  memoryConsolidation: {
+    id: "memoryConsolidation",
+    displayName: "Memory Consolidation",
+    description: "Merges and deduplicates related memories.",
+    domain: "memory",
+  },
+  memoryRetrieval: {
+    id: "memoryRetrieval",
+    displayName: "Memory Retrieval",
+    description: "Retrieves relevant memories to augment the agent context.",
+    domain: "memory",
+  },
+  memoryV2Migration: {
+    id: "memoryV2Migration",
+    displayName: "Memory V2 Migration",
+    description: "One-time migration of memories to the V2 storage format.",
+    domain: "memory",
+  },
+  memoryV2Sweep: {
+    id: "memoryV2Sweep",
+    displayName: "Memory V2 Sweep",
+    description: "Background sweep pass for V2 memory maintenance.",
+    domain: "memory",
+  },
+  recall: {
+    id: "recall",
+    displayName: "Recall",
+    description: "Searches memory to answer a specific question during a turn.",
+    domain: "memory",
+  },
+  narrativeRefinement: {
+    id: "narrativeRefinement",
+    displayName: "Narrative Refinement",
+    description: "Refines the autobiographical narrative stored in memory.",
+    domain: "memory",
+  },
+  patternScan: {
+    id: "patternScan",
+    displayName: "Pattern Scan",
+    description: "Scans memories for recurring behavioral patterns.",
+    domain: "memory",
+  },
 
   // workspace
-  conversationSummarization: { id: "conversationSummarization", displayName: "Conversation Summarization", description: "Generates a summary of a completed conversation.", domain: "workspace" },
-  commitMessage: { id: "commitMessage", displayName: "Commit Message", description: "Generates a git commit message for staged changes.", domain: "workspace" },
+  conversationSummarization: {
+    id: "conversationSummarization",
+    displayName: "Conversation Summarization",
+    description: "Generates a summary of a completed conversation.",
+    domain: "workspace",
+  },
+  commitMessage: {
+    id: "commitMessage",
+    displayName: "Commit Message",
+    description: "Generates a git commit message for staged changes.",
+    domain: "workspace",
+  },
 
   // ui
-  conversationStarters: { id: "conversationStarters", displayName: "Conversation Starters", description: "Generates suggested conversation openers for the home screen.", domain: "ui" },
-  conversationTitle: { id: "conversationTitle", displayName: "Conversation Title", description: "Generates a title for a conversation from its content.", domain: "ui" },
-  identityIntro: { id: "identityIntro", displayName: "Identity Intro", description: "Generates the assistant's introductory identity text.", domain: "ui" },
-  emptyStateGreeting: { id: "emptyStateGreeting", displayName: "Empty State Greeting", description: "Generates a greeting shown on the empty conversation screen.", domain: "ui" },
-  guardianQuestionCopy: { id: "guardianQuestionCopy", displayName: "Guardian Question Copy", description: "Generates copy for guardian onboarding questions.", domain: "ui" },
-  approvalCopy: { id: "approvalCopy", displayName: "Approval Copy", description: "Generates copy for tool approval prompts shown to the user.", domain: "ui" },
-  approvalConversation: { id: "approvalConversation", displayName: "Approval Conversation", description: "Handles conversational approval flows.", domain: "ui" },
-  feedEventCopy: { id: "feedEventCopy", displayName: "Feed Event Copy", description: "Generates copy for home feed event cards.", domain: "ui" },
-  trustRuleSuggestion: { id: "trustRuleSuggestion", displayName: "Trust Rule Suggestion", description: "Suggests a trust rule pattern when the user creates a new rule.", domain: "ui" },
+  conversationStarters: {
+    id: "conversationStarters",
+    displayName: "Conversation Starters",
+    description:
+      "Generates suggested conversation openers for the home screen.",
+    domain: "ui",
+  },
+  conversationTitle: {
+    id: "conversationTitle",
+    displayName: "Conversation Title",
+    description: "Generates a title for a conversation from its content.",
+    domain: "ui",
+  },
+  identityIntro: {
+    id: "identityIntro",
+    displayName: "Identity Intro",
+    description: "Generates the assistant's introductory identity text.",
+    domain: "ui",
+  },
+  emptyStateGreeting: {
+    id: "emptyStateGreeting",
+    displayName: "Empty State Greeting",
+    description: "Generates a greeting shown on the empty conversation screen.",
+    domain: "ui",
+  },
+  guardianQuestionCopy: {
+    id: "guardianQuestionCopy",
+    displayName: "Guardian Question Copy",
+    description: "Generates copy for guardian onboarding questions.",
+    domain: "ui",
+  },
+  approvalCopy: {
+    id: "approvalCopy",
+    displayName: "Approval Copy",
+    description: "Generates copy for tool approval prompts shown to the user.",
+    domain: "ui",
+  },
+  approvalConversation: {
+    id: "approvalConversation",
+    displayName: "Approval Conversation",
+    description: "Handles conversational approval flows.",
+    domain: "ui",
+  },
+  feedEventCopy: {
+    id: "feedEventCopy",
+    displayName: "Feed Event Copy",
+    description: "Generates copy for home feed event cards.",
+    domain: "ui",
+  },
+  trustRuleSuggestion: {
+    id: "trustRuleSuggestion",
+    displayName: "Trust Rule Suggestion",
+    description:
+      "Suggests a trust rule pattern when the user creates a new rule.",
+    domain: "ui",
+  },
 
   // notifications
-  notificationDecision: { id: "notificationDecision", displayName: "Notification Decision", description: "Decides whether a background event warrants sending a notification.", domain: "notifications" },
-  preferenceExtraction: { id: "preferenceExtraction", displayName: "Preference Extraction", description: "Extracts notification and communication preferences from messages.", domain: "notifications" },
+  notificationDecision: {
+    id: "notificationDecision",
+    displayName: "Notification Decision",
+    description:
+      "Decides whether a background event warrants sending a notification.",
+    domain: "notifications",
+  },
+  preferenceExtraction: {
+    id: "preferenceExtraction",
+    displayName: "Preference Extraction",
+    description:
+      "Extracts notification and communication preferences from messages.",
+    domain: "notifications",
+  },
 
   // skills
-  interactionClassifier: { id: "interactionClassifier", displayName: "Interaction Classifier", description: "Classifies the type of interaction to route it correctly.", domain: "skills" },
-  styleAnalyzer: { id: "styleAnalyzer", displayName: "Style Analyzer", description: "Analyzes the user's communication style for personalization.", domain: "skills" },
-  inviteInstructionGenerator: { id: "inviteInstructionGenerator", displayName: "Invite Instruction Generator", description: "Generates setup instructions for new skill invites.", domain: "skills" },
-  skillCategoryInference: { id: "skillCategoryInference", displayName: "Skill Category Inference", description: "Infers the category of a skill from its description.", domain: "skills" },
-  meetConsentMonitor: { id: "meetConsentMonitor", displayName: "Meet Consent Monitor", description: "Monitors meeting consent signals during live calls.", domain: "skills" },
-  meetChatOpportunity: { id: "meetChatOpportunity", displayName: "Meet Chat Opportunity", description: "Identifies opportunities to engage in meeting chat.", domain: "skills" },
-  inference: { id: "inference", displayName: "Inference", description: "General-purpose LLM inference call site for skill use.", domain: "skills" },
+  interactionClassifier: {
+    id: "interactionClassifier",
+    displayName: "Interaction Classifier",
+    description: "Classifies the type of interaction to route it correctly.",
+    domain: "skills",
+  },
+  styleAnalyzer: {
+    id: "styleAnalyzer",
+    displayName: "Style Analyzer",
+    description: "Analyzes the user's communication style for personalization.",
+    domain: "skills",
+  },
+  inviteInstructionGenerator: {
+    id: "inviteInstructionGenerator",
+    displayName: "Invite Instruction Generator",
+    description: "Generates setup instructions for new skill invites.",
+    domain: "skills",
+  },
+  skillCategoryInference: {
+    id: "skillCategoryInference",
+    displayName: "Skill Category Inference",
+    description: "Infers the category of a skill from its description.",
+    domain: "skills",
+  },
+  meetConsentMonitor: {
+    id: "meetConsentMonitor",
+    displayName: "Meet Consent Monitor",
+    description: "Monitors meeting consent signals during live calls.",
+    domain: "skills",
+  },
+  meetChatOpportunity: {
+    id: "meetChatOpportunity",
+    displayName: "Meet Chat Opportunity",
+    description: "Identifies opportunities to engage in meeting chat.",
+    domain: "skills",
+  },
+  inference: {
+    id: "inference",
+    displayName: "Inference",
+    description: "General-purpose LLM inference call site for skill use.",
+    domain: "skills",
+  },
 };
 
+// Source of truth for call-site display metadata. API responses and usage
+// display paths should reuse this catalog instead of defining separate labels.
 export const CALL_SITE_CATALOG: CallSiteEntry[] = Object.values(CATALOG_RECORD);


### PR DESCRIPTION
## Summary
- Document the call-site catalog as the source of truth for display metadata.
- Clarify that the usage label helper is only a compatibility wrapper over that catalog.

Part of plan: usage-label-metadata.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/28999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
