### PR TITLE
Bridge Velay HTTP request frames into the local gateway listener

### DIFF
--- a/gateway/src/velay/http-bridge.test.ts
+++ b/gateway/src/velay/http-bridge.test.ts
@@ -1,0 +1,200 @@
+import { Buffer } from "node:buffer";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { VELAY_FRAME_TYPES, type VelayHttpRequestFrame } from "./protocol.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { bridgeVelayHttpRequest } = await import("./http-bridge.js");
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+});
+
+function makeFrame(
+  overrides: Partial<VelayHttpRequestFrame> = {},
+): VelayHttpRequestFrame {
+  return {
+    type: VELAY_FRAME_TYPES.httpRequest,
+    request_id: "req-123",
+    method: "POST",
+    path: "/webhooks/example",
+    headers: {},
+    ...overrides,
+  };
+}
+
+function base64(text: string): string {
+  return Buffer.from(text).toString("base64");
+}
+
+function decodeBase64(body: string | undefined): string {
+  return Buffer.from(body ?? "", "base64").toString("utf8");
+}
+
+describe("Velay HTTP bridge", () => {
+  test("forwards JSON body frames to the gateway loopback listener", async () => {
+    const captured: {
+      url: string;
+      method: string;
+      body: string;
+      headers: Headers;
+    }[] = [];
+    fetchMock = mock(
+      async (input: string | URL | Request, _init?: RequestInit) => {
+        const req = input as Request;
+        captured.push({
+          url: req.url,
+          method: req.method,
+          body: await req.text(),
+          headers: req.headers,
+        });
+        return Response.json({ ok: true });
+      },
+    );
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({
+        path: "/webhooks/example",
+        headers: {
+          "content-type": ["application/json"],
+          connection: ["keep-alive"],
+          host: ["public.example.com"],
+          "x-webhook-id": ["evt-123"],
+        },
+        body_base64: base64(JSON.stringify({ message: "hello" })),
+      }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(response.status_code).toBe(200);
+    expect(captured[0].url).toBe("http://127.0.0.1:7830/webhooks/example");
+    expect(captured[0].method).toBe("POST");
+    expect(captured[0].body).toBe('{"message":"hello"}');
+    expect(captured[0].headers.get("content-type")).toBe("application/json");
+    expect(captured[0].headers.get("host")).toBe("public.example.com");
+    expect(captured[0].headers.get("x-webhook-id")).toBe("evt-123");
+    expect(captured[0].headers.has("connection")).toBe(false);
+  });
+
+  test("preserves form bodies and raw query strings for Twilio webhook routes", async () => {
+    const captured: { url: string; body: string; headers: Headers }[] = [];
+    fetchMock = mock(
+      async (input: string | URL | Request, _init?: RequestInit) => {
+        const req = input as Request;
+        captured.push({
+          url: req.url,
+          body: await req.text(),
+          headers: req.headers,
+        });
+        return new Response("<Response/>", {
+          status: 200,
+          headers: { "content-type": "text/xml" },
+        });
+      },
+    );
+
+    await bridgeVelayHttpRequest(
+      makeFrame({
+        path: "/webhooks/twilio/voice",
+        raw_query: "callSessionId=session-123&redirect=%2Fnext%3Fx%3D1",
+        headers: {
+          "content-type": ["application/x-www-form-urlencoded"],
+        },
+        body_base64: base64("CallSid=CA123&From=%2B15550100&To=%2B15550101"),
+      }),
+      "http://127.0.0.1:7830/",
+    );
+
+    const expectedUrl =
+      "http://127.0.0.1:7830/webhooks/twilio/voice" +
+      "?callSessionId=session-123&redirect=%2Fnext%3Fx%3D1";
+    expect(captured[0].url).toBe(expectedUrl);
+    expect(captured[0].body).toBe(
+      "CallSid=CA123&From=%2B15550100&To=%2B15550101",
+    );
+    expect(captured[0].headers.get("content-type")).toBe(
+      "application/x-www-form-urlencoded",
+    );
+  });
+
+  test("converts loopback responses back into Velay response frames", async () => {
+    fetchMock = mock(async () => {
+      return new Response("created", {
+        status: 201,
+        headers: {
+          "content-type": "text/plain",
+          "x-result": "preserved",
+          connection: "keep-alive",
+          "transfer-encoding": "chunked",
+        },
+      });
+    });
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ request_id: "req-response" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(response).toEqual({
+      type: VELAY_FRAME_TYPES.httpResponse,
+      request_id: "req-response",
+      status_code: 201,
+      headers: {
+        "content-type": ["text/plain"],
+        "x-result": ["preserved"],
+      },
+      body_base64: base64("created"),
+    });
+  });
+
+  test("rejects unsafe absolute paths without contacting the loopback listener", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch");
+    });
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ path: "https://example.com/webhooks/example" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status_code).toBe(502);
+    expect(decodeBase64(response.body_base64)).toBe('{"error":"Bad Gateway"}');
+  });
+
+  test("returns a 502 response frame when the body is not valid base64", async () => {
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ body_base64: "not base64" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status_code).toBe(502);
+  });
+
+  test("returns a 502 response frame when loopback fetch fails", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("connection refused");
+    });
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame(),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(response.status_code).toBe(502);
+    expect(response.request_id).toBe("req-123");
+  });
+});

