### PR TITLE
Add shared Slack text rendering helpers

### DIFF
--- a/packages/slack-text/bun.lock
+++ b/packages/slack-text/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/slack-text",
+      "devDependencies": {
+        "@types/bun": "1.3.10",
+        "typescript": "5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/packages/slack-text/package.json
+++ b/packages/slack-text/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vellumai/slack-text",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.10",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractSlackUserMentionIds,
+  renderSlackTextForModel,
+  stripLeadingSlackMentionFallback,
+  stripLeadingSlackUserMention,
+} from "./index.js";
+
+describe("extractSlackUserMentionIds", () => {
+  test("returns unique user mention IDs in encounter order", () => {
+    expect(
+      extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again"),
+    ).toEqual(["U123", "W456"]);
+  });
+});
+
+describe("stripLeadingSlackUserMention", () => {
+  test("strips only leading mentions for the exact bot ID", () => {
+    expect(stripLeadingSlackUserMention("<@U111> <@U222> hi", "U111")).toBe(
+      "<@U222> hi",
+    );
+  });
+
+  test("strips repeated leading mentions for the exact bot ID", () => {
+    expect(stripLeadingSlackUserMention(" <@U111> <@U111> hi", "U111")).toBe(
+      "hi",
+    );
+  });
+
+  test("preserves text when the leading mention is a different user", () => {
+    expect(stripLeadingSlackUserMention("<@U222> hi <@U111>", "U111")).toBe(
+      "<@U222> hi <@U111>",
+    );
+  });
+});
+
+describe("stripLeadingSlackMentionFallback", () => {
+  test("strips only the first leading Slack user mention", () => {
+    expect(stripLeadingSlackMentionFallback(" <@U111> <@U222> hi")).toBe(
+      "<@U222> hi",
+    );
+  });
+});
+
+describe("renderSlackTextForModel", () => {
+  test("renders resolved user mentions", () => {
+    expect(
+      renderSlackTextForModel("hello <@U123>", {
+        userLabels: { U123: "Alice" },
+      }),
+    ).toBe("hello @Alice");
+  });
+
+  test("renders multiple mentions and never emits unresolved user IDs", () => {
+    const rendered = renderSlackTextForModel("<@U123> <@W456> <@U789>", {
+      userLabels: { U123: "Alice", W456: "Bob" },
+    });
+
+    expect(rendered).toBe("@Alice @Bob @unknown-user");
+    expect(rendered).not.toContain("U789");
+  });
+
+  test("renders channel references with labels and fallbacks", () => {
+    expect(
+      renderSlackTextForModel("<#C123|general> <#C456>", {
+        channelLabels: { C456: "support" },
+      }),
+    ).toBe("#general #support");
+
+    expect(renderSlackTextForModel("<#C789>")).toBe("#unknown-channel");
+  });
+
+  test("renders special broadcasts", () => {
+    expect(renderSlackTextForModel("<!here> <!channel> <!everyone>")).toBe(
+      "@here @channel @everyone",
+    );
+  });
+
+  test("renders usergroups with labels and fallback", () => {
+    expect(
+      renderSlackTextForModel("<!subteam^S123|eng> <!subteam^S456>"),
+    ).toBe("@eng @usergroup");
+  });
+
+  test("renders labeled and unlabeled links", () => {
+    expect(
+      renderSlackTextForModel(
+        "<https://example.com|Example> <https://example.org>",
+      ),
+    ).toBe("Example (https://example.com) https://example.org");
+  });
+
+  test("sanitizes malicious and empty labels before adding prefixes", () => {
+    expect(
+      renderSlackTextForModel(
+        "<@U123> <#C123> <#C456|#  > <!subteam^S123|@eng>",
+        {
+          userLabels: { U123: " @<system>  prompt " },
+          channelLabels: { C123: "#<ops>" },
+        },
+      ),
+    ).toBe("@system prompt #ops #unknown-channel @eng");
+  });
+
+  test("uses sanitized custom fallbacks", () => {
+    expect(
+      renderSlackTextForModel("<@U123> <#C123>", {
+        userFallbackLabel: "@ missing user ",
+        channelFallbackLabel: "# missing channel ",
+      }),
+    ).toBe("@missing user #missing channel");
+  });
+});

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -1,0 +1,177 @@
+export interface RenderSlackTextOptions {
+  userLabels?: Record<string, string>;
+  channelLabels?: Record<string, string>;
+  userFallbackLabel?: string;
+  channelFallbackLabel?: string;
+}
+
+const SLACK_USER_MENTION_RE = /<@([UW][A-Z0-9]+)>/g;
+const LEADING_SLACK_USER_MENTION_RE = /^\s*<@[UW][A-Z0-9]+>\s*/;
+
+export function extractSlackUserMentionIds(text: string): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+
+  for (const match of text.matchAll(SLACK_USER_MENTION_RE)) {
+    const id = match[1];
+    if (!seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+
+  return ids;
+}
+
+export function stripLeadingSlackUserMention(
+  text: string,
+  userId: string,
+): string {
+  if (!isSlackUserId(userId)) {
+    return text;
+  }
+
+  const mention = `<@${userId}>`;
+  let stripped = text;
+
+  while (true) {
+    const next = stripLeadingExactToken(stripped, mention);
+    if (next === stripped) {
+      return stripped;
+    }
+    stripped = next;
+  }
+}
+
+export function stripLeadingSlackMentionFallback(text: string): string {
+  return text.replace(LEADING_SLACK_USER_MENTION_RE, "");
+}
+
+export function renderSlackTextForModel(
+  text: string,
+  options: RenderSlackTextOptions = {},
+): string {
+  return text.replace(/<([^<>\s][^<>]*)>/g, (token, content: string) => {
+    if (content.startsWith("@")) {
+      return renderUserMention(content, options);
+    }
+
+    if (content.startsWith("#")) {
+      return renderChannelReference(content, options);
+    }
+
+    if (content.startsWith("!")) {
+      return renderSpecialReference(content);
+    }
+
+    if (looksLikeUrl(content)) {
+      return renderLink(content);
+    }
+
+    return token;
+  });
+}
+
+function renderUserMention(
+  content: string,
+  options: RenderSlackTextOptions,
+): string {
+  const id = content.slice(1);
+  if (!isSlackUserId(id)) {
+    return `<${content}>`;
+  }
+
+  const fallback = sanitizeLabel(options.userFallbackLabel, "unknown-user");
+  const label = sanitizeLabel(options.userLabels?.[id], fallback);
+  return `@${label}`;
+}
+
+function renderChannelReference(
+  content: string,
+  options: RenderSlackTextOptions,
+): string {
+  const [idWithPrefix, label] = splitSlackLabel(content);
+  const channelId = idWithPrefix.slice(1);
+  const fallback = sanitizeLabel(options.channelFallbackLabel, "unknown-channel");
+  const resolvedLabel = label ?? options.channelLabels?.[channelId];
+  return `#${sanitizeLabel(resolvedLabel, fallback)}`;
+}
+
+function renderSpecialReference(content: string): string {
+  if (
+    content === "!here" ||
+    content === "!channel" ||
+    content === "!everyone"
+  ) {
+    return `@${content.slice(1)}`;
+  }
+
+  const subteam = /^!subteam\^[^|>]+(?:\|(.+))?$/.exec(content);
+  if (subteam) {
+    return `@${sanitizeLabel(subteam[1], "usergroup")}`;
+  }
+
+  return `<${content}>`;
+}
+
+function renderLink(content: string): string {
+  const [url, label] = splitSlackLabel(content);
+  if (!label) {
+    return url;
+  }
+
+  return `${sanitizeLabel(label, url)} (${url})`;
+}
+
+function splitSlackLabel(content: string): [string, string | undefined] {
+  const separatorIndex = content.indexOf("|");
+  if (separatorIndex === -1) {
+    return [content, undefined];
+  }
+
+  return [
+    content.slice(0, separatorIndex),
+    content.slice(separatorIndex + 1),
+  ];
+}
+
+function sanitizeLabel(label: string | undefined, fallback: string): string {
+  const sanitized = label
+    ?.replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[@#]+/, "")
+    .trim();
+
+  if (sanitized) {
+    return sanitized;
+  }
+
+  const sanitizedFallback = fallback
+    .replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[@#]+/, "")
+    .trim();
+
+  return sanitizedFallback || "unknown";
+}
+
+function stripLeadingExactToken(text: string, token: string): string {
+  const leadingWhitespaceLength = text.length - text.trimStart().length;
+  const afterWhitespace = text.slice(leadingWhitespaceLength);
+
+  if (!afterWhitespace.startsWith(token)) {
+    return text;
+  }
+
+  return afterWhitespace.slice(token.length).trimStart();
+}
+
+function isSlackUserId(value: string): boolean {
+  return /^[UW][A-Z0-9]+$/.test(value);
+}
+
+function looksLikeUrl(content: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\/\S+$/i.test(splitSlackLabel(content)[0]);
+}

--- a/packages/slack-text/tsconfig.json
+++ b/packages/slack-text/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Add private @vellumai/slack-text package for deterministic Slack mrkdwn rendering
- Convert Slack user, channel, broadcast, usergroup, and link tokens into model-facing labels
- Add mention extraction and leading assistant-mention stripping helpers

## Validation
- cd packages/slack-text && bun test src/index.test.ts
- cd packages/slack-text && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
