### PR TITLE
Add context window profile slider

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -4,8 +4,8 @@ import VellumAssistantShared
 /// Form view that edits a single `InferenceProfile` fragment. Mirrors the
 /// daemon's `LLMConfigFragment` shape — see `assistant/src/config/schemas/
 /// llm.ts` — exposing the leaves the macOS UI cares about: provider, model,
-/// maxTokens (maximum output tokens), effort, speed, verbosity, temperature,
-/// and the two `thinking` sub-fields.
+/// maxTokens (maximum output tokens), contextWindow.maxInputTokens, effort,
+/// speed, verbosity, temperature, and the two `thinking` sub-fields.
 ///
 /// State ownership:
 /// - Edits flow through `@Binding var profile`, so the parent (the
@@ -55,6 +55,15 @@ struct InferenceProfileEditor: View {
     /// Keep the slider range positive to match the daemon schema.
     static let minSliderMaxOutputTokens: Int = 1
     static let maxOutputTokensStep: Double = 1_000
+
+    /// Conservative inherited context-window budget for profiles that do
+    /// not opt into a larger/smaller explicit value. Mirrors the daemon's
+    /// current default.
+    static let defaultContextWindowTokens: Int = 200_000
+
+    /// Keep the slider range positive to match the daemon schema.
+    static let minSliderContextWindowTokens: Int = 1
+    static let contextWindowTokensStep: Double = 50_000
 
     /// Tracks whether the user has manually edited the Key field. When
     /// false, the key auto-derives from the Display Name as kebab-case.
@@ -120,6 +129,7 @@ struct InferenceProfileEditor: View {
                     if visibility.maxTokens {
                         maxTokensField
                     }
+                    contextWindowField
                     if visibility.effort {
                         effortField
                     }
@@ -311,6 +321,7 @@ struct InferenceProfileEditor: View {
                             profile.model = nil
                         }
                         Self.clampMaxOutputTokensForSelectedModel(&profile)
+                        Self.clampContextWindowForSelectedModel(&profile)
                     }
                 ),
                 options: store.dynamicProviderIds.map { provider in
@@ -342,6 +353,7 @@ struct InferenceProfileEditor: View {
                     set: { newValue in
                         profile.model = newValue.isEmpty ? nil : newValue
                         Self.clampMaxOutputTokensForSelectedModel(&profile)
+                        Self.clampContextWindowForSelectedModel(&profile)
                     }
                 ),
                 options: models.map { model in
@@ -382,6 +394,56 @@ struct InferenceProfileEditor: View {
             .disabled(limit == nil)
             .help(limit == nil ? "Max output token metadata is unavailable for this model." : "Maximum tokens the model may generate in one response.")
             .accessibilityLabel("Max output tokens")
+            .accessibilityValue(Self.formattedTokenCount(value))
+        }
+    }
+
+    private var contextWindowField: some View {
+        let model = selectedModelEntry
+        let limit = model?.contextWindowTokens
+        let value = Self.contextWindowSliderValue(
+            maxInputTokens: profile.contextWindowMaxInputTokens,
+            model: model
+        )
+        let upperBound = Self.contextWindowSliderUpperBound(value: value, limit: limit)
+
+        return labeled(
+            "Context Window",
+            spacing: VSpacing.sm,
+            accessory: {
+                Spacer(minLength: 0)
+                Text(contextWindowAccessoryText(value: value, model: model))
+                    .font(VFont.bodySmallDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        ) {
+            VSlider(
+                value: Binding(
+                    get: {
+                        Double(Self.contextWindowSliderValue(
+                            maxInputTokens: profile.contextWindowMaxInputTokens,
+                            model: model
+                        ))
+                    },
+                    set: { newValue in
+                        guard let limit else { return }
+                        profile.contextWindowMaxInputTokens = Self.clampedContextWindowTokens(
+                            Int(newValue.rounded()),
+                            limit: limit
+                        )
+                    }
+                ),
+                range: Double(Self.minSliderContextWindowTokens)...Double(upperBound),
+                step: Self.contextWindowTokensStep,
+                showTickMarks: true
+            )
+            .disabled(limit == nil)
+            .help(
+                limit == nil
+                    ? "Context window metadata is unavailable for this model."
+                    : "Maximum input tokens the assistant may keep in context."
+            )
+            .accessibilityLabel("Context window")
             .accessibilityValue(Self.formattedTokenCount(value))
         }
     }
@@ -499,7 +561,11 @@ struct InferenceProfileEditor: View {
         Self.maxOutputTokenLimit(provider: profile.provider, model: profile.model)
     }
 
-    static func maxOutputTokenLimit(provider rawProvider: String?, model rawModel: String?) -> Int? {
+    var selectedModelEntry: LLMModelEntry? {
+        Self.modelEntry(provider: profile.provider, model: profile.model)
+    }
+
+    static func modelEntry(provider rawProvider: String?, model rawModel: String?) -> LLMModelEntry? {
         guard
             let provider = rawProvider?.trimmingCharacters(in: .whitespacesAndNewlines),
             !provider.isEmpty,
@@ -508,7 +574,11 @@ struct InferenceProfileEditor: View {
         else {
             return nil
         }
-        return LLMProviderRegistry.model(provider: provider, id: model)?.maxOutputTokens
+        return LLMProviderRegistry.model(provider: provider, id: model)
+    }
+
+    static func maxOutputTokenLimit(provider rawProvider: String?, model rawModel: String?) -> Int? {
+        modelEntry(provider: rawProvider, model: rawModel)?.maxOutputTokens
     }
 
     static func maxOutputSliderValue(maxTokens: Int?, limit: Int?) -> Int {
@@ -535,6 +605,42 @@ struct InferenceProfileEditor: View {
         profile.maxTokens = clampedMaxOutputTokens(current, limit: limit)
     }
 
+    static func contextWindowTokenLimit(provider rawProvider: String?, model rawModel: String?) -> Int? {
+        modelEntry(provider: rawProvider, model: rawModel)?.contextWindowTokens
+    }
+
+    static func effectiveDefaultContextWindowTokens(model: LLMModelEntry?) -> Int {
+        let defaultTokens = max(model?.defaultContextWindowTokens ?? defaultContextWindowTokens, 1)
+        guard let limit = model?.contextWindowTokens else {
+            return defaultTokens
+        }
+        return clampedContextWindowTokens(defaultTokens, limit: limit)
+    }
+
+    static func contextWindowSliderValue(maxInputTokens: Int?, model: LLMModelEntry?) -> Int {
+        let value = max(maxInputTokens ?? effectiveDefaultContextWindowTokens(model: model), 1)
+        guard let limit = model?.contextWindowTokens else { return value }
+        return clampedContextWindowTokens(value, limit: limit)
+    }
+
+    static func contextWindowSliderUpperBound(value: Int, limit: Int?) -> Int {
+        max(minSliderContextWindowTokens, limit ?? max(value, defaultContextWindowTokens))
+    }
+
+    static func clampedContextWindowTokens(_ value: Int, limit: Int) -> Int {
+        min(max(value, 1), limit)
+    }
+
+    static func clampContextWindowForSelectedModel(_ profile: inout InferenceProfile) {
+        guard
+            let current = profile.contextWindowMaxInputTokens,
+            let limit = contextWindowTokenLimit(provider: profile.provider, model: profile.model)
+        else {
+            return
+        }
+        profile.contextWindowMaxInputTokens = clampedContextWindowTokens(current, limit: limit)
+    }
+
     static func formattedTokenCount(_ tokens: Int) -> String {
         guard tokens >= 1_000 else { return "\(tokens)" }
         return "\(Int((Double(tokens) / 1_000).rounded()))K"
@@ -548,9 +654,22 @@ struct InferenceProfileEditor: View {
         return "\(valueText) / \(Self.formattedTokenCount(limit)) max"
     }
 
+    private func contextWindowAccessoryText(value: Int, model: LLMModelEntry?) -> String {
+        let valueText = Self.formattedTokenCount(value)
+        guard let limit = model?.contextWindowTokens else {
+            return "\(valueText) · catalog limit unavailable"
+        }
+        var text = "\(valueText) / \(Self.formattedTokenCount(limit)) max"
+        if let threshold = model?.longContextPricingThresholdTokens, value > threshold {
+            text += " · long-context pricing"
+        }
+        return text
+    }
+
     private func saveVisibleProfile() {
         var visibleProfile = parameterVisibility.sanitized(profile)
         Self.clampMaxOutputTokensForSelectedModel(&visibleProfile)
+        Self.clampContextWindowForSelectedModel(&visibleProfile)
         profile = visibleProfile
         onSave()
     }

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -436,20 +436,103 @@ final class InferenceProfileEditorTests: XCTestCase {
         XCTAssertEqual(profile.maxTokens, 64_000)
     }
 
-    func testContextWindowMaxInputTokensRoundTripsThroughProfileJSON() {
-        let profile = InferenceProfile(
+    func testGPT55ContextWindowSliderLimitIs1050K() {
+        let limit = InferenceProfileEditor.contextWindowTokenLimit(
+            provider: "openai",
+            model: "gpt-5.5"
+        )
+
+        XCTAssertEqual(limit, 1_050_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.contextWindowSliderUpperBound(value: 200_000, limit: limit),
+            1_050_000
+        )
+    }
+
+    func testGPT54ContextWindowSliderLimitIs1050K() {
+        let limit = InferenceProfileEditor.contextWindowTokenLimit(
+            provider: "openai",
+            model: "gpt-5.4"
+        )
+
+        XCTAssertEqual(limit, 1_050_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.contextWindowSliderUpperBound(value: 200_000, limit: limit),
+            1_050_000
+        )
+    }
+
+    func testSonnet46ContextWindowSliderLimitIs1000K() {
+        let limit = InferenceProfileEditor.contextWindowTokenLimit(
+            provider: "anthropic",
+            model: "claude-sonnet-4-6"
+        )
+
+        XCTAssertEqual(limit, 1_000_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.contextWindowSliderUpperBound(value: 200_000, limit: limit),
+            1_000_000
+        )
+    }
+
+    func testHaiku45ContextWindowSliderLimitIs200K() {
+        let limit = InferenceProfileEditor.contextWindowTokenLimit(
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001"
+        )
+
+        XCTAssertEqual(limit, 200_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.contextWindowSliderUpperBound(value: 200_000, limit: limit),
+            200_000
+        )
+    }
+
+    func testContextWindowSliderDefaultsToEffectiveDefaultBudget() {
+        let model = InferenceProfileEditor.modelEntry(
+            provider: "openai",
+            model: "gpt-5.5"
+        )
+
+        XCTAssertEqual(
+            InferenceProfileEditor.contextWindowSliderValue(maxInputTokens: nil, model: model),
+            200_000
+        )
+    }
+
+    func testSwitchingToLowerContextModelClampsExistingOverride() {
+        var profile = InferenceProfile(
             name: "long-context",
             provider: "openai",
             model: "gpt-5.5",
-            contextWindowMaxInputTokens: 150000
+            contextWindowMaxInputTokens: 1_000_000
+        )
+
+        profile.provider = "anthropic"
+        profile.model = "claude-haiku-4-5-20251001"
+        InferenceProfileEditor.clampContextWindowForSelectedModel(&profile)
+
+        XCTAssertEqual(profile.contextWindowMaxInputTokens, 200_000)
+    }
+
+    func testCustomContextWindow150KRoundTripsAndAppearsInSummary() {
+        let profile = InferenceProfile(
+            name: "custom-context",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            contextWindowMaxInputTokens: 150_000
         )
 
         let json = profile.toJSON()
         let contextWindow = json["contextWindow"] as? [String: Any]
 
-        XCTAssertEqual(contextWindow?["maxInputTokens"] as? Int, 150000)
-        let decoded = InferenceProfile(name: "long-context", json: json)
-        XCTAssertEqual(decoded.contextWindowMaxInputTokens, 150000)
+        XCTAssertEqual(contextWindow?["maxInputTokens"] as? Int, 150_000)
+        let decoded = InferenceProfile(name: "custom-context", json: json)
+        XCTAssertEqual(decoded.contextWindowMaxInputTokens, 150_000)
+        XCTAssertEqual(
+            InferenceProfilesSheet.summary(for: decoded, store: store),
+            "Claude Sonnet 4.6 \u{00B7} 150K context"
+        )
     }
 
     func testOmittedContextWindowContinuesToInheritDefaults() {

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -65,6 +65,11 @@ public struct LLMModelEntry: Decodable {
     public let displayName: String
     /// Maximum context window in tokens. Optional — omitted when unknown.
     public let contextWindowTokens: Int?
+    /// Conservative default context budget in tokens. Optional — callers
+    /// should fall back to their schema default when omitted.
+    public let defaultContextWindowTokens: Int?
+    /// Token threshold where the provider may apply long-context pricing.
+    public let longContextPricingThresholdTokens: Int?
     /// Maximum output tokens per response. Optional — omitted when unknown.
     public let maxOutputTokens: Int?
     /// Whether the model supports extended thinking / reasoning.
@@ -82,6 +87,8 @@ public struct LLMModelEntry: Decodable {
         id: String,
         displayName: String,
         contextWindowTokens: Int? = nil,
+        defaultContextWindowTokens: Int? = nil,
+        longContextPricingThresholdTokens: Int? = nil,
         maxOutputTokens: Int? = nil,
         supportsThinking: Bool? = nil,
         supportsCaching: Bool? = nil,
@@ -92,6 +99,8 @@ public struct LLMModelEntry: Decodable {
         self.id = id
         self.displayName = displayName
         self.contextWindowTokens = contextWindowTokens
+        self.defaultContextWindowTokens = defaultContextWindowTokens
+        self.longContextPricingThresholdTokens = longContextPricingThresholdTokens
         self.maxOutputTokens = maxOutputTokens
         self.supportsThinking = supportsThinking
         self.supportsCaching = supportsCaching
@@ -242,24 +251,31 @@ private let fallbackCatalog = LLMProviderCatalog(
                     id: "claude-opus-4-7",
                     displayName: "Claude Opus 4.7",
                     contextWindowTokens: 1_000_000,
+                    defaultContextWindowTokens: 200_000,
+                    longContextPricingThresholdTokens: 200_000,
                     maxOutputTokens: 128_000
                 ),
                 LLMModelEntry(
                     id: "claude-opus-4-6",
                     displayName: "Claude Opus 4.6",
                     contextWindowTokens: 1_000_000,
+                    defaultContextWindowTokens: 200_000,
+                    longContextPricingThresholdTokens: 200_000,
                     maxOutputTokens: 128_000
                 ),
                 LLMModelEntry(
                     id: "claude-sonnet-4-6",
                     displayName: "Claude Sonnet 4.6",
                     contextWindowTokens: 1_000_000,
+                    defaultContextWindowTokens: 200_000,
+                    longContextPricingThresholdTokens: 200_000,
                     maxOutputTokens: 64_000
                 ),
                 LLMModelEntry(
                     id: "claude-haiku-4-5-20251001",
                     displayName: "Claude Haiku 4.5",
                     contextWindowTokens: 200_000,
+                    defaultContextWindowTokens: 200_000,
                     maxOutputTokens: 64_000
                 ),
             ]
@@ -283,30 +299,35 @@ private let fallbackCatalog = LLMProviderCatalog(
                     id: "gpt-5.5",
                     displayName: "GPT-5.5",
                     contextWindowTokens: 1_050_000,
+                    defaultContextWindowTokens: 200_000,
                     maxOutputTokens: 128_000
                 ),
                 LLMModelEntry(
                     id: "gpt-5.4",
                     displayName: "GPT-5.4",
                     contextWindowTokens: 1_050_000,
+                    defaultContextWindowTokens: 200_000,
                     maxOutputTokens: 128_000
                 ),
                 LLMModelEntry(
                     id: "gpt-5.2",
                     displayName: "GPT-5.2",
                     contextWindowTokens: 400_000,
+                    defaultContextWindowTokens: 200_000,
                     maxOutputTokens: 128_000
                 ),
                 LLMModelEntry(
                     id: "gpt-5.4-mini",
                     displayName: "GPT-5.4 Mini",
                     contextWindowTokens: 400_000,
+                    defaultContextWindowTokens: 200_000,
                     maxOutputTokens: 128_000
                 ),
                 LLMModelEntry(
                     id: "gpt-5.4-nano",
                     displayName: "GPT-5.4 Nano",
                     contextWindowTokens: 400_000,
+                    defaultContextWindowTokens: 200_000,
                     maxOutputTokens: 128_000
                 ),
             ]


### PR DESCRIPTION
## Summary
- Adds a model-aware context window slider to inference profiles.
- Bounds and clamps context budgets using model catalog metadata.

Part of plan: dynamic-model-context-config.md (PR 7 of 9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
