### PR TITLE
fix: honor disabled ingress in Twilio sync

### DIFF
--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -5,15 +5,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let mockSecureKeys: Record<string, string | null> = {};
 let mockLoadConfigResult: Record<string, unknown> = {};
 
-function resolveMockTwilioBaseUrl(config: Record<string, unknown>): string {
-  const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  const base =
-    (ingress.twilioPublicBaseUrl as string | undefined) ||
-    (ingress.publicBaseUrl as string | undefined) ||
-    "https://test.example.com";
-  return base.trim().replace(/\/+$/, "");
-}
-
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
@@ -29,13 +20,6 @@ mock.module("../config/loader.js", () => ({
   loadConfig: () => mockLoadConfigResult,
 }));
 
-mock.module("../inbound/public-ingress-urls.js", () => ({
-  getTwilioPublicBaseUrl: (config: Record<string, unknown>) =>
-    resolveMockTwilioBaseUrl(config),
-  getTwilioRelayUrl: (config: Record<string, unknown>) =>
-    `${resolveMockTwilioBaseUrl(config).replace(/^http/, "ws")}/twilio/relay`,
-}));
-
 import { getTwilioConfig } from "../calls/twilio-config.js";
 import { credentialKey } from "../security/credential-key.js";
 
@@ -45,6 +29,9 @@ describe("twilio-config", () => {
       [credentialKey("twilio", "auth_token")]: "test_auth_token",
     };
     mockLoadConfigResult = {
+      ingress: {
+        publicBaseUrl: "https://test.example.com",
+      },
       twilio: {
         accountSid: "AC_test_sid",
         phoneNumber: "+15550123",
@@ -58,7 +45,9 @@ describe("twilio-config", () => {
     expect(config.authToken).toBe("test_auth_token");
     expect(config.phoneNumber).toBe("+15550123");
     expect(config.webhookBaseUrl).toBe("https://test.example.com");
-    expect(config.wssBaseUrl).toBe("wss://test.example.com/twilio/relay");
+    expect(config.wssBaseUrl).toBe(
+      "wss://test.example.com/webhooks/twilio/relay",
+    );
   });
 
   test("uses Twilio-specific public base URL when generic ingress is empty", async () => {
@@ -76,11 +65,16 @@ describe("twilio-config", () => {
     const config = await getTwilioConfig();
 
     expect(config.webhookBaseUrl).toBe("https://twilio.example.com");
-    expect(config.wssBaseUrl).toBe("wss://twilio.example.com/twilio/relay");
+    expect(config.wssBaseUrl).toBe(
+      "wss://twilio.example.com/webhooks/twilio/relay",
+    );
   });
 
   test("throws ConfigError when account SID is missing", async () => {
     mockLoadConfigResult = {
+      ingress: {
+        publicBaseUrl: "https://test.example.com",
+      },
       twilio: { accountSid: "", phoneNumber: "+15550123" },
     };
     expect(getTwilioConfig()).rejects.toThrow(
@@ -91,6 +85,9 @@ describe("twilio-config", () => {
   test("throws ConfigError when auth token is missing", async () => {
     mockSecureKeys = {};
     mockLoadConfigResult = {
+      ingress: {
+        publicBaseUrl: "https://test.example.com",
+      },
       twilio: {
         accountSid: "AC_test_sid",
         phoneNumber: "+15550123",
@@ -103,6 +100,9 @@ describe("twilio-config", () => {
 
   test("throws ConfigError when phone number is missing", async () => {
     mockLoadConfigResult = {
+      ingress: {
+        publicBaseUrl: "https://test.example.com",
+      },
       twilio: {
         accountSid: "AC_test_sid",
         phoneNumber: "",
@@ -114,7 +114,11 @@ describe("twilio-config", () => {
   });
 
   test("throws ConfigError when twilio config section is absent", async () => {
-    mockLoadConfigResult = {};
+    mockLoadConfigResult = {
+      ingress: {
+        publicBaseUrl: "https://test.example.com",
+      },
+    };
     expect(getTwilioConfig()).rejects.toThrow(
       /Twilio credentials not configured/,
     );

--- a/gateway/src/twilio/webhook-sync.test.ts
+++ b/gateway/src/twilio/webhook-sync.test.ts
@@ -1,19 +1,39 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
-import {
-  getMockFetchCalls,
-  mockFetch,
-  resetMockFetch,
-} from "../__tests__/mock-fetch.js";
-import { syncConfiguredTwilioPhoneNumberWebhooks } from "./webhook-sync.js";
-
 const ACCOUNT_SID = "AC123";
 const AUTH_TOKEN = "auth-token";
 const PHONE_NUMBER = "+15550100";
 const PHONE_NUMBER_SID = "PN123";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+interface MockedResponse {
+  body?: unknown;
+  status: number;
+}
+
+interface MockFetchEntry {
+  init: Partial<RequestInit>;
+  path: string;
+  response: MockedResponse | Response;
+}
+
+const mockFetchEntries: MockFetchEntry[] = [];
+const mockFetchCalls: { init: RequestInit; path: string }[] = [];
+let fetchImpl: ReturnType<typeof mock<FetchFn>> = mockFetchImpl();
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchImpl(...args),
+}));
+
+const { syncConfiguredTwilioPhoneNumberWebhooks } =
+  await import("./webhook-sync.js");
 
 afterEach(() => {
   resetMockFetch();
@@ -24,6 +44,7 @@ function makeCaches(opts: {
   accountSid?: string;
   accountSidCredential?: string;
   authToken?: string;
+  ingressEnabled?: boolean;
   publicBaseUrl?: string;
   twilioPublicBaseUrl?: string;
 }): { credentials: CredentialCache; configFile: ConfigFileCache } {
@@ -50,9 +71,73 @@ function makeCaches(opts: {
     configFile: {
       getString: (section: string, key: string) =>
         configValues[section]?.[key] ?? undefined,
+      getBoolean: (section: string, key: string) => {
+        if (section === "ingress" && key === "enabled") {
+          return opts.ingressEnabled;
+        }
+        return undefined;
+      },
       invalidate: () => {},
     } as unknown as ConfigFileCache,
   };
+}
+
+function mockFetchImpl(): ReturnType<typeof mock<FetchFn>> {
+  return mock(
+    async (input: string | URL | Request, actualInit?: RequestInit) => {
+      const url = String(input);
+      mockFetchCalls.push({ path: url, init: actualInit ?? {} });
+
+      const idx = mockFetchEntries.findIndex((entry) => {
+        if (!url.includes(entry.path)) return false;
+        for (const [key, value] of Object.entries(entry.init)) {
+          const actualValue = (
+            actualInit as Record<string, unknown> | undefined
+          )?.[key];
+          if (actualValue !== value) {
+            return false;
+          }
+        }
+        return true;
+      });
+
+      if (idx === -1) {
+        return new Response(JSON.stringify({ detail: "No mock matched" }), {
+          status: 500,
+        });
+      }
+
+      const entry = mockFetchEntries[idx];
+      mockFetchEntries.splice(idx, 1);
+
+      if (entry.response instanceof Response) {
+        return entry.response;
+      }
+
+      return new Response(JSON.stringify(entry.response.body ?? null), {
+        status: entry.response.status,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  );
+}
+
+function mockFetch(
+  path: string,
+  init: Partial<RequestInit>,
+  response: MockedResponse | Response,
+): void {
+  mockFetchEntries.push({ path, init, response });
+}
+
+function getMockFetchCalls(): { init: RequestInit; path: string }[] {
+  return mockFetchCalls;
+}
+
+function resetMockFetch(): void {
+  mockFetchEntries.length = 0;
+  mockFetchCalls.length = 0;
+  fetchImpl = mockFetchImpl();
 }
 
 function mockTwilioLookupAndUpdate(): void {
@@ -160,6 +245,21 @@ describe("syncConfiguredTwilioPhoneNumberWebhooks", () => {
         accountSid: ACCOUNT_SID,
         authToken: undefined,
         publicBaseUrl: "https://generic.example.test",
+      }),
+    );
+
+    expect(getMockFetchCalls()).toEqual([]);
+  });
+
+  test("skips without Twilio REST calls when public ingress is disabled", async () => {
+    await syncConfiguredTwilioPhoneNumberWebhooks(
+      makeCaches({
+        phoneNumber: PHONE_NUMBER,
+        accountSid: ACCOUNT_SID,
+        authToken: AUTH_TOKEN,
+        ingressEnabled: false,
+        publicBaseUrl: "https://generic.example.test",
+        twilioPublicBaseUrl: "https://velay.example.test/twilio",
       }),
     );
 

--- a/gateway/src/twilio/webhook-sync.ts
+++ b/gateway/src/twilio/webhook-sync.ts
@@ -40,6 +40,10 @@ function buildWebhookUrls(baseUrl: string): {
 function resolveEffectiveTwilioBaseUrl(
   configFile: ConfigFileCache,
 ): string | undefined {
+  if (configFile.getBoolean("ingress", "enabled", { force: true }) === false) {
+    return undefined;
+  }
+
   const twilioBaseUrl = normalizePublicBaseUrl(
     configFile.getString("ingress", "twilioPublicBaseUrl"),
   );

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -47,9 +47,36 @@ function makeCredentials(values: Record<string, string | undefined>) {
 }
 
 function makeConfigFileCache(invalidations: { count: number }) {
+  const invalidateCallbacks = new Set<() => void>();
   return {
+    getBoolean: (section: string, key: string) => {
+      let sectionValue: unknown;
+      try {
+        sectionValue = readConfig()[section];
+      } catch {
+        return undefined;
+      }
+      if (
+        !sectionValue ||
+        typeof sectionValue !== "object" ||
+        Array.isArray(sectionValue)
+      ) {
+        return undefined;
+      }
+      const value = (sectionValue as Record<string, unknown>)[key];
+      return typeof value === "boolean" ? value : undefined;
+    },
     invalidate: () => {
       invalidations.count++;
+      for (const callback of invalidateCallbacks) {
+        callback();
+      }
+    },
+    onInvalidate: (callback: () => void) => {
+      invalidateCallbacks.add(callback);
+      return () => {
+        invalidateCallbacks.delete(callback);
+      };
     },
   } as unknown as ConfigFileCache;
 }
@@ -255,6 +282,137 @@ describe("VelayTunnelClient", () => {
       existing: { preserved: true },
     });
     expect(invalidations.count).toBe(1);
+  });
+
+  test("waits without connecting when public ingress is disabled", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    const invalidations = { count: 0 };
+    writeConfig({
+      ingress: {
+        enabled: false,
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://stale-velay.example.test",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+    const client = makeClient({
+      sockets,
+      reconnectDelays,
+      configFile: makeConfigFileCache(invalidations),
+    });
+
+    client.start();
+    await flushPromises();
+
+    expect(sockets).toHaveLength(0);
+    expect(reconnectDelays).toEqual([10]);
+    expect(readConfig()).toEqual({
+      ingress: {
+        enabled: false,
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(1);
+    await client.stop();
+  });
+
+  test("closes without publishing when public ingress is disabled after connecting", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    const invalidations = { count: 0 };
+    writeConfig({
+      ingress: {
+        enabled: true,
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    const client = makeClient({
+      sockets,
+      reconnectDelays,
+      configFile: makeConfigFileCache(invalidations),
+    });
+
+    client.start();
+    await flushPromises();
+    expect(sockets).toHaveLength(1);
+
+    writeConfig({
+      ingress: {
+        enabled: false,
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "public ingress disabled" },
+    ]);
+    expect(reconnectDelays).toEqual([10]);
+    expect(readConfig()).toEqual({
+      ingress: {
+        enabled: false,
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(0);
+  });
+
+  test("closes and clears a published URL when public ingress is disabled while connected", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const reconnectDelays: number[] = [];
+    const invalidations = { count: 0 };
+    const configFile = makeConfigFileCache(invalidations);
+    writeConfig({
+      ingress: {
+        enabled: true,
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    const client = makeClient({
+      sockets,
+      reconnectDelays,
+      configFile,
+    });
+
+    client.start();
+    await flushPromises();
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+
+    writeConfig({
+      ingress: {
+        enabled: false,
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://velay-public.example.test/",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
+    configFile.invalidate();
+    await flushPromises();
+
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "public ingress disabled" },
+    ]);
+    expect(reconnectDelays).toEqual([10]);
+    expect(readConfig()).toEqual({
+      ingress: {
+        enabled: false,
+        publicBaseUrl: "https://ngrok.example.test",
+      },
+    });
+    expect(invalidations.count).toBe(3);
   });
 
   test("rejects registration when Velay returns a different assistant ID", async () => {

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -85,6 +85,7 @@ export class VelayTunnelClient {
   private reconnectAttempt = 0;
   private reconnectTimer: unknown = null;
   private publishedTwilioPublicBaseUrl: string | undefined;
+  private unsubscribeConfigInvalidation: (() => void) | undefined;
 
   constructor(private readonly options: VelayTunnelClientOptions) {
     this.webSocketConstructor =
@@ -107,6 +108,11 @@ export class VelayTunnelClient {
   start(): void {
     if (this.running) return;
     this.running = true;
+    this.unsubscribeConfigInvalidation ??= this.options.configFile.onInvalidate(
+      () => {
+        this.handleConfigInvalidated();
+      },
+    );
     this.startAsync().catch((err) => {
       this.connecting = false;
       log.error({ err }, "Failed to start Velay tunnel client");
@@ -117,6 +123,8 @@ export class VelayTunnelClient {
   async stop(): Promise<void> {
     this.running = false;
     this.connecting = false;
+    this.unsubscribeConfigInvalidation?.();
+    this.unsubscribeConfigInvalidation = undefined;
     if (this.reconnectTimer) {
       this.timerApi.clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -138,6 +146,14 @@ export class VelayTunnelClient {
   private async connect(): Promise<void> {
     if (!this.running || this.connecting) return;
     this.connecting = true;
+
+    if (this.isPublicIngressDisabled()) {
+      this.connecting = false;
+      await this.clearPublishedTwilioPublicBaseUrl();
+      log.info("Velay tunnel waiting because public ingress is disabled");
+      this.scheduleReconnect();
+      return;
+    }
 
     let apiKeyRaw: string | undefined;
     let platformAssistantIdRaw: string | undefined;
@@ -295,6 +311,15 @@ export class VelayTunnelClient {
       return;
     }
 
+    if (this.isPublicIngressDisabled()) {
+      log.info(
+        { publicUrl },
+        "Skipping Velay Twilio public URL publish because public ingress is disabled",
+      );
+      this.disconnectActiveWebSocket(originWs, 1000, "public ingress disabled");
+      return;
+    }
+
     await writeManagedTwilioPublicBaseUrl(publicUrl, this.options.configFile);
     this.publishedTwilioPublicBaseUrl = publicUrl;
     log.info({ publicUrl }, "Velay tunnel registered");
@@ -375,6 +400,22 @@ export class VelayTunnelClient {
         this.scheduleReconnect();
       });
     }, delay);
+  }
+
+  private handleConfigInvalidated(): void {
+    const ws = this.ws;
+    if (!ws || !this.isPublicIngressDisabled()) return;
+
+    log.info("Closing Velay tunnel because public ingress is disabled");
+    this.disconnectActiveWebSocket(ws, 1000, "public ingress disabled");
+  }
+
+  private isPublicIngressDisabled(): boolean {
+    return (
+      this.options.configFile.getBoolean("ingress", "enabled", {
+        force: true,
+      }) === false
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Makes Velay Twilio publish and webhook sync honor ingress.enabled=false.
- Fixes assistant and gateway test isolation around Twilio URL/sync coverage.

Fixes gaps identified during plan review for velay-twilio-ingress.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
