### PR TITLE
fix: consolidate Velay bridge utilities

### DIFF
--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -1,5 +1,6 @@
+import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
-import { stripHopByHop } from "@vellumai/assistant-client";
+import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
 
 import type { VelayHeaders } from "./protocol.js";
 
@@ -21,6 +22,38 @@ export function isSafeOriginRelativePath(path: string): boolean {
 export function formatRawQuery(rawQuery: string | undefined): string {
   if (!rawQuery) return "";
   return `?${rawQuery.replace(/^\?/, "")}`;
+}
+
+export function buildLoopbackHttpUrl(
+  gatewayLoopbackBaseUrl: string,
+  path: string,
+  rawQuery?: string,
+): string | undefined {
+  if (!isSafeOriginRelativePath(path)) return undefined;
+  return buildUpstreamUrl(
+    gatewayLoopbackBaseUrl,
+    path,
+    formatRawQuery(rawQuery),
+  );
+}
+
+export function buildLoopbackWebSocketUrl(
+  gatewayLoopbackBaseUrl: string,
+  path: string,
+  rawQuery?: string,
+): string | undefined {
+  const httpUrl = buildLoopbackHttpUrl(gatewayLoopbackBaseUrl, path, rawQuery);
+  if (!httpUrl) return undefined;
+
+  try {
+    const url = new URL(httpUrl);
+    if (url.protocol === "http:") url.protocol = "ws:";
+    if (url.protocol === "https:") url.protocol = "wss:";
+    if (url.protocol !== "ws:" && url.protocol !== "wss:") return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
 }
 
 export function headersToWeb(headers: VelayHeaders): Headers {
@@ -63,6 +96,38 @@ export function isBase64(value: string): boolean {
   return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
     value,
   );
+}
+
+export function decodeBase64Bytes(value: string): Uint8Array | undefined {
+  if (!isBase64(value)) return undefined;
+  return new Uint8Array(Buffer.from(value, "base64"));
+}
+
+export function decodeOptionalBase64ArrayBuffer(
+  value: string | undefined,
+): { ok: true; value?: ArrayBuffer } | { ok: false } {
+  if (!value) return { ok: true };
+
+  const bytes = decodeBase64Bytes(value);
+  if (bytes === undefined) return { ok: false };
+  return { ok: true, value: bytesToArrayBuffer(bytes) };
+}
+
+export function encodeBase64(value: string | ArrayBuffer | Uint8Array): string {
+  if (typeof value === "string") return Buffer.from(value).toString("base64");
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(value).toString("base64");
+  }
+  return Buffer.from(value).toString("base64");
+}
+
+export async function binaryLikeToBytes(data: unknown): Promise<Uint8Array> {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  }
+  if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
+  return Buffer.from(String(data));
 }
 
 export function closeWebSocket(
@@ -141,4 +206,10 @@ function truncateCloseReason(reason: string): string {
     byteLength += characterLength;
   }
   return truncated;
+}
+
+function bytesToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer as ArrayBuffer;
 }

--- a/gateway/src/velay/http-bridge.ts
+++ b/gateway/src/velay/http-bridge.ts
@@ -1,13 +1,12 @@
-import { Buffer } from "node:buffer";
-import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
+import { stripHopByHop } from "@vellumai/assistant-client";
 
 import { fetchImpl } from "../fetch.js";
 import {
-  formatRawQuery,
+  buildLoopbackHttpUrl,
+  decodeOptionalBase64ArrayBuffer,
+  encodeBase64,
   headersFromVelay,
   headersToVelay,
-  isBase64,
-  isSafeOriginRelativePath,
 } from "./bridge-utils.js";
 import {
   VELAY_FRAME_TYPES,
@@ -21,10 +20,14 @@ export async function bridgeVelayHttpRequest(
   frame: VelayHttpRequestFrame,
   gatewayLoopbackBaseUrl: string,
 ): Promise<VelayHttpResponseFrame> {
-  const url = buildLoopbackUrl(gatewayLoopbackBaseUrl, frame);
+  const url = buildLoopbackHttpUrl(
+    gatewayLoopbackBaseUrl,
+    frame.path,
+    frame.raw_query,
+  );
   if (!url) return badGatewayFrame(frame.request_id);
 
-  const body = decodeBody(frame.body_base64);
+  const body = decodeOptionalBase64ArrayBuffer(frame.body_base64);
   if (!body.ok) return badGatewayFrame(frame.request_id);
 
   const request = buildLoopbackRequest(frame, url, body.value);
@@ -42,7 +45,7 @@ export async function bridgeVelayHttpRequest(
     request_id: frame.request_id,
     status_code: response.status,
     headers: headersToVelay(stripHopByHop(new Headers(response.headers))),
-    body_base64: Buffer.from(await response.arrayBuffer()).toString("base64"),
+    body_base64: encodeBase64(await response.arrayBuffer()),
   };
 }
 
@@ -69,41 +72,12 @@ function buildLoopbackRequest(
   }
 }
 
