### PR TITLE
revert: drop deprecated/ from vbundle skipDirs (#29002)

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -568,7 +568,7 @@ export function buildExportVBundle(
     files.push(
       ...walkDirectory(workspaceDir, "workspace", {
         includeBinary: true,
-        skipDirs: ["embedding-models", "data/qdrant", "signals"],
+        skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
       }),
     );
   }
@@ -906,7 +906,7 @@ export async function streamExportVBundle(
     allFileMetadata.push(
       ...walkDirectoryForMetadata(workspaceDir, "workspace", {
         includeBinary: true,
-        skipDirs: ["embedding-models", "data/qdrant", "signals"],
+        skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
       }),
     );
   }


### PR DESCRIPTION
## Summary

Reverts #29002. Self-review surfaced two problems:

1. **Premise was wrong.** PR #29002 was justified by an assumption that #28747 moves `backup.key` into `workspace/deprecated/`. The actually-merged #28747 places it at `workspace/.backup.key` (see `assistant/src/backup/paths.ts:143` and migration 061), which is not under any skipDir. Nothing was relying on `deprecated/` being walked.
2. **Real secret leak.** `workspace/deprecated/actor-token-signing-key` is a 32-byte HMAC actor-token signing key (`token-service.ts:55-117`). With #29002 in place, plaintext `.vbundle` exports ship this secret verbatim, and managed-mode bundles silently violate their own `secrets_redacted: true` contract since `vbundle-builder.ts` has no file-level redaction pass.

The `deprecated/` skip was originally added in #22127 specifically to prevent signing-key leak. Restoring it.

## Test plan
- [ ] CI green on the revert
- [ ] After merge, exporting an unencrypted vbundle from a workspace with `workspace/deprecated/actor-token-signing-key` confirms the key is excluded from the archive (`tar -tf`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
