### PR TITLE
fix(macos): stop applying draft threshold override to existing conversations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
@@ -202,12 +202,14 @@ struct ComposerSettingsMenu: View {
             currentPreset = preset
         }
 
-        onDraftInteractiveOverrideChange?(
-            ComposerThresholdPicker.stagedDraftOverride(
-                for: preset,
-                globalInteractive: globalInteractive
+        if assistantConversationId == nil {
+            onDraftInteractiveOverrideChange?(
+                ComposerThresholdPicker.stagedDraftOverride(
+                    for: preset,
+                    globalInteractive: globalInteractive
+                )
             )
-        )
+        }
 
         writeVersion &+= 1
         let currentWriteVersion = writeVersion
@@ -247,9 +249,26 @@ struct ComposerSettingsMenu: View {
                     let conversationOverride = try await thresholdClient.getConversationOverride(
                         conversationId: conversationIdString
                     )
-                    override = conversationOverride ?? draftInteractiveOverride
+                    if let diagnostic = ComposerThresholdPicker.displayOverrideDiagnostic(
+                        assistantConversationId: assistantConversationId,
+                        conversationOverride: conversationOverride,
+                        draftInteractiveOverride: draftInteractiveOverride
+                    ) {
+                        log.debug(
+                            "Threshold settings menu ignoring draft override for existing conversation (\(diagnostic, privacy: .public))"
+                        )
+                    }
+                    override = ComposerThresholdPicker.displayOverride(
+                        assistantConversationId: assistantConversationId,
+                        conversationOverride: conversationOverride,
+                        draftInteractiveOverride: draftInteractiveOverride
+                    )
                 } else {
-                    override = draftInteractiveOverride
+                    override = ComposerThresholdPicker.displayOverride(
+                        assistantConversationId: assistantConversationId,
+                        conversationOverride: nil,
+                        draftInteractiveOverride: draftInteractiveOverride
+                    )
                 }
 
                 guard !Task.isCancelled else { return }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerThresholdPicker.swift
@@ -225,14 +225,16 @@ struct ComposerThresholdPicker: View {
             currentPreset = preset
         }
 
-        // Keep draft state in sync immediately so first-send bootstrap carries
-        // the current selection even before any network write completes.
-        onDraftInteractiveOverrideChange?(
-            Self.stagedDraftOverride(
-                for: preset,
-                globalInteractive: globalInteractive
+        // Keep draft state in sync only while this is still a draft chat.
+        // Existing conversations must rely on persisted per-conversation state.
+        if assistantConversationId == nil {
+            onDraftInteractiveOverrideChange?(
+                Self.stagedDraftOverride(
+                    for: preset,
+                    globalInteractive: globalInteractive
+                )
             )
-        )
+        }
 
         // Serialize writes instead of canceling in-flight network calls.
         // Cancellation doesn't guarantee the underlying HTTP request stops,
@@ -279,13 +281,26 @@ struct ComposerThresholdPicker: View {
                     let conversationOverride = try await thresholdClient.getConversationOverride(
                         conversationId: conversationIdString
                     )
-                    // During first-send bootstrap, the client can receive a
-                    // conversation ID before the server has persisted the new
-                    // override row. Fall back to the staged draft value to
-                    // avoid a one-frame flash to the global default.
-                    override = conversationOverride ?? draftInteractiveOverride
+                    if let diagnostic = Self.displayOverrideDiagnostic(
+                        assistantConversationId: assistantConversationId,
+                        conversationOverride: conversationOverride,
+                        draftInteractiveOverride: draftInteractiveOverride
+                    ) {
+                        log.debug(
+                            "Threshold picker ignoring draft override for existing conversation (\(diagnostic, privacy: .public))"
+                        )
+                    }
+                    override = Self.displayOverride(
+                        assistantConversationId: assistantConversationId,
+                        conversationOverride: conversationOverride,
+                        draftInteractiveOverride: draftInteractiveOverride
+                    )
                 } else {
-                    override = draftInteractiveOverride
+                    override = Self.displayOverride(
+                        assistantConversationId: assistantConversationId,
+                        conversationOverride: nil,
+                        draftInteractiveOverride: draftInteractiveOverride
+                    )
                 }
 
                 guard !Task.isCancelled else { return }
@@ -356,5 +371,35 @@ struct ComposerThresholdPicker: View {
         case .set(let threshold): threshold
         case .clear: nil
         }
+    }
+
+    /// Returns the override string to display in the picker for the current
+    /// context. Draft override state only applies before a conversation exists.
+    static func displayOverride(
+        assistantConversationId: String?,
+        conversationOverride: String?,
+        draftInteractiveOverride: String?
+    ) -> String? {
+        if canonicalConversationId(assistantConversationId) == nil {
+            return draftInteractiveOverride
+        }
+        return conversationOverride
+    }
+
+    /// Optional debug diagnostic when draft threshold state exists for an
+    /// existing conversation and disagrees with persisted conversation state.
+    static func displayOverrideDiagnostic(
+        assistantConversationId: String?,
+        conversationOverride: String?,
+        draftInteractiveOverride: String?
+    ) -> String? {
+        guard canonicalConversationId(assistantConversationId) != nil else { return nil }
+        guard let draftInteractiveOverride else { return nil }
+        if let conversationOverride {
+            return conversationOverride == draftInteractiveOverride
+                ? nil
+                : "draft_conflicts_with_conversation_override"
+        }
+        return "draft_present_without_conversation_override"
     }
 }

