### PR TITLE
fix: require guardian grant for trusted_contact host/side-effect tools

### DIFF
--- a/assistant/src/__tests__/platform-bash-auto-approve.test.ts
+++ b/assistant/src/__tests__/platform-bash-auto-approve.test.ts
@@ -245,13 +245,11 @@ describe("platform-hosted bash auto-approval", () => {
     expect(promptCalled).toBe(true);
   });
 
-  test("bash NOT auto-approved for non-guardian actors via platform path (sandbox bash is allowed)", async () => {
+  test("bash NOT auto-approved for non-guardian actors via platform path (trusted_contact requires grant)", async () => {
     checkResultOverride = { decision: "prompt", reason: "Needs approval" };
 
-    const platformAutoApproveCalled = false;
     const trackingPrompter = {
       prompt: async () => {
-        // If this is called, we know the platform auto-approve did NOT fire
         return { decision: "allow" as const };
       },
       resolveConfirmation: () => {},
@@ -270,11 +268,10 @@ describe("platform-hosted bash auto-approval", () => {
       }),
     );
 
-    // With requireFreshApproval, trusted_contact+bash goes through check()
-    // which returns "prompt" and then the interactive prompter is called.
-    // The platform auto-approve path (guardian-only) is NOT taken.
-    expect(result.isError).toBe(false);
-    void platformAutoApproveCalled; // suppress unused warning
+    // trusted_contact now requires a guardian-scoped grant for side-effect
+    // tools. Without a grant, the pre-execution gate denies the invocation
+    // before the permission checker or prompter is reached.
+    expect(result.isError).toBe(true);
   });
 
   test("bash NOT auto-approved when requireFreshApproval is set", async () => {

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -518,7 +518,7 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
     }
   });
 
-  test("trusted contact bypasses tool grants for sandboxed side-effect tools", async () => {
+  test("trusted contact requires grant for sandboxed side-effect tools", async () => {
     const result = await handler.checkPreExecutionGates(
       "bash",
       { command: "echo hello" },
@@ -529,12 +529,11 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
       emitLifecycleEvent,
     );
 
-    expect(result.allowed).toBe(true);
+    expect(result.allowed).toBe(false);
     expect(events.filter((e) => e.type === "permission_denied")).toHaveLength(
-      0,
+      1,
     );
   });
-
 });
 
 afterAll(() => {

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -700,15 +700,14 @@ describe("ToolExecutor verification control-plane policy gate", () => {
     expect(result.content).toBe("ok");
   });
 
-  test("non-guardian invocation of unrelated bash command is allowed (sandbox bash is auto-approved)", async () => {
+  test("non-guardian invocation of unrelated bash command requires guardian grant", async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "bash",
       { command: "curl http://localhost:3000/v1/messages" },
       makeContext({ trustClass: "trusted_contact" }),
     );
-    expect(result.isError).toBe(false);
-    expect(result.content).toBe("ok");
+    expect(result.isError).toBe(true);
   });
 
   test("non-guardian invocation of unrelated tool is unaffected", async () => {

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -292,11 +292,7 @@ export class ToolApprovalHandler {
       executionTarget,
     );
 
-    if (
-      isUntrustedTrustClass(context.trustClass) &&
-      guardianApprovalRequired &&
-      context.trustClass !== "trusted_contact"
-    ) {
+    if (isUntrustedTrustClass(context.trustClass) && guardianApprovalRequired) {
       const inputDigest = computeToolApprovalDigest(name, input);
       needsGrantConsumption = true;
       deferredConsumeParams = {


### PR DESCRIPTION
## Summary

- Remove the `context.trustClass !== "trusted_contact"` exclusion from the scoped-grant consumption check in `ToolApprovalHandler.checkPreExecutionGates`. This was a dangling bypass left after PR #28389 removed the `isConversationHostAccessEnabled` gate that previously covered trusted contacts.
- Trusted contacts now go through the same guardian grant path as other untrusted actors for host and side-effect tools, closing the authorization bypass that allowed low-risk host_bash commands to auto-approve without guardian approval.
- Update the corresponding test to assert that trusted contacts require grants (previously asserted they bypassed them).

**Codex finding:** https://chatgpt.com/codex/cloud/security/findings/48514fa6d92481919473b9abd81c6753?sev=critical%2Chigh

## Original prompt

Fix security vulnerability: trusted contacts bypass guardian approval for host/side-effect tools. The `trusted_contact` exclusion in `tool-approval-handler.ts:298` was introduced in PR #28376 alongside a separate host_access gate. PR #28389 removed that gate as dead code, leaving the exclusion as a dangling bypass that allows trusted contacts to invoke host_bash without guardian-scoped grant consumption.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
