### PR TITLE
Start Velay tunnel client from the gateway

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -11,6 +11,7 @@ export type GatewayConfig = {
   assistantRuntimeBaseUrl: string;
   defaultAssistantId: string | undefined;
   gatewayInternalBaseUrl: string;
+  velayBaseUrl?: string;
   logFile: LogFileConfig;
   maxAttachmentBytes: Record<
     "telegram" | "slack" | "whatsapp" | "default",
@@ -92,6 +93,7 @@ export function loadConfig(): GatewayConfig {
   const assistantRuntimeBaseUrl = `http://${assistantHost}:${runtimePort}`;
 
   const gatewayInternalBaseUrl = `http://127.0.0.1:${port}`;
+  const velayBaseUrl = process.env.VELAY_BASE_URL?.trim() || undefined;
 
   // Read operational settings from workspace config (Docker) or env vars (CLI).
   const wsConfig = readWorkspaceConfig();
@@ -142,6 +144,7 @@ export function loadConfig(): GatewayConfig {
       routingEntryCount: routingEntries.length,
       unmappedPolicy,
       hasDefaultAssistant: !!defaultAssistantId,
+      hasVelayBaseUrl: !!velayBaseUrl,
       port,
       runtimeProxyRequireAuth,
       trustProxy: false,
@@ -153,6 +156,7 @@ export function loadConfig(): GatewayConfig {
     assistantRuntimeBaseUrl,
     defaultAssistantId,
     gatewayInternalBaseUrl,
+    velayBaseUrl,
     logFile,
     maxAttachmentBytes: {
       telegram: 20 * 1024 * 1024, // Telegram Bot API getFile (download) limit

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -156,6 +156,7 @@ import { AvatarSyncWatcher } from "./avatar-sync/avatar-sync-watcher.js";
 import { SlackAvatarSyncer } from "./avatar-sync/slack-avatar-syncer.js";
 import { initGatewayDb } from "./db/connection.js";
 import { runPostAssistantReady } from "./post-assistant-ready.js";
+import { createVelayTunnelClient } from "./velay/client.js";
 
 const log = getLogger("main");
 
@@ -277,6 +278,10 @@ async function main() {
   // caches at call time, with automatic TTL refresh.
   const credentialCache = new CredentialCache();
   const configFileCache = new ConfigFileCache();
+  const velayTunnelClient = createVelayTunnelClient(config, {
+    credentials: credentialCache,
+    configFile: configFileCache,
+  });
 
   // ── Avatar sync ──
   const avatarChannelSyncer = new AvatarChannelSyncer();
@@ -1532,6 +1537,7 @@ async function main() {
 
   log.info({ port: server.port }, "Gateway HTTP server listening");
   logAuthBypassState();
+  velayTunnelClient?.start();
 
   // Start periodic background cleanup for dedup caches
   telegramDedupCache.startCleanup();
@@ -2020,6 +2026,7 @@ async function main() {
     avatarSyncWatcher.stop();
     featureFlagWatcher.stop();
     remoteFeatureFlagSync.stop();
+    velayTunnelClient?.stop();
     ipcServer.stop();
     telegramDedupCache.stopCleanup();
     whatsappDedupCache.stopCleanup();

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -41,7 +41,7 @@ type Listener = (event?: unknown) => void;
 
 class FakeWebSocket {
   binaryType: BinaryType = "blob";
-  readyState = WS_CONNECTING;
+  readyState: number = WS_CONNECTING;
   sent: string[] = [];
   closes: { code?: number; reason?: string }[] = [];
   private readonly listeners = new Map<string, Listener[]>();

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -342,6 +342,81 @@ describe("VelayTunnelClient", () => {
     });
   });
 
+  test("clears the published Twilio public URL when the tunnel disconnects", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    const invalidations = { count: 0 };
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    const client = makeClient({
+      sockets,
+      reconnectDelays,
+      configFile: makeConfigFileCache(invalidations),
+    });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+
+    sockets[0].readyState = WS_CLOSED;
+    sockets[0].emit("close", { code: 1006, reason: "" });
+    await flushPromises();
+
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(2);
+    expect(reconnectDelays).toEqual([10]);
+  });
+
+  test("does not clear a newer Twilio public URL on stale tunnel close", async () => {
+    const sockets: FakeWebSocket[] = [];
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    const client = makeClient({ sockets });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public-1.example.test",
+    });
+    await flushPromises();
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://velay-public-2.example.test",
+      },
+    });
+
+    sockets[0].readyState = WS_CLOSED;
+    sockets[0].emit("close", { code: 1006, reason: "" });
+    await flushPromises();
+
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://velay-public-2.example.test",
+      },
+    });
+  });
+
   test("dispatches HTTP and WebSocket frames to the loopback bridges", async () => {
     const sockets: FakeWebSocket[] = [];
     const websocketFrames: VelayWebSocketInboundFrame[] = [];

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -1,0 +1,444 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GatewayConfig } from "../config.js";
+import type { ConfigFileCache } from "../config-file-cache.js";
+import type { CredentialCache } from "../credential-cache.js";
+import { credentialKey } from "../credential-key.js";
+import {
+  VELAY_FRAME_TYPES,
+  VELAY_TUNNEL_SUBPROTOCOL,
+  VELAY_WEBSOCKET_MESSAGE_TYPES,
+  type VelayFrame,
+  type VelayHttpRequestFrame,
+  type VelayHttpResponseFrame,
+  type VelayWebSocketInboundFrame,
+} from "./protocol.js";
+
+let workspaceDir = "";
+
+mock.module("../credential-reader.js", () => ({
+  getWorkspaceDir: () => workspaceDir,
+  readCredential: async () => undefined,
+}));
+
+const { VelayTunnelClient, createVelayTunnelClient } =
+  await import("./client.js");
+
+const WS_CONNECTING = WebSocket.CONNECTING;
+const WS_OPEN = WebSocket.OPEN;
+const WS_CLOSED = WebSocket.CLOSED;
+
+type Listener = (event?: unknown) => void;
+
+class FakeWebSocket {
+  binaryType: BinaryType = "blob";
+  readyState = WS_CONNECTING;
+  sent: string[] = [];
+  closes: { code?: number; reason?: string }[] = [];
+  private readonly listeners = new Map<string, Listener[]>();
+
+  constructor(
+    readonly url: string,
+    readonly options: unknown,
+  ) {}
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  send(message: string): void {
+    this.sent.push(message);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = WS_CLOSED;
+    this.closes.push({ code, reason });
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+function makeWebSocketConstructor(created: FakeWebSocket[]) {
+  return function FakeWebSocketConstructor(
+    this: unknown,
+    url: string,
+    options: unknown,
+  ) {
+    const ws = new FakeWebSocket(url, options);
+    created.push(ws);
+    return ws;
+  } as unknown as {
+    new (url: string | URL, options?: unknown): WebSocket;
+  };
+}
+
+function makeCredentials(values: Record<string, string | undefined>) {
+  return {
+    get: async (key: string) => values[key],
+  } as unknown as CredentialCache;
+}
+
+function makeConfigFileCache(invalidations: { count: number }) {
+  return {
+    invalidate: () => {
+      invalidations.count++;
+    },
+  } as unknown as ConfigFileCache;
+}
+
+function makeTimerApi(delays: number[]) {
+  return {
+    setTimeout: (_fn: () => void, delayMs: number) => {
+      delays.push(delayMs);
+      return { delayMs };
+    },
+    clearTimeout: () => {},
+  };
+}
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: join(workspaceDir, "logs"), retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 1,
+      slack: 1,
+      whatsapp: 1,
+      default: 1,
+    },
+    maxAttachmentConcurrency: 1,
+    maxWebhookPayloadBytes: 1,
+    port: 7830,
+    routingEntries: [],
+    runtimeInitialBackoffMs: 1,
+    runtimeMaxRetries: 0,
+    runtimeProxyRequireAuth: true,
+    runtimeTimeoutMs: 1,
+    shutdownDrainMs: 1,
+    unmappedPolicy: "reject",
+    trustProxy: false,
+    ...overrides,
+  };
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  mkdirSync(workspaceDir, { recursive: true });
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data),
+    "utf-8",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function makeClient(
+  overrides: {
+    credentials?: CredentialCache;
+    configFile?: ConfigFileCache;
+    sockets?: FakeWebSocket[];
+    httpBridge?: (
+      frame: VelayHttpRequestFrame,
+      gatewayLoopbackBaseUrl: string,
+    ) => Promise<VelayHttpResponseFrame>;
+    websocketFrames?: VelayWebSocketInboundFrame[];
+    reconnectDelays?: number[];
+  } = {},
+) {
+  const sockets = overrides.sockets ?? [];
+  const reconnectDelays = overrides.reconnectDelays ?? [];
+  return new VelayTunnelClient({
+    velayBaseUrl: "http://velay.example.test",
+    gatewayLoopbackBaseUrl: "http://127.0.0.1:7830",
+    credentials:
+      overrides.credentials ??
+      makeCredentials({
+        [credentialKey("vellum", "assistant_api_key")]: "api-key-123",
+        [credentialKey("vellum", "platform_assistant_id")]: "asst-123",
+      }),
+    configFile: overrides.configFile ?? makeConfigFileCache({ count: 0 }),
+    webSocketConstructor: makeWebSocketConstructor(sockets),
+    httpBridge: overrides.httpBridge,
+    webSocketBridgeFactory:
+      overrides.websocketFrames === undefined
+        ? undefined
+        : () =>
+            ({
+              handleFrame: (frame: VelayWebSocketInboundFrame) => {
+                overrides.websocketFrames?.push(frame);
+              },
+              closeAll: () => {},
+            }) as never,
+    reconnect: { baseDelayMs: 10, maxDelayMs: 10, jitterRatio: 0 },
+    timerApi: makeTimerApi(reconnectDelays),
+  });
+}
+
+function sendFrame(ws: FakeWebSocket, frame: VelayFrame): void {
+  ws.emit("message", { data: JSON.stringify(frame) });
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "velay-client-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("VelayTunnelClient", () => {
+  test("stays disabled when VELAY_BASE_URL is unset", () => {
+    const client = createVelayTunnelClient(makeConfig(), {
+      credentials: makeCredentials({}),
+      configFile: makeConfigFileCache({ count: 0 }),
+    });
+
+    expect(client).toBeUndefined();
+  });
+
+  test("retries without opening a socket when the assistant API key is missing", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays,
+      credentials: makeCredentials({
+        [credentialKey("vellum", "platform_assistant_id")]: "asst-123",
+      }),
+    });
+
+    client.start();
+    await flushPromises();
+
+    expect(sockets).toHaveLength(0);
+    expect(reconnectDelays).toEqual([10]);
+    client.stop();
+  });
+
+  test("registers with Velay and publishes the Twilio public URL", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const invalidations = { count: 0 };
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+      existing: { preserved: true },
+    });
+    const client = makeClient({
+      sockets,
+      configFile: makeConfigFileCache(invalidations),
+    });
+
+    client.start();
+    await flushPromises();
+
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].url).toBe("ws://velay.example.test/v1/register");
+    expect(sockets[0].options).toEqual({
+      protocols: [VELAY_TUNNEL_SUBPROTOCOL],
+      headers: { Authorization: "Api-Key api-key-123" },
+    });
+
+    sockets[0].readyState = WS_OPEN;
+    sockets[0].emit("open");
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://velay-public.example.test",
+      },
+      existing: { preserved: true },
+    });
+    expect(invalidations.count).toBe(1);
+  });
+
+  test("rejects registration when Velay returns a different assistant ID", async () => {
+    const sockets: FakeWebSocket[] = [];
+    writeConfig({
+      ingress: { publicBaseUrl: "https://ngrok.example.test" },
+    });
+    const client = makeClient({ sockets });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-other",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+
+    expect(sockets[0].closes).toEqual([
+      { code: 1008, reason: "assistant ID mismatch" },
+    ]);
+    expect(readConfig()).toEqual({
+      ingress: { publicBaseUrl: "https://ngrok.example.test" },
+    });
+  });
+
+  test("writes only ingress.twilioPublicBaseUrl when publishing a Velay URL", async () => {
+    const sockets: FakeWebSocket[] = [];
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        otherIngressSetting: "keep-me",
+      },
+      gateway: {
+        runtimeProxyRequireAuth: false,
+      },
+    });
+    const client = makeClient({ sockets });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        otherIngressSetting: "keep-me",
+        twilioPublicBaseUrl: "https://velay-public.example.test",
+      },
+      gateway: {
+        runtimeProxyRequireAuth: false,
+      },
+    });
+  });
+
+  test("dispatches HTTP and WebSocket frames to the loopback bridges", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const websocketFrames: VelayWebSocketInboundFrame[] = [];
+    const httpBridge = mock(
+      async (
+        frame: VelayHttpRequestFrame,
+        gatewayLoopbackBaseUrl: string,
+      ): Promise<VelayHttpResponseFrame> => ({
+        type: VELAY_FRAME_TYPES.httpResponse,
+        request_id: frame.request_id,
+        status_code:
+          gatewayLoopbackBaseUrl === "http://127.0.0.1:7830" ? 204 : 500,
+      }),
+    );
+    const client = makeClient({ sockets, httpBridge, websocketFrames });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.httpRequest,
+      request_id: "req-123",
+      method: "POST",
+      path: "/webhooks/twilio/voice",
+      headers: {},
+    });
+    await flushPromises();
+
+    expect(httpBridge).toHaveBeenCalledTimes(1);
+    expect(sockets[0].sent.map((raw) => JSON.parse(raw))).toEqual([
+      {
+        type: VELAY_FRAME_TYPES.httpResponse,
+        request_id: "req-123",
+        status_code: 204,
+      },
+    ]);
+
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.websocketOpen,
+      connection_id: "conn-123",
+      path: "/webhooks/twilio/relay",
+      headers: {},
+    });
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: "",
+    });
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.websocketClose,
+      connection_id: "conn-123",
+      code: 1000,
+      reason: "done",
+    });
+
+    expect(websocketFrames.map((frame) => frame.type)).toEqual([
+      VELAY_FRAME_TYPES.websocketOpen,
+      VELAY_FRAME_TYPES.websocketMessage,
+      VELAY_FRAME_TYPES.websocketClose,
+    ]);
+  });
+
+  test("stops reconnecting and closes bridged sockets on shutdown", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    let closeAllCount = 0;
+    const client = new VelayTunnelClient({
+      velayBaseUrl: "http://velay.example.test",
+      gatewayLoopbackBaseUrl: "http://127.0.0.1:7830",
+      credentials: makeCredentials({
+        [credentialKey("vellum", "assistant_api_key")]: "api-key-123",
+      }),
+      configFile: makeConfigFileCache({ count: 0 }),
+      webSocketConstructor: makeWebSocketConstructor(sockets),
+      webSocketBridgeFactory: () =>
+        ({
+          handleFrame: () => {},
+          closeAll: () => {
+            closeAllCount++;
+          },
+        }) as never,
+      reconnect: { baseDelayMs: 10, maxDelayMs: 10, jitterRatio: 0 },
+      timerApi: makeTimerApi(reconnectDelays),
+    });
+
+    client.start();
+    await flushPromises();
+    client.stop();
+    sockets[0].emit("close", { code: 1000, reason: "gateway shutdown" });
+    await flushPromises();
+
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "gateway shutdown" },
+    ]);
+    expect(closeAllCount).toBe(1);
+    expect(reconnectDelays).toEqual([]);
+  });
+});

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -1,0 +1,523 @@
+import { Buffer } from "node:buffer";
+import type { OutgoingHttpHeaders } from "node:http";
+
+import type { GatewayConfig } from "../config.js";
+import type { ConfigFileCache } from "../config-file-cache.js";
+import type { CredentialCache } from "../credential-cache.js";
+import { credentialKey } from "../credential-key.js";
+import {
+  enqueueConfigWrite,
+  readConfigFile,
+  writeConfigFileAtomic,
+} from "../http/routes/config-file-utils.js";
+import { getLogger } from "../logger.js";
+import { bridgeVelayHttpRequest } from "./http-bridge.js";
+import {
+  VELAY_FRAME_TYPES,
+  VELAY_TUNNEL_SUBPROTOCOL,
+  type VelayFrame,
+  type VelayHttpRequestFrame,
+  type VelayRegisteredFrame,
+  type VelayWebSocketInboundFrame,
+} from "./protocol.js";
+import { VelayWebSocketBridge } from "./websocket-bridge.js";
+
+const log = getLogger("velay-client");
+
+const BASE_RECONNECT_DELAY_MS = 500;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const RECONNECT_JITTER_RATIO = 0.5;
+
+export type WebSocketConstructorWithOptions = {
+  new (
+    url: string | URL,
+    options?: {
+      protocols?: string | string[];
+      headers?: OutgoingHttpHeaders;
+    },
+  ): WebSocket;
+};
+
+export type VelayTunnelClientOptions = {
+  velayBaseUrl: string;
+  gatewayLoopbackBaseUrl: string;
+  credentials: CredentialCache;
+  configFile: ConfigFileCache;
+  webSocketConstructor?: WebSocketConstructorWithOptions;
+  httpBridge?: typeof bridgeVelayHttpRequest;
+  webSocketBridgeFactory?: (
+    gatewayLoopbackBaseUrl: string,
+    sendFrame: (frame: VelayFrame) => void,
+  ) => VelayWebSocketBridge;
+  reconnect?: {
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+    jitterRatio?: number;
+    random?: () => number;
+  };
+  timerApi?: TimerApi;
+};
+
+export type TimerApi = {
+  setTimeout: (fn: () => void, delayMs: number) => unknown;
+  clearTimeout: (timer: unknown) => void;
+};
+
+export class VelayTunnelClient {
+  private readonly webSocketConstructor: WebSocketConstructorWithOptions;
+  private readonly httpBridge: typeof bridgeVelayHttpRequest;
+  private readonly webSocketBridge: VelayWebSocketBridge;
+  private readonly baseReconnectDelayMs: number;
+  private readonly maxReconnectDelayMs: number;
+  private readonly reconnectJitterRatio: number;
+  private readonly random: () => number;
+  private readonly timerApi: TimerApi;
+  private ws: WebSocket | null = null;
+  private running = false;
+  private connecting = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: unknown = null;
+
+  constructor(private readonly options: VelayTunnelClientOptions) {
+    this.webSocketConstructor =
+      options.webSocketConstructor ??
+      (WebSocket as unknown as WebSocketConstructorWithOptions);
+    this.httpBridge = options.httpBridge ?? bridgeVelayHttpRequest;
+    this.webSocketBridge = (
+      options.webSocketBridgeFactory ?? defaultWebSocketBridgeFactory
+    )(options.gatewayLoopbackBaseUrl, (frame) => this.sendFrame(frame));
+    this.baseReconnectDelayMs =
+      options.reconnect?.baseDelayMs ?? BASE_RECONNECT_DELAY_MS;
+    this.maxReconnectDelayMs =
+      options.reconnect?.maxDelayMs ?? MAX_RECONNECT_DELAY_MS;
+    this.reconnectJitterRatio =
+      options.reconnect?.jitterRatio ?? RECONNECT_JITTER_RATIO;
+    this.random = options.reconnect?.random ?? Math.random;
+    this.timerApi = options.timerApi ?? defaultTimerApi;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.connect().catch((err) => {
+      this.connecting = false;
+      log.error({ err }, "Failed to start Velay tunnel client");
+      this.scheduleReconnect();
+    });
+  }
+
+  stop(): void {
+    this.running = false;
+    this.connecting = false;
+    if (this.reconnectTimer) {
+      this.timerApi.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    const ws = this.ws;
+    this.ws = null;
+    this.webSocketBridge.closeAll();
+    if (ws) {
+      closeWebSocket(ws, 1000, "gateway shutdown");
+    }
+  }
+
+  private async connect(): Promise<void> {
+    if (!this.running || this.connecting) return;
+    this.connecting = true;
+
+    let apiKeyRaw: string | undefined;
+    let platformAssistantIdRaw: string | undefined;
+    try {
+      [apiKeyRaw, platformAssistantIdRaw] = await Promise.all([
+        this.options.credentials.get(
+          credentialKey("vellum", "assistant_api_key"),
+        ),
+        this.options.credentials.get(
+          credentialKey("vellum", "platform_assistant_id"),
+        ),
+      ]);
+    } catch (err) {
+      this.connecting = false;
+      log.warn({ err }, "Failed to read Velay tunnel credentials");
+      this.scheduleReconnect();
+      return;
+    }
+
+    if (!this.running) {
+      this.connecting = false;
+      return;
+    }
+
+    const apiKey = apiKeyRaw?.trim();
+    const platformAssistantId = platformAssistantIdRaw?.trim() || undefined;
+    if (!apiKey) {
+      this.connecting = false;
+      log.info("Velay tunnel waiting for assistant API key");
+      this.scheduleReconnect();
+      return;
+    }
+
+    let registerUrl: string;
+    try {
+      registerUrl = buildRegisterWebSocketUrl(this.options.velayBaseUrl);
+    } catch (err) {
+      this.connecting = false;
+      log.error({ err }, "Invalid Velay base URL");
+      this.scheduleReconnect();
+      return;
+    }
+
+    try {
+      const ws = new this.webSocketConstructor(registerUrl, {
+        protocols: [VELAY_TUNNEL_SUBPROTOCOL],
+        headers: { Authorization: `Api-Key ${apiKey}` },
+      });
+      ws.binaryType = "arraybuffer";
+      this.ws = ws;
+      this.connecting = false;
+
+      ws.addEventListener("open", () => {
+        if (this.ws !== ws || !this.running) return;
+        this.reconnectAttempt = 0;
+        log.info("Velay tunnel connected");
+      });
+
+      ws.addEventListener("message", (event) => {
+        void this.handleMessage(event.data, ws, platformAssistantId).catch(
+          (err) => {
+            log.error({ err }, "Failed to handle Velay frame");
+          },
+        );
+      });
+
+      ws.addEventListener("close", (event) => {
+        this.handleClose(ws, event);
+      });
+
+      ws.addEventListener("error", (event) => {
+        if (this.ws !== ws || !this.running) return;
+        log.warn({ error: String(event) }, "Velay tunnel WebSocket error");
+        if (ws.readyState === WebSocket.CONNECTING) {
+          this.disconnectActiveWebSocket(ws);
+        }
+      });
+    } catch (err) {
+      this.ws = null;
+      this.connecting = false;
+      log.warn({ err }, "Failed to connect Velay tunnel");
+      this.scheduleReconnect();
+    }
+  }
+
+  private async handleMessage(
+    data: unknown,
+    originWs: WebSocket,
+    platformAssistantId: string | undefined,
+  ): Promise<void> {
+    if (this.ws !== originWs || !this.running) return;
+
+    const frame = parseVelayFrame(data);
+    if (!frame) {
+      log.warn("Ignoring malformed Velay frame");
+      return;
+    }
+
+    switch (frame.type) {
+      case VELAY_FRAME_TYPES.registered:
+        await this.handleRegisteredFrame(frame, originWs, platformAssistantId);
+        return;
+      case VELAY_FRAME_TYPES.httpRequest:
+        await this.handleHttpRequestFrame(frame, originWs);
+        return;
+      case VELAY_FRAME_TYPES.websocketOpen:
+      case VELAY_FRAME_TYPES.websocketMessage:
+      case VELAY_FRAME_TYPES.websocketClose:
+        this.webSocketBridge.handleFrame(frame);
+        return;
+      default:
+        log.debug({ type: frame.type }, "Ignoring unsupported Velay frame");
+    }
+  }
+
+  private async handleRegisteredFrame(
+    frame: VelayRegisteredFrame,
+    originWs: WebSocket,
+    platformAssistantId: string | undefined,
+  ): Promise<void> {
+    if (platformAssistantId && frame.assistant_id !== platformAssistantId) {
+      log.error(
+        {
+          expectedAssistantId: platformAssistantId,
+          receivedAssistantId: frame.assistant_id,
+        },
+        "Velay registered assistant ID mismatch",
+      );
+      this.disconnectActiveWebSocket(originWs, 1008, "assistant ID mismatch");
+      return;
+    }
+
+    await writeTwilioPublicBaseUrl(frame.public_url, this.options.configFile);
+    log.info({ publicUrl: frame.public_url }, "Velay tunnel registered");
+  }
+
+  private async handleHttpRequestFrame(
+    frame: VelayHttpRequestFrame,
+    originWs: WebSocket,
+  ): Promise<void> {
+    const response = await this.httpBridge(
+      frame,
+      this.options.gatewayLoopbackBaseUrl,
+    );
+    if (this.ws !== originWs || !this.running) return;
+    this.sendFrame(response);
+  }
+
+  private handleClose(ws: WebSocket, event: CloseEvent): void {
+    if (this.ws !== ws) return;
+    this.ws = null;
+    this.connecting = false;
+    this.webSocketBridge.closeAll();
+    log.info(
+      { code: event.code, reason: event.reason },
+      "Velay tunnel disconnected",
+    );
+    this.scheduleReconnect();
+  }
+
+  private disconnectActiveWebSocket(
+    ws: WebSocket,
+    code?: number,
+    reason?: string,
+  ): void {
+    if (this.ws !== ws) return;
+    this.ws = null;
+    this.connecting = false;
+    this.webSocketBridge.closeAll();
+    closeWebSocket(ws, code, reason);
+    this.scheduleReconnect();
+  }
+
+  private sendFrame(frame: VelayFrame): void {
+    const ws = this.ws;
+    if (!this.running || !ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify(frame));
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.running || this.reconnectTimer) return;
+
+    const backoff = Math.min(
+      this.baseReconnectDelayMs * Math.pow(2, this.reconnectAttempt),
+      this.maxReconnectDelayMs,
+    );
+    const jitter = backoff * this.reconnectJitterRatio * this.random();
+    const delay = Math.round(backoff + jitter);
+    this.reconnectAttempt++;
+
+    this.reconnectTimer = this.timerApi.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect().catch((err) => {
+        this.connecting = false;
+        log.error({ err }, "Velay reconnect failed");
+        this.scheduleReconnect();
+      });
+    }, delay);
+  }
+}
+
+export function createVelayTunnelClient(
+  config: GatewayConfig,
+  deps: {
+    credentials: CredentialCache;
+    configFile: ConfigFileCache;
+  },
+): VelayTunnelClient | undefined {
+  if (!config.velayBaseUrl) return undefined;
+  return new VelayTunnelClient({
+    velayBaseUrl: config.velayBaseUrl,
+    gatewayLoopbackBaseUrl: config.gatewayInternalBaseUrl,
+    credentials: deps.credentials,
+    configFile: deps.configFile,
+  });
+}
+
+const defaultTimerApi: TimerApi = {
+  setTimeout: (fn, delayMs) => setTimeout(fn, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+};
+
+function defaultWebSocketBridgeFactory(
+  gatewayLoopbackBaseUrl: string,
+  sendFrame: (frame: VelayFrame) => void,
+): VelayWebSocketBridge {
+  return new VelayWebSocketBridge(gatewayLoopbackBaseUrl, sendFrame);
+}
+
+async function writeTwilioPublicBaseUrl(
+  publicUrl: string,
+  configFile: ConfigFileCache,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    enqueueConfigWrite(() => {
+      try {
+        const result = readConfigFile();
+        if (!result.ok) {
+          log.error(
+            { detail: result.detail },
+            "Cannot publish Velay public URL because config.json is malformed",
+          );
+          resolve();
+          return;
+        }
+
+        const data = result.data;
+        const ingress =
+          data.ingress &&
+          typeof data.ingress === "object" &&
+          !Array.isArray(data.ingress)
+            ? { ...(data.ingress as Record<string, unknown>) }
+            : {};
+        if (ingress.twilioPublicBaseUrl === publicUrl) {
+          resolve();
+          return;
+        }
+
+        ingress.twilioPublicBaseUrl = publicUrl;
+        data.ingress = ingress;
+        writeConfigFileAtomic(data);
+        configFile.invalidate();
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function buildRegisterWebSocketUrl(baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  const url = new URL("v1/register", normalizedBaseUrl);
+  if (url.protocol === "http:") url.protocol = "ws:";
+  if (url.protocol === "https:") url.protocol = "wss:";
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error("VELAY_BASE_URL must use http, https, ws, or wss");
+  }
+  return url.toString();
+}
+
+function parseVelayFrame(data: unknown): VelayFrame | undefined {
+  const raw = decodeWebSocketData(data);
+  if (raw === undefined) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const frame = parsed as Record<string, unknown>;
+
+  switch (frame.type) {
+    case VELAY_FRAME_TYPES.registered:
+      return isRegisteredFrame(frame) ? frame : undefined;
+    case VELAY_FRAME_TYPES.httpRequest:
+      return isHttpRequestFrame(frame) ? frame : undefined;
+    case VELAY_FRAME_TYPES.websocketOpen:
+    case VELAY_FRAME_TYPES.websocketMessage:
+    case VELAY_FRAME_TYPES.websocketClose:
+      return isWebSocketInboundFrame(frame) ? frame : undefined;
+    default:
+      return undefined;
+  }
+}
+
+function decodeWebSocketData(data: unknown): string | undefined {
+  if (typeof data === "string") return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString(
+      "utf8",
+    );
+  }
+  return undefined;
+}
+
+function isRegisteredFrame(
+  frame: Record<string, unknown>,
+): frame is VelayRegisteredFrame {
+  return (
+    frame.type === VELAY_FRAME_TYPES.registered &&
+    typeof frame.assistant_id === "string" &&
+    typeof frame.public_url === "string"
+  );
+}
+
+function isHttpRequestFrame(
+  frame: Record<string, unknown>,
+): frame is VelayHttpRequestFrame {
+  return (
+    frame.type === VELAY_FRAME_TYPES.httpRequest &&
+    typeof frame.request_id === "string" &&
+    typeof frame.method === "string" &&
+    typeof frame.path === "string" &&
+    isOptionalString(frame.raw_query) &&
+    isOptionalString(frame.body_base64) &&
+    isVelayHeaders(frame.headers)
+  );
+}
+
+function isWebSocketInboundFrame(
+  frame: Record<string, unknown>,
+): frame is VelayWebSocketInboundFrame {
+  if (frame.type === VELAY_FRAME_TYPES.websocketOpen) {
+    return (
+      typeof frame.connection_id === "string" &&
+      typeof frame.path === "string" &&
+      isOptionalString(frame.raw_query) &&
+      isOptionalString(frame.subprotocol) &&
+      isVelayHeaders(frame.headers)
+    );
+  }
+  if (frame.type === VELAY_FRAME_TYPES.websocketMessage) {
+    return (
+      typeof frame.connection_id === "string" &&
+      typeof frame.message_type === "string" &&
+      isOptionalString(frame.body_base64)
+    );
+  }
+  if (frame.type === VELAY_FRAME_TYPES.websocketClose) {
+    return (
+      typeof frame.connection_id === "string" &&
+      (frame.code === undefined || typeof frame.code === "number") &&
+      isOptionalString(frame.reason)
+    );
+  }
+  return false;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isVelayHeaders(value: unknown): value is Record<string, string[]> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(
+    (headerValues) =>
+      Array.isArray(headerValues) &&
+      headerValues.every((headerValue) => typeof headerValue === "string"),
+  );
+}
+
+function closeWebSocket(ws: WebSocket, code?: number, reason?: string): void {
+  if (
+    ws.readyState === WebSocket.CONNECTING ||
+    ws.readyState === WebSocket.OPEN
+  ) {
+    ws.close(code, reason);
+  }
+}

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -77,6 +77,7 @@ export class VelayTunnelClient {
   private connecting = false;
   private reconnectAttempt = 0;
   private reconnectTimer: unknown = null;
+  private publishedTwilioPublicBaseUrl: string | undefined;
 
   constructor(private readonly options: VelayTunnelClientOptions) {
     this.webSocketConstructor =
@@ -116,6 +117,7 @@ export class VelayTunnelClient {
     const ws = this.ws;
     this.ws = null;
     this.webSocketBridge.closeAll();
+    this.clearPublishedTwilioPublicBaseUrl();
     if (ws) {
       closeWebSocket(ws, 1000, "gateway shutdown");
     }
@@ -257,6 +259,7 @@ export class VelayTunnelClient {
     }
 
     await writeTwilioPublicBaseUrl(frame.public_url, this.options.configFile);
+    this.publishedTwilioPublicBaseUrl = frame.public_url;
     log.info({ publicUrl: frame.public_url }, "Velay tunnel registered");
   }
 
@@ -277,6 +280,7 @@ export class VelayTunnelClient {
     this.ws = null;
     this.connecting = false;
     this.webSocketBridge.closeAll();
+    this.clearPublishedTwilioPublicBaseUrl();
     log.info(
       { code: event.code, reason: event.reason },
       "Velay tunnel disconnected",
@@ -293,8 +297,20 @@ export class VelayTunnelClient {
     this.ws = null;
     this.connecting = false;
     this.webSocketBridge.closeAll();
+    this.clearPublishedTwilioPublicBaseUrl();
     closeWebSocket(ws, code, reason);
     this.scheduleReconnect();
+  }
+
+  private clearPublishedTwilioPublicBaseUrl(): void {
+    const publicUrl = this.publishedTwilioPublicBaseUrl;
+    if (!publicUrl) return;
+    this.publishedTwilioPublicBaseUrl = undefined;
+    void clearTwilioPublicBaseUrl(publicUrl, this.options.configFile).catch(
+      (err) => {
+        log.error({ err }, "Failed to clear Velay Twilio public URL");
+      },
+    );
   }
 
   private sendFrame(frame: VelayFrame): void {
@@ -383,6 +399,51 @@ async function writeTwilioPublicBaseUrl(
         }
 
         ingress.twilioPublicBaseUrl = publicUrl;
+        data.ingress = ingress;
+        writeConfigFileAtomic(data);
+        configFile.invalidate();
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+async function clearTwilioPublicBaseUrl(
+  publicUrl: string,
+  configFile: ConfigFileCache,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    enqueueConfigWrite(() => {
+      try {
+        const result = readConfigFile();
+        if (!result.ok) {
+          log.error(
+            { detail: result.detail },
+            "Cannot clear Velay public URL because config.json is malformed",
+          );
+          resolve();
+          return;
+        }
+
+        const data = result.data;
+        if (
+          !data.ingress ||
+          typeof data.ingress !== "object" ||
+          Array.isArray(data.ingress)
+        ) {
+          resolve();
+          return;
+        }
+
+        const ingress = { ...(data.ingress as Record<string, unknown>) };
+        if (ingress.twilioPublicBaseUrl !== publicUrl) {
+          resolve();
+          return;
+        }
+
+        delete ingress.twilioPublicBaseUrl;
         data.ingress = ingress;
         writeConfigFileAtomic(data);
         configFile.invalidate();


### PR DESCRIPTION
## Summary
- Add VELAY_BASE_URL gateway config and start/stop a Velay tunnel client when configured.
- Register with Velay using platform credentials, publish only ingress.twilioPublicBaseUrl, and dispatch HTTP/WebSocket frames to loopback bridges.
- Cover disabled mode, retry paths, registration validation, config writes, frame dispatch, and shutdown behavior in tests.

Part of plan: velay-twilio-ingress.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
