### PR TITLE
fix: tidy Velay protocol and ingress helpers

### DIFF
--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -27,7 +27,7 @@
  * All public-facing ingress URL construction is centralized here.
  */
 
-import { normalizePublicBaseUrl } from "@vellumai/service-contracts/twilio-ingress";
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/ingress";
 
 import { getIngressPublicBaseUrl } from "../config/env.js";
 

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,4 +1,4 @@
-import { normalizePublicBaseUrl } from "@vellumai/service-contracts/twilio-ingress";
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/ingress";
 
 import { resolveTwilioPhoneNumber } from "../calls/twilio-config.js";
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -14,6 +14,10 @@ import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
 import {
+  FakeWebSocket,
+  makeFakeWebSocketConstructor,
+} from "./test-fake-websocket.js";
+import {
   VELAY_FRAME_TYPES,
   VELAY_TUNNEL_SUBPROTOCOL,
   VELAY_WEBSOCKET_MESSAGE_TYPES,
@@ -33,66 +37,8 @@ mock.module("../credential-reader.js", () => ({
 const { VelayTunnelClient, createVelayTunnelClient } =
   await import("./client.js");
 
-const WS_CONNECTING = WebSocket.CONNECTING;
 const WS_OPEN = WebSocket.OPEN;
 const WS_CLOSED = WebSocket.CLOSED;
-
-type Listener = (event?: unknown) => void;
-
-class FakeWebSocket {
-  binaryType: BinaryType = "blob";
-  readyState: number = WS_CONNECTING;
-  sent: string[] = [];
-  closes: { code?: number; reason?: string }[] = [];
-  private readonly listeners = new Map<string, Listener[]>();
-
-  constructor(
-    readonly url: string,
-    readonly options: unknown,
-  ) {}
-
-  addEventListener(type: string, listener: Listener): void {
-    const listeners = this.listeners.get(type) ?? [];
-    listeners.push(listener);
-    this.listeners.set(type, listeners);
-  }
-
-  send(message: string): void {
-    this.sent.push(message);
-  }
-
-  close(code?: number, reason?: string): void {
-    if (
-      code !== undefined &&
-      code !== 1000 &&
-      (!Number.isInteger(code) || code < 3000 || code > 4999)
-    ) {
-      throw new Error("invalid close code");
-    }
-    this.readyState = WS_CLOSED;
-    this.closes.push({ code, reason });
-  }
-
-  emit(type: string, event: unknown = {}): void {
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
-    }
-  }
-}
-
-function makeWebSocketConstructor(created: FakeWebSocket[]) {
-  return function FakeWebSocketConstructor(
-    this: unknown,
-    url: string,
-    options: unknown,
-  ) {
-    const ws = new FakeWebSocket(url, options);
-    created.push(ws);
-    return ws;
-  } as unknown as {
-    new (url: string | URL, options?: unknown): WebSocket;
-  };
-}
 
 function makeCredentials(values: Record<string, string | undefined>) {
   return {
@@ -183,7 +129,7 @@ function makeClient(
         [credentialKey("vellum", "platform_assistant_id")]: "asst-123",
       }),
     configFile: overrides.configFile ?? makeConfigFileCache({ count: 0 }),
-    webSocketConstructor: makeWebSocketConstructor(sockets),
+    webSocketConstructor: makeFakeWebSocketConstructor(sockets),
     httpBridge: overrides.httpBridge,
     webSocketBridgeFactory:
       overrides.websocketFrames === undefined
@@ -472,7 +418,7 @@ describe("VelayTunnelClient", () => {
     expect(reconnectDelays).toEqual([10]);
   });
 
-  test("does not clear a newer Twilio public URL on stale tunnel close", async () => {
+  test("preserves a newer Twilio public URL and clears stale Velay ownership on stale tunnel close", async () => {
     const sockets: FakeWebSocket[] = [];
     const invalidations = { count: 0 };
     writeConfig({
@@ -510,10 +456,25 @@ describe("VelayTunnelClient", () => {
       ingress: {
         publicBaseUrl: "https://ngrok.example.test",
         twilioPublicBaseUrl: "https://velay-public-2.example.test",
-        twilioPublicBaseUrlManagedBy: "velay",
       },
     });
-    expect(invalidations.count).toBe(1);
+    expect(invalidations.count).toBe(2);
+
+    expect(
+      createVelayTunnelClient(makeConfig(), {
+        credentials: makeCredentials({}),
+        configFile: makeConfigFileCache(invalidations),
+      }),
+    ).toBeUndefined();
+    await flushPromises();
+
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://velay-public-2.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(2);
   });
 
   test("clears stale Velay-managed Twilio public URL on startup before connecting", async () => {
@@ -623,7 +584,7 @@ describe("VelayTunnelClient", () => {
     await flushPromises();
 
     expect(httpBridge).toHaveBeenCalledTimes(1);
-    expect(sockets[0].sent.map((raw) => JSON.parse(raw))).toEqual([
+    expect(sockets[0].sent.map((raw) => JSON.parse(raw as string))).toEqual([
       {
         type: VELAY_FRAME_TYPES.httpResponse,
         request_id: "req-123",
@@ -669,7 +630,7 @@ describe("VelayTunnelClient", () => {
         [credentialKey("vellum", "platform_assistant_id")]: "asst-123",
       }),
       configFile: makeConfigFileCache({ count: 0 }),
-      webSocketConstructor: makeWebSocketConstructor(sockets),
+      webSocketConstructor: makeFakeWebSocketConstructor(sockets),
       webSocketBridgeFactory: () =>
         ({
           handleFrame: () => {},

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
 
 import {
@@ -22,10 +21,10 @@ import { closeWebSocket } from "./bridge-utils.js";
 import {
   VELAY_FRAME_TYPES,
   VELAY_TUNNEL_SUBPROTOCOL,
+  parseVelayFrame,
   type VelayFrame,
   type VelayHttpRequestFrame,
   type VelayRegisteredFrame,
-  type VelayWebSocketInboundFrame,
 } from "./protocol.js";
 import { VelayWebSocketBridge } from "./websocket-bridge.js";
 
@@ -495,7 +494,9 @@ async function clearManagedTwilioPublicBaseUrl(
         expectedPublicUrl !== undefined &&
         ingress[TWILIO_PUBLIC_BASE_URL_FIELD] !== expectedPublicUrl
       ) {
-        return false;
+        delete ingress[TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD];
+        data.ingress = ingress;
+        return true;
       }
 
       delete ingress[TWILIO_PUBLIC_BASE_URL_FIELD];
@@ -541,112 +542,4 @@ function buildRegisterWebSocketUrl(baseUrl: string): string {
     throw new Error("VELAY_BASE_URL must use http, https, ws, or wss");
   }
   return url.toString();
-}
-
-function parseVelayFrame(data: unknown): VelayFrame | undefined {
-  const raw = decodeWebSocketData(data);
-  if (raw === undefined) return undefined;
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return undefined;
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return undefined;
-  }
-  const frame = parsed as Record<string, unknown>;
-
-  switch (frame.type) {
-    case VELAY_FRAME_TYPES.registered:
-      return isRegisteredFrame(frame) ? frame : undefined;
-    case VELAY_FRAME_TYPES.httpRequest:
-      return isHttpRequestFrame(frame) ? frame : undefined;
-    case VELAY_FRAME_TYPES.websocketOpen:
-    case VELAY_FRAME_TYPES.websocketMessage:
-    case VELAY_FRAME_TYPES.websocketClose:
-      return isWebSocketInboundFrame(frame) ? frame : undefined;
-    default:
-      return undefined;
-  }
-}
-
-function decodeWebSocketData(data: unknown): string | undefined {
-  if (typeof data === "string") return data;
-  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
-  if (ArrayBuffer.isView(data)) {
-    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString(
-      "utf8",
-    );
-  }
-  return undefined;
-}
-
-function isRegisteredFrame(
-  frame: Record<string, unknown>,
-): frame is VelayRegisteredFrame {
-  return (
-    frame.type === VELAY_FRAME_TYPES.registered &&
-    typeof frame.assistant_id === "string" &&
-    typeof frame.public_url === "string"
-  );
-}
-
-function isHttpRequestFrame(
-  frame: Record<string, unknown>,
-): frame is VelayHttpRequestFrame {
-  return (
-    frame.type === VELAY_FRAME_TYPES.httpRequest &&
-    typeof frame.request_id === "string" &&
-    typeof frame.method === "string" &&
-    typeof frame.path === "string" &&
-    isOptionalString(frame.raw_query) &&
-    isOptionalString(frame.body_base64) &&
-    isVelayHeaders(frame.headers)
-  );
-}
-
-function isWebSocketInboundFrame(
-  frame: Record<string, unknown>,
-): frame is VelayWebSocketInboundFrame {
-  if (frame.type === VELAY_FRAME_TYPES.websocketOpen) {
-    return (
-      typeof frame.connection_id === "string" &&
-      typeof frame.path === "string" &&
-      isOptionalString(frame.raw_query) &&
-      isOptionalString(frame.subprotocol) &&
-      isVelayHeaders(frame.headers)
-    );
-  }
-  if (frame.type === VELAY_FRAME_TYPES.websocketMessage) {
-    return (
-      typeof frame.connection_id === "string" &&
-      typeof frame.message_type === "string" &&
-      isOptionalString(frame.body_base64)
-    );
-  }
-  if (frame.type === VELAY_FRAME_TYPES.websocketClose) {
-    return (
-      typeof frame.connection_id === "string" &&
-      (frame.code === undefined || typeof frame.code === "number") &&
-      isOptionalString(frame.reason)
-    );
-  }
-  return false;
-}
-
-function isOptionalString(value: unknown): value is string | undefined {
-  return value === undefined || typeof value === "string";
-}
-
-function isVelayHeaders(value: unknown): value is Record<string, string[]> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  return Object.values(value).every(
-    (headerValues) =>
-      Array.isArray(headerValues) &&
-      headerValues.every((headerValue) => typeof headerValue === "string"),
-  );
 }

--- a/gateway/src/velay/protocol.ts
+++ b/gateway/src/velay/protocol.ts
@@ -1,3 +1,7 @@
+import { Buffer } from "node:buffer";
+
+import { z } from "zod";
+
 export const VELAY_TUNNEL_SUBPROTOCOL = "velay-tunnel-v1";
 
 export const VELAY_FRAME_TYPES = {
@@ -92,3 +96,80 @@ export type VelayWebSocketInboundFrame =
   | VelayWebSocketOpenFrame
   | VelayWebSocketMessageFrame
   | VelayWebSocketCloseFrame;
+
+const headersSchema = z.record(z.string(), z.array(z.string()));
+
+const registeredFrameSchema = z.object({
+  type: z.literal(VELAY_FRAME_TYPES.registered),
+  assistant_id: z.string(),
+  public_url: z.string(),
+});
+
+const httpRequestFrameSchema = z.object({
+  type: z.literal(VELAY_FRAME_TYPES.httpRequest),
+  request_id: z.string(),
+  method: z.string(),
+  path: z.string(),
+  raw_query: z.string().optional(),
+  headers: headersSchema,
+  body_base64: z.string().optional(),
+});
+
+const websocketOpenFrameSchema = z.object({
+  type: z.literal(VELAY_FRAME_TYPES.websocketOpen),
+  connection_id: z.string(),
+  path: z.string(),
+  raw_query: z.string().optional(),
+  headers: headersSchema,
+  subprotocol: z.string().optional(),
+});
+
+const websocketMessageFrameSchema = z.object({
+  type: z.literal(VELAY_FRAME_TYPES.websocketMessage),
+  connection_id: z.string(),
+  message_type: z.custom<VelayWebSocketMessageType>(
+    (value) => typeof value === "string",
+  ),
+  body_base64: z.string().optional(),
+});
+
+const websocketCloseFrameSchema = z.object({
+  type: z.literal(VELAY_FRAME_TYPES.websocketClose),
+  connection_id: z.string(),
+  code: z.number().optional(),
+  reason: z.string().optional(),
+});
+
+const inboundFrameSchema = z.discriminatedUnion("type", [
+  registeredFrameSchema,
+  httpRequestFrameSchema,
+  websocketOpenFrameSchema,
+  websocketMessageFrameSchema,
+  websocketCloseFrameSchema,
+]);
+
+export function parseVelayFrame(data: unknown): VelayFrame | undefined {
+  const raw = decodeWebSocketData(data);
+  if (raw === undefined) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+
+  const result = inboundFrameSchema.safeParse(parsed);
+  return result.success ? result.data : undefined;
+}
+
+function decodeWebSocketData(data: unknown): string | undefined {
+  if (typeof data === "string") return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString(
+      "utf8",
+    );
+  }
+  return undefined;
+}

--- a/gateway/src/velay/test-fake-websocket.ts
+++ b/gateway/src/velay/test-fake-websocket.ts
@@ -1,0 +1,69 @@
+type Listener = (event?: unknown) => void;
+
+export class FakeWebSocket {
+  static CONNECTING = WebSocket.CONNECTING;
+  static OPEN = WebSocket.OPEN;
+  static CLOSING = WebSocket.CLOSING;
+  static CLOSED = WebSocket.CLOSED;
+
+  binaryType: BinaryType = "blob";
+  readyState: number = WebSocket.CONNECTING;
+  sent: (string | Uint8Array)[] = [];
+  closes: { code?: number; reason?: string }[] = [];
+  private readonly listeners = new Map<string, Listener[]>();
+
+  constructor(
+    readonly url = "",
+    readonly options: unknown = undefined,
+    private readonly closeOptions: { validateReason?: boolean } = {},
+  ) {}
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  send(message: string | Uint8Array): void {
+    this.sent.push(message);
+  }
+
+  close(code?: number, reason?: string): void {
+    if (
+      code !== undefined &&
+      code !== 1000 &&
+      (!Number.isInteger(code) || code < 3000 || code > 4999)
+    ) {
+      throw new Error("invalid close code");
+    }
+    if (
+      this.closeOptions.validateReason &&
+      reason !== undefined &&
+      new TextEncoder().encode(reason).byteLength > 123
+    ) {
+      throw new Error("invalid close reason");
+    }
+    this.readyState = WebSocket.CLOSED;
+    this.closes.push({ code, reason });
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+export function makeFakeWebSocketConstructor(created: FakeWebSocket[]) {
+  return function FakeWebSocketConstructor(
+    this: unknown,
+    url: string,
+    options: unknown,
+  ) {
+    const ws = new FakeWebSocket(url, options);
+    created.push(ws);
+    return ws;
+  } as unknown as {
+    new (url: string | URL, options?: unknown): WebSocket;
+  };
+}

--- a/gateway/src/velay/websocket-bridge.test.ts
+++ b/gateway/src/velay/websocket-bridge.test.ts
@@ -7,60 +7,10 @@ import {
   type VelayFrame,
   type VelayWebSocketOpenFrame,
 } from "./protocol.js";
+import { FakeWebSocket } from "./test-fake-websocket.js";
 import { VelayWebSocketBridge } from "./websocket-bridge.js";
 
-const WS_CONNECTING = WebSocket.CONNECTING;
 const WS_OPEN = WebSocket.OPEN;
-const WS_CLOSED = WebSocket.CLOSED;
-
-type Listener = (event?: unknown) => void;
-
-class FakeWebSocket {
-  static CONNECTING = WS_CONNECTING;
-  static OPEN = WS_OPEN;
-  static CLOSING = 2;
-  static CLOSED = WS_CLOSED;
-
-  binaryType: BinaryType = "blob";
-  readyState: number = WS_CONNECTING;
-  sent: (string | Uint8Array)[] = [];
-  closes: { code?: number; reason?: string }[] = [];
-  private readonly listeners = new Map<string, Listener[]>();
-
-  addEventListener(type: string, listener: Listener): void {
-    const listeners = this.listeners.get(type) ?? [];
-    listeners.push(listener);
-    this.listeners.set(type, listeners);
-  }
-
-  send(message: string | Uint8Array): void {
-    this.sent.push(message);
-  }
-
-  close(code?: number, reason?: string): void {
-    if (
-      code !== undefined &&
-      code !== 1000 &&
-      (!Number.isInteger(code) || code < 3000 || code > 4999)
-    ) {
-      throw new Error("invalid close code");
-    }
-    if (
-      reason !== undefined &&
-      new TextEncoder().encode(reason).byteLength > 123
-    ) {
-      throw new Error("invalid close reason");
-    }
-    this.readyState = WS_CLOSED;
-    this.closes.push({ code, reason });
-  }
-
-  emit(type: string, event: unknown = {}): void {
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
-    }
-  }
-}
 
 const OriginalWebSocket = globalThis.WebSocket;
 let fakeSocket: FakeWebSocket;
@@ -69,7 +19,7 @@ let bridge: VelayWebSocketBridge;
 let WebSocketMock: ReturnType<typeof mock>;
 
 beforeEach(() => {
-  fakeSocket = new FakeWebSocket();
+  fakeSocket = new FakeWebSocket("", undefined, { validateReason: true });
   sentFrames = [];
   WebSocketMock = mock(() => fakeSocket);
   Object.assign(WebSocketMock, FakeWebSocket);
@@ -177,6 +127,21 @@ describe("VelayWebSocketBridge", () => {
     });
 
     expect(fakeSocket.sent).toEqual(['{"event":"start"}']);
+  });
+
+  test("preserves leading UTF-8 BOM bytes in Velay text frames", () => {
+    bridge.open(makeOpenFrame());
+    fakeSocket.readyState = WS_OPEN;
+    fakeSocket.emit("open");
+
+    bridge.message({
+      type: VELAY_FRAME_TYPES.websocketMessage,
+      connection_id: "conn-123",
+      message_type: VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+      body_base64: base64(new Uint8Array([0xef, 0xbb, 0xbf, 0x68, 0x69])),
+    });
+
+    expect(fakeSocket.sent).toEqual(["\ufeffhi"]);
   });
 
   test("forwards local text frames back to Velay as websocket_message frames", async () => {

--- a/gateway/src/velay/websocket-bridge.ts
+++ b/gateway/src/velay/websocket-bridge.ts
@@ -21,6 +21,7 @@ import {
 } from "./protocol.js";
 
 const MAX_PENDING_MESSAGES = 100;
+const textFrameDecoder = new TextDecoder("utf-8", { ignoreBOM: true });
 
 type PendingMessage = string | Uint8Array;
 
@@ -293,7 +294,7 @@ function decodeVelayMessage(
   if (bytes === undefined) return undefined;
 
   if (frame.message_type === VELAY_WEBSOCKET_MESSAGE_TYPES.text) {
-    return new TextDecoder().decode(bytes);
+    return textFrameDecoder.decode(bytes);
   }
   if (frame.message_type === VELAY_WEBSOCKET_MESSAGE_TYPES.binary) {
     return bytes;

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
+    "./ingress": "./src/ingress.ts",
     "./twilio-ingress": "./src/twilio-ingress.ts",
     "./trust-rules": "./src/trust-rules.ts",
     "./handles": "./src/handles.ts",

--- a/packages/service-contracts/src/__tests__/contracts.test.ts
+++ b/packages/service-contracts/src/__tests__/contracts.test.ts
@@ -33,6 +33,7 @@ describe("package independence", () => {
     "../transport.ts",
     "../credential-rpc.ts",
     "../trust-rules.ts",
+    "../ingress.ts",
     "../twilio-ingress.ts",
     "../error.ts",
   ];

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -7,9 +7,10 @@
  *   - `@vellumai/service-contracts/credential-rpc`  — transport, RPC, handles, grants, rendering, error
  *   - `@vellumai/service-contracts/trust-rules`     — trust-rule types and parsing helpers
  *   - `@vellumai/service-contracts/twilio-ingress`  — shared Twilio ingress config constants
+ *   - `@vellumai/service-contracts/ingress`         — shared public ingress URL helpers
  *
  * Fine-grained subpaths are also available for low-friction migration:
- *   `./rpc`, `./handles`, `./grants`, `./rendering`, `./error`, `./trust-rules`, `./twilio-ingress`
+ *   `./rpc`, `./handles`, `./grants`, `./rendering`, `./error`, `./trust-rules`, `./ingress`, `./twilio-ingress`
  *
  * Neutral wire-protocol contracts for communication between the assistant
  * daemon and the Credential Execution Service (CES). This package is
@@ -24,4 +25,5 @@ export * from "./grants.js";
 export * from "./rpc.js";
 export * from "./rendering.js";
 export * from "./trust-rules.js";
+export * from "./ingress.js";
 export * from "./twilio-ingress.js";

--- a/packages/service-contracts/src/ingress.ts
+++ b/packages/service-contracts/src/ingress.ts
@@ -1,0 +1,5 @@
+export function normalizePublicBaseUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().replace(/\/+$/, "");
+  return normalized.length > 0 ? normalized : undefined;
+}

--- a/packages/service-contracts/src/twilio-ingress.ts
+++ b/packages/service-contracts/src/twilio-ingress.ts
@@ -3,8 +3,4 @@ export const TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD =
   "twilioPublicBaseUrlManagedBy";
 export const VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER = "velay";
 
-export function normalizePublicBaseUrl(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const normalized = value.trim().replace(/\/+$/, "");
-  return normalized.length > 0 ? normalized : undefined;
-}
+export { normalizePublicBaseUrl } from "./ingress.js";


### PR DESCRIPTION
## Summary
- Moves Velay frame parsing into the protocol module and shares Velay test socket helpers.
- Preserves text-frame BOM behavior, clears stale Velay ownership markers safely, and moves generic ingress URL normalization to a neutral shared module.

Fixes gaps identified during plan review for velay-twilio-ingress.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
