### PR TITLE
fix: complete Twilio ingress lifecycle triggers

### DIFF
--- a/gateway/src/__tests__/config-file-watcher.test.ts
+++ b/gateway/src/__tests__/config-file-watcher.test.ts
@@ -164,4 +164,21 @@ describe("Twilio webhook sync config-change triggers", () => {
     expect(isOnlyVelayTwilioIngressChange(event)).toBe(true);
     expect(shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)).toBe(false);
   });
+
+  test("syncs when Twilio phone configuration becomes available", () => {
+    const event = makeEvent(["twilio"], {
+      twilio: ["phoneNumber", "accountSid"],
+    });
+
+    expect(isOnlyVelayTwilioIngressChange(event)).toBe(false);
+    expect(shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)).toBe(true);
+  });
+
+  test("does not sync when unrelated Twilio configuration changes", () => {
+    const event = makeEvent(["twilio"], {
+      twilio: ["assistantPhoneNumbers"],
+    });
+
+    expect(shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)).toBe(false);
+  });
 });

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -146,11 +146,17 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 function makeCaches(
   opts: {
     authToken?: string;
+    ingressEnabled?: boolean;
     ingressUrl?: string;
     twilioIngressUrl?: string;
   } = {},
 ) {
-  const { authToken = AUTH_TOKEN, ingressUrl, twilioIngressUrl } = opts;
+  const {
+    authToken = AUTH_TOKEN,
+    ingressEnabled,
+    ingressUrl,
+    twilioIngressUrl,
+  } = opts;
   const credentials = {
     get: async (key: string, _opts?: { force?: boolean }) => {
       if (key === credentialKey("twilio", "auth_token")) return authToken;
@@ -164,6 +170,10 @@ function makeCaches(
       if (section === "ingress" && key === "twilioPublicBaseUrl") {
         return twilioIngressUrl;
       }
+      return undefined;
+    },
+    getBoolean: (section: string, key: string) => {
+      if (section === "ingress" && key === "enabled") return ingressEnabled;
       return undefined;
     },
     getRecord: () => undefined,
@@ -257,6 +267,20 @@ describe("Twilio voice webhook", () => {
     });
     const res = await handler(req);
     expect(res.status).toBe(403);
+  });
+
+  test("rejects while public ingress is disabled", async () => {
+    const handler = createTwilioVoiceWebhookHandler(
+      makeConfig(),
+      makeCaches({ ingressEnabled: false }),
+    );
+    const url = "http://localhost:7830/webhooks/twilio/voice";
+    const req = buildSignedRequest(url, { From: "+15550100" }, AUTH_TOKEN);
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("forwards valid signed request to runtime and returns response", async () => {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1922,6 +1922,15 @@ async function main() {
       }
     }
 
+    if (changed.has("twilio")) {
+      syncConfiguredTwilioPhoneNumberWebhooks({
+        credentials: credentialCache,
+        configFile: configFileCache,
+      }).catch((err) => {
+        log.warn({ err }, "Twilio webhook sync failed after credential change");
+      });
+    }
+
     // Register email callback route with the platform so inbound email
     // webhooks are forwarded to this gateway (same pattern as Telegram).
     // Fires on initial credential load and whenever vellum credentials change
@@ -1973,10 +1982,7 @@ async function main() {
         credentials: credentialCache,
         configFile: configFileCache,
       }).catch((err) => {
-        log.warn(
-          { err },
-          "Twilio webhook sync failed after ingress URL change",
-        );
+        log.warn({ err }, "Twilio webhook sync failed after config change");
       });
     }
 

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -198,6 +198,15 @@ function readConfiguredIngressUrls(
   };
 }
 
+function isPublicIngressDisabled(
+  configFile: ConfigFileCache | undefined,
+): boolean {
+  if (!configFile || typeof configFile.getBoolean !== "function") {
+    return false;
+  }
+  return configFile.getBoolean("ingress", "enabled", { force: true }) === false;
+}
+
 /**
  * Validate an incoming Twilio webhook request:
  * - Enforces POST method
@@ -224,6 +233,14 @@ export async function validateTwilioWebhookRequest(
   if (contentLength && Number(contentLength) > config.maxWebhookPayloadBytes) {
     log.warn({ contentLength }, "Twilio webhook payload too large");
     return Response.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  if (isPublicIngressDisabled(caches?.configFile)) {
+    log.warn(
+      { webhookKind: inferWebhookKind(req.url) },
+      "Twilio webhook rejected because public ingress is disabled",
+    );
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   // Resolve the auth token from cache

--- a/gateway/src/twilio/webhook-sync-trigger.ts
+++ b/gateway/src/twilio/webhook-sync-trigger.ts
@@ -6,6 +6,8 @@ import {
 import type { ConfigChangeEvent } from "../config-file-watcher.js";
 
 const PUBLIC_BASE_URL_FIELD = "publicBaseUrl";
+const TWILIO_PHONE_NUMBER_FIELD = "phoneNumber";
+const TWILIO_ACCOUNT_SID_FIELD = "accountSid";
 
 export function isOnlyVelayTwilioIngressChange(
   event: ConfigChangeEvent,
@@ -29,13 +31,23 @@ export function isOnlyVelayTwilioIngressChange(
 export function shouldSyncTwilioPhoneWebhooksAfterConfigChange(
   event: ConfigChangeEvent,
 ): boolean {
-  if (!event.changedKeys.has("ingress")) {
+  if (event.changedKeys.has("ingress")) {
+    const ingressFields = event.changedFields.get("ingress");
+    if (
+      ingressFields?.has(TWILIO_PUBLIC_BASE_URL_FIELD) === true ||
+      ingressFields?.has(PUBLIC_BASE_URL_FIELD) === true
+    ) {
+      return true;
+    }
+  }
+
+  if (!event.changedKeys.has("twilio")) {
     return false;
   }
 
-  const ingressFields = event.changedFields.get("ingress");
+  const twilioFields = event.changedFields.get("twilio");
   return (
-    ingressFields?.has(TWILIO_PUBLIC_BASE_URL_FIELD) === true ||
-    ingressFields?.has(PUBLIC_BASE_URL_FIELD) === true
+    twilioFields?.has(TWILIO_PHONE_NUMBER_FIELD) === true ||
+    twilioFields?.has(TWILIO_ACCOUNT_SID_FIELD) === true
   );
 }

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -221,9 +221,12 @@ describe("VelayTunnelClient", () => {
     await client.stop();
   });
 
-  test("retries without opening a socket when the platform assistant ID is missing", async () => {
+  test("opens a socket and registers when the platform assistant ID is missing", async () => {
     const sockets: FakeWebSocket[] = [];
     const reconnectDelays: number[] = [];
+    writeConfig({
+      ingress: { publicBaseUrl: "https://ngrok.example.test" },
+    });
     const client = makeClient({
       sockets,
       reconnectDelays,
@@ -235,8 +238,24 @@ describe("VelayTunnelClient", () => {
     client.start();
     await flushPromises();
 
-    expect(sockets).toHaveLength(0);
-    expect(reconnectDelays).toEqual([10]);
+    expect(sockets).toHaveLength(1);
+    sockets[0].readyState = WS_OPEN;
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-from-velay",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+
+    expect(sockets[0].closes).toEqual([]);
+    expect(reconnectDelays).toEqual([]);
+    expect(readConfig()).toEqual({
+      ingress: {
+        publicBaseUrl: "https://ngrok.example.test",
+        twilioPublicBaseUrl: "https://velay-public.example.test/",
+        twilioPublicBaseUrlManagedBy: "velay",
+      },
+    });
     await client.stop();
   });
 

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -186,12 +186,6 @@ export class VelayTunnelClient {
       this.scheduleReconnect();
       return;
     }
-    if (!platformAssistantId) {
-      this.connecting = false;
-      log.info("Velay tunnel waiting for platform assistant ID");
-      this.scheduleReconnect();
-      return;
-    }
     const expectedAssistantId = platformAssistantId;
 
     let registerUrl: string;
@@ -249,7 +243,7 @@ export class VelayTunnelClient {
   private async handleMessage(
     data: unknown,
     originWs: WebSocket,
-    platformAssistantId: string,
+    platformAssistantId: string | undefined,
   ): Promise<void> {
     if (this.ws !== originWs || !this.running) return;
 
@@ -279,9 +273,9 @@ export class VelayTunnelClient {
   private async handleRegisteredFrame(
     frame: VelayRegisteredFrame,
     originWs: WebSocket,
-    platformAssistantId: string,
+    platformAssistantId: string | undefined,
   ): Promise<void> {
-    if (frame.assistant_id !== platformAssistantId) {
+    if (platformAssistantId && frame.assistant_id !== platformAssistantId) {
       log.error(
         {
           expectedAssistantId: platformAssistantId,


### PR DESCRIPTION
## Summary
- Makes Velay assistant ID verification optional as planned.
- Retries Twilio webhook sync when Twilio credentials/phone config arrive and rejects Twilio webhooks while ingress is disabled.

Fixes gaps identified during plan review for velay-twilio-ingress.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
