### PR TITLE
feat(macos): notify on turn end when app is unfocused

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationActivityStore.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationActivityStore.swift
@@ -66,6 +66,8 @@ final class ConversationActivityStore {
     /// ConversationManager uses this to drain pending notification catch-ups.
     @ObservationIgnored var onBusyToIdle: ((UUID) -> Void)?
 
+    @ObservationIgnored var onTurnComplete: ((UUID) -> Void)?
+
     // MARK: - Assistant activity observation
 
     /// Snapshot of the latest assistant message's structural properties,
@@ -307,6 +309,7 @@ final class ConversationActivityStore {
         // tool calls within a single turn, which produced duplicate sounds.
         if let previousTick, turnCompletionTick > previousTick {
             SoundManager.shared.play(.taskComplete)
+            onTurnComplete?(conversationId)
         }
         if stateChanged {
             switch state {

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -237,6 +237,9 @@ final class ConversationManager: ConversationRestorerDelegate {
         activityStore.onAssistantActivityChange = { [weak self] conversationId, previousSnapshot, currentSnapshot in
             self?.handleAssistantMessageArrival(conversationId: conversationId, previousSnapshot: previousSnapshot, currentSnapshot: currentSnapshot)
         }
+        activityStore.onTurnComplete = { [weak self] conversationId in
+            self?.postTurnCompleteNotificationIfNeeded(conversationId: conversationId)
+        }
 
         enterDraftMode()
         conversationRestorer.delegate = self
@@ -480,6 +483,41 @@ final class ConversationManager: ConversationRestorerDelegate {
             self.conversationRestorer.requestReconnectHistory(conversationId: conversationId)
         }
         return viewModel
+    }
+
+    // MARK: - Turn-end notification
+
+    private func postTurnCompleteNotificationIfNeeded(conversationId: UUID) {
+        guard !NSApp.isActive else { return }
+        guard let conversation = listStore.conversations.first(where: { $0.id == conversationId }) else { return }
+        if conversation.shouldSuppressUnreadIndicator { return }
+        guard let vm = selectionStore.chatViewModels[conversationId] else { return }
+        // Voice path posts its own VOICE_RESPONSE_COMPLETE notification; skip to avoid duplicates.
+        if vm.isVoiceModeActive { return }
+
+        let lastAssistantText = vm.messages.last(where: { $0.role == .assistant })?.text ?? ""
+        let bodyText = lastAssistantText.isEmpty ? "Response complete" : String(lastAssistantText.prefix(200))
+
+        let content = UNMutableNotificationContent()
+        content.title = conversation.title
+        content.subtitle = "Response ready"
+        content.body = bodyText
+        content.sound = .default
+        content.categoryIdentifier = "ACTIVITY_COMPLETE"
+        content.threadIdentifier = conversationId.uuidString
+        content.userInfo = ["conversationId": conversationId.uuidString]
+        content.attachAppIcon()
+
+        let request = UNNotificationRequest(
+            identifier: "turn-complete-\(conversationId.uuidString)-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+        Task { @MainActor in
+            if let error = await UNUserNotificationCenter.current().safeAdd(request) {
+                log.error("Failed to post turn-complete notification: \(error.localizedDescription)")
+            }
+        }
     }
 
     // MARK: - Conversation CRUD


### PR DESCRIPTION
## Summary
- Add `onTurnComplete` callback to `ConversationActivityStore` that fires 1:1 with the daemon's `message_complete` event (reuses the existing `turnCompletionTick` gate that drives the task-complete sound).
- Wire it in `ConversationManager` to post a `UNNotificationRequest` with the previously-dormant `ACTIVITY_COMPLETE` category. Skipped when the app is focused, the conversation is background/scheduled, or voice mode is active (the existing `VOICE_RESPONSE_COMPLETE` path covers that case).
- Tap handler at `AppDelegate+Notifications.swift:469-480` already opens the conversation by `userInfo["conversationId"]` — no changes needed there.

## Original prompt
I want to get a mac os notification (similar to how I get a notification when the assistant needs my permission for something) when a running turn on a non-background conversation ends if the app isn't focused.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
