### PR TITLE
Let main agent inherit profile max tokens

### DIFF
--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -16,10 +16,18 @@ import type { Message, ProviderResponse } from "../providers/types.js";
 
 // Use an object wrapper so TypeScript doesn't narrow the captured type to
 // `undefined` based on the initial assignment in the test setup.
-const captured: { callSite?: string } = {};
+const captured: {
+  callSite?: string;
+  constructorMaxTokens?: unknown;
+  resolvedMaxTokens?: unknown;
+  resolvedHasMaxTokens?: boolean;
+} = {};
 
 function clearCaptured(): void {
   captured.callSite = undefined;
+  captured.constructorMaxTokens = undefined;
+  captured.resolvedMaxTokens = undefined;
+  captured.resolvedHasMaxTokens = undefined;
 }
 
 mock.module("../util/logger.js", () => ({
@@ -97,6 +105,14 @@ mock.module("../prompts/system-prompt.js", () => ({
   buildSystemPrompt: () => "system prompt",
 }));
 
+mock.module("../prompts/persona-resolver.js", () => ({
+  resolvePersonaContext: () => ({
+    userPersona: undefined,
+    channelPersona: undefined,
+    userSlug: undefined,
+  }),
+}));
+
 mock.module("../permissions/trust-store.js", () => ({
   clearCache: () => {},
 }));
@@ -165,7 +181,22 @@ mock.module("../memory/retriever.js", () => ({
 // The 6th positional parameter is `callSite` (see assistant/src/agent/loop.ts).
 mock.module("../agent/loop.js", () => ({
   AgentLoop: class {
-    constructor() {}
+    constructor(
+      _provider: unknown,
+      _systemPrompt: string,
+      config?: Record<string, unknown>,
+      _tools?: unknown,
+      _toolExecutor?: unknown,
+      _resolveTools?: unknown,
+      resolveSystemPrompt?: (history: Message[]) => Record<string, unknown>,
+    ) {
+      captured.constructorMaxTokens = config?.maxTokens;
+      const resolved = resolveSystemPrompt?.([]);
+      captured.resolvedMaxTokens = resolved?.maxTokens;
+      captured.resolvedHasMaxTokens =
+        resolved !== undefined &&
+        Object.prototype.hasOwnProperty.call(resolved, "maxTokens");
+    }
     getToolTokenBudget() {
       return 0;
     }
@@ -234,6 +265,10 @@ mock.module("../memory/canonical-guardian-store.js", () => ({
 }));
 
 import { Conversation } from "../daemon/conversation.js";
+import {
+  clearAllActiveConversations,
+  getOrCreateConversation,
+} from "../daemon/conversation-store.js";
 
 function makeConversation(): Conversation {
   const provider = {
@@ -304,5 +339,47 @@ describe("processMessage callSite threading", () => {
     await conversation.processMessage("Plain user message", [], () => {});
 
     expect(captured.callSite).toBe("mainAgent");
+  });
+
+  test("does not pin default maxTokens when maxResponseTokens is absent", async () => {
+    mockConversation = {
+      id: "conv-store-default",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [];
+    clearCaptured();
+    clearAllActiveConversations();
+
+    await getOrCreateConversation("conv-store-default");
+
+    expect(captured.constructorMaxTokens).toBeUndefined();
+    expect(captured.resolvedMaxTokens).toBeUndefined();
+    expect(captured.resolvedHasMaxTokens).toBe(false);
+  });
+
+  test("preserves explicit maxResponseTokens at conversation creation", async () => {
+    mockConversation = {
+      id: "conv-store-explicit",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [];
+    clearCaptured();
+    clearAllActiveConversations();
+
+    await getOrCreateConversation("conv-store-explicit", {
+      maxResponseTokens: 1234,
+    });
+
+    expect(captured.constructorMaxTokens).toBe(1234);
+    expect(captured.resolvedMaxTokens).toBe(1234);
+    expect(captured.resolvedHasMaxTokens).toBe(true);
   });
 });

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -241,8 +241,7 @@ export async function getOrCreateConversation(
 
       const systemPrompt =
         storedOptions?.systemPromptOverride ?? buildSystemPrompt();
-      const maxTokens =
-        storedOptions?.maxResponseTokens ?? config.llm.default.maxTokens;
+      const maxTokens = storedOptions?.maxResponseTokens;
 
       const sharedCesClient = _cesClientPromise
         ? await _cesClientPromise

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -15,7 +15,7 @@
  * - conversation-usage.ts        — recordUsage
  */
 
-import type { ResolvedSystemPrompt } from "../agent/loop.js";
+import type { AgentLoopConfig, ResolvedSystemPrompt } from "../agent/loop.js";
 import { AgentLoop } from "../agent/loop.js";
 import type {
   InterfaceId,
@@ -352,7 +352,7 @@ export class Conversation {
     conversationId: string,
     provider: Provider,
     systemPrompt: string,
-    maxTokens: number,
+    maxTokens: number | undefined,
     sendToClient: (msg: ServerMessage) => void,
     workingDir: string,
     memoryPolicy?: ConversationMemoryPolicy,
@@ -478,8 +478,10 @@ export class Conversation {
                 onboardingContext: this.getOnboardingContext(),
               });
             })(),
-        maxTokens: configuredMaxTokens,
       };
+      if (configuredMaxTokens !== undefined) {
+        resolved.maxTokens = configuredMaxTokens;
+      }
       if (resolvedModel !== undefined) {
         resolved.model = resolvedModel;
       }
@@ -498,18 +500,22 @@ export class Conversation {
       initialContextWindow,
     );
 
+    const agentLoopConfig: Partial<AgentLoopConfig> = {
+      thinking: llmDefault.thinking,
+      effort: llmDefault.effort,
+      ...(fastModeEnabled && resolvedSpeed === "fast"
+        ? { speed: resolvedSpeed }
+        : {}),
+      ...(cacheTtl ? { cacheTtl } : {}),
+    };
+    if (configuredMaxTokens !== undefined) {
+      agentLoopConfig.maxTokens = configuredMaxTokens;
+    }
+
     this.agentLoop = new AgentLoop(
       provider,
       systemPrompt,
-      {
-        maxTokens,
-        thinking: llmDefault.thinking,
-        effort: llmDefault.effort,
-        ...(fastModeEnabled && resolvedSpeed === "fast"
-          ? { speed: resolvedSpeed }
-          : {}),
-        ...(cacheTtl ? { cacheTtl } : {}),
-      },
+      agentLoopConfig,
       toolDefs.length > 0 ? toolDefs : undefined,
       toolDefs.length > 0 ? toolExecutor : undefined,
       resolveTools,

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfileEditor.swift
@@ -397,19 +397,16 @@ struct InferenceProfileEditor: View {
                     .accessibilityLabel("Max output tokens")
                     .accessibilityValue(Self.formattedTokenCount(value))
                 } else {
-                    VTextField(
-                        placeholder: String(Self.defaultMaxOutputTokens),
-                        text: Binding(
-                            get: { profile.maxTokens.map(String.init) ?? "" },
-                            set: { newValue in
-                                profile.maxTokens = Self.manualMaxOutputTokensValue(newValue)
-                            }
-                        ),
-                        maxWidth: 160,
-                        size: .small
+                    VSlider(
+                        value: .constant(Double(value)),
+                        range: Double(Self.minSliderMaxOutputTokens)...Double(upperBound),
+                        step: Self.maxOutputTokensStep,
+                        showTickMarks: true
                     )
+                    .disabled(true)
                     .help("Max output token metadata is unavailable for this model.")
-                    Spacer(minLength: 0)
+                    .accessibilityLabel("Max output tokens")
+                    .accessibilityValue(Self.formattedTokenCount(value))
                 }
                 VButton(
                     label: "Inherit",
@@ -618,14 +615,6 @@ struct InferenceProfileEditor: View {
 
     static func clampedMaxOutputTokens(_ value: Int, limit: Int) -> Int {
         min(max(value, 1), limit)
-    }
-
-    static func manualMaxOutputTokensValue(_ rawValue: String) -> Int? {
-        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let value = Int(trimmed) else {
-            return nil
-        }
-        return max(value, minSliderMaxOutputTokens)
     }
 
     static func clearingMaxOutputTokensOverride(_ profile: InferenceProfile) -> InferenceProfile {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfileEditorTests.swift
@@ -285,7 +285,7 @@ final class InferenceProfileEditorTests: XCTestCase {
         ))
     }
 
-    func testCatalogModelWithoutStaticOutputMetadataCanUseManualMaxTokens() {
+    func testCatalogModelWithoutStaticOutputMetadataKeepsMaxTokensReadOnly() {
         let (editor, _) = makeEditor(profile: InferenceProfile(
             name: "gemini-preview",
             provider: "gemini",
@@ -299,8 +299,12 @@ final class InferenceProfileEditorTests: XCTestCase {
             model: "gemini-3.1-pro-preview"
         ))
         XCTAssertEqual(
-            InferenceProfileEditor.manualMaxOutputTokensValue("128000"),
-            128_000
+            InferenceProfileEditor.maxOutputSliderValue(maxTokens: 96_000, limit: nil),
+            96_000
+        )
+        XCTAssertEqual(
+            InferenceProfileEditor.maxOutputSliderUpperBound(value: 96_000, limit: nil),
+            96_000
         )
     }
 

--- a/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSlider.swift
@@ -58,8 +58,7 @@ public struct VSlider: View {
                         let newFraction = (drag.location.x - thumbSize / 2) / trackWidth
                         let clampedFraction = min(max(newFraction, 0), 1)
                         let rawValue = range.lowerBound + clampedFraction * (range.upperBound - range.lowerBound)
-                        let snapped = round(rawValue / step) * step
-                        value = min(max(snapped, range.lowerBound), range.upperBound)
+                        value = Self.snappedValue(rawValue, in: range, step: step)
                     }
                     .onEnded { _ in
                         isDragging = false
@@ -115,10 +114,7 @@ public struct VSlider: View {
     // MARK: - Tick Marks
 
     private func tickMarksView(trackWidth: CGFloat, fraction: Double) -> some View {
-        // Build tick values as multiples of step within the range
-        let firstTick = ceil(range.lowerBound / step) * step
-        let lastTick = floor(range.upperBound / step) * step
-        let tickValues = stride(from: firstTick, through: lastTick, by: step).map { $0 }
+        let tickValues = Self.tickValues(in: range, step: step)
         let maxTicks = 20
         let tickStep = tickValues.count > maxTicks ? tickValues.count / maxTicks : 1
         let rangeSpan = range.upperBound - range.lowerBound
@@ -140,5 +136,24 @@ public struct VSlider: View {
                 }
             }
         }
+    }
+
+    static func snappedValue(_ rawValue: Double, in range: ClosedRange<Double>, step: Double) -> Double {
+        let clampedRawValue = min(max(rawValue, range.lowerBound), range.upperBound)
+        guard step > 0, range.upperBound > range.lowerBound else {
+            return clampedRawValue
+        }
+        let stepsFromLowerBound = ((clampedRawValue - range.lowerBound) / step).rounded()
+        let snapped = range.lowerBound + stepsFromLowerBound * step
+        return min(max(snapped, range.lowerBound), range.upperBound)
+    }
+
+    static func tickValues(in range: ClosedRange<Double>, step: Double) -> [Double] {
+        guard step > 0, range.upperBound >= range.lowerBound else {
+            return []
+        }
+        let span = range.upperBound - range.lowerBound
+        let stepCount = Int(floor(span / step))
+        return (0...stepCount).map { range.lowerBound + Double($0) * step }
     }
 }

--- a/clients/shared/Tests/VSliderTests.swift
+++ b/clients/shared/Tests/VSliderTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class VSliderTests: XCTestCase {
+    func testSnappingIsRelativeToLowerBound() {
+        XCTAssertEqual(
+            VSlider.snappedValue(5.6, in: 1...10, step: 3),
+            7
+        )
+        XCTAssertEqual(
+            VSlider.snappedValue(2.4, in: 1...10, step: 3),
+            1
+        )
+    }
+
+    func testTickValuesStartAtLowerBound() {
+        XCTAssertEqual(
+            VSlider.tickValues(in: 1...10, step: 3),
+            [1, 4, 7, 10]
+        )
+    }
+}

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -185,10 +185,10 @@ public struct LLMProviderEntry: Decodable {
 
 /// Top-level schema for `llm-provider-catalog.json`.
 ///
-/// The JSON file is expected to live at `meta/llm-provider-catalog.json`
-/// and be copied into `Contents/Resources` by `build.sh` once the later
-/// PRs in the LLM catalog plan land. Until then, this registry always
-/// returns the fallback data.
+/// The JSON file is generated from `meta/llm-provider-catalog.json` and
+/// copied into `Contents/Resources` by the client build. The hard-coded
+/// fallback below keeps startup resilient when the bundled resource is
+/// missing, unreadable, or corrupt.
 public struct LLMProviderCatalog: Decodable {
     public let version: Int
     public let providers: [LLMProviderEntry]
@@ -479,10 +479,9 @@ private let fallbackCatalog = LLMProviderCatalog(
 // MARK: - Loader
 
 /// Cached catalog loaded once per process lifetime.
-/// The bundled `llm-provider-catalog.json` (when present in later PRs)
-/// is immutable at runtime, so reading it more than once is unnecessary
-/// I/O. Swift guarantees thread-safe lazy initialization of static
-/// properties.
+/// The bundled `llm-provider-catalog.json` is immutable at runtime, so
+/// reading it more than once is unnecessary I/O. Swift guarantees
+/// thread-safe lazy initialization of static properties.
 private let _cachedLLMProviderCatalog: LLMProviderCatalog = {
     guard let url = Bundle.main.url(forResource: "llm-provider-catalog", withExtension: "json") else {
         log.warning("llm-provider-catalog.json not found in bundle — using fallback catalog")


### PR DESCRIPTION
Fixes run-plan review gaps for main-agent max token resolution and profile editor slider behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
