### PR TITLE
fix(macos): treat 503 as permanent on signed-url upload to skip 7s retry backoff

### DIFF
--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -86,7 +86,7 @@ public enum PlatformMigrationClient {
         let (data, statusCode) = try await executeWithRetry(
             request: request,
             label: "signed-url",
-            nonRetryableStatusCodes: [404]
+            nonRetryableStatusCodes: [404, 503]
         )
 
         if statusCode == 503 || statusCode == 404 {


### PR DESCRIPTION
## Summary
Add 503 to `nonRetryableStatusCodes` in `requestSignedUploadUrl()` so a 'GCS not configured' response maps to `.signedUrlsNotAvailable` immediately instead of after ~7s of exponential-backoff retry sleep (1s + 2s + 4s).

The 503 path is a permanent semantic signal (the platform's `_signed_url_backend_unavailable_response` returned when the storage backend isn't configured) — not a transient server error worth retrying. The doc comment on `executeWithRetry` already cites 503 as an example of this pattern.

Caught by Devin on #29110 review and confirmed in the round-2 self-review integration pass. The legacy `requestUploadUrl()` had the same wart; the migration's parameterized 404/503 test made it observable.

Part of plan: upload-url-consolidation-swift.md (self-review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
