### PR TITLE
fix(macos): cache activeConversation to isolate toolbar views from list-store observation (LUM-1310)

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -185,6 +185,8 @@ Prefer migrating the parent to `@Observable` so the bridge becomes unnecessary (
 
 **Why this matters:** With `@Observable`, property-level tracking means a sidebar view reading `conversations` is not invalidated when `activeConversationId` changes (owned by a different store). This eliminates the broad invalidation cascade that previously caused 100+ sidebar row rebuilds on every conversation switch.
 
+**Cross-store observation rule:** Computed properties on one `@Observable` store must not read stored properties from another `@Observable` store — this silently bridges observation dependencies across the isolation boundary, defeating the purpose of the decomposition. If cross-store data is needed, use a cached stored property synchronized via a callback from the source store, with an equality guard (`!=`) to suppress no-op writes. See `ConversationSelectionStore.activeConversation` and `ConversationListStore.onDerivedPropertiesRecomputed` for the reference pattern. ([Observation framework — access tracking](https://developer.apple.com/documentation/observation))
+
 ---
 
 ## Performance and Resource Management

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationListStore.swift
@@ -284,6 +284,7 @@ final class ConversationListStore {
             if !sidebarGroupEntries.isEmpty { sidebarGroupEntries = [] }
             if !systemSidebarGroupEntries.isEmpty { systemSidebarGroupEntries = [] }
             if !customSidebarGroupEntries.isEmpty { customSidebarGroupEntries = [] }
+            onDerivedPropertiesRecomputed?()
             return
         }
         let currentSortedGroups = groups.sorted { $0.sortPosition < $1.sortPosition }
@@ -337,6 +338,7 @@ final class ConversationListStore {
         }
         groupedConversations = grouped
         recomputeSidebarGroupEntries()
+        onDerivedPropertiesRecomputed?()
     }
 
     /// Derive sidebar group entries from `groupedConversations` and the current
@@ -829,6 +831,11 @@ final class ConversationListStore {
             self.isLoadingMoreConversations = false
         }
     }
+
+    /// Callback invoked after derived properties are recomputed (i.e. on every
+    /// `conversations` or `groups` mutation) so the selection store can refresh
+    /// its cached active conversation. Wired by ConversationManager during init.
+    @ObservationIgnored var onDerivedPropertiesRecomputed: (() -> Void)?
 
     /// Callback invoked after conversations are appended, so the manager
     /// can schedule VM eviction. Wired by ConversationManager during init.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -323,6 +323,13 @@ final class ConversationManager: ConversationRestorerDelegate {
             self?.markActiveConversationSeenIfNeeded()
         }
 
