### PR TITLE
Bridge Velay WebSocket frames into existing Twilio gateway upgrades

### DIFF
--- a/gateway/src/velay/protocol.ts
+++ b/gateway/src/velay/protocol.ts
@@ -17,6 +17,8 @@ export const VELAY_WEBSOCKET_MESSAGE_TYPES = {
 } as const;
 
 export type VelayHeaders = Record<string, string[]>;
+export type VelayWebSocketMessageType =
+  (typeof VELAY_WEBSOCKET_MESSAGE_TYPES)[keyof typeof VELAY_WEBSOCKET_MESSAGE_TYPES];
 
 export type VelayRegisteredFrame = {
   type: typeof VELAY_FRAME_TYPES.registered;
@@ -65,7 +67,7 @@ export type VelayWebSocketOpenErrorFrame = {
 export type VelayWebSocketMessageFrame = {
   type: typeof VELAY_FRAME_TYPES.websocketMessage;
   connection_id: string;
-  message_type: keyof typeof VELAY_WEBSOCKET_MESSAGE_TYPES;
+  message_type: VelayWebSocketMessageType;
   body_base64?: string;
 };
 
@@ -83,5 +85,17 @@ export type VelayFrame =
   | VelayWebSocketOpenFrame
   | VelayWebSocketOpenedFrame
   | VelayWebSocketOpenErrorFrame
+  | VelayWebSocketMessageFrame
+  | VelayWebSocketCloseFrame;
+
+export type VelayWebSocketFrame =
+  | VelayWebSocketOpenFrame
+  | VelayWebSocketOpenedFrame
+  | VelayWebSocketOpenErrorFrame
+  | VelayWebSocketMessageFrame
+  | VelayWebSocketCloseFrame;
+
+export type VelayWebSocketInboundFrame =
+  | VelayWebSocketOpenFrame
   | VelayWebSocketMessageFrame
   | VelayWebSocketCloseFrame;

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -1,0 +1,317 @@
+import { Buffer } from "node:buffer";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  VELAY_FRAME_TYPES,
+  VELAY_WEBSOCKET_MESSAGE_TYPES,
+  type VelayFrame,
+  type VelayWebSocketOpenFrame,
+} from "./protocol.js";
+import { VelayWebSocketBridge } from "./websocket-bridge.js";
+
+const WS_CONNECTING = WebSocket.CONNECTING;
+const WS_OPEN = WebSocket.OPEN;
+const WS_CLOSED = WebSocket.CLOSED;
+
+type Listener = (event?: unknown) => void;
+
+class FakeWebSocket {
+  static CONNECTING = WS_CONNECTING;
+  static OPEN = WS_OPEN;
+  static CLOSING = 2;
+  static CLOSED = WS_CLOSED;
+
+  binaryType: BinaryType = "blob";
+  readyState = WS_CONNECTING;
+  sent: (string | Uint8Array)[] = [];
+  closes: { code?: number; reason?: string }[] = [];
+  private readonly listeners = new Map<string, Listener[]>();
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  send(message: string | Uint8Array): void {
+    this.sent.push(message);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = WS_CLOSED;
+    this.closes.push({ code, reason });
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+const OriginalWebSocket = globalThis.WebSocket;
+let fakeSocket: FakeWebSocket;
+let sentFrames: VelayFrame[];
+let bridge: VelayWebSocketBridge;
+let WebSocketMock: ReturnType<typeof mock>;
+
+beforeEach(() => {
+  fakeSocket = new FakeWebSocket();
+  sentFrames = [];
+  WebSocketMock = mock(() => fakeSocket);
+  Object.assign(WebSocketMock, FakeWebSocket);
+  globalThis.WebSocket = WebSocketMock as unknown as typeof WebSocket;
+  bridge = new VelayWebSocketBridge("http://127.0.0.1:7830", (frame) => {
+    sentFrames.push(frame);
+  });
+});
+
+afterAll(() => {
+  globalThis.WebSocket = OriginalWebSocket;
+});
+
+function makeOpenFrame(
+  overrides: Partial<VelayWebSocketOpenFrame> = {},
+): VelayWebSocketOpenFrame {
+  return {
+    type: VELAY_FRAME_TYPES.websocketOpen,
+    connection_id: "conn-123",
+    path: "/webhooks/twilio/relay",
+    raw_query: "callSessionId=session-123&token=edge-token",
+    headers: {},
+    ...overrides,
+  };
+}
+
+function base64(text: string | Uint8Array): string {
+  return Buffer.from(text).toString("base64");
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("VelayWebSocketBridge", () => {
+  test("opens a loopback WebSocket and sends websocket_opened after local open", () => {
+    bridge.handleFrame(
+      makeOpenFrame({
+        headers: {
+          authorization: ["Bearer edge-token"],
+          connection: ["upgrade"],
+          host: ["public.example.com"],
+          "sec-websocket-key": ["client-key"],
+          "x-twilio-signature": ["sig-123"],
+        },
+        subprotocol: "twilio-relay",
+      }),
+    );
+
+    expect(sentFrames).toEqual([]);
+    expect(WebSocketMock).toHaveBeenCalledTimes(1);
+
+    const [url, options] = WebSocketMock.mock.calls[0] as [
+      string,
+      { headers: Record<string, string>; protocol?: string },
+    ];
+    expect(url).toBe(
+      "ws://127.0.0.1:7830/webhooks/twilio/relay?callSessionId=session-123&token=edge-token",
+    );
+    expect(options.protocol).toBe("twilio-relay");
+    expect(options.headers.authorization).toBe("Bearer edge-token");
+    expect(options.headers.host).toBe("public.example.com");
+    expect(options.headers["x-twilio-signature"]).toBe("sig-123");
+    expect(options.headers.connection).toBeUndefined();
+    expect(options.headers["sec-websocket-key"]).toBeUndefined();
+
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    expect(sentFrames).toEqual([
+      {
+        type: VELAY_FRAME_TYPES.websocketOpened,
+        connection_id: "conn-123",
+      },
+    ]);
+  });
+
+  test("sends websocket_open_error when the local upgrade fails before open", () => {
+    bridge.open(makeOpenFrame());
+
+    fakeSocket.emit("error");
+
+    expect(sentFrames).toEqual([
+      {
+        type: VELAY_FRAME_TYPES.websocketOpenError,
+        connection_id: "conn-123",
+        reason: "WebSocket connection failed",
+      },
+    ]);
+    expect(bridge.getConnectionCount()).toBe(0);
+    expect(fakeSocket.closes).toEqual([{ code: undefined, reason: undefined }]);
+  });
+
+  test("forwards text frames from Velay to the local gateway WebSocket", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.message({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: base64('{"event":"start"}'),
+    });
+
+    expect(fakeSocket.sent).toEqual(['{"event":"start"}']);
+  });
+
+  test("forwards local text frames back to Velay as websocket_message frames", async () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    fakeSocket.emit("message", { data: "hello from gateway" });
+    await flushPromises();
+
+    expect(sentFrames.at(-1)).toEqual({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: base64("hello from gateway"),
+    });
+  });
+
+  test("preserves binary frames in both directions", async () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.message({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.binary,
+      body_base64: base64(new Uint8Array([1, 2, 3])),
+    });
+
+    expect(fakeSocket.sent[0]).toEqual(new Uint8Array([1, 2, 3]));
+
+    fakeSocket.emit("message", { data: new Uint8Array([4, 5, 6]) });
+    await flushPromises();
+
+    expect(sentFrames.at(-1)).toEqual({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.binary,
+      body_base64: base64(new Uint8Array([4, 5, 6])),
+    });
+  });
+
+  test("forwards close frames and cleans up the connection map", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.close({
+      type: VELAY_FRAME_TYPES.websocketClose,
+      connection_id: "conn-123",
+      code: 1000,
+      reason: "done",
+    });
+
+    expect(fakeSocket.closes).toEqual([{ code: 1000, reason: "done" }]);
+    expect(bridge.getConnectionCount()).toBe(0);
+
+    fakeSocket.emit("close", { code: 1000, reason: "done" });
+    expect(
+      sentFrames.filter(
+        (frame) => frame.type === VELAY_FRAME_TYPES.websocketClose,
+      ),
+    ).toEqual([]);
+  });
+
+  test("keeps empty text frames distinct from invalid payloads", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.message({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: "",
+    });
+
+    expect(fakeSocket.sent).toEqual([""]);
+    expect(fakeSocket.closes).toEqual([]);
+  });
+
+  test("rejects invalid base64 payloads and cleans up", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.message({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: "not base64",
+    });
+
+    expect(fakeSocket.closes).toEqual([
+      { code: 1003, reason: "Invalid message" },
+    ]);
+    expect(bridge.getConnectionCount()).toBe(0);
+  });
+
+  test("buffers Velay messages until local open", () => {
+    bridge.open(makeOpenFrame());
+
+    bridge.message({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: base64("early"),
+    });
+
+    expect(fakeSocket.sent).toEqual([]);
+
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    expect(fakeSocket.sent).toEqual(["early"]);
+  });
+
+  test("sends websocket_open_error without connecting for unsafe paths", () => {
+    bridge.open(
+      makeOpenFrame({
+        path: "https://example.com/webhooks/twilio/relay",
+      }),
+    );
+
+    expect(WebSocketMock).not.toHaveBeenCalled();
+    expect(sentFrames).toEqual([
+      {
+        type: VELAY_FRAME_TYPES.websocketOpenError,
+        connection_id: "conn-123",
+        reason: "Invalid WebSocket path",
+      },
+    ]);
+  });
+
+  test("forwards local close frames back to Velay and cleans up", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    fakeSocket.emit("close", { code: 1001, reason: "going away" });
+
+    expect(bridge.getConnectionCount()).toBe(0);
+    expect(sentFrames.at(-1)).toEqual({
+      type: VELAY_FRAME_TYPES.websocketClose,
+      connection_id: "conn-123",
+      code: 1001,
+      reason: "going away",
+    });
+  });
+});

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -22,7 +22,7 @@ class FakeWebSocket {
   static CLOSED = WS_CLOSED;
 
   binaryType: BinaryType = "blob";
-  readyState = WS_CONNECTING;
+  readyState: number = WS_CONNECTING;
   sent: (string | Uint8Array)[] = [];
   closes: { code?: number; reason?: string }[] = [];
   private readonly listeners = new Map<string, Listener[]>();

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -1,0 +1,381 @@
+import { Buffer } from "node:buffer";
+import type { OutgoingHttpHeaders } from "node:http";
+import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
+
+import {
+  VELAY_FRAME_TYPES,
+  VELAY_WEBSOCKET_MESSAGE_TYPES,
+  type VelayFrame,
+  type VelayHeaders,
+  type VelayWebSocketCloseFrame,
+  type VelayWebSocketInboundFrame,
+  type VelayWebSocketMessageFrame,
+  type VelayWebSocketOpenErrorFrame,
+  type VelayWebSocketOpenedFrame,
+  type VelayWebSocketOpenFrame,
+} from "./protocol.js";
+
+const MAX_PENDING_MESSAGES = 100;
+
+type PendingMessage = string | Uint8Array;
+
+type BridgeConnection = {
+  ws: WebSocket;
+  opened: boolean;
+  openErrorSent: boolean;
+  pendingMessages: PendingMessage[];
+  suppressNextCloseFrame: boolean;
+};
+
+type SendVelayFrame = (frame: VelayFrame) => void;
+
+export class VelayWebSocketBridge {
+  private readonly connections = new Map<string, BridgeConnection>();
+
+  constructor(
+    private readonly gatewayLoopbackBaseUrl: string,
+    private readonly sendFrame: SendVelayFrame,
+  ) {}
+
+  handleFrame(frame: VelayWebSocketInboundFrame): void {
+    switch (frame.type) {
+      case VELAY_FRAME_TYPES.websocketOpen:
+        this.open(frame);
+        return;
+      case VELAY_FRAME_TYPES.websocketMessage:
+        this.message(frame);
+        return;
+      case VELAY_FRAME_TYPES.websocketClose:
+        this.close(frame);
+        return;
+    }
+  }
+
+  open(frame: VelayWebSocketOpenFrame): void {
+    this.closeExisting(frame.connection_id);
+
+    const url = buildLoopbackWebSocketUrl(this.gatewayLoopbackBaseUrl, frame);
+    if (!url) {
+      this.sendOpenError(frame.connection_id, "Invalid WebSocket path");
+      return;
+    }
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url, {
+        headers: headersFromVelay(frame.headers),
+        ...(frame.subprotocol ? { protocol: frame.subprotocol } : {}),
+      });
+    } catch {
+      this.sendOpenError(frame.connection_id, "WebSocket connection failed");
+      return;
+    }
+
+    const connection: BridgeConnection = {
+      ws,
+      opened: false,
+      openErrorSent: false,
+      pendingMessages: [],
+      suppressNextCloseFrame: false,
+    };
+    this.connections.set(frame.connection_id, connection);
+
+    ws.binaryType = "arraybuffer";
+    ws.addEventListener("open", () => {
+      if (this.connections.get(frame.connection_id) !== connection) return;
+
+      connection.opened = true;
+      this.sendFrame({
+        type: VELAY_FRAME_TYPES.websocketOpened,
+        connection_id: frame.connection_id,
+      } satisfies VelayWebSocketOpenedFrame);
+
+      for (const message of connection.pendingMessages) {
+        ws.send(message);
+      }
+      connection.pendingMessages = [];
+    });
+
+    ws.addEventListener("message", (event) => {
+      void this.forwardLocalMessage(
+        frame.connection_id,
+        connection,
+        event.data,
+      );
+    });
+
+    ws.addEventListener("close", (event) => {
+      this.handleLocalClose(frame.connection_id, connection, event);
+    });
+
+    ws.addEventListener("error", () => {
+      if (connection.opened) return;
+      this.failOpeningConnection(
+        frame.connection_id,
+        connection,
+        "WebSocket connection failed",
+      );
+    });
+  }
+
+  message(frame: VelayWebSocketMessageFrame): void {
+    const connection = this.connections.get(frame.connection_id);
+    if (!connection) return;
+
+    const message = decodeVelayMessage(frame);
+    if (message === undefined) {
+      this.closeConnection(
+        frame.connection_id,
+        connection,
+        1003,
+        "Invalid message",
+      );
+      return;
+    }
+
+    if (connection.opened && connection.ws.readyState === WebSocket.OPEN) {
+      connection.ws.send(message);
+      return;
+    }
+
+    if (connection.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+      this.closeConnection(
+        frame.connection_id,
+        connection,
+        1008,
+        "Buffer overflow",
+      );
+      return;
+    }
+    connection.pendingMessages.push(message);
+  }
+
+  close(frame: VelayWebSocketCloseFrame): void {
+    const connection = this.connections.get(frame.connection_id);
+    if (!connection) return;
+
+    connection.suppressNextCloseFrame = true;
+    this.closeConnection(
+      frame.connection_id,
+      connection,
+      frame.code,
+      frame.reason,
+    );
+  }
+
+  closeAll(code = 1001, reason = "Tunnel closed"): void {
+    for (const [connectionId, connection] of this.connections) {
+      connection.suppressNextCloseFrame = true;
+      this.closeConnection(connectionId, connection, code, reason);
+    }
+  }
+
+  getConnectionCount(): number {
+    return this.connections.size;
+  }
+
+  private async forwardLocalMessage(
+    connectionId: string,
+    connection: BridgeConnection,
+    data: unknown,
+  ): Promise<void> {
+    if (this.connections.get(connectionId) !== connection) return;
+
+    const message = await encodeLocalMessage(connectionId, data);
+    if (this.connections.get(connectionId) !== connection) return;
+    this.sendFrame(message);
+  }
+
+  private handleLocalClose(
+    connectionId: string,
+    connection: BridgeConnection,
+    event: CloseEvent,
+  ): void {
+    if (this.connections.get(connectionId) !== connection) return;
+    this.connections.delete(connectionId);
+    connection.pendingMessages = [];
+
+    if (!connection.opened) {
+      this.sendOpenErrorOnce(
+        connectionId,
+        connection,
+        "WebSocket connection failed",
+      );
+      return;
+    }
+
+    if (connection.suppressNextCloseFrame) return;
+    this.sendFrame({
+      type: VELAY_FRAME_TYPES.websocketClose,
+      connection_id: connectionId,
+      code: event.code,
+      reason: event.reason,
+    } satisfies VelayWebSocketCloseFrame);
+  }
+
+  private failOpeningConnection(
+    connectionId: string,
+    connection: BridgeConnection,
+    reason: string,
+  ): void {
+    if (this.connections.get(connectionId) === connection) {
+      this.connections.delete(connectionId);
+    }
+    connection.pendingMessages = [];
+    this.sendOpenErrorOnce(connectionId, connection, reason);
+    closeWebSocket(connection.ws);
+  }
+
+  private closeExisting(connectionId: string): void {
+    const existing = this.connections.get(connectionId);
+    if (!existing) return;
+    existing.suppressNextCloseFrame = true;
+    this.closeConnection(connectionId, existing, 1000, "Replaced");
+  }
+
+  private closeConnection(
+    connectionId: string,
+    connection: BridgeConnection,
+    code?: number,
+    reason?: string,
+  ): void {
+    if (this.connections.get(connectionId) === connection) {
+      this.connections.delete(connectionId);
+    }
+    connection.pendingMessages = [];
+    closeWebSocket(connection.ws, code, reason);
+  }
+
+  private sendOpenError(connectionId: string, reason: string): void {
+    this.sendFrame({
+      type: VELAY_FRAME_TYPES.websocketOpenError,
+      connection_id: connectionId,
+      reason,
+    } satisfies VelayWebSocketOpenErrorFrame);
+  }
+
+  private sendOpenErrorOnce(
+    connectionId: string,
+    connection: BridgeConnection,
+    reason: string,
+  ): void {
+    if (connection.openErrorSent) return;
+    connection.openErrorSent = true;
+    this.sendOpenError(connectionId, reason);
+  }
+}
+
+function buildLoopbackWebSocketUrl(
+  gatewayLoopbackBaseUrl: string,
+  frame: VelayWebSocketOpenFrame,
+): string | undefined {
+  if (!isSafeOriginRelativePath(frame.path)) return undefined;
+
+  const rawQuery = frame.raw_query ?? "";
+  const query = rawQuery === "" ? "" : `?${rawQuery.replace(/^\?/, "")}`;
+  const httpUrl = buildUpstreamUrl(gatewayLoopbackBaseUrl, frame.path, query);
+
+  try {
+    const url = new URL(httpUrl);
+    if (url.protocol === "http:") url.protocol = "ws:";
+    if (url.protocol === "https:") url.protocol = "wss:";
+    if (url.protocol !== "ws:" && url.protocol !== "wss:") return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function isSafeOriginRelativePath(path: string): boolean {
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (path.includes("\\") || path.includes("?") || path.includes("#")) {
+    return false;
+  }
+  try {
+    const parsed = new URL(path, "http://127.0.0.1");
+    return parsed.origin === "http://127.0.0.1" && parsed.pathname === path;
+  } catch {
+    return false;
+  }
+}
+
+function headersFromVelay(headers: VelayHeaders): OutgoingHttpHeaders {
+  const cleaned = stripHopByHop(headersToWeb(headers));
+  const outgoing: OutgoingHttpHeaders = {};
+
+  for (const [name, value] of cleaned.entries()) {
+    if (name.startsWith("sec-websocket-")) continue;
+    outgoing[name] = value;
+  }
+  return outgoing;
+}
+
+function headersToWeb(headers: VelayHeaders): Headers {
+  const webHeaders = new Headers();
+  for (const [name, values] of Object.entries(headers)) {
+    for (const value of values) {
+      webHeaders.append(name, value);
+    }
+  }
+  return webHeaders;
+}
+
+function decodeVelayMessage(
+  frame: VelayWebSocketMessageFrame,
+): PendingMessage | undefined {
+  if (!isBase64(frame.body_base64 ?? "")) return undefined;
+
+  const bytes = Buffer.from(frame.body_base64 ?? "", "base64");
+  if (frame.message_type === VELAY_WEBSOCKET_MESSAGE_TYPES.text) {
+    return bytes.toString("utf8");
+  }
+  if (frame.message_type === VELAY_WEBSOCKET_MESSAGE_TYPES.binary) {
+    return new Uint8Array(bytes);
+  }
+  return undefined;
+}
+
+async function encodeLocalMessage(
+  connectionId: string,
+  data: unknown,
+): Promise<VelayWebSocketMessageFrame> {
+  if (typeof data === "string") {
+    return {
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: connectionId,
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: Buffer.from(data).toString("base64"),
+    };
+  }
+
+  return {
+    type: VELAY_FRAME_TYPES.websocketMessage,
+    connection_id: connectionId,
+    message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.binary,
+    body_base64: Buffer.from(await binaryToBytes(data)).toString("base64"),
+  };
+}
+
+async function binaryToBytes(data: unknown): Promise<Uint8Array> {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
+  return Buffer.from(String(data));
+}
+
+function closeWebSocket(ws: WebSocket, code?: number, reason?: string): void {
+  if (
+    ws.readyState === WebSocket.OPEN ||
+    ws.readyState === WebSocket.CONNECTING
+  ) {
+    ws.close(code, reason);
+  }
+}
+
+function isBase64(value: string): boolean {
+  return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+    value,
+  );
+}

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -19,6 +19,16 @@ const MAX_PENDING_MESSAGES = 100;
 
 type PendingMessage = string | Uint8Array;
 
+type WebSocketConstructorWithHeaders = {
+  new (
+    url: string,
+    options?: {
+      headers?: OutgoingHttpHeaders;
+      protocol?: string;
+    },
+  ): WebSocket;
+};
+
 type BridgeConnection = {
   ws: WebSocket;
   opened: boolean;
@@ -62,7 +72,9 @@ export class VelayWebSocketBridge {
 
     let ws: WebSocket;
     try {
-      ws = new WebSocket(url, {
+      const WebSocketWithHeaders =
+        WebSocket as unknown as WebSocketConstructorWithHeaders;
+      ws = new WebSocketWithHeaders(url, {
         headers: headersFromVelay(frame.headers),
         ...(frame.subprotocol ? { protocol: frame.subprotocol } : {}),
       });


### PR DESCRIPTION
## Summary
- Add a Velay WebSocket bridge that opens loopback gateway WebSocket clients per Velay connection.
- Forward open/message/close frames bidirectionally while preserving text and binary payloads.
- Cover open success/failure, message forwarding, binary payloads, and cleanup in tests.

Part of plan: velay-twilio-ingress.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
