### PR TITLE
fix: simplify Slack app mention normalizer args

### DIFF
--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -173,6 +173,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-1a",
       config,
+      undefined,
       "xoxb-test",
     );
     expect(result1).not.toBeNull();
@@ -186,6 +187,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-1b",
       config,
+      undefined,
       "xoxb-test",
     );
     expect(result2).not.toBeNull();
@@ -218,6 +220,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-pw",
       config,
+      undefined,
       "xoxb-test",
     );
     expect(result).not.toBeNull();
@@ -308,6 +311,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-3",
       config,
+      undefined,
       "xoxb-test",
     );
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -331,46 +331,6 @@ function withBotUserId(
   };
 }
 
-function parseAppMentionArgs(
-  botTokenOrBotUserId?: string,
-  botTokenOrContext?: string | SlackTextRenderContext,
-  maybeContext?: SlackTextRenderContext,
-): { botToken?: string; renderContext: SlackTextRenderContext } {
-  const firstArgIsToken = isSlackBotToken(botTokenOrBotUserId);
-
-  if (
-    typeof botTokenOrContext === "object" ||
-    typeof maybeContext === "object"
-  ) {
-    return {
-      botToken: firstArgIsToken
-        ? botTokenOrBotUserId
-        : typeof botTokenOrContext === "string"
-          ? botTokenOrContext
-          : undefined,
-      renderContext: withBotUserId(
-        firstArgIsToken ? undefined : botTokenOrBotUserId,
-        {
-          ...(typeof botTokenOrContext === "object" ? botTokenOrContext : {}),
-          ...maybeContext,
-        },
-      ),
-    };
-  }
-
-  return {
-    botToken: firstArgIsToken ? botTokenOrBotUserId : botTokenOrContext,
-    renderContext: withBotUserId(
-      firstArgIsToken ? undefined : botTokenOrBotUserId,
-      undefined,
-    ),
-  };
-}
-
-function isSlackBotToken(value: string | undefined): boolean {
-  return value?.startsWith("xox") ?? false;
-}
-
 function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
   type: "image" | "document";
   fileId: string;
@@ -587,24 +547,23 @@ export function normalizeSlackAppMention(
   event: SlackAppMentionEvent,
   eventId: string,
   config: GatewayConfig,
-  botTokenOrBotUserId?: string,
-  botTokenOrContext?: string | SlackTextRenderContext,
-  maybeContext?: SlackTextRenderContext,
+  botUserId?: string,
+  botToken?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
-  const { botToken, renderContext } = parseAppMentionArgs(
-    botTokenOrBotUserId,
-    botTokenOrContext,
-    maybeContext,
-  );
   const routing = resolveAssistant(config, event.channel, event.user);
   if (isRejection(routing)) {
     return null;
   }
 
-  const content = renderSlackInboundText(event.text, renderContext, {
-    stripLeadingBotMention: true,
-    fallbackStripFirstMention: true,
-  });
+  const content = renderSlackInboundText(
+    event.text,
+    withBotUserId(botUserId, renderContext),
+    {
+      stripLeadingBotMention: true,
+      fallbackStripFirstMention: true,
+    },
+  );
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -794,6 +794,7 @@ export class SlackSocketModeClient {
         event as SlackAppMentionEvent,
         eventId,
         this.config.gatewayConfig,
+        this.config.botUserId,
         this.config.botToken,
         renderContext,
       );


### PR DESCRIPTION
## Summary
- Replaces app-mention token sniffing with explicit bot user ID, bot token, and render context parameters.

Fixes slop gap identified during plan re-review for slack-mention-display-names.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
