### PR TITLE
fix: prevent --help flag from bypassing bash risk classifier

### DIFF
--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -797,6 +797,22 @@ describe("unknown commands", () => {
     });
     expect(result.riskLevel).toBe("high");
   });
+
+  test("bundled short flags with value flag do not trigger help shortcut", async () => {
+    const result = await classifier.classify({
+      command: "tar -xf --help /etc/passwd",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("known command without argSchema + --help uses base risk", async () => {
+    const result = await classifier.classify({
+      command: "kill --help",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
 });
 
 // ── Variable expansion escalation ────────────────────────────────────────────

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -765,18 +765,34 @@ describe("unknown commands", () => {
     expect(result.matchType).toBe("registry");
   });
 
-  test("unknown command with --help → low risk", async () => {
+  test("unknown command with --help → unknown risk", async () => {
     const result = await classifier.classify({
       command: "mycustomtool --help",
       toolName: "bash",
     });
-    expect(result.riskLevel).toBe("low");
-    expect(result.matchType).toBe("registry");
+    expect(result.riskLevel).toBe("unknown");
+    expect(result.matchType).toBe("unknown");
   });
 
   test("--help after -- is positional, not help mode", async () => {
     const result = await classifier.classify({
       command: "rm -- --help",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+
+  test("value-taking flags do not trigger help shortcut", async () => {
+    const result = await classifier.classify({
+      command: "tar -f --help /etc/passwd",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("commands without arg schema do not use help shortcut", async () => {
+    const result = await classifier.classify({
+      command: "bash --rcfile --help -c 'rm -rf /'",
       toolName: "bash",
     });
     expect(result.riskLevel).toBe("high");

--- a/gateway/src/risk/bash-risk-classifier.ts
+++ b/gateway/src/risk/bash-risk-classifier.ts
@@ -189,14 +189,36 @@ const RM_BENIGN_FLAGS = new Set([
 ]);
 
 /**
- * Returns true when the command arguments include a top-level `--help` flag.
+ * Returns true when args contain a top-level help option that is not consumed
+ * as a value by another flag.
  *
- * This intentionally ignores any `--help` token that appears after `--`
- * because those are positional arguments, not options.
+ * This intentionally ignores:
+ * - any `--help` token that appears after `--` (positional mode), and
+ * - any `--help` token consumed as the value of a known value-taking flag.
+ *
+ * Help-mode shortcuts are only enabled for commands with an arg schema.
  */
-function hasHelpFlag(args: string[]): boolean {
-  for (const arg of args) {
+function hasStandaloneHelpFlag(args: string[], schema?: ArgSchema): boolean {
+  if (!schema) return false;
+
+  const valueFlags = new Set(schema.valueFlags ?? []);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
     if (arg === "--") return false;
+
+    // Value-taking flags consume the next token (if present), so that token
+    // must not be interpreted as a standalone top-level option.
+    if (valueFlags.has(arg)) {
+      if (i + 1 < args.length) i++;
+      continue;
+    }
+
+    if (arg.startsWith("-") && arg.includes("=")) {
+      const eqIdx = arg.indexOf("=");
+      const flagPart = arg.slice(0, eqIdx);
+      if (valueFlags.has(flagPart)) continue;
+    }
+
     if (arg === "--help" || arg.startsWith("--help=")) return true;
   }
   return false;
@@ -280,14 +302,6 @@ export function classifySegment(
   }
 
   if (!spec) {
-    // Unknown command with --help is just viewing help → low risk
-    if (hasHelpFlag(segment.args)) {
-      return {
-        risk: "low",
-        reason: `${segment.program} help output`,
-        matchType: "registry",
-      };
-    }
     return {
       risk: "unknown",
       reason: `Unknown command: ${segment.program}`,
@@ -299,7 +313,11 @@ export function classifySegment(
   //     Commands WITH subcommands (e.g. `assistant`) skip this — their
   //     subcommand resolution may assign elevated risk that --help must
   //     not bypass.
-  if (!spec.subcommands && !spec.isWrapper && hasHelpFlag(segment.args)) {
+  if (
+    !spec.subcommands &&
+    !spec.isWrapper &&
+    hasStandaloneHelpFlag(segment.args, spec.argSchema)
+  ) {
     return {
       risk: "low",
       reason: `${segment.program} help output`,

--- a/gateway/src/risk/bash-risk-classifier.ts
+++ b/gateway/src/risk/bash-risk-classifier.ts
@@ -213,6 +213,18 @@ function hasStandaloneHelpFlag(args: string[], schema?: ArgSchema): boolean {
       continue;
     }
 
+    // Short-flag bundles: -xf where -f is a value flag.  POSIX convention
+    // places the value-consuming flag last in a bundle, so check the final
+    // character.  If it matches a known short value flag, the next token is
+    // its value and must be skipped.
+    if (arg.startsWith("-") && !arg.startsWith("--") && arg.length > 2) {
+      const lastChar = arg[arg.length - 1];
+      if (lastChar && valueFlags.has(`-${lastChar}`)) {
+        if (i + 1 < args.length) i++;
+        continue;
+      }
+    }
+
     if (arg.startsWith("-") && arg.includes("=")) {
       const eqIdx = arg.indexOf("=");
       const flagPart = arg.slice(0, eqIdx);

--- a/gateway/src/risk/risk-classifier-parity.test.ts
+++ b/gateway/src/risk/risk-classifier-parity.test.ts
@@ -51,7 +51,7 @@ const BASH_TEST_CASES: Array<[string, RiskLevel]> = [
   ["command -v rm", RiskLevel.Low],
   ["command -V sudo", RiskLevel.Low],
   ["rm --help", RiskLevel.Low],
-  ["mycustomtool --help", RiskLevel.Low],
+  ["mycustomtool --help", RiskLevel.Medium],
 
   // Medium risk
   ["git push origin main", RiskLevel.Medium],


### PR DESCRIPTION
## Summary

- Replace `hasHelpFlag` with `hasStandaloneHelpFlag` that accounts for value-consuming flags (e.g. `tar -f` consumes the next token) and requires an `ArgSchema` to enable the shortcut
- Remove the unknown-command help shortcut — unknown commands with `--help` now correctly return `unknown` risk instead of `low`
- Add tests for bypass scenarios: `tar -f --help /etc/passwd` (medium), `bash --rcfile --help -c 'rm -rf /'` (high)

Codex finding: https://chatgpt.com/codex/cloud/security/findings/13edaecd0d388191b7421ac9d99701ec

## Original prompt

Fix: Help-flag shortcut in bash risk classifier can downgrade risky commands. The `hasHelpFlag` function naively scans raw arguments for `--help` and immediately returns low risk, without checking whether `--help` is consumed as a value by a preceding value-taking flag. This allows high-risk commands to be downgraded to low risk, bypassing user approval.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
