### PR TITLE
Cherry-pick fixes onto release/v0.7.1

### DIFF
--- a/assistant/src/__tests__/call-site-routing-provider.test.ts
+++ b/assistant/src/__tests__/call-site-routing-provider.test.ts
@@ -296,4 +296,112 @@ describe("CallSiteRoutingProvider", () => {
     expect(wrapped.name).toBe("anthropic");
     expect(wrapped.tokenEstimationProvider).toBe("anthropic");
   });
+
+  test("name getter reflects the routed provider during sendMessage and reverts after", async () => {
+    // Regression: emitLlmCallStartedIfNeeded fires on the first text_delta,
+    // *during* the sendMessage call (before the response completes). It reads
+    // provider.name directly — if that's always the default name the trace
+    // event says "LLM call to anthropic" even when the call went to openai.
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      callSites: {
+        memoryRetrieval: { provider: "openai", model: "gpt-5.5" },
+      },
+    });
+
+    const defaultProvider = makeProvider("anthropic", () => {});
+    const namesDuringCall: string[] = [];
+
+    const altProvider: Provider = {
+      name: "openai",
+      async sendMessage() {
+        // Simulate reading provider.name mid-stream (as handleTextDelta does).
+        namesDuringCall.push(wrapped.name);
+        return makeResponse("openai");
+      },
+    };
+
+    const wrapped = new CallSiteRoutingProvider(defaultProvider, (name) =>
+      name === "openai" ? altProvider : undefined,
+    );
+
+    expect(wrapped.name).toBe("anthropic"); // idle → default
+    await wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "memoryRetrieval" },
+    });
+    expect(namesDuringCall).toEqual(["openai"]); // mid-call → routed provider
+    expect(wrapped.name).toBe("anthropic"); // after call → reverted to default
+  });
+
+  test("concurrent sendMessage calls each see their own provider name (no clobbering)", async () => {
+    // Regression: if _routedProviderName were a plain instance field, concurrent
+    // calls (e.g. main turn + title-gen both in-flight) would clobber each
+    // other. AsyncLocalStorage gives each call its own async-context slot.
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      callSites: {
+        memoryRetrieval: { provider: "openai", model: "gpt-5.5" },
+        conversationTitle: { provider: "fireworks", model: "qwen3-235b" },
+      },
+    });
+
+    const defaultProvider = makeProvider("anthropic", () => {});
+    const nameSeenByOpenAI: string[] = [];
+    const nameSeenByFireworks: string[] = [];
+
+    // Shared resolve handles so we can interleave the two calls:
+    // openAI starts → fireworks starts → openAI resolves → fireworks resolves
+    let resolveOpenAI!: () => void;
+    let resolveFireworks!: () => void;
+
+    const openAIProvider: Provider = {
+      name: "openai",
+      async sendMessage() {
+        // Yield so fireworks call can start before we complete.
+        await new Promise<void>((r) => {
+          resolveOpenAI = r;
+        });
+        nameSeenByOpenAI.push(wrapped.name);
+        return makeResponse("openai");
+      },
+    };
+
+    const fireworksProvider: Provider = {
+      name: "fireworks",
+      async sendMessage() {
+        await new Promise<void>((r) => {
+          resolveFireworks = r;
+        });
+        nameSeenByFireworks.push(wrapped.name);
+        return makeResponse("fireworks");
+      },
+    };
+
+    const wrapped = new CallSiteRoutingProvider(defaultProvider, (name) => {
+      if (name === "openai") return openAIProvider;
+      if (name === "fireworks") return fireworksProvider;
+      return undefined;
+    });
+
+    // Start both calls concurrently (do not await yet).
+    const callA = wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "memoryRetrieval" }, // → openai
+    });
+    const callB = wrapped.sendMessage(DUMMY_MESSAGES, undefined, undefined, {
+      config: { callSite: "conversationTitle" }, // → fireworks
+    });
+
+    // Let both reach their suspension point, then resolve in order.
+    await Promise.resolve(); // flush microtasks so both calls are in-flight
+    resolveOpenAI();
+    resolveFireworks();
+
+    await Promise.all([callA, callB]);
+
+    // Each call must have seen its own provider, not the other's.
+    expect(nameSeenByOpenAI).toEqual(["openai"]);
+    expect(nameSeenByFireworks).toEqual(["fireworks"]);
+    // And the idle name reverts to the default.
+    expect(wrapped.name).toBe("anthropic");
+  });
 });

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -950,6 +950,159 @@ describe("session-agent-loop", () => {
     });
   });
 
