### PR TITLE
[JARVIS-657] Close the macOS Coding Agents right slot without navigating

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -318,6 +318,18 @@ public final class MainWindowState {
         LayoutConfigStore.save(layoutConfig)
     }
 
+    /// Hide the right slot, optionally only when it is showing a specific
+    /// native panel. Preserves the current slot content and width so reopening
+    /// restores the user's existing panel size.
+    func hideRightSlot(_ panel: NativePanelId? = nil) {
+        if let panel, layoutConfig.right.content != .native(panel) {
+            return
+        }
+
+        layoutConfig.right.visible = false
+        LayoutConfigStore.save(layoutConfig)
+    }
+
     /// Replace the right slot's content and force the slot visible. Used by
     /// client-side deep links (e.g. tapping an inline `acp_spawn` tool block
     /// to open the Coding Agents panel). Unlike ``toggleRightSlot(_:)`` this

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -155,7 +155,7 @@ extension MainWindowView {
             ACPSessionsPanel(
                 store: acpSessionStore,
                 activeConversationId: conversationManager.activeConversationId?.uuidString,
-                onClose: { windowState.navigateBackOrDismiss() }
+                onClose: { windowState.hideRightSlot(.acpSessions) }
             )
         }
     }

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -1,8 +1,45 @@
 import XCTest
 @testable import VellumAssistantLib
+@testable import VellumAssistantShared
 
 @MainActor
 final class MainWindowStateNavigationHistoryTests: XCTestCase {
+    private var layoutConfigBackup: Data?
+    private var layoutConfigExisted = false
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let url = Self.layoutConfigURL()
+        layoutConfigExisted = FileManager.default.fileExists(atPath: url.path)
+        if layoutConfigExisted {
+            layoutConfigBackup = try Data(contentsOf: url)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        let url = Self.layoutConfigURL()
+        if layoutConfigExisted, let data = layoutConfigBackup {
+            try data.write(to: url, options: .atomic)
+        } else {
+            try? FileManager.default.removeItem(at: url)
+        }
+        layoutConfigBackup = nil
+        layoutConfigExisted = false
+        try super.tearDownWithError()
+    }
+
+    /// Mirrors `LayoutConfigStore.configURL` — keep this in sync if the
+    /// production path changes. Hard-coded so tests do not reach into the
+    /// production enum's `private` static.
+    private static func layoutConfigURL() -> URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        return appSupport
+            .appendingPathComponent(VellumEnvironment.current.appSupportDirectoryName, isDirectory: true)
+            .appendingPathComponent("layout-config.json")
+    }
 
     func testBackForwardAcrossConversationPanelApp() {
         let state = MainWindowState()
@@ -161,5 +198,56 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         XCTAssertNil(state.inspectorMessageId)
         XCTAssertEqual(state.selection, .conversation(convId))
         XCTAssertEqual(state.navigationHistory.backStack, backStackBefore)
+    }
+
+    func testHideRightSlotForACPSessionsPreservesSelection() {
+        let state = MainWindowState()
+        let conversationId = UUID()
+        state.selection = .conversation(conversationId)
+        state.layoutConfig.right = SlotConfig(
+            content: .native(.acpSessions),
+            width: 512,
+            visible: true
+        )
+
+        state.hideRightSlot(.acpSessions)
+
+        XCTAssertEqual(state.selection, .conversation(conversationId))
+        XCTAssertEqual(state.layoutConfig.right.content, .native(.acpSessions))
+        XCTAssertEqual(state.layoutConfig.right.width, 512)
+        XCTAssertFalse(state.layoutConfig.right.visible)
+        XCTAssertFalse(LayoutConfigStore.load().right.visible)
+    }
+
+    func testHideRightSlotForACPSessionsDoesNotPopBackStack() {
+        let state = MainWindowState()
+        let conversationId = UUID()
+        state.selection = .conversation(conversationId)
+        state.selection = .panel(.settings)
+        let backStackBefore = state.navigationHistory.backStack
+        state.layoutConfig.right = SlotConfig(
+            content: .native(.acpSessions),
+            width: 400,
+            visible: true
+        )
+
+        state.hideRightSlot(.acpSessions)
+
+        XCTAssertEqual(state.navigationHistory.backStack, backStackBefore)
+        XCTAssertEqual(state.selection, .panel(.settings))
+    }
+
+    func testHideRightSlotMismatchedPanelLeavesRightSlotUnchanged() {
+        let state = MainWindowState()
+        state.layoutConfig.right = SlotConfig(
+            content: .native(.settings),
+            width: 360,
+            visible: true
+        )
+        let rightSlotBefore = state.layoutConfig.right
+
+        state.hideRightSlot(.acpSessions)
+
+        XCTAssertEqual(state.layoutConfig.right, rightSlotBefore)
     }
 }


### PR DESCRIPTION
## Summary
- Adds right-slot hiding support to MainWindowState.
- Wires the Coding Agents panel close button to hide the right slot instead of navigating.
- Adds regression coverage for selection/history preservation.

Part of JARVIS-657.
Part of plan: coding-agents-panel.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
