### PR TITLE
fix: harden Velay bridge frame handling

### DIFF
--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -1,0 +1,134 @@
+import type { OutgoingHttpHeaders } from "node:http";
+import { stripHopByHop } from "@vellumai/assistant-client";
+
+import type { VelayHeaders } from "./protocol.js";
+
+const MAX_WEBSOCKET_CLOSE_REASON_BYTES = 123;
+
+export function isSafeOriginRelativePath(path: string): boolean {
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (path.includes("\\") || path.includes("?") || path.includes("#")) {
+    return false;
+  }
+  try {
+    const parsed = new URL(path, "http://127.0.0.1");
+    return parsed.origin === "http://127.0.0.1" && parsed.pathname === path;
+  } catch {
+    return false;
+  }
+}
+
+export function formatRawQuery(rawQuery: string | undefined): string {
+  if (!rawQuery) return "";
+  return `?${rawQuery.replace(/^\?/, "")}`;
+}
+
+export function headersToWeb(headers: VelayHeaders): Headers {
+  const webHeaders = new Headers();
+  for (const [name, values] of Object.entries(headers)) {
+    for (const value of values) {
+      webHeaders.append(name, value);
+    }
+  }
+  return webHeaders;
+}
+
+export function headersToVelay(headers: Headers): VelayHeaders {
+  const velayHeaders: VelayHeaders = {};
+  for (const [name, value] of headers.entries()) {
+    velayHeaders[name] ??= [];
+    velayHeaders[name].push(value);
+  }
+  return velayHeaders;
+}
+
+export function headersFromVelay(headers: VelayHeaders): Headers {
+  return stripHopByHop(headersToWeb(headers));
+}
+
+export function websocketHeadersFromVelay(
+  headers: VelayHeaders,
+): OutgoingHttpHeaders {
+  const cleaned = headersFromVelay(headers);
+  const outgoing: OutgoingHttpHeaders = {};
+
+  for (const [name, value] of cleaned.entries()) {
+    if (name.startsWith("sec-websocket-")) continue;
+    outgoing[name] = value;
+  }
+  return outgoing;
+}
+
+export function isBase64(value: string): boolean {
+  return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+    value,
+  );
+}
+
+export function closeWebSocket(
+  ws: WebSocket,
+  code?: number,
+  reason?: string,
+): void {
+  if (
+    ws.readyState !== WebSocket.OPEN &&
+    ws.readyState !== WebSocket.CONNECTING
+  ) {
+    return;
+  }
+
+  const closeArgs = sanitizeWebSocketCloseArgs(code, reason);
+  try {
+    if (!closeArgs) {
+      ws.close();
+      return;
+    }
+    ws.close(closeArgs.code, closeArgs.reason);
+  } catch {
+    try {
+      ws.close();
+    } catch {
+      // The socket is already closing or the runtime rejected the close call.
+    }
+  }
+}
+
+export function sanitizeWebSocketCloseArgs(
+  code?: number,
+  reason?: string,
+): { code: number; reason?: string } | undefined {
+  if (!isValidWebSocketCloseCode(code)) return undefined;
+
+  const sanitizedReason =
+    typeof reason === "string" ? truncateCloseReason(reason) : undefined;
+  return sanitizedReason === undefined
+    ? { code }
+    : { code, reason: sanitizedReason };
+}
+
+function isValidWebSocketCloseCode(code: number | undefined): code is number {
+  return (
+    code === 1000 ||
+    (typeof code === "number" &&
+      Number.isInteger(code) &&
+      code >= 3000 &&
+      code <= 4999)
+  );
+}
+
+function truncateCloseReason(reason: string): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(reason).byteLength <= MAX_WEBSOCKET_CLOSE_REASON_BYTES) {
+    return reason;
+  }
+
+  let truncated = "";
+  let byteLength = 0;
+  for (const character of reason) {
+    const characterLength = encoder.encode(character).byteLength;
+    if (byteLength + characterLength > MAX_WEBSOCKET_CLOSE_REASON_BYTES) break;
+    truncated += character;
+    byteLength += characterLength;
+  }
+  return truncated;
+}

