### PR TITLE
fix: complete Twilio webhook sync triggers

### DIFF
--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -27,7 +27,11 @@
  * All public-facing ingress URL construction is centralized here.
  */
 
-import { normalizePublicBaseUrl } from "@vellumai/service-contracts/ingress";
+import {
+  normalizePublicBaseUrl,
+  TWILIO_STATUS_WEBHOOK_PATH,
+  TWILIO_VOICE_WEBHOOK_PATH,
+} from "@vellumai/service-contracts/twilio-ingress";
 
 import { getIngressPublicBaseUrl } from "../config/env.js";
 
@@ -110,9 +114,9 @@ export function getTwilioVoiceWebhookUrl(
 ): string {
   const base = getTwilioPublicBaseUrl(config);
   if (callSessionId) {
-    return `${base}/webhooks/twilio/voice?callSessionId=${callSessionId}`;
+    return `${base}${TWILIO_VOICE_WEBHOOK_PATH}?callSessionId=${callSessionId}`;
   }
-  return `${base}/webhooks/twilio/voice`;
+  return `${base}${TWILIO_VOICE_WEBHOOK_PATH}`;
 }
 
 /**
@@ -120,7 +124,7 @@ export function getTwilioVoiceWebhookUrl(
  */
 export function getTwilioStatusCallbackUrl(config: IngressConfig): string {
   const base = getTwilioPublicBaseUrl(config);
-  return `${base}/webhooks/twilio/status`;
+  return `${base}${TWILIO_STATUS_WEBHOOK_PATH}`;
 }
 
 /**

--- a/gateway/src/__tests__/config-file-watcher.test.ts
+++ b/gateway/src/__tests__/config-file-watcher.test.ts
@@ -6,6 +6,10 @@ import {
   ConfigFileWatcher,
   type ConfigChangeEvent,
 } from "../config-file-watcher.js";
+import {
+  isOnlyVelayTwilioIngressChange,
+  shouldSyncTwilioPhoneWebhooksAfterConfigChange,
+} from "../twilio/webhook-sync-trigger.js";
 import { testWorkspaceDir } from "./test-preload.js";
 
 const configPath = join(testWorkspaceDir, "config.json");
@@ -20,6 +24,22 @@ function pollOnce(watcher: ConfigFileWatcher): void {
       pollOnce: () => void;
     }
   ).pollOnce();
+}
+
+function makeEvent(
+  changedKeys: string[],
+  changedFields: Record<string, string[]>,
+): ConfigChangeEvent {
+  return {
+    data: {},
+    changedKeys: new Set(changedKeys),
+    changedFields: new Map(
+      Object.entries(changedFields).map(([section, fields]) => [
+        section,
+        new Set(fields),
+      ]),
+    ),
+  };
 }
 
 afterEach(() => {
@@ -116,5 +136,32 @@ describe("ConfigFileWatcher", () => {
     expect(events[1].changedFields.get("ingress")).toEqual(
       new Set(["publicBaseUrl"]),
     );
+  });
+});
+
+describe("Twilio webhook sync config-change triggers", () => {
+  test("syncs when generic public ingress changes without a Twilio override", () => {
+    const event = makeEvent(["ingress"], { ingress: ["publicBaseUrl"] });
+
+    expect(isOnlyVelayTwilioIngressChange(event)).toBe(false);
+    expect(shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)).toBe(true);
+  });
+
+  test("syncs when the Twilio-specific public ingress changes", () => {
+    const event = makeEvent(["ingress"], {
+      ingress: ["twilioPublicBaseUrl", "twilioPublicBaseUrlManagedBy"],
+    });
+
+    expect(isOnlyVelayTwilioIngressChange(event)).toBe(true);
+    expect(shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)).toBe(true);
+  });
+
+  test("does not sync when only the Velay manager marker changes", () => {
+    const event = makeEvent(["ingress"], {
+      ingress: ["twilioPublicBaseUrlManagedBy"],
+    });
+
+    expect(isOnlyVelayTwilioIngressChange(event)).toBe(true);
+    expect(shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)).toBe(false);
   });
 });

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,11 +2,6 @@ process.title = "vellum-gateway";
 
 import { randomBytes } from "node:crypto";
 
-import {
-  TWILIO_PUBLIC_BASE_URL_FIELD,
-  TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
-} from "@vellumai/service-contracts/twilio-ingress";
-
 import { AuthRateLimiter } from "./auth-rate-limiter.js";
 import {
   loadOrCreateSigningKey,
@@ -15,10 +10,7 @@ import {
 import { validateEdgeToken, mintServiceToken } from "./auth/token-exchange.js";
 import { findGuardianForChannelActor } from "./auth/guardian-bootstrap.js";
 import { ConfigFileCache } from "./config-file-cache.js";
-import {
-  ConfigFileWatcher,
-  type ConfigChangeEvent,
-} from "./config-file-watcher.js";
+import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { FeatureFlagWatcher } from "./feature-flag-watcher.js";
 import { RemoteFeatureFlagSync } from "./remote-feature-flag-sync.js";
 import { loadConfig } from "./config.js";
@@ -151,6 +143,10 @@ import { isNewCommand, handleNewCommand } from "./webhook-pipeline.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 import { registerEmailCallbackRoute } from "./email/register-callback.js";
 import { syncConfiguredTwilioPhoneNumberWebhooks } from "./twilio/webhook-sync.js";
+import {
+  isOnlyVelayTwilioIngressChange,
+  shouldSyncTwilioPhoneWebhooksAfterConfigChange,
+} from "./twilio/webhook-sync-trigger.js";
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import {
@@ -205,23 +201,6 @@ function detectCredentialChanges(
     changed.add(service);
   }
   return changed;
-}
-
-function isOnlyVelayTwilioIngressChange(event: ConfigChangeEvent): boolean {
-  if (event.changedKeys.size !== 1 || !event.changedKeys.has("ingress")) {
-    return false;
-  }
-
-  const ingressFields = event.changedFields.get("ingress");
-  if (!ingressFields || ingressFields.size === 0) {
-    return false;
-  }
-
-  return [...ingressFields].every(
-    (field) =>
-      field === TWILIO_PUBLIC_BASE_URL_FIELD ||
-      field === TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
-  );
 }
 
 // Shared rate limiter for auth failures and unauthenticated endpoints
@@ -1967,7 +1946,6 @@ async function main() {
 
     // Side effect: reconcile Telegram webhook when ingress URL changes
     const onlyVelayTwilioIngressChanged = isOnlyVelayTwilioIngressChange(event);
-    const ingressFields = event.changedFields.get("ingress");
 
     if (
       event.changedKeys.has("ingress") &&
@@ -1982,17 +1960,14 @@ async function main() {
       });
     }
 
-    if (
-      onlyVelayTwilioIngressChanged &&
-      ingressFields?.has(TWILIO_PUBLIC_BASE_URL_FIELD)
-    ) {
+    if (shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)) {
       syncConfiguredTwilioPhoneNumberWebhooks({
         credentials: credentialCache,
         configFile: configFileCache,
       }).catch((err) => {
         log.warn(
           { err },
-          "Twilio webhook sync failed after Velay ingress URL change",
+          "Twilio webhook sync failed after ingress URL change",
         );
       });
     }

--- a/gateway/src/twilio/webhook-sync-trigger.ts
+++ b/gateway/src/twilio/webhook-sync-trigger.ts
@@ -1,0 +1,41 @@
+import {
+  TWILIO_PUBLIC_BASE_URL_FIELD,
+  TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
+} from "@vellumai/service-contracts/twilio-ingress";
+
+import type { ConfigChangeEvent } from "../config-file-watcher.js";
+
+const PUBLIC_BASE_URL_FIELD = "publicBaseUrl";
+
+export function isOnlyVelayTwilioIngressChange(
+  event: ConfigChangeEvent,
+): boolean {
+  if (event.changedKeys.size !== 1 || !event.changedKeys.has("ingress")) {
+    return false;
+  }
+
+  const ingressFields = event.changedFields.get("ingress");
+  if (!ingressFields || ingressFields.size === 0) {
+    return false;
+  }
+
+  return [...ingressFields].every(
+    (field) =>
+      field === TWILIO_PUBLIC_BASE_URL_FIELD ||
+      field === TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
+  );
+}
+
+export function shouldSyncTwilioPhoneWebhooksAfterConfigChange(
+  event: ConfigChangeEvent,
+): boolean {
+  if (!event.changedKeys.has("ingress")) {
+    return false;
+  }
+
+  const ingressFields = event.changedFields.get("ingress");
+  return (
+    ingressFields?.has(TWILIO_PUBLIC_BASE_URL_FIELD) === true ||
+    ingressFields?.has(PUBLIC_BASE_URL_FIELD) === true
+  );
+}

--- a/gateway/src/twilio/webhook-sync.test.ts
+++ b/gateway/src/twilio/webhook-sync.test.ts
@@ -22,11 +22,13 @@ afterEach(() => {
 function makeCaches(opts: {
   phoneNumber?: string;
   accountSid?: string;
+  accountSidCredential?: string;
   authToken?: string;
   publicBaseUrl?: string;
   twilioPublicBaseUrl?: string;
 }): { credentials: CredentialCache; configFile: ConfigFileCache } {
   const credentialValues = new Map<string, string | undefined>([
+    [credentialKey("twilio", "account_sid"), opts.accountSidCredential],
     [credentialKey("twilio", "auth_token"), opts.authToken],
   ]);
   const configValues: Record<string, Record<string, string | undefined>> = {
@@ -130,6 +132,25 @@ describe("syncConfiguredTwilioPhoneNumberWebhooks", () => {
     expect(body.get("StatusCallback")).toBe(
       "https://generic.example.test/webhooks/twilio/status",
     );
+  });
+
+  test("uses credential-store account SID before legacy config fallback", async () => {
+    mockTwilioLookupAndUpdate();
+
+    await syncConfiguredTwilioPhoneNumberWebhooks(
+      makeCaches({
+        phoneNumber: PHONE_NUMBER,
+        accountSid: "AC_CONFIG_STALE",
+        accountSidCredential: ACCOUNT_SID,
+        authToken: AUTH_TOKEN,
+        publicBaseUrl: "https://generic.example.test/",
+      }),
+    );
+
+    const calls = getMockFetchCalls();
+    expect(calls).toHaveLength(2);
+    expect(calls[0].path).toContain(`/Accounts/${ACCOUNT_SID}/`);
+    expect(calls[1].path).toContain(`/Accounts/${ACCOUNT_SID}/`);
   });
 
   test("skips without Twilio REST calls when required inputs are missing", async () => {

--- a/gateway/src/twilio/webhook-sync.ts
+++ b/gateway/src/twilio/webhook-sync.ts
@@ -1,4 +1,8 @@
-import { normalizePublicBaseUrl } from "@vellumai/service-contracts/twilio-ingress";
+import {
+  normalizePublicBaseUrl,
+  TWILIO_STATUS_WEBHOOK_PATH,
+  TWILIO_VOICE_WEBHOOK_PATH,
+} from "@vellumai/service-contracts/twilio-ingress";
 
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
@@ -7,9 +11,6 @@ import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
 
 const log = getLogger("twilio-webhook-sync");
-
-const TWILIO_VOICE_PATH = "/webhooks/twilio/voice";
-const TWILIO_STATUS_PATH = "/webhooks/twilio/status";
 
 export type TwilioWebhookSyncCaches = {
   credentials: CredentialCache;
@@ -31,8 +32,8 @@ function buildWebhookUrls(baseUrl: string): {
   statusCallbackUrl: string;
 } {
   return {
-    voiceUrl: `${baseUrl}${TWILIO_VOICE_PATH}`,
-    statusCallbackUrl: `${baseUrl}${TWILIO_STATUS_PATH}`,
+    voiceUrl: `${baseUrl}${TWILIO_VOICE_WEBHOOK_PATH}`,
+    statusCallbackUrl: `${baseUrl}${TWILIO_STATUS_WEBHOOK_PATH}`,
   };
 }
 
@@ -134,9 +135,12 @@ export async function syncConfiguredTwilioPhoneNumberWebhooks(
     const phoneNumber = caches.configFile
       .getString("twilio", "phoneNumber")
       ?.trim();
-    const accountSid = caches.configFile
-      .getString("twilio", "accountSid")
-      ?.trim();
+    const accountSidFromCredentials = (
+      await caches.credentials.get(credentialKey("twilio", "account_sid"))
+    )?.trim();
+    const accountSid =
+      accountSidFromCredentials ||
+      caches.configFile.getString("twilio", "accountSid")?.trim();
     const authToken = (
       await caches.credentials.get(credentialKey("twilio", "auth_token"))
     )?.trim();

--- a/packages/service-contracts/src/twilio-ingress.ts
+++ b/packages/service-contracts/src/twilio-ingress.ts
@@ -2,5 +2,7 @@ export const TWILIO_PUBLIC_BASE_URL_FIELD = "twilioPublicBaseUrl";
 export const TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD =
   "twilioPublicBaseUrlManagedBy";
 export const VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER = "velay";
+export const TWILIO_VOICE_WEBHOOK_PATH = "/webhooks/twilio/voice";
+export const TWILIO_STATUS_WEBHOOK_PATH = "/webhooks/twilio/status";
 
 export { normalizePublicBaseUrl } from "./ingress.js";


### PR DESCRIPTION
## Summary
- Syncs Twilio phone webhooks when generic public ingress changes as well as Twilio-specific Velay ingress.
- Resolves Twilio account SID from credentials with config fallback and shares Twilio webhook path constants.

Fixes gaps identified during plan review for velay-twilio-ingress.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
