### PR TITLE
fix: tighten gateway Slack mention fallback

### DIFF
--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -315,6 +315,24 @@ describe("Slack inbound mention rendering", () => {
     expect(result!.event.message.conversationExternalId).toBe("C_CHANNEL1");
   });
 
+  test("channel messages without bot user ID strip only the first leading mention fallback", () => {
+    const config = makeConfig();
+    const event = makeChannelMessageEvent({
+      text: "<@UBOT> <@ULEO> hello",
+    });
+    const result = normalizeSlackChannelMessage(
+      event,
+      "evt-channel-fallback-render",
+      config,
+      undefined,
+      undefined,
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo hello");
+  });
+
   test("message edits render mentions and preserve edit metadata", () => {
     const config = makeConfig();
     const event = makeMessageChangedEvent({

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -392,6 +392,18 @@ function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
     }));
 }
 
+function extractSlackFileMap(
+  files: SlackFile[] | undefined,
+): Map<string, SlackFile> | undefined {
+  if (!files || files.length === 0) return undefined;
+  const downloadableFiles = files.filter(
+    (f) => f.url_private_download || f.url_private,
+  );
+  return downloadableFiles.length
+    ? new Map(downloadableFiles.map((f) => [f.id, f]))
+    : undefined;
+}
+
 export type NormalizedSlackEvent = {
   event: GatewayInboundEvent;
   routing: RouteResult;
@@ -446,13 +458,7 @@ export function normalizeSlackDirectMessage(
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
   const attachments = extractSlackAttachments(event.files);
-  const slackFiles = event.files?.length
-    ? new Map(
-        event.files
-          .filter((f) => f.url_private_download || f.url_private)
-          .map((f) => [f.id, f]),
-      )
-    : undefined;
+  const slackFiles = extractSlackFileMap(event.files);
 
   // Use cache-only lookup to avoid blocking normalization on network calls.
   // A background fetch warms the cache for subsequent messages from this user.
@@ -524,19 +530,13 @@ export function normalizeSlackChannelMessage(
   const content = renderSlackInboundText(
     event.text,
     withBotUserId(botUserId, renderContext),
-    { stripLeadingBotMention: true },
+    { stripLeadingBotMention: true, fallbackStripFirstMention: true },
   );
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
   const attachments = extractSlackAttachments(event.files);
-  const slackFiles = event.files?.length
-    ? new Map(
-        event.files
-          .filter((f) => f.url_private_download || f.url_private)
-          .map((f) => [f.id, f]),
-      )
-    : undefined;
+  const slackFiles = extractSlackFileMap(event.files);
 
   const userInfo =
     botToken && event.user
@@ -609,13 +609,7 @@ export function normalizeSlackAppMention(
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
   const attachments = extractSlackAttachments(event.files);
-  const slackFiles = event.files?.length
-    ? new Map(
-        event.files
-          .filter((f) => f.url_private_download || f.url_private)
-          .map((f) => [f.id, f]),
-      )
-    : undefined;
+  const slackFiles = extractSlackFileMap(event.files);
 
   const userInfo =
     botToken && event.user


### PR DESCRIPTION
## Summary
- Restores first-mention fallback stripping for channel messages when the bot user ID is unavailable.
- Consolidates Slack file-map extraction in gateway normalizers.

Fixes gaps identified during plan review for slack-mention-display-names.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
