### PR TITLE
fix: scrub Twilio ingress transfer state

### DIFF
--- a/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
+++ b/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
@@ -8,6 +8,8 @@ describe("sanitizeConfigForTransfer", () => {
       ingress: {
         publicBaseUrl: "https://example.com",
         enabled: true,
+        twilioPublicBaseUrl: "https://velay-public.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
         webhook: { path: "/hook" },
       },
       daemon: { port: 3000, logLevel: "debug" },
@@ -31,6 +33,8 @@ describe("sanitizeConfigForTransfer", () => {
 
     expect(result.ingress.publicBaseUrl).toBe("");
     expect(result.ingress.enabled).toBeUndefined();
+    expect(result.ingress.twilioPublicBaseUrl).toBeUndefined();
+    expect(result.ingress.twilioPublicBaseUrlManagedBy).toBeUndefined();
     expect(result.daemon).toBeUndefined();
     expect(result.skills.load.extraDirs).toEqual([]);
     expect(result.hostBrowser).toEqual({
@@ -135,11 +139,32 @@ describe("sanitizeConfigForTransfer", () => {
     expect(result.skills.load.builtIn).toBe(true);
   });
 
-  test("preserves nested ingress fields other than publicBaseUrl and enabled", () => {
+  test("strips Velay-managed Twilio ingress state during transfer", () => {
+    const input = {
+      ingress: {
+        publicBaseUrl: "https://old.url",
+        enabled: true,
+        twilioPublicBaseUrl: "https://velay-public.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+        webhook: { path: "/webhook" },
+      },
+    };
+
+    const result = JSON.parse(sanitizeConfigForTransfer(JSON.stringify(input)));
+
+    expect(result.ingress).toEqual({
+      publicBaseUrl: "",
+      webhook: { path: "/webhook" },
+    });
+  });
+
+  test("preserves nested ingress fields other than environment-specific URL state", () => {
     const input = {
       ingress: {
         publicBaseUrl: "https://old.url",
         enabled: false,
+        twilioPublicBaseUrl: "https://velay-public.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
         webhook: { path: "/webhook", secret: "abc" },
         rateLimit: { max: 50, window: 60 },
       },
@@ -151,6 +176,8 @@ describe("sanitizeConfigForTransfer", () => {
     expect(result.ingress.rateLimit).toEqual({ max: 50, window: 60 });
     expect(result.ingress.publicBaseUrl).toBe("");
     expect(result.ingress.enabled).toBeUndefined();
+    expect(result.ingress.twilioPublicBaseUrl).toBeUndefined();
+    expect(result.ingress.twilioPublicBaseUrlManagedBy).toBeUndefined();
   });
 
   test("handles config missing some target fields", () => {

--- a/assistant/src/config/sanitize-for-transfer.ts
+++ b/assistant/src/config/sanitize-for-transfer.ts
@@ -5,6 +5,8 @@
  * Fields removed or reset:
  * - `ingress.publicBaseUrl` → set to `""`
  * - `ingress.enabled` → deleted
+ * - `ingress.twilioPublicBaseUrl` → deleted
+ * - `ingress.twilioPublicBaseUrlManagedBy` → deleted
  * - `daemon` → deleted entirely
  * - `skills.load.extraDirs` → set to `[]`
  * - `hostBrowser.cdpInspect.desktopAuto` → deleted **only when the source
@@ -41,6 +43,8 @@ export function sanitizeConfigForTransfer(configJson: string): string {
     const ingress = config.ingress as Record<string, unknown>;
     ingress.publicBaseUrl = "";
     delete ingress.enabled;
+    delete ingress.twilioPublicBaseUrl;
+    delete ingress.twilioPublicBaseUrlManagedBy;
   }
 
   // Strip daemon entirely

--- a/gateway/src/config-file-utils.ts
+++ b/gateway/src/config-file-utils.ts
@@ -1,21 +1,22 @@
-import {
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  existsSync,
-  renameSync,
-} from "node:fs";
-import { join, dirname } from "node:path";
 import { randomBytes } from "node:crypto";
-import { getWorkspaceDir } from "../../credential-reader.js";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { getWorkspaceDir } from "./credential-reader.js";
 
 /**
- * Serializes config writes so concurrent PATCH requests don't race on
+ * Serializes config writes so concurrent config mutations don't race on
  * read-modify-write. Each write awaits the previous one before proceeding.
  *
- * This chain is shared across all config mutation routes (feature flags,
- * privacy config, etc.) to prevent concurrent writes to the same
- * config.json from overwriting each other's changes.
+ * This chain is shared across all gateway config mutations to prevent
+ * concurrent writes to the same config.json from overwriting each other's
+ * changes.
  */
 let configWriteChain: Promise<void> = Promise.resolve();
 

--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -3,7 +3,7 @@ import {
   enqueueConfigWrite,
   readConfigFile,
   writeConfigFileAtomic,
-} from "./config-file-utils.js";
+} from "../../config-file-utils.js";
 
 const log = getLogger("privacy-config");
 

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -618,6 +618,28 @@ describe("VelayTunnelClient", () => {
     ]);
   });
 
+  test("ignores websocket messages with invalid message types", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const websocketFrames: VelayWebSocketInboundFrame[] = [];
+    const client = makeClient({ sockets, websocketFrames });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+
+    sockets[0].emit("message", {
+      data: JSON.stringify({
+        type: VELAY_FRAME_TYPES.websocketMessage,
+        connection_id: "conn-123",
+        message_type: "json",
+        body_base64: "",
+      }),
+    });
+    await flushPromises();
+
+    expect(websocketFrames).toEqual([]);
+  });
+
   test("stops reconnecting and closes bridged sockets on shutdown", async () => {
     const sockets: FakeWebSocket[] = [];
     const reconnectDelays: number[] = [];

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -14,7 +14,7 @@ import {
   enqueueConfigWrite,
   readConfigFile,
   writeConfigFileAtomic,
-} from "../http/routes/config-file-utils.js";
+} from "../config-file-utils.js";
 import { getLogger } from "../logger.js";
 import { bridgeVelayHttpRequest } from "./http-bridge.js";
 import { closeWebSocket } from "./bridge-utils.js";

--- a/gateway/src/velay/protocol.ts
+++ b/gateway/src/velay/protocol.ts
@@ -124,12 +124,15 @@ const websocketOpenFrameSchema = z.object({
   subprotocol: z.string().optional(),
 });
 
+const websocketMessageTypeSchema = z.enum([
+  VELAY_WEBSOCKET_MESSAGE_TYPES.text,
+  VELAY_WEBSOCKET_MESSAGE_TYPES.binary,
+]);
+
 const websocketMessageFrameSchema = z.object({
   type: z.literal(VELAY_FRAME_TYPES.websocketMessage),
   connection_id: z.string(),
-  message_type: z.custom<VelayWebSocketMessageType>(
-    (value) => typeof value === "string",
-  ),
+  message_type: websocketMessageTypeSchema,
   body_base64: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary
- Scrubs environment-specific Twilio ingress state during workspace transfer.
- Tightens Velay frame parsing and moves config file write utilities out of route-local scope.

Fixes gaps identified during plan review for velay-twilio-ingress.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
