### PR TITLE
Add model-aware max token slider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -4,8 +4,8 @@ import VellumAssistantShared
 /// Form view that edits a single `InferenceProfile` fragment. Mirrors the
 /// daemon's `LLMConfigFragment` shape — see `assistant/src/config/schemas/
 /// llm.ts` — exposing the leaves the macOS UI cares about: provider, model,
-/// maxTokens, effort, speed, verbosity, temperature, and the two `thinking`
-/// sub-fields.
+/// maxTokens (maximum output tokens), effort, speed, verbosity, temperature,
+/// and the two `thinking` sub-fields.
 ///
 /// State ownership:
 /// - Edits flow through `@Binding var profile`, so the parent (the
@@ -47,10 +47,14 @@ struct InferenceProfileEditor: View {
     /// the slider position matches what the toggle-on path will write.
     private static let defaultTemperatureWhenSet: Double = 0.7
 
-    /// Live-edited maxTokens text. Kept as a string so partial input
-    /// (empty field, mid-typing) doesn't immediately clobber the binding
-    /// with `0`. Synced into `profile.maxTokens` on every change.
-    @State private var maxTokensText: String = ""
+    /// Schema default for `llm.default.maxTokens`. Profiles that omit
+    /// `maxTokens` inherit this through the resolver, so the slider displays
+    /// it as the default position without writing a profile override.
+    static let defaultMaxOutputTokens: Int = 64_000
+
+    /// Keep the slider range positive to match the daemon schema.
+    static let minSliderMaxOutputTokens: Int = 1
+    static let maxOutputTokensStep: Double = 1_000
 
     /// Tracks whether the user has manually edited the Key field. When
     /// false, the key auto-derives from the Display Name as kebab-case.
@@ -140,7 +144,6 @@ struct InferenceProfileEditor: View {
         }
         .background(VColor.surfaceLift)
         .onAppear {
-            syncMaxTokensFromBinding()
             // Only treat the key as user-owned for edits and views of
             // existing profiles. Creates and duplicates keep the key
             // auto-derived from Display Name so renaming stays in sync.
@@ -148,7 +151,6 @@ struct InferenceProfileEditor: View {
                 isKeyDirty = true
             }
         }
-        .onChange(of: profile.maxTokens) { _, _ in syncMaxTokensFromBinding() }
     }
 
     // MARK: - Toolbar
@@ -308,6 +310,7 @@ struct InferenceProfileEditor: View {
                         } else {
                             profile.model = nil
                         }
