### PR TITLE
fix(macos): drop unnecessary nonisolated(unsafe) on bundledAppIcon

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -558,14 +558,8 @@ final class AvatarAppearanceManager {
     /// `applicationIconImage` is set at runtime and already includes all
     /// system-resolved representations.
     ///
-    /// `nonisolated(unsafe)` so `start()` can warm the lazy initializer from
-    /// a `Task.detached` (the surrounding class is `@MainActor`, which would
-    /// otherwise main-actor-isolate this static). `NSWorkspace.icon(forFile:)`
-    /// is documented as thread-safe and the property is `let`, so reads after
-    /// init are safe from any context.
-    ///
     /// Reference: https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
-    private nonisolated(unsafe) static let bundledAppIcon: NSImage = {
+    private static let bundledAppIcon: NSImage = {
         NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
     }()
 


### PR DESCRIPTION
## Summary
- `NSImage` is `Sendable`, so `nonisolated(unsafe)` on the `bundledAppIcon` static `let` is no longer needed and Swift now emits a warning for it.
- Remove the modifier and the doc paragraph that explained the (now stale) rationale; keep the `NSWorkspace` reference comment.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift:568:13: warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'NSImage', consider removing it
566 |     ///
567 |     /// Reference: https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
568 |     private nonisolated(unsafe) static let bundledAppIcon: NSImage = {
    |             \`- warning: 'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'NSImage', consider removing it
569 |         NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
570 |     }()
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
