### PR TITLE
fix: harden Velay client URL lifecycle

### DIFF
--- a/assistant/src/config/schemas/ingress.ts
+++ b/assistant/src/config/schemas/ingress.ts
@@ -91,6 +91,10 @@ const IngressBaseSchema = z
     twilioPublicBaseUrl: emptyOrAbsoluteHttpUrl("ingress.twilioPublicBaseUrl")
       .optional()
       .describe("Twilio-specific public-facing base URL for webhook callbacks"),
+    twilioPublicBaseUrlManagedBy: z
+      .literal("velay")
+      .optional()
+      .describe("Marks a Twilio-specific public base URL managed by Velay"),
     webhook: IngressWebhookConfigSchema.default(
       IngressWebhookConfigSchema.parse({}),
     ),

--- a/gateway/src/__tests__/config-file-watcher.test.ts
+++ b/gateway/src/__tests__/config-file-watcher.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  ConfigFileWatcher,
+  type ConfigChangeEvent,
+} from "../config-file-watcher.js";
+import { testWorkspaceDir } from "./test-preload.js";
+
+const configPath = join(testWorkspaceDir, "config.json");
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(configPath, JSON.stringify(data), "utf-8");
+}
+
+function pollOnce(watcher: ConfigFileWatcher): void {
+  (
+    watcher as unknown as {
+      pollOnce: () => void;
+    }
+  ).pollOnce();
+}
+
+afterEach(() => {
+  try {
+    if (existsSync(configPath)) unlinkSync(configPath);
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe("ConfigFileWatcher", () => {
+  test("reports shallow ingress fields changed by Velay-managed Twilio URL writes", () => {
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://public.example.test",
+      },
+    });
+    const events: ConfigChangeEvent[] = [];
+    const watcher = new ConfigFileWatcher((event) => {
+      events.push(event);
+    });
+
+    pollOnce(watcher);
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://public.example.test",
+        twilioPublicBaseUrl: "https://velay.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+    pollOnce(watcher);
+
+    expect(events).toHaveLength(2);
+    expect(events[1].changedKeys).toEqual(new Set(["ingress"]));
+    expect(events[1].changedFields.get("ingress")).toEqual(
+      new Set(["twilioPublicBaseUrl", "twilioPublicBaseUrlManagedBy"]),
+    );
+  });
+
+  test("reports Twilio-only fields when Velay creates ingress from scratch", () => {
+    writeConfig({
+      gateway: {
+        runtimeProxyRequireAuth: false,
+      },
+    });
+    const events: ConfigChangeEvent[] = [];
+    const watcher = new ConfigFileWatcher((event) => {
+      events.push(event);
+    });
+
+    pollOnce(watcher);
+    writeConfig({
+      gateway: {
+        runtimeProxyRequireAuth: false,
+      },
+      ingress: {
+        twilioPublicBaseUrl: "https://velay.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+    pollOnce(watcher);
+
+    expect(events).toHaveLength(2);
+    expect(events[1].changedKeys).toEqual(new Set(["ingress"]));
+    expect(events[1].changedFields.get("ingress")).toEqual(
+      new Set(["twilioPublicBaseUrl", "twilioPublicBaseUrlManagedBy"]),
+    );
+  });
+
+  test("distinguishes public ingress URL changes from Twilio-only changes", () => {
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://old-public.example.test",
+        twilioPublicBaseUrl: "https://velay.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+    const events: ConfigChangeEvent[] = [];
+    const watcher = new ConfigFileWatcher((event) => {
+      events.push(event);
+    });
+
+    pollOnce(watcher);
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://new-public.example.test",
+        twilioPublicBaseUrl: "https://velay.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+    pollOnce(watcher);
+
+    expect(events).toHaveLength(2);
+    expect(events[1].changedFields.get("ingress")).toEqual(
+      new Set(["publicBaseUrl"]),
+    );
+  });
+});

--- a/gateway/src/config-file-watcher.ts
+++ b/gateway/src/config-file-watcher.ts
@@ -18,6 +18,11 @@ export type ConfigChangeEvent = {
   data: Record<string, unknown>;
   /** Top-level keys whose serialized value changed since the last poll. */
   changedKeys: Set<string>;
+  /**
+   * Shallow object fields that changed for changed top-level object keys.
+   * Non-object replacements are represented by the top-level key only.
+   */
+  changedFields: Map<string, Set<string>>;
 };
 
 export type ConfigChangeCallback = (event: ConfigChangeEvent) => void;
@@ -46,6 +51,7 @@ export class ConfigFileWatcher {
   private watchingDirectory = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private lastSerialized: Map<string, string> = new Map();
+  private lastValues: Map<string, unknown> = new Map();
   private callback: ConfigChangeCallback;
   private configPath: string;
 
@@ -137,6 +143,7 @@ export class ConfigFileWatcher {
     const data = readConfigFile(this.configPath);
 
     const changedKeys = new Set<string>();
+    const changedFields = new Map<string, Set<string>>();
 
     // Detect changed or added keys
     const allKeys = new Set([
@@ -150,10 +157,19 @@ export class ConfigFileWatcher {
 
       if (newVal !== oldVal) {
         changedKeys.add(key);
+        const fieldChanges = diffObjectFields(
+          this.lastValues.get(key),
+          key in data ? data[key] : undefined,
+        );
+        if (fieldChanges.size > 0) {
+          changedFields.set(key, fieldChanges);
+        }
         if (newVal !== undefined) {
           this.lastSerialized.set(key, newVal);
+          this.lastValues.set(key, data[key]);
         } else {
           this.lastSerialized.delete(key);
+          this.lastValues.delete(key);
         }
       }
     }
@@ -162,6 +178,34 @@ export class ConfigFileWatcher {
 
     log.info({ changedKeys: [...changedKeys] }, "Config file changed");
 
-    this.callback({ data, changedKeys });
+    this.callback({ data, changedKeys, changedFields });
   }
+}
+
+function diffObjectFields(oldValue: unknown, newValue: unknown): Set<string> {
+  if (!isPlainRecord(oldValue) && !isPlainRecord(newValue)) {
+    return new Set();
+  }
+
+  const oldRecord = isPlainRecord(oldValue) ? oldValue : {};
+  const newRecord = isPlainRecord(newValue) ? newValue : {};
+  const changed = new Set<string>();
+  const allKeys = new Set([
+    ...Object.keys(oldRecord),
+    ...Object.keys(newRecord),
+  ]);
+  for (const key of allKeys) {
+    const oldSerialized =
+      key in oldRecord ? JSON.stringify(oldRecord[key]) : undefined;
+    const newSerialized =
+      key in newRecord ? JSON.stringify(newRecord[key]) : undefined;
+    if (oldSerialized !== newSerialized) {
+      changed.add(key);
+    }
+  }
+  return changed;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -9,7 +9,10 @@ import {
 import { validateEdgeToken, mintServiceToken } from "./auth/token-exchange.js";
 import { findGuardianForChannelActor } from "./auth/guardian-bootstrap.js";
 import { ConfigFileCache } from "./config-file-cache.js";
-import { ConfigFileWatcher } from "./config-file-watcher.js";
+import {
+  ConfigFileWatcher,
+  type ConfigChangeEvent,
+} from "./config-file-watcher.js";
 import { FeatureFlagWatcher } from "./feature-flag-watcher.js";
 import { RemoteFeatureFlagSync } from "./remote-feature-flag-sync.js";
 import { loadConfig } from "./config.js";
@@ -195,6 +198,23 @@ function detectCredentialChanges(
     changed.add(service);
   }
   return changed;
+}
+
+function isOnlyVelayTwilioIngressChange(event: ConfigChangeEvent): boolean {
+  if (event.changedKeys.size !== 1 || !event.changedKeys.has("ingress")) {
+    return false;
+  }
+
+  const ingressFields = event.changedFields.get("ingress");
+  if (!ingressFields || ingressFields.size === 0) {
+    return false;
+  }
+
+  return [...ingressFields].every(
+    (field) =>
+      field === "twilioPublicBaseUrl" ||
+      field === "twilioPublicBaseUrlManagedBy",
+  );
 }
 
 // Shared rate limiter for auth failures and unauthenticated endpoints
@@ -1939,7 +1959,13 @@ async function main() {
     configFileCache.invalidate();
 
     // Side effect: reconcile Telegram webhook when ingress URL changes
-    if (event.changedKeys.has("ingress") && isTelegramConfigured()) {
+    const onlyVelayTwilioIngressChanged = isOnlyVelayTwilioIngressChange(event);
+
+    if (
+      event.changedKeys.has("ingress") &&
+      !onlyVelayTwilioIngressChanged &&
+      isTelegramConfigured()
+    ) {
       reconcileTelegramWebhook(telegramCaches).catch((err) => {
         log.error(
           { err },
@@ -1950,7 +1976,11 @@ async function main() {
 
     // Side effect: re-register email callback when ingress URL changes so
     // the platform callback route points at the new self-hosted URL.
-    if (event.changedKeys.has("ingress") && vellumReady) {
+    if (
+      event.changedKeys.has("ingress") &&
+      !onlyVelayTwilioIngressChanged &&
+      vellumReady
+    ) {
       registerEmailCallbackRoute({
         credentials: credentialCache,
         configFile: configFileCache,
@@ -2020,13 +2050,15 @@ async function main() {
   process.on("SIGTERM", () => {
     log.info("SIGTERM received, starting graceful shutdown");
     draining = true;
+    const shutdownTasks: Promise<void>[] = [];
     sleepWakeDetector.stop();
     credentialWatcher.stop();
     configFileWatcher.stop();
     avatarSyncWatcher.stop();
     featureFlagWatcher.stop();
     remoteFeatureFlagSync.stop();
-    velayTunnelClient?.stop();
+    const velayStop = velayTunnelClient?.stop();
+    if (velayStop) shutdownTasks.push(velayStop);
     ipcServer.stop();
     telegramDedupCache.stopCleanup();
     whatsappDedupCache.stopCleanup();
@@ -2038,8 +2070,10 @@ async function main() {
     }
     setTimeout(() => {
       log.info("Drain window elapsed, stopping server");
-      server.stop(true);
-      process.exit(0);
+      void Promise.allSettled(shutdownTasks).then(() => {
+        server.stop(true);
+        process.exit(0);
+      });
     }, drainMs);
   });
 }

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -198,8 +198,9 @@ function sendFrame(ws: FakeWebSocket, frame: VelayFrame): void {
 }
 
 async function flushPromises(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let i = 0; i < 6; i++) {
+    await Promise.resolve();
+  }
 }
 
 beforeEach(() => {
@@ -211,13 +212,14 @@ afterEach(() => {
 });
 
 describe("VelayTunnelClient", () => {
-  test("stays disabled when VELAY_BASE_URL is unset", () => {
+  test("stays disabled when VELAY_BASE_URL is unset", async () => {
     const client = createVelayTunnelClient(makeConfig(), {
       credentials: makeCredentials({}),
       configFile: makeConfigFileCache({ count: 0 }),
     });
 
     expect(client).toBeUndefined();
+    await flushPromises();
   });
 
   test("retries without opening a socket when the assistant API key is missing", async () => {
@@ -236,7 +238,26 @@ describe("VelayTunnelClient", () => {
 
     expect(sockets).toHaveLength(0);
     expect(reconnectDelays).toEqual([10]);
-    client.stop();
+    await client.stop();
+  });
+
+  test("retries without opening a socket when the platform assistant ID is missing", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays,
+      credentials: makeCredentials({
+        [credentialKey("vellum", "assistant_api_key")]: "api-key-123",
+      }),
+    });
+
+    client.start();
+    await flushPromises();
+
+    expect(sockets).toHaveLength(0);
+    expect(reconnectDelays).toEqual([10]);
+    await client.stop();
   });
 
   test("registers with Velay and publishes the Twilio public URL", async () => {
@@ -276,6 +297,7 @@ describe("VelayTunnelClient", () => {
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
         twilioPublicBaseUrl: "https://velay-public.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
       },
       existing: { preserved: true },
     });
@@ -335,11 +357,45 @@ describe("VelayTunnelClient", () => {
         publicBaseUrl: "https://ngrok.example.test",
         otherIngressSetting: "keep-me",
         twilioPublicBaseUrl: "https://velay-public.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
       },
       gateway: {
         runtimeProxyRequireAuth: false,
       },
     });
+  });
+
+  test("rejects registration with an invalid public URL", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    const invalidations = { count: 0 };
+    writeConfig({
+      ingress: { publicBaseUrl: "https://ngrok.example.test" },
+    });
+    const client = makeClient({
+      sockets,
+      reconnectDelays,
+      configFile: makeConfigFileCache(invalidations),
+    });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "notaurl",
+    });
+    await flushPromises();
+
+    expect(sockets[0].closes).toEqual([
+      { code: 1008, reason: "invalid public URL" },
+    ]);
+    expect(readConfig()).toEqual({
+      ingress: { publicBaseUrl: "https://ngrok.example.test" },
+    });
+    expect(invalidations.count).toBe(0);
+    expect(reconnectDelays).toEqual([10]);
   });
 
   test("clears the published Twilio public URL when the tunnel disconnects", async () => {
@@ -402,6 +458,7 @@ describe("VelayTunnelClient", () => {
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
         twilioPublicBaseUrl: "https://velay-public-2.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
       },
     });
 
@@ -413,8 +470,86 @@ describe("VelayTunnelClient", () => {
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
         twilioPublicBaseUrl: "https://velay-public-2.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
       },
     });
+  });
+
+  test("clears stale managed Velay URL on startup before connecting", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const invalidations = { count: 0 };
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://stale-velay.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+    const client = makeClient({
+      sockets,
+      configFile: makeConfigFileCache(invalidations),
+    });
+
+    client.start();
+    await flushPromises();
+
+    expect(sockets).toHaveLength(1);
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(1);
+    await client.stop();
+  });
+
+  test("disabled Velay cleanup clears managed URL and preserves manual URL", async () => {
+    const invalidations = { count: 0 };
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://stale-velay.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+
+    expect(
+      createVelayTunnelClient(makeConfig(), {
+        credentials: makeCredentials({}),
+        configFile: makeConfigFileCache(invalidations),
+      }),
+    ).toBeUndefined();
+    await flushPromises();
+
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(1);
+
+    writeConfig({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://manual.example.test",
+      },
+    });
+
+    expect(
+      createVelayTunnelClient(makeConfig(), {
+        credentials: makeCredentials({}),
+        configFile: makeConfigFileCache(invalidations),
+      }),
+    ).toBeUndefined();
+    await flushPromises();
+
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://manual.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(1);
   });
 
   test("dispatches HTTP and WebSocket frames to the loopback bridges", async () => {
@@ -490,6 +625,7 @@ describe("VelayTunnelClient", () => {
       gatewayLoopbackBaseUrl: "http://127.0.0.1:7830",
       credentials: makeCredentials({
         [credentialKey("vellum", "assistant_api_key")]: "api-key-123",
+        [credentialKey("vellum", "platform_assistant_id")]: "asst-123",
       }),
       configFile: makeConfigFileCache({ count: 0 }),
       webSocketConstructor: makeWebSocketConstructor(sockets),
@@ -506,7 +642,7 @@ describe("VelayTunnelClient", () => {
 
     client.start();
     await flushPromises();
-    client.stop();
+    await client.stop();
     sockets[0].emit("close", { code: 1000, reason: "gateway shutdown" });
     await flushPromises();
 

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -27,6 +27,7 @@ const log = getLogger("velay-client");
 const BASE_RECONNECT_DELAY_MS = 500;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const RECONNECT_JITTER_RATIO = 0.5;
+const VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER = "velay";
 
 export type WebSocketConstructorWithOptions = {
   new (
@@ -100,14 +101,14 @@ export class VelayTunnelClient {
   start(): void {
     if (this.running) return;
     this.running = true;
-    this.connect().catch((err) => {
+    this.startAsync().catch((err) => {
       this.connecting = false;
       log.error({ err }, "Failed to start Velay tunnel client");
       this.scheduleReconnect();
     });
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.running = false;
     this.connecting = false;
     if (this.reconnectTimer) {
@@ -117,10 +118,15 @@ export class VelayTunnelClient {
     const ws = this.ws;
     this.ws = null;
     this.webSocketBridge.closeAll();
-    this.clearPublishedTwilioPublicBaseUrl();
+    await this.clearPublishedTwilioPublicBaseUrl();
     if (ws) {
       closeWebSocket(ws, 1000, "gateway shutdown");
     }
+  }
+
+  private async startAsync(): Promise<void> {
+    await clearManagedTwilioPublicBaseUrl(this.options.configFile);
+    await this.connect();
   }
 
   private async connect(): Promise<void> {
@@ -158,6 +164,13 @@ export class VelayTunnelClient {
       this.scheduleReconnect();
       return;
     }
+    if (!platformAssistantId) {
+      this.connecting = false;
+      log.info("Velay tunnel waiting for platform assistant ID");
+      this.scheduleReconnect();
+      return;
+    }
+    const expectedAssistantId = platformAssistantId;
 
     let registerUrl: string;
     try {
@@ -185,7 +198,7 @@ export class VelayTunnelClient {
       });
 
       ws.addEventListener("message", (event) => {
-        void this.handleMessage(event.data, ws, platformAssistantId).catch(
+        void this.handleMessage(event.data, ws, expectedAssistantId).catch(
           (err) => {
             log.error({ err }, "Failed to handle Velay frame");
           },
@@ -214,7 +227,7 @@ export class VelayTunnelClient {
   private async handleMessage(
     data: unknown,
     originWs: WebSocket,
-    platformAssistantId: string | undefined,
+    platformAssistantId: string,
   ): Promise<void> {
     if (this.ws !== originWs || !this.running) return;
 
@@ -244,9 +257,9 @@ export class VelayTunnelClient {
   private async handleRegisteredFrame(
     frame: VelayRegisteredFrame,
     originWs: WebSocket,
-    platformAssistantId: string | undefined,
+    platformAssistantId: string,
   ): Promise<void> {
-    if (platformAssistantId && frame.assistant_id !== platformAssistantId) {
+    if (frame.assistant_id !== platformAssistantId) {
       log.error(
         {
           expectedAssistantId: platformAssistantId,
@@ -258,7 +271,19 @@ export class VelayTunnelClient {
       return;
     }
 
-    await writeTwilioPublicBaseUrl(frame.public_url, this.options.configFile);
+    if (!isEmptyOrAbsoluteHttpUrl(frame.public_url)) {
+      log.error(
+        { publicUrl: frame.public_url },
+        "Velay registered invalid Twilio public URL",
+      );
+      this.disconnectActiveWebSocket(originWs, 1008, "invalid public URL");
+      return;
+    }
+
+    await writeManagedTwilioPublicBaseUrl(
+      frame.public_url,
+      this.options.configFile,
+    );
     this.publishedTwilioPublicBaseUrl = frame.public_url;
     log.info({ publicUrl: frame.public_url }, "Velay tunnel registered");
   }
@@ -280,7 +305,7 @@ export class VelayTunnelClient {
     this.ws = null;
     this.connecting = false;
     this.webSocketBridge.closeAll();
-    this.clearPublishedTwilioPublicBaseUrl();
+    void this.clearPublishedTwilioPublicBaseUrl();
     log.info(
       { code: event.code, reason: event.reason },
       "Velay tunnel disconnected",
@@ -297,20 +322,20 @@ export class VelayTunnelClient {
     this.ws = null;
     this.connecting = false;
     this.webSocketBridge.closeAll();
-    this.clearPublishedTwilioPublicBaseUrl();
+    void this.clearPublishedTwilioPublicBaseUrl();
     closeWebSocket(ws, code, reason);
     this.scheduleReconnect();
   }
 
-  private clearPublishedTwilioPublicBaseUrl(): void {
+  private async clearPublishedTwilioPublicBaseUrl(): Promise<void> {
     const publicUrl = this.publishedTwilioPublicBaseUrl;
     if (!publicUrl) return;
     this.publishedTwilioPublicBaseUrl = undefined;
-    void clearTwilioPublicBaseUrl(publicUrl, this.options.configFile).catch(
-      (err) => {
-        log.error({ err }, "Failed to clear Velay Twilio public URL");
-      },
-    );
+    try {
+      await clearManagedTwilioPublicBaseUrl(this.options.configFile, publicUrl);
+    } catch (err) {
+      log.error({ err }, "Failed to clear Velay Twilio public URL");
+    }
   }
 
   private sendFrame(frame: VelayFrame): void {
@@ -348,7 +373,12 @@ export function createVelayTunnelClient(
     configFile: ConfigFileCache;
   },
 ): VelayTunnelClient | undefined {
-  if (!config.velayBaseUrl) return undefined;
+  if (!config.velayBaseUrl) {
+    void clearManagedTwilioPublicBaseUrl(deps.configFile).catch((err) => {
+      log.error({ err }, "Failed to clear disabled Velay Twilio public URL");
+    });
+    return undefined;
+  }
   return new VelayTunnelClient({
     velayBaseUrl: config.velayBaseUrl,
     gatewayLoopbackBaseUrl: config.gatewayInternalBaseUrl,
@@ -369,38 +399,27 @@ function defaultWebSocketBridgeFactory(
   return new VelayWebSocketBridge(gatewayLoopbackBaseUrl, sendFrame);
 }
 
-async function writeTwilioPublicBaseUrl(
-  publicUrl: string,
+async function mutateConfigFile(
   configFile: ConfigFileCache,
+  malformedLogMessage: string,
+  mutate: (data: Record<string, unknown>) => boolean,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     enqueueConfigWrite(() => {
       try {
         const result = readConfigFile();
         if (!result.ok) {
-          log.error(
-            { detail: result.detail },
-            "Cannot publish Velay public URL because config.json is malformed",
-          );
+          log.error({ detail: result.detail }, malformedLogMessage);
           resolve();
           return;
         }
 
-        const data = result.data;
-        const ingress =
-          data.ingress &&
-          typeof data.ingress === "object" &&
-          !Array.isArray(data.ingress)
-            ? { ...(data.ingress as Record<string, unknown>) }
-            : {};
-        if (ingress.twilioPublicBaseUrl === publicUrl) {
+        if (!mutate(result.data)) {
           resolve();
           return;
         }
 
-        ingress.twilioPublicBaseUrl = publicUrl;
-        data.ingress = ingress;
-        writeConfigFileAtomic(data);
+        writeConfigFileAtomic(result.data);
         configFile.invalidate();
         resolve();
       } catch (err) {
@@ -410,49 +429,82 @@ async function writeTwilioPublicBaseUrl(
   });
 }
 
-async function clearTwilioPublicBaseUrl(
+async function writeManagedTwilioPublicBaseUrl(
   publicUrl: string,
   configFile: ConfigFileCache,
 ): Promise<void> {
-  return new Promise((resolve, reject) => {
-    enqueueConfigWrite(() => {
-      try {
-        const result = readConfigFile();
-        if (!result.ok) {
-          log.error(
-            { detail: result.detail },
-            "Cannot clear Velay public URL because config.json is malformed",
-          );
-          resolve();
-          return;
-        }
-
-        const data = result.data;
-        if (
-          !data.ingress ||
-          typeof data.ingress !== "object" ||
-          Array.isArray(data.ingress)
-        ) {
-          resolve();
-          return;
-        }
-
-        const ingress = { ...(data.ingress as Record<string, unknown>) };
-        if (ingress.twilioPublicBaseUrl !== publicUrl) {
-          resolve();
-          return;
-        }
-
-        delete ingress.twilioPublicBaseUrl;
-        data.ingress = ingress;
-        writeConfigFileAtomic(data);
-        configFile.invalidate();
-        resolve();
-      } catch (err) {
-        reject(err);
+  return mutateConfigFile(
+    configFile,
+    "Cannot publish Velay public URL because config.json is malformed",
+    (data) => {
+      const ingress = getMutableIngress(data);
+      if (
+        ingress.twilioPublicBaseUrl === publicUrl &&
+        ingress.twilioPublicBaseUrlManagedBy ===
+          VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER
+      ) {
+        return false;
       }
-    });
-  });
+
+      ingress.twilioPublicBaseUrl = publicUrl;
+      ingress.twilioPublicBaseUrlManagedBy =
+        VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER;
+      data.ingress = ingress;
+      return true;
+    },
+  );
+}
+
+async function clearManagedTwilioPublicBaseUrl(
+  configFile: ConfigFileCache,
+  expectedPublicUrl?: string,
+): Promise<void> {
+  return mutateConfigFile(
+    configFile,
+    "Cannot clear Velay public URL because config.json is malformed",
+    (data) => {
+      if (
+        !data.ingress ||
+        typeof data.ingress !== "object" ||
+        Array.isArray(data.ingress)
+      ) {
+        return false;
+      }
+
+      const ingress = { ...(data.ingress as Record<string, unknown>) };
+      if (
+        ingress.twilioPublicBaseUrlManagedBy !==
+        VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER
+      ) {
+        return false;
+      }
+      if (
+        expectedPublicUrl !== undefined &&
+        ingress.twilioPublicBaseUrl !== expectedPublicUrl
+      ) {
+        return false;
+      }
+
+      delete ingress.twilioPublicBaseUrl;
+      delete ingress.twilioPublicBaseUrlManagedBy;
+      data.ingress = ingress;
+      return true;
+    },
+  );
+}
+
+function getMutableIngress(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  return data.ingress &&
+    typeof data.ingress === "object" &&
+    !Array.isArray(data.ingress)
+    ? { ...(data.ingress as Record<string, unknown>) }
+    : {};
+}
+
+function isEmptyOrAbsoluteHttpUrl(value: string): boolean {
+  return value === "" || /^https?:\/\//i.test(value);
 }
 
 function buildRegisterWebSocketUrl(baseUrl: string): string {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for velay-twilio-ingress.md.

**Gap:** Velay client could publish without assistant identity, persist stale URLs, write invalid URLs, and trigger unrelated ingress side effects.
**Fix:** Require identity, validate and mark managed URLs, clear stale managed state safely, and avoid non-Twilio ingress churn.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
