### PR TITLE
fix: normalize Slack mention edge cases

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -93,6 +93,29 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
     };
   }
 
+  if (method === "search.messages") {
+    return {
+      ok: true,
+      messages: {
+        total: 1,
+        matches: [
+          {
+            iid: "search-1",
+            ts: "1700000002.000300",
+            text: "Search result for <@ULEO> and <@UMISSING>",
+            user: "USENDER",
+            username: "sender",
+            channel: { id: "C_HISTORY", name: "history" },
+            permalink:
+              "https://example.slack.com/archives/C_HISTORY/p1700000002000300",
+            thread_ts: "1700000000.000100",
+          },
+        ],
+        paging: { count: 20, total: 1, page: 1, pages: 1 },
+      },
+    };
+  }
+
   if (method === "users.info") {
     return fakeUserInfoResponse(parsed.searchParams.get("user") ?? "");
   }
@@ -181,5 +204,23 @@ describe("Slack adapter mention rendering", () => {
       name: "Thread Sender",
     });
     expect(messages[0].threadId).toBe("1700000000.000100");
+  });
+
+  test("search renders Slack user mentions for model-facing text", async () => {
+    const result = await slackProvider.search!(undefined, "from:sender");
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe(
+      "Search result for @Leo and @unknown-user",
+    );
+    expect(result.messages[0].sender).toEqual({
+      id: "USENDER",
+      name: "sender",
+    });
+    expect(result.messages[0].metadata).toEqual({
+      permalink:
+        "https://example.slack.com/archives/C_HISTORY/p1700000002000300",
+      channelName: "history",
+    });
   });
 });

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  extractSlackUserMentionIds,
+  buildSlackUserLabelMap,
   renderSlackTextForModel,
 } from "@vellumai/slack-text";
 
@@ -253,12 +253,15 @@ function mapMessage(
   };
 }
 
