### PR TITLE
feat(macos): default task_progress to inline, add pop-out toggle

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+SurfaceHandling.swift
@@ -336,16 +336,6 @@ extension ChatViewModel {
         flushStreamingBuffer()
         flushPartialOutputBuffer()
 
-        // Show floating overlay for task_progress cards (macOS only)
-        #if os(macOS)
-        if case .card(let cardData) = surface.data,
-           cardData.template == "task_progress",
-           let templateData = cardData.templateData,
-           let progressData = TaskProgressData.parse(from: templateData, fallbackTitle: cardData.title) {
-            TaskProgressOverlayManager.shared.show(data: progressData, surfaceId: msg.surfaceId)
-        }
-        #endif
-
         // On macOS, dynamic pages with no explicit display mode (or "panel")
         // are routed to the workspace by SurfaceManager. If the dynamic page
         // has a preview, also render a compact preview card inline in chat.

--- a/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineCardWidget.swift
@@ -4,9 +4,11 @@ import SwiftUI
 /// Supports template-based rendering for specialized layouts (e.g. weather forecasts).
 public struct InlineCardWidget: View {
     public let data: CardSurfaceData
+    public let onPopOut: (() -> Void)?
 
-    public init(data: CardSurfaceData) {
+    public init(data: CardSurfaceData, onPopOut: (() -> Void)? = nil) {
         self.data = data
+        self.onPopOut = onPopOut
     }
 
     public var body: some View {
@@ -17,7 +19,7 @@ public struct InlineCardWidget: View {
         } else if data.template == "task_progress",
                   let templateData = data.templateData,
                   let progressData = TaskProgressData.parse(from: templateData, fallbackTitle: data.title) {
-            InlineTaskProgressWidget(data: progressData)
+            InlineTaskProgressWidget(data: progressData, onPopOut: onPopOut)
         } else {
             standardCardLayout
         }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -218,7 +218,17 @@ public struct InlineSurfaceRouter: View {
     private var surfaceContent: some View {
         switch surface.data {
         case .card(let data):
-            InlineCardWidget(data: data)
+            #if os(macOS)
+            let onPopOut: (() -> Void)? = (data.template == "task_progress") ? {
+                if let templateData = data.templateData,
+                   let progressData = TaskProgressData.parse(from: templateData, fallbackTitle: data.title) {
+                    TaskProgressOverlayManager.shared.show(data: progressData, surfaceId: surface.id)
+                }
+            } : nil
+            #else
+            let onPopOut: (() -> Void)? = nil
+            #endif
+            InlineCardWidget(data: data, onPopOut: onPopOut)
         case .documentPreview(let data):
             InlineDocumentPreview(data: data) {
                 NotificationCenter.default.post(

--- a/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineTaskProgressWidget.swift
@@ -61,9 +61,11 @@ public struct TaskProgressData {
 
 public struct InlineTaskProgressWidget: View {
     public let data: TaskProgressData
+    public let onPopOut: (() -> Void)?
 
-    public init(data: TaskProgressData) {
+    public init(data: TaskProgressData, onPopOut: (() -> Void)? = nil) {
         self.data = data
+        self.onPopOut = onPopOut
     }
 
     public var body: some View {
@@ -85,6 +87,16 @@ public struct InlineTaskProgressWidget: View {
             Spacer()
 
             statusBadge(for: data.status)
+
+            if let onPopOut {
+                Button(action: onPopOut) {
+                    VIconView(.arrowUpRight, size: 10)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+                .buttonStyle(.plain)
+                .help("Pop out")
+                .accessibilityLabel("Pop out to floating window")
+            }
         }
     }
 

--- a/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
+++ b/clients/shared/Features/Chat/TaskProgressOverlayManager.swift
@@ -166,10 +166,12 @@ private struct TaskProgressOverlayView: View {
                     Button {
                         manager.close()
                     } label: {
-                        VIconView(.x, size: 10)
+                        VIconView(.arrowDownToLine, size: 10)
                             .foregroundStyle(VColor.contentSecondary)
                     }
                     .buttonStyle(.plain)
+                    .help("Dock inline")
+                    .accessibilityLabel("Dock inline")
                     .padding(.top, VSpacing.sm)
                     .padding(.trailing, VSpacing.sm)
                 }


### PR DESCRIPTION
## Summary
- Render `task_progress` cards inline in chat by default instead of auto-creating a floating panel. Removes eager NSPanel allocation on every surface arrival.
- Add a pop-out (`arrow-up-right`) button to the inline widget header so users can move it to a floating panel on demand.
- Replace the floating overlay's X button with a dock-inline (`arrow-down-to-line`) button — closing the overlay reveals the inline rendering automatically.

## Original prompt
I want this TODO list window to be inlined into the existing desktop app UI instead of popping out as a separate window by default. The user should be able to click a button on the TODO list to switch between inline and separate window mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
