### PR TITLE
Add Slack mention rendering regression tests

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2298,6 +2298,24 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     });
   }
 
+  test("normalized Slack mention labels stay in assembled model context", async () => {
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m-normalized-mention",
+        createdAt: 1700000000_000,
+        text: "@leo can you check this?",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+    ];
+
+    const result = await runSlackChannelAssembly(rows);
+    const renderedContext = texts(result).join("\n");
+
+    expect(renderedContext).toContain("@leo can you check this?");
+    expect(renderedContext).not.toContain("<@U_LEO>");
+    expect(renderedContext).not.toContain("U_LEO");
+  });
+
   // ── Scenario 1: reply in mid-thread ──────────────────────────────────
   // Alice posts to thread A, Bob replies in thread B (cross-thread). Then
   // Alice posts a follow-up reply in thread A. Cross-thread visibility:

--- a/assistant/src/__tests__/inbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/inbound-slack-persistence.test.ts
@@ -194,6 +194,37 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
     expect(slackMeta!.displayName).toBe("Bob");
   });
 
+  test("Slack normalized content is persisted with raw channelTs in slackMeta", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "@leo can you check this?",
+      [],
+      "req-normalized-content",
+      {
+        slackInbound: {
+          channelId: "C0123CHANNEL",
+          channelTs: "1700000015.123456",
+          displayName: "Alice",
+        },
+      },
+      undefined,
+    );
+
+    expect(JSON.parse(addMessageCalls.at(-1)!.content)).toEqual([
+      { type: "text", text: "@leo can you check this?" },
+    ]);
+
+    const slackMeta = readPersistedSlackMeta();
+    expect(slackMeta).not.toBeNull();
+    expect(slackMeta!.channelTs).toBe("1700000015.123456");
+    expect(slackMeta!.displayName).toBe("Alice");
+  });
+
   test("Slack message without displayName omits the field", async () => {
     const ctx = createTestContext({
       userMessageChannel: "slack",

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -728,6 +728,39 @@ describe("attachment extraction in normalize functions", () => {
         expect(result!.slackFiles!.get("F030")!.id).toBe("F030");
       });
 
+      it("normalizes DM file_share mentions without stripping the bot mention", () => {
+        const config = makeConfig();
+        const event = makeDmEvent({
+          subtype: "file_share",
+          text: "<@UBOT> <@ULEO> shared this",
+          files: [
+            makeSlackFile({
+              id: "F032",
+              mimetype: "image/png",
+              name: "mention.png",
+            }),
+          ],
+        });
+        const result = normalizeSlackDirectMessage(
+          event,
+          "evt-fs-mentions-dm",
+          config,
+          "UBOT",
+          undefined,
+          { userLabels: { UBOT: "assistant", ULEO: "leo" } },
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.content).toBe(
+          "@assistant @leo shared this",
+        );
+        expect(result!.event.message.content).not.toContain("ULEO");
+        expect(result!.event.message.attachments).toHaveLength(1);
+        expect(result!.event.message.attachments![0].fileId).toBe("F032");
+        expect(result!.slackFiles).toBeDefined();
+        expect(result!.slackFiles!.get("F032")!.id).toBe("F032");
+      });
+
       it("normalizes DM with file_share subtype without files", () => {
         const config = makeConfig();
         const event = makeDmEvent({ subtype: "file_share" });
@@ -767,6 +800,43 @@ describe("attachment extraction in normalize functions", () => {
         expect(result!.event.message.attachments![0].fileId).toBe("F031");
         expect(result!.event.message.attachments![0].type).toBe("image");
         expect(result!.slackFiles).toBeDefined();
+      });
+
+      it("normalizes channel file_share mentions after stripping only the bot mention", () => {
+        const config = makeConfig();
+        const event = makeChannelEvent({
+          subtype: "file_share",
+          text: "<@UBOT> <@ULEO> shared this",
+          files: [
+            makeSlackFile({
+              id: "F033",
+              mimetype: "application/pdf",
+              name: "mention.pdf",
+            }),
+          ],
+        });
+        const result = normalizeSlackChannelMessage(
+          event,
+          "evt-fs-mentions-channel",
+          config,
+          "UBOT",
+          undefined,
+          { userLabels: { ULEO: "leo" } },
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.content).toBe("@leo shared this");
+        expect(result!.event.message.content).not.toContain("ULEO");
+        expect(result!.event.message.attachments).toHaveLength(1);
+        expect(result!.event.message.attachments![0]).toEqual({
+          type: "document",
+          fileId: "F033",
+          fileName: "mention.pdf",
+          mimeType: "application/pdf",
+          fileSize: 12345,
+        });
+        expect(result!.slackFiles).toBeDefined();
+        expect(result!.slackFiles!.get("F033")!.id).toBe("F033");
       });
 
       it("normalizes channel message with file_share subtype without files", () => {


### PR DESCRIPTION
## Summary
- Adds regression coverage showing Slack mention labels stay normalized through persistence and runtime context.
- Extends gateway parser coverage for direct/channel message forms with mentions.

Part of plan: slack-mention-display-names.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
