### PR TITLE
Slack Mention Display Names

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -23,6 +23,7 @@ COPY packages/credential-storage ./packages/credential-storage
 COPY packages/egress-proxy ./packages/egress-proxy
 COPY packages/gateway-client ./packages/gateway-client
 COPY packages/skill-host-contracts ./packages/skill-host-contracts
+COPY packages/slack-text ./packages/slack-text
 
 # Install deps for shared packages that have their own file: dependencies.
 # Without this, bun's module resolution at runtime walks up from e.g.

--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -20,6 +20,7 @@
         "@vellumai/gateway-client": "file:../packages/gateway-client",
         "@vellumai/service-contracts": "file:../packages/service-contracts",
         "@vellumai/skill-host-contracts": "file:../packages/skill-host-contracts",
+        "@vellumai/slack-text": "file:../packages/slack-text",
         "archiver": "7.0.1",
         "commander": "13.1.0",
         "croner": "10.0.1",
@@ -421,6 +422,8 @@
     "@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "@vellumai/skill-host-contracts": ["@vellumai/skill-host-contracts@file:../packages/skill-host-contracts", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
+
+    "@vellumai/slack-text": ["@vellumai/slack-text@file:../packages/slack-text", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.33", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw=="],
 

--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -12,6 +12,7 @@
     "@vellumai/egress-proxy",
     "@vellumai/gateway-client",
     "@vellumai/service-contracts",
+    "@vellumai/slack-text",
     "@resvg/resvg-js-darwin-arm64",
     "@resvg/resvg-js-darwin-x64",
     "@vellumai/skill-host-contracts",

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -46,6 +46,7 @@
     "@vellumai/egress-proxy": "file:../packages/egress-proxy",
     "@vellumai/gateway-client": "file:../packages/gateway-client",
     "@vellumai/skill-host-contracts": "file:../packages/skill-host-contracts",
+    "@vellumai/slack-text": "file:../packages/slack-text",
     "archiver": "7.0.1",
     "commander": "13.1.0",
     "croner": "10.0.1",
@@ -75,7 +76,8 @@
     "@vellumai/service-contracts",
     "@vellumai/egress-proxy",
     "@vellumai/gateway-client",
-    "@vellumai/skill-host-contracts"
+    "@vellumai/skill-host-contracts",
+    "@vellumai/slack-text"
   ],
   "overrides": {
     "lodash": "4.18.1",

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -2298,6 +2298,24 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     });
   }
 
+  test("normalized Slack mention labels stay in assembled model context", async () => {
+    const rows: MessageRow[] = [
+      userRow({
+        id: "m-normalized-mention",
+        createdAt: 1700000000_000,
+        text: "@leo can you check this?",
+        slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+      }),
+    ];
+
+    const result = await runSlackChannelAssembly(rows);
+    const renderedContext = texts(result).join("\n");
+
+    expect(renderedContext).toContain("@leo can you check this?");
+    expect(renderedContext).not.toContain("<@U_LEO>");
+    expect(renderedContext).not.toContain("U_LEO");
+  });
+
   // ── Scenario 1: reply in mid-thread ──────────────────────────────────
   // Alice posts to thread A, Bob replies in thread B (cross-thread). Then
   // Alice posts a follow-up reply in thread A. Cross-thread visibility:

--- a/assistant/src/__tests__/inbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/inbound-slack-persistence.test.ts
@@ -194,6 +194,37 @@ describe("PR 11 — inbound Slack message metadata persistence", () => {
     expect(slackMeta!.displayName).toBe("Bob");
   });
 
+  test("Slack normalized content is persisted with raw channelTs in slackMeta", async () => {
+    const ctx = createTestContext({
+      userMessageChannel: "slack",
+      assistantMessageChannel: "slack",
+    });
+
+    await persistQueuedMessageBody(
+      ctx,
+      "@leo can you check this?",
+      [],
+      "req-normalized-content",
+      {
+        slackInbound: {
+          channelId: "C0123CHANNEL",
+          channelTs: "1700000015.123456",
+          displayName: "Alice",
+        },
+      },
+      undefined,
+    );
+
+    expect(JSON.parse(addMessageCalls.at(-1)!.content)).toEqual([
+      { type: "text", text: "@leo can you check this?" },
+    ]);
+
+    const slackMeta = readPersistedSlackMeta();
+    expect(slackMeta).not.toBeNull();
+    expect(slackMeta!.channelTs).toBe("1700000015.123456");
+    expect(slackMeta!.displayName).toBe("Alice");
+  });
+
   test("Slack message without displayName omits the field", async () => {
     const ctx = createTestContext({
       userMessageChannel: "slack",

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuthConnection } from "../../../../oauth/connection.js";
+import { credentialKey } from "../../../../security/credential-key.js";
+
+const BOT_TOKEN = "xoxb-BOT";
+
+const getSecureKeyAsyncMock = mock(
+  async (_key: string): Promise<string | null> => null,
+);
+mock.module("../../../../security/secure-keys.js", () => ({
+  getSecureKeyAsync: getSecureKeyAsyncMock,
+}));
+
+mock.module("../../../../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnection: async (): Promise<OAuthConnection> => {
+    throw new Error("OAuth fallback was not expected");
+  },
+}));
+mock.module("../../../../oauth/oauth-store.js", () => ({
+  isProviderConnected: async () => false,
+}));
+
+const findContactChannelMock = mock(() => undefined);
+const upsertContactChannelMock = mock(() => {});
+mock.module("../../../../contacts/contact-store.js", () => ({
+  findContactChannel: findContactChannelMock,
+}));
+mock.module("../../../../contacts/contacts-write.js", () => ({
+  upsertContactChannel: upsertContactChannelMock,
+}));
+
+import { slackProvider } from "../adapter.js";
+
+const originalFetch = globalThis.fetch;
+
+function installFetchStub() {
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const headers = new Headers(init?.headers ?? {});
+    expect(headers.get("authorization")).toBe(`Bearer ${BOT_TOKEN}`);
+
+    return new Response(JSON.stringify(fakeSlackResponse(url)), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function fakeSlackResponse(url: string): Record<string, unknown> {
+  const parsed = new URL(url);
+  const method = parsed.pathname.split("/").at(-1);
+
+  if (method === "conversations.history") {
+    return {
+      ok: true,
+      has_more: false,
+      messages: [
+        {
+          type: "message",
+          ts: "1700000000.000100",
+          user: "USENDER",
+          text: "History for <@ULEO> and <@UMISSING>",
+          thread_ts: "1700000000.000100",
+          reply_count: 2,
+          reactions: [{ name: "eyes", count: 1, users: ["ULEO"] }],
+        },
+      ],
+    };
+  }
+
+  if (method === "conversations.replies") {
+    return {
+      ok: true,
+      has_more: false,
+      messages: [
+        {
+          type: "message",
+          ts: "1700000001.000200",
+          user: "UTHREAD",
+          text: "Thread follow-up for <@ULEO>",
+          thread_ts: "1700000000.000100",
+        },
+      ],
+    };
+  }
+
+  if (method === "users.info") {
+    return fakeUserInfoResponse(parsed.searchParams.get("user") ?? "");
+  }
+
+  return { ok: true };
+}
+
+function fakeUserInfoResponse(userId: string): Record<string, unknown> {
+  if (userId === "ULEO") {
+    return {
+      ok: true,
+      user: {
+        id: "ULEO",
+        name: "leo",
+        profile: { display_name: "Leo" },
+      },
+    };
+  }
+
+  if (userId === "USENDER") {
+    return {
+      ok: true,
+      user: {
+        id: "USENDER",
+        name: "sender",
+        profile: { display_name: "Sender" },
+      },
+    };
+  }
+
+  if (userId === "UTHREAD") {
+    return {
+      ok: true,
+      user: {
+        id: "UTHREAD",
+        name: "thread_sender",
+        profile: { display_name: "Thread Sender" },
+      },
+    };
+  }
+
+  return { ok: false, error: "user_not_found" };
+}
+
+describe("Slack adapter mention rendering", () => {
+  beforeEach(async () => {
+    getSecureKeyAsyncMock.mockReset();
+    getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
+      if (key === credentialKey("slack_channel", "bot_token")) {
+        return BOT_TOKEN;
+      }
+      return null;
+    });
+    findContactChannelMock.mockClear();
+    upsertContactChannelMock.mockClear();
+    installFetchStub();
+    await slackProvider.resolveConnection!();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("getHistory renders Slack user mentions for model-facing text without changing sender identity", async () => {
+    const messages = await slackProvider.getHistory(undefined, "C_HISTORY");
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("History for @Leo and @unknown-user");
+    expect(messages[0].sender).toEqual({ id: "USENDER", name: "Sender" });
+    expect(messages[0].threadId).toBe("1700000000.000100");
+    expect(messages[0].replyCount).toBe(2);
+    expect(messages[0].reactions).toEqual([{ name: "eyes", count: 1 }]);
+  });
+
+  test("getThreadReplies renders Slack user mentions for model-facing text without changing sender identity", async () => {
+    const messages = await slackProvider.getThreadReplies!(
+      undefined,
+      "C_HISTORY",
+      "1700000000.000100",
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe("Thread follow-up for @Leo");
+    expect(messages[0].sender).toEqual({
+      id: "UTHREAD",
+      name: "Thread Sender",
+    });
+    expect(messages[0].threadId).toBe("1700000000.000100");
+  });
+});

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -93,6 +93,29 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
     };
   }
 
+  if (method === "search.messages") {
+    return {
+      ok: true,
+      messages: {
+        total: 1,
+        matches: [
+          {
+            iid: "search-1",
+            ts: "1700000002.000300",
+            text: "Search result for <@ULEO> and <@UMISSING>",
+            user: "USENDER",
+            username: "sender",
+            channel: { id: "C_HISTORY", name: "history" },
+            permalink:
+              "https://example.slack.com/archives/C_HISTORY/p1700000002000300",
+            thread_ts: "1700000000.000100",
+          },
+        ],
+        paging: { count: 20, total: 1, page: 1, pages: 1 },
+      },
+    };
+  }
+
   if (method === "users.info") {
     return fakeUserInfoResponse(parsed.searchParams.get("user") ?? "");
   }
@@ -181,5 +204,23 @@ describe("Slack adapter mention rendering", () => {
       name: "Thread Sender",
     });
     expect(messages[0].threadId).toBe("1700000000.000100");
+  });
+
+  test("search renders Slack user mentions for model-facing text", async () => {
+    const result = await slackProvider.search!(undefined, "from:sender");
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe(
+      "Search result for @Leo and @unknown-user",
+    );
+    expect(result.messages[0].sender).toEqual({
+      id: "USENDER",
+      name: "sender",
+    });
+    expect(result.messages[0].metadata).toEqual({
+      permalink:
+        "https://example.slack.com/archives/C_HISTORY/p1700000002000300",
+      channelName: "history",
+    });
   });
 });

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -5,6 +5,11 @@
  * implements the MessagingProvider interface.
  */
 
