### PR TITLE
[JARVIS-657] Hide macOS Coding Agents panel entry points behind a client flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -930,7 +930,8 @@ struct ToolCallStepDetailRow: View {
     /// in `clients/shared/` so iOS and macOS accept identical payload shapes
     /// from a single implementation.
     var acpSessionIdToOpen: String? {
-        guard toolCall.toolName == "acp_spawn",
+        guard CodingAgentsPanelFeatureFlag.isEnabled,
+              toolCall.toolName == "acp_spawn",
               toolCall.isComplete,
               !toolCall.isError,
               let result = toolCall.result,
@@ -1080,6 +1081,7 @@ struct ToolCallStepDetailRow: View {
     /// `internal` and `static` so unit tests can exercise the side effects
     /// against an injected `MainWindowState` / `ACPSessionStore` pair.
     static func openACPSession(id: String) {
+        guard CodingAgentsPanelFeatureFlag.isEnabled else { return }
         guard let appDelegate = AppDelegate.shared else { return }
         applyACPSessionDeepLink(
             id: id,
@@ -1098,7 +1100,9 @@ struct ToolCallStepDetailRow: View {
         windowState: MainWindowState?,
         store: ACPSessionStore?
     ) {
-        guard let windowState, let store else { return }
+        guard CodingAgentsPanelFeatureFlag.isEnabled,
+              let windowState,
+              let store else { return }
         windowState.showRightSlot(.native(.acpSessions))
         // Setting the id triggers ``ACPSessionsPanel/consumeSelectedSessionIdIfPresent``
         // which pushes the matching view model onto the panel's

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -152,11 +152,13 @@ extension MainWindowView {
         case .home:
             homePanelView(onDismiss: { windowState.selection = nil })
         case .acpSessions:
-            ACPSessionsPanel(
-                store: acpSessionStore,
-                activeConversationId: conversationManager.activeConversationId?.uuidString,
-                onClose: { windowState.hideRightSlot(.acpSessions) }
-            )
+            if CodingAgentsPanelFeatureFlag.isEnabled {
+                ACPSessionsPanel(
+                    store: acpSessionStore,
+                    activeConversationId: conversationManager.activeConversationId?.uuidString,
+                    onClose: { windowState.hideRightSlot(.acpSessions) }
+                )
+            }
         }
     }
 
@@ -631,7 +633,8 @@ extension MainWindowView {
     @ViewBuilder
     func defaultChatLayout(windowSize: CGSize) -> some View {
         let config = windowState.layoutConfig
-        let showConfigPanel = config.right.visible && config.right.content != .empty
+        let isDisabledACPSessionsRightSlot = Self.isDisabledACPSessionsRightSlot(config.right)
+        let showConfigPanel = config.right.visible && config.right.content != .empty && !isDisabledACPSessionsRightSlot
         let showSubagentPanel = windowState.selectedSubagentId != nil && conversationManager.activeViewModel != nil
 
         VSplitView(
@@ -671,6 +674,25 @@ extension MainWindowView {
                 }
             }
         )
+        .onAppear {
+            hideDisabledACPSessionsRightSlotIfNeeded(config.right)
+        }
+        .onChange(of: config.right) { _, rightSlot in
+            hideDisabledACPSessionsRightSlotIfNeeded(rightSlot)
+        }
+    }
+
+    static func isDisabledACPSessionsRightSlot(_ rightSlot: SlotConfig) -> Bool {
+        !CodingAgentsPanelFeatureFlag.isEnabled
+            && rightSlot.visible
+            && rightSlot.content == .native(.acpSessions)
+    }
+
+    private func hideDisabledACPSessionsRightSlotIfNeeded(_ rightSlot: SlotConfig) {
+        guard Self.isDisabledACPSessionsRightSlot(rightSlot) else { return }
+        Task { @MainActor in
+            windowState.hideRightSlot(.acpSessions)
+        }
     }
 
     @ViewBuilder

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift
@@ -1,12 +1,11 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Skeleton list view for the Coding Agents (ACP sessions) panel.
+/// List view for the Coding Agents (ACP sessions) panel.
 ///
 /// Drives off the shared ``ACPSessionStore`` so SSE-driven inserts/updates
-/// stream into the list without explicit refresh logic. Routing into the
-/// panel is wired up in a follow-up PR (see ``PanelCoordinator``); this PR
-/// only stands up the visual shell.
+/// stream into the list without explicit refresh logic. Visibility and
+/// right-slot routing are owned by ``PanelCoordinator``.
 ///
 /// The empty state mirrors ``SubagentDetailPanel`` — same `VEmptyState`
 /// shape, same panel chrome — so the two coding-agent surfaces feel like a

--- a/clients/macos/vellum-assistant/Features/MainWindow/TopBarView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/TopBarView.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 import VellumAssistantShared
 
+enum CodingAgentsPanelFeatureFlag {
+    static let key = "coding-agents-panel"
+
+    static var isEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled(key)
+    }
+}
+
 /// Main window toolbar: sidebar toggle, home, search, navigation,
 /// coding agents, update button, and conversation title overlay.
 struct TopBarView: View {
@@ -72,15 +80,17 @@ struct TopBarView: View {
                     .vTooltip(homeTooltip)
                 }
 
-                VButton(
-                    label: "Coding Agents",
-                    iconOnly: VIcon.terminal.rawValue,
-                    style: .ghost,
-                    isActive: windowState.isRightSlotShowing(.acpSessions)
-                ) {
-                    windowState.toggleRightSlot(.acpSessions)
+                if Self.isCodingAgentsButtonVisible {
+                    VButton(
+                        label: "Coding Agents",
+                        iconOnly: VIcon.terminal.rawValue,
+                        style: .ghost,
+                        isActive: windowState.isRightSlotShowing(.acpSessions)
+                    ) {
+                        windowState.toggleRightSlot(.acpSessions)
+                    }
+                    .vTooltip("Coding Agents")
                 }
-                .vTooltip("Coding Agents")
 
                 VButton(label: "Search", iconOnly: VIcon.search.rawValue, style: .ghost) {
                     AppDelegate.shared?.toggleCommandPalette()
@@ -203,5 +213,9 @@ struct TopBarView: View {
         }
         .frame(height: 48)
         .background(VColor.surfaceBase)
+    }
+
+    static var isCodingAgentsButtonVisible: Bool {
+        CodingAgentsPanelFeatureFlag.isEnabled
     }
 }

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatBubbleACPSpawnTests.swift
@@ -16,6 +16,8 @@ import XCTest
 final class ChatBubbleACPSpawnTests: XCTestCase {
     private var layoutConfigBackup: Data?
     private var layoutConfigExisted = false
+    private var codingAgentsPanelOverrideExisted = false
+    private var codingAgentsPanelOverrideValue = false
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -24,9 +26,24 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
         if layoutConfigExisted {
             layoutConfigBackup = try Data(contentsOf: url)
         }
+        let defaultsKey = Self.codingAgentsPanelDefaultsKey()
+        codingAgentsPanelOverrideExisted = SharedUserDefaults.standard.object(forKey: defaultsKey) != nil
+        codingAgentsPanelOverrideValue = SharedUserDefaults.standard.bool(forKey: defaultsKey)
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: true)
     }
 
     override func tearDownWithError() throws {
+        if codingAgentsPanelOverrideExisted {
+            MacOSClientFeatureFlagManager.shared.setOverride(
+                CodingAgentsPanelFeatureFlag.key,
+                enabled: codingAgentsPanelOverrideValue
+            )
+        } else {
+            MacOSClientFeatureFlagManager.shared.removeOverride(CodingAgentsPanelFeatureFlag.key)
+        }
+        codingAgentsPanelOverrideExisted = false
+        codingAgentsPanelOverrideValue = false
+
         let url = Self.layoutConfigURL()
         if layoutConfigExisted, let data = layoutConfigBackup {
             try data.write(to: url, options: .atomic)
@@ -49,6 +66,10 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
         return appSupport
             .appendingPathComponent(VellumEnvironment.current.appSupportDirectoryName, isDirectory: true)
             .appendingPathComponent("layout-config.json")
+    }
+
+    private static func codingAgentsPanelDefaultsKey() -> String {
+        "MacOSFeatureFlag.codingagentspanel"
     }
 
     // MARK: - extractAcpSessionId
@@ -119,6 +140,43 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
         XCTAssertNil(ToolCallProgressBar.extractAcpSessionId(from: #"{"acpSessionId":null}"#))
     }
 
+    func test_acpSessionIdToOpen_isNilWhenCodingAgentsPanelFlagDisabled() {
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: false)
+        let toolCall = ToolCallData(
+            toolName: "acp_spawn",
+            inputSummary: "spawn",
+            result: #"{"acpSessionId":"acp-disabled"}"#,
+            isComplete: true
+        )
+        let row = ToolCallStepDetailRow(
+            toolCall: toolCall,
+            phase: .complete,
+            isDetailExpanded: .constant(false)
+        )
+
+        XCTAssertNil(
+            row.acpSessionIdToOpen,
+            "Disabled panel flag must force acp_spawn rows through the ordinary expandable tool-row path"
+        )
+    }
+
+    func test_acpSessionIdToOpen_returnsIdWhenCodingAgentsPanelFlagEnabled() {
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: true)
+        let toolCall = ToolCallData(
+            toolName: "acp_spawn",
+            inputSummary: "spawn",
+            result: #"{"acpSessionId":"acp-enabled"}"#,
+            isComplete: true
+        )
+        let row = ToolCallStepDetailRow(
+            toolCall: toolCall,
+            phase: .complete,
+            isDetailExpanded: .constant(false)
+        )
+
+        XCTAssertEqual(row.acpSessionIdToOpen, "acp-enabled")
+    }
+
     // MARK: - applyACPSessionDeepLink
 
     /// End-to-end of the deep-link side effects: the right slot flips to
@@ -177,6 +235,29 @@ final class ChatBubbleACPSpawnTests: XCTestCase {
         )
 
         XCTAssertEqual(windowState.layoutConfig.right.width, 512)
+    }
+
+    func test_applyACPSessionDeepLink_isNoOpWhenCodingAgentsPanelFlagDisabled() {
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: false)
+        let windowState = MainWindowState()
+        windowState.layoutConfig.right = SlotConfig(content: .empty, width: 512, visible: false)
+        let store = ACPSessionStore()
+
+        ToolCallStepDetailRow.applyACPSessionDeepLink(
+            id: "acp-disabled",
+            windowState: windowState,
+            store: store
+        )
+
+        XCTAssertEqual(
+            windowState.layoutConfig.right,
+            SlotConfig(content: .empty, width: 512, visible: false),
+            "Disabled panel flag must not mutate persisted right-slot layout"
+        )
+        XCTAssertNil(
+            store.selectedSessionId,
+            "Disabled panel flag must not select a session for the hidden panel"
+        )
     }
 
     /// Either the window state or the store being nil must short-circuit

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -6,6 +6,8 @@ import XCTest
 final class MainWindowStateNavigationHistoryTests: XCTestCase {
     private var layoutConfigBackup: Data?
     private var layoutConfigExisted = false
+    private var codingAgentsPanelOverrideExisted = false
+    private var codingAgentsPanelOverrideValue = false
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -14,9 +16,23 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         if layoutConfigExisted {
             layoutConfigBackup = try Data(contentsOf: url)
         }
+        let defaultsKey = Self.codingAgentsPanelDefaultsKey()
+        codingAgentsPanelOverrideExisted = SharedUserDefaults.standard.object(forKey: defaultsKey) != nil
+        codingAgentsPanelOverrideValue = SharedUserDefaults.standard.bool(forKey: defaultsKey)
     }
 
     override func tearDownWithError() throws {
+        if codingAgentsPanelOverrideExisted {
+            MacOSClientFeatureFlagManager.shared.setOverride(
+                CodingAgentsPanelFeatureFlag.key,
+                enabled: codingAgentsPanelOverrideValue
+            )
+        } else {
+            MacOSClientFeatureFlagManager.shared.removeOverride(CodingAgentsPanelFeatureFlag.key)
+        }
+        codingAgentsPanelOverrideExisted = false
+        codingAgentsPanelOverrideValue = false
+
         let url = Self.layoutConfigURL()
         if layoutConfigExisted, let data = layoutConfigBackup {
             try data.write(to: url, options: .atomic)
@@ -39,6 +55,10 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         return appSupport
             .appendingPathComponent(VellumEnvironment.current.appSupportDirectoryName, isDirectory: true)
             .appendingPathComponent("layout-config.json")
+    }
+
+    private static func codingAgentsPanelDefaultsKey() -> String {
+        "MacOSFeatureFlag.codingagentspanel"
     }
 
     func testBackForwardAcrossConversationPanelApp() {
@@ -249,5 +269,56 @@ final class MainWindowStateNavigationHistoryTests: XCTestCase {
         state.hideRightSlot(.acpSessions)
 
         XCTAssertEqual(state.layoutConfig.right, rightSlotBefore)
+    }
+
+    func testCodingAgentsToolbarVisibilityFollowsClientFlag() {
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: false)
+        XCTAssertFalse(TopBarView.isCodingAgentsButtonVisible)
+
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: true)
+        XCTAssertTrue(TopBarView.isCodingAgentsButtonVisible)
+    }
+
+    func testDisabledCodingAgentsRightSlotIsDetectedForCleanup() {
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: false)
+        let staleRightSlot = SlotConfig(
+            content: .native(.acpSessions),
+            width: 512,
+            visible: true
+        )
+
+        XCTAssertTrue(
+            MainWindowView.isDisabledACPSessionsRightSlot(staleRightSlot),
+            "Disabled flag plus persisted visible ACP right slot must trigger cleanup"
+        )
+    }
+
+    func testEnabledCodingAgentsRightSlotIsNotTreatedAsStale() {
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: true)
+        let rightSlot = SlotConfig(
+            content: .native(.acpSessions),
+            width: 512,
+            visible: true
+        )
+
+        XCTAssertFalse(MainWindowView.isDisabledACPSessionsRightSlot(rightSlot))
+    }
+
+    func testStaleCodingAgentsRightSlotCleanupPreservesContentAndWidth() {
+        MacOSClientFeatureFlagManager.shared.setOverride(CodingAgentsPanelFeatureFlag.key, enabled: false)
+        let state = MainWindowState()
+        state.layoutConfig.right = SlotConfig(
+            content: .native(.acpSessions),
+            width: 512,
+            visible: true
+        )
+
+        if MainWindowView.isDisabledACPSessionsRightSlot(state.layoutConfig.right) {
+            state.hideRightSlot(.acpSessions)
+        }
+
+        XCTAssertEqual(state.layoutConfig.right.content, .native(.acpSessions))
+        XCTAssertEqual(state.layoutConfig.right.width, 512)
+        XCTAssertFalse(state.layoutConfig.right.visible)
     }
 }


### PR DESCRIPTION
## Summary
- Gates macOS Coding Agents panel entry points and ACP deep links behind coding-agents-panel.
- Cleans stale persisted right-slot state when the panel is disabled.
- Keeps ACP tool output usable without the panel UI.

Apple refs checked (2026-05-01): Not applicable; no new Apple APIs or platform behavior introduced.

Part of JARVIS-657.
Part of plan: coding-agents-panel.md (PR 3 of 4)