### PR TITLE
fix: repair Twilio ingress lifecycle semantics

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -326,6 +326,27 @@ describe("ChannelReadinessService", () => {
     });
   });
 
+  test("phone readiness falls back to generic ingress when Twilio-specific ingress is whitespace", async () => {
+    mockHasTwilioCredentials = true;
+    mockTwilioPhoneNumber = "+15550123";
+    mockRawConfig = {
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.com",
+        twilioPublicBaseUrl: "   ",
+      },
+    };
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("phone");
+
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.localChecks).toContainEqual({
+      name: "ingress",
+      passed: true,
+      message: "Twilio public ingress URL is configured",
+    });
+  });
+
   test("telegram readiness still requires generic public ingress", async () => {
     mockSecureKeys[credentialKey("telegram", "bot_token")] = "123:abc";
     mockSecureKeys[credentialKey("telegram", "webhook_secret")] = "secret";

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -27,6 +27,8 @@
  * All public-facing ingress URL construction is centralized here.
  */
 
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/twilio-ingress";
+
 import { getIngressPublicBaseUrl } from "../config/env.js";
 
 export interface IngressConfig {
@@ -35,13 +37,6 @@ export interface IngressConfig {
     publicBaseUrl?: string;
     twilioPublicBaseUrl?: string;
   };
-}
-
-/**
- * Trim whitespace and strip trailing slashes from a URL string.
- */
-function normalizeUrl(url: string): string {
-  return url.trim().replace(/\/+$/, "");
 }
 
 function assertPublicIngressEnabled(config: IngressConfig): void {
@@ -66,16 +61,12 @@ export function getPublicBaseUrl(config: IngressConfig): string {
   assertPublicIngressEnabled(config);
 
   const ingressValue = config.ingress?.publicBaseUrl;
-  if (ingressValue) {
-    const normalized = normalizeUrl(ingressValue);
-    if (normalized) return normalized;
-  }
+  const normalizedIngressValue = normalizePublicBaseUrl(ingressValue);
+  if (normalizedIngressValue) return normalizedIngressValue;
 
   const ingressEnvValue = getIngressPublicBaseUrl();
-  if (ingressEnvValue) {
-    const normalized = normalizeUrl(ingressEnvValue);
-    if (normalized) return normalized;
-  }
+  const normalizedIngressEnvValue = normalizePublicBaseUrl(ingressEnvValue);
+  if (normalizedIngressEnvValue) return normalizedIngressEnvValue;
 
   throw new Error(
     "No public base URL configured. Set ingress.publicBaseUrl in config.",
@@ -86,10 +77,8 @@ export function getTwilioPublicBaseUrl(config: IngressConfig): string {
   assertPublicIngressEnabled(config);
 
   const ingressValue = config.ingress?.twilioPublicBaseUrl;
-  if (ingressValue) {
-    const normalized = normalizeUrl(ingressValue);
-    if (normalized) return normalized;
-  }
+  const normalizedIngressValue = normalizePublicBaseUrl(ingressValue);
+  if (normalizedIngressValue) return normalizedIngressValue;
 
   try {
     return getPublicBaseUrl(config);

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,3 +1,5 @@
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/twilio-ingress";
+
 import { resolveTwilioPhoneNumber } from "../calls/twilio-config.js";
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
 import { getChannelInvitePolicy } from "../channels/config.js";
@@ -23,8 +25,9 @@ function hasIngressConfigured(options: { twilio?: boolean } = {}): boolean {
   try {
     const raw = loadRawConfig();
     const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
-    const publicBaseUrl = (ingress.publicBaseUrl as string) ?? "";
-    const twilioPublicBaseUrl = (ingress.twilioPublicBaseUrl as string) ?? "";
+    const publicBaseUrl = normalizePublicBaseUrl(ingress.publicBaseUrl) ?? "";
+    const twilioPublicBaseUrl =
+      normalizePublicBaseUrl(ingress.twilioPublicBaseUrl) ?? "";
     const effectiveBaseUrl = options.twilio
       ? twilioPublicBaseUrl || publicBaseUrl
       : publicBaseUrl;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,6 +1,12 @@
 process.title = "vellum-gateway";
 
 import { randomBytes } from "node:crypto";
+
+import {
+  TWILIO_PUBLIC_BASE_URL_FIELD,
+  TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
+} from "@vellumai/service-contracts/twilio-ingress";
+
 import { AuthRateLimiter } from "./auth-rate-limiter.js";
 import {
   loadOrCreateSigningKey,
@@ -212,8 +218,8 @@ function isOnlyVelayTwilioIngressChange(event: ConfigChangeEvent): boolean {
 
   return [...ingressFields].every(
     (field) =>
-      field === "twilioPublicBaseUrl" ||
-      field === "twilioPublicBaseUrlManagedBy",
+      field === TWILIO_PUBLIC_BASE_URL_FIELD ||
+      field === TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
   );
 }
 

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -1,3 +1,5 @@
+import { TWILIO_PUBLIC_BASE_URL_FIELD } from "@vellumai/service-contracts/twilio-ingress";
+
 import type { CredentialCache } from "../credential-cache.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { GatewayConfig } from "../config.js";
@@ -184,7 +186,10 @@ function readConfiguredIngressUrls(
 
   return {
     ingressUrl: configFile.getString("ingress", "publicBaseUrl"),
-    twilioIngressUrl: configFile.getString("ingress", "twilioPublicBaseUrl"),
+    twilioIngressUrl: configFile.getString(
+      "ingress",
+      TWILIO_PUBLIC_BASE_URL_FIELD,
+    ),
   };
 }
 

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -510,12 +510,13 @@ describe("VelayTunnelClient", () => {
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
         twilioPublicBaseUrl: "https://velay-public-2.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
       },
     });
-    expect(invalidations.count).toBe(2);
+    expect(invalidations.count).toBe(1);
   });
 
-  test("clears stale Velay marker on startup before connecting", async () => {
+  test("clears stale Velay-managed Twilio public URL on startup before connecting", async () => {
     const sockets: FakeWebSocket[] = [];
     const invalidations = { count: 0 };
     writeConfig({
@@ -537,14 +538,13 @@ describe("VelayTunnelClient", () => {
     expect(readConfig()).toEqual({
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
-        twilioPublicBaseUrl: "https://stale-velay.example.test",
       },
     });
     expect(invalidations.count).toBe(1);
     await client.stop();
   });
 
-  test("disabled Velay cleanup clears stale marker and preserves Twilio URL", async () => {
+  test("disabled Velay cleanup clears stale managed URL and preserves manual Twilio URL", async () => {
     const invalidations = { count: 0 };
     writeConfig({
       ingress: {
@@ -565,7 +565,6 @@ describe("VelayTunnelClient", () => {
     expect(readConfig()).toEqual({
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
-        twilioPublicBaseUrl: "https://stale-velay.example.test",
       },
     });
     expect(invalidations.count).toBe(1);

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -1,6 +1,12 @@
 import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
 
+import {
+  TWILIO_PUBLIC_BASE_URL_FIELD,
+  TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
+  VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER,
+} from "@vellumai/service-contracts/twilio-ingress";
+
 import type { GatewayConfig } from "../config.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
@@ -28,7 +34,6 @@ const log = getLogger("velay-client");
 const BASE_RECONNECT_DELAY_MS = 500;
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const RECONNECT_JITTER_RATIO = 0.5;
-const VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER = "velay";
 const VELAY_POLICY_CLOSE_CODE = 4008;
 
 export type WebSocketConstructorWithOptions = {
@@ -127,7 +132,7 @@ export class VelayTunnelClient {
   }
 
   private async startAsync(): Promise<void> {
-    await clearStaleVelayTwilioPublicBaseUrlMarker(this.options.configFile);
+    await clearManagedTwilioPublicBaseUrl(this.options.configFile);
     await this.connect();
   }
 
@@ -382,14 +387,9 @@ export function createVelayTunnelClient(
   },
 ): VelayTunnelClient | undefined {
   if (!config.velayBaseUrl) {
-    void clearStaleVelayTwilioPublicBaseUrlMarker(deps.configFile).catch(
-      (err) => {
-        log.error(
-          { err },
-          "Failed to clear disabled Velay Twilio public URL marker",
-        );
-      },
-    );
+    void clearManagedTwilioPublicBaseUrl(deps.configFile).catch((err) => {
+      log.error({ err }, "Failed to clear disabled Velay Twilio public URL");
+    });
     return undefined;
   }
   return new VelayTunnelClient({
@@ -452,46 +452,16 @@ async function writeManagedTwilioPublicBaseUrl(
     (data) => {
       const ingress = getMutableIngress(data);
       if (
-        ingress.twilioPublicBaseUrl === publicUrl &&
-        ingress.twilioPublicBaseUrlManagedBy ===
+        ingress[TWILIO_PUBLIC_BASE_URL_FIELD] === publicUrl &&
+        ingress[TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD] ===
           VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER
       ) {
         return false;
       }
 
-      ingress.twilioPublicBaseUrl = publicUrl;
-      ingress.twilioPublicBaseUrlManagedBy =
+      ingress[TWILIO_PUBLIC_BASE_URL_FIELD] = publicUrl;
+      ingress[TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD] =
         VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER;
-      data.ingress = ingress;
-      return true;
-    },
-  );
-}
-
-async function clearStaleVelayTwilioPublicBaseUrlMarker(
-  configFile: ConfigFileCache,
-): Promise<void> {
-  return mutateConfigFile(
-    configFile,
-    "Cannot clear Velay public URL marker because config.json is malformed",
-    (data) => {
-      if (
-        !data.ingress ||
-        typeof data.ingress !== "object" ||
-        Array.isArray(data.ingress)
-      ) {
-        return false;
-      }
-
-      const ingress = { ...(data.ingress as Record<string, unknown>) };
-      if (
-        ingress.twilioPublicBaseUrlManagedBy !==
-        VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER
-      ) {
-        return false;
-      }
-
-      delete ingress.twilioPublicBaseUrlManagedBy;
       data.ingress = ingress;
       return true;
     },
@@ -516,22 +486,20 @@ async function clearManagedTwilioPublicBaseUrl(
 
       const ingress = { ...(data.ingress as Record<string, unknown>) };
       if (
-        ingress.twilioPublicBaseUrlManagedBy !==
+        ingress[TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD] !==
         VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER
       ) {
         return false;
       }
       if (
         expectedPublicUrl !== undefined &&
-        ingress.twilioPublicBaseUrl !== expectedPublicUrl
+        ingress[TWILIO_PUBLIC_BASE_URL_FIELD] !== expectedPublicUrl
       ) {
-        delete ingress.twilioPublicBaseUrlManagedBy;
-        data.ingress = ingress;
-        return true;
+        return false;
       }
 
-      delete ingress.twilioPublicBaseUrl;
-      delete ingress.twilioPublicBaseUrlManagedBy;
+      delete ingress[TWILIO_PUBLIC_BASE_URL_FIELD];
+      delete ingress[TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD];
       data.ingress = ingress;
       return true;
     },

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
+    "./twilio-ingress": "./src/twilio-ingress.ts",
     "./trust-rules": "./src/trust-rules.ts",
     "./handles": "./src/handles.ts",
     "./grants": "./src/grants.ts",

--- a/packages/service-contracts/src/__tests__/contracts.test.ts
+++ b/packages/service-contracts/src/__tests__/contracts.test.ts
@@ -33,6 +33,7 @@ describe("package independence", () => {
     "../transport.ts",
     "../credential-rpc.ts",
     "../trust-rules.ts",
+    "../twilio-ingress.ts",
     "../error.ts",
   ];
 
@@ -219,6 +220,7 @@ describe("ToolResponseBaseSchema", () => {
       result: { html: "<html></html>" },
     });
     expect(result.success).toBe(true);
+    if (!result.success) throw new Error("Expected successful response");
     expect(result.result).toEqual({ html: "<html></html>" });
   });
 
@@ -238,6 +240,7 @@ describe("ToolResponseBaseSchema", () => {
       },
     });
     expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected failed response");
     expect(result.error.code).toBe("TOOL_FAILED");
   });
 

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -6,9 +6,10 @@
  *
  *   - `@vellumai/service-contracts/credential-rpc`  — transport, RPC, handles, grants, rendering, error
  *   - `@vellumai/service-contracts/trust-rules`     — trust-rule types and parsing helpers
+ *   - `@vellumai/service-contracts/twilio-ingress`  — shared Twilio ingress config constants
  *
  * Fine-grained subpaths are also available for low-friction migration:
- *   `./rpc`, `./handles`, `./grants`, `./rendering`, `./error`, `./trust-rules`
+ *   `./rpc`, `./handles`, `./grants`, `./rendering`, `./error`, `./trust-rules`, `./twilio-ingress`
  *
  * Neutral wire-protocol contracts for communication between the assistant
  * daemon and the Credential Execution Service (CES). This package is
@@ -23,3 +24,4 @@ export * from "./grants.js";
 export * from "./rpc.js";
 export * from "./rendering.js";
 export * from "./trust-rules.js";
+export * from "./twilio-ingress.js";

--- a/packages/service-contracts/src/twilio-ingress.ts
+++ b/packages/service-contracts/src/twilio-ingress.ts
@@ -1,0 +1,10 @@
+export const TWILIO_PUBLIC_BASE_URL_FIELD = "twilioPublicBaseUrl";
+export const TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD =
+  "twilioPublicBaseUrlManagedBy";
+export const VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER = "velay";
+
+export function normalizePublicBaseUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().replace(/\/+$/, "");
+  return normalized.length > 0 ? normalized : undefined;
+}


### PR DESCRIPTION
## Summary
- Clears stale Velay-managed Twilio ingress when Velay is disabled or startup cleanup runs.
- Preserves ownership on newer managed URLs and fixes voice readiness fallback for whitespace Twilio URLs.

Fixes gaps identified during plan review for velay-twilio-ingress.md.

**Gap:** Twilio ingress lifecycle and fallback semantics
**What was expected:** Velay-managed Twilio ingress is cleared when disabled/stale, newer managed URLs retain ownership, and readiness treats whitespace Twilio URLs as empty.
**What was found:** Marker-only cleanup left stale URLs active, mismatch cleanup stripped ownership, and readiness chose fallback before trimming.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
