### PR TITLE
fix(runtime): drop deprecated/ from vbundle skipDirs to prevent silent file loss

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -568,7 +568,7 @@ export function buildExportVBundle(
     files.push(
       ...walkDirectory(workspaceDir, "workspace", {
         includeBinary: true,
-        skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
+        skipDirs: ["embedding-models", "data/qdrant", "signals"],
       }),
     );
   }
@@ -906,7 +906,7 @@ export async function streamExportVBundle(
     allFileMetadata.push(
       ...walkDirectoryForMetadata(workspaceDir, "workspace", {
         includeBinary: true,
-        skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
+        skipDirs: ["embedding-models", "data/qdrant", "signals"],
       }),
     );
   }


### PR DESCRIPTION
## Summary
- Remove "deprecated" from the vbundle-builder skipDirs lists at lines 571 and 909.
- Prevents silent file loss when load-bearing files (e.g. backup.key per #28747) live under workspace/deprecated/.
- Importer-side WORKSPACE_PRESERVE_PATHS is intentionally unchanged so old/partial bundles still preserve live deprecated/ contents.

Part of plan: vbundle-skipdirs-drop-deprecated.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