+                        Self.clampMaxOutputTokensForSelectedModel(&profile)
                     }
                 ),
                 options: store.dynamicProviderIds.map { provider in
@@ -338,6 +341,7 @@ struct InferenceProfileEditor: View {
                     get: { profile.model ?? "" },
                     set: { newValue in
                         profile.model = newValue.isEmpty ? nil : newValue
+                        Self.clampMaxOutputTokensForSelectedModel(&profile)
                     }
                 ),
                 options: models.map { model in
@@ -349,20 +353,36 @@ struct InferenceProfileEditor: View {
     }
 
     private var maxTokensField: some View {
-        labeled("Max Tokens") {
-            VTextField(
-                placeholder: "e.g. 16000",
-                text: Binding(
-                    get: { maxTokensText },
+        let limit = selectedModelMaxOutputTokens
+        let value = Self.maxOutputSliderValue(maxTokens: profile.maxTokens, limit: limit)
+        let upperBound = Self.maxOutputSliderUpperBound(value: value, limit: limit)
+
+        return labeled(
+            "Max Output Tokens",
+            spacing: VSpacing.sm,
+            accessory: {
+                Spacer(minLength: 0)
+                Text(maxOutputTokensAccessoryText(value: value, limit: limit))
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        ) {
+            VSlider(
+                value: Binding(
+                    get: { Double(Self.maxOutputSliderValue(maxTokens: profile.maxTokens, limit: limit)) },
                     set: { newValue in
-                        // Strip non-digit characters so paste-from-clipboard
-                        // stays sane.
-                        let digits = newValue.filter { $0.isNumber }
-                        maxTokensText = digits
-                        profile.maxTokens = digits.isEmpty ? nil : Int(digits)
+                        guard let limit else { return }
+                        profile.maxTokens = Self.clampedMaxOutputTokens(Int(newValue.rounded()), limit: limit)
                     }
-                )
+                ),
+                range: Double(Self.minSliderMaxOutputTokens)...Double(upperBound),
+                step: Self.maxOutputTokensStep,
+                showTickMarks: true
             )
+            .disabled(limit == nil)
+            .help(limit == nil ? "Max output token metadata is unavailable for this model." : "Maximum tokens the model may generate in one response.")
+            .accessibilityLabel("Max output tokens")
+            .accessibilityValue(Self.formattedTokenCount(value))
         }
     }
 
@@ -475,15 +495,63 @@ struct InferenceProfileEditor: View {
 
     // MARK: - Helpers
 
-    /// Pull `profile.maxTokens` into the text-field shadow state. Called on
-    /// appear and whenever the binding changes externally (e.g. parent
-    /// resets the draft after a Save) so the field reflects the live value.
-    private func syncMaxTokensFromBinding() {
-        maxTokensText = profile.maxTokens.map(String.init) ?? ""
+    var selectedModelMaxOutputTokens: Int? {
+        Self.maxOutputTokenLimit(provider: profile.provider, model: profile.model)
+    }
+
+    static func maxOutputTokenLimit(provider rawProvider: String?, model rawModel: String?) -> Int? {
+        guard
+            let provider = rawProvider?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !provider.isEmpty,
+            let model = rawModel?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !model.isEmpty
+        else {
+            return nil
+        }
+        return LLMProviderRegistry.model(provider: provider, id: model)?.maxOutputTokens
+    }
+
+    static func maxOutputSliderValue(maxTokens: Int?, limit: Int?) -> Int {
+        let value = max(maxTokens ?? defaultMaxOutputTokens, 1)
+        guard let limit else { return value }
+        return clampedMaxOutputTokens(value, limit: limit)
+    }
+
+    static func maxOutputSliderUpperBound(value: Int, limit: Int?) -> Int {
+        max(minSliderMaxOutputTokens, limit ?? max(value, defaultMaxOutputTokens))
+    }
+
+    static func clampedMaxOutputTokens(_ value: Int, limit: Int) -> Int {
+        min(max(value, 1), limit)
+    }
+
+    static func clampMaxOutputTokensForSelectedModel(_ profile: inout InferenceProfile) {
+        guard
+            let current = profile.maxTokens,
+            let limit = maxOutputTokenLimit(provider: profile.provider, model: profile.model)
+        else {
+            return
+        }
+        profile.maxTokens = clampedMaxOutputTokens(current, limit: limit)
+    }
+
+    static func formattedTokenCount(_ tokens: Int) -> String {
+        guard tokens >= 1_000 else { return "\(tokens)" }
+        return "\(Int((Double(tokens) / 1_000).rounded()))K"
+    }
+
+    private func maxOutputTokensAccessoryText(value: Int, limit: Int?) -> String {
+        let valueText = Self.formattedTokenCount(value)
+        guard let limit else {
+            return "\(valueText) · catalog limit unavailable"
+        }
+        return "\(valueText) / \(Self.formattedTokenCount(limit)) max"
     }
 
     private func saveVisibleProfile() {
-        profile = parameterVisibility.sanitized(profile)
+        var visibleProfile = parameterVisibility.sanitized(profile)
+        Self.clampMaxOutputTokensForSelectedModel(&visibleProfile)
+        profile = visibleProfile
         onSave()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileParameterVisibility.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileParameterVisibility.swift
@@ -2,6 +2,8 @@ import Foundation
 import VellumAssistantShared
 
 struct InferenceProfileParameterVisibility: Equatable {
+    /// `maxTokens` is the provider request's maximum output token budget;
+    /// it is intentionally separate from `contextWindow.maxInputTokens`.
     var maxTokens: Bool
     var effort: Bool
     var speed: Bool
@@ -21,7 +23,7 @@ struct InferenceProfileParameterVisibility: Equatable {
     static func resolve(
         provider rawProvider: String?,
         model rawModel: String?,
-        isKnownModel: Bool,
+        isKnownModel _: Bool,
         modelEntry: LLMModelEntry?
     ) -> InferenceProfileParameterVisibility {
         guard
@@ -34,7 +36,6 @@ struct InferenceProfileParameterVisibility: Equatable {
         }
 
         let modelId = model.lowercased()
-        let modelIsKnown = isKnownModel || modelEntry != nil
         let usesAnthropicWire = provider == "anthropic" || (provider == "openrouter" && modelId.hasPrefix("anthropic/"))
         let supportsThinking = modelSupportsThinking(
             provider: provider,
@@ -43,7 +44,7 @@ struct InferenceProfileParameterVisibility: Equatable {
         )
 
         return InferenceProfileParameterVisibility(
-            maxTokens: modelIsKnown,
+            maxTokens: true,
             effort: supportsEffort(
                 provider: provider,
                 modelId: modelId,

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -683,6 +683,12 @@ struct InferenceProfilesSheet: View {
         if visibility.effort, let effort = profile.effort, !effort.isEmpty {
             pieces.append("\(effort) effort")
         }
+        if visibility.maxTokens, let maxTokens = profile.maxTokens {
+            pieces.append("\(InferenceProfileEditor.formattedTokenCount(maxTokens)) output")
+        }
+        if let contextMax = profile.contextWindowMaxInputTokens {
+            pieces.append("\(InferenceProfileEditor.formattedTokenCount(contextMax)) context")
+        }
         if visibility.thinking, let thinkingEnabled = profile.thinkingEnabled {
             pieces.append("thinking \(thinkingEnabled ? "on" : "off")")
         }

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -270,6 +270,21 @@ final class InferenceProfileEditorTests: XCTestCase {
         )
     }
 
+    func testUnknownModelStillShowsDisabledMaxOutputControl() {
+        let visibility = InferenceProfileParameterVisibility.resolve(
+            provider: "anthropic",
+            model: "claude-vintage-1900",
+            isKnownModel: false,
+            modelEntry: nil
+        )
+
+        XCTAssertTrue(visibility.maxTokens)
+        XCTAssertNil(InferenceProfileEditor.maxOutputTokenLimit(
+            provider: "anthropic",
+            model: "claude-vintage-1900"
+        ))
+    }
+
     func testOpenRouterReasoningModelsShowEffortAndThinking() {
         let visibility = InferenceProfileParameterVisibility.resolve(
             provider: "openrouter",
@@ -356,6 +371,69 @@ final class InferenceProfileEditorTests: XCTestCase {
         XCTAssertEqual(sanitized.temperature, .unset)
         XCTAssertNil(sanitized.thinkingEnabled)
         XCTAssertNil(sanitized.thinkingStreamThinking)
+    }
+
+    func testGPT55MaxOutputSliderLimitIs128K() {
+        let limit = InferenceProfileEditor.maxOutputTokenLimit(
+            provider: "openai",
+            model: "gpt-5.5"
+        )
+
+        XCTAssertEqual(limit, 128_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.maxOutputSliderUpperBound(value: 64_000, limit: limit),
+            128_000
+        )
+        XCTAssertEqual(InferenceProfileEditor.formattedTokenCount(128_000), "128K")
+    }
+
+    func testSonnet46MaxOutputSliderLimitIs64K() {
+        let limit = InferenceProfileEditor.maxOutputTokenLimit(
+            provider: "anthropic",
+            model: "claude-sonnet-4-6"
+        )
+
+        XCTAssertEqual(limit, 64_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.maxOutputSliderUpperBound(value: 64_000, limit: limit),
+            64_000
+        )
+        XCTAssertEqual(InferenceProfileEditor.formattedTokenCount(64_000), "64K")
+    }
+
+    func testHaiku45MaxOutputSliderLimitIs64K() {
+        let limit = InferenceProfileEditor.maxOutputTokenLimit(
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001"
+        )
+
+        XCTAssertEqual(limit, 64_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.maxOutputSliderUpperBound(value: 64_000, limit: limit),
+            64_000
+        )
+    }
+
+    func testSwitchingToLowerOutputModelClampsExistingMaxTokens() {
+        var profile = InferenceProfile(
+            name: "high-output",
+            provider: "openai",
+            model: "gpt-5.5",
+            maxTokens: 128_000
+        )
+        XCTAssertEqual(
+            InferenceProfileEditor.maxOutputSliderValue(
+                maxTokens: profile.maxTokens,
+                limit: InferenceProfileEditor.maxOutputTokenLimit(provider: profile.provider, model: profile.model)
+            ),
+            128_000
+        )
+
+        profile.provider = "anthropic"
+        profile.model = "claude-sonnet-4-6"
+        InferenceProfileEditor.clampMaxOutputTokensForSelectedModel(&profile)
+
+        XCTAssertEqual(profile.maxTokens, 64_000)
     }
 
     func testContextWindowMaxInputTokensRoundTripsThroughProfileJSON() {

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -218,9 +218,8 @@ public enum LLMProviderRegistry {
 /// The entries below mirror the inline catalog in
 /// `clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift`
 /// so that fallback behaviour matches what the onboarding flow already
-/// shows users. Capability flags and pricing are intentionally omitted in
-/// this first scaffold PR; they will be populated in a later PR when the
-/// full JSON catalog is wired up.
+/// shows users. Pricing is intentionally omitted from the fallback; the
+/// bundled JSON catalog remains the authoritative source when present.
 private let fallbackCatalog = LLMProviderCatalog(
     version: 0,
     providers: [
@@ -239,10 +238,30 @@ private let fallbackCatalog = LLMProviderCatalog(
             ),
             defaultModel: "claude-opus-4-7",
             models: [
-                LLMModelEntry(id: "claude-opus-4-7", displayName: "Claude Opus 4.7"),
-                LLMModelEntry(id: "claude-opus-4-6", displayName: "Claude Opus 4.6"),
-                LLMModelEntry(id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6"),
-                LLMModelEntry(id: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5"),
+                LLMModelEntry(
+                    id: "claude-opus-4-7",
+                    displayName: "Claude Opus 4.7",
+                    contextWindowTokens: 1_000_000,
+                    maxOutputTokens: 128_000
+                ),
+                LLMModelEntry(
+                    id: "claude-opus-4-6",
+                    displayName: "Claude Opus 4.6",
+                    contextWindowTokens: 1_000_000,
+                    maxOutputTokens: 128_000
+                ),
+                LLMModelEntry(
+                    id: "claude-sonnet-4-6",
+                    displayName: "Claude Sonnet 4.6",
+                    contextWindowTokens: 1_000_000,
+                    maxOutputTokens: 64_000
+                ),
+                LLMModelEntry(
+                    id: "claude-haiku-4-5-20251001",
+                    displayName: "Claude Haiku 4.5",
+                    contextWindowTokens: 200_000,
+                    maxOutputTokens: 64_000
+                ),
             ]
         ),
         LLMProviderEntry(
@@ -260,11 +279,36 @@ private let fallbackCatalog = LLMProviderCatalog(
             ),
             defaultModel: "gpt-5.5",
             models: [
-                LLMModelEntry(id: "gpt-5.5", displayName: "GPT-5.5"),
-                LLMModelEntry(id: "gpt-5.4", displayName: "GPT-5.4"),
-                LLMModelEntry(id: "gpt-5.2", displayName: "GPT-5.2"),
-                LLMModelEntry(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
-                LLMModelEntry(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
+                LLMModelEntry(
+                    id: "gpt-5.5",
+                    displayName: "GPT-5.5",
+                    contextWindowTokens: 1_050_000,
+                    maxOutputTokens: 128_000
+                ),
+                LLMModelEntry(
+                    id: "gpt-5.4",
+                    displayName: "GPT-5.4",
+                    contextWindowTokens: 1_050_000,
+                    maxOutputTokens: 128_000
+                ),
+                LLMModelEntry(
+                    id: "gpt-5.2",
+                    displayName: "GPT-5.2",
+                    contextWindowTokens: 400_000,
+                    maxOutputTokens: 128_000
+                ),
+                LLMModelEntry(
+                    id: "gpt-5.4-mini",
+                    displayName: "GPT-5.4 Mini",
+                    contextWindowTokens: 400_000,
+                    maxOutputTokens: 128_000
+                ),
+                LLMModelEntry(
+                    id: "gpt-5.4-nano",
+                    displayName: "GPT-5.4 Nano",
+                    contextWindowTokens: 400_000,
+                    maxOutputTokens: 128_000
+                ),
             ]
         ),
         LLMProviderEntry(


### PR DESCRIPTION
## Summary
- Replaces max token text entry with a model-aware slider.
- Clamps max output tokens using model catalog metadata.

Part of plan: dynamic-model-context-config.md (PR 6 of 9)

Apple refs checked (2026-05-01): Apple HIG Sliders; SwiftUI Slider documentation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
