### PR TITLE
fix: suppress generic secret redaction for non-literal assignment values

### DIFF
--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  _isNonLiteralGenericValue,
   _isPlaceholder,
   redactSecrets,
   scanText,
@@ -493,6 +494,12 @@ MIIEpAIBAAKCAQEA0Z3VS5JJcds3xfn/ygWep4PAtGoSNQ==
 // Edge cases / false positives
 // ---------------------------------------------------------------------------
 describe("false positive resistance", () => {
+  test("does not flag GitHub Actions SHA-pinned action ref", () => {
+    expectNoMatch(
+      "uses: actions/create-github-app-token@a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0",
+    );
+  });
+
   test("does not flag base64-encoded images", () => {
     // A typical short base64 image data chunk — should not trigger
     const img = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA";
@@ -521,6 +528,140 @@ describe("false positive resistance", () => {
     const matches = scanText(pubKey);
     const privKeys = matches.filter((m) => m.type === "Private Key");
     expect(privKeys).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generic secret non-literal suppression
+// ---------------------------------------------------------------------------
+describe("generic secret non-literal suppression", () => {
+  // --- Suppressed cases (should NOT match) ---
+
+  test("does not flag GitHub Actions template expression (quoted)", () => {
+    const input = 'token: "${{ secrets.GITHUB_TOKEN }}"';
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  test("does not flag GitHub Actions template expression (unquoted)", () => {
+    const input = "token=${{ secrets.GITHUB_TOKEN }}";
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  test("does not flag shell variable reference", () => {
+    const input = "token=$GITHUB_TOKEN_VALUE";
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  test("does not flag braced shell variable", () => {
+    const input = "token=${DATABASE_SECRET}";
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  test("does not flag UUID after credential keyword", () => {
+    const input = "token=f47ac10b-58cc-4372-a567-0e02b2c3d479";
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  test("does not flag SRI integrity hash", () => {
+    const input = "token=sha512-abcdefghijklmnop";
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  test("does not flag Go module hash", () => {
+    const input = "secret=h1:abcdefghijklmnop";
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  test("does not flag npm integrity hash", () => {
+    const input = "token=sha256:abcdef1234567890abcdef1234567890";
+    const matches = scanText(input);
+    const generic = matches.filter(
+      (m) => m.type === "Generic Secret Assignment",
+    );
+    expect(generic).toHaveLength(0);
+  });
+
+  // --- Preserved detection (MUST still match) ---
+
+  test("still flags real quoted secret", () => {
+    expectMatch('password="SuperSecret123!"', "Generic Secret Assignment");
+  });
+
+  test("still flags hex string after credential keyword", () => {
+    // 32-char hex — bare hex can be a real credential
+    expectMatch(
+      "SECRET=a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6",
+      "Generic Secret Assignment",
+    );
+  });
+
+  test("still flags mixed alphanumeric after keyword", () => {
+    expectMatch("token=aB3xY7mN9pQ2wK5v", "Generic Secret Assignment");
+  });
+
+  test("still flags base64-ish string after keyword", () => {
+    expectMatch(
+      'secret="dGhpcyBpcyBhIHJlYWwgc2VjcmV0IHZhbHVl"',
+      "Generic Secret Assignment",
+    );
+  });
+
+  // --- Unit tests for _isNonLiteralGenericValue ---
+
+  test("_isNonLiteralGenericValue: template expressions", () => {
+    expect(_isNonLiteralGenericValue("${{ secrets.X }}")).toBe(true);
+  });
+
+  test("_isNonLiteralGenericValue: shell vars", () => {
+    expect(_isNonLiteralGenericValue("$TOKEN")).toBe(true);
+    expect(_isNonLiteralGenericValue("${TOKEN}")).toBe(true);
+  });
+
+  test("_isNonLiteralGenericValue: UUIDs", () => {
+    expect(
+      _isNonLiteralGenericValue("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+    ).toBe(true);
+  });
+
+  test("_isNonLiteralGenericValue: integrity hashes", () => {
+    expect(_isNonLiteralGenericValue("sha256:abc123")).toBe(true);
+    expect(_isNonLiteralGenericValue("h1:abc123")).toBe(true);
+  });
+
+  test("_isNonLiteralGenericValue: literal strings return false", () => {
+    expect(_isNonLiteralGenericValue("SuperSecret123!")).toBe(false);
+    expect(_isNonLiteralGenericValue("aB3xY7mN9pQ2wK5v")).toBe(false);
+    expect(_isNonLiteralGenericValue("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6")).toBe(
+      false,
+    );
   });
 });
 

--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -663,6 +663,17 @@ describe("generic secret non-literal suppression", () => {
       false,
     );
   });
+
+  test("_isNonLiteralGenericValue: dollar-prefixed passwords return false", () => {
+    expect(_isNonLiteralGenericValue("$uperSecret123")).toBe(false);
+    expect(_isNonLiteralGenericValue("$4ltyP4ssw0rd!")).toBe(false);
+    expect(_isNonLiteralGenericValue("$ecretValue!@#")).toBe(false);
+  });
+
+  test("still flags dollar-prefixed passwords after credential keyword", () => {
+    expectMatch("password=$uperSecret123", "Generic Secret Assignment");
+    expectMatch("password=$4ltyP4ssw0rd!", "Generic Secret Assignment");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -232,9 +232,10 @@ function isNonLiteralGenericValue(value: string): boolean {
   if (/^\$\{\{.*\}\}$/s.test(value)) return true;
 
   // Shell / env variable references: $GITHUB_TOKEN, ${DB_PASSWORD}
-  // Requires valid POSIX variable name (letter/underscore start, word chars only)
-  // to avoid suppressing passwords like $uperSecret123 or $4ltyP4ssw0rd!
-  if (/^\$[A-Za-z_]\w*$/.test(value) || /^\$\{[^}]+\}$/.test(value))
+  // Only ALL_CAPS names (SCREAMING_SNAKE_CASE) are suppressed for the bare
+  // $VAR form — this avoids passwords like $uperSecret123 which are valid
+  // POSIX names but clearly not env var references.
+  if (/^\$[A-Z_][A-Z0-9_]*$/.test(value) || /^\$\{[^}]+\}$/.test(value))
     return true;
 
   // UUIDs: generated identifiers, not credential values

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -214,6 +214,44 @@ function isLikelyAwsSecret(value: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Non-literal value suppression for Generic Secret Assignment
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the captured value is structurally NOT a literal secret
+ * string — i.e., it is a reference, expression, or well-known hash format.
+ * Used to suppress false positives from the "Generic Secret Assignment"
+ * patterns without weakening detection of real credential values.
+ *
+ * Bare hex strings of any length are explicitly NOT suppressed — a 32/40/64
+ * char hex string assigned to `token=` or `secret=` can absolutely be a real
+ * credential (e.g. a raw HMAC key, Stripe-style opaque hex token).
+ */
+function isNonLiteralGenericValue(value: string): boolean {
+  // Template expressions: GitHub Actions ${{ secrets.X }}, Terraform, etc.
+  if (/^\$\{\{.*\}\}$/s.test(value)) return true;
+
+  // Shell / env variable references: $GITHUB_TOKEN, ${DB_PASSWORD}
+  if (/^\$\w/.test(value) || /^\$\{[^}]+\}$/.test(value)) return true;
+
+  // UUIDs: generated identifiers, not credential values
+  // (Heroku-style UUID credentials are already handled by their own keyword-gated pattern.)
+  if (
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  )
+    return true;
+
+  // Algorithm-prefixed integrity hashes: SRI (sha512-...), npm integrity,
+  // Go module sums (h1:...), etc.
+  if (/^(?:sha(?:1|256|384|512)|md5|h1|blake2[bs])[-:]/i.test(value))
+    return true;
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // Scan function
 // ---------------------------------------------------------------------------
 
@@ -247,6 +285,14 @@ export function scanText(text: string): SecretMatch[] {
 
       // Extra validation for AWS Secret Keys to avoid hex-string false positives
       if (pattern.type === "AWS Secret Key" && !isLikelyAwsSecret(value))
+        continue;
+
+      // Suppress non-literal values (template expressions, shell vars, UUIDs,
+      // integrity hashes) for Generic Secret Assignment patterns
+      if (
+        pattern.type === "Generic Secret Assignment" &&
+        isNonLiteralGenericValue(value)
+      )
         continue;
 
       const key = `${startIndex}:${endIndex}`;
@@ -299,3 +345,4 @@ export function redactSecrets(text: string): string {
 
 // Exported for testing only
 export { isPlaceholder as _isPlaceholder };
+export { isNonLiteralGenericValue as _isNonLiteralGenericValue };

--- a/assistant/src/security/secret-scanner.ts
+++ b/assistant/src/security/secret-scanner.ts
@@ -232,7 +232,10 @@ function isNonLiteralGenericValue(value: string): boolean {
   if (/^\$\{\{.*\}\}$/s.test(value)) return true;
 
   // Shell / env variable references: $GITHUB_TOKEN, ${DB_PASSWORD}
-  if (/^\$\w/.test(value) || /^\$\{[^}]+\}$/.test(value)) return true;
+  // Requires valid POSIX variable name (letter/underscore start, word chars only)
+  // to avoid suppressing passwords like $uperSecret123 or $4ltyP4ssw0rd!
+  if (/^\$[A-Za-z_]\w*$/.test(value) || /^\$\{[^}]+\}$/.test(value))
+    return true;
 
   // UUIDs: generated identifiers, not credential values
   // (Heroku-style UUID credentials are already handled by their own keyword-gated pattern.)


### PR DESCRIPTION
## Summary
- Add isNonLiteralGenericValue() to suppress false positives from template expressions, shell vars, UUIDs, and integrity hashes in Generic Secret Assignment detection
- Add regression test for GitHub Actions SHA-pinned action ref (locks in entropy scanner removal)
- Bare hex strings intentionally NOT suppressed — they can be real credentials

Closes JARVIS-635

Part of plan: fix-generic-secret-false-positives.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
