### PR TITLE
Harden Velay HTTP bridge path scope

### DIFF
--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -6,6 +6,15 @@ import type { VelayHeaders } from "./protocol.js";
 
 const MAX_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 
+
+const VELAY_ALLOWED_HTTP_PATH_PREFIXES = ["/webhooks/twilio/"] as const;
+
+export function isAllowedVelayHttpPath(path: string): boolean {
+  return VELAY_ALLOWED_HTTP_PATH_PREFIXES.some((prefix) =>
+    path.startsWith(prefix),
+  );
+}
+
 export function isSafeOriginRelativePath(path: string): boolean {
   if (!path.startsWith("/") || path.startsWith("//")) return false;
   if (path.includes("\\") || path.includes("?") || path.includes("#")) {
@@ -29,7 +38,9 @@ export function buildLoopbackHttpUrl(
   path: string,
   rawQuery?: string,
 ): string | undefined {
-  if (!isSafeOriginRelativePath(path)) return undefined;
+  if (!isSafeOriginRelativePath(path) || !isAllowedVelayHttpPath(path)) {
+    return undefined;
+  }
   return buildUpstreamUrl(
     gatewayLoopbackBaseUrl,
     path,

--- a/gateway/src/velay/http-bridge.test.ts
+++ b/gateway/src/velay/http-bridge.test.ts
@@ -163,6 +163,17 @@ describe("Velay HTTP bridge", () => {
     });
   });
 
+
+  test("rejects non-Twilio paths without contacting the loopback listener", async () => {
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ path: "/v1/guardian/init" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status_code).toBe(502);
+  });
+
   test("rejects unsafe absolute paths without contacting the loopback listener", async () => {
     fetchMock = mock(async () => {
       throw new Error("should not fetch");

--- a/gateway/src/velay/http-bridge.test.ts
+++ b/gateway/src/velay/http-bridge.test.ts
@@ -18,6 +18,8 @@ mock.module("../fetch.js", () => ({
 
 const { bridgeVelayHttpRequest } = await import("./http-bridge.js");
 
+const TWILIO_EXAMPLE_PATH = "/webhooks/twilio/example";
+
 afterEach(() => {
   fetchMock = mock(async () => new Response());
 });
@@ -29,7 +31,7 @@ function makeFrame(
     type: VELAY_FRAME_TYPES.httpRequest,
     request_id: "req-123",
     method: "POST",
-    path: "/webhooks/example",
+    path: TWILIO_EXAMPLE_PATH,
     headers: {},
     ...overrides,
   };
@@ -66,7 +68,7 @@ describe("Velay HTTP bridge", () => {
 
     const response = await bridgeVelayHttpRequest(
       makeFrame({
-        path: "/webhooks/example",
+        path: TWILIO_EXAMPLE_PATH,
         headers: {
           "content-type": ["application/json"],
           connection: ["keep-alive"],
@@ -79,7 +81,7 @@ describe("Velay HTTP bridge", () => {
     );
 
     expect(response.status_code).toBe(200);
-    expect(captured[0].url).toBe("http://127.0.0.1:7830/webhooks/example");
+    expect(captured[0].url).toBe(`http://127.0.0.1:7830${TWILIO_EXAMPLE_PATH}`);
     expect(captured[0].method).toBe("POST");
     expect(captured[0].body).toBe('{"message":"hello"}');
     expect(captured[0].headers.get("content-type")).toBe("application/json");
@@ -163,7 +165,6 @@ describe("Velay HTTP bridge", () => {
     });
   });
 
-
   test("rejects non-Twilio paths without contacting the loopback listener", async () => {
     const response = await bridgeVelayHttpRequest(
       makeFrame({ path: "/v1/guardian/init" }),
@@ -209,6 +210,7 @@ describe("Velay HTTP bridge", () => {
       "http://127.0.0.1:7830",
     );
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.status_code).toBe(502);
     expect(response.request_id).toBe("req-123");
   });


### PR DESCRIPTION
### Motivation
- The Velay HTTP bridge previously forwarded arbitrary origin-relative paths from the public tunnel into the gateway loopback, allowing a remote request to reach local-only endpoints such as `/v1/guardian/init` and bypass loopback-based protections. 
- A minimal, targeted restriction is needed so the tunnel only exposes intended webhook routes (Twilio webhooks) and does not break other gateway behavior.

### Description
- Add a small allowlist constant `VELAY_ALLOWED_HTTP_PATH_PREFIXES` and helper `isAllowedVelayHttpPath(path)` in `gateway/src/velay/bridge-utils.ts` to enumerate allowed Velay-forwardable prefixes (`/webhooks/twilio/`).
- Require the allowlist in `buildLoopbackHttpUrl(...)` so loopback URLs are only constructed for syntactically safe _and_ allowlisted paths.
- Add a regression unit test in `gateway/src/velay/http-bridge.test.ts` that verifies non-Twilio paths (example: `/v1/guardian/init`) are rejected and never cause a loopback fetch.

### Testing
- Added a unit test: `gateway/src/velay/http-bridge.test.ts` includes `rejects non-Twilio paths without contacting the loopback listener` which asserts `/v1/guardian/init` is rejected (test committed with the change).
- Attempted to run the test suite with `cd gateway && bun test src/velay/http-bridge.test.ts` but `bun` was not available in this environment so automated tests could not be executed here (test addition is in place and should pass when run in CI or a developer environment with Bun installed).
- Local commit and pre-commit hooks completed (checks requiring Bun were skipped in this environment) and the change is committed as described.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f49ba74aec8323a18efd8964896d65)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
