### PR TITLE
[JARVIS-657] Declare the Coding Agents panel client feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -354,6 +354,14 @@
       "defaultEnabled": true
     },
     {
+      "id": "coding-agents-panel",
+      "scope": "client",
+      "key": "coding-agents-panel",
+      "label": "Coding Agents Panel",
+      "description": "Gate native macOS/iOS Coding Agents panel entry points and inline ACP session deep links.",
+      "defaultEnabled": false
+    },
+    {
       "id": "compaction-playground",
       "scope": "assistant",
       "key": "compaction-playground",


### PR DESCRIPTION
## Summary
- Adds the client-scoped coding-agents-panel feature flag.
- Syncs bundled feature flag registry copies.

Part of JARVIS-657.
Part of plan: coding-agents-panel.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
