### PR TITLE
fix: finish Twilio ingress cleanup

### DIFF
--- a/assistant/src/config/sanitize-for-transfer.ts
+++ b/assistant/src/config/sanitize-for-transfer.ts
@@ -1,3 +1,8 @@
+import {
+  TWILIO_PUBLIC_BASE_URL_FIELD,
+  TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
+} from "@vellumai/service-contracts/twilio-ingress";
+
 /**
  * Strips environment-specific fields from config JSON before transferring
  * between local and platform environments (teleport/restore).
@@ -43,8 +48,8 @@ export function sanitizeConfigForTransfer(configJson: string): string {
     const ingress = config.ingress as Record<string, unknown>;
     ingress.publicBaseUrl = "";
     delete ingress.enabled;
-    delete ingress.twilioPublicBaseUrl;
-    delete ingress.twilioPublicBaseUrlManagedBy;
+    delete ingress[TWILIO_PUBLIC_BASE_URL_FIELD];
+    delete ingress[TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD];
   }
 
   // Strip daemon entirely

--- a/assistant/src/config/schemas/ingress.ts
+++ b/assistant/src/config/schemas/ingress.ts
@@ -1,3 +1,8 @@
+import {
+  TWILIO_PUBLIC_BASE_URL_FIELD,
+  TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD,
+  VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER,
+} from "@vellumai/service-contracts/twilio-ingress";
 import { z } from "zod";
 
 function emptyOrAbsoluteHttpUrl(fieldPath: string) {
@@ -88,11 +93,13 @@ const IngressBaseSchema = z
       .describe(
         "Public-facing base URL for the ingress server (used in webhook callbacks)",
       ),
-    twilioPublicBaseUrl: emptyOrAbsoluteHttpUrl("ingress.twilioPublicBaseUrl")
+    [TWILIO_PUBLIC_BASE_URL_FIELD]: emptyOrAbsoluteHttpUrl(
+      `ingress.${TWILIO_PUBLIC_BASE_URL_FIELD}`,
+    )
       .optional()
       .describe("Twilio-specific public-facing base URL for webhook callbacks"),
-    twilioPublicBaseUrlManagedBy: z
-      .literal("velay")
+    [TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD]: z
+      .literal(VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER)
       .optional()
       .describe("Marks a Twilio-specific public base URL managed by Velay"),
     webhook: IngressWebhookConfigSchema.default(

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -29,6 +29,9 @@
 
 import {
   normalizePublicBaseUrl,
+  TWILIO_CONNECT_ACTION_WEBHOOK_PATH,
+  TWILIO_MEDIA_STREAM_WEBHOOK_PATH,
+  TWILIO_RELAY_WEBHOOK_PATH,
   TWILIO_STATUS_WEBHOOK_PATH,
   TWILIO_VOICE_WEBHOOK_PATH,
 } from "@vellumai/service-contracts/twilio-ingress";
@@ -132,7 +135,7 @@ export function getTwilioStatusCallbackUrl(config: IngressConfig): string {
  */
 export function getTwilioConnectActionUrl(config: IngressConfig): string {
   const base = getTwilioPublicBaseUrl(config);
-  return `${base}/webhooks/twilio/connect-action`;
+  return `${base}${TWILIO_CONNECT_ACTION_WEBHOOK_PATH}`;
 }
 
 /**
@@ -142,7 +145,7 @@ export function getTwilioConnectActionUrl(config: IngressConfig): string {
 export function getTwilioRelayUrl(config: IngressConfig): string {
   const base = getTwilioPublicBaseUrl(config);
   const wsBase = base.replace(/^http(s?)/, "ws$1");
-  return `${wsBase}/webhooks/twilio/relay`;
+  return `${wsBase}${TWILIO_RELAY_WEBHOOK_PATH}`;
 }
 
 /**
@@ -154,7 +157,7 @@ export function getTwilioRelayUrl(config: IngressConfig): string {
 export function getTwilioMediaStreamUrl(config: IngressConfig): string {
   const base = getTwilioPublicBaseUrl(config);
   const wsBase = base.replace(/^http(s?)/, "ws$1");
-  return `${wsBase}/webhooks/twilio/media-stream`;
+  return `${wsBase}${TWILIO_MEDIA_STREAM_WEBHOOK_PATH}`;
 }
 
 /**

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -1,6 +1,13 @@
 import { describe, test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  TWILIO_CONNECT_ACTION_WEBHOOK_PATH,
+  TWILIO_MEDIA_STREAM_WEBHOOK_PATH,
+  TWILIO_RELAY_WEBHOOK_PATH,
+  TWILIO_STATUS_WEBHOOK_PATH,
+  TWILIO_VOICE_WEBHOOK_PATH,
+} from "@vellumai/service-contracts/twilio-ingress";
 import { buildSchema } from "../schema.js";
 
 /** A route extracted from source: path + optional HTTP method. */
