### PR TITLE
fix: use Twilio ingress base consistently

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -38,6 +38,11 @@ mock.module("../config/loader.js", () => {
     },
     memory: { enabled: false },
     notifications: {},
+    ingress: {
+      enabled: true,
+      publicBaseUrl: "https://generic.example.com",
+      twilioPublicBaseUrl: "",
+    },
     services: {
       tts: {
         mode: "your-own" as const,
@@ -468,6 +473,8 @@ describe("call-controller", () => {
     const cfg = loadConfig();
     cfg.services.tts.provider = "elevenlabs";
     cfg.services.tts.providers["fish-audio"].referenceId = "";
+    cfg.ingress.publicBaseUrl = "https://generic.example.com";
+    cfg.ingress.twilioPublicBaseUrl = "";
     // Reset TTS provider registry to ensure clean state
     registerTestTtsProviders();
   });
@@ -2528,6 +2535,51 @@ describe("call-controller", () => {
 
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken.last).toBe(true);
+
+    controller.destroy();
+  });
+
+  test("synthesized provider: play URL uses Twilio-specific public base URL", async () => {
+    const cfg = loadConfig();
+    cfg.ingress.publicBaseUrl = "https://generic.example.com";
+    cfg.ingress.twilioPublicBaseUrl = "https://twilio.example.com/";
+    cfg.services.tts.provider = "fish-audio";
+    cfg.services.tts.providers["fish-audio"].referenceId = "fish-ref-123";
+
+    _resetTtsProviderRegistry();
+    const fishAudioStreaming: TtsProvider = {
+      id: "fish-audio",
+      capabilities: {
+        supportsStreaming: true,
+        supportedFormats: ["mp3", "wav", "opus"],
+      },
+      async synthesize() {
+        return {
+          audio: Buffer.from("fish-audio-buffer"),
+          contentType: "audio/mpeg",
+        };
+      },
+      async synthesizeStream(_request, onChunk) {
+        onChunk(Buffer.from("fish-audio-stream"));
+        return {
+          audio: Buffer.from("fish-audio-stream"),
+          contentType: "audio/mpeg",
+        };
+      },
+    };
+    registerTtsProvider(fishAudioStreaming);
+
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Hello from synthesized path."]),
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Hi");
+
+    expect(relay.sentPlayUrls.length).toBeGreaterThan(0);
+    expect(relay.sentPlayUrls[0]).toStartWith(
+      "https://twilio.example.com/v1/audio/",
+    );
 
     controller.destroy();
   });

--- a/assistant/src/__tests__/public-ingress-urls.test.ts
+++ b/assistant/src/__tests__/public-ingress-urls.test.ts
@@ -33,6 +33,7 @@ import {
   getTelegramWebhookUrl,
   getTwilioConnectActionUrl,
   getTwilioMediaStreamUrl,
+  getTwilioPublicBaseUrl,
   getTwilioRelayUrl,
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
@@ -223,6 +224,18 @@ describe("Twilio-specific public base URL selection", () => {
     expect(getTwilioMediaStreamUrl(config)).toBe(
       "wss://twilio.example.com/webhooks/twilio/media-stream",
     );
+  });
+
+  test("Twilio public base resolver accepts twilioPublicBaseUrl without generic publicBaseUrl", () => {
+    const result = getTwilioPublicBaseUrl({
+      ingress: {
+        enabled: true,
+        publicBaseUrl: "",
+        twilioPublicBaseUrl: "  https://twilio-only.example.com///  ",
+      },
+    });
+
+    expect(result).toBe("https://twilio-only.example.com");
   });
 
   test("Twilio URL builders fall back to ingress.publicBaseUrl", () => {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -143,6 +143,7 @@ mock.module("../tts/provider-registry.js", () => ({
 // Mock public ingress URLs for synthesized TTS path
 mock.module("../inbound/public-ingress-urls.js", () => ({
   getPublicBaseUrl: () => "https://test.example.com",
+  getTwilioPublicBaseUrl: () => "https://test.example.com",
 }));
 
 // ── Helpers for building mock provider responses ────────────────────

--- a/assistant/src/__tests__/voice-ingress-preflight.test.ts
+++ b/assistant/src/__tests__/voice-ingress-preflight.test.ts
@@ -33,4 +33,27 @@ describe("voice ingress preflight", () => {
       expect(result.ingressConfig.ingress?.enabled).toBe(false);
     }
   });
+
+  test("accepts Twilio-specific public base URL when generic ingress URL is absent", async () => {
+    mockLoadConfig = () => ({
+      ingress: {
+        enabled: true,
+        publicBaseUrl: "",
+        twilioPublicBaseUrl: "https://twilio.example.com/",
+      },
+    });
+
+    const result = await preflightVoiceIngress();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.publicBaseUrl).toBe("https://twilio.example.com");
+      expect(result.ingressConfig.ingress?.publicBaseUrl).toBe(
+        "https://twilio.example.com",
+      );
+      expect(result.ingressConfig.ingress?.twilioPublicBaseUrl).toBe(
+        "https://twilio.example.com/",
+      );
+    }
+  });
 });

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -11,7 +11,7 @@
 import { loadConfig } from "../config/loader.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { TrustContext } from "../daemon/trust-context.js";
-import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
+import { getTwilioPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 import {
   expireCanonicalGuardianRequest,
   getCanonicalRequestByPendingQuestionId,
@@ -773,7 +773,7 @@ export class CallController {
       const storeFormat = outputFormat ? "pcm" : format;
       handle = createStreamingEntry(storeFormat);
       const config = loadConfig();
-      const baseUrl = getPublicBaseUrl(config);
+      const baseUrl = getTwilioPublicBaseUrl(config);
       const url = `${baseUrl}/v1/audio/${handle.audioId}`;
       const sendPlayUrlOnce = (): void => {
         if (playUrlSent) return;

--- a/assistant/src/calls/call-speech-output.ts
+++ b/assistant/src/calls/call-speech-output.ts
@@ -15,7 +15,7 @@
  */
 
 import { loadConfig } from "../config/loader.js";
-import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
+import { getTwilioPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";
 import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
@@ -102,7 +102,7 @@ async function synthesizeAndPlay(
     const storeFormat = outputFormat ? "pcm" : format;
     handle = createStreamingEntry(storeFormat);
     const config = loadConfig();
-    const baseUrl = getPublicBaseUrl(config);
+    const baseUrl = getTwilioPublicBaseUrl(config);
     const url = `${baseUrl}/v1/audio/${handle.audioId}`;
     const sendPlayUrlOnce = (): void => {
       if (playUrlSent) return;

--- a/assistant/src/calls/voice-ingress-preflight.ts
+++ b/assistant/src/calls/voice-ingress-preflight.ts
@@ -1,7 +1,7 @@
 import { getIsPlatform } from "../config/env-registry.js";
 import { loadConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
-import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
+import { getTwilioPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 
 const SERVICE_UNAVAILABLE_STATUS = 503 as const;
 
@@ -44,12 +44,12 @@ export async function preflightVoiceIngress(): Promise<VoiceIngressPreflightResu
 
   let publicBaseUrl: string;
   try {
-    publicBaseUrl = getPublicBaseUrl(ingressConfig);
+    publicBaseUrl = getTwilioPublicBaseUrl(ingressConfig);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return fail(
       msg ||
-        "Outbound voice calls require public ingress to be enabled and a public base URL (ingress.publicBaseUrl).",
+        "Outbound voice calls require public ingress to be enabled and a Twilio public base URL (ingress.twilioPublicBaseUrl or ingress.publicBaseUrl).",
     );
   }
 

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -82,7 +82,7 @@ export function getPublicBaseUrl(config: IngressConfig): string {
   );
 }
 
-function getTwilioPublicBaseUrl(config: IngressConfig): string {
+export function getTwilioPublicBaseUrl(config: IngressConfig): string {
   assertPublicIngressEnabled(config);
 
   const ingressValue = config.ingress?.twilioPublicBaseUrl;
@@ -91,7 +91,19 @@ function getTwilioPublicBaseUrl(config: IngressConfig): string {
     if (normalized) return normalized;
   }
 
-  return getPublicBaseUrl(config);
+  try {
+    return getPublicBaseUrl(config);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      /No public base URL configured/.test(err.message)
+    ) {
+      throw new Error(
+        "No Twilio public base URL configured. Set ingress.twilioPublicBaseUrl or ingress.publicBaseUrl in config.",
+      );
+    }
+    throw err;
+  }
 }
 
 /**

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -147,9 +147,10 @@ function makeCaches(
   opts: {
     authToken?: string;
     ingressUrl?: string;
+    twilioIngressUrl?: string;
   } = {},
 ) {
-  const { authToken = AUTH_TOKEN, ingressUrl } = opts;
+  const { authToken = AUTH_TOKEN, ingressUrl, twilioIngressUrl } = opts;
   const credentials = {
     get: async (key: string, _opts?: { force?: boolean }) => {
       if (key === credentialKey("twilio", "auth_token")) return authToken;
@@ -160,6 +161,9 @@ function makeCaches(
   const configFile = {
     getString: (section: string, key: string) => {
       if (section === "ingress" && key === "publicBaseUrl") return ingressUrl;
+      if (section === "ingress" && key === "twilioPublicBaseUrl") {
+        return twilioIngressUrl;
+      }
       return undefined;
     },
     getRecord: () => undefined,
@@ -474,6 +478,61 @@ describe("Twilio connect-action webhook", () => {
 });
 
 describe("Twilio webhook signature with canonical ingress base URL", () => {
+  test("prefers twilioPublicBaseUrl over publicBaseUrl for signature validation", async () => {
+    fetchMock = mock(
+      async () =>
+        new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+    );
+
+    const twilioBaseUrl = "https://twilio.example.com";
+    const publicBaseUrl = "https://public.example.com";
+    const handler = createTwilioVoiceWebhookHandler(
+      makeConfig(),
+      makeCaches({
+        ingressUrl: publicBaseUrl,
+        twilioIngressUrl: twilioBaseUrl,
+      }),
+    );
+
+    const localUrl =
+      "http://localhost:7830/webhooks/twilio/voice?callSessionId=sig-test";
+    const twilioUrl =
+      twilioBaseUrl + "/webhooks/twilio/voice?callSessionId=sig-test";
+    const publicUrl =
+      publicBaseUrl + "/webhooks/twilio/voice?callSessionId=sig-test";
+    const params = { CallSid: "CA123" };
+    const signature = computeSignature(twilioUrl, params, AUTH_TOKEN);
+    const req = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body: new URLSearchParams(params).toString(),
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const successLog = findLogCall("Twilio webhook signature validated");
+    expect(successLog.method).toBe("info");
+    expect(successLog.data).toMatchObject({
+      webhookKind: "voice",
+      validatedCandidateSource: "configured_ingress",
+      validatedCandidateUrl: twilioUrl,
+      candidateCount: 3,
+      candidateSources: [
+        "configured_ingress",
+        "configured_ingress",
+        "raw_request",
+      ],
+      candidateUrls: [twilioUrl, publicUrl, localUrl],
+    });
+  });
+
   test("validates signature against ingressPublicBaseUrl when configured", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
     fetchMock = mock(
@@ -610,7 +669,7 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
 
     const successLog = findLogCall(
       "Twilio signature validated against raw request URL fallback — " +
-        "ingress.publicBaseUrl may be stale or mismatched with the actual webhook registration",
+        "configured Twilio ingress may be stale or mismatched with the actual webhook registration",
     );
     expect(successLog.method).toBe("warn");
     expect(successLog.data).toMatchObject({
@@ -714,7 +773,66 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
   });
 });
 
-describe("Twilio webhook force retry on credential-missing", () => {
+describe("Twilio webhook force retry", () => {
+  test("refreshes Twilio-specific ingress URL before retrying signature validation", async () => {
+    fetchMock = mock(
+      async () =>
+        new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+    );
+
+    let refreshCount = 0;
+    const credentials = {
+      get: async () => AUTH_TOKEN,
+      invalidate: () => {},
+    } as unknown as CredentialCache;
+
+    const staleTwilioBaseUrl = "https://stale-twilio.example.com";
+    const freshTwilioBaseUrl = "https://fresh-twilio.example.com";
+    const genericBaseUrl = "https://generic.example.com";
+    const configFile = {
+      getString: (section: string, key: string) => {
+        if (section !== "ingress") return undefined;
+        if (key === "twilioPublicBaseUrl") {
+          return refreshCount > 0 ? freshTwilioBaseUrl : staleTwilioBaseUrl;
+        }
+        if (key === "publicBaseUrl") return genericBaseUrl;
+        return undefined;
+      },
+      getRecord: () => undefined,
+      refreshNow: () => {
+        refreshCount++;
+      },
+    } as unknown as ConfigFileCache;
+
+    const handler = createTwilioVoiceWebhookHandler(makeConfig(), {
+      credentials,
+      configFile,
+    });
+
+    const localUrl =
+      "http://localhost:7830/webhooks/twilio/voice?callSessionId=sess-refresh";
+    const freshTwilioUrl =
+      freshTwilioBaseUrl + "/webhooks/twilio/voice?callSessionId=sess-refresh";
+    const params = { CallSid: "CA123" };
+    const signature = computeSignature(freshTwilioUrl, params, AUTH_TOKEN);
+    const req = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": signature,
+      },
+      body: new URLSearchParams(params).toString(),
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(refreshCount).toBe(1);
+  });
+
   test("succeeds after force-refreshing a missing auth token", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
     fetchMock = mock(

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -55,6 +55,7 @@ function normalizeUrlForLog(url: string): string {
 type ResolvedValidationContext = {
   authToken: string | undefined;
   ingressUrl: string | undefined;
+  twilioIngressUrl: string | undefined;
 };
 
 function buildSignatureUrlCandidateDetails(
@@ -85,6 +86,7 @@ function buildSignatureUrlCandidateDetails(
     addCandidate(`${normalized}${pathAndQuery}`, source);
   };
 
+  addBase(resolved.twilioIngressUrl, "configured_ingress");
   addBase(resolved.ingressUrl, "configured_ingress");
 
   const forwardedProto =
@@ -173,6 +175,19 @@ export type TwilioValidationCaches = {
   configFile?: ConfigFileCache;
 };
 
+function readConfiguredIngressUrls(
+  configFile: ConfigFileCache | undefined,
+): Pick<ResolvedValidationContext, "ingressUrl" | "twilioIngressUrl"> {
+  if (!configFile) {
+    return { ingressUrl: undefined, twilioIngressUrl: undefined };
+  }
+
+  return {
+    ingressUrl: configFile.getString("ingress", "publicBaseUrl"),
+    twilioIngressUrl: configFile.getString("ingress", "twilioPublicBaseUrl"),
+  };
+}
+
 /**
  * Validate an incoming Twilio webhook request:
  * - Enforces POST method
@@ -206,12 +221,17 @@ export async function validateTwilioWebhookRequest(
     ? await caches.credentials.get(credentialKey("twilio", "auth_token"))
     : undefined;
 
-  // Resolve ingress URL from cache
-  let ingressUrl = caches?.configFile
-    ? caches.configFile.getString("ingress", "publicBaseUrl")
-    : undefined;
+  // Resolve ingress URLs from cache. Twilio-specific ingress wins, then
+  // the generic public ingress URL remains the compatibility fallback.
+  let { ingressUrl, twilioIngressUrl } = readConfiguredIngressUrls(
+    caches?.configFile,
+  );
 
-  let resolved: ResolvedValidationContext = { authToken, ingressUrl };
+  let resolved: ResolvedValidationContext = {
+    authToken,
+    ingressUrl,
+    twilioIngressUrl,
+  };
 
   let validationDiagnostics = buildValidationDiagnostics(req, resolved);
   let { logContext: validationLogContext, signatureUrlCandidates } =
@@ -226,16 +246,21 @@ export async function validateTwilioWebhookRequest(
     );
     if (freshAuthToken) {
       let freshIngressUrl = ingressUrl;
+      let freshTwilioIngressUrl = twilioIngressUrl;
       if (caches.configFile) {
         caches.configFile.refreshNow();
-        freshIngressUrl = caches.configFile.getString(
-          "ingress",
-          "publicBaseUrl",
-        );
+        const freshIngressUrls = readConfiguredIngressUrls(caches.configFile);
+        freshIngressUrl = freshIngressUrls.ingressUrl;
+        freshTwilioIngressUrl = freshIngressUrls.twilioIngressUrl;
       }
       authToken = freshAuthToken;
       ingressUrl = freshIngressUrl;
-      resolved = { authToken: freshAuthToken, ingressUrl: freshIngressUrl };
+      twilioIngressUrl = freshTwilioIngressUrl;
+      resolved = {
+        authToken: freshAuthToken,
+        ingressUrl: freshIngressUrl,
+        twilioIngressUrl: freshTwilioIngressUrl,
+      };
       validationDiagnostics = buildValidationDiagnostics(req, resolved);
       ({ logContext: validationLogContext, signatureUrlCandidates } =
         validationDiagnostics);
@@ -298,19 +323,24 @@ export async function validateTwilioWebhookRequest(
       { force: true },
     );
     let freshIngressUrl: string | undefined;
+    let freshTwilioIngressUrl: string | undefined;
     if (caches.configFile) {
       caches.configFile.refreshNow();
-      freshIngressUrl = caches.configFile.getString("ingress", "publicBaseUrl");
+      const freshIngressUrls = readConfiguredIngressUrls(caches.configFile);
+      freshIngressUrl = freshIngressUrls.ingressUrl;
+      freshTwilioIngressUrl = freshIngressUrls.twilioIngressUrl;
     }
 
     const retryAuthToken = freshAuthToken;
     const retryIngressUrl = freshIngressUrl;
+    const retryTwilioIngressUrl = freshTwilioIngressUrl;
 
     if (retryAuthToken) {
       // Rebuild candidates with potentially updated ingress URL
       const retryResolved: ResolvedValidationContext = {
         authToken: retryAuthToken,
         ingressUrl: retryIngressUrl,
+        twilioIngressUrl: retryTwilioIngressUrl,
       };
       const retryDiagnostics = buildValidationDiagnostics(req, retryResolved);
       const retryCandidateUrls = retryDiagnostics.signatureUrlCandidates.map(
@@ -325,9 +355,13 @@ export async function validateTwilioWebhookRequest(
 
       if (validatingIndex !== -1) {
         log.info(
-          "Twilio webhook signature validated after forced credential refresh",
+          "Twilio webhook signature validated after forced cache refresh",
         );
         // Update references for the success log below
+        ingressUrl = retryIngressUrl;
+        twilioIngressUrl = retryTwilioIngressUrl;
+        validationLogContext = retryDiagnostics.logContext;
+        signatureUrlCandidates = retryDiagnostics.signatureUrlCandidates;
         signatureCandidateUrls = retryCandidateUrls;
       }
     }
@@ -351,12 +385,12 @@ export async function validateTwilioWebhookRequest(
     validatedCandidateUrl: normalizeUrlForLog(validatingCandidate.url),
   };
 
-  // When ingressPublicBaseUrl is configured and the signature only validated
+  // When a configured ingress URL is present and the signature only validated
   // against the raw local URL (last candidate), log a warning. This indicates
   // a likely drift between the configured ingress URL and the actual webhook
   // registration — the ingress URL should match what Twilio is signing against.
   if (
-    ingressUrl &&
+    (twilioIngressUrl || ingressUrl) &&
     validatingIndex === signatureCandidateUrls.length - 1 &&
     signatureCandidateUrls.length > 1
   ) {
@@ -364,9 +398,10 @@ export async function validateTwilioWebhookRequest(
       {
         ...successLogContext,
         ingressPublicBaseUrl: ingressUrl,
+        twilioPublicBaseUrl: twilioIngressUrl,
       },
       "Twilio signature validated against raw request URL fallback — " +
-        "ingress.publicBaseUrl may be stale or mismatched with the actual webhook registration",
+        "configured Twilio ingress may be stale or mismatched with the actual webhook registration",
     );
   } else {
     log.info(successLogContext, "Twilio webhook signature validated");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for velay-twilio-ingress.md.

**Gap:** Twilio-specific base URL was not used by validation, preflight, and Twilio-served audio.
**Fix:** Prefer ingress.twilioPublicBaseUrl for Twilio validation/preflight/audio while preserving generic ingress behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
