### PR TITLE
Normalize Slack mentions in backfilled history

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -20,6 +20,7 @@
         "@vellumai/gateway-client": "file:../packages/gateway-client",
         "@vellumai/service-contracts": "file:../packages/service-contracts",
         "@vellumai/skill-host-contracts": "file:../packages/skill-host-contracts",
+        "@vellumai/slack-text": "file:../packages/slack-text",
         "archiver": "7.0.1",
         "commander": "13.1.0",
         "croner": "10.0.1",
@@ -421,6 +422,8 @@
     "@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "@vellumai/skill-host-contracts": ["@vellumai/skill-host-contracts@file:../packages/skill-host-contracts", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
+
+    "@vellumai/slack-text": ["@vellumai/slack-text@file:../packages/slack-text", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.33", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw=="],
 

--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -12,6 +12,7 @@
     "@vellumai/egress-proxy",
     "@vellumai/gateway-client",
     "@vellumai/service-contracts",
+    "@vellumai/slack-text",
     "@resvg/resvg-js-darwin-arm64",
     "@resvg/resvg-js-darwin-x64",
     "@vellumai/skill-host-contracts",

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -46,6 +46,7 @@
     "@vellumai/egress-proxy": "file:../packages/egress-proxy",
     "@vellumai/gateway-client": "file:../packages/gateway-client",
     "@vellumai/skill-host-contracts": "file:../packages/skill-host-contracts",
+    "@vellumai/slack-text": "file:../packages/slack-text",
     "archiver": "7.0.1",
     "commander": "13.1.0",
     "croner": "10.0.1",
@@ -75,7 +76,8 @@
     "@vellumai/service-contracts",
     "@vellumai/egress-proxy",
     "@vellumai/gateway-client",
