### PR TITLE
Add Twilio-specific public ingress URL selection

### DIFF
--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -26,15 +26,47 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import { setIngressPublicBaseUrl } from "../config/env.js";
+import { IngressConfigSchema } from "../config/schemas/ingress.js";
 import {
   getOAuthCallbackUrl,
   getPublicBaseUrl,
   getTelegramWebhookUrl,
   getTwilioConnectActionUrl,
+  getTwilioMediaStreamUrl,
   getTwilioRelayUrl,
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
 } from "../inbound/public-ingress-urls.js";
+
+// ---------------------------------------------------------------------------
+// IngressConfigSchema
+// ---------------------------------------------------------------------------
+
+describe("IngressConfigSchema", () => {
+  test("accepts a Twilio-specific absolute HTTP(S) public base URL", () => {
+    const result = IngressConfigSchema.parse({
+      twilioPublicBaseUrl: "https://twilio.example.com",
+    });
+
+    expect(result.twilioPublicBaseUrl).toBe("https://twilio.example.com");
+  });
+
+  test("accepts an empty Twilio-specific public base URL", () => {
+    const result = IngressConfigSchema.parse({
+      twilioPublicBaseUrl: "",
+    });
+
+    expect(result.twilioPublicBaseUrl).toBe("");
+  });
+
+  test("rejects a relative Twilio-specific public base URL", () => {
+    expect(() =>
+      IngressConfigSchema.parse({
+        twilioPublicBaseUrl: "/webhooks/twilio",
+      }),
+    ).toThrow(/ingress\.twilioPublicBaseUrl must be an absolute URL/);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // getPublicBaseUrl — fallback chain
@@ -152,6 +184,96 @@ describe("getPublicBaseUrl", () => {
     setIngressPublicBaseUrl("  https://ingress-env.example.com  ");
     const result = getPublicBaseUrl({});
     expect(result).toBe("https://ingress-env.example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Twilio-specific public base URL selection
+// ---------------------------------------------------------------------------
+
+describe("Twilio-specific public base URL selection", () => {
+  beforeEach(() => {
+    setIngressPublicBaseUrl(undefined);
+  });
+
+  afterEach(() => {
+    setIngressPublicBaseUrl(undefined);
+  });
+
+  test("Twilio URL builders prefer ingress.twilioPublicBaseUrl", () => {
+    const config = {
+      ingress: {
+        publicBaseUrl: "https://generic.example.com",
+        twilioPublicBaseUrl: "  https://twilio.example.com///  ",
+      },
+    };
+
+    expect(getTwilioVoiceWebhookUrl(config, "session-123")).toBe(
+      "https://twilio.example.com/webhooks/twilio/voice?callSessionId=session-123",
+    );
+    expect(getTwilioStatusCallbackUrl(config)).toBe(
+      "https://twilio.example.com/webhooks/twilio/status",
+    );
+    expect(getTwilioConnectActionUrl(config)).toBe(
+      "https://twilio.example.com/webhooks/twilio/connect-action",
+    );
+    expect(getTwilioRelayUrl(config)).toBe(
+      "wss://twilio.example.com/webhooks/twilio/relay",
+    );
+    expect(getTwilioMediaStreamUrl(config)).toBe(
+      "wss://twilio.example.com/webhooks/twilio/media-stream",
+    );
+  });
+
+  test("Twilio URL builders fall back to ingress.publicBaseUrl", () => {
+    const config = {
+      ingress: {
+        publicBaseUrl: "https://generic.example.com",
+      },
+    };
+
+    expect(getTwilioVoiceWebhookUrl(config)).toBe(
+      "https://generic.example.com/webhooks/twilio/voice",
+    );
+    expect(getTwilioStatusCallbackUrl(config)).toBe(
+      "https://generic.example.com/webhooks/twilio/status",
+    );
+    expect(getTwilioConnectActionUrl(config)).toBe(
+      "https://generic.example.com/webhooks/twilio/connect-action",
+    );
+    expect(getTwilioRelayUrl(config)).toBe(
+      "wss://generic.example.com/webhooks/twilio/relay",
+    );
+    expect(getTwilioMediaStreamUrl(config)).toBe(
+      "wss://generic.example.com/webhooks/twilio/media-stream",
+    );
+  });
+
+  test("Twilio URL builders fall back to module-level ingress state", () => {
+    setIngressPublicBaseUrl("https://ingress-env.example.com");
+
+    expect(
+      getTwilioStatusCallbackUrl({
+        ingress: { twilioPublicBaseUrl: "" },
+      }),
+    ).toBe("https://ingress-env.example.com/webhooks/twilio/status");
+  });
+
+  test("non-Twilio URL builders ignore ingress.twilioPublicBaseUrl", () => {
+    const config = {
+      ingress: {
+        publicBaseUrl: "https://generic.example.com",
+        twilioPublicBaseUrl: "https://twilio.example.com",
+      },
+    };
+
+    expect(getPublicBaseUrl(config)).toBe("https://generic.example.com");
+    expect(getOAuthCallbackUrl(config)).toBe(
+      "https://generic.example.com/webhooks/oauth/callback",
+    );
+    expect(getTelegramWebhookUrl(config)).toBe(
+      "https://generic.example.com/webhooks/telegram",
+    );
   });
 });
 

--- a/assistant/src/config/schemas/ingress.ts
+++ b/assistant/src/config/schemas/ingress.ts
@@ -1,5 +1,14 @@
 import { z } from "zod";
 
+function emptyOrAbsoluteHttpUrl(fieldPath: string) {
+  return z
+    .string({ error: `${fieldPath} must be a string` })
+    .refine(
+      (val) => val === "" || /^https?:\/\//i.test(val),
+      `${fieldPath} must be an absolute URL starting with http:// or https://`,
+    );
+}
+
 const IngressWebhookConfigSchema = z
   .object({
     secret: z
@@ -74,16 +83,14 @@ const IngressBaseSchema = z
       .boolean({ error: "ingress.enabled must be a boolean" })
       .optional()
       .describe("Whether the ingress HTTP server is enabled"),
-    publicBaseUrl: z
-      .string({ error: "ingress.publicBaseUrl must be a string" })
-      .refine(
-        (val) => val === "" || /^https?:\/\//i.test(val),
-        "ingress.publicBaseUrl must be an absolute URL starting with http:// or https://",
-      )
+    publicBaseUrl: emptyOrAbsoluteHttpUrl("ingress.publicBaseUrl")
       .default("")
       .describe(
         "Public-facing base URL for the ingress server (used in webhook callbacks)",
       ),
+    twilioPublicBaseUrl: emptyOrAbsoluteHttpUrl("ingress.twilioPublicBaseUrl")
+      .optional()
+      .describe("Twilio-specific public-facing base URL for webhook callbacks"),
     webhook: IngressWebhookConfigSchema.default(
       IngressWebhookConfigSchema.parse({}),
     ),

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -30,7 +30,11 @@
 import { getIngressPublicBaseUrl } from "../config/env.js";
 
 export interface IngressConfig {
-  ingress?: { enabled?: boolean; publicBaseUrl?: string };
+  ingress?: {
+    enabled?: boolean;
+    publicBaseUrl?: string;
+    twilioPublicBaseUrl?: string;
+  };
 }
 
 /**
@@ -38,6 +42,14 @@ export interface IngressConfig {
  */
 function normalizeUrl(url: string): string {
   return url.trim().replace(/\/+$/, "");
+}
+
+function assertPublicIngressEnabled(config: IngressConfig): void {
+  if (config.ingress?.enabled === false) {
+    throw new Error(
+      "Public ingress is disabled. Ask the assistant to enable it, or update it from the Settings page.",
+    );
+  }
 }
 
 /**
@@ -51,11 +63,7 @@ function normalizeUrl(url: string): string {
  * Throws if no source provides a non-empty value or if ingress is disabled.
  */
 export function getPublicBaseUrl(config: IngressConfig): string {
-  if (config.ingress?.enabled === false) {
-    throw new Error(
-      "Public ingress is disabled. Ask the assistant to enable it, or update it from the Settings page.",
-    );
-  }
+  assertPublicIngressEnabled(config);
 
   const ingressValue = config.ingress?.publicBaseUrl;
   if (ingressValue) {
@@ -74,6 +82,18 @@ export function getPublicBaseUrl(config: IngressConfig): string {
   );
 }
 
+function getTwilioPublicBaseUrl(config: IngressConfig): string {
+  assertPublicIngressEnabled(config);
+
+  const ingressValue = config.ingress?.twilioPublicBaseUrl;
+  if (ingressValue) {
+    const normalized = normalizeUrl(ingressValue);
+    if (normalized) return normalized;
+  }
+
+  return getPublicBaseUrl(config);
+}
+
 /**
  * Build the Twilio voice webhook URL.
  *
@@ -87,7 +107,7 @@ export function getTwilioVoiceWebhookUrl(
   config: IngressConfig,
   callSessionId?: string,
 ): string {
-  const base = getPublicBaseUrl(config);
+  const base = getTwilioPublicBaseUrl(config);
   if (callSessionId) {
     return `${base}/webhooks/twilio/voice?callSessionId=${callSessionId}`;
   }
@@ -98,7 +118,7 @@ export function getTwilioVoiceWebhookUrl(
  * Build the Twilio status callback URL.
  */
 export function getTwilioStatusCallbackUrl(config: IngressConfig): string {
-  const base = getPublicBaseUrl(config);
+  const base = getTwilioPublicBaseUrl(config);
   return `${base}/webhooks/twilio/status`;
 }
 
@@ -106,7 +126,7 @@ export function getTwilioStatusCallbackUrl(config: IngressConfig): string {
  * Build the Twilio connect-action callback URL.
  */
 export function getTwilioConnectActionUrl(config: IngressConfig): string {
-  const base = getPublicBaseUrl(config);
+  const base = getTwilioPublicBaseUrl(config);
   return `${base}/webhooks/twilio/connect-action`;
 }
 
@@ -115,7 +135,7 @@ export function getTwilioConnectActionUrl(config: IngressConfig): string {
  * Converts http:// → ws:// and https:// → wss://.
  */
 export function getTwilioRelayUrl(config: IngressConfig): string {
-  const base = getPublicBaseUrl(config);
+  const base = getTwilioPublicBaseUrl(config);
   const wsBase = base.replace(/^http(s?)/, "ws$1");
   return `${wsBase}/webhooks/twilio/relay`;
 }
@@ -127,7 +147,7 @@ export function getTwilioRelayUrl(config: IngressConfig): string {
  * Converts http:// → ws:// and https:// → wss://.
  */
 export function getTwilioMediaStreamUrl(config: IngressConfig): string {
-  const base = getPublicBaseUrl(config);
+  const base = getTwilioPublicBaseUrl(config);
   const wsBase = base.replace(/^http(s?)/, "ws$1");
   return `${wsBase}/webhooks/twilio/media-stream`;
 }


### PR DESCRIPTION
## Summary
- Add an optional Twilio-specific public ingress base URL.
- Route Twilio webhook and WebSocket URL builders through that override while preserving generic public URL behavior.
- Cover Twilio preference, fallback, and non-Twilio behavior in tests.

Part of plan: velay-twilio-ingress.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
