### PR TITLE
fix: restore headless execution context to strict "none" threshold

### DIFF
--- a/assistant/__tests__/permissions/gateway-threshold-reader.test.ts
+++ b/assistant/__tests__/permissions/gateway-threshold-reader.test.ts
@@ -97,8 +97,8 @@ describe("getAutoApproveThreshold", () => {
 
     _clearGlobalCacheForTesting();
 
-    // headless also maps to autonomous
-    expect(await getAutoApproveThreshold(undefined, "headless")).toBe("low");
+    // headless remains strict regardless of autonomous global setting
+    expect(await getAutoApproveThreshold(undefined, "headless")).toBe("none");
   });
 
   test("returns conversation override when it exists", async () => {
@@ -159,9 +159,7 @@ describe("getAutoApproveThreshold", () => {
     _clearGlobalCacheForTesting();
 
     // background → "none" (maps to autonomous, which defaults to "none")
-    expect(await getAutoApproveThreshold(undefined, "background")).toBe(
-      "none",
-    );
+    expect(await getAutoApproveThreshold(undefined, "background")).toBe("none");
 
     _clearGlobalCacheForTesting();
 
@@ -213,9 +211,9 @@ describe("getAutoApproveThreshold", () => {
     expect(second).toBe("low");
     expect(fetchCount).toBe(1); // Still 1, cache hit
 
-    // Third call — still cached
+    // Third call — headless always returns "none" regardless of cache
     const third = await getAutoApproveThreshold(undefined, "headless");
-    expect(third).toBe("low");
+    expect(third).toBe("none");
     expect(fetchCount).toBe(1); // Still 1
 
     // After clearing cache, should re-fetch

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -74,7 +74,11 @@ describe("ask rule", () => {
   const askRule = makeRule({ decision: "ask" });
 
   test("ask at Low risk", () => {
-    const result = evaluate({ riskLevel: RiskLevel.Low, matchedRule: askRule, autoApproveUpTo: "none" });
+    const result = evaluate({
+      riskLevel: RiskLevel.Low,
+      matchedRule: askRule,
+      autoApproveUpTo: "none",
+    });
     expect(result.decision).toBe("prompt");
     expect(result.reason).toContain("ask rule");
     expect(result.matchedRule).toBe(askRule);
@@ -1007,8 +1011,8 @@ describe("resolveThreshold", () => {
       expect(resolveThreshold(perContext, "background")).toBe("medium");
     });
 
-    test("returns autonomous threshold for headless context", () => {
-      expect(resolveThreshold(perContext, "headless")).toBe("medium");
+    test("returns strict threshold for headless context", () => {
+      expect(resolveThreshold(perContext, "headless")).toBe("none");
     });
 
     test("defaults to conversation when executionContext is omitted", () => {
@@ -1227,9 +1231,9 @@ describe("guardian threshold-based auto-approve (ordinal comparison)", () => {
       expect(convThreshold).toBe("medium");
     });
 
-    test("undefined config → low threshold for headless", () => {
+    test("undefined config → none threshold for headless", () => {
       const hlThreshold = resolveThreshold(undefined, "headless");
-      expect(hlThreshold).toBe("low");
+      expect(hlThreshold).toBe("none");
     });
 
     test("undefined config + no context → medium (conversation default)", () => {

--- a/assistant/src/permissions/approval-policy.test.ts
+++ b/assistant/src/permissions/approval-policy.test.ts
@@ -982,14 +982,14 @@ describe("resolveThreshold", () => {
       expect(resolveThreshold("medium", "background")).toBe("medium");
     });
 
-    test("returns scalar for headless context", () => {
+    test("returns none for headless context regardless of scalar", () => {
       expect(resolveThreshold("none", "headless")).toBe("none");
+      expect(resolveThreshold("high", "headless")).toBe("none");
     });
 
-    test("returns high scalar for any context", () => {
+    test("returns high scalar for non-headless contexts", () => {
       expect(resolveThreshold("high", "conversation")).toBe("high");
       expect(resolveThreshold("high", "background")).toBe("high");
-      expect(resolveThreshold("high", "headless")).toBe("high");
     });
 
     test("returns scalar when executionContext is omitted", () => {

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -61,7 +61,8 @@ type ThresholdConfig =
  * Resolve a threshold config to a scalar threshold for the given execution
  * context.
  *
- * - Scalar string → returned as-is for all contexts
+ * - Scalar string → returned as-is for non-headless contexts
+
  * - Object with per-context overrides → returns the value for the context
  *   (`background` resolves to the `autonomous` field; `headless` always
  *   resolves to `"none"` regardless of configured thresholds)

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -72,6 +72,7 @@ export function resolveThreshold(
   configValue: ThresholdConfig | undefined,
   executionContext?: ExecutionContext,
 ): ThresholdScalar {
+  if (executionContext === "headless") return "none";
   if (configValue == null) {
     return CONTEXT_DEFAULTS[executionContext ?? "conversation"];
   }
@@ -80,7 +81,6 @@ export function resolveThreshold(
   }
   const ctx = executionContext ?? "conversation";
   if (ctx === "conversation") return configValue.conversation;
-  if (ctx === "headless") return "none";
   return configValue.autonomous;
 }
 

--- a/assistant/src/permissions/approval-policy.ts
+++ b/assistant/src/permissions/approval-policy.ts
@@ -49,7 +49,7 @@ const CONTEXT_DEFAULTS: Record<
 > = {
   conversation: "medium",
   background: "low",
-  headless: "low",
+  headless: "none",
 };
 
 type ThresholdScalar = "none" | "low" | "medium" | "high";
@@ -63,7 +63,8 @@ type ThresholdConfig =
  *
  * - Scalar string → returned as-is for all contexts
  * - Object with per-context overrides → returns the value for the context
- *   (`background` and `headless` both resolve to the `autonomous` field)
+ *   (`background` resolves to the `autonomous` field; `headless` always
+ *   resolves to `"none"` regardless of configured thresholds)
  *
  * When `executionContext` is omitted, defaults to `"conversation"`.
  */
@@ -79,6 +80,7 @@ export function resolveThreshold(
   }
   const ctx = executionContext ?? "conversation";
   if (ctx === "conversation") return configValue.conversation;
+  if (ctx === "headless") return "none";
   return configValue.autonomous;
 }
 

--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -61,6 +61,16 @@ function mapExecutionContextToField(
   return "autonomous";
 }
 
+function resolveExecutionContextThreshold(
+  executionContext: ExecutionContext,
+  globalThresholds: GlobalThresholds,
+): string {
+  if (executionContext === "headless") {
+    return "none";
+  }
+  return globalThresholds[mapExecutionContextToField(executionContext)];
+}
+
 function isValidThreshold(value: string): value is Threshold {
   return (
     value === "none" ||
@@ -135,13 +145,15 @@ export async function getAutoApproveThreshold(
   // Fetch global thresholds (with 30s cache)
   try {
     const global = await fetchGlobalThresholds();
-    const field = mapExecutionContextToField(ctx);
-    const value = global[field];
+    const value = resolveExecutionContextThreshold(ctx, global);
     if (isValidThreshold(value)) {
       return value;
     }
     // Unexpected value from gateway — default to "none" (Strict).
-    log.warn({ field, value }, "Gateway returned unexpected threshold value, defaulting to none");
+    log.warn(
+      { executionContext: ctx, value },
+      "Gateway returned unexpected threshold value, defaulting to none",
+    );
     return "none";
   } catch (err) {
     // Gateway unreachable — default to "none" (Strict) so no tools are


### PR DESCRIPTION
## Summary

- Hardcodes headless execution context to always resolve to `"none"` (strictest) threshold in both `gateway-threshold-reader.ts` and `approval-policy.ts`, restoring the security boundary that was lost when PR #28464 collapsed background+headless into a shared `autonomous` field
- Updates `CONTEXT_DEFAULTS.headless` from `"low"` to `"none"` as defense-in-depth for callers that bypass the gateway IPC path
- Does NOT change gateway defaults (`interactive: "medium"`, `autonomous: "low"`) — those are intentional product decisions from PR #28477

Codex finding: https://chatgpt.com/codex/cloud/security/findings/83baa4dcd6f48191bb35847b1f2a5f99?sev=critical%2Chigh

## Original prompt
Fix: Restore headless execution context to strict "none" threshold (security regression from #28464)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