+        // List store → selection store: refresh cached active conversation after
+        // any conversations mutation so views stay current without tracking the
+        // full conversations array.
+        listStore.onDerivedPropertiesRecomputed = { [weak self] in
+            self?.selectionStore.refreshActiveConversation()
+        }
+
         // List store → selection store: schedule eviction after appending conversations
         listStore.onConversationsAppended = { [weak self] in
             self?.selectionStore.scheduleEvictionIfNeeded()

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
@@ -201,23 +201,16 @@ final class ConversationSelectionStore {
 
     // MARK: - Active Conversation Cache
 
-    /// Cached active conversation model, updated explicitly when the selection
-    /// changes or when the list store's conversations array mutates. Stored
-    /// rather than computed so that views reading this property track only the
-    /// `activeConversation` stored property — not `listStore.conversations`.
-    /// This breaks the cross-store observation dependency that previously caused
-    /// every `conversations` mutation (seen/unseen flips, pagination appends,
-    /// heartbeat timestamps) to invalidate TopBarView and other toolbar views.
-    /// Writes are equality-guarded so mutations that don't affect the active
-    /// conversation produce no observation notification.
+    /// The active conversation model, if one is selected and exists in the list.
+    ///
+    /// Stored rather than computed so that views track only this property — not
+    /// `listStore.conversations`. Synchronized by ``refreshActiveConversation()``
+    /// and writes in ``performActivation(for:)`` / ``performDeactivation()``.
     private(set) var activeConversation: ConversationModel?
 
-    /// Refresh the cached ``activeConversation`` from `listStore.conversations`.
-    /// Called when the conversations array mutates (title change, conversationId
-    /// backfill, seen/unseen flip, pagination append) so the cached model stays
-    /// current. The equality guard (`!=`) ensures no observation notification
-    /// fires when the active conversation's fields are unchanged — which is the
-    /// common case for mutations targeting other conversations.
+    /// Synchronize ``activeConversation`` with the current conversations array.
+    /// The equality guard skips the write when the active conversation's fields
+    /// are unchanged, avoiding unnecessary observation notifications.
     func refreshActiveConversation() {
         guard let activeConversationId else {
             if activeConversation != nil { activeConversation = nil }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationSelectionStore.swift
@@ -58,6 +58,7 @@ final class ConversationSelectionStore {
         draftViewModel = nil
         draftLocalId = nil
         activeConversationId = conversationId
+        activeConversation = listStore.conversations.first { $0.id == conversationId }
 
         let vm = getOrCreateViewModel(for: conversationId)
         vm?.ensureMessageLoopStarted()
@@ -84,6 +85,7 @@ final class ConversationSelectionStore {
     /// stop channel refresh, and notify observation.
     func performDeactivation() {
         activeConversationId = nil
+        activeConversation = nil
         onActiveViewModelChanged?(nil)
         stopChannelRefresh()
     }
@@ -197,12 +199,34 @@ final class ConversationSelectionStore {
         migrateStorageKeysIfNeeded()
     }
 
-    // MARK: - Computed Properties
+    // MARK: - Active Conversation Cache
 
-    /// The active conversation model, if one is selected and exists in the list.
-    var activeConversation: ConversationModel? {
-        guard let activeConversationId else { return nil }
-        return listStore.conversations.first { $0.id == activeConversationId }
+    /// Cached active conversation model, updated explicitly when the selection
+    /// changes or when the list store's conversations array mutates. Stored
+    /// rather than computed so that views reading this property track only the
+    /// `activeConversation` stored property — not `listStore.conversations`.
+    /// This breaks the cross-store observation dependency that previously caused
+    /// every `conversations` mutation (seen/unseen flips, pagination appends,
+    /// heartbeat timestamps) to invalidate TopBarView and other toolbar views.
+    /// Writes are equality-guarded so mutations that don't affect the active
+    /// conversation produce no observation notification.
+    private(set) var activeConversation: ConversationModel?
+
+    /// Refresh the cached ``activeConversation`` from `listStore.conversations`.
+    /// Called when the conversations array mutates (title change, conversationId
+    /// backfill, seen/unseen flip, pagination append) so the cached model stays
+    /// current. The equality guard (`!=`) ensures no observation notification
+    /// fires when the active conversation's fields are unchanged — which is the
+    /// common case for mutations targeting other conversations.
+    func refreshActiveConversation() {
+        guard let activeConversationId else {
+            if activeConversation != nil { activeConversation = nil }
+            return
+        }
+        let updated = listStore.conversations.first { $0.id == activeConversationId }
+        if updated != activeConversation {
+            activeConversation = updated
+        }
     }
 
     /// The ChatViewModel for the active conversation, or the draft ViewModel


### PR DESCRIPTION
`ConversationSelectionStore.activeConversation` was a computed property that read `listStore.conversations`, silently bridging an `@Observable` tracking dependency across the 3-store isolation boundary. Any `conversations` mutation — seen/unseen flips, pagination appends, heartbeat timestamps, title changes on *any* conversation — invalidated every view reading `activeConversation` (TopBarView, ConversationTitleOverlay, PanelCoordinator, SidebarView) and re-triggered an O(n) linear scan. This replaces it with a cached stored property, equality-guarded to suppress no-op writes, so views only re-evaluate when the active conversation's fields actually change.

## Why needed

Sentry (MACOS-R3) reported a 2s+ app hang in `TopBarView.body` during `MainWindowView.coreLayoutBase`. The stack trace showed `activeConversation.getter` reading through to `ConversationListStore.conversations`, creating an observation dependency that re-ran the O(n) `first(where:)` scan on every unrelated mutation. With `@Observable`'s property-level tracking, reading a stored property from another store inside a computed property transparently registers a cross-store dependency — defeating the isolation the 3-store decomposition was designed to provide.

## What changed

- **`ConversationSelectionStore.activeConversation`**: converted from computed to stored `private(set)` property. Updated in `performActivation(for:)` and `performDeactivation()`.
- **`ConversationSelectionStore.refreshActiveConversation()`**: new synchronization method called on every `conversations` mutation. Uses `!=` equality guard so writes only fire when the active conversation's fields actually changed.
- **`ConversationListStore.onDerivedPropertiesRecomputed`**: new callback invoked at the end of `recomputeDerivedProperties()`, wired by `ConversationManager` to call `refreshActiveConversation()`.
- **`clients/AGENTS.md`**: added cross-store observation rule to the 3-Store Architecture section.

## Why safe

- The stored property returns the same value as the old computed property — just cached. All 6 view-level call sites chain through `ConversationManager.activeConversation` → `selectionStore.activeConversation` and benefit automatically.
- `refreshActiveConversation()` hooks into `recomputeDerivedProperties()`, which already runs on every `conversations.didSet`. This is the same synchronization pattern used by `sidebarGroupEntries`, `visibleConversations`, and other cached derived properties in `ConversationListStore`.
- The equality guard (`!=`) uses `ConversationModel`'s auto-synthesized `Equatable` (it conforms to `Hashable`), ensuring all fields are compared.
- Imperative call sites (`getOrCreateViewModel`, `removeAbandonedEmptyConversation`, `startChannelRefreshIfNeeded`) still read `listStore.conversations` directly — they're not in view bodies, so no observation dependency is created.

## Alternatives considered and rejected

| Approach | Why rejected |
|---|---|
| `@ObservationIgnored` dictionary index (`[UUID: ConversationModel]`) on `ConversationListStore` | **Staleness bug**: dictionary rebuilds in `recomputeDerivedProperties()` but `@ObservationIgnored` means views are never notified of changes — title renames, pin toggles, and `conversationId` backfills on the active conversation would display stale data. |
| `ObservationBoundaryView` around TopBarView | TopBarView is already a standalone `View` struct. The problem isn't view scope — it's that the computed property itself creates the cross-store dependency. A boundary would also block legitimate dependencies TopBarView needs (e.g., `activeConversationId`). |
| Move needed fields to `ChatViewModel` | Would duplicate state (`title`, `isPinned`, `forkParent`, `isChannelConversation`) between `ConversationModel` and `ChatViewModel`, creating a fragile synchronization surface. |
| Limit `conversations` array size | Doesn't fix the observation dependency — even a small array mutation triggers unnecessary view invalidation. The O(n) scan cost is secondary to the spurious re-evaluation. |

## Root cause analysis

1. **How did the code get into this state?** The 3-store decomposition correctly separated `ConversationListStore` from `ConversationSelectionStore`, but `activeConversation` remained a computed property reading `listStore.conversations` — bridging back across the isolation boundary.
2. **What decisions led to it?** The computed property was a natural convenience that worked correctly under `ObservableObject` (object-level tracking). After migration to `@Observable` (property-level tracking), the same read inside a computed property transparently registers an observation dependency on the entire array from any view that reads the computed result. This semantic difference isn't visible in the source code.
3. **Warning signs missed?** The TopBarView extraction (LUM-841) added `ObservationBoundaryView` around `chatContentView` for a related stall but didn't audit computed properties for cross-store reads. The 3-store decomposition docstring explicitly states the isolation goal but didn't include a rule against cross-store reads in computed properties.
4. **Prevention:** Added a "Cross-store observation rule" to `clients/AGENTS.md` under the 3-Store Architecture section: computed properties on one `@Observable` store must not read stored properties from another store. The rule links to the Observation framework documentation and points to `activeConversation` / `onDerivedPropertiesRecomputed` as the reference pattern.

## References

- [Observation framework — access tracking](https://developer.apple.com/documentation/observation)
- [Managing model data in your app](https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app)
- [WWDC23 — Discover Observation in SwiftUI](https://developer.apple.com/videos/play/wwdc2023/10149/)
- [WWDC21 — Demystify SwiftUI](https://developer.apple.com/videos/play/wwdc2021/10022/)

Apple refs checked (2026-05-01).

---

- Requested by: @ashleeradka
- Session: https://app.devin.ai/sessions/69bd87cf12c5467c9b6ce2a5ec62cbcc
