### PR TITLE
Fix OpenAI call-site/profile provider mismatch

### DIFF
--- a/assistant/src/__tests__/workspace-migration-064-unwind-main-agent-opus-seed.test.ts
+++ b/assistant/src/__tests__/workspace-migration-064-unwind-main-agent-opus-seed.test.ts
@@ -1,0 +1,222 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { unwindMainAgentOpusSeedMigration } from "../workspace/migrations/064-unwind-main-agent-opus-seed.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-064-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("064-unwind-main-agent-opus-seed migration", () => {
+  test("has correct migration id", () => {
+    expect(unwindMainAgentOpusSeedMigration.id).toBe(
+      "064-unwind-main-agent-opus-seed",
+    );
+  });
+
+  test("removes exact seeded mainAgent override and moves missing activeProfile to quality", () => {
+    writeConfig({
+      llm: {
+        callSites: {
+          mainAgent: { model: "claude-opus-4-7", maxTokens: 32000 },
+        },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        activeProfile: string;
+        callSites: Record<string, unknown>;
+      };
+    };
+    expect(config.llm.activeProfile).toBe("quality-optimized");
+    expect(config.llm.callSites.mainAgent).toBeUndefined();
+  });
+
+  test("moves old balanced activeProfile to quality before removing seed", () => {
+    writeConfig({
+      llm: {
+        activeProfile: "balanced",
+        callSites: {
+          mainAgent: { model: "claude-opus-4-7", maxTokens: 32000 },
+        },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { activeProfile: string; callSites: Record<string, unknown> };
+    };
+    expect(config.llm.activeProfile).toBe("quality-optimized");
+    expect(config.llm.callSites.mainAgent).toBeUndefined();
+  });
+
+  test("preserves custom activeProfile while removing the stale seed", () => {
+    writeConfig({
+      llm: {
+        activeProfile: "gpt-5-5",
+        callSites: {
+          mainAgent: { model: "claude-opus-4-7", maxTokens: 32000 },
+        },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { activeProfile: string; callSites: Record<string, unknown> };
+    };
+    expect(config.llm.activeProfile).toBe("gpt-5-5");
+    expect(config.llm.callSites.mainAgent).toBeUndefined();
+  });
+
+  test("removes only seeded model and maxTokens when user fields are present", () => {
+    writeConfig({
+      llm: {
+        activeProfile: "balanced",
+        callSites: {
+          mainAgent: {
+            model: "claude-opus-4-7",
+            maxTokens: 32000,
+            effort: "low",
+            thinking: { enabled: false },
+          },
+        },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: {
+        activeProfile: string;
+        callSites: Record<string, Record<string, unknown>>;
+      };
+    };
+    expect(config.llm.activeProfile).toBe("quality-optimized");
+    expect(config.llm.callSites.mainAgent).toEqual({
+      effort: "low",
+      thinking: { enabled: false },
+    });
+  });
+
+  test("does not mutate mainAgent entries with explicit provider", () => {
+    const mainAgent = {
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      maxTokens: 32000,
+    };
+    writeConfig({
+      llm: {
+        activeProfile: "balanced",
+        callSites: { mainAgent },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { activeProfile: string; callSites: Record<string, unknown> };
+    };
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.callSites.mainAgent).toEqual(mainAgent);
+  });
+
+  test("does not mutate mainAgent entries with explicit profile", () => {
+    const mainAgent = {
+      profile: "quality-optimized",
+      model: "claude-opus-4-7",
+      maxTokens: 32000,
+    };
+    writeConfig({
+      llm: {
+        activeProfile: "balanced",
+        callSites: { mainAgent },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { activeProfile: string; callSites: Record<string, unknown> };
+    };
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.callSites.mainAgent).toEqual(mainAgent);
+  });
+
+  test("does not mutate explicit user pins with different maxTokens", () => {
+    const mainAgent = {
+      model: "claude-opus-4-7",
+      maxTokens: 64000,
+    };
+    writeConfig({
+      llm: {
+        activeProfile: "balanced",
+        callSites: { mainAgent },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { activeProfile: string; callSites: Record<string, unknown> };
+    };
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.callSites.mainAgent).toEqual(mainAgent);
+  });
+
+  test("does not mutate non-main-agent call sites", () => {
+    writeConfig({
+      llm: {
+        activeProfile: "balanced",
+        callSites: {
+          interactionClassifier: {
+            model: "claude-opus-4-7",
+            maxTokens: 32000,
+          },
+        },
+      },
+    });
+
+    unwindMainAgentOpusSeedMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { activeProfile: string; callSites: Record<string, unknown> };
+    };
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.callSites.interactionClassifier).toEqual({
+      model: "claude-opus-4-7",
+      maxTokens: 32000,
+    });
+  });
+});

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -83,12 +83,12 @@ export function seedInferenceProfiles(): void {
     profiles[name] = { ...seed };
   }
 
-  // Reset to "balanced" when the current value references a missing profile
+  // Reset to the default managed profile when the current value is missing.
   if (
     typeof llm.activeProfile !== "string" ||
     !(llm.activeProfile in profiles)
   ) {
-    llm.activeProfile = "balanced";
+    llm.activeProfile = "quality-optimized";
   }
 
   const profileOrder = Array.isArray(llm.profileOrder)

--- a/assistant/src/workspace/migrations/064-unwind-main-agent-opus-seed.ts
+++ b/assistant/src/workspace/migrations/064-unwind-main-agent-opus-seed.ts
@@ -1,0 +1,68 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const SEEDED_MAIN_AGENT_MODEL = "claude-opus-4-7";
+const SEEDED_MAIN_AGENT_MAX_TOKENS = 32000;
+const OLD_MANAGED_DEFAULT_PROFILE = "balanced";
+const OPUS_MANAGED_PROFILE = "quality-optimized";
+
+export const unwindMainAgentOpusSeedMigration: WorkspaceMigration = {
+  id: "064-unwind-main-agent-opus-seed",
+  description:
+    "Remove seeded mainAgent Opus model override and select the Opus managed profile",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const callSites = readObject(llm.callSites);
+    if (callSites === null) return;
+
+    const mainAgent = readObject(callSites.mainAgent);
+    if (mainAgent === null) return;
+    if ("provider" in mainAgent || "profile" in mainAgent) return;
+    if (mainAgent.model !== SEEDED_MAIN_AGENT_MODEL) return;
+    if (mainAgent.maxTokens !== SEEDED_MAIN_AGENT_MAX_TOKENS) return;
+
+    if (
+      llm.activeProfile === undefined ||
+      llm.activeProfile === OLD_MANAGED_DEFAULT_PROFILE
+    ) {
+      llm.activeProfile = OPUS_MANAGED_PROFILE;
+    }
+
+    delete mainAgent.model;
+    delete mainAgent.maxTokens;
+
+    if (Object.keys(mainAgent).length === 0) {
+      delete callSites.mainAgent;
+    } else {
+      callSites.mainAgent = mainAgent;
+    }
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: restoring the static call-site override would mask
+    // the user's active inference profile for main assistant conversations.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -61,6 +61,7 @@ import { memoryV2InitMigration } from "./060-memory-v2-init.js";
 import { moveBackupKeyToWorkspaceMigration } from "./061-move-backup-key-to-workspace.js";
 import { dropMemoryV2EdgesJsonMigration } from "./062-drop-memory-v2-edges-json.js";
 import { releaseNotesDynamicModelContextMigration } from "./063-release-notes-dynamic-model-context.js";
+import { unwindMainAgentOpusSeedMigration } from "./064-unwind-main-agent-opus-seed.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -133,4 +134,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   moveBackupKeyToWorkspaceMigration,
   dropMemoryV2EdgesJsonMigration,
   releaseNotesDynamicModelContextMigration,
+  unwindMainAgentOpusSeedMigration,
 ];

--- a/cli/src/__tests__/config-utils.test.ts
+++ b/cli/src/__tests__/config-utils.test.ts
@@ -1,6 +1,19 @@
+import { readFileSync, rmSync } from "fs";
 import { describe, expect, test } from "bun:test";
 
-import { buildInitialConfig, buildNestedConfig } from "../lib/config-utils.js";
+import { buildNestedConfig, writeInitialConfig } from "../lib/config-utils.js";
+
+function readInitialConfig(
+  configValues: Record<string, string>,
+): Record<string, unknown> {
+  const path = writeInitialConfig(configValues);
+  expect(path).toBeDefined();
+  try {
+    return JSON.parse(readFileSync(path!, "utf-8")) as Record<string, unknown>;
+  } finally {
+    if (path !== undefined) rmSync(path, { force: true });
+  }
+}
 
 describe("config-utils", () => {
   test("buildNestedConfig only converts dot-notation values", () => {
@@ -19,9 +32,9 @@ describe("config-utils", () => {
     });
   });
 
-  test("buildInitialConfig seeds mainAgent callSite for Anthropic default", () => {
+  test("writeInitialConfig does not add a mainAgent callSite for Anthropic defaults", () => {
     expect(
-      buildInitialConfig({
+      readInitialConfig({
         "llm.default.provider": "anthropic",
         "llm.default.model": "claude-opus-4-7",
       }),
@@ -31,41 +44,35 @@ describe("config-utils", () => {
           provider: "anthropic",
           model: "claude-opus-4-7",
         },
-        callSites: {
-          mainAgent: {
-            model: "claude-opus-4-7",
-            maxTokens: 32000,
-          },
-        },
       },
     });
   });
 
-  test("buildInitialConfig seeds Opus when provider falls back to Anthropic", () => {
+  test("writeInitialConfig preserves profile-based Anthropic model selection", () => {
     expect(
-      buildInitialConfig({
-        "services.inference.mode": "managed",
+      readInitialConfig({
+        "llm.activeProfile": "quality-optimized",
+        "llm.profiles.quality-optimized.provider": "anthropic",
+        "llm.profiles.quality-optimized.model": "claude-opus-4-7",
+        "llm.profiles.quality-optimized.maxTokens": "32000",
       }),
     ).toEqual({
-      services: {
-        inference: {
-          mode: "managed",
-        },
-      },
       llm: {
-        callSites: {
-          mainAgent: {
+        activeProfile: "quality-optimized",
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
             model: "claude-opus-4-7",
-            maxTokens: 32000,
+            maxTokens: "32000",
           },
         },
       },
     });
   });
 
-  test("buildInitialConfig preserves explicit mainAgent overrides", () => {
+  test("writeInitialConfig preserves explicit mainAgent overrides without rewriting them", () => {
     expect(
-      buildInitialConfig({
+      readInitialConfig({
         "llm.default.provider": "anthropic",
         "llm.default.model": "claude-opus-4-7",
         "llm.callSites.mainAgent.model": "claude-haiku-4-5-20251001",
@@ -85,9 +92,9 @@ describe("config-utils", () => {
     });
   });
 
-  test("buildInitialConfig respects explicit non-default Anthropic models", () => {
+  test("writeInitialConfig respects explicit non-default Anthropic models", () => {
     expect(
-      buildInitialConfig({
+      readInitialConfig({
         "llm.default.provider": "anthropic",
         "llm.default.model": "claude-haiku-4-5-20251001",
       }),
@@ -101,9 +108,9 @@ describe("config-utils", () => {
     });
   });
 
-  test("buildInitialConfig respects active profile provider overrides", () => {
+  test("writeInitialConfig leaves active OpenAI profile config unchanged", () => {
     expect(
-      buildInitialConfig({
+      readInitialConfig({
         "llm.activeProfile": "fast",
         "llm.profiles.fast.provider": "openai",
         "llm.profiles.fast.model": "gpt-5.5",
@@ -121,29 +128,9 @@ describe("config-utils", () => {
     });
   });
 
-  test("buildInitialConfig uses active profile model when deciding to seed", () => {
+  test("writeInitialConfig does not add Opus for non-Anthropic providers", () => {
     expect(
-      buildInitialConfig({
-        "llm.activeProfile": "fast",
-        "llm.profiles.fast.provider": "anthropic",
-        "llm.profiles.fast.model": "claude-haiku-4-5-20251001",
-      }),
-    ).toEqual({
-      llm: {
-        activeProfile: "fast",
-        profiles: {
-          fast: {
-            provider: "anthropic",
-            model: "claude-haiku-4-5-20251001",
-          },
-        },
-      },
-    });
-  });
-
-  test("buildInitialConfig does not seed Opus for non-Anthropic providers", () => {
-    expect(
-      buildInitialConfig({
+      readInitialConfig({
         "llm.default.provider": "openai",
         "llm.default.model": "gpt-5.5",
       }),

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -15,7 +15,7 @@ import {
   VALID_SPECIES,
 } from "../lib/constants";
 import type { RemoteHost, Species } from "../lib/constants";
-import { buildInitialConfig } from "../lib/config-utils";
+import { buildNestedConfig } from "../lib/config-utils";
 import { hatchDocker } from "../lib/docker";
 import { hatchGcp } from "../lib/gcp";
 import type { PollResult, WatchHatchingResult } from "../lib/gcp";
@@ -123,11 +123,7 @@ export async function buildStartupScript(
   // and export the env var so the daemon reads it on first boot.
   let configWriteBlock = "";
   if (Object.keys(configValues).length > 0) {
-    const configJson = JSON.stringify(
-      buildInitialConfig(configValues),
-      null,
-      2,
-    );
+    const configJson = JSON.stringify(buildNestedConfig(configValues), null, 2);
     configWriteBlock = `
 echo "Writing default workspace config..."
 VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH="/tmp/vellum-initial-config-$$.json"

--- a/cli/src/lib/config-utils.ts
+++ b/cli/src/lib/config-utils.ts
@@ -2,11 +2,6 @@ import { writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-const ANTHROPIC_PROVIDER = "anthropic";
-const ANTHROPIC_DEFAULT_MODEL = "claude-opus-4-7";
-const MAIN_AGENT_OPUS_MODEL = "claude-opus-4-7";
-const MAIN_AGENT_OPUS_MAX_TOKENS = 32000;
-
 /**
  * Convert flat dot-notation key=value pairs into a nested config object.
  *
@@ -38,20 +33,6 @@ export function buildNestedConfig(
 }
 
 /**
- * Build the first-boot workspace config overlay passed to the assistant during
- * hatch. Anthropic onboarding sets `llm.default.model` to Sonnet so background
- * fallback work stays cheaper, while the main conversation thread should remain
- * on Opus via the same call-site override seeded by workspace migration 050.
- */
-export function buildInitialConfig(
-  configValues: Record<string, string>,
-): Record<string, unknown> {
-  const config = buildNestedConfig(configValues);
-  seedAnthropicMainAgentCallSite(config);
-  return config;
-}
-
-/**
  * Write arbitrary key-value pairs to a temporary JSON file and return its
  * path. The caller passes this path to the daemon via the
  * VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH env var so the daemon can merge the
@@ -68,88 +49,11 @@ export function writeInitialConfig(
 ): string | undefined {
   if (Object.keys(configValues).length === 0) return undefined;
 
-  const config = buildInitialConfig(configValues);
+  const config = buildNestedConfig(configValues);
   const tempPath = join(
     tmpdir(),
     `vellum-default-workspace-config-${process.pid}-${Date.now()}.json`,
   );
   writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n");
   return tempPath;
-}
-
-function seedAnthropicMainAgentCallSite(config: Record<string, unknown>): void {
-  const llm = ensureObject(config, "llm");
-
-  const existingCallSites = readObject(llm.callSites);
-  if (existingCallSites !== null && "mainAgent" in existingCallSites) return;
-
-  const { provider, model } = resolveInitialMainAgentBaseSelection(llm);
-  if (provider !== ANTHROPIC_PROVIDER) return;
-
-  if (
-    model !== undefined &&
-    model !== ANTHROPIC_DEFAULT_MODEL &&
-    model !== MAIN_AGENT_OPUS_MODEL
-  ) {
-    return;
-  }
-
-  const callSites = ensureObject(llm, "callSites");
-
-  callSites.mainAgent = {
-    model: MAIN_AGENT_OPUS_MODEL,
-    maxTokens: MAIN_AGENT_OPUS_MAX_TOKENS,
-  };
-}
-
-function resolveInitialMainAgentBaseSelection(llm: Record<string, unknown>): {
-  provider: string;
-  model?: string;
-} {
-  const defaultBlock = readObject(llm.default);
-  let provider = readString(defaultBlock?.provider) ?? ANTHROPIC_PROVIDER;
-  let model = readString(defaultBlock?.model);
-
-  const profiles = readObject(llm.profiles);
-  const activeProfileName = readString(llm.activeProfile);
-  const activeProfile =
-    profiles !== null && activeProfileName !== undefined
-      ? readObject(profiles[activeProfileName])
-      : null;
-
-  if (activeProfile !== null) {
-    provider = readString(activeProfile.provider) ?? provider;
-    model = readString(activeProfile.model) ?? model;
-  }
-
-  return model === undefined ? { provider } : { provider, model };
-}
-
-function ensureObject(
-  parent: Record<string, unknown>,
-  key: string,
-): Record<string, unknown> {
-  const existing = parent[key];
-  if (
-    existing != null &&
-    typeof existing === "object" &&
-    !Array.isArray(existing)
-  ) {
-    return existing as Record<string, unknown>;
-  }
-
-  const next: Record<string, unknown> = {};
-  parent[key] = next;
-  return next;
-}
-
-function readObject(value: unknown): Record<string, unknown> | null {
-  if (value == null || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
-
-function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }


### PR DESCRIPTION
## Summary
Removes the hidden mainAgent Opus call-site seed and makes the default main assistant model flow through the managed inference profile instead.

## Self-review result
PASS — plan faithfulness, integration, and slop/reuse checks found no gaps.

## PRs merged into feature branch
- #29071: Move Opus default to inference profile and unwind mainAgent seed

Part of plan: fix-openai-callsite-profile-mismatch.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
