### PR TITLE
fix: sync Twilio webhooks for Velay ingress

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -150,6 +150,7 @@ import { fetchImpl } from "./fetch.js";
 import { isNewCommand, handleNewCommand } from "./webhook-pipeline.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 import { registerEmailCallbackRoute } from "./email/register-callback.js";
+import { syncConfiguredTwilioPhoneNumberWebhooks } from "./twilio/webhook-sync.js";
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import {
@@ -1966,6 +1967,7 @@ async function main() {
 
     // Side effect: reconcile Telegram webhook when ingress URL changes
     const onlyVelayTwilioIngressChanged = isOnlyVelayTwilioIngressChange(event);
+    const ingressFields = event.changedFields.get("ingress");
 
     if (
       event.changedKeys.has("ingress") &&
@@ -1976,6 +1978,21 @@ async function main() {
         log.error(
           { err },
           "Failed to reconcile Telegram webhook after ingress URL change",
+        );
+      });
+    }
+
+    if (
+      onlyVelayTwilioIngressChanged &&
+      ingressFields?.has(TWILIO_PUBLIC_BASE_URL_FIELD)
+    ) {
+      syncConfiguredTwilioPhoneNumberWebhooks({
+        credentials: credentialCache,
+        configFile: configFileCache,
+      }).catch((err) => {
+        log.warn(
+          { err },
+          "Twilio webhook sync failed after Velay ingress URL change",
         );
       });
     }

--- a/gateway/src/twilio/webhook-sync.test.ts
+++ b/gateway/src/twilio/webhook-sync.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { ConfigFileCache } from "../config-file-cache.js";
+import type { CredentialCache } from "../credential-cache.js";
+import { credentialKey } from "../credential-key.js";
+import {
+  getMockFetchCalls,
+  mockFetch,
+  resetMockFetch,
+} from "../__tests__/mock-fetch.js";
+import { syncConfiguredTwilioPhoneNumberWebhooks } from "./webhook-sync.js";
+
+const ACCOUNT_SID = "AC123";
+const AUTH_TOKEN = "auth-token";
+const PHONE_NUMBER = "+15550100";
+const PHONE_NUMBER_SID = "PN123";
+
+afterEach(() => {
+  resetMockFetch();
+});
+
+function makeCaches(opts: {
+  phoneNumber?: string;
+  accountSid?: string;
+  authToken?: string;
+  publicBaseUrl?: string;
+  twilioPublicBaseUrl?: string;
+}): { credentials: CredentialCache; configFile: ConfigFileCache } {
+  const credentialValues = new Map<string, string | undefined>([
+    [credentialKey("twilio", "auth_token"), opts.authToken],
+  ]);
+  const configValues: Record<string, Record<string, string | undefined>> = {
+    twilio: {
+      phoneNumber: opts.phoneNumber,
+      accountSid: opts.accountSid,
+    },
+    ingress: {
+      publicBaseUrl: opts.publicBaseUrl,
+      twilioPublicBaseUrl: opts.twilioPublicBaseUrl,
+    },
+  };
+
+  return {
+    credentials: {
+      get: async (key: string) => credentialValues.get(key),
+      invalidate: () => {},
+    } as unknown as CredentialCache,
+    configFile: {
+      getString: (section: string, key: string) =>
+        configValues[section]?.[key] ?? undefined,
+      invalidate: () => {},
+    } as unknown as ConfigFileCache,
+  };
+}
+
+function mockTwilioLookupAndUpdate(): void {
+  mockFetch(
+    `/Accounts/${ACCOUNT_SID}/IncomingPhoneNumbers.json?PhoneNumber=${encodeURIComponent(
+      PHONE_NUMBER,
+    )}`,
+    { method: "GET" },
+    {
+      status: 200,
+      body: {
+        incoming_phone_numbers: [
+          { sid: PHONE_NUMBER_SID, phone_number: PHONE_NUMBER },
+        ],
+      },
+    },
+  );
+  mockFetch(
+    `/Accounts/${ACCOUNT_SID}/IncomingPhoneNumbers/${PHONE_NUMBER_SID}.json`,
+    { method: "POST" },
+    { status: 200, body: {} },
+  );
+}
+
+describe("syncConfiguredTwilioPhoneNumberWebhooks", () => {
+  test("syncs phone webhooks to twilioPublicBaseUrl when configured", async () => {
+    mockTwilioLookupAndUpdate();
+
+    await syncConfiguredTwilioPhoneNumberWebhooks(
+      makeCaches({
+        phoneNumber: PHONE_NUMBER,
+        accountSid: ACCOUNT_SID,
+        authToken: AUTH_TOKEN,
+        publicBaseUrl: "https://generic.example.test",
+        twilioPublicBaseUrl: " https://velay.example.test/twilio/ ",
+      }),
+    );
+
+    const calls = getMockFetchCalls();
+    expect(calls).toHaveLength(2);
+    const body = new URLSearchParams(String(calls[1].init.body));
+    expect(body.get("VoiceUrl")).toBe(
+      "https://velay.example.test/twilio/webhooks/twilio/voice",
+    );
+    expect(body.get("VoiceMethod")).toBe("POST");
+    expect(body.get("StatusCallback")).toBe(
+      "https://velay.example.test/twilio/webhooks/twilio/status",
+    );
+    expect(body.get("StatusCallbackMethod")).toBe("POST");
+    expect(calls[1].init.headers).toEqual({
+      Authorization:
+        "Basic " +
+        Buffer.from(`${ACCOUNT_SID}:${AUTH_TOKEN}`).toString("base64"),
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+  });
+
+  test("falls back to generic publicBaseUrl when Twilio-specific URL is cleared", async () => {
+    mockTwilioLookupAndUpdate();
+
+    await syncConfiguredTwilioPhoneNumberWebhooks(
+      makeCaches({
+        phoneNumber: PHONE_NUMBER,
+        accountSid: ACCOUNT_SID,
+        authToken: AUTH_TOKEN,
+        publicBaseUrl: "https://generic.example.test/",
+        twilioPublicBaseUrl: " ",
+      }),
+    );
+
+    const calls = getMockFetchCalls();
+    expect(calls).toHaveLength(2);
+    const body = new URLSearchParams(String(calls[1].init.body));
+    expect(body.get("VoiceUrl")).toBe(
+      "https://generic.example.test/webhooks/twilio/voice",
+    );
+    expect(body.get("StatusCallback")).toBe(
+      "https://generic.example.test/webhooks/twilio/status",
+    );
+  });
+
+  test("skips without Twilio REST calls when required inputs are missing", async () => {
+    await syncConfiguredTwilioPhoneNumberWebhooks(
+      makeCaches({
+        phoneNumber: PHONE_NUMBER,
+        accountSid: ACCOUNT_SID,
+        authToken: undefined,
+        publicBaseUrl: "https://generic.example.test",
+      }),
+    );
+
+    expect(getMockFetchCalls()).toEqual([]);
+  });
+
+  test("does not throw when Twilio lookup fails", async () => {
+    mockFetch(
+      `/Accounts/${ACCOUNT_SID}/IncomingPhoneNumbers.json?PhoneNumber=${encodeURIComponent(
+        PHONE_NUMBER,
+      )}`,
+      { method: "GET" },
+      { status: 500, body: { error: "unavailable" } },
+    );
+
+    await expect(
+      syncConfiguredTwilioPhoneNumberWebhooks(
+        makeCaches({
+          phoneNumber: PHONE_NUMBER,
+          accountSid: ACCOUNT_SID,
+          authToken: AUTH_TOKEN,
+          publicBaseUrl: "https://generic.example.test",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(getMockFetchCalls()).toHaveLength(1);
+  });
+});

--- a/gateway/src/twilio/webhook-sync.ts
+++ b/gateway/src/twilio/webhook-sync.ts
@@ -1,0 +1,191 @@
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/twilio-ingress";
+
+import type { ConfigFileCache } from "../config-file-cache.js";
+import type { CredentialCache } from "../credential-cache.js";
+import { credentialKey } from "../credential-key.js";
+import { fetchImpl } from "../fetch.js";
+import { getLogger } from "../logger.js";
+
+const log = getLogger("twilio-webhook-sync");
+
+const TWILIO_VOICE_PATH = "/webhooks/twilio/voice";
+const TWILIO_STATUS_PATH = "/webhooks/twilio/status";
+
+export type TwilioWebhookSyncCaches = {
+  credentials: CredentialCache;
+  configFile: ConfigFileCache;
+};
+
+function twilioAuthHeader(accountSid: string, authToken: string): string {
+  return (
+    "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64")
+  );
+}
+
+function twilioBaseUrl(accountSid: string): string {
+  return `https://api.twilio.com/2010-04-01/Accounts/${accountSid}`;
+}
+
+function buildWebhookUrls(baseUrl: string): {
+  voiceUrl: string;
+  statusCallbackUrl: string;
+} {
+  return {
+    voiceUrl: `${baseUrl}${TWILIO_VOICE_PATH}`,
+    statusCallbackUrl: `${baseUrl}${TWILIO_STATUS_PATH}`,
+  };
+}
+
+function resolveEffectiveTwilioBaseUrl(
+  configFile: ConfigFileCache,
+): string | undefined {
+  const twilioBaseUrl = normalizePublicBaseUrl(
+    configFile.getString("ingress", "twilioPublicBaseUrl"),
+  );
+  if (twilioBaseUrl) return twilioBaseUrl;
+
+  return normalizePublicBaseUrl(
+    configFile.getString("ingress", "publicBaseUrl"),
+  );
+}
+
+async function lookupIncomingPhoneNumberSid(
+  accountSid: string,
+  authToken: string,
+  phoneNumber: string,
+): Promise<string | undefined> {
+  const response = await fetchImpl(
+    `${twilioBaseUrl(
+      accountSid,
+    )}/IncomingPhoneNumbers.json?PhoneNumber=${encodeURIComponent(
+      phoneNumber,
+    )}`,
+    {
+      method: "GET",
+      headers: { Authorization: twilioAuthHeader(accountSid, authToken) },
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    log.warn(
+      { status: response.status, detail },
+      "Twilio phone number lookup failed during webhook sync",
+    );
+    return undefined;
+  }
+
+  const data = (await response.json().catch(() => undefined)) as
+    | {
+        incoming_phone_numbers?: Array<{
+          sid?: string;
+          phone_number?: string;
+        }>;
+      }
+    | undefined;
+
+  const match = data?.incoming_phone_numbers?.find(
+    (number) => number.phone_number === phoneNumber && number.sid,
+  );
+  return match?.sid;
+}
+
+async function updateIncomingPhoneNumberWebhooks(
+  accountSid: string,
+  authToken: string,
+  phoneNumberSid: string,
+  urls: { voiceUrl: string; statusCallbackUrl: string },
+): Promise<boolean> {
+  const body = new URLSearchParams({
+    VoiceUrl: urls.voiceUrl,
+    VoiceMethod: "POST",
+    StatusCallback: urls.statusCallbackUrl,
+    StatusCallbackMethod: "POST",
+  });
+
+  const response = await fetchImpl(
+    `${twilioBaseUrl(accountSid)}/IncomingPhoneNumbers/${phoneNumberSid}.json`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: twilioAuthHeader(accountSid, authToken),
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body,
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+
+  if (response.ok) return true;
+
+  const detail = await response.text().catch(() => "");
+  log.warn(
+    { status: response.status, detail },
+    "Twilio phone number webhook update failed",
+  );
+  return false;
+}
+
+export async function syncConfiguredTwilioPhoneNumberWebhooks(
+  caches: TwilioWebhookSyncCaches,
+): Promise<void> {
+  try {
+    const phoneNumber = caches.configFile
+      .getString("twilio", "phoneNumber")
+      ?.trim();
+    const accountSid = caches.configFile
+      .getString("twilio", "accountSid")
+      ?.trim();
+    const authToken = (
+      await caches.credentials.get(credentialKey("twilio", "auth_token"))
+    )?.trim();
+    const baseUrl = resolveEffectiveTwilioBaseUrl(caches.configFile);
+
+    if (!phoneNumber || !accountSid || !authToken || !baseUrl) {
+      log.debug(
+        {
+          hasPhoneNumber: !!phoneNumber,
+          hasAccountSid: !!accountSid,
+          hasAuthToken: !!authToken,
+          hasBaseUrl: !!baseUrl,
+        },
+        "Skipping Twilio webhook sync because configuration is incomplete",
+      );
+      return;
+    }
+
+    const phoneNumberSid = await lookupIncomingPhoneNumberSid(
+      accountSid,
+      authToken,
+      phoneNumber,
+    );
+    if (!phoneNumberSid) {
+      log.warn(
+        { phoneNumber },
+        "Skipping Twilio webhook sync because configured phone number was not found",
+      );
+      return;
+    }
+
+    const urls = buildWebhookUrls(baseUrl);
+    const updated = await updateIncomingPhoneNumberWebhooks(
+      accountSid,
+      authToken,
+      phoneNumberSid,
+      urls,
+    );
+    if (!updated) return;
+
+    log.info(
+      {
+        phoneNumber,
+        voiceUrl: urls.voiceUrl,
+        statusCallbackUrl: urls.statusCallbackUrl,
+      },
+      "Synced Twilio phone number webhooks",
+    );
+  } catch (err) {
+    log.warn({ err }, "Twilio webhook sync skipped after non-fatal error");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds best-effort gateway Twilio webhook sync when Velay-managed Twilio ingress changes.
- Keeps Telegram/email side effects skipped for Twilio-only Velay config writes.

Fixes integration gap identified during plan review for velay-twilio-ingress.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
