### PR TITLE
Fix Managed Call-Site Catalog Fetch

### DIFF
--- a/clients/macos/vellum-assistantTests/SettingsClientCallSiteCatalogTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsClientCallSiteCatalogTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+private final class SettingsClientCallSiteCatalogURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class SettingsClientCallSiteCatalogTests: XCTestCase {
+    private let assistantId = "00000000-0000-4000-8000-000000000001"
+    private var originalPrimaryLockfileData: Data?
+    private var primaryLockfileExisted = false
+    private var previousToken: String?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        SettingsClientCallSiteCatalogURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(SettingsClientCallSiteCatalogURLProtocol.self)
+
+        let primaryLockfileURL = LockfilePaths.primary
+        primaryLockfileExisted = FileManager.default.fileExists(atPath: primaryLockfileURL.path)
+        if primaryLockfileExisted {
+            originalPrimaryLockfileData = try Data(contentsOf: primaryLockfileURL)
+        }
+
+        try installManagedLockfileFixture()
+        previousToken = SessionTokenManager.getToken()
+        SessionTokenManager.setToken("stub-session-token")
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocol.unregisterClass(SettingsClientCallSiteCatalogURLProtocol.self)
+        SettingsClientCallSiteCatalogURLProtocol.requestHandler = nil
+
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+
+        if primaryLockfileExisted {
+            try originalPrimaryLockfileData?.write(to: LockfilePaths.primary, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: LockfilePaths.primary)
+        }
+
+        try super.tearDownWithError()
+    }
+
+    func testFetchCallSiteCatalogUsesAssistantScopedManagedPathAndDecodesResponse() async throws {
+        let requestExpectation = expectation(description: "call-site catalog request")
+        var capturedRequest: URLRequest?
+
+        SettingsClientCallSiteCatalogURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"""
+                {
+                  "domains": [
+                    {
+                      "id": "agentLoop",
+                      "displayName": "Agent Loop"
+                    }
+                  ],
+                  "callSites": [
+                    {
+                      "id": "mainAgent",
+                      "displayName": "Main Agent",
+                      "description": "The primary conversation agent.",
+                      "domain": "agentLoop"
+                    }
+                  ]
+                }
+                """#.utf8
+            )
+            return (response, data)
+        }
+
+        let catalog = await SettingsClient().fetchCallSiteCatalog()
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "https://platform.vellum.ai/v1/assistants/\(assistantId)/config/llm/call-sites/"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "GET")
+        XCTAssertEqual(catalog?.domains.count, 1)
+        XCTAssertEqual(catalog?.domains.first?.id, "agentLoop")
+        XCTAssertEqual(catalog?.domains.first?.displayName, "Agent Loop")
+        XCTAssertEqual(catalog?.callSites.count, 1)
+        XCTAssertEqual(catalog?.callSites.first?.id, "mainAgent")
+        XCTAssertEqual(catalog?.callSites.first?.displayName, "Main Agent")
+        XCTAssertEqual(catalog?.callSites.first?.domain, "agentLoop")
+    }
+
+    private func installManagedLockfileFixture() throws {
+        let lockfile: [String: Any] = [
+            "activeAssistant": assistantId,
+            "assistants": [
+                [
+                    "assistantId": assistantId,
+                    "name": "Example Assistant",
+                    "cloud": "vellum",
+                    "runtimeUrl": "https://platform.vellum.ai",
+                    "hatchedAt": "2026-01-01T00:00:00Z",
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
+        try data.write(to: LockfilePaths.primary, options: .atomic)
+    }
+}

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -604,7 +604,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchCallSiteCatalog() async -> CallSiteCatalogResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "config/llm/call-sites", timeout: 10
+                path: "assistants/{assistantId}/config/llm/call-sites", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchCallSiteCatalog failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary
Fixes the managed macOS settings regression where the LLM call-site task/action catalog could render empty after the static fallback was removed. The client now fetches the catalog through the active assistant-scoped route, and the rollout adds a managed-mode URL/decode regression test.

## Self-review result
PASS — external feedback, plan faithfulness, integration review, and slop/reuse audit all found no gaps.

## PRs merged into feature branch
- #29076: Fix managed call-site catalog fetch path

Part of plan: fix-managed-call-site-catalog.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
