### PR TITLE
Normalize Slack mentions in gateway inbound content

### DIFF
--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -8,6 +8,7 @@
         "@vellumai/assistant-client": "file:../packages/assistant-client",
         "@vellumai/ces-client": "file:../packages/ces-client",
         "@vellumai/service-contracts": "file:../packages/service-contracts",
+        "@vellumai/slack-text": "file:../packages/slack-text",
         "drizzle-kit": "0.30.6",
         "drizzle-orm": "0.45.2",
         "file-type": "21.3.0",
@@ -208,6 +209,8 @@
     "@vellumai/ces-client": ["@vellumai/ces-client@file:../packages/ces-client", { "dependencies": { "@vellumai/service-contracts": "file:../service-contracts" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
+
+    "@vellumai/slack-text": ["@vellumai/slack-text@file:../packages/slack-text", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -499,6 +502,8 @@
 
     "@vellumai/service-contracts/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
+    "@vellumai/slack-text/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "gel/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
@@ -558,6 +563,8 @@
     "@vellumai/ces-client/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "@vellumai/service-contracts/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+
+    "@vellumai/slack-text/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "gel/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -4,6 +4,7 @@
   "ignoreDependencies": [
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
-    "@vellumai/service-contracts"
+    "@vellumai/service-contracts",
+    "@vellumai/slack-text"
   ]
 }

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -27,6 +27,7 @@
     "@vellumai/assistant-client": "file:../packages/assistant-client",
     "@vellumai/ces-client": "file:../packages/ces-client",
     "@vellumai/service-contracts": "file:../packages/service-contracts",
+    "@vellumai/slack-text": "file:../packages/slack-text",
     "drizzle-kit": "0.30.6",
     "drizzle-orm": "0.45.2",
     "file-type": "21.3.0",

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -2,8 +2,12 @@ import { describe, test, expect } from "bun:test";
 import {
   stripBotMention,
   normalizeSlackAppMention,
+  normalizeSlackChannelMessage,
+  normalizeSlackDirectMessage,
   normalizeSlackMessageEdit,
   type SlackAppMentionEvent,
+  type SlackChannelMessageEvent,
+  type SlackDirectMessageEvent,
   type SlackMessageChangedEvent,
 } from "../slack/normalize.js";
 import type { GatewayConfig } from "../config.js";
@@ -53,8 +57,16 @@ describe("stripBotMention", () => {
     expect(stripBotMention("<@U123BOT> hello world")).toBe("hello world");
   });
 
-  test("strips multiple leading bot mentions", () => {
-    expect(stripBotMention("<@U123BOT> <@U456OTHER> hello")).toBe("hello");
+  test("strips repeated leading bot mentions while preserving a following human mention", () => {
+    expect(
+      stripBotMention("<@U123BOT> <@U123BOT> <@U456OTHER> hello", "U123BOT"),
+    ).toBe("<@U456OTHER> hello");
+  });
+
+  test("fallback strips only the first leading mention", () => {
+    expect(stripBotMention("<@U123BOT> <@U456OTHER> hello")).toBe(
+      "<@U456OTHER> hello",
+    );
   });
 
   test("falls back to original text when stripping produces empty string", () => {
@@ -132,7 +144,37 @@ describe("normalizeSlackAppMention", () => {
     const result = await normalizeSlackAppMention(event, "evt-006", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("<@U123BOT>");
+    expect(result!.event.message.content).toBe("@unknown-user");
+  });
+
+  test("renders a human mention after stripping the app mention", async () => {
+    const config = makeConfig();
+    const event = makeEvent({ text: "<@UBOT> <@ULEO> can you check?" });
+    const result = await normalizeSlackAppMention(
+      event,
+      "evt-mention-label",
+      config,
+      "UBOT",
+      undefined,
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo can you check?");
+  });
+
+  test("renders unresolved user mentions with the unknown-user fallback", async () => {
+    const config = makeConfig();
+    const event = makeEvent({ text: "<@UBOT> <@UUNKNOWN> can you check?" });
+    const result = await normalizeSlackAppMention(
+      event,
+      "evt-unknown-mention",
+      config,
+      "UBOT",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@unknown-user can you check?");
   });
 
   test("thread_ts is preserved in return value", async () => {
@@ -201,6 +243,101 @@ describe("normalizeSlackAppMention", () => {
     expect(result!.event.raw).toEqual(
       event as unknown as Record<string, unknown>,
     );
+  });
+});
+
+function makeDirectMessageEvent(
+  overrides: Partial<SlackDirectMessageEvent> = {},
+): SlackDirectMessageEvent {
+  return {
+    type: "message",
+    user: "U_USER123",
+    text: "hello world",
+    ts: "1700000000.000100",
+    channel: "D_DIRECT1",
+    channel_type: "im",
+    ...overrides,
+  };
+}
+
+function makeChannelMessageEvent(
+  overrides: Partial<SlackChannelMessageEvent> = {},
+): SlackChannelMessageEvent {
+  return {
+    type: "message",
+    user: "U_USER123",
+    text: "hello world",
+    ts: "1700000000.000100",
+    channel: "C_CHANNEL1",
+    channel_type: "channel",
+    ...overrides,
+  };
+}
+
+describe("Slack inbound mention rendering", () => {
+  test("direct messages render mentions without stripping the bot mention", () => {
+    const config = makeConfig();
+    const event = makeDirectMessageEvent({
+      text: "<@UBOT> <@ULEO> hello",
+    });
+    const result = normalizeSlackDirectMessage(
+      event,
+      "evt-dm-render",
+      config,
+      "UBOT",
+      undefined,
+      { userLabels: { UBOT: "assistant", ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@assistant @leo hello");
+    expect(result!.event.actor.actorExternalId).toBe("U_USER123");
+    expect(result!.event.message.conversationExternalId).toBe("D_DIRECT1");
+  });
+
+  test("channel messages strip only the configured bot mention and render remaining mentions", () => {
+    const config = makeConfig();
+    const event = makeChannelMessageEvent({
+      text: "<@UBOT> <@ULEO> hello",
+    });
+    const result = normalizeSlackChannelMessage(
+      event,
+      "evt-channel-render",
+      config,
+      "UBOT",
+      undefined,
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo hello");
+    expect(result!.event.actor.actorExternalId).toBe("U_USER123");
+    expect(result!.event.message.conversationExternalId).toBe("C_CHANNEL1");
+  });
+
+  test("message edits render mentions and preserve edit metadata", () => {
+    const config = makeConfig();
+    const event = makeMessageChangedEvent({
+      message: {
+        user: "U_USER123",
+        text: "<@UBOT> <@ULEO> edited",
+        ts: "1700000000.000100",
+      },
+    });
+    const result = normalizeSlackMessageEdit(
+      event,
+      "evt-edit-render",
+      config,
+      "UBOT",
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo edited");
+    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.externalMessageId).toBe("evt-edit-render");
+    expect(result!.event.source.messageId).toBe("1700000000.000100");
+    expect(result!.event.actor.actorExternalId).toBe("U_USER123");
   });
 });
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,3 +1,8 @@
+import {
+  renderSlackTextForModel,
+  stripLeadingSlackMentionFallback,
+  stripLeadingSlackUserMention,
+} from "@vellumai/slack-text";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
@@ -275,15 +280,95 @@ export interface SlackMessageDeletedEvent {
   };
 }
 
+export type SlackTextRenderContext = {
+  botUserId?: string;
+  userLabels?: Record<string, string>;
+};
+
 /**
- * Strip leading bot-mention tokens (`<@U...>`) from the message text.
- * Slack wraps mentions as `<@UXXXXXX>`, often at the start of an
- * app_mention event's text field. We remove all leading occurrences
- * so the assistant receives clean user content.
+ * Strip leading bot-mention tokens from Slack message text.
+ *
+ * When the bot user ID is known, only that exact mention is stripped. Without a
+ * bot user ID, strip just one leading mention as an app_mention compatibility
+ * fallback.
  */
-export function stripBotMention(text: string): string {
-  const stripped = text.replace(/^(<@[A-Z0-9]+>\s*)+/i, "").trim();
-  return stripped || text.trim();
+export function stripBotMention(text: string, botUserId?: string): string {
+  const stripped = botUserId
+    ? stripLeadingSlackUserMention(text, botUserId)
+    : stripLeadingSlackMentionFallback(text);
+  return stripped.trim() || text.trim();
+}
+
+function renderSlackInboundText(
+  text: string,
+  context: SlackTextRenderContext = {},
+  options: {
+    stripLeadingBotMention?: boolean;
+    fallbackStripFirstMention?: boolean;
+  } = {},
+): string {
+  let stripped = text;
+  if (options.stripLeadingBotMention) {
+    stripped = context.botUserId
+      ? stripBotMention(text, context.botUserId)
+      : options.fallbackStripFirstMention
+        ? stripBotMention(text)
+        : text.trim();
+  }
+
+  return renderSlackTextForModel(stripped, {
+    userLabels: context.userLabels,
+  });
+}
+
+function withBotUserId(
+  botUserId: string | undefined,
+  context: SlackTextRenderContext | undefined,
+): SlackTextRenderContext {
+  return {
+    ...context,
+    botUserId: context?.botUserId ?? botUserId,
+  };
+}
+
+function parseAppMentionArgs(
+  botTokenOrBotUserId?: string,
+  botTokenOrContext?: string | SlackTextRenderContext,
+  maybeContext?: SlackTextRenderContext,
+): { botToken?: string; renderContext: SlackTextRenderContext } {
+  const firstArgIsToken = isSlackBotToken(botTokenOrBotUserId);
+
+  if (
+    typeof botTokenOrContext === "object" ||
+    typeof maybeContext === "object"
+  ) {
+    return {
+      botToken: firstArgIsToken
+        ? botTokenOrBotUserId
+        : typeof botTokenOrContext === "string"
+          ? botTokenOrContext
+          : undefined,
+      renderContext: withBotUserId(
+        firstArgIsToken ? undefined : botTokenOrBotUserId,
+        {
+          ...(typeof botTokenOrContext === "object" ? botTokenOrContext : {}),
+          ...maybeContext,
+        },
+      ),
+    };
+  }
+
+  return {
+    botToken: firstArgIsToken ? botTokenOrBotUserId : botTokenOrContext,
+    renderContext: withBotUserId(
+      firstArgIsToken ? undefined : botTokenOrBotUserId,
+      undefined,
+    ),
+  };
+}
+
+function isSlackBotToken(value: string | undefined): boolean {
+  return value?.startsWith("xox") ?? false;
 }
 
 function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
@@ -332,6 +417,7 @@ export function normalizeSlackDirectMessage(
   config: GatewayConfig,
   botUserId?: string,
   botToken?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
   // Ignore messages from the bot itself
   if (botUserId && event.user === botUserId) return null;
@@ -374,6 +460,10 @@ export function normalizeSlackDirectMessage(
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
       : undefined;
+  const content = renderSlackInboundText(
+    event.text,
+    withBotUserId(botUserId, renderContext),
+  );
 
   return {
     event: {
@@ -381,7 +471,7 @@ export function normalizeSlackDirectMessage(
       sourceChannel: "slack",
       receivedAt: new Date().toISOString(),
       message: {
-        content: event.text,
+        content,
         conversationExternalId: event.channel,
         externalMessageId,
         ...(attachments.length > 0 ? { attachments } : {}),
@@ -421,6 +511,7 @@ export function normalizeSlackChannelMessage(
   config: GatewayConfig,
   botUserId?: string,
   botToken?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
   if (botUserId && event.user === botUserId) return null;
   // file_share is allowed so image/file uploads are delivered to the assistant.
@@ -430,7 +521,11 @@ export function normalizeSlackChannelMessage(
   const routing = resolveAssistant(config, event.channel, event.user);
   if (isRejection(routing)) return null;
 
-  const content = stripBotMention(event.text);
+  const content = renderSlackInboundText(
+    event.text,
+    withBotUserId(botUserId, renderContext),
+    { stripLeadingBotMention: true },
+  );
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
@@ -492,14 +587,24 @@ export function normalizeSlackAppMention(
   event: SlackAppMentionEvent,
   eventId: string,
   config: GatewayConfig,
-  botToken?: string,
+  botTokenOrBotUserId?: string,
+  botTokenOrContext?: string | SlackTextRenderContext,
+  maybeContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
+  const { botToken, renderContext } = parseAppMentionArgs(
+    botTokenOrBotUserId,
+    botTokenOrContext,
+    maybeContext,
+  );
   const routing = resolveAssistant(config, event.channel, event.user);
   if (isRejection(routing)) {
     return null;
   }
 
-  const content = stripBotMention(event.text);
+  const content = renderSlackInboundText(event.text, renderContext, {
+    stripLeadingBotMention: true,
+    fallbackStripFirstMention: true,
+  });
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
@@ -792,6 +897,7 @@ export function normalizeSlackMessageEdit(
   eventId: string,
   config: GatewayConfig,
   botUserId?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
   const edited = event.message;
   if (!edited) return null;
@@ -817,7 +923,14 @@ export function normalizeSlackMessageEdit(
   }
   if (isRejection(routing)) return null;
 
-  const content = stripBotMention(edited.text);
+  const content = renderSlackInboundText(
+    edited.text,
+    withBotUserId(botUserId, renderContext),
+    {
+      stripLeadingBotMention: true,
+      fallbackStripFirstMention: !botUserId,
+    },
+  );
 
   // Each edit event gets a unique externalMessageId so the dedup pipeline
   // does not discard subsequent edits of the same Slack message.


### PR DESCRIPTION
## Summary
- Adds the shared Slack text renderer to gateway inbound normalization.
- Preserves human mentions after stripping only the assistant mention.

Part of plan: slack-mention-display-names.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
