### PR TITLE
chore(cli): consolidate restore.ts onto unified signed-url endpoint

### DIFF
--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -9,7 +9,7 @@ import {
 import {
   readPlatformToken,
   rollbackPlatformAssistant,
-  platformRequestUploadUrl,
+  platformRequestSignedUrl,
   platformUploadToSignedUrl,
   platformImportPreflightFromGcs,
   platformImportBundleFromGcs,
@@ -180,7 +180,8 @@ async function restorePlatform(
   }
 
   // Step 1.5 — Upload to GCS via signed URL
-  const { uploadUrl, bundleKey } = await platformRequestUploadUrl(
+  const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
+    { operation: "upload" },
     token,
     entry.runtimeUrl,
   );

--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -291,7 +291,7 @@ describe("platformRequestSignedUrl", () => {
     expect(signedUrlCalls[0]!.headers.Authorization).toBeUndefined();
   });
 
-  test("503 → throws so callers can fall back to legacy inline upload", async () => {
+  test("5xx error response → surfaces platform detail message", async () => {
     const { fetchMock } = captureFetch(() => {
       return new Response(JSON.stringify({ detail: "temporarily down" }), {
         status: 503,
@@ -305,7 +305,7 @@ describe("platformRequestSignedUrl", () => {
         VAK_TOKEN,
         PLATFORM_URL,
       ),
-    ).rejects.toThrow(/503/);
+    ).rejects.toThrow(/temporarily down/);
   });
 });
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -815,8 +815,7 @@ export function parseUnifiedJobStatus(
  *   runtime can GET the bundle from during an import-from-GCS flow.
  *
  * Retries once with a fresh org-ID cache on 401 to match the retry pattern
- * used by other authenticated platform helpers. 503 is bubbled up so
- * callers can decide to fall back (e.g. legacy inline upload).
+ * used by other authenticated platform helpers.
  */
 export async function platformRequestSignedUrl(
   params: {
@@ -872,12 +871,6 @@ export async function platformRequestSignedUrl(
       expiresAt: json.expires_at,
       maxContentLength: json.max_content_length,
     };
-  }
-
-  if (response.status === 503) {
-    throw new Error(
-      `Signed URL endpoint unavailable (503) — caller may fall back`,
-    );
   }
 
   const errorBody = (await response.json().catch(() => ({}))) as {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -669,45 +669,6 @@ export async function rollbackPlatformAssistant(
 // Signed-URL upload flow
 // ---------------------------------------------------------------------------
 
-export async function platformRequestUploadUrl(
-  token: string,
-  platformUrl?: string,
-): Promise<{ uploadUrl: string; bundleKey: string; expiresAt: string }> {
-  const resolvedUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(`${resolvedUrl}/v1/migrations/upload-url/`, {
-    method: "POST",
-    headers: await authHeaders(token, platformUrl),
-    body: JSON.stringify({ content_type: "application/octet-stream" }),
-  });
-
-  if (response.status === 201) {
-    const body = (await response.json()) as {
-      upload_url: string;
-      bundle_key: string;
-      expires_at: string;
-    };
-    return {
-      uploadUrl: body.upload_url,
-      bundleKey: body.bundle_key,
-      expiresAt: body.expires_at,
-    };
-  }
-
-  if (response.status === 404 || response.status === 503) {
-    throw new Error(
-      "Signed uploads are not available on this platform instance",
-    );
-  }
-
-  const errorBody = (await response.json().catch(() => ({}))) as {
-    detail?: string;
-  };
-  throw new Error(
-    errorBody.detail ??
-      `Failed to request upload URL: ${response.status} ${response.statusText}`,
-  );
-}
-
 export async function platformUploadToSignedUrl(
   uploadUrl: string,
   bundleData: Uint8Array<ArrayBuffer>,


### PR DESCRIPTION
## Summary
- Migrate `cli/src/commands/restore.ts` from the legacy `platformRequestUploadUrl` helper onto the unified `platformRequestSignedUrl({ operation: "upload" }, ...)` endpoint, matching the pattern already used by `cli/src/commands/teleport.ts`.
- Delete the now-dead `platformRequestUploadUrl` helper from `cli/src/lib/platform-client.ts`.
- Slop-pass cleanup: drop the dead 503 fallback branch and stale "callers may fall back" docstring sentence from `platformRequestSignedUrl` (only `restore.ts`'s now-deleted try/catch fallback ever consumed that branch). Update the corresponding test to assert the platform's `detail` is surfaced through the generic error path.

## Self-review result
PASS — 1 gap found (round 1) and fixed; round 2 returned PASS across all four passes (external feedback, plan faithfulness, integration, slop/reuse).

## PRs merged into feature branch
- #29004: chore(cli): migrate restore.ts to unified signed-url endpoint
- #29007: fix(cli): remove dead 503 fallback scaffolding from platformRequestSignedUrl

Part of plan: cli-upload-url-consolidation.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