+import {
+  extractSlackUserMentionIds,
+  renderSlackTextForModel,
+} from "@vellumai/slack-text";
+
 import { findContactChannel } from "../../../contacts/contact-store.js";
 import { upsertContactChannel } from "../../../contacts/contacts-write.js";
 import type { OAuthConnection } from "../../../oauth/connection.js";
@@ -218,6 +223,7 @@ function mapMessage(
   msg: SlackMessage,
   channelId: string,
   senderName: string,
+  renderedText: string,
 ): Message {
   // Bot-authored when Slack sets `subtype: "bot_message"` or attributes the
   // row to a `bot_id` with no user. Backfill callers rely on this flag to
@@ -229,7 +235,7 @@ function mapMessage(
     id: msg.ts,
     conversationId: channelId,
     sender: { id: msg.user ?? msg.bot_id ?? "unknown", name: senderName },
-    text: msg.text,
+    text: renderedText,
     timestamp: parseFloat(msg.ts) * 1000,
     threadId: msg.thread_ts,
     replyCount: msg.reply_count,
@@ -265,12 +271,49 @@ async function mapSlackMessages(
   channelId: string,
   slackMessages: SlackMessage[],
 ): Promise<Message[]> {
+  const userLabels = await buildMentionUserLabels(auth, slackMessages);
   const messages: Message[] = [];
   for (const msg of slackMessages) {
     const name = await resolveUserName(auth, msg.user ?? "");
-    messages.push(mapMessage(msg, channelId, name));
+    messages.push(
+      mapMessage(
+        msg,
+        channelId,
+        name,
+        renderSlackTextForModel(msg.text, { userLabels }),
+      ),
+    );
   }
   return messages;
+}
+
+async function buildMentionUserLabels(
+  auth: OAuthConnection | string,
+  slackMessages: SlackMessage[],
+): Promise<Record<string, string>> {
+  const mentionUserIds = [
+    ...new Set(
+      slackMessages.flatMap((msg) => extractSlackUserMentionIds(msg.text)),
+    ),
+  ];
+  if (mentionUserIds.length === 0) return {};
+
+  const userLabels: Record<string, string> = {};
+
+  await Promise.all(
+    mentionUserIds.map(async (userId) => {
+      try {
+        const label = await resolveUserName(auth, userId);
+        if (label && label !== userId) {
+          userLabels[userId] = label;
+        }
+      } catch {
+        // Leave unresolved mentions out so the renderer uses @unknown-user.
+      }
+    }),
+  );
+
+  return userLabels;
 }
 
 export const slackProvider: MessagingProvider = {

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -274,7 +274,10 @@ async function mapSlackMessages(
   channelId: string,
   slackMessages: SlackMessage[],
 ): Promise<Message[]> {
-  const userLabels = await buildMentionUserLabels(auth, slackMessages);
+  const userLabels = await buildMentionUserLabels(
+    auth,
+    slackMessages.map((msg) => msg.text),
+  );
   const messages: Message[] = [];
   for (const msg of slackMessages) {
     const name = await resolveUserName(auth, msg.user ?? "");
@@ -292,11 +295,10 @@ async function mapSlackMessages(
 
 async function buildMentionUserLabels(
   auth: OAuthConnection | string,
-  slackMessages: SlackMessage[],
+  textValues: Iterable<string | undefined>,
 ): Promise<Record<string, string>> {
-  return buildSlackUserLabelMap(
-    slackMessages.map((msg) => msg.text),
-    (userId) => resolveUserName(auth, userId),
+  return buildSlackUserLabelMap(textValues, (userId) =>
+    resolveUserName(auth, userId),
   );
 }
 
@@ -304,9 +306,9 @@ async function mapSearchMatches(
   auth: OAuthConnection | string,
   matches: SlackSearchMatch[],
 ): Promise<Message[]> {
-  const userLabels = await buildSlackUserLabelMap(
+  const userLabels = await buildMentionUserLabels(
+    auth,
     matches.map((match) => match.text),
-    (userId) => resolveUserName(auth, userId),
   );
   return matches.map((match) => mapSearchMatch(match, userLabels));
 }

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  extractSlackUserMentionIds,
+  buildSlackUserLabelMap,
   renderSlackTextForModel,
 } from "@vellumai/slack-text";
 
@@ -253,12 +253,15 @@ function mapMessage(
   };
 }
 
-function mapSearchMatch(match: SlackSearchMatch): Message {
+function mapSearchMatch(
+  match: SlackSearchMatch,
+  userLabels: Record<string, string>,
+): Message {
   return {
     id: match.ts,
     conversationId: match.channel.id,
     sender: { id: match.user ?? "unknown", name: match.username ?? "unknown" },
-    text: match.text,
+    text: renderSlackTextForModel(match.text, { userLabels }),
     timestamp: parseFloat(match.ts) * 1000,
     threadId: match.thread_ts,
     platform: "slack",
@@ -291,29 +294,21 @@ async function buildMentionUserLabels(
   auth: OAuthConnection | string,
   slackMessages: SlackMessage[],
 ): Promise<Record<string, string>> {
-  const mentionUserIds = [
-    ...new Set(
-      slackMessages.flatMap((msg) => extractSlackUserMentionIds(msg.text)),
-    ),
-  ];
-  if (mentionUserIds.length === 0) return {};
-
-  const userLabels: Record<string, string> = {};
-
-  await Promise.all(
-    mentionUserIds.map(async (userId) => {
-      try {
-        const label = await resolveUserName(auth, userId);
-        if (label && label !== userId) {
-          userLabels[userId] = label;
-        }
-      } catch {
-        // Leave unresolved mentions out so the renderer uses @unknown-user.
-      }
-    }),
+  return buildSlackUserLabelMap(
+    slackMessages.map((msg) => msg.text),
+    (userId) => resolveUserName(auth, userId),
   );
+}
 
-  return userLabels;
+async function mapSearchMatches(
+  auth: OAuthConnection | string,
+  matches: SlackSearchMatch[],
+): Promise<Message[]> {
+  const userLabels = await buildSlackUserLabelMap(
+    matches.map((match) => match.text),
+    (userId) => resolveUserName(auth, userId),
+  );
+  return matches.map((match) => mapSearchMatch(match, userLabels));
 }
 
 export const slackProvider: MessagingProvider = {
@@ -487,12 +482,14 @@ export const slackProvider: MessagingProvider = {
     query: string,
     options?: SearchOptions,
   ): Promise<SearchResult> {
-    const resp = await runReadWithFallback(connection, (auth) =>
-      slack.searchMessages(auth, query, options?.count ?? 20),
-    );
+    let auth: OAuthConnection | string = getReadAuth(connection);
+    const resp = await runReadWithFallback(connection, async (a) => {
+      auth = a;
+      return slack.searchMessages(a, query, options?.count ?? 20);
+    });
     return {
       total: resp.messages.total,
-      messages: resp.messages.matches.map(mapSearchMatch),
+      messages: await mapSearchMatches(auth, resp.messages.matches),
       hasMore: resp.messages.paging.page < resp.messages.paging.pages,
     };
   },

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,6 +12,7 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY packages/assistant-client ./packages/assistant-client
 COPY packages/ces-client ./packages/ces-client
 COPY packages/service-contracts ./packages/service-contracts
+COPY packages/slack-text ./packages/slack-text
 
 # Install deps for shared packages that have their own file: dependencies.
 RUN cd /app/packages/ces-client && bun install --frozen-lockfile

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -8,6 +8,7 @@
         "@vellumai/assistant-client": "file:../packages/assistant-client",
         "@vellumai/ces-client": "file:../packages/ces-client",
         "@vellumai/service-contracts": "file:../packages/service-contracts",
+        "@vellumai/slack-text": "file:../packages/slack-text",
         "drizzle-kit": "0.30.6",
         "drizzle-orm": "0.45.2",
         "file-type": "21.3.0",
@@ -208,6 +209,8 @@
     "@vellumai/ces-client": ["@vellumai/ces-client@file:../packages/ces-client", { "dependencies": { "@vellumai/service-contracts": "file:../service-contracts" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
+
+    "@vellumai/slack-text": ["@vellumai/slack-text@file:../packages/slack-text", { "devDependencies": { "@types/bun": "1.3.10", "typescript": "5.9.3" } }],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -499,6 +502,8 @@
 
     "@vellumai/service-contracts/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
+    "@vellumai/slack-text/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "gel/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
@@ -558,6 +563,8 @@
     "@vellumai/ces-client/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "@vellumai/service-contracts/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+
+    "@vellumai/slack-text/@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "gel/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -4,6 +4,7 @@
   "ignoreDependencies": [
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
-    "@vellumai/service-contracts"
+    "@vellumai/service-contracts",
+    "@vellumai/slack-text"
   ]
 }

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -27,6 +27,7 @@
     "@vellumai/assistant-client": "file:../packages/assistant-client",
     "@vellumai/ces-client": "file:../packages/ces-client",
     "@vellumai/service-contracts": "file:../packages/service-contracts",
+    "@vellumai/slack-text": "file:../packages/slack-text",
     "drizzle-kit": "0.30.6",
     "drizzle-orm": "0.45.2",
     "file-type": "21.3.0",

--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -225,6 +225,68 @@ describe("normalizeSlackAppMention with display name", () => {
     expect(result!.event.actor.username).toBe("testuser");
   });
 
+  test("renders cache-warmed mention labels in model-facing content", async () => {
+    fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          user: {
+            name: "leo",
+            real_name: "Leo Example",
+            profile: { display_name: "Leo" },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const config = makeConfig();
+    const event = makeEvent({
+      text: "<@U123BOT> <@ULEO> please look",
+    });
+    const userInfo = await resolveSlackUser("ULEO", "xoxb-test");
+
+    const result = normalizeSlackAppMention(
+      event,
+      "evt-mention-cache",
+      config,
+      "U123BOT",
+      undefined,
+      { userLabels: userInfo ? { ULEO: userInfo.displayName } : {} },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@Leo please look");
+    expect(result!.event.message.content).not.toContain("<@ULEO>");
+    expect(result!.event.message.content).not.toContain("ULEO");
+  });
+
+  test("renders unresolved mention IDs with fallback labels when lookup fails", async () => {
+    fetchMock = mock(async () => {
+      return new Response("", { status: 500 });
+    });
+
+    const config = makeConfig();
+    const event = makeEvent({
+      text: "<@U123BOT> <@UFAIL> please look",
+    });
+    const userInfo = await resolveSlackUser("UFAIL", "xoxb-test");
+
+    const result = normalizeSlackAppMention(
+      event,
+      "evt-mention-fallback",
+      config,
+      "U123BOT",
+      undefined,
+      { userLabels: userInfo ? { UFAIL: userInfo.displayName } : {} },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@unknown-user please look");
+    expect(result!.event.message.content).not.toContain("<@UFAIL>");
+    expect(result!.event.message.content).not.toContain("UFAIL");
+  });
+
   test("omits displayName when bot token is not configured", () => {
     const config = makeConfig();
     const event = makeEvent();

--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -173,6 +173,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-1a",
       config,
+      undefined,
       "xoxb-test",
     );
     expect(result1).not.toBeNull();
@@ -186,6 +187,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-1b",
       config,
+      undefined,
       "xoxb-test",
     );
     expect(result2).not.toBeNull();
@@ -218,6 +220,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-pw",
       config,
+      undefined,
       "xoxb-test",
     );
     expect(result).not.toBeNull();
@@ -308,6 +311,7 @@ describe("normalizeSlackAppMention with display name", () => {
       event,
       "evt-dn-3",
       config,
+      undefined,
       "xoxb-test",
     );
 

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -315,6 +315,24 @@ describe("Slack inbound mention rendering", () => {
     expect(result!.event.message.conversationExternalId).toBe("C_CHANNEL1");
   });
 
+  test("channel messages without bot user ID strip only the first leading mention fallback", () => {
+    const config = makeConfig();
+    const event = makeChannelMessageEvent({
+      text: "<@UBOT> <@ULEO> hello",
+    });
+    const result = normalizeSlackChannelMessage(
+      event,
+      "evt-channel-fallback-render",
+      config,
+      undefined,
+      undefined,
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo hello");
+  });
+
   test("message edits render mentions and preserve edit metadata", () => {
     const config = makeConfig();
     const event = makeMessageChangedEvent({

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -2,8 +2,12 @@ import { describe, test, expect } from "bun:test";
 import {
   stripBotMention,
   normalizeSlackAppMention,
+  normalizeSlackChannelMessage,
+  normalizeSlackDirectMessage,
   normalizeSlackMessageEdit,
   type SlackAppMentionEvent,
+  type SlackChannelMessageEvent,
+  type SlackDirectMessageEvent,
   type SlackMessageChangedEvent,
 } from "../slack/normalize.js";
 import type { GatewayConfig } from "../config.js";
@@ -53,8 +57,16 @@ describe("stripBotMention", () => {
     expect(stripBotMention("<@U123BOT> hello world")).toBe("hello world");
   });
 
-  test("strips multiple leading bot mentions", () => {
-    expect(stripBotMention("<@U123BOT> <@U456OTHER> hello")).toBe("hello");
+  test("strips repeated leading bot mentions while preserving a following human mention", () => {
+    expect(
+      stripBotMention("<@U123BOT> <@U123BOT> <@U456OTHER> hello", "U123BOT"),
+    ).toBe("<@U456OTHER> hello");
+  });
+
+  test("fallback strips only the first leading mention", () => {
+    expect(stripBotMention("<@U123BOT> <@U456OTHER> hello")).toBe(
+      "<@U456OTHER> hello",
+    );
   });
 
   test("falls back to original text when stripping produces empty string", () => {
@@ -132,7 +144,37 @@ describe("normalizeSlackAppMention", () => {
     const result = await normalizeSlackAppMention(event, "evt-006", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("<@U123BOT>");
+    expect(result!.event.message.content).toBe("@unknown-user");
+  });
+
+  test("renders a human mention after stripping the app mention", async () => {
+    const config = makeConfig();
+    const event = makeEvent({ text: "<@UBOT> <@ULEO> can you check?" });
+    const result = await normalizeSlackAppMention(
+      event,
+      "evt-mention-label",
+      config,
+      "UBOT",
+      undefined,
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo can you check?");
+  });
+
+  test("renders unresolved user mentions with the unknown-user fallback", async () => {
+    const config = makeConfig();
+    const event = makeEvent({ text: "<@UBOT> <@UUNKNOWN> can you check?" });
+    const result = await normalizeSlackAppMention(
+      event,
+      "evt-unknown-mention",
+      config,
+      "UBOT",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@unknown-user can you check?");
   });
 
   test("thread_ts is preserved in return value", async () => {
@@ -201,6 +243,101 @@ describe("normalizeSlackAppMention", () => {
     expect(result!.event.raw).toEqual(
       event as unknown as Record<string, unknown>,
     );
+  });
+});
+
+function makeDirectMessageEvent(
+  overrides: Partial<SlackDirectMessageEvent> = {},
+): SlackDirectMessageEvent {
+  return {
+    type: "message",
+    user: "U_USER123",
+    text: "hello world",
+    ts: "1700000000.000100",
+    channel: "D_DIRECT1",
+    channel_type: "im",
+    ...overrides,
+  };
+}
+
+function makeChannelMessageEvent(
+  overrides: Partial<SlackChannelMessageEvent> = {},
+): SlackChannelMessageEvent {
+  return {
+    type: "message",
+    user: "U_USER123",
+    text: "hello world",
+    ts: "1700000000.000100",
+    channel: "C_CHANNEL1",
+    channel_type: "channel",
+    ...overrides,
+  };
+}
+
+describe("Slack inbound mention rendering", () => {
+  test("direct messages render mentions without stripping the bot mention", () => {
+    const config = makeConfig();
+    const event = makeDirectMessageEvent({
+      text: "<@UBOT> <@ULEO> hello",
+    });
+    const result = normalizeSlackDirectMessage(
+      event,
+      "evt-dm-render",
+      config,
+      "UBOT",
+      undefined,
+      { userLabels: { UBOT: "assistant", ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@assistant @leo hello");
+    expect(result!.event.actor.actorExternalId).toBe("U_USER123");
+    expect(result!.event.message.conversationExternalId).toBe("D_DIRECT1");
+  });
+
+  test("channel messages strip only the configured bot mention and render remaining mentions", () => {
+    const config = makeConfig();
+    const event = makeChannelMessageEvent({
+      text: "<@UBOT> <@ULEO> hello",
+    });
+    const result = normalizeSlackChannelMessage(
+      event,
+      "evt-channel-render",
+      config,
+      "UBOT",
+      undefined,
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo hello");
+    expect(result!.event.actor.actorExternalId).toBe("U_USER123");
+    expect(result!.event.message.conversationExternalId).toBe("C_CHANNEL1");
+  });
+
+  test("message edits render mentions and preserve edit metadata", () => {
+    const config = makeConfig();
+    const event = makeMessageChangedEvent({
+      message: {
+        user: "U_USER123",
+        text: "<@UBOT> <@ULEO> edited",
+        ts: "1700000000.000100",
+      },
+    });
+    const result = normalizeSlackMessageEdit(
+      event,
+      "evt-edit-render",
+      config,
+      "UBOT",
+      { userLabels: { ULEO: "leo" } },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.content).toBe("@leo edited");
+    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.externalMessageId).toBe("evt-edit-render");
+    expect(result!.event.source.messageId).toBe("1700000000.000100");
+    expect(result!.event.actor.actorExternalId).toBe("U_USER123");
   });
 });
 

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -103,7 +103,7 @@ function createHarness(
   harness.config = {
     appToken: "xapp-test",
     botToken: "xoxb-test",
-    botUserId: "U-bot",
+    botUserId: "UBOT",
     botUsername: "assistant",
     teamName: "Example Team",
     gatewayConfig: makeConfig(),
@@ -151,7 +151,7 @@ describe("SlackSocketModeClient thread tracking", () => {
             event: {
               type: "app_mention",
               user: "U-mentioned",
-              text: "<@U-bot> can you help here?",
+              text: "<@UBOT> can you help here?",
               ts: "1700000000.000100",
               channel: "C-thread",
               thread_ts: "1700000000.000000",
@@ -160,6 +160,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-mention");
@@ -185,6 +186,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(2);
       expect(emitted[1].event.source.updateId).toBe("Ev-reply");
@@ -194,6 +196,156 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted[1].event.source.chatType).toBe("channel");
       expect(emitted[1].threadTs).toBe("1700000000.000000");
       expect(emitted[1].event.source.threadId).toBe("1700000000.000000");
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("tracks app mention thread before slow mentioned-user lookup completes", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    let resolveDelayedMention: ((response: Response) => void) | undefined;
+
+    fetchMock = mock(async (input) => {
+      const url = new URL(String(input));
+      const userId = url.searchParams.get("user");
+      if (userId === "ULEO") {
+        return new Promise<Response>((resolve) => {
+          resolveDelayedMention = resolve;
+        });
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-race-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-race-mention",
+            event: {
+              type: "app_mention",
+              user: "U-actor",
+              text: "<@UBOT> <@ULEO> can you help here?",
+              ts: "1700000000.000150",
+              channel: "C-thread",
+              thread_ts: "1700000000.000140",
+            },
+          },
+        }),
+        ws,
+      );
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-race-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-race-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "following up while lookup is still pending",
+              ts: "1700000000.000160",
+              channel: "C-thread",
+              channel_type: "channel",
+              thread_ts: "1700000000.000140",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-race-reply");
+      expect(emitted[0].event.message.content).toBe(
+        "following up while lookup is still pending",
+      );
+
+      expect(resolveDelayedMention).toBeDefined();
+      resolveDelayedMention!(makeSlackUserResponse());
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(2);
+      expect(emitted[1].event.source.updateId).toBe("Ev-race-mention");
+      expect(emitted[1].event.message.content).toBe(
+        "@Example User can you help here?",
+      );
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("does not pre-track unrouted app mention threads during slow mentioned-user lookup", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    let resolveDelayedMention: ((response: Response) => void) | undefined;
+
+    fetchMock = mock(async (input) => {
+      const url = new URL(String(input));
+      const userId = url.searchParams.get("user");
+      if (userId === "USLOW") {
+        return new Promise<Response>((resolve) => {
+          resolveDelayedMention = resolve;
+        });
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-unrouted-mention",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-unrouted-mention",
+            event: {
+              type: "app_mention",
+              user: "U-actor",
+              text: "<@UBOT> <@USLOW> can you help here?",
+              ts: "1700000000.000250",
+              channel: "C-unrouted",
+              thread_ts: "1700000000.000240",
+            },
+          },
+        }),
+        ws,
+      );
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-unrouted-reply",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-unrouted-reply",
+            event: {
+              type: "message",
+              user: "U-reply",
+              text: "reply should not be admitted by rejected mention",
+              ts: "1700000000.000260",
+              channel: "C-unrouted",
+              channel_type: "channel",
+              thread_ts: "1700000000.000240",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
+
+      expect(resolveDelayedMention).toBeDefined();
+      resolveDelayedMention!(makeSlackUserResponse());
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(0);
     } finally {
       rawDb.close();
     }
@@ -220,7 +372,7 @@ describe("SlackSocketModeClient thread tracking", () => {
             event: {
               type: "app_mention",
               user: "U-mentioned",
-              text: "<@U-bot> can you help here?",
+              text: "<@UBOT> can you help here?",
               ts: "1700000000.000300",
               channel: "C-thread",
             },
@@ -228,6 +380,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-top-level-mention");
@@ -253,6 +406,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(2);
       expect(emitted[1].event.source.updateId).toBe("Ev-top-level-reply");
@@ -294,6 +448,7 @@ describe("SlackSocketModeClient thread tracking", () => {
         }),
         ws,
       );
+      await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-dm");
@@ -411,6 +566,7 @@ describe("SlackSocketModeClient thread tracking", () => {
           }),
           ws,
         );
+        await flushAsyncEventEmission();
 
         expect(emitted).toHaveLength(1);
       } finally {
@@ -418,4 +574,57 @@ describe("SlackSocketModeClient thread tracking", () => {
       }
     },
   );
+
+  test("renders live app mention user IDs as display-name labels", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    fetchMock = mock(async (input) => {
+      const url = new URL(String(input));
+      const userId = url.searchParams.get("user");
+      if (userId === "ULEO") {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            user: {
+              name: "leo",
+              profile: { display_name: "Leo" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return makeSlackUserResponse();
+    });
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-mention-label",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-mention-label",
+            event: {
+              type: "app_mention",
+              user: "U-actor",
+              text: "<@UBOT> <@ULEO> please look",
+              ts: "1700000000.000800",
+              channel: "C-thread",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.message.content).toBe("@Leo please look");
+      expect(emitted[0].event.message.content).not.toContain("<@ULEO>");
+      expect(emitted[0].event.message.content).not.toContain("ULEO");
+    } finally {
+      rawDb.close();
+    }
+  });
 });

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -201,7 +201,7 @@ describe("SlackSocketModeClient thread tracking", () => {
     }
   });
 
-  test("tracks app mention thread before slow mentioned-user lookup completes", async () => {
+  test("emits a slow app mention before its immediate thread reply", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];
     const client = createHarness(store, (event) => emitted.push(event));
@@ -260,20 +260,20 @@ describe("SlackSocketModeClient thread tracking", () => {
       );
       await flushAsyncEventEmission();
 
-      expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.source.updateId).toBe("Ev-race-reply");
-      expect(emitted[0].event.message.content).toBe(
-        "following up while lookup is still pending",
-      );
+      expect(emitted).toHaveLength(0);
 
       expect(resolveDelayedMention).toBeDefined();
       resolveDelayedMention!(makeSlackUserResponse());
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(2);
-      expect(emitted[1].event.source.updateId).toBe("Ev-race-mention");
-      expect(emitted[1].event.message.content).toBe(
+      expect(emitted[0].event.source.updateId).toBe("Ev-race-mention");
+      expect(emitted[0].event.message.content).toBe(
         "@Example User can you help here?",
+      );
+      expect(emitted[1].event.source.updateId).toBe("Ev-race-reply");
+      expect(emitted[1].event.message.content).toBe(
+        "following up while lookup is still pending",
       );
     } finally {
       rawDb.close();

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -728,6 +728,39 @@ describe("attachment extraction in normalize functions", () => {
         expect(result!.slackFiles!.get("F030")!.id).toBe("F030");
       });
 
+      it("normalizes DM file_share mentions without stripping the bot mention", () => {
+        const config = makeConfig();
+        const event = makeDmEvent({
+          subtype: "file_share",
+          text: "<@UBOT> <@ULEO> shared this",
+          files: [
+            makeSlackFile({
+              id: "F032",
+              mimetype: "image/png",
+              name: "mention.png",
+            }),
+          ],
+        });
+        const result = normalizeSlackDirectMessage(
+          event,
+          "evt-fs-mentions-dm",
+          config,
+          "UBOT",
+          undefined,
+          { userLabels: { UBOT: "assistant", ULEO: "leo" } },
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.content).toBe(
+          "@assistant @leo shared this",
+        );
+        expect(result!.event.message.content).not.toContain("ULEO");
+        expect(result!.event.message.attachments).toHaveLength(1);
+        expect(result!.event.message.attachments![0].fileId).toBe("F032");
+        expect(result!.slackFiles).toBeDefined();
+        expect(result!.slackFiles!.get("F032")!.id).toBe("F032");
+      });
+
       it("normalizes DM with file_share subtype without files", () => {
         const config = makeConfig();
         const event = makeDmEvent({ subtype: "file_share" });
@@ -767,6 +800,43 @@ describe("attachment extraction in normalize functions", () => {
         expect(result!.event.message.attachments![0].fileId).toBe("F031");
         expect(result!.event.message.attachments![0].type).toBe("image");
         expect(result!.slackFiles).toBeDefined();
+      });
+
+      it("normalizes channel file_share mentions after stripping only the bot mention", () => {
+        const config = makeConfig();
+        const event = makeChannelEvent({
+          subtype: "file_share",
+          text: "<@UBOT> <@ULEO> shared this",
+          files: [
+            makeSlackFile({
+              id: "F033",
+              mimetype: "application/pdf",
+              name: "mention.pdf",
+            }),
+          ],
+        });
+        const result = normalizeSlackChannelMessage(
+          event,
+          "evt-fs-mentions-channel",
+          config,
+          "UBOT",
+          undefined,
+          { userLabels: { ULEO: "leo" } },
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.event.message.content).toBe("@leo shared this");
+        expect(result!.event.message.content).not.toContain("ULEO");
+        expect(result!.event.message.attachments).toHaveLength(1);
+        expect(result!.event.message.attachments![0]).toEqual({
+          type: "document",
+          fileId: "F033",
+          fileName: "mention.pdf",
+          mimeType: "application/pdf",
+          fileSize: 12345,
+        });
+        expect(result!.slackFiles).toBeDefined();
+        expect(result!.slackFiles!.get("F033")!.id).toBe("F033");
       });
 
       it("normalizes channel message with file_share subtype without files", () => {

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,3 +1,8 @@
+import {
+  renderSlackTextForModel,
+  stripLeadingSlackMentionFallback,
+  stripLeadingSlackUserMention,
+} from "@vellumai/slack-text";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
@@ -275,15 +280,95 @@ export interface SlackMessageDeletedEvent {
   };
 }
 
+export type SlackTextRenderContext = {
+  botUserId?: string;
+  userLabels?: Record<string, string>;
+};
+
 /**
- * Strip leading bot-mention tokens (`<@U...>`) from the message text.
- * Slack wraps mentions as `<@UXXXXXX>`, often at the start of an
- * app_mention event's text field. We remove all leading occurrences
- * so the assistant receives clean user content.
+ * Strip leading bot-mention tokens from Slack message text.
+ *
+ * When the bot user ID is known, only that exact mention is stripped. Without a
+ * bot user ID, strip just one leading mention as an app_mention compatibility
+ * fallback.
  */
-export function stripBotMention(text: string): string {
-  const stripped = text.replace(/^(<@[A-Z0-9]+>\s*)+/i, "").trim();
-  return stripped || text.trim();
+export function stripBotMention(text: string, botUserId?: string): string {
+  const stripped = botUserId
+    ? stripLeadingSlackUserMention(text, botUserId)
+    : stripLeadingSlackMentionFallback(text);
+  return stripped.trim() || text.trim();
+}
+
+function renderSlackInboundText(
+  text: string,
+  context: SlackTextRenderContext = {},
+  options: {
+    stripLeadingBotMention?: boolean;
+    fallbackStripFirstMention?: boolean;
+  } = {},
+): string {
+  let stripped = text;
+  if (options.stripLeadingBotMention) {
+    stripped = context.botUserId
+      ? stripBotMention(text, context.botUserId)
+      : options.fallbackStripFirstMention
+        ? stripBotMention(text)
+        : text.trim();
+  }
+
+  return renderSlackTextForModel(stripped, {
+    userLabels: context.userLabels,
+  });
+}
+
+function withBotUserId(
+  botUserId: string | undefined,
+  context: SlackTextRenderContext | undefined,
+): SlackTextRenderContext {
+  return {
+    ...context,
+    botUserId: context?.botUserId ?? botUserId,
+  };
+}
+
+function parseAppMentionArgs(
+  botTokenOrBotUserId?: string,
+  botTokenOrContext?: string | SlackTextRenderContext,
+  maybeContext?: SlackTextRenderContext,
+): { botToken?: string; renderContext: SlackTextRenderContext } {
+  const firstArgIsToken = isSlackBotToken(botTokenOrBotUserId);
+
+  if (
+    typeof botTokenOrContext === "object" ||
+    typeof maybeContext === "object"
+  ) {
+    return {
+      botToken: firstArgIsToken
+        ? botTokenOrBotUserId
+        : typeof botTokenOrContext === "string"
+          ? botTokenOrContext
+          : undefined,
+      renderContext: withBotUserId(
+        firstArgIsToken ? undefined : botTokenOrBotUserId,
+        {
+          ...(typeof botTokenOrContext === "object" ? botTokenOrContext : {}),
+          ...maybeContext,
+        },
+      ),
+    };
+  }
+
+  return {
+    botToken: firstArgIsToken ? botTokenOrBotUserId : botTokenOrContext,
+    renderContext: withBotUserId(
+      firstArgIsToken ? undefined : botTokenOrBotUserId,
+      undefined,
+    ),
+  };
+}
+
+function isSlackBotToken(value: string | undefined): boolean {
+  return value?.startsWith("xox") ?? false;
 }
 
 function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
@@ -332,6 +417,7 @@ export function normalizeSlackDirectMessage(
   config: GatewayConfig,
   botUserId?: string,
   botToken?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
   // Ignore messages from the bot itself
   if (botUserId && event.user === botUserId) return null;
@@ -374,6 +460,10 @@ export function normalizeSlackDirectMessage(
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
       : undefined;
+  const content = renderSlackInboundText(
+    event.text,
+    withBotUserId(botUserId, renderContext),
+  );
 
   return {
     event: {
@@ -381,7 +471,7 @@ export function normalizeSlackDirectMessage(
       sourceChannel: "slack",
       receivedAt: new Date().toISOString(),
       message: {
-        content: event.text,
+        content,
         conversationExternalId: event.channel,
         externalMessageId,
         ...(attachments.length > 0 ? { attachments } : {}),
@@ -421,6 +511,7 @@ export function normalizeSlackChannelMessage(
   config: GatewayConfig,
   botUserId?: string,
   botToken?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
   if (botUserId && event.user === botUserId) return null;
   // file_share is allowed so image/file uploads are delivered to the assistant.
@@ -430,7 +521,11 @@ export function normalizeSlackChannelMessage(
   const routing = resolveAssistant(config, event.channel, event.user);
   if (isRejection(routing)) return null;
 
-  const content = stripBotMention(event.text);
+  const content = renderSlackInboundText(
+    event.text,
+    withBotUserId(botUserId, renderContext),
+    { stripLeadingBotMention: true },
+  );
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
@@ -492,14 +587,24 @@ export function normalizeSlackAppMention(
   event: SlackAppMentionEvent,
   eventId: string,
   config: GatewayConfig,
-  botToken?: string,
+  botTokenOrBotUserId?: string,
+  botTokenOrContext?: string | SlackTextRenderContext,
+  maybeContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
+  const { botToken, renderContext } = parseAppMentionArgs(
+    botTokenOrBotUserId,
+    botTokenOrContext,
+    maybeContext,
+  );
   const routing = resolveAssistant(config, event.channel, event.user);
   if (isRejection(routing)) {
     return null;
   }
 
-  const content = stripBotMention(event.text);
+  const content = renderSlackInboundText(event.text, renderContext, {
+    stripLeadingBotMention: true,
+    fallbackStripFirstMention: true,
+  });
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
@@ -792,6 +897,7 @@ export function normalizeSlackMessageEdit(
   eventId: string,
   config: GatewayConfig,
   botUserId?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
   const edited = event.message;
   if (!edited) return null;
@@ -817,7 +923,14 @@ export function normalizeSlackMessageEdit(
   }
   if (isRejection(routing)) return null;
 
-  const content = stripBotMention(edited.text);
+  const content = renderSlackInboundText(
+    edited.text,
+    withBotUserId(botUserId, renderContext),
+    {
+      stripLeadingBotMention: true,
+      fallbackStripFirstMention: !botUserId,
+    },
+  );
 
   // Each edit event gets a unique externalMessageId so the dedup pipeline
   // does not discard subsequent edits of the same Slack message.

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -331,46 +331,6 @@ function withBotUserId(
   };
 }
 
-function parseAppMentionArgs(
-  botTokenOrBotUserId?: string,
-  botTokenOrContext?: string | SlackTextRenderContext,
-  maybeContext?: SlackTextRenderContext,
-): { botToken?: string; renderContext: SlackTextRenderContext } {
-  const firstArgIsToken = isSlackBotToken(botTokenOrBotUserId);
-
-  if (
-    typeof botTokenOrContext === "object" ||
-    typeof maybeContext === "object"
-  ) {
-    return {
-      botToken: firstArgIsToken
-        ? botTokenOrBotUserId
-        : typeof botTokenOrContext === "string"
-          ? botTokenOrContext
-          : undefined,
-      renderContext: withBotUserId(
-        firstArgIsToken ? undefined : botTokenOrBotUserId,
-        {
-          ...(typeof botTokenOrContext === "object" ? botTokenOrContext : {}),
-          ...maybeContext,
-        },
-      ),
-    };
-  }
-
-  return {
-    botToken: firstArgIsToken ? botTokenOrBotUserId : botTokenOrContext,
-    renderContext: withBotUserId(
-      firstArgIsToken ? undefined : botTokenOrBotUserId,
-      undefined,
-    ),
-  };
-}
-
-function isSlackBotToken(value: string | undefined): boolean {
-  return value?.startsWith("xox") ?? false;
-}
-
 function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
   type: "image" | "document";
   fileId: string;
@@ -587,24 +547,23 @@ export function normalizeSlackAppMention(
   event: SlackAppMentionEvent,
   eventId: string,
   config: GatewayConfig,
-  botTokenOrBotUserId?: string,
-  botTokenOrContext?: string | SlackTextRenderContext,
-  maybeContext?: SlackTextRenderContext,
+  botUserId?: string,
+  botToken?: string,
+  renderContext?: SlackTextRenderContext,
 ): NormalizedSlackEvent | null {
-  const { botToken, renderContext } = parseAppMentionArgs(
-    botTokenOrBotUserId,
-    botTokenOrContext,
-    maybeContext,
-  );
   const routing = resolveAssistant(config, event.channel, event.user);
   if (isRejection(routing)) {
     return null;
   }
 
-  const content = renderSlackInboundText(event.text, renderContext, {
-    stripLeadingBotMention: true,
-    fallbackStripFirstMention: true,
-  });
+  const content = renderSlackInboundText(
+    event.text,
+    withBotUserId(botUserId, renderContext),
+    {
+      stripLeadingBotMention: true,
+      fallbackStripFirstMention: true,
+    },
+  );
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -392,6 +392,18 @@ function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
     }));
 }
 
+function extractSlackFileMap(
+  files: SlackFile[] | undefined,
+): Map<string, SlackFile> | undefined {
+  if (!files || files.length === 0) return undefined;
+  const downloadableFiles = files.filter(
+    (f) => f.url_private_download || f.url_private,
+  );
+  return downloadableFiles.length
+    ? new Map(downloadableFiles.map((f) => [f.id, f]))
+    : undefined;
+}
+
 export type NormalizedSlackEvent = {
   event: GatewayInboundEvent;
   routing: RouteResult;
@@ -446,13 +458,7 @@ export function normalizeSlackDirectMessage(
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
   const attachments = extractSlackAttachments(event.files);
-  const slackFiles = event.files?.length
-    ? new Map(
-        event.files
-          .filter((f) => f.url_private_download || f.url_private)
-          .map((f) => [f.id, f]),
-      )
-    : undefined;
+  const slackFiles = extractSlackFileMap(event.files);
 
   // Use cache-only lookup to avoid blocking normalization on network calls.
   // A background fetch warms the cache for subsequent messages from this user.
@@ -524,19 +530,13 @@ export function normalizeSlackChannelMessage(
   const content = renderSlackInboundText(
     event.text,
     withBotUserId(botUserId, renderContext),
-    { stripLeadingBotMention: true },
+    { stripLeadingBotMention: true, fallbackStripFirstMention: true },
   );
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
   const attachments = extractSlackAttachments(event.files);
-  const slackFiles = event.files?.length
-    ? new Map(
-        event.files
-          .filter((f) => f.url_private_download || f.url_private)
-          .map((f) => [f.id, f]),
-      )
-    : undefined;
+  const slackFiles = extractSlackFileMap(event.files);
 
   const userInfo =
     botToken && event.user
@@ -609,13 +609,7 @@ export function normalizeSlackAppMention(
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
   const attachments = extractSlackAttachments(event.files);
-  const slackFiles = event.files?.length
-    ? new Map(
-        event.files
-          .filter((f) => f.url_private_download || f.url_private)
-          .map((f) => [f.id, f]),
-      )
-    : undefined;
+  const slackFiles = extractSlackFileMap(event.files);
 
   const userInfo =
     botToken && event.user

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1,7 +1,9 @@
+import { extractSlackUserMentionIds } from "@vellumai/slack-text";
 import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
 import { SlackStore } from "../db/slack-store.js";
+import { isRejection, resolveAssistant } from "../routing/resolve-assistant.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
@@ -30,6 +32,7 @@ const MAX_BACKOFF_MS = 30_000;
 const DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
 const DEDUP_CLEANUP_INTERVAL_MS = 60 * 60 * 1_000;
 const ACTIVE_THREAD_TTL_MS = 24 * 60 * 60 * 1_000;
+const USER_RESOLVE_TIMEOUT_MS = 3_000;
 
 export type SlackSocketModeConfig = {
   appToken: string;
@@ -586,7 +589,20 @@ export class SlackSocketModeClient {
     }
     this.store.markEventSeen(eventId, DEDUP_TTL_MS);
 
-    this.normalizeAndEmit(
+    if (isAppMention) {
+      const appMentionEvent = event as SlackAppMentionEvent;
+      const threadTs = appMentionEvent.thread_ts ?? appMentionEvent.ts;
+      const routing = resolveAssistant(
+        this.config.gatewayConfig,
+        appMentionEvent.channel,
+        appMentionEvent.user,
+      );
+      if (threadTs && !isRejection(routing)) {
+        this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
+      }
+    }
+
+    void this.normalizeAndEmit(
       event,
       eventId,
       isAppMention,
@@ -596,10 +612,61 @@ export class SlackSocketModeClient {
       isMessageChanged,
       isMessageDeleted,
       isDm,
-    );
+    ).catch((err) => {
+      log.error({ err, eventId }, "Slack event normalization failed");
+    });
   }
 
-  private normalizeAndEmit(
+  private extractTextBearingContent(
+    event:
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent
+      | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent,
+  ): string | undefined {
+    if (
+      event.type === "message" &&
+      (event as SlackMessageChangedEvent).subtype === "message_changed"
+    ) {
+      return (event as SlackMessageChangedEvent).message?.text;
+    }
+
+    if (event.type === "app_mention" || event.type === "message") {
+      return (event as SlackAppMentionEvent | SlackDirectMessageEvent).text;
+    }
+
+    return undefined;
+  }
+
+  private async resolveMentionLabelsForText(
+    text: string,
+  ): Promise<Record<string, string>> {
+    const ids = extractSlackUserMentionIds(text).filter(
+      (id) => id !== this.config.botUserId,
+    );
+    const uniqueIds = [...new Set(ids)];
+    if (uniqueIds.length === 0) return {};
+
+    const entries = await Promise.all(
+      uniqueIds.map(async (id): Promise<[string, string] | undefined> => {
+        const userInfo = await Promise.race([
+          resolveSlackUser(id, this.config.botToken),
+          new Promise<undefined>((resolve) =>
+            setTimeout(resolve, USER_RESOLVE_TIMEOUT_MS),
+          ),
+        ]);
+        if (!userInfo) return undefined;
+        return [id, userInfo.displayName || userInfo.username];
+      }),
+    );
+
+    return Object.fromEntries(entries.filter((entry) => entry !== undefined));
+  }
+
+  private async normalizeAndEmit(
     event:
       | SlackAppMentionEvent
       | SlackDirectMessageEvent
@@ -616,7 +683,14 @@ export class SlackSocketModeClient {
     isMessageChanged: boolean,
     isMessageDeleted: boolean,
     isDm: boolean,
-  ): void {
+  ): Promise<void> {
+    const text = this.extractTextBearingContent(event);
+    const userLabels = text ? await this.resolveMentionLabelsForText(text) : {};
+    const renderContext = {
+      botUserId: this.config.botUserId,
+      userLabels,
+    };
+
     let normalized: NormalizedSlackEvent | null;
     if (isReactionAdded) {
       normalized = normalizeSlackReactionAdded(
@@ -638,6 +712,7 @@ export class SlackSocketModeClient {
         eventId,
         this.config.gatewayConfig,
         this.config.botToken,
+        renderContext,
       );
     } else if (isMessageChanged) {
       normalized = normalizeSlackMessageEdit(
@@ -645,6 +720,7 @@ export class SlackSocketModeClient {
         eventId,
         this.config.gatewayConfig,
         this.config.botUserId,
+        renderContext,
       );
     } else if (isMessageDeleted) {
       normalized = normalizeSlackMessageDelete(
@@ -659,6 +735,7 @@ export class SlackSocketModeClient {
         this.config.gatewayConfig,
         this.config.botUserId,
         this.config.botToken,
+        renderContext,
       );
     } else if (isDm) {
       normalized = normalizeSlackDirectMessage(
@@ -667,6 +744,7 @@ export class SlackSocketModeClient {
         this.config.gatewayConfig,
         this.config.botUserId,
         this.config.botToken,
+        renderContext,
       );
     } else {
       log.warn(
@@ -707,22 +785,21 @@ export class SlackSocketModeClient {
     // ensures the event is always emitted even if the Slack API hangs.
     const actor = normalized.event.actor;
     if (actor?.actorExternalId && !actor.displayName) {
-      const USER_RESOLVE_TIMEOUT_MS = 3_000;
-      Promise.race([
+      const mentionedLabel = userLabels[actor.actorExternalId];
+      if (mentionedLabel) {
+        actor.displayName = mentionedLabel;
+      }
+
+      const userInfo = await Promise.race([
         resolveSlackUser(actor.actorExternalId, this.config.botToken),
-        new Promise<undefined>((r) => setTimeout(r, USER_RESOLVE_TIMEOUT_MS)),
-      ])
-        .then((userInfo) => {
-          if (userInfo) {
-            actor.displayName = userInfo.displayName;
-            actor.username = userInfo.username;
-          }
-          this.onEvent(normalized!);
-        })
-        .catch(() => {
-          this.onEvent(normalized!);
-        });
-      return;
+        new Promise<undefined>((resolve) =>
+          setTimeout(resolve, USER_RESOLVE_TIMEOUT_MS),
+        ),
+      ]);
+      if (userInfo) {
+        actor.displayName = userInfo.displayName;
+        actor.username = userInfo.username;
+      }
     }
 
     this.onEvent(normalized);

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -794,6 +794,7 @@ export class SlackSocketModeClient {
         event as SlackAppMentionEvent,
         eventId,
         this.config.gatewayConfig,
+        this.config.botUserId,
         this.config.botToken,
         renderContext,
       );

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1,4 +1,4 @@
-import { extractSlackUserMentionIds } from "@vellumai/slack-text";
+import { buildSlackUserLabelMap } from "@vellumai/slack-text";
 import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
@@ -64,6 +64,7 @@ export class SlackSocketModeClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private dedupCleanupTimer: ReturnType<typeof setInterval> | null = null;
   private store: SlackStore;
+  private emitQueues: Map<string, Promise<void>> | undefined = new Map();
 
   constructor(
     config: SlackSocketModeConfig,
@@ -602,7 +603,7 @@ export class SlackSocketModeClient {
       }
     }
 
-    void this.normalizeAndEmit(
+    this.enqueueNormalizeAndEmit(
       event,
       eventId,
       isAppMention,
@@ -612,9 +613,7 @@ export class SlackSocketModeClient {
       isMessageChanged,
       isMessageDeleted,
       isDm,
-    ).catch((err) => {
-      log.error({ err, eventId }, "Slack event normalization failed");
-    });
+    );
   }
 
   private extractTextBearingContent(
@@ -644,14 +643,9 @@ export class SlackSocketModeClient {
   private async resolveMentionLabelsForText(
     text: string,
   ): Promise<Record<string, string>> {
-    const ids = extractSlackUserMentionIds(text).filter(
-      (id) => id !== this.config.botUserId,
-    );
-    const uniqueIds = [...new Set(ids)];
-    if (uniqueIds.length === 0) return {};
-
-    const entries = await Promise.all(
-      uniqueIds.map(async (id): Promise<[string, string] | undefined> => {
+    return buildSlackUserLabelMap(
+      [text],
+      async (id): Promise<string | undefined> => {
         const userInfo = await Promise.race([
           resolveSlackUser(id, this.config.botToken),
           new Promise<undefined>((resolve) =>
@@ -659,11 +653,100 @@ export class SlackSocketModeClient {
           ),
         ]);
         if (!userInfo) return undefined;
-        return [id, userInfo.displayName || userInfo.username];
-      }),
+        return userInfo.displayName || userInfo.username;
+      },
+      { ignoredUserIds: [this.config.botUserId] },
     );
+  }
 
-    return Object.fromEntries(entries.filter((entry) => entry !== undefined));
+  private enqueueNormalizeAndEmit(
+    event:
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent
+      | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent,
+    eventId: string,
+    isAppMention: boolean,
+    isActiveThreadReply: boolean,
+    isReactionAdded: boolean,
+    isReactionRemoved: boolean,
+    isMessageChanged: boolean,
+    isMessageDeleted: boolean,
+    isDm: boolean,
+  ): void {
+    const queues = (this.emitQueues ??= new Map());
+    const orderingKey = this.getEventOrderingKey(event, eventId);
+    const previous = queues.get(orderingKey) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(() =>
+        this.normalizeAndEmit(
+          event,
+          eventId,
+          isAppMention,
+          isActiveThreadReply,
+          isReactionAdded,
+          isReactionRemoved,
+          isMessageChanged,
+          isMessageDeleted,
+          isDm,
+        ),
+      );
+
+    queues.set(orderingKey, current);
+    void current
+      .catch((err: unknown) => {
+        log.error({ err, eventId }, "Slack event normalization failed");
+      })
+      .finally(() => {
+        if (queues.get(orderingKey) === current) {
+          queues.delete(orderingKey);
+        }
+      });
+  }
+
+  private getEventOrderingKey(
+    event:
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent
+      | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent,
+    eventId: string,
+  ): string {
+    if (event.type === "reaction_added" || event.type === "reaction_removed") {
+      const reaction = event as
+        | SlackReactionAddedEvent
+        | SlackReactionRemovedEvent;
+      return `${reaction.item.channel}:${reaction.item.ts}`;
+    }
+
+    if (
+      event.type === "message" &&
+      (event as SlackMessageChangedEvent).subtype === "message_changed"
+    ) {
+      const changed = event as SlackMessageChangedEvent;
+      return `${changed.channel}:${changed.message.thread_ts ?? changed.message.ts ?? eventId}`;
+    }
+
+    if (
+      event.type === "message" &&
+      (event as SlackMessageDeletedEvent).subtype === "message_deleted"
+    ) {
+      const deleted = event as SlackMessageDeletedEvent;
+      return `${deleted.channel}:${deleted.previous_message?.thread_ts ?? deleted.deleted_ts ?? eventId}`;
+    }
+
+    const message = event as
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent;
+    return `${message.channel}:${message.thread_ts ?? message.ts ?? eventId}`;
   }
 
   private async normalizeAndEmit(

--- a/packages/slack-text/bun.lock
+++ b/packages/slack-text/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@vellumai/slack-text",
+      "devDependencies": {
+        "@types/bun": "1.3.10",
+        "typescript": "5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/packages/slack-text/package.json
+++ b/packages/slack-text/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vellumai/slack-text",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.10",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildSlackUserLabelMap,
   extractSlackUserMentionIds,
   renderSlackTextForModel,
   stripLeadingSlackMentionFallback,
@@ -10,7 +11,7 @@ import {
 describe("extractSlackUserMentionIds", () => {
   test("returns unique user mention IDs in encounter order", () => {
     expect(
-      extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again"),
+      extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again")
     ).toEqual(["U123", "W456"]);
   });
 });
@@ -18,19 +19,19 @@ describe("extractSlackUserMentionIds", () => {
 describe("stripLeadingSlackUserMention", () => {
   test("strips only leading mentions for the exact bot ID", () => {
     expect(stripLeadingSlackUserMention("<@U111> <@U222> hi", "U111")).toBe(
-      "<@U222> hi",
+      "<@U222> hi"
     );
   });
 
   test("strips repeated leading mentions for the exact bot ID", () => {
     expect(stripLeadingSlackUserMention(" <@U111> <@U111> hi", "U111")).toBe(
-      "hi",
+      "hi"
     );
   });
 
   test("preserves text when the leading mention is a different user", () => {
     expect(stripLeadingSlackUserMention("<@U222> hi <@U111>", "U111")).toBe(
-      "<@U222> hi <@U111>",
+      "<@U222> hi <@U111>"
     );
   });
 });
@@ -38,7 +39,7 @@ describe("stripLeadingSlackUserMention", () => {
 describe("stripLeadingSlackMentionFallback", () => {
   test("strips only the first leading Slack user mention", () => {
     expect(stripLeadingSlackMentionFallback(" <@U111> <@U222> hi")).toBe(
-      "<@U222> hi",
+      "<@U222> hi"
     );
   });
 });
@@ -48,7 +49,7 @@ describe("renderSlackTextForModel", () => {
     expect(
       renderSlackTextForModel("hello <@U123>", {
         userLabels: { U123: "Alice" },
-      }),
+      })
     ).toBe("hello @Alice");
   });
 
@@ -61,11 +62,19 @@ describe("renderSlackTextForModel", () => {
     expect(rendered).not.toContain("U789");
   });
 
+  test("treats ID-shaped resolved user labels as unresolved", () => {
+    expect(
+      renderSlackTextForModel("hello <@U123>", {
+        userLabels: { U123: "U123" },
+      })
+    ).toBe("hello @unknown-user");
+  });
+
   test("renders channel references with labels and fallbacks", () => {
     expect(
       renderSlackTextForModel("<#C123|general> <#C456>", {
         channelLabels: { C456: "support" },
-      }),
+      })
     ).toBe("#general #support");
 
     expect(renderSlackTextForModel("<#C789>")).toBe("#unknown-channel");
@@ -73,21 +82,21 @@ describe("renderSlackTextForModel", () => {
 
   test("renders special broadcasts", () => {
     expect(renderSlackTextForModel("<!here> <!channel> <!everyone>")).toBe(
-      "@here @channel @everyone",
+      "@here @channel @everyone"
     );
   });
 
   test("renders usergroups with labels and fallback", () => {
-    expect(
-      renderSlackTextForModel("<!subteam^S123|eng> <!subteam^S456>"),
-    ).toBe("@eng @usergroup");
+    expect(renderSlackTextForModel("<!subteam^S123|eng> <!subteam^S456>")).toBe(
+      "@eng @usergroup"
+    );
   });
 
   test("renders labeled and unlabeled links", () => {
     expect(
       renderSlackTextForModel(
-        "<https://example.com|Example> <https://example.org>",
-      ),
+        "<https://example.com|Example> <https://example.org>"
+      )
     ).toBe("Example (https://example.com) https://example.org");
   });
 
@@ -98,8 +107,8 @@ describe("renderSlackTextForModel", () => {
         {
           userLabels: { U123: " @<system>  prompt " },
           channelLabels: { C123: "#<ops>" },
-        },
-      ),
+        }
+      )
     ).toBe("@system prompt #ops #unknown-channel @eng");
   });
 
@@ -108,7 +117,37 @@ describe("renderSlackTextForModel", () => {
       renderSlackTextForModel("<@U123> <#C123>", {
         userFallbackLabel: "@ missing user ",
         channelFallbackLabel: "# missing channel ",
-      }),
+      })
     ).toBe("@missing user #missing channel");
+  });
+});
+
+describe("buildSlackUserLabelMap", () => {
+  test("dedupes mentioned users across text inputs and ignores configured IDs", async () => {
+    const resolved: string[] = [];
+    const labels = await buildSlackUserLabelMap(
+      ["<@U123> hi <@U999>", undefined, "<@U123> and <@W456>"],
+      async (userId) => {
+        resolved.push(userId);
+        return userId === "W456" ? "Bob" : "Alice";
+      },
+      { ignoredUserIds: ["U999"] }
+    );
+
+    expect(resolved).toEqual(["U123", "W456"]);
+    expect(labels).toEqual({ U123: "Alice", W456: "Bob" });
+  });
+
+  test("omits unresolved labels and labels equal to the Slack user ID", async () => {
+    const labels = await buildSlackUserLabelMap(
+      ["<@U123> <@U456> <@U789>"],
+      async (userId) => {
+        if (userId === "U123") return "U123";
+        if (userId === "U456") return "";
+        return "Alice";
+      }
+    );
+
+    expect(labels).toEqual({ U789: "Alice" });
   });
 });

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractSlackUserMentionIds,
+  renderSlackTextForModel,
+  stripLeadingSlackMentionFallback,
+  stripLeadingSlackUserMention,
+} from "./index.js";
+
+describe("extractSlackUserMentionIds", () => {
+  test("returns unique user mention IDs in encounter order", () => {
+    expect(
+      extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again"),
+    ).toEqual(["U123", "W456"]);
+  });
+});
+
+describe("stripLeadingSlackUserMention", () => {
+  test("strips only leading mentions for the exact bot ID", () => {
+    expect(stripLeadingSlackUserMention("<@U111> <@U222> hi", "U111")).toBe(
+      "<@U222> hi",
+    );
+  });
+
+  test("strips repeated leading mentions for the exact bot ID", () => {
+    expect(stripLeadingSlackUserMention(" <@U111> <@U111> hi", "U111")).toBe(
+      "hi",
+    );
+  });
+
+  test("preserves text when the leading mention is a different user", () => {
+    expect(stripLeadingSlackUserMention("<@U222> hi <@U111>", "U111")).toBe(
+      "<@U222> hi <@U111>",
+    );
+  });
+});
+
+describe("stripLeadingSlackMentionFallback", () => {
+  test("strips only the first leading Slack user mention", () => {
+    expect(stripLeadingSlackMentionFallback(" <@U111> <@U222> hi")).toBe(
+      "<@U222> hi",
+    );
+  });
+});
+
+describe("renderSlackTextForModel", () => {
+  test("renders resolved user mentions", () => {
+    expect(
+      renderSlackTextForModel("hello <@U123>", {
+        userLabels: { U123: "Alice" },
+      }),
+    ).toBe("hello @Alice");
+  });
+
+  test("renders multiple mentions and never emits unresolved user IDs", () => {
+    const rendered = renderSlackTextForModel("<@U123> <@W456> <@U789>", {
+      userLabels: { U123: "Alice", W456: "Bob" },
+    });
+
+    expect(rendered).toBe("@Alice @Bob @unknown-user");
+    expect(rendered).not.toContain("U789");
+  });
+
+  test("renders channel references with labels and fallbacks", () => {
+    expect(
+      renderSlackTextForModel("<#C123|general> <#C456>", {
+        channelLabels: { C456: "support" },
+      }),
+    ).toBe("#general #support");
+
+    expect(renderSlackTextForModel("<#C789>")).toBe("#unknown-channel");
+  });
+
+  test("renders special broadcasts", () => {
+    expect(renderSlackTextForModel("<!here> <!channel> <!everyone>")).toBe(
+      "@here @channel @everyone",
+    );
+  });
+
+  test("renders usergroups with labels and fallback", () => {
+    expect(
+      renderSlackTextForModel("<!subteam^S123|eng> <!subteam^S456>"),
+    ).toBe("@eng @usergroup");
+  });
+
+  test("renders labeled and unlabeled links", () => {
+    expect(
+      renderSlackTextForModel(
+        "<https://example.com|Example> <https://example.org>",
+      ),
+    ).toBe("Example (https://example.com) https://example.org");
+  });
+
+  test("sanitizes malicious and empty labels before adding prefixes", () => {
+    expect(
+      renderSlackTextForModel(
+        "<@U123> <#C123> <#C456|#  > <!subteam^S123|@eng>",
+        {
+          userLabels: { U123: " @<system>  prompt " },
+          channelLabels: { C123: "#<ops>" },
+        },
+      ),
+    ).toBe("@system prompt #ops #unknown-channel @eng");
+  });
+
+  test("uses sanitized custom fallbacks", () => {
+    expect(
+      renderSlackTextForModel("<@U123> <#C123>", {
+        userFallbackLabel: "@ missing user ",
+        channelFallbackLabel: "# missing channel ",
+      }),
+    ).toBe("@missing user #missing channel");
+  });
+});

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -1,0 +1,177 @@
+export interface RenderSlackTextOptions {
+  userLabels?: Record<string, string>;
+  channelLabels?: Record<string, string>;
+  userFallbackLabel?: string;
+  channelFallbackLabel?: string;
+}
+
+const SLACK_USER_MENTION_RE = /<@([UW][A-Z0-9]+)>/g;
+const LEADING_SLACK_USER_MENTION_RE = /^\s*<@[UW][A-Z0-9]+>\s*/;
+
+export function extractSlackUserMentionIds(text: string): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+
+  for (const match of text.matchAll(SLACK_USER_MENTION_RE)) {
+    const id = match[1];
+    if (!seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+
+  return ids;
+}
+
+export function stripLeadingSlackUserMention(
+  text: string,
+  userId: string,
+): string {
+  if (!isSlackUserId(userId)) {
+    return text;
+  }
+
+  const mention = `<@${userId}>`;
+  let stripped = text;
+
+  while (true) {
+    const next = stripLeadingExactToken(stripped, mention);
+    if (next === stripped) {
+      return stripped;
+    }
+    stripped = next;
+  }
+}
+
+export function stripLeadingSlackMentionFallback(text: string): string {
+  return text.replace(LEADING_SLACK_USER_MENTION_RE, "");
+}
+
+export function renderSlackTextForModel(
+  text: string,
+  options: RenderSlackTextOptions = {},
+): string {
+  return text.replace(/<([^<>\s][^<>]*)>/g, (token, content: string) => {
+    if (content.startsWith("@")) {
+      return renderUserMention(content, options);
+    }
+
+    if (content.startsWith("#")) {
+      return renderChannelReference(content, options);
+    }
+
+    if (content.startsWith("!")) {
+      return renderSpecialReference(content);
+    }
+
+    if (looksLikeUrl(content)) {
+      return renderLink(content);
+    }
+
+    return token;
+  });
+}
+
+function renderUserMention(
+  content: string,
+  options: RenderSlackTextOptions,
+): string {
+  const id = content.slice(1);
+  if (!isSlackUserId(id)) {
+    return `<${content}>`;
+  }
+
+  const fallback = sanitizeLabel(options.userFallbackLabel, "unknown-user");
+  const label = sanitizeLabel(options.userLabels?.[id], fallback);
+  return `@${label}`;
+}
+
+function renderChannelReference(
+  content: string,
+  options: RenderSlackTextOptions,
+): string {
+  const [idWithPrefix, label] = splitSlackLabel(content);
+  const channelId = idWithPrefix.slice(1);
+  const fallback = sanitizeLabel(options.channelFallbackLabel, "unknown-channel");
+  const resolvedLabel = label ?? options.channelLabels?.[channelId];
+  return `#${sanitizeLabel(resolvedLabel, fallback)}`;
+}
+
+function renderSpecialReference(content: string): string {
+  if (
+    content === "!here" ||
+    content === "!channel" ||
+    content === "!everyone"
+  ) {
+    return `@${content.slice(1)}`;
+  }
+
+  const subteam = /^!subteam\^[^|>]+(?:\|(.+))?$/.exec(content);
+  if (subteam) {
+    return `@${sanitizeLabel(subteam[1], "usergroup")}`;
+  }
+
+  return `<${content}>`;
+}
+
+function renderLink(content: string): string {
+  const [url, label] = splitSlackLabel(content);
+  if (!label) {
+    return url;
+  }
+
+  return `${sanitizeLabel(label, url)} (${url})`;
+}
+
+function splitSlackLabel(content: string): [string, string | undefined] {
+  const separatorIndex = content.indexOf("|");
+  if (separatorIndex === -1) {
+    return [content, undefined];
+  }
+
+  return [
+    content.slice(0, separatorIndex),
+    content.slice(separatorIndex + 1),
+  ];
+}
+
+function sanitizeLabel(label: string | undefined, fallback: string): string {
+  const sanitized = label
+    ?.replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[@#]+/, "")
+    .trim();
+
+  if (sanitized) {
+    return sanitized;
+  }
+
+  const sanitizedFallback = fallback
+    .replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[@#]+/, "")
+    .trim();
+
+  return sanitizedFallback || "unknown";
+}
+
+function stripLeadingExactToken(text: string, token: string): string {
+  const leadingWhitespaceLength = text.length - text.trimStart().length;
+  const afterWhitespace = text.slice(leadingWhitespaceLength);
+
+  if (!afterWhitespace.startsWith(token)) {
+    return text;
+  }
+
+  return afterWhitespace.slice(token.length).trimStart();
+}
+
+function isSlackUserId(value: string): boolean {
+  return /^[UW][A-Z0-9]+$/.test(value);
+}
+
+function looksLikeUrl(content: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\/\S+$/i.test(splitSlackLabel(content)[0]);
+}

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -5,6 +5,10 @@ export interface RenderSlackTextOptions {
   channelFallbackLabel?: string;
 }
 
+export interface BuildSlackUserLabelMapOptions {
+  ignoredUserIds?: Iterable<string | undefined>;
+}
+
 const SLACK_USER_MENTION_RE = /<@([UW][A-Z0-9]+)>/g;
 const LEADING_SLACK_USER_MENTION_RE = /^\s*<@[UW][A-Z0-9]+>\s*/;
 
@@ -25,7 +29,7 @@ export function extractSlackUserMentionIds(text: string): string[] {
 
 export function stripLeadingSlackUserMention(
   text: string,
-  userId: string,
+  userId: string
 ): string {
   if (!isSlackUserId(userId)) {
     return text;
@@ -49,7 +53,7 @@ export function stripLeadingSlackMentionFallback(text: string): string {
 
 export function renderSlackTextForModel(
   text: string,
-  options: RenderSlackTextOptions = {},
+  options: RenderSlackTextOptions = {}
 ): string {
   return text.replace(/<([^<>\s][^<>]*)>/g, (token, content: string) => {
     if (content.startsWith("@")) {
@@ -72,9 +76,51 @@ export function renderSlackTextForModel(
   });
 }
 
+export async function buildSlackUserLabelMap(
+  texts: Iterable<string | undefined>,
+  resolveLabel: (userId: string) => Promise<string | undefined | null>,
+  options: BuildSlackUserLabelMapOptions = {}
+): Promise<Record<string, string>> {
+  const ignored = new Set(
+    [...(options.ignoredUserIds ?? [])].filter(
+      (id): id is string => typeof id === "string" && id.length > 0
+    )
+  );
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  for (const text of texts) {
+    if (!text) continue;
+    for (const id of extractSlackUserMentionIds(text)) {
+      if (ignored.has(id) || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+  }
+
+  if (ids.length === 0) return {};
+
+  const entries = await Promise.all(
+    ids.map(
+      async (id): Promise<[string, string] | undefined> => {
+        try {
+          const label = await resolveLabel(id);
+          const sanitized = sanitizeOptionalLabel(label ?? undefined);
+          if (!sanitized || sanitized === id) return undefined;
+          return [id, sanitized];
+        } catch {
+          return undefined;
+        }
+      }
+    )
+  );
+
+  return Object.fromEntries(entries.filter((entry) => entry !== undefined));
+}
+
 function renderUserMention(
   content: string,
-  options: RenderSlackTextOptions,
+  options: RenderSlackTextOptions
 ): string {
   const id = content.slice(1);
   if (!isSlackUserId(id)) {
@@ -83,16 +129,22 @@ function renderUserMention(
 
   const fallback = sanitizeLabel(options.userFallbackLabel, "unknown-user");
   const label = sanitizeLabel(options.userLabels?.[id], fallback);
+  if (label === id) {
+    return `@${fallback}`;
+  }
   return `@${label}`;
 }
 
 function renderChannelReference(
   content: string,
-  options: RenderSlackTextOptions,
+  options: RenderSlackTextOptions
 ): string {
   const [idWithPrefix, label] = splitSlackLabel(content);
   const channelId = idWithPrefix.slice(1);
-  const fallback = sanitizeLabel(options.channelFallbackLabel, "unknown-channel");
+  const fallback = sanitizeLabel(
+    options.channelFallbackLabel,
+    "unknown-channel"
+  );
   const resolvedLabel = label ?? options.channelLabels?.[channelId];
   return `#${sanitizeLabel(resolvedLabel, fallback)}`;
 }
@@ -129,10 +181,7 @@ function splitSlackLabel(content: string): [string, string | undefined] {
     return [content, undefined];
   }
 
-  return [
-    content.slice(0, separatorIndex),
-    content.slice(separatorIndex + 1),
-  ];
+  return [content.slice(0, separatorIndex), content.slice(separatorIndex + 1)];
 }
 
 function sanitizeLabel(label: string | undefined, fallback: string): string {
@@ -155,6 +204,15 @@ function sanitizeLabel(label: string | undefined, fallback: string): string {
     .trim();
 
   return sanitizedFallback || "unknown";
+}
+
+function sanitizeOptionalLabel(label: string | undefined): string | undefined {
+  return label
+    ?.replace(/[<>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^[@#]+/, "")
+    .trim();
 }
 
 function stripLeadingExactToken(text: string, token: string): string {

--- a/packages/slack-text/tsconfig.json
+++ b/packages/slack-text/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Normalizes model-facing Slack mention text so assistants see human-readable labels like `@leo` or `@unknown-user` instead of raw Slack `<@U...>` IDs. The rollout covers live gateway ingress, assistant-side Slack backfill/search reads, persistence/runtime assembly regressions, and Docker packaging for the new shared package.

## Self-review result
PASS after remediation. Fixed review gaps for Docker build inputs, gateway fallback stripping, Slack search mention rendering, raw-ID label fallback, live per-thread ordering, and cleanup of duplicated/overloaded mention helpers.

## PRs merged into feature branch
- #29001: Add shared Slack text rendering helpers
- #29010: Normalize Slack mentions in gateway inbound content
- #29012: Normalize Slack mentions in backfilled history
- #29022: Resolve Slack mention display names on live ingress
- #29030: Add Slack mention rendering regression tests

### Fix PRs
- #29034: include Slack text package in Docker builds
- #29035: tighten gateway Slack mention fallback
- #29036: normalize Slack mention edge cases
- #29039: simplify Slack app mention normalizer args
- #29040: reuse assistant Slack mention label helper

Part of plan: slack-mention-display-names.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
