### PR TITLE
fix: silence Swift 6 main-actor warning on bundledAppIcon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -558,8 +558,14 @@ final class AvatarAppearanceManager {
     /// `applicationIconImage` is set at runtime and already includes all
     /// system-resolved representations.
     ///
+    /// `nonisolated(unsafe)` so `start()` can warm the lazy initializer from
+    /// a `Task.detached` (the surrounding class is `@MainActor`, which would
+    /// otherwise main-actor-isolate this static). `NSWorkspace.icon(forFile:)`
+    /// is documented as thread-safe and the property is `let`, so reads after
+    /// init are safe from any context.
+    ///
     /// Reference: https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
-    private static let bundledAppIcon: NSImage = {
+    private nonisolated(unsafe) static let bundledAppIcon: NSImage = {
         NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
     }()
 


### PR DESCRIPTION
## Summary
- The class is `@MainActor`, so `bundledAppIcon` was implicitly main-actor-isolated. Accessing it from `Task.detached` in `start()` produced a Swift 6 warning that becomes an error under the Swift 6 language mode.
- Marked the static `let` as `nonisolated(unsafe)`. The pre-warm (and `restoreBundleIcon()` consumer) read an immutable `let` whose initializer calls `NSWorkspace.icon(forFile:)`, which Apple documents as thread-safe.
- The `Task.detached` pre-warm is preserved so the initial `NSWorkspace` icon resolution does not block the main thread when `restoreBundleIcon()` runs during disconnect / clearCustomAvatar / 404 paths.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift:113:34: warning: main actor-isolated static property 'bundledAppIcon' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode
111 |         // NSWorkspace.icon(forFile:) is documented as thread-safe.
112 |         // Reference: https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
113 |         Task.detached { _ = Self.bundledAppIcon }
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
