### PR TITLE
fix(context): make /compact shrink when projection lies about fit

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -97,6 +97,52 @@ describe("ContextWindowManager", () => {
     );
   });
 
+  test("forced compaction summarizes when projection fits but real usage exceeds target", async () => {
+    let summaryCalls = 0;
+    const provider = createProvider(() => {
+      summaryCalls += 1;
+      return {
+        content: [
+          { type: "text", text: "## Summary\n- forced compaction ran" },
+        ],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 25 },
+        stopReason: "end_turn",
+      };
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 10_000,
+        targetBudgetRatio: 0.5,
+      }),
+    });
+    // Tiny live messages so the projection trivially fits target — without
+    // the fix this would route through the "already fits" skip path.
+    const history: Message[] = [
+      message("user", "u1"),
+      message("assistant", "a1"),
+      message("user", "u2"),
+      message("assistant", "a2"),
+    ];
+
+    const result = await manager.maybeCompact(history, undefined, {
+      force: true,
+      // Simulate a live conversation that's well over target. In production
+      // this happens when synthetic tool_result truncation in the projection
+      // is far more aggressive than what the real messages allow.
+      precomputedEstimate: 50_000,
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(summaryCalls).toBe(1);
+    expect(result.reason).not.toBe(
+      "conversation already fits within the compaction target",
+    );
+    expect(result.compactedMessages).toBeGreaterThan(0);
+  });
+
   test("compacts old turns and keeps recent user turns", async () => {
     let summaryCalls = 0;
     const provider = createProvider(() => {

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -494,6 +494,7 @@ export class ContextWindowManager {
       targetInputTokensOverride: options?.targetInputTokensOverride,
       conversationOriginChannel: options?.conversationOriginChannel,
       force: options?.force,
+      previousEstimatedInputTokens,
     });
     if (keepPlan.keepFromIndex <= summaryOffset) {
       // All turns fit after truncation projection, but the real in-memory
@@ -788,6 +789,7 @@ export class ContextWindowManager {
       targetInputTokensOverride?: number;
       conversationOriginChannel?: string;
       force?: boolean;
+      previousEstimatedInputTokens?: number;
     },
   ): { keepFromIndex: number; keepTurns: number } {
     // Slack-originated conversations rely on multi-turn thread context
@@ -869,6 +871,20 @@ export class ContextWindowManager {
       while (lo > 0 && projectedTokensForKeep(lo) > targetTokens) {
         lo--;
       }
+    }
+
+    // The projection's summary-swap and tool_result truncation can make
+    // projectedTokensForKeep(hi) optimistically fit even when the live
+    // conversation is well over target — sending /compact through the
+    // "already fits" skip path as a no-op. Clamp lo so summarization runs.
+    if (
+      opts?.force &&
+      floorIsImplicitDefault &&
+      lo === userTurnStarts.length &&
+      lo > 0 &&
+      (opts?.previousEstimatedInputTokens ?? 0) > targetTokens
+    ) {
+      lo -= 1;
     }
 
     const keepTurns = lo;


### PR DESCRIPTION
## Summary
- `/compact` was a no-op for conversations 80%+ full because `pickKeepBoundary`'s synthetic projection (summary placeholder + tool_result truncation) said all turns already fit the compaction target, even when live tokens were well over.
- Pass `previousEstimatedInputTokens` into `pickKeepBoundary` and, when force=true with the implicit floor, clamp `lo` by one turn whenever live tokens exceed target so summarization actually runs.
- Adds a regression test that fakes the projection-vs-real divergence via `precomputedEstimate`.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
