### PR TITLE
fix(cli): remove dead 503 fallback scaffolding from platformRequestSignedUrl

### DIFF
--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -291,7 +291,7 @@ describe("platformRequestSignedUrl", () => {
     expect(signedUrlCalls[0]!.headers.Authorization).toBeUndefined();
   });
 
-  test("503 → throws so callers can fall back to legacy inline upload", async () => {
+  test("5xx error response → surfaces platform detail message", async () => {
     const { fetchMock } = captureFetch(() => {
       return new Response(JSON.stringify({ detail: "temporarily down" }), {
         status: 503,
@@ -305,7 +305,7 @@ describe("platformRequestSignedUrl", () => {
         VAK_TOKEN,
         PLATFORM_URL,
       ),
-    ).rejects.toThrow(/503/);
+    ).rejects.toThrow(/temporarily down/);
   });
 });
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -815,8 +815,7 @@ export function parseUnifiedJobStatus(
  *   runtime can GET the bundle from during an import-from-GCS flow.
  *
  * Retries once with a fresh org-ID cache on 401 to match the retry pattern
- * used by other authenticated platform helpers. 503 is bubbled up so
- * callers can decide to fall back (e.g. legacy inline upload).
+ * used by other authenticated platform helpers.
  */
 export async function platformRequestSignedUrl(
   params: {
@@ -872,12 +871,6 @@ export async function platformRequestSignedUrl(
       expiresAt: json.expires_at,
       maxContentLength: json.max_content_length,
     };
-  }
-
-  if (response.status === 503) {
-    throw new Error(
-      `Signed URL endpoint unavailable (503) — caller may fall back`,
-    );
   }
 
   const errorBody = (await response.json().catch(() => ({}))) as {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cli-upload-url-consolidation.md.

**Gap:** Dead 503 fallback scaffolding in platformRequestSignedUrl
**What was found:** After PR #29004 deleted the legacy `platformRequestUploadUrl` helper and its caller's try/catch fallback, `platformRequestSignedUrl` still has a 503 branch + docstring sentence claiming "callers may fall back". No caller relies on that behavior anymore — the special-case is dead code and the docstring is misleading.
**Fix:** Remove the 503 branch (let 503 fall through to the generic error handler so the platform's `detail` is surfaced), trim the misleading docstring sentence, and update the corresponding test to assert the generic-error path.

Part of plan: cli-upload-url-consolidation.md (slop pass cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
