### PR TITLE
fix(runtime): drop stale trust/trust.json bullet from vbundle-validator doc-comment

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -5,7 +5,6 @@
  * - manifest.json: metadata with schema_version, checksums, and bundle info
  * - workspace/: the entire workspace directory tree (new format), OR
  *   data/db/assistant.db + config/settings.json (old format)
- * - trust/trust.json: trust rules (optional)
  *
  * Validation steps:
  * 1. Archive structure: valid gzip tar with required entries


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan self-review for vbundle-trustpath-rip.

**Gap:** Stale `trust/trust.json` bullet in `vbundle-validator.ts` header doc-comment.
**What was expected:** After ripping `trustPath` plumbing in #29005, no doc-comment in migrations should document `trust/trust.json` as a bundleable component.
**What was found:** Sibling validator header still listed `trust/trust.json: trust rules (optional)` in its archive-layout list.

Pairs with #29005.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