@@ -8,6 +15,14 @@ interface ExtractedRoute {
   path: string;
   method: string | null; // null means "any method"
 }
+
+const ROUTE_PATH_CONSTANTS: Record<string, string> = {
+  TWILIO_CONNECT_ACTION_WEBHOOK_PATH,
+  TWILIO_MEDIA_STREAM_WEBHOOK_PATH,
+  TWILIO_RELAY_WEBHOOK_PATH,
+  TWILIO_STATUS_WEBHOOK_PATH,
+  TWILIO_VOICE_WEBHOOK_PATH,
+};
 
 /**
  * Extracts route paths from the gateway index.ts source code.
@@ -40,6 +55,17 @@ function extractRoutesFromSource(): ExtractedRoute[] {
       continue;
     }
 
+    // Match shared path constants: `path: SOME_WEBHOOK_PATH`
+    const constantMatch = line.match(/path:\s*([A-Z0-9_]+)\b/);
+    const constantPath = constantMatch
+      ? ROUTE_PATH_CONSTANTS[constantMatch[1]]
+      : undefined;
+    if (constantPath) {
+      const method = findMethodNearPath(lines, i);
+      routes.push({ path: constantPath, method });
+      continue;
+    }
+
     // Match regex paths: `path: /^\/v1\/contacts\/([^/]+)$/`
     const regexMatch = line.match(/path:\s*\/\^(.*?)\$\//);
     if (regexMatch) {
@@ -56,6 +82,20 @@ function extractRoutesFromSource(): ExtractedRoute[] {
     if (preRouterMatch && !seenPreRouterPaths.has(preRouterMatch[1])) {
       seenPreRouterPaths.add(preRouterMatch[1]);
       routes.push({ path: preRouterMatch[1], method: null });
+    }
+
+    const preRouterConstantMatch = line.match(
+      /url\.pathname\s*===\s*([A-Z0-9_]+)\b/,
+    );
+    const preRouterConstantPath = preRouterConstantMatch
+      ? ROUTE_PATH_CONSTANTS[preRouterConstantMatch[1]]
+      : undefined;
+    if (
+      preRouterConstantPath &&
+      !seenPreRouterPaths.has(preRouterConstantPath)
+    ) {
+      seenPreRouterPaths.add(preRouterConstantPath);
+      routes.push({ path: preRouterConstantPath, method: null });
     }
   }
 

--- a/gateway/src/config-file-cache.ts
+++ b/gateway/src/config-file-cache.ts
@@ -6,27 +6,13 @@
  * is passed to a getter, or when `refreshNow()` is called explicitly.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { getWorkspaceDir } from "./credential-reader.js";
+import { readConfigFileOrEmpty } from "./config-file-utils.js";
 
 const DEFAULT_TTL_MS = 1000;
 
 type ReadOptions = {
   force?: boolean;
 };
-
-function readConfigFile(path: string): Record<string, unknown> {
-  try {
-    if (!existsSync(path)) return {};
-    const raw = readFileSync(path, "utf-8");
-    const data = JSON.parse(raw);
-    if (!data || typeof data !== "object" || Array.isArray(data)) return {};
-    return data as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
 
 /**
  * Iterate entries and keep only those whose value is a non-empty,
@@ -48,21 +34,19 @@ function normalizeRecord(raw: unknown): Record<string, string> | undefined {
 
 export class ConfigFileCache {
   private ttlMs: number;
-  private configPath: string;
   private snapshot: Record<string, unknown> = {};
   private lastReadAt = 0;
   private invalidateCallbacks: Set<() => void> = new Set();
 
   constructor(opts?: { ttlMs?: number }) {
     this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
-    this.configPath = join(getWorkspaceDir(), "config.json");
   }
 
   /** Read the config file if the cached snapshot is stale or force is set. */
   private ensureFresh(opts?: ReadOptions): void {
     const now = Date.now();
     if (opts?.force || now - this.lastReadAt >= this.ttlMs) {
-      this.snapshot = readConfigFile(this.configPath);
+      this.snapshot = readConfigFileOrEmpty();
       this.lastReadAt = Date.now();
     }
   }
