### PR TITLE
chore(runtime): rip vestigial trustPath plumbing from vbundle-builder

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -6,7 +6,6 @@
  * - workspace/: the entire ~/.vellum/workspace/ directory tree (DB, config,
  *   skills, prompts, attachments, etc.) — excluding large/regenerable
  *   dirs (embedding-models/, data/qdrant/)
- * - trust/trust.json: trust rules (optional)
  */
 
 import { createHash, randomUUID } from "node:crypto";
@@ -501,8 +500,6 @@ export interface BuildExportVBundleOptions {
   exportOptions: VBundleExportOptions;
   /** Whether secrets were stripped from the bundle before archiving. */
   secretsRedacted: boolean;
-  /** Absolute path to trust.json. If provided and the file exists, it is included in the archive. */
-  trustPath?: string;
   /**
    * Absolute path to the workspace directory (~/.vellum/workspace/).
    * When provided and exists, the entire directory tree is walked and
@@ -529,7 +526,7 @@ export interface BuildExportVBundleOptions {
  * Walks the entire workspace directory (~/.vellum/workspace/) and includes
  * all files in the archive, skipping only large/regenerable directories
  * (embedding-models/, data/qdrant/). Binary files (SQLite DB, attachments)
- * are included. Trust rules are handled separately.
+ * are included.
  *
  * The WAL is checkpointed before the walk so the exported DB file contains
  * all committed rows.
@@ -544,7 +541,6 @@ export function buildExportVBundle(
     exportOptions,
     secretsRedacted,
     checkpoint,
-    trustPath,
     workspaceDir,
     credentials,
   } = options;
@@ -579,12 +575,6 @@ export function buildExportVBundle(
     const configJson = new TextDecoder().decode(configEntry.data);
     const sanitized = sanitizeConfigForTransfer(configJson);
     configEntry.data = new TextEncoder().encode(sanitized);
-  }
-
-  // Include trust rules if the file exists.
-  if (trustPath && existsSync(trustPath)) {
-    const trustData = new Uint8Array(readFileSync(trustPath));
-    files.push({ path: "trust/trust.json", data: trustData });
   }
 
   // Include credential entries if provided
@@ -885,7 +875,6 @@ export async function streamExportVBundle(
     exportOptions,
     secretsRedacted,
     checkpoint,
-    trustPath,
     workspaceDir,
     credentials,
   } = options;
@@ -909,18 +898,6 @@ export async function streamExportVBundle(
         skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
       }),
     );
-  }
-
-  // Include trust rules if the file exists
-  if (trustPath && existsSync(trustPath)) {
-    const trustStat = lstatSync(trustPath);
-    if (trustStat.isFile()) {
-      allFileMetadata.push({
-        archivePath: "trust/trust.json",
-        diskPath: trustPath,
-        size: trustStat.size,
-      });
-    }
   }
 
   // Sanitize workspace/config.json: read from disk, sanitize, and replace the

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -5,7 +5,6 @@
  * - manifest.json: metadata with schema_version, checksums, and bundle info
  * - workspace/: the entire workspace directory tree (new format), OR
  *   data/db/assistant.db + config/settings.json (old format)
- * - trust/trust.json: trust rules (optional)
  *
  * Validation steps:
  * 1. Archive structure: valid gzip tar with required entries


### PR DESCRIPTION
## Summary
Trust rules now live in gateway SQLite at \`\${GATEWAY_SECURITY_DIR}/gateway.sqlite\` (separate Docker volume, not bundleable) and trust-rules-v3 has been GA. The `trustPath` option on `BuildExportVBundleOptions` had zero current callers — this branch rips the field, both destructurings, and both `if (trustPath && existsSync(trustPath))` blocks from `buildExportVBundle` and `streamExportVBundle`, plus stale `trust/trust.json` mentions from sibling doc-comments.

## Self-review result
PASS — 1 gap found in round 1 (stale paired doc-comment in `vbundle-validator.ts`), fixed in #29011. Round 2 of all four passes returned PASS on this plan's scope. Pass 4 surfaced two **pre-existing** documentation inaccuracies outside this plan's scope (CLI backup help text and a streaming-importer comment) — not addressed here; see below.

## PRs merged into feature branch
- #29005: chore(runtime): rip vestigial trustPath plumbing from vbundle-builder
- #29011: fix(runtime): drop stale trust/trust.json bullet from vbundle-validator doc-comment

## Out-of-scope observations (deferred)
Round-2 self-review noted pre-existing stale wording (not introduced by this branch) worth a follow-up:
- `assistant/src/cli/commands/backup.ts` lines 524, 660, 931 — backup help/safety-gate text mentions "trust rules" as bundle/cached content; trust never lived in the workspace bundle.
- `assistant/src/runtime/migrations/vbundle-streaming-importer.ts` lines 21–22, 813 — comments promise "config/trust cache invalidation" but only `invalidateConfigCache()` runs.

Part of plan: vbundle-trustpath-rip.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
