### PR TITLE
test(macos): consolidate signed-url upload tests after self-review

### DIFF
--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -163,6 +163,8 @@ final class PlatformMigrationClientPollJobStatusTests: XCTestCase {
 private final class ObservedRequest: @unchecked Sendable {
     var url: URL?
     var method: String?
+    var body: Data?
+    var sessionTokenHeader: String?
 }
 
 @MainActor
@@ -191,14 +193,14 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
 
     func testRequestSignedUploadUrlPostsToUnifiedEndpointWithOperationUpload() async throws {
         let observed = ObservedRequest()
-        let captureBody = CapturedBody()
         JobStatusURLProtocol.requestHandler = { request in
             observed.url = request.url
             observed.method = request.httpMethod
+            observed.sessionTokenHeader = request.value(forHTTPHeaderField: "X-Session-Token")
             if let stream = request.httpBodyStream {
-                captureBody.data = Self.readAll(from: stream)
+                observed.body = Self.readAll(from: stream)
             } else {
-                captureBody.data = request.httpBody
+                observed.body = request.httpBody
             }
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -218,8 +220,9 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
             "Expected URL to end with unified signed-url path; got \(url.absoluteString)"
         )
         XCTAssertEqual(observed.method, "POST")
+        XCTAssertEqual(observed.sessionTokenHeader, "test-session-token")
 
-        let bodyData = try XCTUnwrap(captureBody.data)
+        let bodyData = try XCTUnwrap(observed.body)
         let bodyJson = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
         )
@@ -231,53 +234,38 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
         XCTAssertEqual(resp.expiresAt, "2026-05-01T00:00:00Z")
     }
 
-    func testRequestSignedUploadUrlMaps503ToSignedUrlsNotAvailable() async {
-        JobStatusURLProtocol.requestHandler = { request in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 503,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(#"{"detail":"GCS not configured"}"#.utf8))
-        }
-
-        do {
-            _ = try await PlatformMigrationClient.requestSignedUploadUrl()
-            XCTFail("Expected signedUrlsNotAvailable to be thrown")
-        } catch let error as PlatformMigrationClient.PlatformMigrationError {
-            if case .signedUrlsNotAvailable = error {
-                // expected
-            } else {
-                XCTFail("Expected .signedUrlsNotAvailable, got \(error)")
-            }
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
+    func testRequestSignedUploadUrlMapsUnavailableStatusesToSignedUrlsNotAvailable() async {
+        for statusCode in [404, 503] {
+            await assertMapsToSignedUrlsNotAvailable(statusCode: statusCode)
         }
     }
 
-    func testRequestSignedUploadUrlMaps404ToSignedUrlsNotAvailable() async {
+    private func assertMapsToSignedUrlsNotAvailable(
+        statusCode: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
         JobStatusURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
-                statusCode: 404,
+                statusCode: statusCode,
                 httpVersion: nil,
                 headerFields: nil
             )!
-            return (response, Data(#"{"detail":"not found"}"#.utf8))
+            return (response, Data(#"{"detail":"unavailable"}"#.utf8))
         }
 
         do {
             _ = try await PlatformMigrationClient.requestSignedUploadUrl()
-            XCTFail("Expected signedUrlsNotAvailable to be thrown")
+            XCTFail("Expected signedUrlsNotAvailable for status \(statusCode)", file: file, line: line)
         } catch let error as PlatformMigrationClient.PlatformMigrationError {
             if case .signedUrlsNotAvailable = error {
                 // expected
             } else {
-                XCTFail("Expected .signedUrlsNotAvailable, got \(error)")
+                XCTFail("Expected .signedUrlsNotAvailable for status \(statusCode), got \(error)", file: file, line: line)
             }
         } catch {
-            XCTFail("Unexpected error type: \(error)")
+            XCTFail("Unexpected error type for status \(statusCode): \(error)", file: file, line: line)
         }
     }
 
@@ -294,8 +282,4 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
         }
         return data
     }
-}
-
-private final class CapturedBody: @unchecked Sendable {
-    var data: Data?
 }


### PR DESCRIPTION
## Summary
Self-review fixes for #29105 (upload-url → signed-url migration). Three small test-file improvements; no production-code changes.

- Fold the new `CapturedBody` carrier class into the existing `ObservedRequest` (add `body` and `sessionTokenHeader` fields). Eliminates a parallel single-field class right next to its near-identical sibling.
- Parameterize `testRequestSignedUploadUrlMaps{503,404}ToSignedUrlsNotAvailable` into one loop-driven test calling a private `assertMapsToSignedUrlsNotAvailable(statusCode:)` helper. Same coverage, ~30 fewer lines of copy-paste.
- Assert `X-Session-Token` header is sent on the unified `/v1/migrations/signed-url/` request. The plan emphasized auth-header parity with the legacy method; the test now actually verifies it.

Part of plan: upload-url-consolidation-swift.md (self-review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