@@ -121,7 +105,7 @@ export class ConfigFileCache {
 
   /** Immediately re-read config.json, updating the cached snapshot. */
   refreshNow(): void {
-    this.snapshot = readConfigFile(this.configPath);
+    this.snapshot = readConfigFileOrEmpty();
     this.lastReadAt = Date.now();
   }
 

--- a/gateway/src/config-file-utils.ts
+++ b/gateway/src/config-file-utils.ts
@@ -10,6 +10,8 @@ import { dirname, join } from "node:path";
 
 import { getWorkspaceDir } from "./credential-reader.js";
 
+export const CONFIG_FILENAME = "config.json";
+
 /**
  * Serializes config writes so concurrent config mutations don't race on
  * read-modify-write. Each write awaits the previous one before proceeding.
@@ -29,7 +31,7 @@ export function enqueueConfigWrite(fn: () => void): void {
 }
 
 export function getConfigPath(): string {
-  return join(getWorkspaceDir(), "config.json");
+  return join(getWorkspaceDir(), CONFIG_FILENAME);
 }
 
 export type ConfigReadResult =
@@ -55,6 +57,15 @@ export function readConfigFile(): ConfigReadResult {
   } catch (err) {
     return { ok: false, reason: "malformed", detail: String(err) };
   }
+}
+
+export function readConfigFileOrEmpty(options?: {
+  onMalformed?: (detail: string) => void;
+}): Record<string, unknown> {
+  const result = readConfigFile();
+  if (result.ok) return result.data;
+  options?.onMalformed?.(result.detail);
+  return {};
 }
 
 /**

--- a/gateway/src/config-file-watcher.ts
+++ b/gateway/src/config-file-watcher.ts
@@ -3,15 +3,18 @@
  * Uses the same fs.watch() + debounce pattern as CredentialWatcher.
  */
 
-import { existsSync, readFileSync, watch, type FSWatcher } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, watch, type FSWatcher } from "node:fs";
+import { dirname } from "node:path";
+import {
+  CONFIG_FILENAME,
+  getConfigPath,
+  readConfigFileOrEmpty,
+} from "./config-file-utils.js";
 import { getLogger } from "./logger.js";
-import { getWorkspaceDir } from "./credential-reader.js";
 
 const log = getLogger("config-file-watcher");
 
 const DEBOUNCE_MS = 500;
