### PR TITLE
Fix macOS CI after call-site catalog changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CallSiteOverride.swift
@@ -158,8 +158,7 @@ public final class CallSiteCatalog {
         guard let response else {
             loadFailed = true
             log.error(
-                "CallSiteCatalog fetch failed — daemon may be running without GET config/llm/call-sites. " +
-                "The Action Overrides sheet will be empty until the daemon is updated and the sheet is reopened."
+                "CallSiteCatalog fetch failed — daemon may be running without GET config/llm/call-sites. The Action Overrides sheet will be empty until the daemon is updated and the sheet is reopened."
             )
             return false
         }

--- a/clients/macos/vellum-assistantTests/SettingsClientCallSiteCatalogTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsClientCallSiteCatalogTests.swift
@@ -145,6 +145,11 @@ final class SettingsClientCallSiteCatalogTests: XCTestCase {
             ],
         ]
         let data = try JSONSerialization.data(withJSONObject: lockfile, options: [.sortedKeys])
-        try data.write(to: LockfilePaths.primary, options: .atomic)
+        let primaryLockfileURL = LockfilePaths.primary
+        try FileManager.default.createDirectory(
+            at: primaryLockfileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: primaryLockfileURL, options: .atomic)
     }
 }


### PR DESCRIPTION
## Summary
- Fix the macOS Action Overrides fallback log so it remains an OSLogMessage literal and compiles under Swift.
- Create the managed lockfile fixture parent directory before the new call-site catalog test writes lockfile.json.
- Validated with ./build.sh test --filter SettingsClientCallSiteCatalogTests and ./build.sh from clients/macos.

## Original prompt
please look into why latest CI checks are failing; run until CI is passing again and cut a release after that
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