-    "@vellumai/skill-host-contracts"
+    "@vellumai/skill-host-contracts",
+    "@vellumai/slack-text"
   ],
   "overrides": {
     "lodash": "4.18.1",

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { credentialKey } from "../../../../security/credential-key.js";
+
+const BOT_TOKEN = "xoxb-BOT";
+
+const getSecureKeyAsyncMock = mock(
+  async (_key: string): Promise<string | null> => null,
+);
+mock.module("../../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: getSecureKeyAsyncMock,
+}));
+
+mock.module("../../../../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: async (): Promise<OAuthConnection> => {
+    throw new Error("OAuth fallback was not expected");
+  },
+}));
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  isProviderConnected: async () => false,
+}));
+
+const findContactChannelMock = mock(() => undefined);
+const upsertContactChannelMock = mock(() => {});
+mock.module("../../../../contacts/contact-store.js", () => ({
+  findContactChannel: findContactChannelMock,
+}));
+mock.module("../../../../contacts/contacts-write.js", () => ({
+  upsertContactChannel: upsertContactChannelMock,
+}));
+
+import { slackProvider } from "../adapter.js";
+
+const originalFetch = globalThis.fetch;
+
+function installFetchStub() {
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const headers = new Headers(init?.headers ?? {});
+    expect(headers.get("authorization")).toBe(`Bearer ${BOT_TOKEN}`);
+
+    return new Response(JSON.stringify(fakeSlackResponse(url)), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function fakeSlackResponse(url: string): Record<string, unknown> {
+  const parsed = new URL(url);
+  const method = parsed.pathname.split("/").at(-1);
+
+  if (method === "conversations.history") {
+    return {
+      ok: true,
+      has_more: false,
+      messages: [
+        {
+          type: "message",
+          ts: "1700000000.000100",
+          user: "USENDER",
+          text: "History for <@ULEO> and <@UMISSING>",
+          thread_ts: "1700000000.000100",
+          reply_count: 2,
+          reactions: [{ name: "eyes", count: 1, users: ["ULEO"] }],
+        },
+      ],
+    };
+  }
+
+  if (method === "conversations.replies") {
+    return {
+      ok: true,
+      has_more: false,
+      messages: [
+        {
+          type: "message",
+          ts: "1700000001.000200",
+          user: "UTHREAD",
+          text: "Thread follow-up for <@ULEO>",
+          thread_ts: "1700000000.000100",
+        },
+      ],
+    };
+  }
+
+  if (method === "users.info") {
+    return fakeUserInfoResponse(parsed.searchParams.get("user") ?? "");
+  }
+
+  return { ok: true };
+}
+
+function fakeUserInfoResponse(userId: string): Record<string, unknown> {
+  if (userId === "ULEO") {
+    return {
+      ok: true,
+      user: {
+        id: "ULEO",
+        name: "leo",
+        profile: { display_name: "Leo" },
+      },
+    };
+  }
+
+  if (userId === "USENDER") {
+    return {
+      ok: true,
+      user: {
+        id: "USENDER",
+        name: "sender",
+        profile: { display_name: "Sender" },
+      },
+    };
+  }
+
+  if (userId === "UTHREAD") {
+    return {
+      ok: true,
+      user: {
+        id: "UTHREAD",
+        name: "thread_sender",
+        profile: { display_name: "Thread Sender" },
+      },
+    };
+  }
+
+  return { ok: false, error: "user_not_found" };
+}
+
+describe("Slack adapter mention rendering", () => {
+  beforeEach(async () => {
+    getSecureKeyAsyncMock.mockReset();
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) {
+        return BOT_TOKEN;
+      }
+      return null;
+    });
+    findContactChannelMock.mockClear();
+    upsertContactChannelMock.mockClear();
+    installFetchStub();
+    await slackProvider.resolveConnection!();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("getHistory renders Slack user mentions for model-facing text without changing sender identity", async () => {
+    const messages = await slackProvider.getHistory(undefined, "C_HISTORY");
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("History for @Leo and @unknown-user");
+    expect(messages[0].sender).toEqual({ id: "USENDER", name: "Sender" });
+    expect(messages[0].threadId).toBe("1700000000.000100");
+    expect(messages[0].replyCount).toBe(2);
+    expect(messages[0].reactions).toEqual([{ name: "eyes", count: 1 }]);
+  });
+
+  test("getThreadReplies renders Slack user mentions for model-facing text without changing sender identity", async () => {
+    const messages = await slackProvider.getThreadReplies!(
+      undefined,
+      "C_HISTORY",
+      "1700000000.000100",
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("Thread follow-up for @Leo");
+    expect(messages[0].sender).toEqual({
+      id: "UTHREAD",
+      name: "Thread Sender",
+    });
+    expect(messages[0].threadId).toBe("1700000000.000100");
+  });
+});

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -5,6 +5,11 @@
  * implements the MessagingProvider interface.
  */
 
+import {
+  extractSlackUserMentionIds,
+  renderSlackTextForModel,
+} from "@vellumai/slack-text";
+
 import { findContactChannel } from "../../../contacts/contact-store.js";
 import { upsertContactChannel } from "../../../contacts/contacts-write.js";
 import type { OAuthConnection } from "../../../oauth/connection.js";
@@ -218,6 +223,7 @@ function mapMessage(
   msg: SlackMessage,
   channelId: string,
   senderName: string,
+  renderedText: string,
 ): Message {
   // Bot-authored when Slack sets `subtype: "bot_message"` or attributes the
   // row to a `bot_id` with no user. Backfill callers rely on this flag to
@@ -229,7 +235,7 @@ function mapMessage(
     id: msg.ts,
     conversationId: channelId,
     sender: { id: msg.user ?? msg.bot_id ?? "unknown", name: senderName },
-    text: msg.text,
+    text: renderedText,
     timestamp: parseFloat(msg.ts) * 1000,
     threadId: msg.thread_ts,
     replyCount: msg.reply_count,
@@ -265,12 +271,49 @@ async function mapSlackMessages(
   channelId: string,
   slackMessages: SlackMessage[],
 ): Promise<Message[]> {
+  const userLabels = await buildMentionUserLabels(auth, slackMessages);
   const messages: Message[] = [];
   for (const msg of slackMessages) {
     const name = await resolveUserName(auth, msg.user ?? "");
-    messages.push(mapMessage(msg, channelId, name));
+    messages.push(
+      mapMessage(
+        msg,
+        channelId,
+        name,
+        renderSlackTextForModel(msg.text, { userLabels }),
+      ),
+    );
   }
   return messages;
+}
+
+async function buildMentionUserLabels(
+  auth: OAuthConnection | string,
+  slackMessages: SlackMessage[],
+): Promise<Record<string, string>> {
+  const mentionUserIds = [
+    ...new Set(
+      slackMessages.flatMap((msg) => extractSlackUserMentionIds(msg.text)),
+    ),
+  ];
+  if (mentionUserIds.length === 0) return {};
+
+  const userLabels: Record<string, string> = {};
+
+  await Promise.all(
+    mentionUserIds.map(async (userId) => {
+      try {
+        const label = await resolveUserName(auth, userId);
+        if (label && label !== userId) {
+          userLabels[userId] = label;
+        }
+      } catch {
+        // Leave unresolved mentions out so the renderer uses @unknown-user.
+      }
+    }),
+  );
+
+  return userLabels;
 }
 
 export const slackProvider: MessagingProvider = {


### PR DESCRIPTION
## Summary
- Adds shared Slack mention rendering to assistant Slack history and thread backfill.
- Preserves sender identity fields while normalizing model-facing message text.

Part of plan: slack-mention-display-names.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