-function buildLoopbackUrl(
-  gatewayLoopbackBaseUrl: string,
-  frame: VelayHttpRequestFrame,
-): string | undefined {
-  if (!isSafeOriginRelativePath(frame.path)) return undefined;
-  return buildUpstreamUrl(
-    gatewayLoopbackBaseUrl,
-    frame.path,
-    formatRawQuery(frame.raw_query),
-  );
-}
-
-function decodeBody(
-  bodyBase64: string | undefined,
-): { ok: true; value?: ArrayBuffer } | { ok: false } {
-  if (!bodyBase64) return { ok: true };
-  if (!isBase64(bodyBase64)) {
-    return { ok: false };
-  }
-  const bytes = Buffer.from(bodyBase64, "base64");
-  return {
-    ok: true,
-    value: bytes.buffer.slice(
-      bytes.byteOffset,
-      bytes.byteOffset + bytes.byteLength,
-    ),
-  };
-}
-
 function badGatewayFrame(requestId: string): VelayHttpResponseFrame {
   return {
     type: VELAY_FRAME_TYPES.httpResponse,
     request_id: requestId,
     status_code: 502,
     headers: { "content-type": ["application/json"] },
-    body_base64: Buffer.from(BAD_GATEWAY_BODY).toString("base64"),
+    body_base64: encodeBase64(BAD_GATEWAY_BODY),
   };
 }

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -1,12 +1,11 @@
-import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
-import { buildUpstreamUrl } from "@vellumai/assistant-client";
 
 import {
+  binaryLikeToBytes,
+  buildLoopbackWebSocketUrl,
   closeWebSocket,
-  formatRawQuery,
-  isBase64,
-  isSafeOriginRelativePath,
+  decodeBase64Bytes,
+  encodeBase64,
   websocketHeadersFromVelay,
 } from "./bridge-utils.js";
 import {
@@ -70,7 +69,11 @@ export class VelayWebSocketBridge {
   open(frame: VelayWebSocketOpenFrame): void {
     this.closeExisting(frame.connection_id);
 
-    const url = buildLoopbackWebSocketUrl(this.gatewayLoopbackBaseUrl, frame);
+    const url = buildLoopbackWebSocketUrl(
+      this.gatewayLoopbackBaseUrl,
+      frame.path,
+      frame.raw_query,
+    );
     if (!url) {
       this.sendOpenError(frame.connection_id, "Invalid WebSocket path");
       return;
@@ -283,40 +286,17 @@ export class VelayWebSocketBridge {
   }
 }
 
-function buildLoopbackWebSocketUrl(
-  gatewayLoopbackBaseUrl: string,
-  frame: VelayWebSocketOpenFrame,
-): string | undefined {
-  if (!isSafeOriginRelativePath(frame.path)) return undefined;
-
-  const httpUrl = buildUpstreamUrl(
-    gatewayLoopbackBaseUrl,
-    frame.path,
-    formatRawQuery(frame.raw_query),
-  );
-
-  try {
-    const url = new URL(httpUrl);
-    if (url.protocol === "http:") url.protocol = "ws:";
-    if (url.protocol === "https:") url.protocol = "wss:";
-    if (url.protocol !== "ws:" && url.protocol !== "wss:") return undefined;
-    return url.toString();
-  } catch {
-    return undefined;
-  }
-}
-
 function decodeVelayMessage(
   frame: VelayWebSocketMessageFrame,
 ): PendingMessage | undefined {
-  if (!isBase64(frame.body_base64 ?? "")) return undefined;
+  const bytes = decodeBase64Bytes(frame.body_base64 ?? "");
+  if (bytes === undefined) return undefined;
 
-  const bytes = Buffer.from(frame.body_base64 ?? "", "base64");
   if (frame.message_type === VELAY_WEBSOCKET_MESSAGE_TYPES.text) {
-    return bytes.toString("utf8");
+    return new TextDecoder().decode(bytes);
   }
   if (frame.message_type === VELAY_WEBSOCKET_MESSAGE_TYPES.binary) {
-    return new Uint8Array(bytes);
+    return bytes;
   }
   return undefined;
 }
@@ -330,7 +310,7 @@ async function encodeLocalMessage(
       type: VELAY_FRAME_TYPES.websocketMessage,
       connection_id: connectionId,
       message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
-      body_base64: Buffer.from(data).toString("base64"),
+      body_base64: encodeBase64(data),
     };
   }
 
@@ -338,15 +318,6 @@ async function encodeLocalMessage(
     type: VELAY_FRAME_TYPES.websocketMessage,
     connection_id: connectionId,
     message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.binary,
-    body_base64: Buffer.from(await binaryToBytes(data)).toString("base64"),
+    body_base64: encodeBase64(await binaryLikeToBytes(data)),
   };
-}
-
-async function binaryToBytes(data: unknown): Promise<Uint8Array> {
-  if (data instanceof ArrayBuffer) return new Uint8Array(data);
-  if (ArrayBuffer.isView(data)) {
-    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-  }
-  if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
-  return Buffer.from(String(data));
 }


### PR DESCRIPTION
## Summary
- Consolidates shared Velay bridge URL and base64 helpers.
- Keeps HTTP and WebSocket bridge behavior unchanged while reducing drift.

Fixes gap identified during plan review for velay-twilio-ingress.md.

**Gap:** Consolidate Velay bridge frame plumbing
**What was expected:** HTTP and WebSocket Velay bridges share common path/query/loopback/base64 helpers.
**What was found:** Both bridges duplicated the same frame plumbing independently.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
