### PR TITLE
feat: optional file override for memory v2 consolidation prompt

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -22,6 +22,7 @@ describe("MemoryV2ConfigSchema", () => {
       sparse_weight: 0.3,
       consolidation_interval_hours: 4,
       max_page_chars: 5000,
+      consolidation_prompt_path: null,
     });
   });
 

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -139,6 +139,15 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Soft upper bound on concept-page body length — pages exceeding this are flagged for split during consolidation",
       ),
+    consolidation_prompt_path: z
+      .string({
+        error: "memory.v2.consolidation_prompt_path must be a string",
+      })
+      .nullable()
+      .default(null)
+      .describe(
+        "Optional path to a file whose contents replace the bundled consolidation prompt. Absolute paths are used as-is, a leading `~/` is expanded to the home directory, otherwise the path is resolved under the workspace root. The loaded contents may include `{{CUTOFF}}`, which is substituted with the run's ISO-8601 cutoff timestamp. If the file is missing, unreadable, or empty, the bundled prompt is used and a warning is logged.",
+      ),
   })
   .describe(
     "Memory v2 — concept-page activation model with hourly LLM-driven consolidation",

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -136,10 +136,13 @@ const { CUTOFF_PLACEHOLDER, CONSOLIDATION_PROMPT } =
   await import("../prompts/consolidation.js");
 
 // `isAssistantFeatureFlagEnabled` ignores the `config` argument it receives
-// (resolution is purely from the overrides + registry caches), so we hand
-// the handler a minimal stand-in instead of materializing the full default
-// config.
-const CONFIG = {} as Parameters<typeof memoryV2ConsolidateJob>[1];
+// (resolution is purely from the overrides + registry caches), and the
+// resolver only reads `config.memory.v2.consolidation_prompt_path` — so a
+// minimal stand-in covers both call sites without materializing the full
+// default config.
+const CONFIG = {
+  memory: { v2: { consolidation_prompt_path: null } },
+} as Parameters<typeof memoryV2ConsolidateJob>[1];
 
 function makeJob(): Parameters<typeof memoryV2ConsolidateJob>[0] {
   return {
@@ -277,6 +280,24 @@ describe("memoryV2ConsolidateJob — flag on, non-empty buffer", () => {
     // Cutoff is an ISO-8601 timestamp — check the year prefix matches the
     // current year so we know the substitution actually happened.
     expect(hint).toContain(`${new Date().getFullYear()}`);
+  });
+
+  test("honors memory.v2.consolidation_prompt_path override when set", async () => {
+    writeFileSync(
+      join(tmpWorkspace, "custom-prompt.md"),
+      "CUSTOM CONSOLIDATION at {{CUTOFF}}\n",
+    );
+    const overrideConfig = {
+      memory: { v2: { consolidation_prompt_path: "custom-prompt.md" } },
+    } as Parameters<typeof memoryV2ConsolidateJob>[1];
+
+    const result = await memoryV2ConsolidateJob(makeJob(), overrideConfig);
+
+    expect(result.kind).toBe("invoked");
+    const hint = wakeLastArgs?.hint as string;
+    expect(hint).toMatch(/^CUSTOM CONSOLIDATION at \d{4}-/);
+    expect(hint).not.toContain("You are running memory consolidation");
+    expect(hint).not.toContain(CUTOFF_PLACEHOLDER);
   });
 
   test("enqueues the memory_v2_reembed follow-up job on success", async () => {

--- a/assistant/src/memory/v2/__tests__/prompts-consolidation.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-consolidation.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for `assistant/src/memory/v2/prompts/consolidation.ts` —
+ * specifically `resolveConsolidationPrompt` which loads an optional
+ * file-based override and falls back to the bundled prompt when the
+ * override is missing/empty/unreadable.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const warnCalls: Array<{ data: unknown; msg: string }> = [];
+const recordingLogger = {
+  warn: (data: unknown, msg: string) => {
+    warnCalls.push({ data, msg });
+  },
+  info: () => {},
+  debug: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  child: () => recordingLogger,
+};
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => recordingLogger,
+}));
+
+let tmpWorkspace: string;
+let previousWorkspaceEnv: string | undefined;
+
+beforeAll(() => {
+  tmpWorkspace = mkdtempSync(join(tmpdir(), "memory-v2-prompt-test-"));
+  previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
+});
+
+afterAll(() => {
+  if (previousWorkspaceEnv === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceEnv;
+  }
+  rmSync(tmpWorkspace, { recursive: true, force: true });
+});
+
+const { CONSOLIDATION_PROMPT, CUTOFF_PLACEHOLDER, resolveConsolidationPrompt } =
+  await import("../prompts/consolidation.js");
+
+const CUTOFF = "2026-05-01T12:00:00.000Z";
+
+const bundledPrompt = (): string =>
+  (CONSOLIDATION_PROMPT as string).replaceAll(CUTOFF_PLACEHOLDER, CUTOFF);
+
+beforeEach(() => {
+  warnCalls.length = 0;
+  mkdirSync(tmpWorkspace, { recursive: true });
+});
+
+afterEach(() => {
+  for (const entry of ["custom-prompt.md", "empty.md", "no-placeholder.md"]) {
+    rmSync(join(tmpWorkspace, entry), { force: true });
+  }
+});
+
+describe("resolveConsolidationPrompt — no override", () => {
+  test("returns the bundled prompt with {{CUTOFF}} substituted when overridePath is null", () => {
+    const result = resolveConsolidationPrompt(null, CUTOFF);
+    expect(result).toContain("You are running memory consolidation");
+    expect(result).toContain(CUTOFF);
+    expect(result).not.toContain(CUTOFF_PLACEHOLDER);
+    expect(warnCalls).toHaveLength(0);
+  });
+});
+
+describe("resolveConsolidationPrompt — with override", () => {
+  test("loads an absolute path verbatim and substitutes {{CUTOFF}}", () => {
+    const path = join(tmpWorkspace, "custom-prompt.md");
+    writeFileSync(path, "Custom prompt at {{CUTOFF}}\n");
+
+    const result = resolveConsolidationPrompt(path, CUTOFF);
+
+    expect(result).toBe(`Custom prompt at ${CUTOFF}\n`);
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("resolves a relative path against the workspace dir", () => {
+    writeFileSync(
+      join(tmpWorkspace, "custom-prompt.md"),
+      "Workspace-relative {{CUTOFF}}\n",
+    );
+
+    const result = resolveConsolidationPrompt("custom-prompt.md", CUTOFF);
+
+    expect(result).toBe(`Workspace-relative ${CUTOFF}\n`);
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("expands a leading ~/ to the home directory", () => {
+    const filename = `.vellum-prompt-test-${process.pid}.md`;
+    const path = join(homedir(), filename);
+    writeFileSync(path, "Home dir {{CUTOFF}}\n");
+    try {
+      const result = resolveConsolidationPrompt(`~/${filename}`, CUTOFF);
+      expect(result).toBe(`Home dir ${CUTOFF}\n`);
+      expect(warnCalls).toHaveLength(0);
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+
+  test("returns the file body verbatim when {{CUTOFF}} is absent", () => {
+    const body = "No placeholder here. Just a plain prompt.\n";
+    writeFileSync(join(tmpWorkspace, "no-placeholder.md"), body);
+
+    const result = resolveConsolidationPrompt("no-placeholder.md", CUTOFF);
+
+    expect(result).toBe(body);
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("substitutes every {{CUTOFF}} occurrence (replaceAll, not replace)", () => {
+    writeFileSync(
+      join(tmpWorkspace, "custom-prompt.md"),
+      "{{CUTOFF}} ... {{CUTOFF}} ... {{CUTOFF}}",
+    );
+
+    const result = resolveConsolidationPrompt("custom-prompt.md", CUTOFF);
+
+    expect(result).toBe(`${CUTOFF} ... ${CUTOFF} ... ${CUTOFF}`);
+    expect(result).not.toContain(CUTOFF_PLACEHOLDER);
+  });
+});
+
+describe("resolveConsolidationPrompt — failure modes", () => {
+  test("falls back to bundled prompt and logs a warning when the file is missing", () => {
+    const result = resolveConsolidationPrompt(
+      "/this/path/does/not/exist.md",
+      CUTOFF,
+    );
+
+    expect(result).toBe(bundledPrompt());
+    expect(warnCalls).toHaveLength(1);
+    const data = warnCalls[0].data as Record<string, unknown>;
+    expect(data.code).toBe("ENOENT");
+    expect(data.fallback).toBe("bundled");
+  });
+
+  test("falls back to bundled prompt when the file is empty", () => {
+    const path = join(tmpWorkspace, "empty.md");
+    writeFileSync(path, "");
+
+    const result = resolveConsolidationPrompt(path, CUTOFF);
+
+    expect(result).toBe(bundledPrompt());
+    expect(warnCalls).toHaveLength(1);
+    const data = warnCalls[0].data as Record<string, unknown>;
+    expect(data.reason).toBe("empty_override");
+  });
+
+  test("falls back to bundled prompt when the file is whitespace-only", () => {
+    const path = join(tmpWorkspace, "empty.md");
+    writeFileSync(path, "   \n\n\t\n");
+
+    const result = resolveConsolidationPrompt(path, CUTOFF);
+
+    expect(result).toBe(bundledPrompt());
+    expect(warnCalls).toHaveLength(1);
+    const data = warnCalls[0].data as Record<string, unknown>;
+    expect(data.reason).toBe("empty_override");
+  });
+});

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -66,7 +66,7 @@ import {
   type MemoryJob,
   type MemoryJobType,
 } from "../jobs-store.js";
-import { renderConsolidationPrompt } from "./prompts/consolidation.js";
+import { resolveConsolidationPrompt } from "./prompts/consolidation.js";
 
 const log = getLogger("memory-v2-consolidate");
 
@@ -155,7 +155,10 @@ export async function memoryV2ConsolidateJob(
     try {
       const result = await wakeAgentForOpportunity({
         conversationId: conversation.id,
-        hint: renderConsolidationPrompt(cutoff),
+        hint: resolveConsolidationPrompt(
+          config.memory.v2.consolidation_prompt_path,
+          cutoff,
+        ),
         source: WAKE_SOURCE,
         trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       });

--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -16,6 +16,15 @@
  * the convention established for the sweep prompt.
  */
 
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import { getLogger } from "../../../util/logger.js";
+import { getWorkspaceDir } from "../../../util/platform.js";
+
+const log = getLogger("memory-v2-consolidate-prompt");
+
 /** Sentinel substituted with the cutoff timestamp at runtime. */
 export const CUTOFF_PLACEHOLDER = "{{CUTOFF}}";
 
@@ -196,4 +205,57 @@ This is the engine that decides who you are tomorrow. Be ORGANIZED. Care, judgme
  */
 export function renderConsolidationPrompt(cutoff: string): string {
   return CONSOLIDATION_PROMPT.replaceAll(CUTOFF_PLACEHOLDER, cutoff);
+}
+
+/**
+ * Load the consolidation prompt template, optionally overridden from the file
+ * referenced by `memory.v2.consolidation_prompt_path`, then substitute
+ * `{{CUTOFF}}`. Path-resolution rules are documented on the schema field.
+ *
+ * Failure handling is intentionally permissive — missing file, read error, or
+ * empty/whitespace-only body all log a warning and fall back to the bundled
+ * prompt. Consolidation must never break because of a bad override: the
+ * daemon's startup philosophy is "log and recover."
+ */
+export function resolveConsolidationPrompt(
+  overridePath: string | null,
+  cutoff: string,
+): string {
+  if (overridePath === null) return renderConsolidationPrompt(cutoff);
+
+  const resolvedPath = resolveOverridePath(overridePath);
+  let contents: string;
+  try {
+    contents = readFileSync(resolvedPath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    log.warn(
+      { configuredPath: overridePath, resolvedPath, code, fallback: "bundled" },
+      "consolidation prompt override unreadable; using bundled prompt",
+    );
+    return renderConsolidationPrompt(cutoff);
+  }
+
+  if (contents.trim().length === 0) {
+    log.warn(
+      {
+        configuredPath: overridePath,
+        resolvedPath,
+        reason: "empty_override",
+        fallback: "bundled",
+      },
+      "consolidation prompt override is empty; using bundled prompt",
+    );
+    return renderConsolidationPrompt(cutoff);
+  }
+
+  return contents.replaceAll(CUTOFF_PLACEHOLDER, cutoff);
+}
+
+function resolveOverridePath(overridePath: string): string {
+  if (overridePath.startsWith("~/")) {
+    return join(homedir(), overridePath.slice(2));
+  }
+  if (isAbsolute(overridePath)) return overridePath;
+  return join(getWorkspaceDir(), overridePath);
 }


### PR DESCRIPTION
## Summary
- Adds optional `memory.v2.consolidation_prompt_path` config field; when set, the consolidation job loads its prompt body from that file instead of the bundled `CONSOLIDATION_PROMPT`.
- Path resolution: absolute paths used as-is, leading `~/` expanded to home, otherwise relative to the workspace root. Loaded contents still get `{{CUTOFF}}` substitution.
- Missing/unreadable/empty override → log a warning and fall back to the bundled prompt. Consolidation never breaks on a bad override.

## Original prompt
I want to allow overriding the default consolidation prompt with a new one from a file using config.json. this should be optional and default to no override
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
