### PR TITLE
chore(macos): migrate teleport/transfer upload to unified signed-url endpoint

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -412,7 +412,7 @@ struct AssistantTransferSection: View {
     /// All endpoints are org-scoped, so no `connectedAssistantId` swap is needed.
     private func importBundleToManaged(bundleData: Data) async throws {
         // Step 1: Request a signed upload URL from the platform
-        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+        let uploadInfo = try await PlatformMigrationClient.requestSignedUploadUrl()
 
         // Step 2: Upload bundle directly to GCS via signed URL
         try await PlatformMigrationClient.uploadToSignedUrl(uploadInfo.uploadUrl, bundleData: bundleData)

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -370,7 +370,7 @@ struct TeleportSection: View {
 
         // Step 3 — Upload to GCS via signed URL
         phase = .transferring(step: "Uploading data to cloud...")
-        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+        let uploadInfo = try await PlatformMigrationClient.requestSignedUploadUrl()
         try await PlatformMigrationClient.uploadToSignedUrl(
             uploadInfo.uploadUrl,
             bundleData: bundleData,
@@ -545,7 +545,7 @@ struct TeleportSection: View {
 
         // Step 3 — Upload to GCS via signed URL
         phase = .transferring(step: "Uploading data to cloud...")
-        let uploadInfo = try await PlatformMigrationClient.requestUploadUrl()
+        let uploadInfo = try await PlatformMigrationClient.requestSignedUploadUrl()
         try await PlatformMigrationClient.uploadToSignedUrl(
             uploadInfo.uploadUrl,
             bundleData: bundleData,
@@ -622,7 +622,7 @@ struct TeleportSection: View {
     ///
     /// Always fetches orgs from the API and validates any persisted value.
     /// Persists the resolved org ID to UserDefaults so downstream callers
-    /// (e.g. `PlatformMigrationClient.requestUploadUrl()`) can read it.
+    /// (e.g. `PlatformMigrationClient.requestSignedUploadUrl()`) can read it.
     private func resolveOrganizationId() async throws -> String {
         let orgs = try await AuthService.shared.getOrganizations()
         let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -86,7 +86,7 @@ public enum PlatformMigrationClient {
         let (data, statusCode) = try await executeWithRetry(
             request: request,
             label: "signed-url",
-            nonRetryableStatusCodes: [404]
+            nonRetryableStatusCodes: [404, 503]
         )
 
         if statusCode == 503 || statusCode == 404 {

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -13,14 +13,14 @@ public enum PlatformMigrationClient {
 
     // MARK: - Response Types
 
-    /// Response from the platform's upload URL endpoint.
-    public struct UploadUrlResponse: Decodable {
+    /// Response from the platform's unified signed-URL endpoint.
+    public struct SignedUrlResponse: Decodable {
         public let uploadUrl: String
         public let bundleKey: String
         public let expiresAt: String
 
         private enum CodingKeys: String, CodingKey {
-            case uploadUrl = "upload_url"
+            case uploadUrl = "url"
             case bundleKey = "bundle_key"
             case expiresAt = "expires_at"
         }
@@ -60,14 +60,17 @@ public enum PlatformMigrationClient {
 
     // MARK: - Public API
 
-    /// Requests a signed upload URL from the platform for uploading a migration bundle.
+    /// Requests a signed upload URL from the platform's unified signed-URL endpoint.
     ///
-    /// - Returns: An `UploadUrlResponse` containing the signed URL, bundle key, and expiration.
+    /// POSTs to `/v1/migrations/signed-url/` with `{"operation": "upload"}`. The
+    /// returned signed URL is suitable for a direct GCS PUT of bundle bytes.
+    ///
+    /// - Returns: A `SignedUrlResponse` containing the signed URL, bundle key, and expiration.
     /// - Throws: `PlatformMigrationError` on auth or request failures.
-    public static func requestUploadUrl() async throws -> UploadUrlResponse {
+    public static func requestSignedUploadUrl() async throws -> SignedUrlResponse {
         let (baseURL, token, orgId) = try resolveAuthContext()
 
-        guard let url = URL(string: "\(baseURL)/v1/migrations/upload-url/") else {
+        guard let url = URL(string: "\(baseURL)/v1/migrations/signed-url/") else {
             throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
         }
 
@@ -78,11 +81,11 @@ public enum PlatformMigrationClient {
         if let orgId {
             request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
         }
-        request.httpBody = try JSONSerialization.data(withJSONObject: ["content_type": "application/octet-stream"])
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["operation": "upload"])
 
         let (data, statusCode) = try await executeWithRetry(
             request: request,
-            label: "upload-url",
+            label: "signed-url",
             nonRetryableStatusCodes: [404]
         )
 
@@ -96,13 +99,13 @@ public enum PlatformMigrationClient {
         }
 
         let decoder = JSONDecoder()
-        return try decoder.decode(UploadUrlResponse.self, from: data)
+        return try decoder.decode(SignedUrlResponse.self, from: data)
     }
 
     /// Uploads binary bundle data to a GCS signed URL.
     ///
     /// - Parameters:
-    ///   - url: The signed upload URL from `requestUploadUrl()`.
+    ///   - url: The signed upload URL from `requestSignedUploadUrl()`.
     ///   - bundleData: The raw bundle data to upload.
     /// - Throws: `PlatformMigrationError.uploadFailed` if the upload returns a non-2xx status.
     public static func uploadToSignedUrl(_ url: String, bundleData: Data) async throws {
@@ -126,7 +129,7 @@ public enum PlatformMigrationClient {
     /// Uploads binary bundle data to a GCS signed URL with progress tracking.
     ///
     /// - Parameters:
-    ///   - url: The signed upload URL from `requestUploadUrl()`.
+    ///   - url: The signed upload URL from `requestSignedUploadUrl()`.
     ///   - bundleData: The raw bundle data to upload.
     ///   - onProgress: A closure called on the main actor with values from 0.0 to 1.0
     ///     representing the fraction of bytes uploaded.
@@ -182,7 +185,7 @@ public enum PlatformMigrationClient {
 
     /// Triggers a GCS-based import on the platform after the bundle has been uploaded.
     ///
-    /// - Parameter bundleKey: The bundle key returned by `requestUploadUrl()`.
+    /// - Parameter bundleKey: The bundle key returned by `requestSignedUploadUrl()`.
     /// - Returns: A tuple of the HTTP status code and raw response data.
     /// - Throws: `PlatformMigrationError` on auth failures, or network errors from `URLSession`.
     public static func importFromGcs(bundleKey: String) async throws -> (statusCode: Int, data: Data) {

--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -164,3 +164,138 @@ private final class ObservedRequest: @unchecked Sendable {
     var url: URL?
     var method: String?
 }
+
+@MainActor
+final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
+    private var previousToken: String?
+
+    override func setUp() {
+        super.setUp()
+        JobStatusURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(JobStatusURLProtocol.self)
+        previousToken = SessionTokenManager.getToken()
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(JobStatusURLProtocol.self)
+        JobStatusURLProtocol.requestHandler = nil
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+        super.tearDown()
+    }
+
+    func testRequestSignedUploadUrlPostsToUnifiedEndpointWithOperationUpload() async throws {
+        let observed = ObservedRequest()
+        let captureBody = CapturedBody()
+        JobStatusURLProtocol.requestHandler = { request in
+            observed.url = request.url
+            observed.method = request.httpMethod
+            if let stream = request.httpBodyStream {
+                captureBody.data = Self.readAll(from: stream)
+            } else {
+                captureBody.data = request.httpBody
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 201,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"url":"https://storage.googleapis.com/signed-put?x=1","bundle_key":"uploads/org-123/abc.vbundle","expires_at":"2026-05-01T00:00:00Z"}"#
+            return (response, Data(body.utf8))
+        }
+
+        let resp = try await PlatformMigrationClient.requestSignedUploadUrl()
+
+        let url = try XCTUnwrap(observed.url)
+        XCTAssertTrue(
+            url.absoluteString.hasSuffix("/v1/migrations/signed-url/"),
+            "Expected URL to end with unified signed-url path; got \(url.absoluteString)"
+        )
+        XCTAssertEqual(observed.method, "POST")
+
+        let bodyData = try XCTUnwrap(captureBody.data)
+        let bodyJson = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        )
+        XCTAssertEqual(bodyJson["operation"] as? String, "upload")
+        XCTAssertNil(bodyJson["bundle_key"], "upload requests must omit bundle_key")
+
+        XCTAssertEqual(resp.uploadUrl, "https://storage.googleapis.com/signed-put?x=1")
+        XCTAssertEqual(resp.bundleKey, "uploads/org-123/abc.vbundle")
+        XCTAssertEqual(resp.expiresAt, "2026-05-01T00:00:00Z")
+    }
+
+    func testRequestSignedUploadUrlMaps503ToSignedUrlsNotAvailable() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 503,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"GCS not configured"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedUploadUrl()
+            XCTFail("Expected signedUrlsNotAvailable to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .signedUrlsNotAvailable = error {
+                // expected
+            } else {
+                XCTFail("Expected .signedUrlsNotAvailable, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRequestSignedUploadUrlMaps404ToSignedUrlsNotAvailable() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"not found"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedUploadUrl()
+            XCTFail("Expected signedUrlsNotAvailable to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .signedUrlsNotAvailable = error {
+                // expected
+            } else {
+                XCTFail("Expected .signedUrlsNotAvailable, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    private static func readAll(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: 4096)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}
+
+private final class CapturedBody: @unchecked Sendable {
+    var data: Data?
+}

--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -163,6 +163,8 @@ final class PlatformMigrationClientPollJobStatusTests: XCTestCase {
 private final class ObservedRequest: @unchecked Sendable {
     var url: URL?
     var method: String?
+    var body: Data?
+    var sessionTokenHeader: String?
 }
 
 @MainActor
@@ -191,14 +193,14 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
 
     func testRequestSignedUploadUrlPostsToUnifiedEndpointWithOperationUpload() async throws {
         let observed = ObservedRequest()
-        let captureBody = CapturedBody()
         JobStatusURLProtocol.requestHandler = { request in
             observed.url = request.url
             observed.method = request.httpMethod
+            observed.sessionTokenHeader = request.value(forHTTPHeaderField: "X-Session-Token")
             if let stream = request.httpBodyStream {
-                captureBody.data = Self.readAll(from: stream)
+                observed.body = Self.readAll(from: stream)
             } else {
-                captureBody.data = request.httpBody
+                observed.body = request.httpBody
             }
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -218,8 +220,9 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
             "Expected URL to end with unified signed-url path; got \(url.absoluteString)"
         )
         XCTAssertEqual(observed.method, "POST")
+        XCTAssertEqual(observed.sessionTokenHeader, "test-session-token")
 
-        let bodyData = try XCTUnwrap(captureBody.data)
+        let bodyData = try XCTUnwrap(observed.body)
         let bodyJson = try XCTUnwrap(
             try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
         )
@@ -231,53 +234,38 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
         XCTAssertEqual(resp.expiresAt, "2026-05-01T00:00:00Z")
     }
 
-    func testRequestSignedUploadUrlMaps503ToSignedUrlsNotAvailable() async {
-        JobStatusURLProtocol.requestHandler = { request in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 503,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(#"{"detail":"GCS not configured"}"#.utf8))
-        }
-
-        do {
-            _ = try await PlatformMigrationClient.requestSignedUploadUrl()
-            XCTFail("Expected signedUrlsNotAvailable to be thrown")
-        } catch let error as PlatformMigrationClient.PlatformMigrationError {
-            if case .signedUrlsNotAvailable = error {
-                // expected
-            } else {
-                XCTFail("Expected .signedUrlsNotAvailable, got \(error)")
-            }
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
+    func testRequestSignedUploadUrlMapsUnavailableStatusesToSignedUrlsNotAvailable() async {
+        for statusCode in [404, 503] {
+            await assertMapsToSignedUrlsNotAvailable(statusCode: statusCode)
         }
     }
 
-    func testRequestSignedUploadUrlMaps404ToSignedUrlsNotAvailable() async {
+    private func assertMapsToSignedUrlsNotAvailable(
+        statusCode: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
         JobStatusURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
                 url: request.url!,
-                statusCode: 404,
+                statusCode: statusCode,
                 httpVersion: nil,
                 headerFields: nil
             )!
-            return (response, Data(#"{"detail":"not found"}"#.utf8))
+            return (response, Data(#"{"detail":"unavailable"}"#.utf8))
         }
 
         do {
             _ = try await PlatformMigrationClient.requestSignedUploadUrl()
-            XCTFail("Expected signedUrlsNotAvailable to be thrown")
+            XCTFail("Expected signedUrlsNotAvailable for status \(statusCode)", file: file, line: line)
         } catch let error as PlatformMigrationClient.PlatformMigrationError {
             if case .signedUrlsNotAvailable = error {
                 // expected
             } else {
-                XCTFail("Expected .signedUrlsNotAvailable, got \(error)")
+                XCTFail("Expected .signedUrlsNotAvailable for status \(statusCode), got \(error)", file: file, line: line)
             }
         } catch {
-            XCTFail("Unexpected error type: \(error)")
+            XCTFail("Unexpected error type for status \(statusCode): \(error)", file: file, line: line)
         }
     }
 
@@ -294,8 +282,4 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
         }
         return data
     }
-}
-
-private final class CapturedBody: @unchecked Sendable {
-    var data: Data?
 }


### PR DESCRIPTION
## Summary
Migrates the macOS Swift client off the legacy `POST /v1/migrations/upload-url/` endpoint onto the unified `POST /v1/migrations/signed-url/` endpoint with `{"operation": "upload"}`. The CLI side already shipped this consolidation in #29013; macOS was the last remaining caller. Landing this unblocks platform-side deletion of the deprecated `upload_url` action.

## Self-review result
PASS after 3 review rounds (4 parallel passes per round: external feedback, plan faithfulness, repo integration, slop/reuse audit). Round 1 surfaced 3 test-slop gaps + 1 missing auth-header assertion → fixed in #29110. Round 2 surfaced a production wart (Devin caught: 503 burning ~7s of retry backoff) → fixed in #29112. Round 3 clean.

## PRs merged into feature branch
- #29105: original migration — `UploadUrlResponse` → `SignedUrlResponse`, `requestUploadUrl()` → `requestSignedUploadUrl()`, endpoint/body/log-label swap, 3 call sites + 4 doc-comment refs updated, 3 unit tests added.
- #29110: test consolidation — folded `CapturedBody` into existing `ObservedRequest`, parameterized the 503/404 error-mapping tests, added `X-Session-Token` header assertion.
- #29112: one-character fix — added `503` to `nonRetryableStatusCodes` in `requestSignedUploadUrl()` so "GCS not configured" maps to `.signedUrlsNotAvailable` immediately instead of after ~7s of exponential backoff (Devin caught this on #29110 review).

Part of plan: upload-url-consolidation-swift.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
