### PR TITLE
Preserve profile context and slider fallbacks

### DIFF
--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -155,7 +155,12 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
             maxTokens: 32000,
             contextWindow: {
               maxInputTokens: 900000,
+              targetBudgetRatio: 0.3,
               summaryBudgetRatio: 0.08,
+              overflowRecovery: {
+                enabled: true,
+                maxAttempts: 4,
+              },
             },
             openrouter: {
               only: ["anthropic"],
@@ -166,7 +171,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     };
   });
 
-  test("owns contextWindow while preserving non-UI profile leaves", () => {
+  test("owns contextWindow maxInputTokens while preserving non-UI profile leaves", () => {
     const result = replaceProfileRoute.handler({
       pathParams: { name: "custom" },
       body: {
@@ -185,11 +190,18 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     expect(savedProfile.provider).toBe("openai");
     expect(savedProfile.model).toBe("gpt-5.5");
     expect(savedProfile.maxTokens).toBeUndefined();
-    expect(savedProfile.contextWindow).toBeUndefined();
+    expect(savedProfile.contextWindow).toEqual({
+      targetBudgetRatio: 0.3,
+      summaryBudgetRatio: 0.08,
+      overflowRecovery: {
+        enabled: true,
+        maxAttempts: 4,
+      },
+    });
     expect(savedProfile.openrouter).toEqual({ only: ["anthropic"] });
   });
 
-  test("writes a replacement contextWindow override", () => {
+  test("writes only the replacement contextWindow maxInputTokens override", () => {
     const result = replaceProfileRoute.handler({
       pathParams: { name: "custom" },
       body: {
@@ -197,6 +209,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         model: "gpt-5.5",
         contextWindow: {
           maxInputTokens: 150000,
+          summaryBudgetRatio: 0.2,
         },
       },
     });
@@ -208,7 +221,15 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       }
     ).profiles.custom;
 
-    expect(savedProfile.contextWindow).toEqual({ maxInputTokens: 150000 });
+    expect(savedProfile.contextWindow).toEqual({
+      maxInputTokens: 150000,
+      targetBudgetRatio: 0.3,
+      summaryBudgetRatio: 0.08,
+      overflowRecovery: {
+        enabled: true,
+        maxAttempts: 4,
+      },
+    });
     expect(savedProfile.openrouter).toEqual({ only: ["anthropic"] });
   });
 });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -89,7 +89,6 @@ const INFERENCE_PROFILE_UI_KEYS = new Set([
   "verbosity",
   "temperature",
   "thinking",
-  "contextWindow",
 ]);
 
 function asMutablePlainObject(value: unknown): Record<string, unknown> | null {
@@ -97,6 +96,36 @@ function asMutablePlainObject(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
+}
+
+function mergeInferenceProfileContextWindow(
+  existingProfile: Record<string, unknown>,
+  fragment: Record<string, unknown>,
+  nextProfile: Record<string, unknown>,
+): void {
+  const existingContextWindow =
+    asMutablePlainObject(existingProfile.contextWindow) ?? {};
+  const nextContextWindow: Record<string, unknown> = {
+    ...existingContextWindow,
+  };
+
+  delete nextContextWindow.maxInputTokens;
+
+  if (Object.hasOwn(fragment, "contextWindow")) {
+    const fragmentContextWindow = asMutablePlainObject(fragment.contextWindow);
+    if (
+      fragmentContextWindow &&
+      Object.hasOwn(fragmentContextWindow, "maxInputTokens")
+    ) {
+      nextContextWindow.maxInputTokens = fragmentContextWindow.maxInputTokens;
+    }
+  }
+
+  if (Object.keys(nextContextWindow).length === 0) {
+    delete nextProfile.contextWindow;
+  } else {
+    nextProfile.contextWindow = nextContextWindow;
+  }
 }
 
 function replaceInferenceProfileConfig(
@@ -117,7 +146,14 @@ function replaceInferenceProfileConfig(
   for (const key of INFERENCE_PROFILE_UI_KEYS) {
     delete nextProfile[key];
   }
-  profiles[name] = { ...nextProfile, ...fragment };
+  const fragmentTopLevel = { ...fragment };
+  delete fragmentTopLevel.contextWindow;
+  profiles[name] = { ...nextProfile, ...fragmentTopLevel };
+  mergeInferenceProfileContextWindow(
+    existingProfile,
+    fragment,
+    profiles[name] as Record<string, unknown>,
+  );
 }
 
 function attachEstimatedCost(summary: LlmContextSummary): LlmContextSummary {

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfile.swift
@@ -163,7 +163,7 @@ public struct InferenceProfile: Hashable, Identifiable {
         self.profileDescription = (json["description"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.provider = (json["provider"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.model = (json["model"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-        self.maxTokens = json["maxTokens"] as? Int
+        self.maxTokens = Self.intValue(json["maxTokens"])
         self.effort = (json["effort"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.speed = (json["speed"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         self.verbosity = (json["verbosity"] as? String).flatMap { $0.isEmpty ? nil : $0 }
@@ -276,7 +276,11 @@ public struct InferenceProfile: Hashable, Identifiable {
         if let int = value as? Int {
             return int
         }
-        if let double = value as? Double, double.rounded() == double {
+        if let double = value as? Double,
+           double.isFinite,
+           double.rounded(.towardZero) == double,
+           double >= Double(Int.min),
+           double < Double(Int.max) {
             return Int(double)
         }
         return nil

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -52,7 +52,7 @@ struct InferenceProfileEditor: View {
     /// it as the default position without writing a profile override.
     static let defaultMaxOutputTokens: Int = 64_000
 
-    /// Keep the slider range positive to match the daemon schema.
+    /// Keep the editor range positive to match the daemon schema.
     static let minSliderMaxOutputTokens: Int = 1
     static let maxOutputTokensStep: Double = 1_000
 
@@ -61,8 +61,9 @@ struct InferenceProfileEditor: View {
     /// current default.
     static let defaultContextWindowTokens: Int = 200_000
 
-    /// Keep the slider range positive to match the daemon schema.
-    static let minSliderContextWindowTokens: Int = 1
+    /// Lowest context-window value offered by the UI. The daemon schema
+    /// remains independently positive; this only keeps slider snaps sane.
+    static let minSliderContextWindowTokens: Int = 50_000
     static let contextWindowTokensStep: Double = 50_000
 
     /// Tracks whether the user has manually edited the Key field. When
@@ -379,22 +380,46 @@ struct InferenceProfileEditor: View {
                     .foregroundStyle(VColor.contentTertiary)
             }
         ) {
-            VSlider(
-                value: Binding(
-                    get: { Double(Self.maxOutputSliderValue(maxTokens: profile.maxTokens, limit: limit)) },
-                    set: { newValue in
-                        guard let limit else { return }
-                        profile.maxTokens = Self.clampedMaxOutputTokens(Int(newValue.rounded()), limit: limit)
-                    }
-                ),
-                range: Double(Self.minSliderMaxOutputTokens)...Double(upperBound),
-                step: Self.maxOutputTokensStep,
-                showTickMarks: true
-            )
-            .disabled(limit == nil)
-            .help(limit == nil ? "Max output token metadata is unavailable for this model." : "Maximum tokens the model may generate in one response.")
-            .accessibilityLabel("Max output tokens")
-            .accessibilityValue(Self.formattedTokenCount(value))
+            HStack(spacing: VSpacing.sm) {
+                if let limit {
+                    VSlider(
+                        value: Binding(
+                            get: { Double(Self.maxOutputSliderValue(maxTokens: profile.maxTokens, limit: limit)) },
+                            set: { newValue in
+                                profile.maxTokens = Self.clampedMaxOutputTokens(Int(newValue.rounded()), limit: limit)
+                            }
+                        ),
+                        range: Double(Self.minSliderMaxOutputTokens)...Double(upperBound),
+                        step: Self.maxOutputTokensStep,
+                        showTickMarks: true
+                    )
+                    .help("Maximum tokens the model may generate in one response.")
+                    .accessibilityLabel("Max output tokens")
+                    .accessibilityValue(Self.formattedTokenCount(value))
+                } else {
+                    VTextField(
+                        placeholder: String(Self.defaultMaxOutputTokens),
+                        text: Binding(
+                            get: { profile.maxTokens.map(String.init) ?? "" },
+                            set: { newValue in
+                                profile.maxTokens = Self.manualMaxOutputTokensValue(newValue)
+                            }
+                        ),
+                        maxWidth: 160,
+                        size: .small
+                    )
+                    .help("Max output token metadata is unavailable for this model.")
+                    Spacer(minLength: 0)
+                }
+                VButton(
+                    label: "Inherit",
+                    style: .ghost,
+                    size: .compact,
+                    isDisabled: profile.maxTokens == nil
+                ) {
+                    profile = Self.clearingMaxOutputTokensOverride(profile)
+                }
+            }
         }
     }
 
@@ -595,6 +620,20 @@ struct InferenceProfileEditor: View {
         min(max(value, 1), limit)
     }
 
+    static func manualMaxOutputTokensValue(_ rawValue: String) -> Int? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let value = Int(trimmed) else {
+            return nil
+        }
+        return max(value, minSliderMaxOutputTokens)
+    }
+
+    static func clearingMaxOutputTokensOverride(_ profile: InferenceProfile) -> InferenceProfile {
+        var cleared = profile
+        cleared.maxTokens = nil
+        return cleared
+    }
+
     static func clampMaxOutputTokensForSelectedModel(_ profile: inout InferenceProfile) {
         guard
             let current = profile.maxTokens,
@@ -610,7 +649,10 @@ struct InferenceProfileEditor: View {
     }
 
     static func effectiveDefaultContextWindowTokens(model: LLMModelEntry?) -> Int {
-        let defaultTokens = max(model?.defaultContextWindowTokens ?? defaultContextWindowTokens, 1)
+        let defaultTokens = max(
+            model?.defaultContextWindowTokens ?? defaultContextWindowTokens,
+            minSliderContextWindowTokens
+        )
         guard let limit = model?.contextWindowTokens else {
             return defaultTokens
         }
@@ -618,7 +660,10 @@ struct InferenceProfileEditor: View {
     }
 
     static func contextWindowSliderValue(maxInputTokens: Int?, model: LLMModelEntry?) -> Int {
-        let value = max(maxInputTokens ?? effectiveDefaultContextWindowTokens(model: model), 1)
+        let value = max(
+            maxInputTokens ?? effectiveDefaultContextWindowTokens(model: model),
+            minSliderContextWindowTokens
+        )
         guard let limit = model?.contextWindowTokens else { return value }
         return clampedContextWindowTokens(value, limit: limit)
     }
@@ -628,7 +673,7 @@ struct InferenceProfileEditor: View {
     }
 
     static func clampedContextWindowTokens(_ value: Int, limit: Int) -> Int {
-        min(max(value, 1), limit)
+        min(max(value, minSliderContextWindowTokens), limit)
     }
 
     static func clampContextWindowForSelectedModel(_ profile: inout InferenceProfile) {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -270,7 +270,7 @@ final class InferenceProfileEditorTests: XCTestCase {
         )
     }
 
-    func testUnknownModelStillShowsDisabledMaxOutputControl() {
+    func testUnknownModelStillShowsMaxOutputControlWithoutCatalogLimit() {
         let visibility = InferenceProfileParameterVisibility.resolve(
             provider: "anthropic",
             model: "claude-vintage-1900",
@@ -283,6 +283,25 @@ final class InferenceProfileEditorTests: XCTestCase {
             provider: "anthropic",
             model: "claude-vintage-1900"
         ))
+    }
+
+    func testCatalogModelWithoutStaticOutputMetadataCanUseManualMaxTokens() {
+        let (editor, _) = makeEditor(profile: InferenceProfile(
+            name: "gemini-preview",
+            provider: "gemini",
+            model: "gemini-3.1-pro-preview",
+            maxTokens: 96_000
+        ))
+
+        XCTAssertTrue(editor.canSave)
+        XCTAssertNil(InferenceProfileEditor.maxOutputTokenLimit(
+            provider: "gemini",
+            model: "gemini-3.1-pro-preview"
+        ))
+        XCTAssertEqual(
+            InferenceProfileEditor.manualMaxOutputTokensValue("128000"),
+            128_000
+        )
     }
 
     func testOpenRouterReasoningModelsShowEffortAndThinking() {
@@ -436,6 +455,20 @@ final class InferenceProfileEditorTests: XCTestCase {
         XCTAssertEqual(profile.maxTokens, 64_000)
     }
 
+    func testMaxOutputOverrideCanBeClearedToInherit() {
+        var profile = InferenceProfile(
+            name: "manual-output",
+            provider: "gemini",
+            model: "gemini-3.1-pro-preview",
+            maxTokens: 96_000
+        )
+
+        profile = InferenceProfileEditor.clearingMaxOutputTokensOverride(profile)
+
+        XCTAssertNil(profile.maxTokens)
+        XCTAssertNil(profile.toJSON()["maxTokens"])
+    }
+
     func testGPT55ContextWindowSliderLimitIs1050K() {
         let limit = InferenceProfileEditor.contextWindowTokenLimit(
             provider: "openai",
@@ -497,6 +530,14 @@ final class InferenceProfileEditorTests: XCTestCase {
         XCTAssertEqual(
             InferenceProfileEditor.contextWindowSliderValue(maxInputTokens: nil, model: model),
             200_000
+        )
+    }
+
+    func testContextWindowSliderLowerBoundIsAlignedWithStep() {
+        XCTAssertEqual(InferenceProfileEditor.minSliderContextWindowTokens, 50_000)
+        XCTAssertEqual(
+            InferenceProfileEditor.clampedContextWindowTokens(1, limit: 1_000_000),
+            50_000
         )
     }
 

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileTests.swift
@@ -31,6 +31,37 @@ final class InferenceProfileTests: XCTestCase {
         XCTAssertNil(profile.thinkingStreamThinking)
     }
 
+    func testIntegerFieldsDecodeExactDoublesWithinIntBounds() {
+        let profile = InferenceProfile(
+            name: "numeric-json",
+            json: [
+                "maxTokens": 64000.0,
+                "contextWindow": [
+                    "maxInputTokens": 150000.0,
+                ],
+            ]
+        )
+
+        XCTAssertEqual(profile.maxTokens, 64000)
+        XCTAssertEqual(profile.contextWindowMaxInputTokens, 150000)
+    }
+
+    func testIntegerFieldsIgnoreUnsafeDoubleValues() {
+        let huge = Double.greatestFiniteMagnitude
+        let profile = InferenceProfile(
+            name: "unsafe-numbers",
+            json: [
+                "maxTokens": huge,
+                "contextWindow": [
+                    "maxInputTokens": 150000.5,
+                ],
+            ]
+        )
+
+        XCTAssertNil(profile.maxTokens)
+        XCTAssertNil(profile.contextWindowMaxInputTokens)
+    }
+
     // MARK: - Fully-populated fragment
 
     func testFullyPopulatedFragmentRoundTrips() {


### PR DESCRIPTION
## Summary
- Preserves non-UI context window leaves during profile saves.
- Fixes macOS slider fallback, inherit, and lower-bound edge cases.

Fixes gaps identified during dynamic-model-context self-review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
