### PR TITLE
chore(cli): migrate restore.ts to unified signed-url endpoint

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -9,7 +9,7 @@ import {
 import {
   readPlatformToken,
   rollbackPlatformAssistant,
-  platformRequestUploadUrl,
+  platformRequestSignedUrl,
   platformUploadToSignedUrl,
   platformImportPreflightFromGcs,
   platformImportBundleFromGcs,
@@ -180,7 +180,8 @@ async function restorePlatform(
   }
 
   // Step 1.5 — Upload to GCS via signed URL
-  const { uploadUrl, bundleKey } = await platformRequestUploadUrl(
+  const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
+    { operation: "upload" },
     token,
     entry.runtimeUrl,
   );

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -669,45 +669,6 @@ export async function rollbackPlatformAssistant(
 // Signed-URL upload flow
 // ---------------------------------------------------------------------------
 
-export async function platformRequestUploadUrl(
-  token: string,
-  platformUrl?: string,
-): Promise<{ uploadUrl: string; bundleKey: string; expiresAt: string }> {
-  const resolvedUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(`${resolvedUrl}/v1/migrations/upload-url/`, {
-    method: "POST",
-    headers: await authHeaders(token, platformUrl),
-    body: JSON.stringify({ content_type: "application/octet-stream" }),
-  });
-
-  if (response.status === 201) {
-    const body = (await response.json()) as {
-      upload_url: string;
-      bundle_key: string;
-      expires_at: string;
-    };
-    return {
-      uploadUrl: body.upload_url,
-      bundleKey: body.bundle_key,
-      expiresAt: body.expires_at,
-    };
-  }
-
-  if (response.status === 404 || response.status === 503) {
-    throw new Error(
-      "Signed uploads are not available on this platform instance",
-    );
-  }
-
-  const errorBody = (await response.json().catch(() => ({}))) as {
-    detail?: string;
-  };
-  throw new Error(
-    errorBody.detail ??
-      `Failed to request upload URL: ${response.status} ${response.statusText}`,
-  );
-}
-
 export async function platformUploadToSignedUrl(
   uploadUrl: string,
   bundleData: Uint8Array<ArrayBuffer>,


### PR DESCRIPTION
## Summary
- Switch `cli/src/commands/restore.ts` from the legacy `platformRequestUploadUrl` helper to the unified `platformRequestSignedUrl({ operation: "upload" }, ...)` endpoint already used by teleport.ts.
- Delete the now-unused `platformRequestUploadUrl` helper from `cli/src/lib/platform-client.ts`.
- Note: the plan's catch-block fallback substring change (`"not available"` -> `"unavailable"`) was a no-op for this file — restore.ts has no inline-upload fallback path, so no catch block exists to update.

Part of plan: cli-upload-url-consolidation.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