--- a/gateway/src/velay/http-bridge.test.ts
+++ b/gateway/src/velay/http-bridge.test.ts
@@ -131,14 +131,17 @@ describe("Velay HTTP bridge", () => {
 
   test("converts loopback responses back into Velay response frames", async () => {
     fetchMock = mock(async () => {
+      const headers = new Headers({
+        "content-type": "text/plain",
+        "x-result": "preserved",
+        connection: "keep-alive",
+        "transfer-encoding": "chunked",
+      });
+      headers.append("set-cookie", "session=abc; Path=/; HttpOnly");
+      headers.append("set-cookie", "prefs=dark; Path=/");
       return new Response("created", {
         status: 201,
-        headers: {
-          "content-type": "text/plain",
-          "x-result": "preserved",
-          connection: "keep-alive",
-          "transfer-encoding": "chunked",
-        },
+        headers,
       });
     });
 
@@ -153,6 +156,7 @@ describe("Velay HTTP bridge", () => {
       status_code: 201,
       headers: {
         "content-type": ["text/plain"],
+        "set-cookie": ["session=abc; Path=/; HttpOnly", "prefs=dark; Path=/"],
         "x-result": ["preserved"],
       },
       body_base64: base64("created"),

--- a/gateway/src/velay/http-bridge.ts
+++ b/gateway/src/velay/http-bridge.ts
@@ -3,8 +3,14 @@ import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
 
 import { fetchImpl } from "../fetch.js";
 import {
+  formatRawQuery,
+  headersFromVelay,
+  headersToVelay,
+  isBase64,
+  isSafeOriginRelativePath,
+} from "./bridge-utils.js";
+import {
   VELAY_FRAME_TYPES,
-  type VelayHeaders,
   type VelayHttpRequestFrame,
   type VelayHttpResponseFrame,
 } from "./protocol.js";
@@ -68,33 +74,18 @@ function buildLoopbackUrl(
   frame: VelayHttpRequestFrame,
 ): string | undefined {
   if (!isSafeOriginRelativePath(frame.path)) return undefined;
-  const rawQuery = frame.raw_query ?? "";
-  const query = rawQuery === "" ? "" : `?${rawQuery.replace(/^\?/, "")}`;
-  return buildUpstreamUrl(gatewayLoopbackBaseUrl, frame.path, query);
-}
-
-function isSafeOriginRelativePath(path: string): boolean {
-  if (!path.startsWith("/") || path.startsWith("//")) return false;
-  if (path.includes("\\") || path.includes("?") || path.includes("#")) {
-    return false;
-  }
-  try {
-    const parsed = new URL(path, "http://127.0.0.1");
-    return parsed.origin === "http://127.0.0.1" && parsed.pathname === path;
-  } catch {
-    return false;
-  }
+  return buildUpstreamUrl(
+    gatewayLoopbackBaseUrl,
+    frame.path,
+    formatRawQuery(frame.raw_query),
+  );
 }
 
 function decodeBody(
   bodyBase64: string | undefined,
 ): { ok: true; value?: ArrayBuffer } | { ok: false } {
   if (!bodyBase64) return { ok: true };
-  const isBase64 =
-    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
-      bodyBase64,
-    );
-  if (!isBase64) {
+  if (!isBase64(bodyBase64)) {
     return { ok: false };
   }
   const bytes = Buffer.from(bodyBase64, "base64");
@@ -105,28 +96,6 @@ function decodeBody(
       bytes.byteOffset + bytes.byteLength,
     ),
   };
-}
-
-function headersFromVelay(headers: VelayHeaders): Headers {
-  return stripHopByHop(headersToWeb(headers));
-}
-
-function headersToWeb(headers: VelayHeaders): Headers {
-  const webHeaders = new Headers();
-  for (const [name, values] of Object.entries(headers)) {
-    for (const value of values) {
-      webHeaders.append(name, value);
-    }
-  }
-  return webHeaders;
-}
-
-function headersToVelay(headers: Headers): VelayHeaders {
-  const velayHeaders: VelayHeaders = {};
-  for (const [name, value] of headers.entries()) {
-    velayHeaders[name] = [value];
-  }
-  return velayHeaders;
 }
 
 function badGatewayFrame(requestId: string): VelayHttpResponseFrame {

--- a/gateway/src/velay/protocol.ts
+++ b/gateway/src/velay/protocol.ts
@@ -88,13 +88,6 @@ export type VelayFrame =
   | VelayWebSocketMessageFrame
   | VelayWebSocketCloseFrame;
 
-export type VelayWebSocketFrame =
-  | VelayWebSocketOpenFrame
-  | VelayWebSocketOpenedFrame
-  | VelayWebSocketOpenErrorFrame
-  | VelayWebSocketMessageFrame
-  | VelayWebSocketCloseFrame;
-
 export type VelayWebSocketInboundFrame =
   | VelayWebSocketOpenFrame
   | VelayWebSocketMessageFrame

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -38,6 +38,19 @@ class FakeWebSocket {
   }
 
   close(code?: number, reason?: string): void {
+    if (
+      code !== undefined &&
+      code !== 1000 &&
+      (!Number.isInteger(code) || code < 3000 || code > 4999)
+    ) {
+      throw new Error("invalid close code");
+    }
+    if (
+      reason !== undefined &&
+      new TextEncoder().encode(reason).byteLength > 123
+    ) {
+      throw new Error("invalid close reason");
+    }
     this.readyState = WS_CLOSED;
     this.closes.push({ code, reason });
   }
@@ -112,12 +125,12 @@ describe("VelayWebSocketBridge", () => {
 
     const [url, options] = WebSocketMock.mock.calls[0] as [
       string,
-      { headers: Record<string, string>; protocol?: string },
+      { headers: Record<string, string>; protocols?: string[] },
     ];
     expect(url).toBe(
       "ws://127.0.0.1:7830/webhooks/twilio/relay?callSessionId=session-123&token=edge-token",
     );
-    expect(options.protocol).toBe("twilio-relay");
+    expect(options.protocols).toEqual(["twilio-relay"]);
     expect(options.headers.authorization).toBe("Bearer edge-token");
     expect(options.headers.host).toBe("public.example.com");
     expect(options.headers["x-twilio-signature"]).toBe("sig-123");
@@ -230,6 +243,45 @@ describe("VelayWebSocketBridge", () => {
     ).toEqual([]);
   });
 
+  test("sanitizes invalid close codes from Velay before closing locally", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    expect(() => {
+      bridge.close({
+        type: VELAY_FRAME_TYPES.websocketClose,
+        connection_id: "conn-123",
+        code: 1006,
+        reason: "invalid reserved code",
+      });
+    }).not.toThrow();
+
+    expect(fakeSocket.closes).toEqual([{ code: undefined, reason: undefined }]);
+    expect(bridge.getConnectionCount()).toBe(0);
+  });
+
+  test("truncates overlong close reasons from Velay without splitting UTF-8 characters", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.close({
+      type: VELAY_FRAME_TYPES.websocketClose,
+      connection_id: "conn-123",
+      code: 1000,
+      reason: "🙂".repeat(40),
+    });
+
+    expect(fakeSocket.closes).toEqual([
+      { code: 1000, reason: "🙂".repeat(30) },
+    ]);
+    expect(
+      new TextEncoder().encode(fakeSocket.closes[0].reason).byteLength,
+    ).toBe(120);
+    expect(bridge.getConnectionCount()).toBe(0);
+  });
+
   test("keeps empty text frames distinct from invalid payloads", () => {
     bridge.open(makeOpenFrame());
     fakeSocket.readyState = WS_OPEN;
@@ -258,9 +310,7 @@ describe("VelayWebSocketBridge", () => {
       body_base64: "not base64",
     });
 
-    expect(fakeSocket.closes).toEqual([
-      { code: 1003, reason: "Invalid message" },
-    ]);
+    expect(fakeSocket.closes).toEqual([{ code: undefined, reason: undefined }]);
     expect(bridge.getConnectionCount()).toBe(0);
   });
 

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -1,12 +1,18 @@
 import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
-import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
+import { buildUpstreamUrl } from "@vellumai/assistant-client";
 
+import {
+  closeWebSocket,
+  formatRawQuery,
+  isBase64,
+  isSafeOriginRelativePath,
+  websocketHeadersFromVelay,
+} from "./bridge-utils.js";
 import {
   VELAY_FRAME_TYPES,
   VELAY_WEBSOCKET_MESSAGE_TYPES,
   type VelayFrame,
-  type VelayHeaders,
   type VelayWebSocketCloseFrame,
   type VelayWebSocketInboundFrame,
   type VelayWebSocketMessageFrame,
@@ -24,7 +30,7 @@ type WebSocketConstructorWithHeaders = {
     url: string,
     options?: {
       headers?: OutgoingHttpHeaders;
-      protocol?: string;
+      protocols?: string | string[];
     },
   ): WebSocket;
 };
@@ -75,8 +81,8 @@ export class VelayWebSocketBridge {
       const WebSocketWithHeaders =
         WebSocket as unknown as WebSocketConstructorWithHeaders;
       ws = new WebSocketWithHeaders(url, {
-        headers: headersFromVelay(frame.headers),
-        ...(frame.subprotocol ? { protocol: frame.subprotocol } : {}),
+        headers: websocketHeadersFromVelay(frame.headers),
+        ...(frame.subprotocol ? { protocols: [frame.subprotocol] } : {}),
       });
     } catch {
       this.sendOpenError(frame.connection_id, "WebSocket connection failed");
@@ -283,9 +289,11 @@ function buildLoopbackWebSocketUrl(
 ): string | undefined {
   if (!isSafeOriginRelativePath(frame.path)) return undefined;
 
-  const rawQuery = frame.raw_query ?? "";
-  const query = rawQuery === "" ? "" : `?${rawQuery.replace(/^\?/, "")}`;
-  const httpUrl = buildUpstreamUrl(gatewayLoopbackBaseUrl, frame.path, query);
+  const httpUrl = buildUpstreamUrl(
+    gatewayLoopbackBaseUrl,
+    frame.path,
+    formatRawQuery(frame.raw_query),
+  );
 
   try {
     const url = new URL(httpUrl);
@@ -296,40 +304,6 @@ function buildLoopbackWebSocketUrl(
   } catch {
     return undefined;
   }
-}
-
-function isSafeOriginRelativePath(path: string): boolean {
-  if (!path.startsWith("/") || path.startsWith("//")) return false;
-  if (path.includes("\\") || path.includes("?") || path.includes("#")) {
-    return false;
-  }
-  try {
-    const parsed = new URL(path, "http://127.0.0.1");
-    return parsed.origin === "http://127.0.0.1" && parsed.pathname === path;
-  } catch {
-    return false;
-  }
-}
-
-function headersFromVelay(headers: VelayHeaders): OutgoingHttpHeaders {
-  const cleaned = stripHopByHop(headersToWeb(headers));
-  const outgoing: OutgoingHttpHeaders = {};
-
-  for (const [name, value] of cleaned.entries()) {
-    if (name.startsWith("sec-websocket-")) continue;
-    outgoing[name] = value;
-  }
-  return outgoing;
-}
-
-function headersToWeb(headers: VelayHeaders): Headers {
-  const webHeaders = new Headers();
-  for (const [name, values] of Object.entries(headers)) {
-    for (const value of values) {
-      webHeaders.append(name, value);
-    }
-  }
-  return webHeaders;
 }
 
 function decodeVelayMessage(
@@ -375,19 +349,4 @@ async function binaryToBytes(data: unknown): Promise<Uint8Array> {
   }
   if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
   return Buffer.from(String(data));
-}
-
-function closeWebSocket(ws: WebSocket, code?: number, reason?: string): void {
-  if (
-    ws.readyState === WebSocket.OPEN ||
-    ws.readyState === WebSocket.CONNECTING
-  ) {
-    ws.close(code, reason);
-  }
-}
-
-function isBase64(value: string): boolean {
-  return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
-    value,
-  );
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for velay-twilio-ingress.md.

**Gap:** Velay bridges dropped duplicate headers, forwarded WebSocket subprotocols incorrectly, accepted unsafe close args, and duplicated helper logic.
**Fix:** Preserve header arrays, use Bun-compatible subprotocols, sanitize close frames, and share bridge utilities.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
