### PR TITLE
Manage profile context budgets in settings

### DIFF
--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -12,6 +12,23 @@ import {
   sampleConfig,
   sampleSkills,
 } from "../../../memory/__tests__/fixtures/memory-v2-activation-fixtures.js";
+
+let rawConfigFixture: Record<string, unknown> = {};
+let savedRawConfig: Record<string, unknown> | null = null;
+
+mock.module("../../../config/loader.js", () => ({
+  loadRawConfig: () => structuredClone(rawConfigFixture),
+  saveRawConfig: (raw: Record<string, unknown>) => {
+    savedRawConfig = raw;
+  },
+  deepMergeOverwrite: (
+    target: Record<string, unknown>,
+    overrides: Record<string, unknown>,
+  ) => {
+    Object.assign(target, overrides);
+  },
+}));
+
 import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import {
@@ -37,6 +54,10 @@ initializeDb();
 
 const llmContextRoute = ROUTES.find(
   (r) => r.method === "GET" && r.endpoint === "messages/:id/llm-context",
+)!;
+
+const replaceProfileRoute = ROUTES.find(
+  (r) => r.operationId === "config_llm_profiles_replace",
 )!;
 
 function dispatchLlmContext(messageId: string) {
@@ -119,5 +140,75 @@ describe("GET /v1/messages/:id/llm-context — memoryV2Activation", () => {
     expect(body.memoryV2Activation!.config).toEqual(sampleConfig);
     // Backwards-compat: memoryRecall field still present.
     expect(body).toHaveProperty("memoryRecall");
+  });
+});
+
+describe("PUT /v1/config/llm/profiles/:name", () => {
+  beforeEach(() => {
+    savedRawConfig = null;
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          custom: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            maxTokens: 32000,
+            contextWindow: {
+              maxInputTokens: 900000,
+              summaryBudgetRatio: 0.08,
+            },
+            openrouter: {
+              only: ["anthropic"],
+            },
+          },
+        },
+      },
+    };
+  });
+
+  test("owns contextWindow while preserving non-UI profile leaves", () => {
+    const result = replaceProfileRoute.handler({
+      pathParams: { name: "custom" },
+      body: {
+        provider: "openai",
+        model: "gpt-5.5",
+      },
+    });
+
+    expect(result).toEqual({ ok: true });
+    const savedProfile = (
+      savedRawConfig?.llm as {
+        profiles: Record<string, Record<string, unknown>>;
+      }
+    ).profiles.custom;
+
+    expect(savedProfile.provider).toBe("openai");
+    expect(savedProfile.model).toBe("gpt-5.5");
+    expect(savedProfile.maxTokens).toBeUndefined();
+    expect(savedProfile.contextWindow).toBeUndefined();
+    expect(savedProfile.openrouter).toEqual({ only: ["anthropic"] });
+  });
+
+  test("writes a replacement contextWindow override", () => {
+    const result = replaceProfileRoute.handler({
+      pathParams: { name: "custom" },
+      body: {
+        provider: "openai",
+        model: "gpt-5.5",
+        contextWindow: {
+          maxInputTokens: 150000,
+        },
+      },
+    });
+
+    expect(result).toEqual({ ok: true });
+    const savedProfile = (
+      savedRawConfig?.llm as {
+        profiles: Record<string, Record<string, unknown>>;
+      }
+    ).profiles.custom;
+
+    expect(savedProfile.contextWindow).toEqual({ maxInputTokens: 150000 });
+    expect(savedProfile.openrouter).toEqual({ only: ["anthropic"] });
   });
 });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -89,6 +89,7 @@ const INFERENCE_PROFILE_UI_KEYS = new Set([
   "verbosity",
   "temperature",
   "thinking",
+  "contextWindow",
 ]);
 
 function asMutablePlainObject(value: unknown): Record<string, unknown> | null {

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -10,11 +10,10 @@ import Foundation
 ///
 /// Only the leaves the macOS UI exposes are modeled here: `provider`,
 /// `model`, `maxTokens`, `effort`, `speed`, `verbosity`, `temperature`,
-/// and the two `thinking` sub-fields. Other `LLMConfigFragment` leaves
-/// (e.g. `contextWindow`, `openrouter`) flow through the daemon's config
-/// layer untouched — the JSON mapper preserves only the fields it knows
-/// about, but `SettingsStore.patchConfig` merges into the live config so
-/// unknown keys are not clobbered.
+/// the two `thinking` sub-fields, and `contextWindow.maxInputTokens`.
+/// Other `LLMConfigFragment` leaves (e.g. `openrouter` and non-UI
+/// `contextWindow` sub-fields) are preserved by the JSON mapper so edits
+/// can round-trip profile fragments without clobbering hidden settings.
 ///
 /// Conformance is intentionally limited to `Hashable` and `Identifiable`.
 /// `Codable` is *not* on the list because the wire shape is bespoke (the
@@ -46,6 +45,7 @@ public struct InferenceProfile: Hashable, Identifiable {
     public var effort: String?
     public var speed: String?
     public var verbosity: String?
+    public var contextWindowMaxInputTokens: Int?
 
     /// Three-state temperature so JSON round-trips preserve the daemon's
     /// `null` vs absent distinction. The resolver's `deepMerge` skips
@@ -63,6 +63,8 @@ public struct InferenceProfile: Hashable, Identifiable {
 
     /// Maps to `thinking.streamThinking` in the fragment JSON.
     public var thinkingStreamThinking: Bool?
+
+    private var preservedJSON: [String: Any]
 
     public var id: String { name }
 
@@ -89,6 +91,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         effort: String? = nil,
         speed: String? = nil,
         verbosity: String? = nil,
+        contextWindowMaxInputTokens: Int? = nil,
         temperature: TemperatureValue = .unset,
         thinkingEnabled: Bool? = nil,
         thinkingStreamThinking: Bool? = nil
@@ -103,9 +106,11 @@ public struct InferenceProfile: Hashable, Identifiable {
         self.effort = effort
         self.speed = speed
         self.verbosity = verbosity
+        self.contextWindowMaxInputTokens = contextWindowMaxInputTokens
         self.temperature = temperature
         self.thinkingEnabled = thinkingEnabled
         self.thinkingStreamThinking = thinkingStreamThinking
+        self.preservedJSON = [:]
     }
 
     /// Convenience overload that accepts an `Optional<Double>`. `nil`
@@ -122,6 +127,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         effort: String? = nil,
         speed: String? = nil,
         verbosity: String? = nil,
+        contextWindowMaxInputTokens: Int? = nil,
         temperature: Double?,
         thinkingEnabled: Bool? = nil,
         thinkingStreamThinking: Bool? = nil
@@ -137,6 +143,7 @@ public struct InferenceProfile: Hashable, Identifiable {
             effort: effort,
             speed: speed,
             verbosity: verbosity,
+            contextWindowMaxInputTokens: contextWindowMaxInputTokens,
             temperature: TemperatureValue(value: temperature),
             thinkingEnabled: thinkingEnabled,
             thinkingStreamThinking: thinkingStreamThinking
@@ -160,10 +167,13 @@ public struct InferenceProfile: Hashable, Identifiable {
         self.effort = (json["effort"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.speed = (json["speed"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.verbosity = (json["verbosity"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        let contextWindow = json["contextWindow"] as? [String: Any]
+        self.contextWindowMaxInputTokens = Self.intValue(contextWindow?["maxInputTokens"])
         self.temperature = TemperatureValue(jsonValue: json["temperature"], present: json.keys.contains("temperature"))
         let thinking = json["thinking"] as? [String: Any]
         self.thinkingEnabled = thinking?["enabled"] as? Bool
         self.thinkingStreamThinking = thinking?["streamThinking"] as? Bool
+        self.preservedJSON = Self.preservedJSON(from: json)
     }
 
     /// Returns a copy of `self` with every non-nil field on `fragment`
@@ -178,6 +188,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         if let v = fragment.effort { merged.effort = v }
         if let v = fragment.speed { merged.speed = v }
         if let v = fragment.verbosity { merged.verbosity = v }
+        if let v = fragment.contextWindowMaxInputTokens { merged.contextWindowMaxInputTokens = v }
         // `.unset` means "no opinion" — any other state overrides.
         if fragment.temperature != .unset { merged.temperature = fragment.temperature }
         if let v = fragment.thinkingEnabled { merged.thinkingEnabled = v }
@@ -192,7 +203,7 @@ public struct InferenceProfile: Hashable, Identifiable {
     /// `.explicitNull` so the daemon receives the original wire-shape
     /// distinction between "absent" and "null".
     public func toJSON() -> [String: Any] {
-        var result: [String: Any] = [:]
+        var result = preservedJSON
         if let source { result["source"] = source }
         if let label { result["label"] = label }
         if let profileDescription { result["description"] = profileDescription }
@@ -202,6 +213,17 @@ public struct InferenceProfile: Hashable, Identifiable {
         if let effort { result["effort"] = effort }
         if let speed { result["speed"] = speed }
         if let verbosity { result["verbosity"] = verbosity }
+        var contextWindow = (result["contextWindow"] as? [String: Any]) ?? [:]
+        if let contextWindowMaxInputTokens {
+            contextWindow["maxInputTokens"] = contextWindowMaxInputTokens
+        } else {
+            contextWindow.removeValue(forKey: "maxInputTokens")
+        }
+        if contextWindow.isEmpty {
+            result.removeValue(forKey: "contextWindow")
+        } else {
+            result["contextWindow"] = contextWindow
+        }
         switch temperature {
         case .unset:
             break
@@ -217,6 +239,81 @@ public struct InferenceProfile: Hashable, Identifiable {
             result["thinking"] = thinking
         }
         return result
+    }
+
+    private static func preservedJSON(from json: [String: Any]) -> [String: Any] {
+        var preserved = json
+        for key in [
+            "source",
+            "label",
+            "description",
+            "provider",
+            "model",
+            "maxTokens",
+            "effort",
+            "speed",
+            "verbosity",
+            "temperature",
+            "thinking",
+        ] {
+            preserved.removeValue(forKey: key)
+        }
+
+        if var contextWindow = json["contextWindow"] as? [String: Any] {
+            contextWindow.removeValue(forKey: "maxInputTokens")
+            if contextWindow.isEmpty {
+                preserved.removeValue(forKey: "contextWindow")
+            } else {
+                preserved["contextWindow"] = contextWindow
+            }
+        } else {
+            preserved.removeValue(forKey: "contextWindow")
+        }
+        return preserved
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let int = value as? Int {
+            return int
+        }
+        if let double = value as? Double, double.rounded() == double {
+            return Int(double)
+        }
+        return nil
+    }
+
+    public static func == (lhs: InferenceProfile, rhs: InferenceProfile) -> Bool {
+        lhs.name == rhs.name
+            && lhs.source == rhs.source
+            && lhs.label == rhs.label
+            && lhs.profileDescription == rhs.profileDescription
+            && lhs.provider == rhs.provider
+            && lhs.model == rhs.model
+            && lhs.maxTokens == rhs.maxTokens
+            && lhs.effort == rhs.effort
+            && lhs.speed == rhs.speed
+            && lhs.verbosity == rhs.verbosity
+            && lhs.contextWindowMaxInputTokens == rhs.contextWindowMaxInputTokens
+            && lhs.temperature == rhs.temperature
+            && lhs.thinkingEnabled == rhs.thinkingEnabled
+            && lhs.thinkingStreamThinking == rhs.thinkingStreamThinking
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(source)
+        hasher.combine(label)
+        hasher.combine(profileDescription)
+        hasher.combine(provider)
+        hasher.combine(model)
+        hasher.combine(maxTokens)
+        hasher.combine(effort)
+        hasher.combine(speed)
+        hasher.combine(verbosity)
+        hasher.combine(contextWindowMaxInputTokens)
+        hasher.combine(temperature)
+        hasher.combine(thinkingEnabled)
+        hasher.combine(thinkingStreamThinking)
     }
 }
 
@@ -276,4 +373,3 @@ public enum TemperatureValue: Hashable {
         return nil
     }
 }
-

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -358,6 +358,58 @@ final class InferenceProfileEditorTests: XCTestCase {
         XCTAssertNil(sanitized.thinkingStreamThinking)
     }
 
+    func testContextWindowMaxInputTokensRoundTripsThroughProfileJSON() {
+        let profile = InferenceProfile(
+            name: "long-context",
+            provider: "openai",
+            model: "gpt-5.5",
+            contextWindowMaxInputTokens: 150000
+        )
+
+        let json = profile.toJSON()
+        let contextWindow = json["contextWindow"] as? [String: Any]
+
+        XCTAssertEqual(contextWindow?["maxInputTokens"] as? Int, 150000)
+        let decoded = InferenceProfile(name: "long-context", json: json)
+        XCTAssertEqual(decoded.contextWindowMaxInputTokens, 150000)
+    }
+
+    func testOmittedContextWindowContinuesToInheritDefaults() {
+        let profile = InferenceProfile(
+            name: "default-context",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6"
+        )
+
+        XCTAssertNil(profile.contextWindowMaxInputTokens)
+        XCTAssertNil(profile.toJSON()["contextWindow"])
+    }
+
+    func testContextWindowSiblingLeavesArePreservedWhenContextMaxChanges() {
+        let profile = InferenceProfile(
+            name: "manual",
+            json: [
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-6",
+                "contextWindow": [
+                    "maxInputTokens": 900000,
+                    "summaryBudgetRatio": 0.08,
+                ],
+                "openrouter": ["only": ["anthropic"]],
+            ]
+        )
+        var edited = profile
+        edited.contextWindowMaxInputTokens = nil
+
+        let json = edited.toJSON()
+        let contextWindow = json["contextWindow"] as? [String: Any]
+
+        XCTAssertNil(contextWindow?["maxInputTokens"])
+        XCTAssertEqual(contextWindow?["summaryBudgetRatio"] as? Double, 0.08)
+        let openrouter = json["openrouter"] as? [String: Any]
+        XCTAssertEqual(openrouter?["only"] as? [String], ["anthropic"])
+    }
+
     // MARK: - Validation
 
     func testCanSaveWhenProviderAndModelAreNil() {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
@@ -131,10 +131,10 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertNil(profile.verbosity)
     }
 
-    func testUnknownKeysAreIgnored() {
+    func testUnknownKeysArePreservedThroughJSONRoundTrip() {
         let json: [String: Any] = [
             "provider": "anthropic",
-            "totallyUnknown": "ignored",
+            "totallyUnknown": "preserved",
             "thinking": [
                 "enabled": true,
                 "alsoUnknown": 123,
@@ -144,6 +144,11 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertEqual(profile.provider, "anthropic")
         XCTAssertEqual(profile.thinkingEnabled, true)
         XCTAssertNil(profile.thinkingStreamThinking)
+
+        let reEncoded = profile.toJSON()
+        XCTAssertEqual(reEncoded["totallyUnknown"] as? String, "preserved")
+        let thinking = reEncoded["thinking"] as? [String: Any]
+        XCTAssertNil(thinking?["alsoUnknown"])
     }
 
     // MARK: - Identifiable

--- a/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/SettingsStoreInferenceProfilesTests.swift
@@ -345,6 +345,36 @@ final class SettingsStoreInferenceProfilesTests: XCTestCase {
         XCTAssertNil(stored?.thinkingStreamThinking)
     }
 
+    func testReplaceProfileRoundTripsContextWindowOverride() async {
+        store.loadInferenceProfiles(config: [
+            "llm": [
+                "profiles": [
+                    "long-context": [
+                        "provider": "openai",
+                        "model": "gpt-5.5",
+                        "contextWindow": [
+                            "maxInputTokens": 150000,
+                            "summaryBudgetRatio": 0.05,
+                        ],
+                    ]
+                ]
+            ]
+        ])
+
+        var replacement = store.profiles.first(where: { $0.name == "long-context" })!
+        replacement.contextWindowMaxInputTokens = 175000
+        let success = await store.replaceProfile(name: "long-context", fragment: replacement)
+        XCTAssertTrue(success)
+
+        let call = mockSettingsClient.replaceInferenceProfileCalls[0]
+        let contextWindow = call.fragment["contextWindow"] as? [String: Any]
+        XCTAssertEqual(contextWindow?["maxInputTokens"] as? Int, 175000)
+        XCTAssertEqual(contextWindow?["summaryBudgetRatio"] as? Double, 0.05)
+
+        let stored = store.profiles.first(where: { $0.name == "long-context" })
+        XCTAssertEqual(stored?.contextWindowMaxInputTokens, 175000)
+    }
+
     // MARK: - deleteProfile blocked-by-active
 
     func testDeleteProfileBlockedByActive() async {


### PR DESCRIPTION
## Summary
- Makes profile context window budgets UI-managed.
- Adds macOS profile round-trip support for context window overrides.

Part of plan: dynamic-model-context-config.md (PR 5 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