-function mapSearchMatch(match: SlackSearchMatch): Message {
+function mapSearchMatch(
+  match: SlackSearchMatch,
+  userLabels: Record<string, string>,
+): Message {
   return {
     id: match.ts,
     conversationId: match.channel.id,
     sender: { id: match.user ?? "unknown", name: match.username ?? "unknown" },
-    text: match.text,
+    text: renderSlackTextForModel(match.text, { userLabels }),
     timestamp: parseFloat(match.ts) * 1000,
     threadId: match.thread_ts,
     platform: "slack",
@@ -291,29 +294,21 @@ async function buildMentionUserLabels(
   auth: OAuthConnection | string,
   slackMessages: SlackMessage[],
 ): Promise<Record<string, string>> {
-  const mentionUserIds = [
-    ...new Set(
-      slackMessages.flatMap((msg) => extractSlackUserMentionIds(msg.text)),
-    ),
-  ];
-  if (mentionUserIds.length === 0) return {};
-
-  const userLabels: Record<string, string> = {};
-
-  await Promise.all(
-    mentionUserIds.map(async (userId) => {
-      try {
-        const label = await resolveUserName(auth, userId);
-        if (label && label !== userId) {
-          userLabels[userId] = label;
-        }
-      } catch {
-        // Leave unresolved mentions out so the renderer uses @unknown-user.
-      }
-    }),
+  return buildSlackUserLabelMap(
+    slackMessages.map((msg) => msg.text),
+    (userId) => resolveUserName(auth, userId),
   );
+}
 
-  return userLabels;
+async function mapSearchMatches(
+  auth: OAuthConnection | string,
+  matches: SlackSearchMatch[],
+): Promise<Message[]> {
+  const userLabels = await buildSlackUserLabelMap(
+    matches.map((match) => match.text),
+    (userId) => resolveUserName(auth, userId),
+  );
+  return matches.map((match) => mapSearchMatch(match, userLabels));
 }
 
 export const slackProvider: MessagingProvider = {
@@ -487,12 +482,14 @@ export const slackProvider: MessagingProvider = {
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
-    const resp = await runReadWithFallback(connection, (auth) =>
-      slack.searchMessages(auth, query, options?.count ?? 20),
-    );
+    let auth: OAuthConnection | string = getReadAuth(connection);
+    const resp = await runReadWithFallback(connection, async (a) => {
+      auth = a;
+      return slack.searchMessages(a, query, options?.count ?? 20);
+    });
     return {
       total: resp.messages.total,
-      messages: resp.messages.matches.map(mapSearchMatch),
+      messages: await mapSearchMatches(auth, resp.messages.matches),
       hasMore: resp.messages.paging.page < resp.messages.paging.pages,
     };
   },

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -201,7 +201,7 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
-  test("tracks app mention thread before slow mentioned-user lookup completes", async () => {
+  test("emits a slow app mention before its immediate thread reply", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];
     const client = createHarness(store, (event) => emitted.push(event));
@@ -260,20 +260,20 @@ describe("SlackSocketModeClient thread tracking", () => {
       );
       await flushAsyncEventEmission();
 
-      expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.source.updateId).toBe("Ev-race-reply");
-      expect(emitted[0].event.message.content).toBe(
-        "following up while lookup is still pending",
-      );
+      expect(emitted).toHaveLength(0);
 
       expect(resolveDelayedMention).toBeDefined();
       resolveDelayedMention!(makeSlackUserResponse());
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(2);
-      expect(emitted[1].event.source.updateId).toBe("Ev-race-mention");
-      expect(emitted[1].event.message.content).toBe(
+      expect(emitted[0].event.source.updateId).toBe("Ev-race-mention");
+      expect(emitted[0].event.message.content).toBe(
         "@Example User can you help here?",
+      );
+      expect(emitted[1].event.source.updateId).toBe("Ev-race-reply");
+      expect(emitted[1].event.message.content).toBe(
+        "following up while lookup is still pending",
       );
     } finally {
       rawDb.close();

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1,4 +1,4 @@
-import { extractSlackUserMentionIds } from "@vellumai/slack-text";
+import { buildSlackUserLabelMap } from "@vellumai/slack-text";
 import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
@@ -64,6 +64,7 @@ export class SlackSocketModeClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private dedupCleanupTimer: ReturnType<typeof setInterval> | null = null;
   private store: SlackStore;
+  private emitQueues: Map<string, Promise<void>> | undefined = new Map();
 
   constructor(
     config: SlackSocketModeConfig,
@@ -602,7 +603,7 @@ export class SlackSocketModeClient {
       }
     }
 
-    void this.normalizeAndEmit(
+    this.enqueueNormalizeAndEmit(
       event,
       eventId,
       isAppMention,
@@ -612,9 +613,7 @@ export class SlackSocketModeClient {
       isMessageChanged,
       isMessageDeleted,
       isDm,
-    ).catch((err) => {
-      log.error({ err, eventId }, "Slack event normalization failed");
-    });
+    );
   }
 
   private extractTextBearingContent(
@@ -644,14 +643,9 @@ export class SlackSocketModeClient {
   private async resolveMentionLabelsForText(
     text: string,
   ): Promise<Record<string, string>> {
-    const ids = extractSlackUserMentionIds(text).filter(
-      (id) => id !== this.config.botUserId,
-    );
-    const uniqueIds = [...new Set(ids)];
-    if (uniqueIds.length === 0) return {};
-
-    const entries = await Promise.all(
-      uniqueIds.map(async (id): Promise<[string, string] | undefined> => {
+    return buildSlackUserLabelMap(
+      [text],
+      async (id): Promise<string | undefined> => {
         const userInfo = await Promise.race([
           resolveSlackUser(id, this.config.botToken),
           new Promise<undefined>((resolve) =>
@@ -659,11 +653,100 @@ export class SlackSocketModeClient {
           ),
         ]);
         if (!userInfo) return undefined;
-        return [id, userInfo.displayName || userInfo.username];
-      }),
+        return userInfo.displayName || userInfo.username;
+      },
+      { ignoredUserIds: [this.config.botUserId] },
     );
+  }
 
-    return Object.fromEntries(entries.filter((entry) => entry !== undefined));
+  private enqueueNormalizeAndEmit(
+    event:
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent
+      | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent,
+    eventId: string,
+    isAppMention: boolean,
+    isActiveThreadReply: boolean,
+    isReactionAdded: boolean,
+    isReactionRemoved: boolean,
+    isMessageChanged: boolean,
+    isMessageDeleted: boolean,
+    isDm: boolean,
+  ): void {
+    const queues = (this.emitQueues ??= new Map());
+    const orderingKey = this.getEventOrderingKey(event, eventId);
+    const previous = queues.get(orderingKey) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(() =>
+        this.normalizeAndEmit(
+          event,
+          eventId,
+          isAppMention,
+          isActiveThreadReply,
+          isReactionAdded,
+          isReactionRemoved,
+          isMessageChanged,
+          isMessageDeleted,
+          isDm,
+        ),
+      );
+
+    queues.set(orderingKey, current);
+    void current
+      .catch((err: unknown) => {
+        log.error({ err, eventId }, "Slack event normalization failed");
+      })
+      .finally(() => {
+        if (queues.get(orderingKey) === current) {
+          queues.delete(orderingKey);
+        }
+      });
+  }
+
+  private getEventOrderingKey(
+    event:
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent
+      | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent,
+    eventId: string,
+  ): string {
+    if (event.type === "reaction_added" || event.type === "reaction_removed") {
+      const reaction = event as
+        | SlackReactionAddedEvent
+        | SlackReactionRemovedEvent;
+      return `${reaction.item.channel}:${reaction.item.ts}`;
+    }
+
+    if (
+      event.type === "message" &&
+      (event as SlackMessageChangedEvent).subtype === "message_changed"
+    ) {
+      const changed = event as SlackMessageChangedEvent;
+      return `${changed.channel}:${changed.message.thread_ts ?? changed.message.ts ?? eventId}`;
+    }
+
+    if (
+      event.type === "message" &&
+      (event as SlackMessageDeletedEvent).subtype === "message_deleted"
+    ) {
+      const deleted = event as SlackMessageDeletedEvent;
+      return `${deleted.channel}:${deleted.previous_message?.thread_ts ?? deleted.deleted_ts ?? eventId}`;
+    }
+
+    const message = event as
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent;
+    return `${message.channel}:${message.thread_ts ?? message.ts ?? eventId}`;
   }
 
   private async normalizeAndEmit(

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildSlackUserLabelMap,
   extractSlackUserMentionIds,
   renderSlackTextForModel,
   stripLeadingSlackMentionFallback,
@@ -10,7 +11,7 @@ import {
 describe("extractSlackUserMentionIds", () => {
   test("returns unique user mention IDs in encounter order", () => {
     expect(
-      extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again"),
+      extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again")
     ).toEqual(["U123", "W456"]);
   });
 });
@@ -18,19 +19,19 @@ describe("extractSlackUserMentionIds", () => {
 describe("stripLeadingSlackUserMention", () => {
   test("strips only leading mentions for the exact bot ID", () => {
     expect(stripLeadingSlackUserMention("<@U111> <@U222> hi", "U111")).toBe(
-      "<@U222> hi",
+      "<@U222> hi"
     );
   });
 
   test("strips repeated leading mentions for the exact bot ID", () => {
     expect(stripLeadingSlackUserMention(" <@U111> <@U111> hi", "U111")).toBe(
-      "hi",
+      "hi"
     );
   });
 
   test("preserves text when the leading mention is a different user", () => {
     expect(stripLeadingSlackUserMention("<@U222> hi <@U111>", "U111")).toBe(
-      "<@U222> hi <@U111>",
+      "<@U222> hi <@U111>"
     );
   });
 });
@@ -38,7 +39,7 @@ describe("stripLeadingSlackUserMention", () => {
 describe("stripLeadingSlackMentionFallback", () => {
   test("strips only the first leading Slack user mention", () => {
     expect(stripLeadingSlackMentionFallback(" <@U111> <@U222> hi")).toBe(
-      "<@U222> hi",
+      "<@U222> hi"
     );
   });
 });
@@ -48,7 +49,7 @@ describe("renderSlackTextForModel", () => {
     expect(
       renderSlackTextForModel("hello <@U123>", {
         userLabels: { U123: "Alice" },
-      }),
+      })
     ).toBe("hello @Alice");
   });
 
@@ -61,11 +62,19 @@ describe("renderSlackTextForModel", () => {
     expect(rendered).not.toContain("U789");
   });
 
+  test("treats ID-shaped resolved user labels as unresolved", () => {
+    expect(
+      renderSlackTextForModel("hello <@U123>", {
+        userLabels: { U123: "U123" },
+      })
+    ).toBe("hello @unknown-user");
+  });
+
   test("renders channel references with labels and fallbacks", () => {
     expect(
       renderSlackTextForModel("<#C123|general> <#C456>", {
         channelLabels: { C456: "support" },
-      }),
+      })
     ).toBe("#general #support");
 
     expect(renderSlackTextForModel("<#C789>")).toBe("#unknown-channel");
@@ -73,21 +82,21 @@ describe("renderSlackTextForModel", () => {
 
   test("renders special broadcasts", () => {
     expect(renderSlackTextForModel("<!here> <!channel> <!everyone>")).toBe(
-      "@here @channel @everyone",
+      "@here @channel @everyone"
     );
   });
 
   test("renders usergroups with labels and fallback", () => {
-    expect(
-      renderSlackTextForModel("<!subteam^S123|eng> <!subteam^S456>"),
-    ).toBe("@eng @usergroup");
+    expect(renderSlackTextForModel("<!subteam^S123|eng> <!subteam^S456>")).toBe(
+      "@eng @usergroup"
+    );
   });
 
   test("renders labeled and unlabeled links", () => {
     expect(
       renderSlackTextForModel(
-        "<https://example.com|Example> <https://example.org>",
-      ),
+        "<https://example.com|Example> <https://example.org>"
+      )
     ).toBe("Example (https://example.com) https://example.org");
   });
 
@@ -98,8 +107,8 @@ describe("renderSlackTextForModel", () => {
         {
           userLabels: { U123: " @<system>  prompt " },
           channelLabels: { C123: "#<ops>" },
-        },
-      ),
+        }
+      )
     ).toBe("@system prompt #ops #unknown-channel @eng");
   });
 
@@ -108,7 +117,37 @@ describe("renderSlackTextForModel", () => {
       renderSlackTextForModel("<@U123> <#C123>", {
         userFallbackLabel: "@ missing user ",
         channelFallbackLabel: "# missing channel ",
-      }),
+      })
     ).toBe("@missing user #missing channel");
+  });
+});
+
+describe("buildSlackUserLabelMap", () => {
+  test("dedupes mentioned users across text inputs and ignores configured IDs", async () => {
+    const resolved: string[] = [];
+    const labels = await buildSlackUserLabelMap(
+      ["<@U123> hi <@U999>", undefined, "<@U123> and <@W456>"],
+      async (userId) => {
+        resolved.push(userId);
+        return userId === "W456" ? "Bob" : "Alice";
+      },
+      { ignoredUserIds: ["U999"] }
+    );
+
+    expect(resolved).toEqual(["U123", "W456"]);
+    expect(labels).toEqual({ U123: "Alice", W456: "Bob" });
+  });
+
+  test("omits unresolved labels and labels equal to the Slack user ID", async () => {
+    const labels = await buildSlackUserLabelMap(
+      ["<@U123> <@U456> <@U789>"],
+      async (userId) => {
+        if (userId === "U123") return "U123";
+        if (userId === "U456") return "";
+        return "Alice";
+      }
+    );
+
+    expect(labels).toEqual({ U789: "Alice" });
   });
 });

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -5,6 +5,10 @@ export interface RenderSlackTextOptions {
   channelFallbackLabel?: string;
 }
 
+export interface BuildSlackUserLabelMapOptions {
+  ignoredUserIds?: Iterable<string | undefined>;
+}
+
 const SLACK_USER_MENTION_RE = /<@([UW][A-Z0-9]+)>/g;
 const LEADING_SLACK_USER_MENTION_RE = /^\s*<@[UW][A-Z0-9]+>\s*/;
 
@@ -25,7 +29,7 @@ export function extractSlackUserMentionIds(text: string): string[] {
 
 export function stripLeadingSlackUserMention(
   text: string,
-  userId: string,
+  userId: string
 ): string {
   if (!isSlackUserId(userId)) {
     return text;
@@ -49,7 +53,7 @@ export function stripLeadingSlackMentionFallback(text: string): string {
 
 export function renderSlackTextForModel(
   text: string,
-  options: RenderSlackTextOptions = {},
+  options: RenderSlackTextOptions = {}
 ): string {
   return text.replace(/<([^<>\s][^<>]*)>/g, (token, content: string) => {
     if (content.startsWith("@")) {
@@ -72,9 +76,51 @@ export function renderSlackTextForModel(
   });
 }
 
+export async function buildSlackUserLabelMap(
+  texts: Iterable<string | undefined>,
+  resolveLabel: (userId: string) => Promise<string | undefined | null>,
+  options: BuildSlackUserLabelMapOptions = {}
+): Promise<Record<string, string>> {
+  const ignored = new Set(
+    [...(options.ignoredUserIds ?? [])].filter(
+      (id): id is string => typeof id === "string" && id.length > 0
+    )
+  );
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  for (const text of texts) {
+    if (!text) continue;
+    for (const id of extractSlackUserMentionIds(text)) {
+      if (ignored.has(id) || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+
+  if (ids.length === 0) return {};
+
+  const entries = await Promise.all(
+    ids.map(
+      async (id): Promise<[string, string] | undefined> => {
+        try {
+          const label = await resolveLabel(id);
+          const sanitized = sanitizeOptionalLabel(label ?? undefined);
+          if (!sanitized || sanitized === id) return undefined;
+          return [id, sanitized];
+        } catch {
+          return undefined;
+        }
+      }
+    )
+  );
+
+  return Object.fromEntries(entries.filter((entry) => entry !== undefined));
+}
+
 function renderUserMention(
   content: string,
-  options: RenderSlackTextOptions,
+  options: RenderSlackTextOptions
 ): string {
   const id = content.slice(1);
   if (!isSlackUserId(id)) {
@@ -83,16 +129,22 @@ function renderUserMention(
 
   const fallback = sanitizeLabel(options.userFallbackLabel, "unknown-user");
   const label = sanitizeLabel(options.userLabels?.[id], fallback);
+  if (label === id) {
+    return `@${fallback}`;
+  }
   return `@${label}`;
 }
 
 function renderChannelReference(
   content: string,
-  options: RenderSlackTextOptions,
+  options: RenderSlackTextOptions
 ): string {
   const [idWithPrefix, label] = splitSlackLabel(content);
   const channelId = idWithPrefix.slice(1);
-  const fallback = sanitizeLabel(options.channelFallbackLabel, "unknown-channel");
+  const fallback = sanitizeLabel(
+    options.channelFallbackLabel,
+    "unknown-channel"
+  );
   const resolvedLabel = label ?? options.channelLabels?.[channelId];
   return `#${sanitizeLabel(resolvedLabel, fallback)}`;
 }
@@ -129,10 +181,7 @@ function splitSlackLabel(content: string): [string, string | undefined] {
     return [content, undefined];
   }
 
-  return [
-    content.slice(0, separatorIndex),
-    content.slice(separatorIndex + 1),
-  ];
+  return [content.slice(0, separatorIndex), content.slice(separatorIndex + 1)];
 }
 
 function sanitizeLabel(label: string | undefined, fallback: string): string {
@@ -155,6 +204,15 @@ function sanitizeLabel(label: string | undefined, fallback: string): string {
     .trim();
 
   return sanitizedFallback || "unknown";
+}
+
+function sanitizeOptionalLabel(label: string | undefined): string | undefined {
+  return label
+    ?.replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[@#]+/, "")
+    .trim();
 }
 
 function stripLeadingExactToken(text: string, token: string): string {


### PR DESCRIPTION
## Summary
- Prevents raw Slack IDs from leaking through resolved mention labels.
- Normalizes Slack search result mentions and preserves live per-thread event ordering.

Fixes gaps identified during plan review for slack-mention-display-names.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