--- a/gateway/src/velay/http-bridge.ts
+++ b/gateway/src/velay/http-bridge.ts
@@ -1,0 +1,140 @@
+import { Buffer } from "node:buffer";
+import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
+
+import { fetchImpl } from "../fetch.js";
+import {
+  VELAY_FRAME_TYPES,
+  type VelayHeaders,
+  type VelayHttpRequestFrame,
+  type VelayHttpResponseFrame,
+} from "./protocol.js";
+
+const BAD_GATEWAY_BODY = JSON.stringify({ error: "Bad Gateway" });
+
+export async function bridgeVelayHttpRequest(
+  frame: VelayHttpRequestFrame,
+  gatewayLoopbackBaseUrl: string,
+): Promise<VelayHttpResponseFrame> {
+  const url = buildLoopbackUrl(gatewayLoopbackBaseUrl, frame);
+  if (!url) return badGatewayFrame(frame.request_id);
+
+  const body = decodeBody(frame.body_base64);
+  if (!body.ok) return badGatewayFrame(frame.request_id);
+
+  const request = buildLoopbackRequest(frame, url, body.value);
+  if (!request) return badGatewayFrame(frame.request_id);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(request);
+  } catch {
+    return badGatewayFrame(frame.request_id);
+  }
+
+  return {
+    type: VELAY_FRAME_TYPES.httpResponse,
+    request_id: frame.request_id,
+    status_code: response.status,
+    headers: headersToVelay(stripHopByHop(new Headers(response.headers))),
+    body_base64: Buffer.from(await response.arrayBuffer()).toString("base64"),
+  };
+}
+
+function buildLoopbackRequest(
+  frame: VelayHttpRequestFrame,
+  url: string,
+  body: ArrayBuffer | undefined,
+): Request | undefined {
+  try {
+    const headers = headersFromVelay(frame.headers);
+    if (body !== undefined) {
+      headers.set("content-length", String(body.byteLength));
+    } else {
+      headers.delete("content-length");
+    }
+
+    return new Request(url, {
+      method: frame.method,
+      headers,
+      body,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function buildLoopbackUrl(
+  gatewayLoopbackBaseUrl: string,
+  frame: VelayHttpRequestFrame,
+): string | undefined {
+  if (!isSafeOriginRelativePath(frame.path)) return undefined;
+  const rawQuery = frame.raw_query ?? "";
+  const query = rawQuery === "" ? "" : `?${rawQuery.replace(/^\?/, "")}`;
+  return buildUpstreamUrl(gatewayLoopbackBaseUrl, frame.path, query);
+}
+
+function isSafeOriginRelativePath(path: string): boolean {
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (path.includes("\\") || path.includes("?") || path.includes("#")) {
+    return false;
+  }
+  try {
+    const parsed = new URL(path, "http://127.0.0.1");
+    return parsed.origin === "http://127.0.0.1" && parsed.pathname === path;
+  } catch {
+    return false;
+  }
+}
+
+function decodeBody(
+  bodyBase64: string | undefined,
+): { ok: true; value?: ArrayBuffer } | { ok: false } {
+  if (!bodyBase64) return { ok: true };
+  const isBase64 =
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      bodyBase64,
+    );
+  if (!isBase64) {
+    return { ok: false };
+  }
+  const bytes = Buffer.from(bodyBase64, "base64");
+  return {
+    ok: true,
+    value: bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ),
+  };
+}
+
+function headersFromVelay(headers: VelayHeaders): Headers {
+  return stripHopByHop(headersToWeb(headers));
+}
+
+function headersToWeb(headers: VelayHeaders): Headers {
+  const webHeaders = new Headers();
+  for (const [name, values] of Object.entries(headers)) {
+    for (const value of values) {
+      webHeaders.append(name, value);
+    }
+  }
+  return webHeaders;
+}
+
+function headersToVelay(headers: Headers): VelayHeaders {
+  const velayHeaders: VelayHeaders = {};
+  for (const [name, value] of headers.entries()) {
+    velayHeaders[name] = [value];
+  }
+  return velayHeaders;
+}
+
+function badGatewayFrame(requestId: string): VelayHttpResponseFrame {
+  return {
+    type: VELAY_FRAME_TYPES.httpResponse,
+    request_id: requestId,
+    status_code: 502,
+    headers: { "content-type": ["application/json"] },
+    body_base64: Buffer.from(BAD_GATEWAY_BODY).toString("base64"),
+  };
+}

--- a/gateway/src/velay/protocol.ts
+++ b/gateway/src/velay/protocol.ts
@@ -1,0 +1,87 @@
+export const VELAY_TUNNEL_SUBPROTOCOL = "velay-tunnel-v1";
+
+export const VELAY_FRAME_TYPES = {
+  registered: "registered",
+  httpRequest: "http_request",
+  httpResponse: "http_response",
+  websocketOpen: "websocket_open",
+  websocketOpened: "websocket_opened",
+  websocketOpenError: "websocket_open_error",
+  websocketMessage: "websocket_message",
+  websocketClose: "websocket_close",
+} as const;
+
+export const VELAY_WEBSOCKET_MESSAGE_TYPES = {
+  text: "text",
+  binary: "binary",
+} as const;
+
+export type VelayHeaders = Record<string, string[]>;
+
+export type VelayRegisteredFrame = {
+  type: typeof VELAY_FRAME_TYPES.registered;
+  assistant_id: string;
+  public_url: string;
+};
+
+export type VelayHttpRequestFrame = {
+  type: typeof VELAY_FRAME_TYPES.httpRequest;
+  request_id: string;
+  method: string;
+  path: string;
+  raw_query?: string;
+  headers: VelayHeaders;
+  body_base64?: string;
+};
+
+export type VelayHttpResponseFrame = {
+  type: typeof VELAY_FRAME_TYPES.httpResponse;
+  request_id: string;
+  status_code: number;
+  headers?: VelayHeaders;
+  body_base64?: string;
+};
+
+export type VelayWebSocketOpenFrame = {
+  type: typeof VELAY_FRAME_TYPES.websocketOpen;
+  connection_id: string;
+  path: string;
+  raw_query?: string;
+  headers: VelayHeaders;
+  subprotocol?: string;
+};
+
+export type VelayWebSocketOpenedFrame = {
+  type: typeof VELAY_FRAME_TYPES.websocketOpened;
+  connection_id: string;
+};
+
+export type VelayWebSocketOpenErrorFrame = {
+  type: typeof VELAY_FRAME_TYPES.websocketOpenError;
+  connection_id: string;
+  reason?: string;
+};
+
+export type VelayWebSocketMessageFrame = {
+  type: typeof VELAY_FRAME_TYPES.websocketMessage;
+  connection_id: string;
+  message_type: keyof typeof VELAY_WEBSOCKET_MESSAGE_TYPES;
+  body_base64?: string;
+};
+
+export type VelayWebSocketCloseFrame = {
+  type: typeof VELAY_FRAME_TYPES.websocketClose;
+  connection_id: string;
+  code?: number;
+  reason?: string;
+};
+
+export type VelayFrame =
+  | VelayRegisteredFrame
+  | VelayHttpRequestFrame
+  | VelayHttpResponseFrame
+  | VelayWebSocketOpenFrame
+  | VelayWebSocketOpenedFrame
+  | VelayWebSocketOpenErrorFrame
+  | VelayWebSocketMessageFrame
+  | VelayWebSocketCloseFrame;


### PR DESCRIPTION
## Summary
- Add Velay protocol frame types for HTTP and WebSocket traffic.
- Bridge HTTP request frames to the local gateway listener with safe path/body/header handling.
- Cover JSON/form forwarding, query preservation, response preservation, and unsafe path rejection.

Part of plan: velay-twilio-ingress.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
