### PR TITLE
Load macOS call-site labels from runtime catalog

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
@@ -71,43 +71,81 @@ public struct CallSiteOverride: Identifiable, Equatable, Hashable {
 
 /// Catalog of every LLM call site the assistant exposes.
 ///
-/// Starts pre-seeded with the static catalog so the UI works before the
-/// API fetch completes. `ensureLoaded(using:)` fetches from the assistant
-/// runtime and replaces the seed data with the authoritative API response,
-/// then sets `isLoaded = true`.
+/// Display metadata is owned by the assistant runtime's
+/// `config/llm/call-sites` API. The client may hydrate from the last cached
+/// response while fetching, but must not define a parallel call-site list.
 @MainActor
 @Observable
 public final class CallSiteCatalog {
     public static let shared = CallSiteCatalog()
 
-    public private(set) var domains: [CallSiteDomain] = CallSiteCatalog.staticDomains
-    public private(set) var callSites: [CallSiteOverride] = CallSiteCatalog.staticCallSites
+    public private(set) var domains: [CallSiteDomain]
+    public private(set) var callSites: [CallSiteOverride]
     public private(set) var isLoaded: Bool = false
 
-    @ObservationIgnored private var fetchTask: Task<Void, Never>?
+    @ObservationIgnored private var fetchTask: (id: UUID, task: Task<CallSiteCatalogResponse?, Never>)?
+    @ObservationIgnored private var latestRequestId: UUID?
 
-    private init() {}
+    private static let cachedResponseKey = "llmCallSiteCatalogResponse.v1"
+
+    private init() {
+        if let cached = Self.loadCachedResponse() {
+            self.domains = Self.domains(from: cached)
+            self.callSites = Self.callSites(from: cached)
+        } else {
+            self.domains = []
+            self.callSites = []
+        }
+    }
 
     /// Fetch the catalog from the assistant API if not already loaded.
-    /// Safe to call multiple times — subsequent calls before the first
-    /// fetch completes are no-ops.
-    @MainActor public func ensureLoaded(using client: SettingsClientProtocol = SettingsClient()) {
-        guard !isLoaded, fetchTask == nil else { return }
-        fetchTask = Task { @MainActor in
-            if let response = await client.fetchCallSiteCatalog() {
-                self.domains = response.domains.map { CallSiteDomain(id: $0.id, displayName: $0.displayName) }
-                self.callSites = response.callSites.map {
-                    CallSiteOverride(
-                        id: $0.id,
-                        displayName: $0.displayName,
-                        callSiteDescription: $0.description,
-                        domain: $0.domain
-                    )
-                }
-                self.isLoaded = true
-            }
-            self.fetchTask = nil
+    /// Safe to call multiple times — concurrent callers share one request.
+    @discardableResult
+    @MainActor public func ensureLoaded(using client: SettingsClientProtocol = SettingsClient()) async -> Bool {
+        await load(using: client, force: false)
+    }
+
+    /// Re-fetch the catalog even when a prior response has already loaded.
+    @discardableResult
+    @MainActor public func reload(using client: SettingsClientProtocol = SettingsClient()) async -> Bool {
+        await load(using: client, force: true)
+    }
+
+    @discardableResult
+    private func load(using client: SettingsClientProtocol, force: Bool) async -> Bool {
+        if isLoaded && !force {
+            return true
         }
+
+        let requestId: UUID
+        let task: Task<CallSiteCatalogResponse?, Never>
+        if let fetchTask, !force {
+            requestId = fetchTask.id
+            task = fetchTask.task
+        } else {
+            requestId = UUID()
+            let newTask = Task { @MainActor in await client.fetchCallSiteCatalog() }
+            latestRequestId = requestId
+            fetchTask = (id: requestId, task: newTask)
+            task = newTask
+        }
+
+        let response = await task.value
+        if fetchTask?.id == requestId {
+            fetchTask = nil
+        }
+        guard latestRequestId == requestId else {
+            return false
+        }
+
+        guard let response else {
+            return false
+        }
+
+        apply(response)
+        Self.storeCachedResponse(response)
+        isLoaded = true
+        return true
     }
 
     // MARK: - Computed accessors
@@ -130,58 +168,55 @@ public final class CallSiteCatalog {
     public static var byId: [String: CallSiteOverride] { shared.byId }
     public static var validIds: Set<String> { shared.validIds }
 
-    // MARK: - Static seed (fallback / initial state)
+    // MARK: - Catalog hydration
 
-    private static let staticDomains: [CallSiteDomain] = [
-        CallSiteDomain(id: "agentLoop",     displayName: "Agent Loop"),
-        CallSiteDomain(id: "memory",        displayName: "Memory"),
-        CallSiteDomain(id: "workspace",     displayName: "Workspace"),
-        CallSiteDomain(id: "ui",            displayName: "UI"),
-        CallSiteDomain(id: "notifications", displayName: "Notifications"),
-        CallSiteDomain(id: "skills",        displayName: "Skills"),
-    ]
+    private func apply(_ response: CallSiteCatalogResponse) {
+        domains = Self.domains(from: response)
+        callSites = Self.callSites(from: response)
+    }
 
-    private static let staticCallSites: [CallSiteOverride] = [
-        // agentLoop
-        CallSiteOverride(id: "mainAgent",         displayName: "Main Agent",         callSiteDescription: "The primary conversation agent that handles user messages.",             domain: "agentLoop"),
-        CallSiteOverride(id: "subagentSpawn",     displayName: "Subagent Spawn",     callSiteDescription: "Spawns a subagent to handle a delegated subtask.",                      domain: "agentLoop"),
-        CallSiteOverride(id: "heartbeatAgent",    displayName: "Heartbeat Agent",    callSiteDescription: "Runs background tasks and proactive checks on a schedule.",              domain: "agentLoop"),
-        CallSiteOverride(id: "filingAgent",       displayName: "Filing Agent",       callSiteDescription: "Files memories and updates the knowledge base after conversations.",     domain: "agentLoop"),
-        CallSiteOverride(id: "compactionAgent",   displayName: "Compaction Agent",   callSiteDescription: "Compacts conversation history to stay within context limits.",           domain: "agentLoop"),
-        CallSiteOverride(id: "analyzeConversation", displayName: "Analyze Conversation", callSiteDescription: "Analyzes conversation content for summaries and insights.",          domain: "agentLoop"),
-        CallSiteOverride(id: "callAgent",         displayName: "Call Agent",         callSiteDescription: "Handles voice call conversations.",                                      domain: "agentLoop"),
-        // memory
-        CallSiteOverride(id: "memoryExtraction",    displayName: "Memory Extraction",    callSiteDescription: "Extracts memorable facts from conversation turns.",                  domain: "memory"),
-        CallSiteOverride(id: "memoryConsolidation", displayName: "Memory Consolidation", callSiteDescription: "Merges and deduplicates related memories.",                         domain: "memory"),
-        CallSiteOverride(id: "memoryRetrieval",     displayName: "Memory Retrieval",     callSiteDescription: "Retrieves relevant memories to augment the agent context.",          domain: "memory"),
-        CallSiteOverride(id: "memoryV2Migration",   displayName: "Memory V2 Migration",  callSiteDescription: "One-time migration of memories to the V2 storage format.",           domain: "memory"),
-        CallSiteOverride(id: "memoryV2Sweep",       displayName: "Memory V2 Sweep",      callSiteDescription: "Background sweep pass for V2 memory maintenance.",                   domain: "memory"),
-        CallSiteOverride(id: "recall",              displayName: "Recall",               callSiteDescription: "Searches memory to answer a specific question during a turn.",        domain: "memory"),
-        CallSiteOverride(id: "narrativeRefinement", displayName: "Narrative Refinement", callSiteDescription: "Refines the autobiographical narrative stored in memory.",            domain: "memory"),
-        CallSiteOverride(id: "patternScan",         displayName: "Pattern Scan",         callSiteDescription: "Scans memories for recurring behavioral patterns.",                   domain: "memory"),
-        // workspace
-        CallSiteOverride(id: "conversationSummarization", displayName: "Conversation Summarization", callSiteDescription: "Generates a summary of a completed conversation.",       domain: "workspace"),
-        CallSiteOverride(id: "commitMessage",             displayName: "Commit Message",             callSiteDescription: "Generates a git commit message for staged changes.",      domain: "workspace"),
-        // ui
-        CallSiteOverride(id: "conversationStarters", displayName: "Conversation Starters", callSiteDescription: "Generates suggested conversation openers for the home screen.",   domain: "ui"),
-        CallSiteOverride(id: "conversationTitle",    displayName: "Conversation Title",    callSiteDescription: "Generates a title for a conversation from its content.",           domain: "ui"),
-        CallSiteOverride(id: "identityIntro",        displayName: "Identity Intro",        callSiteDescription: "Generates the assistant's introductory identity text.",            domain: "ui"),
-        CallSiteOverride(id: "emptyStateGreeting",   displayName: "Empty State Greeting",  callSiteDescription: "Generates a greeting shown on the empty conversation screen.",     domain: "ui"),
-        CallSiteOverride(id: "guardianQuestionCopy", displayName: "Guardian Question Copy", callSiteDescription: "Generates copy for guardian onboarding questions.",               domain: "ui"),
-        CallSiteOverride(id: "approvalCopy",         displayName: "Approval Copy",         callSiteDescription: "Generates copy for tool approval prompts shown to the user.",      domain: "ui"),
-        CallSiteOverride(id: "approvalConversation", displayName: "Approval Conversation", callSiteDescription: "Handles conversational approval flows.",                           domain: "ui"),
-        CallSiteOverride(id: "feedEventCopy",        displayName: "Feed Event Copy",        callSiteDescription: "Generates copy for home feed event cards.",                        domain: "ui"),
-        CallSiteOverride(id: "trustRuleSuggestion",  displayName: "Trust Rule Suggestion",  callSiteDescription: "Suggests a trust rule pattern when the user creates a new rule.",  domain: "ui"),
-        // notifications
-        CallSiteOverride(id: "notificationDecision",  displayName: "Notification Decision",  callSiteDescription: "Decides whether a background event warrants sending a notification.", domain: "notifications"),
-        CallSiteOverride(id: "preferenceExtraction",  displayName: "Preference Extraction",  callSiteDescription: "Extracts notification and communication preferences from messages.",    domain: "notifications"),
-        // skills
-        CallSiteOverride(id: "interactionClassifier",      displayName: "Interaction Classifier",      callSiteDescription: "Classifies the type of interaction to route it correctly.",   domain: "skills"),
-        CallSiteOverride(id: "styleAnalyzer",              displayName: "Style Analyzer",              callSiteDescription: "Analyzes the user's communication style for personalization.", domain: "skills"),
-        CallSiteOverride(id: "inviteInstructionGenerator", displayName: "Invite Instruction Generator", callSiteDescription: "Generates setup instructions for new skill invites.",          domain: "skills"),
-        CallSiteOverride(id: "skillCategoryInference",     displayName: "Skill Category Inference",    callSiteDescription: "Infers the category of a skill from its description.",         domain: "skills"),
-        CallSiteOverride(id: "meetConsentMonitor",         displayName: "Meet Consent Monitor",        callSiteDescription: "Monitors meeting consent signals during live calls.",           domain: "skills"),
-        CallSiteOverride(id: "meetChatOpportunity",        displayName: "Meet Chat Opportunity",        callSiteDescription: "Identifies opportunities to engage in meeting chat.",           domain: "skills"),
-        CallSiteOverride(id: "inference",                  displayName: "Inference",                   callSiteDescription: "General-purpose LLM inference call site for skill use.",        domain: "skills"),
-    ]
+    private static func domains(from response: CallSiteCatalogResponse) -> [CallSiteDomain] {
+        response.domains.map { CallSiteDomain(id: $0.id, displayName: $0.displayName) }
+    }
+
+    private static func callSites(from response: CallSiteCatalogResponse) -> [CallSiteOverride] {
+        response.callSites.map {
+            CallSiteOverride(
+                id: $0.id,
+                displayName: $0.displayName,
+                callSiteDescription: $0.description,
+                domain: $0.domain
+            )
+        }
+    }
+
+    private static func loadCachedResponse() -> CallSiteCatalogResponse? {
+        guard let data = UserDefaults.standard.data(forKey: cachedResponseKey) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(CallSiteCatalogResponse.self, from: data)
+    }
+
+    private static func storeCachedResponse(_ response: CallSiteCatalogResponse) {
+        guard let data = try? JSONEncoder().encode(response) else {
+            return
+        }
+        UserDefaults.standard.set(data, forKey: cachedResponseKey)
+    }
+
+    func replaceForTesting(_ response: CallSiteCatalogResponse, isLoaded: Bool = true) {
+        fetchTask = nil
+        latestRequestId = nil
+        apply(response)
+        self.isLoaded = isLoaded
+    }
+
+    func clearForTesting() {
+        fetchTask = nil
+        latestRequestId = nil
+        domains = []
+        callSites = []
+        isLoaded = false
+        UserDefaults.standard.removeObject(forKey: Self.cachedResponseKey)
+    }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverridesSheet.swift
@@ -122,7 +122,7 @@ struct CallSiteOverridesSheet: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onAppear { syncDraftsFromStore() }
         .task {
-            catalog.ensureLoaded()
+            await store.ensureCallSiteCatalogLoaded()
         }
         .onChange(of: store.callSiteOverrides) { _, _ in
             syncDraftsFromStore()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -71,15 +71,10 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Per-Call-Site LLM Overrides
 
-    /// Catalog of every LLM call site, merged with whatever overrides the
-    /// user has configured under `llm.callSites.<id>` in the workspace
-    /// config. Order matches `CallSiteCatalog.all` so the UI renders a
-    /// stable list grouped by `CallSiteDomain`.
-    ///
-    /// Seeded from the static catalog so the picker has every row available
-    /// before the first daemon fetch completes. Replaced by
-    /// `loadCallSiteOverrides(config:)` once the daemon reports the
-    /// authoritative config.
+    /// Catalog of every LLM call site from the runtime API, merged with
+    /// whatever overrides the user has configured under `llm.callSites.<id>`
+    /// in the workspace config. Order matches `CallSiteCatalog.all` so the
+    /// UI renders a stable list grouped by `CallSiteDomain`.
     @Published var callSiteOverrides: [CallSiteOverride] = CallSiteCatalog.all
 
     // MARK: - Inference Profiles
@@ -447,6 +442,7 @@ public final class SettingsStore: ObservableObject {
     deinit {
         trustRulesObservationTask?.cancel()
         modelInfoObservationTask?.cancel()
+        callSiteCatalogRefreshTask?.cancel()
     }
 
     init(
@@ -790,6 +786,7 @@ public final class SettingsStore: ObservableObject {
         // mutations, so without this the store would stay at init
         // defaults until the user edits config.json.
         refreshDaemonConfig()
+        refreshCallSiteCatalog()
 
         // Refresh config on daemon (re)connect so config-dependent state
         // recovers after the daemon restarts or after a network blip.
@@ -797,6 +794,7 @@ public final class SettingsStore: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.refreshDaemonConfig()
+                self?.refreshCallSiteCatalog(force: true)
             }
             .store(in: &cancellables)
 
@@ -3180,6 +3178,7 @@ public final class SettingsStore: ObservableObject {
     func loadCallSiteOverrides(config: [String: Any]) {
         let llm = config["llm"] as? [String: Any]
         let callSitesRaw = (llm?["callSites"] as? [String: Any]) ?? [:]
+        latestCallSitesRaw = callSitesRaw
         var byId: [String: (provider: String?, model: String?, profile: String?)] = [:]
         for (id, raw) in callSitesRaw {
             guard CallSiteCatalog.validIds.contains(id),
@@ -3422,11 +3421,12 @@ public final class SettingsStore: ObservableObject {
     /// Deletes a profile under `llm.profiles.<name>` after verifying no
     /// references remain. References checked: the global
     /// `llm.activeProfile` pointer and every per-row entry in
-    /// `callSiteOverrides`. When references exist, returns the
-    /// corresponding `.blockedBy*` variant so the caller can guide the
-    /// user through clearing them. Otherwise issues a PATCH with
-    /// `NSNull()` at the profile key, which the daemon's deep-merge
-    /// treats as deletion.
+    /// `callSiteOverrides`, with a raw-config fallback for call sites the
+    /// runtime catalog has not loaded yet. When references exist, returns
+    /// the corresponding `.blockedBy*` variant so the caller can guide the
+    /// user through clearing them. Otherwise issues a PATCH with `NSNull()`
+    /// at the profile key, which the daemon's deep-merge treats as
+    /// deletion.
     @discardableResult
     func deleteProfile(name: String) async -> DeleteProfileResult {
         if profiles.first(where: { $0.name == name })?.isManaged == true {
@@ -3435,9 +3435,7 @@ public final class SettingsStore: ObservableObject {
         if activeProfile == name {
             return .blockedByActive(activeProfile)
         }
-        let conflictingCallSites = callSiteOverrides
-            .filter { $0.profile == name }
-            .map(\.id)
+        let conflictingCallSites = callSiteIdsReferencingProfile(name)
         if !conflictingCallSites.isEmpty {
             return .blockedByCallSites(conflictingCallSites)
         }
@@ -4475,12 +4473,41 @@ public final class SettingsStore: ObservableObject {
     /// applied state when startup, reconnect, and configChanged triggers
     /// fire in quick succession.
     private var configRefreshTask: Task<Void, Never>?
+    private var callSiteCatalogRefreshTask: Task<Void, Never>?
+    private var latestDaemonConfig: [String: Any]?
+    private var latestCallSitesRaw: [String: Any] = [:]
 
     /// Cancels any in-flight config refresh and spawns a fresh one.
     private func refreshDaemonConfig() {
         configRefreshTask?.cancel()
         configRefreshTask = Task { @MainActor [weak self] in
             await self?.loadConfigFromDaemon()
+        }
+    }
+
+    private func refreshCallSiteCatalog(force: Bool = false) {
+        callSiteCatalogRefreshTask?.cancel()
+        callSiteCatalogRefreshTask = Task { @MainActor [weak self] in
+            await self?.ensureCallSiteCatalogLoaded(force: force)
+        }
+    }
+
+    /// Loads the runtime-owned call-site metadata catalog and reapplies the
+    /// latest daemon config so persisted overrides are merged into the newly
+    /// fetched display metadata.
+    func ensureCallSiteCatalogLoaded(force: Bool = false) async {
+        let loaded: Bool
+        if force {
+            loaded = await CallSiteCatalog.shared.reload(using: settingsClient)
+        } else {
+            loaded = await CallSiteCatalog.shared.ensureLoaded(using: settingsClient)
+        }
+        guard loaded else { return }
+
+        if let latestDaemonConfig {
+            loadCallSiteOverrides(config: latestDaemonConfig)
+        } else if callSiteOverrides.isEmpty {
+            callSiteOverrides = CallSiteCatalog.all
         }
     }
 
@@ -4496,6 +4523,8 @@ public final class SettingsStore: ObservableObject {
     /// Applies a daemon-fetched workspace config to all config-dependent
     /// published properties.
     private func applyDaemonConfig(_ config: [String: Any]) {
+        latestDaemonConfig = config
+
         let mediaSettings = Self.loadMediaEmbedSettings(config: config)
         self.mediaEmbedsEnabled = mediaSettings.enabled
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
@@ -4553,6 +4582,32 @@ public final class SettingsStore: ObservableObject {
         if mediaSettings.didDefaultEnabledSince && !isCurrentAssistantRemote {
             persistMediaEmbedState()
         }
+    }
+
+    private func callSiteIdsReferencingProfile(_ profileName: String) -> [String] {
+        var ids: [String] = []
+        var seen = Set<String>()
+
+        func append(_ id: String) {
+            guard seen.insert(id).inserted else { return }
+            ids.append(id)
+        }
+
+        for override in callSiteOverrides where override.profile == profileName {
+            append(override.id)
+        }
+
+        let renderedCallSiteIds = Set(callSiteOverrides.map(\.id))
+        for id in latestCallSitesRaw.keys.sorted() {
+            guard !renderedCallSiteIds.contains(id) else { continue }
+            guard let entry = latestCallSitesRaw[id] as? [String: Any],
+                  let profile = entry["profile"] as? String,
+                  !profile.isEmpty,
+                  profile == profileName else { continue }
+            append(id)
+        }
+
+        return ids
     }
 
     private static func loadUserTimezone(config: [String: Any]) -> String? {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
@@ -202,11 +202,13 @@ final class InferenceProfilesSheetTests: XCTestCase {
     /// Deleting the active profile produces `.blockedByActive`. The sheet
     /// uses this to drive its `BlockedDeleteState.active` presentation.
     func testDeletingActiveProfileReturnsBlockedByActiveResult() async {
-        seedBuiltInsAndCustom()
-        XCTAssertEqual(store.activeProfile, "balanced")
+        seedBuiltInsAndCustom(includeCustom: true)
+        let switched = await store.setActiveProfile("experimental")
+        XCTAssertTrue(switched)
+        XCTAssertEqual(store.activeProfile, "experimental")
 
-        let result = await store.deleteProfile(name: "balanced")
-        XCTAssertEqual(result, .blockedByActive("balanced"))
+        let result = await store.deleteProfile(name: "experimental")
+        XCTAssertEqual(result, .blockedByActive("experimental"))
     }
 
     /// Deleting a profile that's referenced by call sites returns
@@ -295,38 +297,40 @@ final class InferenceProfilesSheetTests: XCTestCase {
 
     // MARK: - Rename flow
 
-    /// Renaming the active profile must atomically migrate the
+    /// Renaming a custom active profile must atomically migrate the
     /// `activeProfile` pointer and any callsite overrides onto the new
     /// name BEFORE deleting the old key, so the rename never leaves a
     /// stale dangling reference. Mirrors the orchestration in
     /// `commitEditor` — exercised here at the store level.
     func testRenameActiveProfileMigratesActivePointerAndDropsOldKey() async {
-        seedBuiltInsAndCustom()
-        XCTAssertEqual(store.activeProfile, "balanced")
+        seedBuiltInsAndCustom(includeCustom: true)
+        let switched = await store.setActiveProfile("experimental")
+        XCTAssertTrue(switched)
+        XCTAssertEqual(store.activeProfile, "experimental")
 
         // Step 1: write the new key with the migrated draft.
         let renamed = InferenceProfile(
-            name: "balanced-renamed",
+            name: "experimental-renamed",
             provider: "anthropic",
             model: "claude-sonnet-4-6",
             maxTokens: 16000,
             effort: "high"
         )
-        let setSuccess = await store.setProfile(name: "balanced-renamed", fragment: renamed)
+        let setSuccess = await store.setProfile(name: "experimental-renamed", fragment: renamed)
         XCTAssertTrue(setSuccess)
 
         // Step 2: re-target the active pointer.
-        let activeSuccess = await store.setActiveProfile("balanced-renamed")
+        let activeSuccess = await store.setActiveProfile("experimental-renamed")
         XCTAssertTrue(activeSuccess)
 
         // Step 3: drop the old key. After re-targeting, this must
         // succeed (no `.blockedByActive`).
-        let result = await store.deleteProfile(name: "balanced")
+        let result = await store.deleteProfile(name: "experimental")
         XCTAssertEqual(result, .deleted)
 
-        XCTAssertEqual(store.activeProfile, "balanced-renamed")
-        XCTAssertFalse(store.profiles.contains(where: { $0.name == "balanced" }))
-        XCTAssertTrue(store.profiles.contains(where: { $0.name == "balanced-renamed" }))
+        XCTAssertEqual(store.activeProfile, "experimental-renamed")
+        XCTAssertFalse(store.profiles.contains(where: { $0.name == "experimental" }))
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "experimental-renamed" }))
     }
 
     /// Renaming a profile referenced by call sites must re-target every

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -399,6 +399,36 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertTrue(store.profiles.contains(where: { $0.name == "fast" }))
     }
 
+    func testDeleteProfileBlockedByRawCallSitesWhenCatalogUnavailable() async {
+        CallSiteCatalog.shared.clearForTesting()
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["model": "claude-sonnet-4-6"],
+                    "fast": ["model": "claude-haiku-4-5"],
+                ],
+            ]
+        ])
+        store.loadCallSiteOverrides(config: [
+            "llm": [
+                "callSites": [
+                    "futureCallSite": ["profile": "fast"],
+                ]
+            ]
+        ])
+        XCTAssertTrue(store.callSiteOverrides.isEmpty)
+
+        let result = await store.deleteProfile(name: "fast")
+        if case .blockedByCallSites(let ids) = result {
+            XCTAssertEqual(ids, ["futureCallSite"])
+        } else {
+            XCTFail("Expected .blockedByCallSites, got \(result)")
+        }
+        XCTAssertNil(lastProfilesPatch())
+        XCTAssertTrue(store.profiles.contains(where: { $0.name == "fast" }))
+    }
+
     // MARK: - deleteProfile success
 
     func testDeleteProfileSucceedsWhenUnreferenced() async {

--- a/clients/macos/vellum-assistantTests/MockSettingsClient.swift
+++ b/clients/macos/vellum-assistantTests/MockSettingsClient.swift
@@ -4,6 +4,12 @@ import Foundation
 
 @MainActor
 final class MockSettingsClient: SettingsClientProtocol {
+    init(seedCallSiteCatalog: Bool = true) {
+        if seedCallSiteCatalog {
+            CallSiteCatalog.shared.replaceForTesting(Self.defaultCallSiteCatalogResponse)
+        }
+    }
+
     // MARK: - Spy State
 
     var fetchVercelConfigCallCount = 0
@@ -49,6 +55,49 @@ final class MockSettingsClient: SettingsClientProtocol {
     var patchConfigResponse: Bool = true
     var replaceInferenceProfileCalls: [(name: String, fragment: [String: Any])] = []
     var replaceInferenceProfileResponse: Bool = true
+    var callSiteCatalogResponse: CallSiteCatalogResponse? = MockSettingsClient.defaultCallSiteCatalogResponse
+
+    static let defaultCallSiteCatalogResponse = CallSiteCatalogResponse(
+        domains: [
+            CallSiteCatalogDomain(id: "agentLoop", displayName: "Agent Loop"),
+            CallSiteCatalogDomain(id: "memory", displayName: "Memory"),
+            CallSiteCatalogDomain(id: "workspace", displayName: "Workspace"),
+            CallSiteCatalogDomain(id: "ui", displayName: "UI"),
+            CallSiteCatalogDomain(id: "skills", displayName: "Skills"),
+        ],
+        callSites: [
+            CallSiteCatalogEntry(
+                id: "mainAgent",
+                displayName: "Main Agent",
+                description: "The primary conversation agent that handles user messages.",
+                domain: "agentLoop"
+            ),
+            CallSiteCatalogEntry(
+                id: "memoryRetrieval",
+                displayName: "Memory Retrieval",
+                description: "Retrieves relevant memories to augment the agent context.",
+                domain: "memory"
+            ),
+            CallSiteCatalogEntry(
+                id: "commitMessage",
+                displayName: "Commit Message",
+                description: "Generates a git commit message for staged changes.",
+                domain: "workspace"
+            ),
+            CallSiteCatalogEntry(
+                id: "trustRuleSuggestion",
+                displayName: "Trust Rule Suggestion",
+                description: "Suggests a trust rule pattern when the user creates a new rule.",
+                domain: "ui"
+            ),
+            CallSiteCatalogEntry(
+                id: "inference",
+                displayName: "Inference",
+                description: "General-purpose LLM inference call site for skill use.",
+                domain: "skills"
+            ),
+        ]
+    )
 
     // MARK: - Protocol Methods
 
@@ -188,5 +237,5 @@ final class MockSettingsClient: SettingsClientProtocol {
         return checkApiKeyExistsResponse
     }
 
-    func fetchCallSiteCatalog() async -> CallSiteCatalogResponse? { nil }
+    func fetchCallSiteCatalog() async -> CallSiteCatalogResponse? { callSiteCatalogResponse }
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
@@ -59,14 +59,15 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
 
     // MARK: - Catalog
 
-    func testCatalogCoversEveryCallSite() {
-        // The catalog enumerates every backend LLM call site grouped across 8 domains
-        // (agent loop, memory, workspace, UI, notifications, voice,
-        // utility, skills). If this count drifts, the catalog and the
-        // backend `LLMCallSiteEnum` have diverged.
-        XCTAssertEqual(CallSiteCatalog.all.count, 35)
-        XCTAssertEqual(CallSiteCatalog.byId.count, 35)
-        XCTAssertEqual(CallSiteCatalog.validIds.count, 35)
+    func testCatalogUsesRuntimeLoadedEntries() {
+        // Production call-site coverage is owned by the assistant runtime
+        // catalog API; these tests seed only the entries they exercise.
+        XCTAssertEqual(
+            CallSiteCatalog.all.map(\.id),
+            ["mainAgent", "memoryRetrieval", "commitMessage", "trustRuleSuggestion", "inference"]
+        )
+        XCTAssertEqual(CallSiteCatalog.byId.count, CallSiteCatalog.all.count)
+        XCTAssertEqual(CallSiteCatalog.validIds.count, CallSiteCatalog.all.count)
     }
 
     func testCatalogHasUniqueIdsAndNonEmptyDisplayNames() {
@@ -307,13 +308,13 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
             ),
             CallSiteOverride(
                 id: "mainAgent",
-                displayName: "Main agent",
+                displayName: "Main Agent",
                 domain: "agentLoop",
                 profile: "fast"
             ),
             CallSiteOverride(
                 id: "trustRuleSuggestion",
-                displayName: "Trust rule suggestion",
+                displayName: "Trust Rule Suggestion",
                 domain: "ui"
             ), // no overrides — should emit explicit nulls to clear
         ]
@@ -402,7 +403,7 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         let updates: [CallSiteOverride] = [
             CallSiteOverride(
                 id: "trustRuleSuggestion",
-                displayName: "Trust rule suggestion",
+                displayName: "Trust Rule Suggestion",
                 domain: "ui",
                 provider: "openai"
             ),
@@ -447,13 +448,13 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         let updates: [CallSiteOverride] = [
             CallSiteOverride(
                 id: "trustRuleSuggestion",
-                displayName: "Trust rule suggestion",
+                displayName: "Trust Rule Suggestion",
                 domain: "ui",
                 provider: "openai"
             ),
             CallSiteOverride(
                 id: "mainAgent",
-                displayName: "Main agent",
+                displayName: "Main Agent",
                 domain: "agentLoop",
                 provider: "anthropic"
             ),

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -645,7 +645,7 @@ struct UsageTabContentViewPopulatedTests {
                 eventCount: 2,
                 groups: [
                     "value:mainAgent": UsageSeriesGroupValue(
-                        group: "Main agent",
+                        group: "Main Agent",
                         groupKey: "mainAgent",
                         totalInputTokens: 100,
                         totalOutputTokens: 50,
@@ -657,7 +657,7 @@ struct UsageTabContentViewPopulatedTests {
         ])
         client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
             UsageGroupBreakdownEntry(
-                group: "Main agent",
+                group: "Main Agent",
                 groupKey: "mainAgent",
                 totalInputTokens: 100,
                 totalOutputTokens: 50,
@@ -675,7 +675,7 @@ struct UsageTabContentViewPopulatedTests {
         #expect(client.lastBreakdownGroupBy == "call_site")
         #expect(joined.contains("Inference Usage"))
         #expect(joined.contains("Daily Trend by Task"))
-        #expect(joined.contains("Main agent"))
+        #expect(joined.contains("Main Agent"))
 
         await store.selectGroupBy(.inferenceProfile)
         #expect(client.lastSeriesGroupBy == "inference_profile")

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -192,7 +192,7 @@ struct UsageDashboardStoreDecodingTests {
         {
             "breakdown": [
                 {
-                    "group": "Main agent",
+                    "group": "Main Agent",
                     "groupKey": "mainAgent",
                     "totalInputTokens": 800,
                     "totalOutputTokens": 400,
@@ -203,7 +203,7 @@ struct UsageDashboardStoreDecodingTests {
         }
         """
         let decoded = try JSONDecoder().decode(UsageBreakdownResponse.self, from: Data(json.utf8))
-        #expect(decoded.breakdown[0].group == "Main agent")
+        #expect(decoded.breakdown[0].group == "Main Agent")
         #expect(decoded.breakdown[0].groupKey == "mainAgent")
     }
 
@@ -222,7 +222,7 @@ struct UsageDashboardStoreDecodingTests {
                     "eventCount": 5,
                     "groups": {
                         "value:mainAgent": {
-                            "group": "Main agent",
+                            "group": "Main Agent",
                             "groupKey": "mainAgent",
                             "totalInputTokens": 500,
                             "totalOutputTokens": 250,
@@ -238,7 +238,7 @@ struct UsageDashboardStoreDecodingTests {
         #expect(decoded.buckets.count == 1)
         #expect(decoded.buckets[0].bucketId == "2026-03-01")
         #expect(decoded.buckets[0].displayLabel == "Mar 1")
-        #expect(decoded.buckets[0].groups["value:mainAgent"]?.group == "Main agent")
+        #expect(decoded.buckets[0].groups["value:mainAgent"]?.group == "Main Agent")
         #expect(decoded.buckets[0].groups["value:mainAgent"]?.groupKey == "mainAgent")
     }
 

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -656,19 +656,36 @@ public struct EmbeddingConfigMessage: Codable {
 }
 // MARK: - Call Site Catalog Types
 
-public struct CallSiteCatalogDomain: Decodable {
+public struct CallSiteCatalogDomain: Codable {
     public let id: String
     public let displayName: String
+
+    public init(id: String, displayName: String) {
+        self.id = id
+        self.displayName = displayName
+    }
 }
 
-public struct CallSiteCatalogEntry: Decodable {
+public struct CallSiteCatalogEntry: Codable {
     public let id: String
     public let displayName: String
     public let description: String
     public let domain: String
+
+    public init(id: String, displayName: String, description: String, domain: String) {
+        self.id = id
+        self.displayName = displayName
+        self.description = description
+        self.domain = domain
+    }
 }
 
-public struct CallSiteCatalogResponse: Decodable {
+public struct CallSiteCatalogResponse: Codable {
     public let domains: [CallSiteCatalogDomain]
     public let callSites: [CallSiteCatalogEntry]
+
+    public init(domains: [CallSiteCatalogDomain], callSites: [CallSiteCatalogEntry]) {
+        self.domains = domains
+        self.callSites = callSites
+    }
 }


### PR DESCRIPTION
## Summary
- Removes the hardcoded macOS LLM call-site catalog so the settings UI uses runtime-owned `/config/llm/call-sites` metadata.
- Caches the last successful catalog response only as a startup fallback while the runtime fetch completes.
- Updates macOS usage/settings fixtures for title-cased task labels and managed-profile delete behavior.

## Tests
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'SettingsStoreCallSiteOverrideTests|UsageDashboardStoreTests|UsageDashboardPanelTests|CallSiteOverridesSheetTests|SettingsStoreInferenceProfilesTests|SettingsStoreInferenceTests|InferenceProfilesSheetTests'`\n\n## Apple refs checked (2026-04-30)\n- No new Apple APIs introduced; existing SwiftUI `.task` and Observation usage retained.\n\nFollow-up to the usage-label metadata plan; addresses post-merge review feedback that the macOS settings UI still duplicated call-site label metadata.\n\nNote: local pre-push Swift build hit a SwiftPM resolver flake resolving `SwiftMath` from cache. Targeted macOS tests above passed after rebasing onto current `origin/main`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