-const CONFIG_FILENAME = "config.json";
 
 export type ConfigChangeEvent = {
   /** Full parsed config.json data. */
@@ -26,25 +29,6 @@ export type ConfigChangeEvent = {
 };
 
 export type ConfigChangeCallback = (event: ConfigChangeEvent) => void;
-
-function getConfigPath(): string {
-  return join(getWorkspaceDir(), CONFIG_FILENAME);
-}
-
-function readConfigFile(path: string): Record<string, unknown> {
-  try {
-    if (!existsSync(path)) return {};
-
-    const raw = readFileSync(path, "utf-8");
-    const data = JSON.parse(raw);
-    if (!data || typeof data !== "object" || Array.isArray(data)) return {};
-
-    return data as Record<string, unknown>;
-  } catch (err) {
-    log.debug({ err }, "Failed to read config file");
-    return {};
-  }
-}
 
 export class ConfigFileWatcher {
   private watcher: FSWatcher | null = null;
@@ -140,7 +124,11 @@ export class ConfigFileWatcher {
   }
 
   private pollOnce(): void {
-    const data = readConfigFile(this.configPath);
+    const data = readConfigFileOrEmpty({
+      onMalformed: (detail) => {
+        log.debug({ err: detail }, "Failed to read config file");
+      },
+    });
 
     const changedKeys = new Set<string>();
     const changedFields = new Map<string, Set<string>>();

--- a/gateway/src/http/routes/twilio-media-websocket.ts
+++ b/gateway/src/http/routes/twilio-media-websocket.ts
@@ -1,4 +1,5 @@
 import { buildWsUpstreamUrl } from "@vellumai/assistant-client";
+import { TWILIO_MEDIA_STREAM_WEBHOOK_PATH } from "@vellumai/service-contracts/twilio-ingress";
 
 import {
   validateEdgeToken,
@@ -12,9 +13,6 @@ const log = getLogger("twilio-media-ws");
 
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
-
-/** Path prefix for media-stream WS upgrades. */
-const MEDIA_STREAM_PATH_PREFIX = "/webhooks/twilio/media-stream";
 
 type MediaStreamSocketData = {
   wsType: "twilio-media-stream";
@@ -44,8 +42,10 @@ export function extractMediaStreamMetadata(url: URL): {
 } {
   // Try path-based extraction first.
   // Expected pathname: /webhooks/twilio/media-stream/<callSessionId>[/<token>]
-  if (url.pathname.startsWith(MEDIA_STREAM_PATH_PREFIX + "/")) {
-    const suffix = url.pathname.slice(MEDIA_STREAM_PATH_PREFIX.length + 1);
+  if (url.pathname.startsWith(TWILIO_MEDIA_STREAM_WEBHOOK_PATH + "/")) {
+    const suffix = url.pathname.slice(
+      TWILIO_MEDIA_STREAM_WEBHOOK_PATH.length + 1,
+    );
     const segments = suffix.split("/").filter(Boolean);
     if (segments.length >= 1) {
       try {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2,6 +2,14 @@ process.title = "vellum-gateway";
 
 import { randomBytes } from "node:crypto";
 
+import {
+  TWILIO_CONNECT_ACTION_WEBHOOK_PATH,
+  TWILIO_MEDIA_STREAM_WEBHOOK_PATH,
+  TWILIO_RELAY_WEBHOOK_PATH,
+  TWILIO_STATUS_WEBHOOK_PATH,
+  TWILIO_VOICE_WEBHOOK_PATH,
+} from "@vellumai/service-contracts/twilio-ingress";
+
 import { AuthRateLimiter } from "./auth-rate-limiter.js";
 import {
   loadOrCreateSigningKey,
@@ -456,15 +464,15 @@ async function main() {
       handler: (req) => handleTelegramWebhook(req),
     },
     {
-      path: "/webhooks/twilio/voice",
+      path: TWILIO_VOICE_WEBHOOK_PATH,
       handler: (req) => handleTwilioVoiceWebhook(req),
     },
     {
-      path: "/webhooks/twilio/status",
+      path: TWILIO_STATUS_WEBHOOK_PATH,
       handler: (req) => handleTwilioStatusWebhook(req),
     },
     {
-      path: "/webhooks/twilio/connect-action",
+      path: TWILIO_CONNECT_ACTION_WEBHOOK_PATH,
       handler: (req) => handleTwilioConnectActionWebhook(req),
     },
     {
@@ -1456,15 +1464,15 @@ async function main() {
       // ── Pre-router: WebSocket upgrades ──
       // Bun's WS upgrade needs `server.upgrade()` which doesn't return
       // a Response, so these can't go through the route table.
-      if (url.pathname === "/webhooks/twilio/relay") {
+      if (url.pathname === TWILIO_RELAY_WEBHOOK_PATH) {
         const upgradeResult = handleTwilioRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         return undefined as unknown as Response;
       }
 
       if (
-        url.pathname === "/webhooks/twilio/media-stream" ||
-        url.pathname.startsWith("/webhooks/twilio/media-stream/")
+        url.pathname === TWILIO_MEDIA_STREAM_WEBHOOK_PATH ||
+        url.pathname.startsWith(`${TWILIO_MEDIA_STREAM_WEBHOOK_PATH}/`)
       ) {
         const upgradeResult = handleTwilioMediaWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -1,4 +1,9 @@
-import { TWILIO_PUBLIC_BASE_URL_FIELD } from "@vellumai/service-contracts/twilio-ingress";
+import {
+  TWILIO_CONNECT_ACTION_WEBHOOK_PATH,
+  TWILIO_PUBLIC_BASE_URL_FIELD,
+  TWILIO_STATUS_WEBHOOK_PATH,
+  TWILIO_VOICE_WEBHOOK_PATH,
+} from "@vellumai/service-contracts/twilio-ingress";
 
 import type { CredentialCache } from "../credential-cache.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
@@ -30,15 +35,15 @@ function firstHeaderValue(value: string | null): string | undefined {
 function inferWebhookKind(reqUrl: string): TwilioWebhookKind {
   const pathname = new URL(reqUrl).pathname;
 
-  if (pathname === "/webhooks/twilio/voice") {
+  if (pathname === TWILIO_VOICE_WEBHOOK_PATH) {
     return "voice";
   }
 
-  if (pathname === "/webhooks/twilio/status") {
+  if (pathname === TWILIO_STATUS_WEBHOOK_PATH) {
     return "status";
   }
 
-  if (pathname === "/webhooks/twilio/connect-action") {
+  if (pathname === TWILIO_CONNECT_ACTION_WEBHOOK_PATH) {
     return "connect-action";
   }
 

--- a/gateway/src/twilio/webhook-sync.ts
+++ b/gateway/src/twilio/webhook-sync.ts
@@ -1,5 +1,6 @@
 import {
   normalizePublicBaseUrl,
+  TWILIO_PUBLIC_BASE_URL_FIELD,
   TWILIO_STATUS_WEBHOOK_PATH,
   TWILIO_VOICE_WEBHOOK_PATH,
 } from "@vellumai/service-contracts/twilio-ingress";
@@ -41,7 +42,7 @@ function resolveEffectiveTwilioBaseUrl(
   configFile: ConfigFileCache,
 ): string | undefined {
   const twilioBaseUrl = normalizePublicBaseUrl(
-    configFile.getString("ingress", "twilioPublicBaseUrl"),
+    configFile.getString("ingress", TWILIO_PUBLIC_BASE_URL_FIELD),
   );
   if (twilioBaseUrl) return twilioBaseUrl;
 

--- a/packages/service-contracts/src/twilio-ingress.ts
+++ b/packages/service-contracts/src/twilio-ingress.ts
@@ -4,5 +4,9 @@ export const TWILIO_PUBLIC_BASE_URL_MANAGED_BY_FIELD =
 export const VELAY_TWILIO_PUBLIC_BASE_URL_MANAGER = "velay";
 export const TWILIO_VOICE_WEBHOOK_PATH = "/webhooks/twilio/voice";
 export const TWILIO_STATUS_WEBHOOK_PATH = "/webhooks/twilio/status";
+export const TWILIO_CONNECT_ACTION_WEBHOOK_PATH =
+  "/webhooks/twilio/connect-action";
+export const TWILIO_RELAY_WEBHOOK_PATH = "/webhooks/twilio/relay";
+export const TWILIO_MEDIA_STREAM_WEBHOOK_PATH = "/webhooks/twilio/media-stream";
 
 export { normalizePublicBaseUrl } from "./ingress.js";


### PR DESCRIPTION
## Summary
- Reuses neutral config-file helpers across gateway cache/watcher code.
- Completes shared Twilio webhook path and managed-field constants across assistant and gateway.

Fixes gaps identified during plan review for velay-twilio-ingress.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
