### PR TITLE
refactor: rename feature flag scope "macos" to "client"

### DIFF
--- a/assistant/src/config/__tests__/feature-flag-registry-guard.test.ts
+++ b/assistant/src/config/__tests__/feature-flag-registry-guard.test.ts
@@ -31,7 +31,7 @@ function loadRegistry(): Record<string, unknown> {
   return JSON.parse(raw);
 }
 
-const VALID_SCOPES = new Set(["assistant", "macos"]);
+const VALID_SCOPES = new Set(["assistant", "client"]);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -169,7 +169,7 @@ describe("unified feature flag registry guard", () => {
       const scope = flag.scope as string;
       if (!VALID_SCOPES.has(scope)) {
         violations.push(
-          `flag '${flag.id}' has invalid scope '${scope}' (expected 'assistant' or 'macos')`,
+          `flag '${flag.id}' has invalid scope '${scope}' (expected 'assistant' or 'client')`,
         );
       }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/FeatureFlagsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/FeatureFlagsCard.swift
@@ -35,7 +35,7 @@ struct FeatureFlagsCard: View {
     @State private var unifiedFlags: [UnifiedFeatureFlag] = []
 
     var body: some View {
-        SettingsCard(title: "Feature Flags", subtitle: "Toggle feature flags for the assistant and macOS app.") {
+        SettingsCard(title: "Feature Flags", subtitle: "Toggle feature flags for the assistant and client apps.") {
             HStack(spacing: VSpacing.sm) {
                 VSearchBar(placeholder: "Search flags...", text: $searchText)
                 VDropdown(
@@ -44,7 +44,7 @@ struct FeatureFlagsCard: View {
                     options: [
                         (label: "All", value: "all"),
                         (label: "Assistant", value: "assistant"),
-                        (label: "macOS", value: "macos")
+                        (label: "Client", value: "client")
                     ],
                     maxWidth: 130
                 )
@@ -99,8 +99,8 @@ struct FeatureFlagsCard: View {
         var flags = unifiedFlags
         if scopeFilter == "assistant" {
             flags = flags.filter { $0.scope == .assistant }
-        } else if scopeFilter == "macos" {
-            flags = flags.filter { $0.scope == .macos }
+        } else if scopeFilter == "client" {
+            flags = flags.filter { $0.scope == .client }
         }
         if !searchText.isEmpty {
             flags = flags.filter { flag in
@@ -145,7 +145,7 @@ struct FeatureFlagsCard: View {
                 description: state.description,
                 defaultEnabled: state.defaultEnabled,
                 enabled: state.enabled,
-                scope: .macos
+                scope: .client
             )
         }
         let macOSKeys = Set(fromMacOS.map { $0.key })
@@ -160,7 +160,7 @@ struct FeatureFlagsCard: View {
                 switch flag.scope {
                 case .assistant:
                     return assistantFlags.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
-                case .macos:
+                case .client:
                     return macOSFlagStates.first(where: { $0.key == flag.key })?.enabled ?? flag.enabled
                 }
             },
@@ -168,7 +168,7 @@ struct FeatureFlagsCard: View {
                 switch flag.scope {
                 case .assistant:
                     setAssistantFlag(key: flag.key, enabled: newValue, flag: flag)
-                case .macos:
+                case .client:
                     setMacOSFlag(key: flag.key, enabled: newValue)
                 }
             }
@@ -182,7 +182,7 @@ struct FeatureFlagsCard: View {
                     Text(flag.label)
                         .font(VFont.bodyMediumLighter)
                         .foregroundStyle(VColor.contentSecondary)
-                    VBadge(label: flag.scope == .assistant ? "Assistant" : "macOS",
+                    VBadge(label: flag.scope == .assistant ? "Assistant" : "Client",
                            tone: flag.scope == .assistant ? .accent : .neutral,
                            emphasis: .subtle)
                 }

--- a/clients/shared/Utilities/FeatureFlagRegistry.swift
+++ b/clients/shared/Utilities/FeatureFlagRegistry.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Scope of a feature flag — determines which platform consumes it.
 public enum FeatureFlagScope: String, Decodable {
     case assistant
-    case macos
+    case client
 }
 
 /// A single entry in the unified feature flag registry.
@@ -25,9 +25,9 @@ public struct FeatureFlagRegistry: Decodable {
 
     // MARK: - Scope filters
 
-    /// Return only flags with `scope == .macos`.
-    public func macosScopeFlags() -> [FeatureFlagDefinition] {
-        flags.filter { $0.scope == .macos }
+    /// Return only flags with `scope == .client`.
+    public func clientScopeFlags() -> [FeatureFlagDefinition] {
+        flags.filter { $0.scope == .client }
     }
 
     /// Return only flags with `scope == .assistant`.

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -52,10 +52,10 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         loadRegistry()
     }
 
-    /// Load macOS-scope flag definitions from the bundled registry.
+    /// Load client-scope flag definitions from the bundled registry.
     private func loadRegistry() {
         if let registry = loadFeatureFlagRegistry() {
-            flagDefinitions = registry.macosScopeFlags()
+            flagDefinitions = registry.clientScopeFlags()
         } else {
             log.warning("Failed to load feature flag registry from bundle — falling back to empty definitions")
             flagDefinitions = []

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -41,7 +41,7 @@ const TEST_REGISTRY = {
     },
     {
       id: "user-hosted-enabled",
-      scope: "macos",
+      scope: "client",
       key: "user-hosted-enabled",
       label: "User Hosted Enabled",
       description: "Enable user-hosted onboarding flow",

--- a/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
+++ b/gateway/src/__tests__/ipc-feature-flag-routes.test.ts
@@ -39,7 +39,7 @@ const TEST_REGISTRY = {
     },
     {
       id: "user-hosted-enabled",
-      scope: "macos",
+      scope: "client",
       key: "user-hosted-enabled",
       label: "User Hosted Enabled",
       description: "Enable user-hosted onboarding flow",

--- a/meta/feature-flags/AGENTS.md
+++ b/meta/feature-flags/AGENTS.md
@@ -11,7 +11,7 @@ Feature flag keys are **simple kebab-case strings** with no prefix or suffix:
 "conversation-starters"
 ```
 
-The `id` and `key` fields in `feature-flag-registry.json` **must match** and both use kebab-case. macOS-scope flags follow the same convention:
+The `id` and `key` fields in `feature-flag-registry.json` **must match** and both use kebab-case. client-scope flags follow the same convention:
 
 ```
 "user-hosted-enabled"

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -19,7 +19,7 @@
     },
     {
       "id": "user-hosted-enabled",
-      "scope": "macos",
+      "scope": "client",
       "key": "user-hosted-enabled",
       "label": "User Hosted Enabled",
       "description": "Enable user-hosted onboarding flow",
@@ -27,7 +27,7 @@
     },
     {
       "id": "local-docker-enabled",
-      "scope": "macos",
+      "scope": "client",
       "key": "local-docker-enabled",
       "label": "Local Docker Mode",
       "description": "When enabled, the Local hosting option uses Docker under the hood for sandboxed execution, hiding the separate Docker card",
@@ -51,7 +51,7 @@
     },
     {
       "id": "mobile-pairing",
-      "scope": "macos",
+      "scope": "client",
       "key": "mobile-pairing",
       "label": "Mobile Pairing",
       "description": "Show the Mobile (iOS) pairing card in Settings > Account",
@@ -67,7 +67,7 @@
     },
     {
       "id": "developer-menu-items",
-      "scope": "macos",
+      "scope": "client",
       "key": "developer-menu-items",
       "label": "Developer Menu Items",
       "description": "Show Component Gallery and Replay Onboarding in the menu bar",
@@ -123,7 +123,7 @@
     },
     {
       "id": "settings-billing",
-      "scope": "macos",
+      "scope": "client",
       "key": "settings-billing",
       "label": "Billing Settings Tab",
       "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
@@ -131,7 +131,7 @@
     },
     {
       "id": "referral-codes",
-      "scope": "macos",
+      "scope": "client",
       "key": "referral-codes",
       "label": "Referral Codes",
       "description": "Surface the Earn Credits referral entry points (sidebar drawer row and Billing tab button) that open the referral modal",
@@ -139,7 +139,7 @@
     },
     {
       "id": "managed-sign-in",
-      "scope": "macos",
+      "scope": "client",
       "key": "managed-sign-in",
       "label": "Managed Sign In",
       "description": "Enable managed (organization-hosted) sign-in flow in the onboarding experience",
@@ -179,7 +179,7 @@
     },
     {
       "id": "quick-input",
-      "scope": "macos",
+      "scope": "client",
       "key": "quick-input",
       "label": "Quick Input",
       "description": "Enable the Quick Input popover on right-click of the menu bar icon",
@@ -187,7 +187,7 @@
     },
     {
       "id": "expand-completed-steps",
-      "scope": "macos",
+      "scope": "client",
       "key": "expand-completed-steps",
       "label": "Expand Completed Steps",
       "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
@@ -195,7 +195,7 @@
     },
     {
       "id": "show-thinking-blocks",
-      "scope": "macos",
+      "scope": "client",
       "key": "show-thinking-blocks",
       "label": "Show Thinking Blocks",
       "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
@@ -267,7 +267,7 @@
     },
     {
       "id": "teleport",
-      "scope": "macos",
+      "scope": "client",
       "key": "teleport",
       "label": "Teleport",
       "description": "Enable teleport UI in General settings for moving assistants between hosting environments",
@@ -275,7 +275,7 @@
     },
     {
       "id": "apple-container",
-      "scope": "macos",
+      "scope": "client",
       "key": "apple-container",
       "label": "Apple Container",
       "description": "Enable assistant sandboxing via Apple Containers on macOS 26+, providing a lightweight native sandbox without third-party dependencies",
@@ -299,7 +299,7 @@
     },
     {
       "id": "fork-from-message",
-      "scope": "macos",
+      "scope": "client",
       "key": "fork-from-message",
       "label": "Fork from Message",
       "description": "Show the 'Fork from here' option in message overflow menus",
@@ -307,7 +307,7 @@
     },
     {
       "id": "onboarding-pre-chat",
-      "scope": "macos",
+      "scope": "client",
       "key": "onboarding-pre-chat",
       "label": "Pre-Chat Onboarding Flow",
       "description": "Gates the 3-screen pre-chat onboarding flow (tools, tasks/tone, name exchange) shown before the first conversation",
@@ -315,7 +315,7 @@
     },
     {
       "id": "home-tab",
-      "scope": "macos",
+      "scope": "client",
       "key": "home-tab",
       "label": "Home Tab",
       "description": "Replace the knowledge graph top-level tab with a new Home page showing relationship progression, facts, and capability tiers",
@@ -339,7 +339,7 @@
     },
     {
       "id": "scroll-debug-overlay",
-      "scope": "macos",
+      "scope": "client",
       "key": "scroll-debug-overlay",
       "label": "Scroll Debug Overlay",
       "description": "Show a live HUD in the top-right of the conversation with scroll geometry, velocity, update rate, and anchor-preserver activity. Developer diagnostic for investigating scroll jank.",
@@ -347,7 +347,7 @@
     },
     {
       "id": "message-height-cache",
-      "scope": "macos",
+      "scope": "client",
       "key": "message-height-cache",
       "label": "Message Height Cache",
       "description": "Swap the transcript's LazyVStack for a plain VStack so scrollContentHeight is the true sum of row heights (no LazyVStack estimator drift). Row frames are not pinned — the earlier frame-pinning approach was removed because it caused overlap when rows grew past their first measurement (streaming, expanding thinking blocks). Tradeoff: eager layout — every row measures up-front, which can stall for many seconds to minutes on very long conversations.",

--- a/meta/feature-flags/loader.ts
+++ b/meta/feature-flags/loader.ts
@@ -14,7 +14,7 @@ import { join } from 'path';
 // Types
 // ---------------------------------------------------------------------------
 
-export type FeatureFlagScope = 'assistant' | 'macos';
+export type FeatureFlagScope = 'assistant' | 'client';
 
 export interface FeatureFlagDefinition {
   id: string;
@@ -55,7 +55,7 @@ export function getAssistantScopeFlags(registry: FeatureFlagRegistry): FeatureFl
   return registry.flags.filter((f) => f.scope === 'assistant');
 }
 
-/** Return only flags with `scope === 'macos'`. */
-export function getMacosScopeFlags(registry: FeatureFlagRegistry): FeatureFlagDefinition[] {
-  return registry.flags.filter((f) => f.scope === 'macos');
+/** Return only flags with `scope === 'client'`. */
+export function getClientScopeFlags(registry: FeatureFlagRegistry): FeatureFlagDefinition[] {
+  return registry.flags.filter((f) => f.scope === 'client');
 }


### PR DESCRIPTION
## Summary
- Rename feature flag scope `macos` to `client` across TypeScript, Swift, JSON registry, and UI
- Rename scope filter functions: `getMacosScopeFlags` → `getClientScopeFlags` (TS), `macosScopeFlags()` → `clientScopeFlags()` (Swift)
- Update Settings UI to show "Client" instead of "macOS" for scope filtering

Part of plan: rename-ff-scope-to-client.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
