### PR TITLE
fix: include Slack text package in Docker builds

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -23,6 +23,7 @@ COPY packages/credential-storage ./packages/credential-storage
 COPY packages/egress-proxy ./packages/egress-proxy
 COPY packages/gateway-client ./packages/gateway-client
 COPY packages/skill-host-contracts ./packages/skill-host-contracts
+COPY packages/slack-text ./packages/slack-text
 
 # Install deps for shared packages that have their own file: dependencies.
 # Without this, bun's module resolution at runtime walks up from e.g.

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,6 +12,7 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY packages/assistant-client ./packages/assistant-client
 COPY packages/ces-client ./packages/ces-client
 COPY packages/service-contracts ./packages/service-contracts
+COPY packages/slack-text ./packages/slack-text
 
 # Install deps for shared packages that have their own file: dependencies.
 RUN cd /app/packages/ces-client && bun install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Copies the new shared Slack text package into assistant and gateway Docker build stages before dependency installation.

Fixes gap identified during plan review for slack-mention-display-names.md.

**Gap:** Docker builds cannot resolve @vellumai/slack-text
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