--- a/clients/macos/vellum-assistantTests/Features/Chat/ComposerThresholdPickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ComposerThresholdPickerTests.swift
@@ -158,6 +158,89 @@ final class ComposerThresholdPickerTests: XCTestCase {
         XCTAssertEqual(ThresholdPreset.from(riskThreshold: .medium), .relaxed)
         XCTAssertEqual(ThresholdPreset.from(riskThreshold: .high), .fullAccess)
     }
+
+    func testDisplayOverrideUsesDraftOnlyBeforeConversationExists() {
+        XCTAssertEqual(
+            ComposerThresholdPicker.displayOverride(
+                assistantConversationId: nil,
+                conversationOverride: nil,
+                draftInteractiveOverride: RiskThreshold.high.rawValue
+            ),
+            RiskThreshold.high.rawValue
+        )
+
+        XCTAssertEqual(
+            ComposerThresholdPicker.displayOverride(
+                assistantConversationId: "   ",
+                conversationOverride: nil,
+                draftInteractiveOverride: RiskThreshold.medium.rawValue
+            ),
+            RiskThreshold.medium.rawValue
+        )
+    }
+
+    func testDisplayOverrideIgnoresDraftForExistingConversationWithoutOverride() {
+        XCTAssertNil(
+            ComposerThresholdPicker.displayOverride(
+                assistantConversationId: "51fc92c1-73f6-4e90-870e-1da80a5a7052",
+                conversationOverride: nil,
+                draftInteractiveOverride: RiskThreshold.high.rawValue
+            )
+        )
+    }
+
+    func testDisplayOverridePrefersConversationOverrideForExistingConversation() {
+        XCTAssertEqual(
+            ComposerThresholdPicker.displayOverride(
+                assistantConversationId: "51fc92c1-73f6-4e90-870e-1da80a5a7052",
+                conversationOverride: RiskThreshold.low.rawValue,
+                draftInteractiveOverride: RiskThreshold.high.rawValue
+            ),
+            RiskThreshold.low.rawValue
+        )
+    }
+
+    func testDisplayOverrideDiagnosticNilForDraftConversation() {
+        XCTAssertNil(
+            ComposerThresholdPicker.displayOverrideDiagnostic(
+                assistantConversationId: nil,
+                conversationOverride: nil,
+                draftInteractiveOverride: RiskThreshold.high.rawValue
+            )
+        )
+    }
+
+    func testDisplayOverrideDiagnosticReportsDraftWithoutConversationOverride() {
+        XCTAssertEqual(
+            ComposerThresholdPicker.displayOverrideDiagnostic(
+                assistantConversationId: "51fc92c1-73f6-4e90-870e-1da80a5a7052",
+                conversationOverride: nil,
+                draftInteractiveOverride: RiskThreshold.high.rawValue
+            ),
+            "draft_present_without_conversation_override"
+        )
+    }
+
+    func testDisplayOverrideDiagnosticReportsConflictWithConversationOverride() {
+        XCTAssertEqual(
+            ComposerThresholdPicker.displayOverrideDiagnostic(
+                assistantConversationId: "51fc92c1-73f6-4e90-870e-1da80a5a7052",
+                conversationOverride: RiskThreshold.low.rawValue,
+                draftInteractiveOverride: RiskThreshold.high.rawValue
+            ),
+            "draft_conflicts_with_conversation_override"
+        )
+    }
+
+    func testDisplayOverrideDiagnosticNilWhenValuesMatch() {
+        XCTAssertNil(
+            ComposerThresholdPicker.displayOverrideDiagnostic(
+                assistantConversationId: "51fc92c1-73f6-4e90-870e-1da80a5a7052",
+                conversationOverride: RiskThreshold.high.rawValue,
+                draftInteractiveOverride: RiskThreshold.high.rawValue
+            )
+        )
+    }
 }
 
 private final class MockThresholdClient: ThresholdClientProtocol {


### PR DESCRIPTION
## Summary
- Guard draft interactive override writes so they only apply before a conversation exists (`assistantConversationId == nil`)
- Extract `displayOverride` and `displayOverrideDiagnostic` static helpers to centralize override resolution logic
- Add unit tests covering draft-only, existing-conversation, and diagnostic edge cases
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
