### PR TITLE
fix: harden Velay registration lifecycle

### DIFF
--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -97,22 +97,32 @@ export function sanitizeWebSocketCloseArgs(
   code?: number,
   reason?: string,
 ): { code: number; reason?: string } | undefined {
-  if (!isValidWebSocketCloseCode(code)) return undefined;
+  const safeCode = toSafeWebSocketCloseCode(code);
+  if (safeCode === undefined) return undefined;
 
   const sanitizedReason =
     typeof reason === "string" ? truncateCloseReason(reason) : undefined;
   return sanitizedReason === undefined
-    ? { code }
-    : { code, reason: sanitizedReason };
+    ? { code: safeCode }
+    : { code: safeCode, reason: sanitizedReason };
 }
 
-function isValidWebSocketCloseCode(code: number | undefined): code is number {
+function toSafeWebSocketCloseCode(
+  code: number | undefined,
+): number | undefined {
+  if (code === 1000) return code;
+  if (typeof code !== "number" || !Number.isInteger(code)) return undefined;
+  if (code >= 3000 && code <= 4999) return code;
+  if (isRemappableProtocolCloseCode(code)) return 3000 + code;
+  return undefined;
+}
+
+function isRemappableProtocolCloseCode(code: number): boolean {
   return (
-    code === 1000 ||
-    (typeof code === "number" &&
-      Number.isInteger(code) &&
-      code >= 3000 &&
-      code <= 4999)
+    code === 1001 ||
+    code === 1002 ||
+    code === 1003 ||
+    (code >= 1007 && code <= 1014)
   );
 }
 

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -62,6 +62,13 @@ class FakeWebSocket {
   }
 
   close(code?: number, reason?: string): void {
+    if (
+      code !== undefined &&
+      code !== 1000 &&
+      (!Number.isInteger(code) || code < 3000 || code > 4999)
+    ) {
+      throw new Error("invalid close code");
+    }
     this.readyState = WS_CLOSED;
     this.closes.push({ code, reason });
   }
@@ -296,7 +303,7 @@ describe("VelayTunnelClient", () => {
     expect(readConfig()).toEqual({
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
-        twilioPublicBaseUrl: "https://velay-public.example.test",
+        twilioPublicBaseUrl: "https://velay-public.example.test/",
         twilioPublicBaseUrlManagedBy: "velay",
       },
       existing: { preserved: true },
@@ -322,7 +329,7 @@ describe("VelayTunnelClient", () => {
     await flushPromises();
 
     expect(sockets[0].closes).toEqual([
-      { code: 1008, reason: "assistant ID mismatch" },
+      { code: 4008, reason: "assistant ID mismatch" },
     ]);
     expect(readConfig()).toEqual({
       ingress: { publicBaseUrl: "https://ngrok.example.test" },
@@ -356,7 +363,7 @@ describe("VelayTunnelClient", () => {
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
         otherIngressSetting: "keep-me",
-        twilioPublicBaseUrl: "https://velay-public.example.test",
+        twilioPublicBaseUrl: "https://velay-public.example.test/",
         twilioPublicBaseUrlManagedBy: "velay",
       },
       gateway: {
@@ -365,18 +372,12 @@ describe("VelayTunnelClient", () => {
     });
   });
 
-  test("rejects registration with an invalid public URL", async () => {
+  test("normalizes a valid registered public URL before publishing", async () => {
     const sockets: FakeWebSocket[] = [];
-    const reconnectDelays: number[] = [];
-    const invalidations = { count: 0 };
     writeConfig({
       ingress: { publicBaseUrl: "https://ngrok.example.test" },
     });
-    const client = makeClient({
-      sockets,
-      reconnectDelays,
-      configFile: makeConfigFileCache(invalidations),
-    });
+    const client = makeClient({ sockets });
 
     client.start();
     await flushPromises();
@@ -384,18 +385,53 @@ describe("VelayTunnelClient", () => {
     sendFrame(sockets[0], {
       type: VELAY_FRAME_TYPES.registered,
       assistant_id: "asst-123",
-      public_url: "notaurl",
+      public_url: "  HTTPS://VELAY-PUBLIC.EXAMPLE.TEST/twilio/../twilio  ",
     });
     await flushPromises();
 
-    expect(sockets[0].closes).toEqual([
-      { code: 1008, reason: "invalid public URL" },
-    ]);
     expect(readConfig()).toEqual({
-      ingress: { publicBaseUrl: "https://ngrok.example.test" },
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://velay-public.example.test/twilio",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
     });
-    expect(invalidations.count).toBe(0);
-    expect(reconnectDelays).toEqual([10]);
+  });
+
+  test("rejects registration with an invalid public URL", async () => {
+    for (const publicUrl of ["", "notaurl", "https://", "ftp://example.test"]) {
+      const sockets: FakeWebSocket[] = [];
+      const reconnectDelays: number[] = [];
+      const invalidations = { count: 0 };
+      writeConfig({
+        ingress: { publicBaseUrl: "https://ngrok.example.test" },
+      });
+      const client = makeClient({
+        sockets,
+        reconnectDelays,
+        configFile: makeConfigFileCache(invalidations),
+      });
+
+      client.start();
+      await flushPromises();
+      sockets[0].readyState = WS_OPEN;
+      sendFrame(sockets[0], {
+        type: VELAY_FRAME_TYPES.registered,
+        assistant_id: "asst-123",
+        public_url: publicUrl,
+      });
+      await flushPromises();
+
+      expect(sockets[0].closes).toEqual([
+        { code: 4008, reason: "invalid public URL" },
+      ]);
+      expect(readConfig()).toEqual({
+        ingress: { publicBaseUrl: "https://ngrok.example.test" },
+      });
+      expect(invalidations.count).toBe(0);
+      expect(reconnectDelays).toEqual([10]);
+      await client.stop();
+    }
   });
 
   test("clears the published Twilio public URL when the tunnel disconnects", async () => {
@@ -438,12 +474,16 @@ describe("VelayTunnelClient", () => {
 
   test("does not clear a newer Twilio public URL on stale tunnel close", async () => {
     const sockets: FakeWebSocket[] = [];
+    const invalidations = { count: 0 };
     writeConfig({
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
       },
     });
-    const client = makeClient({ sockets });
+    const client = makeClient({
+      sockets,
+      configFile: makeConfigFileCache(invalidations),
+    });
 
     client.start();
     await flushPromises();
@@ -470,12 +510,12 @@ describe("VelayTunnelClient", () => {
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
         twilioPublicBaseUrl: "https://velay-public-2.example.test",
-        twilioPublicBaseUrlManagedBy: "velay",
       },
     });
+    expect(invalidations.count).toBe(2);
   });
 
-  test("clears stale managed Velay URL on startup before connecting", async () => {
+  test("clears stale Velay marker on startup before connecting", async () => {
     const sockets: FakeWebSocket[] = [];
     const invalidations = { count: 0 };
     writeConfig({
@@ -497,13 +537,14 @@ describe("VelayTunnelClient", () => {
     expect(readConfig()).toEqual({
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://stale-velay.example.test",
       },
     });
     expect(invalidations.count).toBe(1);
     await client.stop();
   });
 
-  test("disabled Velay cleanup clears managed URL and preserves manual URL", async () => {
+  test("disabled Velay cleanup clears stale marker and preserves Twilio URL", async () => {
     const invalidations = { count: 0 };
     writeConfig({
       ingress: {
@@ -524,6 +565,7 @@ describe("VelayTunnelClient", () => {
     expect(readConfig()).toEqual({
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://stale-velay.example.test",
       },
     });
     expect(invalidations.count).toBe(1);

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -12,6 +12,7 @@ import {
 } from "../http/routes/config-file-utils.js";
 import { getLogger } from "../logger.js";
 import { bridgeVelayHttpRequest } from "./http-bridge.js";
+import { closeWebSocket } from "./bridge-utils.js";
 import {
   VELAY_FRAME_TYPES,
   VELAY_TUNNEL_SUBPROTOCOL,
@@ -28,6 +29,7 @@ const BASE_RECONNECT_DELAY_MS = 500;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const RECONNECT_JITTER_RATIO = 0.5;
 const VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER = "velay";
+const VELAY_POLICY_CLOSE_CODE = 4008;
 
 export type WebSocketConstructorWithOptions = {
   new (
@@ -125,7 +127,7 @@ export class VelayTunnelClient {
   }
 
   private async startAsync(): Promise<void> {
-    await clearManagedTwilioPublicBaseUrl(this.options.configFile);
+    await clearStaleVelayTwilioPublicBaseUrlMarker(this.options.configFile);
     await this.connect();
   }
 
@@ -267,25 +269,31 @@ export class VelayTunnelClient {
         },
         "Velay registered assistant ID mismatch",
       );
-      this.disconnectActiveWebSocket(originWs, 1008, "assistant ID mismatch");
+      this.disconnectActiveWebSocket(
+        originWs,
+        VELAY_POLICY_CLOSE_CODE,
+        "assistant ID mismatch",
+      );
       return;
     }
 
-    if (!isEmptyOrAbsoluteHttpUrl(frame.public_url)) {
+    const publicUrl = normalizeRegisteredPublicUrl(frame.public_url);
+    if (!publicUrl) {
       log.error(
         { publicUrl: frame.public_url },
         "Velay registered invalid Twilio public URL",
       );
-      this.disconnectActiveWebSocket(originWs, 1008, "invalid public URL");
+      this.disconnectActiveWebSocket(
+        originWs,
+        VELAY_POLICY_CLOSE_CODE,
+        "invalid public URL",
+      );
       return;
     }
 
-    await writeManagedTwilioPublicBaseUrl(
-      frame.public_url,
-      this.options.configFile,
-    );
-    this.publishedTwilioPublicBaseUrl = frame.public_url;
-    log.info({ publicUrl: frame.public_url }, "Velay tunnel registered");
+    await writeManagedTwilioPublicBaseUrl(publicUrl, this.options.configFile);
+    this.publishedTwilioPublicBaseUrl = publicUrl;
+    log.info({ publicUrl }, "Velay tunnel registered");
   }
 
   private async handleHttpRequestFrame(
@@ -374,9 +382,14 @@ export function createVelayTunnelClient(
   },
 ): VelayTunnelClient | undefined {
   if (!config.velayBaseUrl) {
-    void clearManagedTwilioPublicBaseUrl(deps.configFile).catch((err) => {
-      log.error({ err }, "Failed to clear disabled Velay Twilio public URL");
-    });
+    void clearStaleVelayTwilioPublicBaseUrlMarker(deps.configFile).catch(
+      (err) => {
+        log.error(
+          { err },
+          "Failed to clear disabled Velay Twilio public URL marker",
+        );
+      },
+    );
     return undefined;
   }
   return new VelayTunnelClient({
@@ -455,6 +468,36 @@ async function writeManagedTwilioPublicBaseUrl(
   );
 }
 
+async function clearStaleVelayTwilioPublicBaseUrlMarker(
+  configFile: ConfigFileCache,
+): Promise<void> {
+  return mutateConfigFile(
+    configFile,
+    "Cannot clear Velay public URL marker because config.json is malformed",
+    (data) => {
+      if (
+        !data.ingress ||
+        typeof data.ingress !== "object" ||
+        Array.isArray(data.ingress)
+      ) {
+        return false;
+      }
+
+      const ingress = { ...(data.ingress as Record<string, unknown>) };
+      if (
+        ingress.twilioPublicBaseUrlManagedBy !==
+        VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER
+      ) {
+        return false;
+      }
+
+      delete ingress.twilioPublicBaseUrlManagedBy;
+      data.ingress = ingress;
+      return true;
+    },
+  );
+}
+
 async function clearManagedTwilioPublicBaseUrl(
   configFile: ConfigFileCache,
   expectedPublicUrl?: string,
@@ -482,7 +525,9 @@ async function clearManagedTwilioPublicBaseUrl(
         expectedPublicUrl !== undefined &&
         ingress.twilioPublicBaseUrl !== expectedPublicUrl
       ) {
-        return false;
+        delete ingress.twilioPublicBaseUrlManagedBy;
+        data.ingress = ingress;
+        return true;
       }
 
       delete ingress.twilioPublicBaseUrl;
@@ -503,8 +548,20 @@ function getMutableIngress(
     : {};
 }
 
-function isEmptyOrAbsoluteHttpUrl(value: string): boolean {
-  return value === "" || /^https?:\/\//i.test(value);
+function normalizeRegisteredPublicUrl(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return undefined;
+    }
+    if (!url.hostname) return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
 }
 
 function buildRegisterWebSocketUrl(baseUrl: string): string {
@@ -624,13 +681,4 @@ function isVelayHeaders(value: unknown): value is Record<string, string[]> {
       Array.isArray(headerValues) &&
       headerValues.every((headerValue) => typeof headerValue === "string"),
   );
-}
-
-function closeWebSocket(ws: WebSocket, code?: number, reason?: string): void {
-  if (
-    ws.readyState === WebSocket.CONNECTING ||
-    ws.readyState === WebSocket.OPEN
-  ) {
-    ws.close(code, reason);
-  }
 }

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -243,7 +243,27 @@ describe("VelayWebSocketBridge", () => {
     ).toEqual([]);
   });
 
-  test("sanitizes invalid close codes from Velay before closing locally", () => {
+  test("remaps protocol close codes from Velay before closing locally", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    expect(() => {
+      bridge.close({
+        type: VELAY_FRAME_TYPES.websocketClose,
+        connection_id: "conn-123",
+        code: 1008,
+        reason: "Policy violation",
+      });
+    }).not.toThrow();
+
+    expect(fakeSocket.closes).toEqual([
+      { code: 4008, reason: "Policy violation" },
+    ]);
+    expect(bridge.getConnectionCount()).toBe(0);
+  });
+
+  test("sanitizes invalid reserved close codes from Velay before closing locally", () => {
     bridge.open(makeOpenFrame());
     fakeSocket.readyState = WS_OPEN;
     fakeSocket.emit("open");
@@ -310,7 +330,9 @@ describe("VelayWebSocketBridge", () => {
       body_base64: "not base64",
     });
 
-    expect(fakeSocket.closes).toEqual([{ code: undefined, reason: undefined }]);
+    expect(fakeSocket.closes).toEqual([
+      { code: 4003, reason: "Invalid message" },
+    ]);
     expect(bridge.getConnectionCount()).toBe(0);
   });
 
@@ -363,5 +385,18 @@ describe("VelayWebSocketBridge", () => {
       code: 1001,
       reason: "going away",
     });
+  });
+
+  test("remaps closeAll going-away semantics to an application close code", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.closeAll();
+
+    expect(fakeSocket.closes).toEqual([
+      { code: 4001, reason: "Tunnel closed" },
+    ]);
+    expect(bridge.getConnectionCount()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- Validates and normalizes Velay registered public URLs before publishing Twilio ingress.
- Hardens WebSocket close/reconnect behavior and preserves manual Twilio URL overrides.

Fixes gap identified during plan review for velay-twilio-ingress.md.

**Gap:** Harden Velay registered URL and close lifecycle
**What was expected:** Velay registration rejects malformed URLs, closes/reconnects safely, and cleanup preserves manual Twilio URL overrides.
**What was found:** Malformed URLs could be published, close paths could throw, and stale management markers could wipe manual overrides.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