+  describe("llm_call_started / llm_call_finished trace coherence", () => {
+    // Regression: the started event was emitted by emitLlmCallStartedIfNeeded
+    // using deps.ctx.provider.name (the default), while the finished event used
+    // event.actualProvider. For routed calls (e.g. gpt-5.5 via openai from an
+    // anthropic-default conversation) this caused started="anthropic" /
+    // finished="openai". The fix passes providerName explicitly from handleUsage
+    // so both events always agree, even when text_delta never fires (tool-only).
+
+    test("started and finished use the same provider name for a streaming response", async () => {
+      // In the real routing scenario, text_delta fires while
+      // CallSiteRoutingProvider's AsyncLocalStorage context holds the active
+      // transport name (covered by call-site-routing-provider.test.ts). Here we
+      // verify the loop wiring: when text_delta fires before usage, the started
+      // event reflects the provider that will also appear on finished.
+      const traceEvents: Array<{
+        label: string;
+        attrs: Record<string, unknown>;
+      }> = [];
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        onEvent({ type: "text_delta", text: "Hi." });
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Hi." }],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 10,
+          outputTokens: 2,
+          model: "gpt-5.5-2026-04-23",
+          actualProvider: "openai",
+          providerDurationMs: 100,
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "Hi." }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        // Provider name matches actualProvider so both paths agree.
+        provider: {
+          name: "openai",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as AgentLoopConversationContext["provider"],
+        traceEmitter: {
+          emit: (
+            event: string,
+            label: string,
+            payload: { attributes?: Record<string, unknown> },
+          ) => {
+            if (event === "llm_call_started" || event === "llm_call_finished") {
+              traceEvents.push({ label, attrs: payload.attributes ?? {} });
+            }
+          },
+        } as unknown as AgentLoopConversationContext["traceEmitter"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      const started = traceEvents.find(
+        (e) =>
+          e.label.startsWith("LLM call to") && !e.label.endsWith("finished"),
+      );
+      const finished = traceEvents.find((e) => e.label.endsWith("finished"));
+
+      expect(started).toBeDefined();
+      expect(finished).toBeDefined();
+      expect(started!.attrs["provider"]).toBe("openai");
+      expect(finished!.attrs["provider"]).toBe("openai");
+    });
+
+    test("started and finished use the same provider name for a tool-call-only response (no text_delta)", async () => {
+      // This is the harder case: no text_delta fires, so emitLlmCallStartedIfNeeded
+      // fires as a fallback inside handleUsage *after* the AsyncLocalStorage
+      // context in CallSiteRoutingProvider has already exited. Without passing
+      // providerName explicitly it would say "anthropic".
+      const traceEvents: Array<{
+        label: string;
+        attrs: Record<string, unknown>;
+      }> = [];
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        // No text_delta — pure tool-call response
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [],
+          },
+        });
+        onEvent({
+          type: "usage",
+          inputTokens: 10,
+          outputTokens: 2,
+          model: "gpt-5.5-2026-04-23",
+          actualProvider: "openai",
+          providerDurationMs: 100,
+        });
+        return messages;
+      };
+
+      const ctx = makeCtx({
+        agentLoopRun,
+        provider: {
+          name: "anthropic",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as AgentLoopConversationContext["provider"],
+        traceEmitter: {
+          emit: (
+            event: string,
+            label: string,
+            payload: { attributes?: Record<string, unknown> },
+          ) => {
+            if (event === "llm_call_started" || event === "llm_call_finished") {
+              traceEvents.push({ label, attrs: payload.attributes ?? {} });
+            }
+          },
+        } as unknown as AgentLoopConversationContext["traceEmitter"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      const started = traceEvents.find(
+        (e) =>
+          e.label.startsWith("LLM call to") && !e.label.endsWith("finished"),
+      );
+      const finished = traceEvents.find((e) => e.label.endsWith("finished"));
+
+      expect(started).toBeDefined();
+      expect(finished).toBeDefined();
+      expect(started!.attrs["provider"]).toBe("openai");
+      expect(finished!.attrs["provider"]).toBe("openai");
+    });
+  });
+
   describe("usage accounting", () => {
     test("records the actual provider for usage accounting", async () => {
       const events: ServerMessage[] = [];

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -233,20 +233,31 @@ export function createEventHandlerState(): EventHandlerState {
 
 // ── Shared Helper ────────────────────────────────────────────────────
 
+// providerNameOverride should be supplied when the caller already knows the
+// resolved provider name (e.g. handleUsage, which has event.actualProvider).
+// When called during streaming (text_delta / thinking_delta) the override is
+// omitted and provider.name is used — the CallSiteRoutingProvider getter
+// returns the active transport name during sendMessage, so they agree.
+// Passing the override from handleUsage guarantees started/finished never
+// disagree even for tool-call-only responses where text_delta never fires
+// (and therefore the started event would otherwise fall back here *after*
+// the AsyncLocalStorage context in CallSiteRoutingProvider has already exited).
 function emitLlmCallStartedIfNeeded(
   state: EventHandlerState,
   deps: EventHandlerDeps,
+  providerNameOverride?: string,
 ): void {
   if (state.llmCallStartedEmitted) return;
   state.llmCallStartedEmitted = true;
+  const providerName = providerNameOverride ?? deps.ctx.provider.name;
   deps.ctx.traceEmitter.emit(
     "llm_call_started",
-    `LLM call to ${deps.ctx.provider.name}`,
+    `LLM call to ${providerName}`,
     {
       requestId: deps.reqId,
       status: "info",
       attributes: {
-        provider: deps.ctx.provider.name,
+        provider: providerName,
         model: state.model || "unknown",
       },
     },
@@ -671,7 +682,8 @@ function annotatePersistedAssistantMessage(
         rec._riskLevel = risk.riskLevel;
         if (risk.riskReason) rec._riskReason = risk.riskReason;
         rec._autoApproved = risk.autoApproved;
-        if (risk.matchedTrustRuleId) rec._matchedTrustRuleId = risk.matchedTrustRuleId;
+        if (risk.matchedTrustRuleId)
+          rec._matchedTrustRuleId = risk.matchedTrustRuleId;
         if (risk.approvalMode) rec._approvalMode = risk.approvalMode;
         if (risk.approvalReason) rec._approvalReason = risk.approvalReason;
         if (risk.riskThreshold) rec._riskThreshold = risk.riskThreshold;
@@ -1052,7 +1064,9 @@ function handleUsage(
     }
   }
 
-  emitLlmCallStartedIfNeeded(state, deps);
+  // Pass providerName so that if text_delta never fired (tool-call-only
+  // responses), the started event uses the same resolved name as finished.
+  emitLlmCallStartedIfNeeded(state, deps, providerName);
 
   deps.ctx.traceEmitter.emit(
     "llm_call_finished",

--- a/assistant/src/providers/call-site-routing.ts
+++ b/assistant/src/providers/call-site-routing.ts
@@ -19,6 +19,8 @@
  * stable identity.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type {
@@ -30,14 +32,28 @@ import type {
 } from "./types.js";
 
 export class CallSiteRoutingProvider implements Provider {
-  public readonly name: string;
   public readonly tokenEstimationProvider?: string;
+
+  // Per-call async context that tracks which provider is currently executing.
+  // Using AsyncLocalStorage instead of a plain instance field means concurrent
+  // sendMessage calls (e.g. the main agent turn and a title-generation call
+  // both in-flight at the same time on the same provider instance) each see
+  // their own value — no clobbering, no premature clear.
+  //
+  // During sendMessage, emitLlmCallStartedIfNeeded reads provider.name on the
+  // first text_delta (before the response completes). The getter below returns
+  // the async-context value so streaming trace events carry the routed
+  // provider's name, not the default's.
+  private readonly _activeProviderContext = new AsyncLocalStorage<string>();
+
+  get name(): string {
+    return this._activeProviderContext.getStore() ?? this.defaultProvider.name;
+  }
 
   constructor(
     private readonly defaultProvider: Provider,
     private readonly getProviderByName: (name: string) => Provider | undefined,
   ) {
-    this.name = defaultProvider.name;
     this.tokenEstimationProvider = defaultProvider.tokenEstimationProvider;
   }
 
@@ -48,23 +64,30 @@ export class CallSiteRoutingProvider implements Provider {
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
     const target = this.selectProvider(options);
-    const response = await target.sendMessage(
-      messages,
-      tools,
-      systemPrompt,
-      options,
-    );
-    // When routing to a non-default provider, stamp actualProvider so that
-    // callers (loop.ts, emitUsage, llm_call_finished) attribute the call to
-    // the right provider instead of falling back to the default provider's
-    // name. Without this, a memoryRetrieval call routed to "openai" from an
-    // "anthropic"-default conversation would be logged and billed as
-    // "anthropic", causing wrong provider labels and $0 cost (no pricing
-    // match for e.g. gpt-5.5 under the anthropic catalog).
-    if (target !== this.defaultProvider && response.actualProvider == null) {
-      return { ...response, actualProvider: target.name };
-    }
-    return response;
+    const isRouted = target !== this.defaultProvider;
+
+    const doSend = async (): Promise<ProviderResponse> => {
+      const response = await target.sendMessage(
+        messages,
+        tools,
+        systemPrompt,
+        options,
+      );
+      // Also stamp actualProvider on the response so that handleUsage /
+      // llm_call_finished (which read event.actualProvider, not provider.name)
+      // attribute the call to the right provider.
+      if (isRouted && response.actualProvider == null) {
+        return { ...response, actualProvider: target.name };
+      }
+      return response;
+    };
+
+    // Run inside the async context so that any code reading provider.name
+    // during streaming (e.g. emitLlmCallStartedIfNeeded on text_delta) sees
+    // the routed provider's name for this specific call, not the default.
+    return isRouted
+      ? this._activeProviderContext.run(target.name, doSend)
+      : doSend();
   }
 
   /**

--- a/assistant/src/providers/ratelimit.ts
+++ b/assistant/src/providers/ratelimit.ts
@@ -12,7 +12,13 @@ import type {
 const log = getLogger("rate-limit");
 
 export class RateLimitProvider implements Provider {
-  public readonly name: string;
+  // Delegate name dynamically so that wrapper providers (e.g.
+  // CallSiteRoutingProvider) whose name getter reflects per-call async context
+  // (AsyncLocalStorage) are reached correctly during streaming — rather than
+  // returning a stale snapshot captured at construction time.
+  get name(): string {
+    return this.inner.name;
+  }
 
   get tokenEstimationProvider(): string | undefined {
     return this.inner.tokenEstimationProvider;
@@ -25,7 +31,6 @@ export class RateLimitProvider implements Provider {
     private readonly config: RateLimitConfig,
     sharedRequestTimestamps?: number[],
   ) {
-    this.name = inner.name;
     this.requestTimestamps = sharedRequestTimestamps ?? [];
   }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -25,7 +25,6 @@ struct ChatView: View {
     /// directly does NOT subscribe parent views to any changes.
     /// See: https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro
     @Bindable var viewModel: ChatViewModel
-    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore: AssistantFeatureFlagStore?
 
     // MARK: - Settings (from SettingsStore, not viewModel)
 
@@ -537,7 +536,6 @@ struct ChatView: View {
     /// `nil` when no manager is wired (preview/testing) so the pill stays
     /// hidden until a real persistence path exists.
     private var inferenceProfilePicker: ChatProfilePickerConfiguration? {
-        guard assistantFeatureFlagStore?.isEnabled("inference-profiles") == true else { return nil }
         guard let conversationManager else { return nil }
         return ChatProfilePickerConfiguration(
             current: currentConversation?.inferenceProfile ?? viewModel.pendingInferenceProfile,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -136,7 +136,6 @@ struct SettingsPanel: View {
         }
     }
 
-    @State private var apiKeyText: String = ""
     @State private var braveKeyText: String = ""
     @State private var perplexityKeyText: String = ""
     @State private var imageGenKeyText: String = ""
@@ -546,7 +545,6 @@ struct SettingsPanel: View {
             InferenceServiceCard(
                 store: store,
                 authManager: authManager,
-                apiKeyText: $apiKeyText,
                 showToast: showToast
             )
 

--- a/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
@@ -7,8 +7,7 @@ import VellumAssistantShared
 /// and expands inline to reveal an `APIKeyTextField` for entry. Keys are
 /// validated and persisted individually via `store.saveInferenceAPIKey()`.
 ///
-/// Opened from the "Manage API Keys..." button on `InferenceServiceCard`
-/// when the inference-profiles feature flag is enabled.
+/// Opened from the "API Keys" button on `InferenceServiceCard`.
 @MainActor
 struct APIKeysSheet: View {
     @ObservedObject var store: SettingsStore

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -4,22 +4,20 @@ import VellumAssistantShared
 /// Card for the inference service with Managed/Your Own mode toggle.
 ///
 /// Shows different content based on mode and auth state:
-/// - **Managed + logged in**: Provider picker (managed-capable only),
-///   Active Profile picker, Manage Profiles button, Save button
+/// - **Managed + logged in**: Active Profile picker, Manage Profiles button,
+///   Save button
 /// - **Managed + not logged in**: Empty state prompting login
-/// - **Your Own**: Provider picker (all), API key field, Active Profile picker,
-///   Manage Profiles button, Save + Reset buttons
+/// - **Your Own**: API keys section, Active Profile picker, Manage Profiles
+///   button, Save button
 ///
 /// Active Model is no longer chosen on this card — it lives inside an
 /// inference profile. The profile dropdown writes through
 /// `store.setActiveProfile(_:)` on selection change; Save persists Provider
-/// and API key only.
+/// only.
 @MainActor
 struct InferenceServiceCard: View {
     @ObservedObject var store: SettingsStore
-    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore: AssistantFeatureFlagStore?
     var authManager: AuthManager
-    @Binding var apiKeyText: String
     var showToast: (String, ToastInfo.Style) -> Void
 
     /// Local draft of the mode selection — only persisted on Save.
@@ -30,14 +28,6 @@ struct InferenceServiceCard: View {
     @State private var draftProvider: String = "anthropic"
     /// Snapshot of the provider at card appear — used to detect provider changes.
     @State private var initialProvider: String = ""
-    /// Guards against provider-change side-effects during initial load.
-    @State private var didInitialSync = false
-    /// Set `true` right before an external store sync updates `draftProvider`,
-    /// so `onChange(of: draftProvider)` can distinguish daemon-driven updates
-    /// from user-initiated picks and skip the API-key reset.
-    @State private var isSyncingProviderFromStore = false
-    /// Whether the current provider has a stored API key (fetched per-component).
-    @State private var providerHasKey = false
     /// Whether the read-only per-call-site overrides sheet is presented.
     @State private var showOverridesSheet = false
     /// Whether the inference profiles management sheet is presented.
@@ -69,29 +59,19 @@ struct InferenceServiceCard: View {
     /// without a manual onChange handler.
     @State private var apiKeysRefreshToken: Int = 0
 
-    // MARK: - Provider Helpers
-
-    private var effectiveProvider: String {
-        draftProvider
-    }
-
-    private var providerDisplayName: String {
-        store.dynamicProviderDisplayName(effectiveProvider)
-    }
-
     // MARK: - Computed State
-
-    private var profilesEnabled: Bool {
-        assistantFeatureFlagStore?.isEnabled("inference-profiles") == true
-    }
 
     private var isLoggedIn: Bool {
         authManager.isAuthenticated
     }
 
-    /// True when at least one key-required provider has a configured API key.
-    private var hasAnyProviderKey: Bool {
-        providerKeyStatuses.values.contains(true)
+    /// True when the user has at least one usable provider — either a keyless
+    /// provider (e.g. Ollama) exists in the catalog, or a key-required
+    /// provider has a configured API key.
+    private var hasUsableProvider: Bool {
+        let hasKeylessProvider = store.providerCatalog.contains { $0.apiKeyPlaceholder == nil }
+        let hasConfiguredKey = providerKeyStatuses.values.contains(true)
+        return hasKeylessProvider || hasConfiguredKey
     }
 
     /// True when changing inference mode/provider would invalidate the current
@@ -135,12 +115,8 @@ struct InferenceServiceCard: View {
             return false
         }
         let modeChanged = draftMode != store.inferenceMode
-        // When profiles are enabled, API keys are managed in the sheet —
-        // the card's Save button only covers mode changes.
-        let hasNewKey = !profilesEnabled && draftMode == "your-own"
-            && !apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let providerChanged = draftProvider != initialProvider
-        return modeChanged || hasNewKey || providerChanged
+        return modeChanged || providerChanged
     }
 
     var body: some View {
@@ -151,21 +127,12 @@ struct InferenceServiceCard: View {
             managedContent: {
                 if isLoggedIn {
                     VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        if profilesEnabled {
-                            activeProfilePicker
-                            secondaryActionsRow
-                            if hasChanges {
-                                ServiceCardActions(
-                                    hasChanges: true,
-                                    isSaving: false,
-                                    onSave: { save() }
-                                )
-                            }
-                        } else {
-                            managedProviderPicker
+                        activeProfilePicker
+                        secondaryActionsRow
+                        if hasChanges {
                             ServiceCardActions(
-                                hasChanges: hasChanges,
-                                isSaving: store.apiKeySaving,
+                                hasChanges: true,
+                                isSaving: false,
                                 onSave: { save() }
                             )
                         }
@@ -176,7 +143,7 @@ struct InferenceServiceCard: View {
             },
             yourOwnContent: {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    if profilesEnabled && hasAnyProviderKey {
+                    if hasUsableProvider {
                         apiKeysSection
                         activeProfilePicker
                         secondaryActionsRow
@@ -187,23 +154,8 @@ struct InferenceServiceCard: View {
                                 onSave: { save() }
                             )
                         }
-                    } else if profilesEnabled {
-                        apiKeysEmptyState
                     } else {
-                        providerPicker
-                        apiKeyField
-                        ServiceCardActions(
-                            hasChanges: hasChanges,
-                            isSaving: store.apiKeySaving,
-                            onSave: { save() },
-                            savingLabel: "Validating...",
-                            onReset: {
-                                store.clearAPIKeyForProvider(effectiveProvider)
-                                providerHasKey = false
-                                apiKeyText = ""
-                            },
-                            showReset: providerHasKey
-                        )
+                        apiKeysEmptyState
                     }
                 }
             },
@@ -232,21 +184,8 @@ struct InferenceServiceCard: View {
         }
         .onAppear {
             draftMode = store.inferenceMode
-            // Mirror the store-sync pattern used in
-            // onChange(of: store.selectedInferenceProvider): flag the pending
-            // mutation BEFORE assigning draftProvider so the deferred
-            // onChange(of: draftProvider) callback (which SwiftUI runs after
-            // this closure returns) skips the API-key reset. Without this,
-            // any user whose saved provider differs from the @State default
-            // "anthropic" sees apiKeyText cleared right after onAppear settles.
-            let alreadyEqualProvider = draftProvider == store.selectedInferenceProvider
-            isSyncingProviderFromStore = true
             draftProvider = store.selectedInferenceProvider
-            if alreadyEqualProvider {
-                isSyncingProviderFromStore = false
-            }
             initialProvider = store.selectedInferenceProvider
-            didInitialSync = true
 
             // If the user is not authenticated and the persisted mode is
             // "managed", reset the draft so the UI shows "your-own".
@@ -323,33 +262,9 @@ struct InferenceServiceCard: View {
             }
         }
         .onChange(of: store.selectedInferenceProvider) { _, newValue in
-            // Sync draft & baseline when the daemon reports a provider
-            // update. Flag the update so onChange(of: draftProvider) skips
-            // the API-key reset that is only appropriate for user picks.
-            let alreadyEqual = draftProvider == newValue
-            isSyncingProviderFromStore = true
+            // Sync draft & baseline when the daemon reports a provider update.
             draftProvider = newValue
-            // If draftProvider already held this value, SwiftUI's
-            // onChange(of: draftProvider) won't fire (it only fires on
-            // actual value transitions), so clear the flag immediately
-            // to prevent the next user-initiated change from being
-            // misclassified as a store sync.
-            if alreadyEqual {
-                isSyncingProviderFromStore = false
-            }
             initialProvider = newValue
-        }
-        .onChange(of: draftProvider) { _, _ in
-            // Clear any unsaved API key text on user-initiated provider
-            // changes — it belongs to the previous provider's context.
-            // External store syncs set isSyncingProviderFromStore before
-            // mutating draftProvider; clear the flag and skip.
-            if isSyncingProviderFromStore {
-                isSyncingProviderFromStore = false
-                return
-            }
-            guard didInitialSync else { return }
-            apiKeyText = ""
         }
         .onChange(of: draftMode) { _, newMode in
             if newMode == "managed" {
@@ -359,9 +274,6 @@ struct InferenceServiceCard: View {
                     draftProvider = "anthropic"
                 }
             }
-        }
-        .task(id: effectiveProvider) {
-            providerHasKey = await APIKeyManager.hasKey(for: effectiveProvider)
         }
         .alert("Heads up", isPresented: $showWebSearchAlert) {
             Button("Go Back", role: .cancel) {}
@@ -397,7 +309,7 @@ struct InferenceServiceCard: View {
 
     /// Consolidated row of ghost-styled buttons for managing API keys,
     /// profiles, and per-task overrides. Shown in both Managed and Your Own
-    /// modes when inference-profiles is enabled.
+    /// modes.
     private var secondaryActionsRow: some View {
         let overridesLabel = store.overridesCount > 0
             ? "\(store.overridesCount) Override\(store.overridesCount == 1 ? "" : "s")"
@@ -441,61 +353,11 @@ struct InferenceServiceCard: View {
         }
     }
 
-    // MARK: - Provider Picker
-
-    private var providerPicker: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Provider")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentSecondary)
-            VDropdown(
-                placeholder: "Select a provider\u{2026}",
-                selection: $draftProvider,
-                options: store.dynamicProviderIds.map { provider in
-                    (label: store.dynamicProviderDisplayName(provider), value: provider)
-                }
-            )
-        }
-    }
-
-    /// Provider picker filtered to managed-capable providers, shown in managed mode.
-    private var managedProviderPicker: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Provider")
-                .font(VFont.labelDefault)
-                .foregroundStyle(VColor.contentSecondary)
-            VDropdown(
-                placeholder: "Select a provider\u{2026}",
-                selection: $draftProvider,
-                options: store.managedCapableProviders.map { entry in
-                    (label: entry.displayName, value: entry.id)
-                }
-            )
-        }
-    }
-
-    // MARK: - API Key Field
-
-    private var apiKeyField: some View {
-        APIKeyTextField(
-            label: "\(providerDisplayName) API Key",
-            hasKey: providerHasKey,
-            text: $apiKeyText,
-            emptyPlaceholder: {
-                if let p = store.dynamicProviderApiKeyPlaceholder(effectiveProvider), !p.isEmpty { return p }
-                return "Enter your API key"
-            }(),
-            errorMessage: store.apiKeySaveError
-        )
-        .disabled(store.apiKeySaving)
-    }
-
     // MARK: - Multi-Provider API Keys Section
 
     /// Compact summary of configured provider API keys, shown in "Your Own"
-    /// mode when the inference-profiles feature flag is enabled and at least
-    /// one key exists. Shows provider chips only — the "API Keys" action
-    /// button lives in the consolidated `secondaryActionsRow`.
+    /// mode when at least one key exists. Shows provider chips only — the
+    /// "API Keys" action button lives in the consolidated `secondaryActionsRow`.
     private var apiKeysSection: some View {
         let configuredProviders = store.providerCatalog
             .filter { $0.apiKeyPlaceholder != nil && providerKeyStatuses[$0.id] == true }
@@ -513,9 +375,9 @@ struct InferenceServiceCard: View {
         }
     }
 
-    /// Friendly empty state shown when profiles are enabled but no provider
-    /// API keys have been configured yet. Replaces the profile picker and
-    /// overrides controls since they can't do anything without credentials.
+    /// Friendly empty state shown when no provider API keys have been
+    /// configured yet. Replaces the profile picker and overrides controls
+    /// since they can't do anything without credentials.
     private var apiKeysEmptyState: some View {
         VStack(spacing: VSpacing.md) {
             VIconView(.keyRound, size: 28)
@@ -611,28 +473,19 @@ struct InferenceServiceCard: View {
                 $0.provider == initialProvider
             }
             if !overridesPinnedToOldProvider.isEmpty {
-                let profilesEnabled = assistantFeatureFlagStore?.isEnabled("inference-profiles") == true
-                if profilesEnabled {
-                    // Show the confirmation dialog so the user can choose
-                    // to keep or reset overrides pinned to the old provider.
-                    pendingOverrideClears = overridesPinnedToOldProvider
-                    pendingOverrideOldProviderName = store.dynamicProviderDisplayName(initialProvider)
-                    showOverrideConfirmation = true
-                    return
-                } else {
-                    // When inference-profiles is off the overrides UI is
-                    // hidden, so silently clear stale overrides to prevent
-                    // invisible provider/model mismatches for affected tasks.
-                    performSaveCore(clearingOverrides: overridesPinnedToOldProvider)
-                    return
-                }
+                // Show the confirmation dialog so the user can choose
+                // to keep or reset overrides pinned to the old provider.
+                pendingOverrideClears = overridesPinnedToOldProvider
+                pendingOverrideOldProviderName = store.dynamicProviderDisplayName(initialProvider)
+                showOverrideConfirmation = true
+                return
             }
         }
 
         performSaveCore(clearingOverrides: [])
     }
 
-    /// Persists the staged inference settings (mode, provider, API key).
+    /// Persists the staged inference settings (mode, provider).
     /// Active Model is no longer written from here — the active profile owns
     /// model selection.
     ///
@@ -674,22 +527,6 @@ struct InferenceServiceCard: View {
         let providerChanged = persistProvider != initialProvider || modeChanged
         if providerChanged {
             initialProvider = draftProvider
-        }
-
-        // Persist API key if entered and in your-own mode (legacy single-key
-        // path). When profiles are enabled, keys are managed in the API Keys
-        // sheet — not inline on this card.
-        if !profilesEnabled {
-            let trimmedKey = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if draftMode == "your-own" && !trimmedKey.isEmpty {
-                let keyTextBinding = $apiKeyText
-                let displayName = providerDisplayName
-                store.saveInferenceAPIKey(trimmedKey, provider: effectiveProvider, onSuccess: { [self] in
-                    providerHasKey = true
-                    keyTextBinding.wrappedValue = ""
-                    showToast("\(displayName) API key saved", .success)
-                })
-            }
         }
 
         // Persist provider in a single PATCH when it changed (or when the

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -4496,6 +4496,14 @@ public final class SettingsStore: ObservableObject {
     /// latest daemon config so persisted overrides are merged into the newly
     /// fetched display metadata.
     func ensureCallSiteCatalogLoaded(force: Bool = false) async {
+        // Snapshot before the async fetch so we know whether the catalog was
+        // already populated. When `force` is false and the catalog is already
+        // loaded, `ensureLoaded` returns immediately without hitting the
+        // network — in that case we must NOT call `loadCallSiteOverrides`
+        // below, because `latestDaemonConfig` may still be the pre-save
+        // snapshot and would revert any optimistic state written by a
+        // concurrent `setCallSiteOverrides` call.
+        let wasAlreadyLoaded = !force && CallSiteCatalog.shared.isLoaded
         let loaded: Bool
         if force {
             loaded = await CallSiteCatalog.shared.reload(using: settingsClient)
@@ -4503,6 +4511,12 @@ public final class SettingsStore: ObservableObject {
             loaded = await CallSiteCatalog.shared.ensureLoaded(using: settingsClient)
         }
         guard loaded else { return }
+
+        // Only re-merge overrides when the catalog was actually (re)fetched.
+        // Skipping when already loaded preserves optimistic state that
+        // `applyDaemonConfig` will reconcile once the next `configChanged`
+        // refresh completes.
+        guard !wasAlreadyLoaded else { return }
 
         if let latestDaemonConfig {
             loadCallSiteOverrides(config: latestDaemonConfig)

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
@@ -16,7 +16,6 @@ final class InferenceServiceCardTests: XCTestCase {
     private var mockSettingsClient: MockSettingsClient!
     private var store: SettingsStore!
     private var authManager: AuthManager!
-    private var apiKeyTextBox: ApiKeyTextBox!
 
     override func setUp() {
         super.setUp()
@@ -30,7 +29,6 @@ final class InferenceServiceCardTests: XCTestCase {
         store = fixture.store
         mockSettingsClient = fixture.mockClient
         authManager = AuthManager()
-        apiKeyTextBox = ApiKeyTextBox()
         // Seed three built-in profiles so the Active Profile dropdown has
         // real options in tests. Inlined rather than reusing
         // `SettingsTestFixture.builtInProfilesPayload` because the card's
@@ -61,28 +59,15 @@ final class InferenceServiceCardTests: XCTestCase {
         store = nil
         mockSettingsClient = nil
         authManager = nil
-        apiKeyTextBox = nil
         super.tearDown()
     }
 
     // MARK: - Helpers
 
-    /// Reference-typed shim so a `@Binding<String>` constructed from get/set
-    /// closures can mutate state across calls. Mirrors the pattern in
-    /// `InferenceProfileEditorTests` so we don't need a rendered view tree.
-    @MainActor
-    private final class ApiKeyTextBox {
-        var text: String = ""
-    }
-
     private func makeCard() -> InferenceServiceCard {
         InferenceServiceCard(
             store: store,
             authManager: authManager,
-            apiKeyText: Binding(
-                get: { self.apiKeyTextBox.text },
-                set: { self.apiKeyTextBox.text = $0 }
-            ),
             showToast: { _, _ in }
         )
     }

--- a/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreCallSiteOverrideTests.swift
@@ -500,6 +500,46 @@ final class SettingsStoreCallSiteOverrideTests: XCTestCase {
         XCTAssertEqual(memory?["provider"] as? String, "anthropic")
     }
 
+    // MARK: - ensureCallSiteCatalogLoaded idempotency
+
+    /// Verifies the race-condition fix: when the catalog is already loaded,
+    /// `ensureCallSiteCatalogLoaded(force:false)` must NOT call
+    /// `loadCallSiteOverrides`, so it cannot revert an optimistic
+    /// `setCallSiteOverrides` update that arrived before the next
+    /// `configChanged`-triggered fetch settles.
+    func testEnsureCallSiteCatalogLoadedDoesNotRevertOptimisticStateWhenAlreadyLoaded() async {
+        // Catalog is pre-loaded via MockSettingsClient (replaceForTesting in setUp).
+        XCTAssertTrue(CallSiteCatalog.shared.isLoaded)
+
+        // Seed a daemon config with no overrides.
+        store.loadCallSiteOverrides(config: [:])
+        XCTAssertEqual(store.overridesCount, 0)
+
+        // Simulate an in-flight setCallSiteOverrides optimistic update.
+        let optimistic = CallSiteOverride(
+            id: "memoryRetrieval",
+            displayName: "Memory Retrieval",
+            domain: "memory",
+            provider: nil,
+            model: nil,
+            profile: "balanced"
+        )
+        if let idx = store.callSiteOverrides.firstIndex(where: { $0.id == "memoryRetrieval" }) {
+            store.callSiteOverrides[idx].profile = "balanced"
+        }
+        XCTAssertEqual(store.overridesCount, 1, "Optimistic update should be visible")
+
+        // Calling ensureCallSiteCatalogLoaded (force=false) while the catalog
+        // is already loaded must not overwrite the optimistic state.
+        await store.ensureCallSiteCatalogLoaded(force: false)
+
+        let afterEnsure = store.callSiteOverrides.first(where: { $0.id == "memoryRetrieval" })
+        XCTAssertEqual(afterEnsure?.profile, "balanced",
+            "ensureCallSiteCatalogLoaded must not revert optimistic override state")
+        XCTAssertEqual(store.overridesCount, 1)
+        _ = optimistic // suppress unused warning
+    }
+
     // MARK: - overridesCount derivation
 
     func testOverridesCountReflectsPartialOverrides() {

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -169,7 +169,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchEmbeddingConfig() async -> EmbeddingConfigMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "config/embeddings", timeout: 10
+                path: "assistants/{assistantId}/config/embeddings", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchEmbeddingConfig failed (HTTP \(response.statusCode))")
@@ -187,7 +187,7 @@ public struct SettingsClient: SettingsClientProtocol {
             var body: [String: Any] = ["provider": provider]
             if let model { body["model"] = model }
             let response = try await GatewayHTTPClient.put(
-                path: "config/embeddings", json: body, timeout: 10
+                path: "assistants/{assistantId}/config/embeddings", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setEmbeddingConfig failed (HTTP \(response.statusCode))")
@@ -203,7 +203,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchTelegramConfig() async -> TelegramConfigResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "integrations/telegram/config", timeout: 10
+                path: "assistants/{assistantId}/integrations/telegram/config", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchTelegramConfig failed (HTTP \(response.statusCode))")

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -370,14 +370,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "inference-profiles",
-      "scope": "assistant",
-      "key": "inference-profiles",
-      "label": "Inference Profiles",
-      "description": "Show inference profile picker in chat, active profile dropdown, Manage Profiles button, and per-task overrides link in Settings",
-      "defaultEnabled": false
-    },
-    {
       "id": "account-deletion",
       "scope": "client",
       "key": "account-deletion",


### PR DESCRIPTION
## Summary
Cherry-picks three fixes from main onto `release/v0.7.1`:
- `a79debc` — fix: name getter on CallSiteRoutingProvider reflects routed provider during streaming (#29109)
- `5951caf` — fix(macos): preserve call-site override state on sheet re-open (#29114)
- `823388d` — feat: GA the inference-profiles feature flag (#29119)

## Test plan
- [ ] Verify call-site routing provider name getter works during streaming
- [ ] Verify macOS call-site override state is preserved on sheet re-open
- [ ] Verify inference-profiles feature flag is GA'd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
