### PR TITLE
fix: complete Twilio-specific ingress consumers

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -292,7 +292,7 @@ describe("ChannelReadinessService", () => {
   test("phone readiness accepts managed callback routing when ingress is absent", async () => {
     mockGetIsPlatform = true;
     mockHasTwilioCredentials = true;
-    mockTwilioPhoneNumber = "+15555550123";
+    mockTwilioPhoneNumber = "+15550123";
 
     const readiness = createReadinessService();
     const [snapshot] = await readiness.getReadiness("phone");
@@ -302,6 +302,47 @@ describe("ChannelReadinessService", () => {
       name: "ingress",
       passed: true,
       message: "Managed platform callback routing is configured",
+    });
+  });
+
+  test("phone readiness accepts Twilio-specific ingress without generic public ingress", async () => {
+    mockHasTwilioCredentials = true;
+    mockTwilioPhoneNumber = "+15550123";
+    mockRawConfig = {
+      ingress: {
+        publicBaseUrl: "",
+        twilioPublicBaseUrl: "https://twilio.example.com",
+      },
+    };
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("phone");
+
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.localChecks).toContainEqual({
+      name: "ingress",
+      passed: true,
+      message: "Twilio public ingress URL is configured",
+    });
+  });
+
+  test("telegram readiness still requires generic public ingress", async () => {
+    mockSecureKeys[credentialKey("telegram", "bot_token")] = "123:abc";
+    mockSecureKeys[credentialKey("telegram", "webhook_secret")] = "secret";
+    mockRawConfig = {
+      ingress: {
+        publicBaseUrl: "",
+        twilioPublicBaseUrl: "https://twilio.example.com",
+      },
+    };
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("telegram");
+
+    expect(snapshot.ready).toBe(false);
+    expect(snapshot.reasons).toContainEqual({
+      code: "ingress",
+      text: "No public ingress URL or managed callback route is configured",
     });
   });
 

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -5,6 +5,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let mockSecureKeys: Record<string, string | null> = {};
 let mockLoadConfigResult: Record<string, unknown> = {};
 
+function resolveMockTwilioBaseUrl(config: Record<string, unknown>): string {
+  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
+  const base =
+    (ingress.twilioPublicBaseUrl as string | undefined) ||
+    (ingress.publicBaseUrl as string | undefined) ||
+    "https://test.example.com";
+  return base.trim().replace(/\/+$/, "");
+}
+
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
@@ -21,8 +30,10 @@ mock.module("../config/loader.js", () => ({
 }));
 
 mock.module("../inbound/public-ingress-urls.js", () => ({
-  getPublicBaseUrl: () => "https://test.example.com",
-  getTwilioRelayUrl: () => "wss://test.example.com/twilio/relay",
+  getTwilioPublicBaseUrl: (config: Record<string, unknown>) =>
+    resolveMockTwilioBaseUrl(config),
+  getTwilioRelayUrl: (config: Record<string, unknown>) =>
+    `${resolveMockTwilioBaseUrl(config).replace(/^http/, "ws")}/twilio/relay`,
 }));
 
 import { getTwilioConfig } from "../calls/twilio-config.js";
@@ -36,7 +47,7 @@ describe("twilio-config", () => {
     mockLoadConfigResult = {
       twilio: {
         accountSid: "AC_test_sid",
-        phoneNumber: "+15551234567",
+        phoneNumber: "+15550123",
       },
     };
   });
@@ -45,14 +56,32 @@ describe("twilio-config", () => {
     const config = await getTwilioConfig();
     expect(config.accountSid).toBe("AC_test_sid");
     expect(config.authToken).toBe("test_auth_token");
-    expect(config.phoneNumber).toBe("+15551234567");
+    expect(config.phoneNumber).toBe("+15550123");
     expect(config.webhookBaseUrl).toBe("https://test.example.com");
     expect(config.wssBaseUrl).toBe("wss://test.example.com/twilio/relay");
   });
 
+  test("uses Twilio-specific public base URL when generic ingress is empty", async () => {
+    mockLoadConfigResult = {
+      ingress: {
+        publicBaseUrl: "",
+        twilioPublicBaseUrl: "  https://twilio.example.com///  ",
+      },
+      twilio: {
+        accountSid: "AC_test_sid",
+        phoneNumber: "+15550123",
+      },
+    };
+
+    const config = await getTwilioConfig();
+
+    expect(config.webhookBaseUrl).toBe("https://twilio.example.com");
+    expect(config.wssBaseUrl).toBe("wss://twilio.example.com/twilio/relay");
+  });
+
   test("throws ConfigError when account SID is missing", async () => {
     mockLoadConfigResult = {
-      twilio: { accountSid: "", phoneNumber: "+15551234567" },
+      twilio: { accountSid: "", phoneNumber: "+15550123" },
     };
     expect(getTwilioConfig()).rejects.toThrow(
       /Twilio credentials not configured/,
@@ -64,7 +93,7 @@ describe("twilio-config", () => {
     mockLoadConfigResult = {
       twilio: {
         accountSid: "AC_test_sid",
-        phoneNumber: "+15551234567",
+        phoneNumber: "+15550123",
       },
     };
     expect(getTwilioConfig()).rejects.toThrow(

--- a/assistant/src/__tests__/twilio-validation.test.ts
+++ b/assistant/src/__tests__/twilio-validation.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockConfig: Record<string, unknown>;
+let mockVerifyCalls: Array<{
+  url: string;
+  params: Record<string, string>;
+  signature: string;
+  authToken: string;
+}> = [];
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => mockConfig,
+}));
+
+mock.module("../calls/twilio-provider.js", () => ({
+  TwilioConversationRelayProvider: class {
+    static getAuthToken() {
+      return "test-auth-token";
+    }
+
+    static verifyWebhookSignature(
+      url: string,
+      params: Record<string, string>,
+      signature: string,
+      authToken: string,
+    ) {
+      mockVerifyCalls.push({ url, params, signature, authToken });
+      return signature === "valid";
+    }
+  },
+}));
+
+import { validateTwilioWebhook } from "../runtime/middleware/twilio-validation.js";
+
+describe("Twilio validation middleware", () => {
+  beforeEach(() => {
+    mockVerifyCalls = [];
+    mockConfig = {
+      ingress: {
+        publicBaseUrl: "https://generic.example.com",
+        twilioPublicBaseUrl: "",
+      },
+    };
+  });
+
+  test("validates signatures against Twilio-specific public ingress first", async () => {
+    mockConfig = {
+      ingress: {
+        publicBaseUrl: "",
+        twilioPublicBaseUrl: "  https://twilio.example.com///  ",
+      },
+    };
+    const req = new Request(
+      "http://127.0.0.1:7821/v1/calls/twilio/voice-webhook?callSessionId=session-123",
+      {
+        method: "POST",
+        headers: { "x-twilio-signature": "valid" },
+        body: new URLSearchParams({ CallSid: "CA123" }),
+      },
+    );
+
+    const result = await validateTwilioWebhook(req);
+
+    expect(result).toEqual({ body: "CallSid=CA123" });
+    expect(mockVerifyCalls).toEqual([
+      {
+        url: "https://twilio.example.com/v1/calls/twilio/voice-webhook?callSessionId=session-123",
+        params: { CallSid: "CA123" },
+        signature: "valid",
+        authToken: "test-auth-token",
+      },
+    ]);
+  });
+
+  test("falls back to generic public ingress when Twilio-specific ingress is empty", async () => {
+    const req = new Request("http://127.0.0.1:7821/v1/calls/twilio/status", {
+      method: "POST",
+      headers: { "x-twilio-signature": "valid" },
+      body: new URLSearchParams({ CallSid: "CA123" }),
+    });
+
+    await validateTwilioWebhook(req);
+
+    expect(mockVerifyCalls[0]?.url).toBe(
+      "https://generic.example.com/v1/calls/twilio/status",
+    );
+  });
+});

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "../config/loader.js";
 import {
-  getPublicBaseUrl,
+  getTwilioPublicBaseUrl,
   getTwilioRelayUrl,
 } from "../inbound/public-ingress-urls.js";
 import { credentialKey } from "../security/credential-key.js";
@@ -44,7 +44,7 @@ export async function getTwilioConfig(): Promise<TwilioConfig> {
   const authToken =
     (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) || "";
   const phoneNumber = resolveTwilioPhoneNumber();
-  const webhookBaseUrl = getPublicBaseUrl(config);
+  const webhookBaseUrl = getTwilioPublicBaseUrl(config);
 
   let wssBaseUrl: string;
   try {

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -19,31 +19,37 @@ import type {
 /** Remote check results are cached for 5 minutes before being considered stale. */
 export const REMOTE_TTL_MS = 5 * 60 * 1000;
 
-function hasIngressConfigured(): boolean {
+function hasIngressConfigured(options: { twilio?: boolean } = {}): boolean {
   try {
     const raw = loadRawConfig();
     const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
     const publicBaseUrl = (ingress.publicBaseUrl as string) ?? "";
+    const twilioPublicBaseUrl = (ingress.twilioPublicBaseUrl as string) ?? "";
+    const effectiveBaseUrl = options.twilio
+      ? twilioPublicBaseUrl || publicBaseUrl
+      : publicBaseUrl;
     const enabled =
       (ingress.enabled as boolean | undefined) ??
-      (publicBaseUrl ? true : false);
-    return enabled && publicBaseUrl.length > 0;
+      (effectiveBaseUrl ? true : false);
+    return enabled && effectiveBaseUrl.trim().length > 0;
   } catch {
     return false;
   }
 }
 
-function hasWebhookRoutingConfigured(allowManagedCallbacks = false): {
+function hasWebhookRoutingConfigured(
+  allowManagedCallbacks = false,
+  options: { twilio?: boolean } = {},
+): {
   configured: boolean;
   usesManagedCallbacks: boolean;
 } {
-  const ingressConfigured = hasIngressConfigured();
+  const ingressConfigured = hasIngressConfigured(options);
   if (ingressConfigured) {
     return { configured: true, usesManagedCallbacks: false };
   }
 
-  const usesManagedCallbacks =
-    allowManagedCallbacks && getIsPlatform();
+  const usesManagedCallbacks = allowManagedCallbacks && getIsPlatform();
   return {
     configured: usesManagedCallbacks,
     usesManagedCallbacks,
@@ -79,19 +85,29 @@ async function checkCredential(
 }
 
 /** Check that public ingress is configured and enabled. */
-function checkIngress(allowManagedCallbacks = false): ReadinessCheckResult {
+function checkIngress(
+  allowManagedCallbacks = false,
+  options: { twilio?: boolean } = {},
+): ReadinessCheckResult {
   const { configured, usesManagedCallbacks } = hasWebhookRoutingConfigured(
     allowManagedCallbacks,
+    options,
   );
   return check(
     "ingress",
     configured,
     usesManagedCallbacks
       ? "Managed platform callback routing is configured"
-      : "Public ingress URL is configured",
+      : options.twilio
+        ? "Twilio public ingress URL is configured"
+        : "Public ingress URL is configured",
     allowManagedCallbacks
-      ? "No public ingress URL or managed callback route is configured"
-      : "Public ingress URL is not configured or disabled",
+      ? options.twilio
+        ? "No Twilio public ingress URL or managed callback route is configured"
+        : "No public ingress URL or managed callback route is configured"
+      : options.twilio
+        ? "Twilio public ingress URL is not configured or disabled"
+        : "Public ingress URL is not configured or disabled",
   );
 }
 
@@ -102,7 +118,7 @@ const voiceProbe: ChannelProbe = {
   async runLocalChecks(): Promise<ReadinessCheckResult[]> {
     const hasCreds = await hasTwilioCredentials();
     const hasPhone = !!resolveTwilioPhoneNumber();
-    const ingress = checkIngress(true);
+    const ingress = checkIngress(true, { twilio: true });
 
     return [
       check(

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -4,7 +4,7 @@
 
 import { TwilioConversationRelayProvider } from "../../calls/twilio-provider.js";
 import { loadConfig } from "../../config/loader.js";
-import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
+import { getTwilioPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 
@@ -86,7 +86,7 @@ export async function validateTwilioWebhook(
   // signature.
   let publicBaseUrl: string | undefined;
   try {
-    publicBaseUrl = getPublicBaseUrl(loadConfig());
+    publicBaseUrl = getTwilioPublicBaseUrl(loadConfig());
   } catch {
     // No webhook base URL configured -- fall back to using req.url as-is
   }


### PR DESCRIPTION
## Summary
- Completes assistant-side Twilio ingress consumers so Velay-only Twilio ingress works without generic public ingress.
- Adds focused regressions for Twilio config/readiness/signature behavior.

Fixes gap identified during plan review for velay-twilio-ingress.md.

**Gap:** Complete assistant-side Twilio-specific ingress consumers
**What was expected:** Twilio voice/call/signature paths prefer ingress.twilioPublicBaseUrl while generic ingress consumers stay unchanged.
**What was found:** Several assistant-side paths still required ingress.publicBaseUrl.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
