### PR TITLE
Resolve Slack mention display names on live ingress

### DIFF
--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -225,6 +225,68 @@ describe("normalizeSlackAppMention with display name", () => {
     expect(result!.event.actor.username).toBe("testuser");
   });
 
+  test("renders cache-warmed mention labels in model-facing content", async () => {
+    fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          user: {
+            name: "leo",
+            real_name: "Leo Example",
+            profile: { display_name: "Leo" },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const config = makeConfig();
+    const event = makeEvent({
+      text: "<@U123BOT> <@ULEO> please look",
+    });
+    const userInfo = await resolveSlackUser("ULEO", "xoxb-test");
+
+    const result = normalizeSlackAppMention(
+      event,
+      "evt-mention-cache",
+      config,
+      "U123BOT",
+      undefined,
+      { userLabels: userInfo ? { ULEO: userInfo.displayName } : {} },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@Leo please look");
+    expect(result!.event.message.content).not.toContain("<@ULEO>");
+    expect(result!.event.message.content).not.toContain("ULEO");
+  });
+
+  test("renders unresolved mention IDs with fallback labels when lookup fails", async () => {
+    fetchMock = mock(async () => {
+      return new Response("", { status: 500 });
+    });
+
+    const config = makeConfig();
+    const event = makeEvent({
+      text: "<@U123BOT> <@UFAIL> please look",
+    });
+    const userInfo = await resolveSlackUser("UFAIL", "xoxb-test");
+
+    const result = normalizeSlackAppMention(
+      event,
+      "evt-mention-fallback",
+      config,
+      "U123BOT",
+      undefined,
+      { userLabels: userInfo ? { UFAIL: userInfo.displayName } : {} },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@unknown-user please look");
+    expect(result!.event.message.content).not.toContain("<@UFAIL>");
+    expect(result!.event.message.content).not.toContain("UFAIL");
+  });
+
   test("omits displayName when bot token is not configured", () => {
     const config = makeConfig();
     const event = makeEvent();

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -103,7 +103,7 @@ function createHarness(
   harness.config = {
     appToken: "xapp-test",
     botToken: "xoxb-test",
-    botUserId: "U-bot",
+    botUserId: "UBOT",
     botUsername: "assistant",
     teamName: "Example Team",
     gatewayConfig: makeConfig(),
@@ -151,7 +151,7 @@ describe("SlackSocketModeClient thread tracking", () => {
             event: {
               type: "app_mention",
               user: "U-mentioned",
-              text: "<@U-bot> can you help here?",
+              text: "<@UBOT> can you help here?",
               ts: "1700000000.000100",
               channel: "C-thread",
               thread_ts: "1700000000.000000",
@@ -160,6 +160,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-mention");
@@ -185,6 +186,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(2);
       expect(emitted[1].event.source.updateId).toBe("Ev-reply");
@@ -220,7 +222,7 @@ describe("SlackSocketModeClient thread tracking", () => {
             event: {
               type: "app_mention",
               user: "U-mentioned",
-              text: "<@U-bot> can you help here?",
+              text: "<@UBOT> can you help here?",
               ts: "1700000000.000300",
               channel: "C-thread",
             },
@@ -228,6 +230,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-top-level-mention");
@@ -253,6 +256,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(2);
       expect(emitted[1].event.source.updateId).toBe("Ev-top-level-reply");
@@ -294,6 +298,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-dm");
@@ -411,6 +416,7 @@ describe("SlackSocketModeClient thread tracking", () => {
           }),
           ws,
         );
+        await flushAsyncEventEmission();
 
         expect(emitted).toHaveLength(1);
       } finally {
@@ -418,4 +424,57 @@ describe("SlackSocketModeClient thread tracking", () => {
       }
     },
   );
+
+  test("renders live app mention user IDs as display-name labels", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    fetchMock = mock(async (input) => {
+      const url = new URL(String(input));
+      const userId = url.searchParams.get("user");
+      if (userId === "ULEO") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: {
+              name: "leo",
+              profile: { display_name: "Leo" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-mention-label",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-mention-label",
+            event: {
+              type: "app_mention",
+              user: "U-actor",
+              text: "<@UBOT> <@ULEO> please look",
+              ts: "1700000000.000800",
+              channel: "C-thread",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.message.content).toBe("@Leo please look");
+      expect(emitted[0].event.message.content).not.toContain("<@ULEO>");
+      expect(emitted[0].event.message.content).not.toContain("ULEO");
+    } finally {
+      rawDb.close();
+    }
+  });
 });

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -280,6 +280,77 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
+  test("does not pre-track unrouted app mention threads during slow mentioned-user lookup", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    let resolveDelayedMention: ((response: Response) => void) | undefined;
+
+    fetchMock = mock(async (input) => {
+      const url = new URL(String(input));
+      const userId = url.searchParams.get("user");
+      if (userId === "USLOW") {
+        return new Promise<Response>((resolve) => {
+          resolveDelayedMention = resolve;
+        });
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-unrouted-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-unrouted-mention",
+            event: {
+              type: "app_mention",
+              user: "U-actor",
+              text: "<@UBOT> <@USLOW> can you help here?",
+              ts: "1700000000.000250",
+              channel: "C-unrouted",
+              thread_ts: "1700000000.000240",
+            },
+          },
+        }),
+        ws,
+      );
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-unrouted-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-unrouted-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "reply should not be admitted by rejected mention",
+              ts: "1700000000.000260",
+              channel: "C-unrouted",
+              channel_type: "channel",
+              thread_ts: "1700000000.000240",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+
+      expect(resolveDelayedMention).toBeDefined();
+      resolveDelayedMention!(makeSlackUserResponse());
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("accepts unmentioned thread replies after a top-level app mention", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -201,6 +201,85 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
+  test("tracks app mention thread before slow mentioned-user lookup completes", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    let resolveDelayedMention: ((response: Response) => void) | undefined;
+
+    fetchMock = mock(async (input) => {
+      const url = new URL(String(input));
+      const userId = url.searchParams.get("user");
+      if (userId === "ULEO") {
+        return new Promise<Response>((resolve) => {
+          resolveDelayedMention = resolve;
+        });
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-race-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-race-mention",
+            event: {
+              type: "app_mention",
+              user: "U-actor",
+              text: "<@UBOT> <@ULEO> can you help here?",
+              ts: "1700000000.000150",
+              channel: "C-thread",
+              thread_ts: "1700000000.000140",
+            },
+          },
+        }),
+        ws,
+      );
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-race-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-race-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "following up while lookup is still pending",
+              ts: "1700000000.000160",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: "1700000000.000140",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-race-reply");
+      expect(emitted[0].event.message.content).toBe(
+        "following up while lookup is still pending",
+      );
+
+      expect(resolveDelayedMention).toBeDefined();
+      resolveDelayedMention!(makeSlackUserResponse());
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1].event.source.updateId).toBe("Ev-race-mention");
+      expect(emitted[1].event.message.content).toBe(
+        "@Example User can you help here?",
+      );
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("accepts unmentioned thread replies after a top-level app mention", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -588,6 +588,14 @@ export class SlackSocketModeClient {
     }
     this.store.markEventSeen(eventId, DEDUP_TTL_MS);
 
+    if (isAppMention) {
+      const appMentionEvent = event as SlackAppMentionEvent;
+      const threadTs = appMentionEvent.thread_ts ?? appMentionEvent.ts;
+      if (threadTs) {
+        this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
+      }
+    }
+
     void this.normalizeAndEmit(
       event,
       eventId,
@@ -774,8 +782,6 @@ export class SlackSocketModeClient {
       const mentionedLabel = userLabels[actor.actorExternalId];
       if (mentionedLabel) {
         actor.displayName = mentionedLabel;
-        this.onEvent(normalized);
-        return;
       }
 
       const userInfo = await Promise.race([

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1,3 +1,4 @@
+import { extractSlackUserMentionIds } from "@vellumai/slack-text";
 import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
@@ -30,6 +31,7 @@ const MAX_BACKOFF_MS = 30_000;
 const DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
 const DEDUP_CLEANUP_INTERVAL_MS = 60 * 60 * 1_000;
 const ACTIVE_THREAD_TTL_MS = 24 * 60 * 60 * 1_000;
+const USER_RESOLVE_TIMEOUT_MS = 3_000;
 
 export type SlackSocketModeConfig = {
   appToken: string;
@@ -586,7 +588,7 @@ export class SlackSocketModeClient {
     }
     this.store.markEventSeen(eventId, DEDUP_TTL_MS);
 
-    this.normalizeAndEmit(
+    void this.normalizeAndEmit(
       event,
       eventId,
       isAppMention,
@@ -596,10 +598,61 @@ export class SlackSocketModeClient {
       isMessageChanged,
       isMessageDeleted,
       isDm,
-    );
+    ).catch((err) => {
+      log.error({ err, eventId }, "Slack event normalization failed");
+    });
   }
 
-  private normalizeAndEmit(
+  private extractTextBearingContent(
+    event:
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent
+      | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent,
+  ): string | undefined {
+    if (
+      event.type === "message" &&
+      (event as SlackMessageChangedEvent).subtype === "message_changed"
+    ) {
+      return (event as SlackMessageChangedEvent).message?.text;
+    }
+
+    if (event.type === "app_mention" || event.type === "message") {
+      return (event as SlackAppMentionEvent | SlackDirectMessageEvent).text;
+    }
+
+    return undefined;
+  }
+
+  private async resolveMentionLabelsForText(
+    text: string,
+  ): Promise<Record<string, string>> {
+    const ids = extractSlackUserMentionIds(text).filter(
+      (id) => id !== this.config.botUserId,
+    );
+    const uniqueIds = [...new Set(ids)];
+    if (uniqueIds.length === 0) return {};
+
+    const entries = await Promise.all(
+      uniqueIds.map(async (id): Promise<[string, string] | undefined> => {
+        const userInfo = await Promise.race([
+          resolveSlackUser(id, this.config.botToken),
+          new Promise<undefined>((resolve) =>
+            setTimeout(resolve, USER_RESOLVE_TIMEOUT_MS),
+          ),
+        ]);
+        if (!userInfo) return undefined;
+        return [id, userInfo.displayName || userInfo.username];
+      }),
+    );
+
+    return Object.fromEntries(entries.filter((entry) => entry !== undefined));
+  }
+
+  private async normalizeAndEmit(
     event:
       | SlackAppMentionEvent
       | SlackDirectMessageEvent
@@ -616,7 +669,14 @@ export class SlackSocketModeClient {
     isMessageChanged: boolean,
     isMessageDeleted: boolean,
     isDm: boolean,
-  ): void {
+  ): Promise<void> {
+    const text = this.extractTextBearingContent(event);
+    const userLabels = text ? await this.resolveMentionLabelsForText(text) : {};
+    const renderContext = {
+      botUserId: this.config.botUserId,
+      userLabels,
+    };
+
     let normalized: NormalizedSlackEvent | null;
     if (isReactionAdded) {
       normalized = normalizeSlackReactionAdded(
@@ -638,6 +698,7 @@ export class SlackSocketModeClient {
         eventId,
         this.config.gatewayConfig,
         this.config.botToken,
+        renderContext,
       );
     } else if (isMessageChanged) {
       normalized = normalizeSlackMessageEdit(
@@ -645,6 +706,7 @@ export class SlackSocketModeClient {
         eventId,
         this.config.gatewayConfig,
         this.config.botUserId,
+        renderContext,
       );
     } else if (isMessageDeleted) {
       normalized = normalizeSlackMessageDelete(
@@ -659,6 +721,7 @@ export class SlackSocketModeClient {
         this.config.gatewayConfig,
         this.config.botUserId,
         this.config.botToken,
+        renderContext,
       );
     } else if (isDm) {
       normalized = normalizeSlackDirectMessage(
@@ -667,6 +730,7 @@ export class SlackSocketModeClient {
         this.config.gatewayConfig,
         this.config.botUserId,
         this.config.botToken,
+        renderContext,
       );
     } else {
       log.warn(
@@ -707,22 +771,23 @@ export class SlackSocketModeClient {
     // ensures the event is always emitted even if the Slack API hangs.
     const actor = normalized.event.actor;
     if (actor?.actorExternalId && !actor.displayName) {
-      const USER_RESOLVE_TIMEOUT_MS = 3_000;
-      Promise.race([
+      const mentionedLabel = userLabels[actor.actorExternalId];
+      if (mentionedLabel) {
+        actor.displayName = mentionedLabel;
+        this.onEvent(normalized);
+        return;
+      }
+
+      const userInfo = await Promise.race([
         resolveSlackUser(actor.actorExternalId, this.config.botToken),
-        new Promise<undefined>((r) => setTimeout(r, USER_RESOLVE_TIMEOUT_MS)),
-      ])
-        .then((userInfo) => {
-          if (userInfo) {
-            actor.displayName = userInfo.displayName;
-            actor.username = userInfo.username;
-          }
-          this.onEvent(normalized!);
-        })
-        .catch(() => {
-          this.onEvent(normalized!);
-        });
-      return;
+        new Promise<undefined>((resolve) =>
+          setTimeout(resolve, USER_RESOLVE_TIMEOUT_MS),
+        ),
+      ]);
+      if (userInfo) {
+        actor.displayName = userInfo.displayName;
+        actor.username = userInfo.username;
+      }
     }
 
     this.onEvent(normalized);

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -3,6 +3,7 @@ import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
 import { SlackStore } from "../db/slack-store.js";
+import { isRejection, resolveAssistant } from "../routing/resolve-assistant.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
@@ -591,7 +592,12 @@ export class SlackSocketModeClient {
     if (isAppMention) {
       const appMentionEvent = event as SlackAppMentionEvent;
       const threadTs = appMentionEvent.thread_ts ?? appMentionEvent.ts;
-      if (threadTs) {
+      const routing = resolveAssistant(
+        this.config.gatewayConfig,
+        appMentionEvent.channel,
+        appMentionEvent.user,
+      );
+      if (threadTs && !isRejection(routing)) {
         this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
       }
     }


### PR DESCRIPTION
## Summary
- Resolves mentioned Slack user labels before live gateway normalization.
- Keeps Socket Mode ACKs independent from user lookup latency.

Part of plan: slack-mention-display-names.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
