### PR TITLE
[JARVIS-657] Hide iOS Coding Agents entry points behind a client flag

### DIFF
--- a/clients/ios/Tests/ACPSessionsViewIOSTests.swift
+++ b/clients/ios/Tests/ACPSessionsViewIOSTests.swift
@@ -129,6 +129,105 @@ final class ACPSessionsViewIOSTests: XCTestCase {
         XCTAssertEqual(store.sessions["acp-1"]?.state.status, .cancelled)
     }
 
+    // MARK: - Client flag gating
+
+    func test_iosRootNavigationView_readsCodingAgentsPanelFromSharedClientFlagManager() {
+        let enabledManager = MacOSClientFeatureFlagManager(
+            environment: ["VELLUM_FLAG_CODING_AGENTS_PANEL": "1"]
+        )
+        let disabledManager = MacOSClientFeatureFlagManager(
+            environment: ["VELLUM_FLAG_CODING_AGENTS_PANEL": "0"]
+        )
+
+        XCTAssertTrue(IOSRootNavigationView.isCodingAgentsPanelEnabled(flagManager: enabledManager))
+        XCTAssertFalse(IOSRootNavigationView.isCodingAgentsPanelEnabled(flagManager: disabledManager))
+    }
+
+    func test_disabledCodingAgentsPanel_doesNotAutoPresentFromSelectedSessionId() {
+        XCTAssertFalse(
+            IOSRootNavigationView.resolvedACPSessionsPresentation(
+                isCodingAgentsPanelEnabled: false,
+                selectedSessionId: "acp-hidden",
+                isCurrentlyPresented: false
+            )
+        )
+    }
+
+    func test_disabledCodingAgentsPanel_closesOpenSheet() {
+        XCTAssertFalse(
+            IOSRootNavigationView.resolvedACPSessionsPresentation(
+                isCodingAgentsPanelEnabled: false,
+                selectedSessionId: nil,
+                isCurrentlyPresented: true
+            )
+        )
+    }
+
+    func test_enabledCodingAgentsPanel_autoPresentsFromSelectedSessionId() {
+        XCTAssertTrue(
+            IOSRootNavigationView.resolvedACPSessionsPresentation(
+                isCodingAgentsPanelEnabled: true,
+                selectedSessionId: "acp-visible",
+                isCurrentlyPresented: false
+            )
+        )
+    }
+
+    func test_enabledCodingAgentsPanel_preservesManualSheetPresentation() {
+        XCTAssertTrue(
+            IOSRootNavigationView.resolvedACPSessionsPresentation(
+                isCodingAgentsPanelEnabled: true,
+                selectedSessionId: nil,
+                isCurrentlyPresented: true
+            )
+        )
+    }
+
+    func test_disabledCodingAgentsPanel_hidesRootToolbarEntryPoint() {
+        let action = IOSRootNavigationView.codingAgentsPanelAction(
+            isEnabled: false,
+            action: {}
+        )
+
+        XCTAssertNil(action)
+    }
+
+    func test_enabledCodingAgentsPanel_exposesRootToolbarEntryPoint() {
+        let action = IOSRootNavigationView.codingAgentsPanelAction(
+            isEnabled: true,
+            action: {}
+        )
+
+        XCTAssertNotNil(action)
+    }
+
+    func test_conversationToolbarsHideCodingAgentsEntryPointWhenDisabled() {
+        XCTAssertFalse(
+            ConversationListView.shouldShowACPSessionsToolbarButton(
+                isCodingAgentsPanelEnabled: false,
+                onShowACPSessions: {}
+            )
+        )
+    }
+
+    func test_conversationToolbarsShowCodingAgentsEntryPointWhenEnabledAndActionExists() {
+        XCTAssertTrue(
+            ConversationListView.shouldShowACPSessionsToolbarButton(
+                isCodingAgentsPanelEnabled: true,
+                onShowACPSessions: {}
+            )
+        )
+    }
+
+    func test_conversationToolbarsHideCodingAgentsEntryPointWithoutAction() {
+        XCTAssertFalse(
+            ConversationListView.shouldShowACPSessionsToolbarButton(
+                isCodingAgentsPanelEnabled: true,
+                onShowACPSessions: nil
+            )
+        )
+    }
+
     // MARK: - Helpers
 
     /// Inserts a synthetic ACP session into the store via the same

--- a/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
+++ b/clients/ios/Tests/ChatBubbleACPSpawnIOSTests.swift
@@ -88,7 +88,8 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
 
         ACPSpawnDeepLinkCard.applyACPSessionDeepLink(
             id: "acp-target-id",
-            store: store
+            store: store,
+            isCodingAgentsPanelEnabled: true
         )
 
         XCTAssertEqual(
@@ -105,7 +106,75 @@ final class ChatBubbleACPSpawnIOSTests: XCTestCase {
     func test_applyACPSessionDeepLink_isNoOpWhenStoreIsNil() {
         // No assertion needed beyond "this didn't crash" — the helper
         // returns void and a nil store has no observable side effect.
-        ACPSpawnDeepLinkCard.applyACPSessionDeepLink(id: "acp-id", store: nil)
+        ACPSpawnDeepLinkCard.applyACPSessionDeepLink(
+            id: "acp-id",
+            store: nil,
+            isCodingAgentsPanelEnabled: true
+        )
+    }
+
+    /// Even direct calls into the card helper must respect the client flag.
+    /// Otherwise disabled UI could still route into the panel if an old
+    /// inline card or test harness invoked the side effect directly.
+    func test_applyACPSessionDeepLink_isNoOpWhenPanelFlagIsDisabled() {
+        let store = ACPSessionStore()
+
+        ACPSpawnDeepLinkCard.applyACPSessionDeepLink(
+            id: "acp-disabled",
+            store: store,
+            isCodingAgentsPanelEnabled: false
+        )
+
+        XCTAssertNil(store.selectedSessionId)
+    }
+
+    // MARK: - inline card feature flag
+
+    /// When the panel flag is enabled and the tool result includes a
+    /// parseable ACP session id, iOS should render the tap-to-open card.
+    func test_shouldRenderACPSpawnDeepLinkCard_enabledForSingleSpawnWithSessionId() {
+        let toolCall = makeAcpSpawnToolCall(isComplete: true, isError: false)
+
+        XCTAssertTrue(
+            ToolCallProgressBar.shouldRenderACPSpawnDeepLinkCard(
+                toolCalls: [toolCall],
+                isCodingAgentsPanelEnabled: true
+            )
+        )
+    }
+
+    /// With the panel flag disabled, the same `acp_spawn` result must fall
+    /// back to the ordinary progress bar so the tool result remains visible
+    /// without offering tap-to-open routing.
+    func test_shouldRenderACPSpawnDeepLinkCard_disabledFallsBackToProgressBar() {
+        let toolCall = makeAcpSpawnToolCall(isComplete: true, isError: false)
+
+        XCTAssertFalse(
+            ToolCallProgressBar.shouldRenderACPSpawnDeepLinkCard(
+                toolCalls: [toolCall],
+                isCodingAgentsPanelEnabled: false
+            )
+        )
+    }
+
+    /// The card remains limited to the single-call case so mixed progress
+    /// groups keep their ordinary step-by-step affordance.
+    func test_shouldRenderACPSpawnDeepLinkCard_requiresSingleSpawnCall() {
+        let spawn = makeAcpSpawnToolCall(isComplete: true, isError: false)
+        let other = ToolCallData(
+            toolName: "bash",
+            inputSummary: "echo ok",
+            result: "<command_completed />",
+            isError: false,
+            isComplete: true
+        )
+
+        XCTAssertFalse(
+            ToolCallProgressBar.shouldRenderACPSpawnDeepLinkCard(
+                toolCalls: [spawn, other],
+                isCodingAgentsPanelEnabled: true
+            )
+        )
     }
 
     // MARK: - statusLabel

--- a/clients/ios/Views/ConversationListView.swift
+++ b/clients/ios/Views/ConversationListView.swift
@@ -107,6 +107,10 @@ struct ConversationListView: View {
     @State private var renameText: String = ""
     @State private var showArchived: Bool = false
 
+    private var isCodingAgentsPanelEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("coding-agents-panel")
+    }
+
     private var activeConversations: [IOSConversation] {
         sortConversationsForDisplay(
             store.conversations.filter { !$0.isArchived },
@@ -232,7 +236,10 @@ struct ConversationListView: View {
                     .accessibilityLabel("Settings")
                 }
             }
-            if let onShowACPSessions {
+            if Self.shouldShowACPSessionsToolbarButton(
+                isCodingAgentsPanelEnabled: isCodingAgentsPanelEnabled,
+                onShowACPSessions: onShowACPSessions
+            ), let onShowACPSessions {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: onShowACPSessions) {
                         VIconView(.terminal, size: 20)
@@ -582,7 +589,10 @@ struct ConversationListView: View {
                     .accessibilityLabel("Settings")
                 }
             }
-            if let onShowACPSessions {
+            if Self.shouldShowACPSessionsToolbarButton(
+                isCodingAgentsPanelEnabled: isCodingAgentsPanelEnabled,
+                onShowACPSessions: onShowACPSessions
+            ), let onShowACPSessions {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: onShowACPSessions) {
                         VIconView(.terminal, size: 20)
@@ -764,6 +774,13 @@ struct ConversationListView: View {
     private func relativeDate(_ date: Date) -> String {
         DateFormatting.relativeTimestamp(date)
     }
+
+    static func shouldShowACPSessionsToolbarButton(
+        isCodingAgentsPanelEnabled: Bool,
+        onShowACPSessions: (() -> Void)?
+    ) -> Bool {
+        isCodingAgentsPanelEnabled && onShowACPSessions != nil
+    }
 }
 
 // MARK: - ConversationChatView
@@ -786,6 +803,10 @@ struct ConversationChatView: View {
     /// Presents the Coding Agents (ACP sessions) sheet. Non-nil only on compact
     /// size classes; iPad reaches it via the persistent sidebar toolbar.
     var onShowACPSessions: (() -> Void)?
+
+    private var isCodingAgentsPanelEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("coding-agents-panel")
+    }
 
     var body: some View {
         let anchorRequest = store.pendingAnchorRequest(for: conversation.id)
@@ -836,7 +857,12 @@ struct ConversationChatView: View {
                 }
                 .hideSharedToolbarBackgroundIfAvailable()
             }
-            if horizontalSizeClass == .compact, let onShowACPSessions {
+            if horizontalSizeClass == .compact,
+               ConversationListView.shouldShowACPSessionsToolbarButton(
+                    isCodingAgentsPanelEnabled: isCodingAgentsPanelEnabled,
+                    onShowACPSessions: onShowACPSessions
+               ),
+               let onShowACPSessions {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(action: onShowACPSessions) {
                         VIconView(.terminal, size: 20)

--- a/clients/ios/Views/IOSRootNavigationView.swift
+++ b/clients/ios/Views/IOSRootNavigationView.swift
@@ -38,6 +38,7 @@ struct IOSRootNavigationView: View {
     /// `ConversationListView` on iPad). Mirrors `isSettingsPresented`.
     @State private var isACPSessionsPresented: Bool = false
     @State private var activeConversationId: UUID?
+    @State private var featureFlagRefreshToken: Int = 0
     /// True when `activeConversationId` was populated by the auto-seed path
     /// (cold start / size-class transition / fallback after deletion) rather
     /// than by an explicit user action. `compactRoot`'s `.task(id:)` uses
@@ -49,50 +50,15 @@ struct IOSRootNavigationView: View {
 
     /// Width of the drawer — capped so the underlying chat still peeks through.
     private let drawerMaxWidth: CGFloat = 360
+    private static let codingAgentsPanelFeatureFlag = "coding-agents-panel"
+
+    private var isCodingAgentsPanelEnabled: Bool {
+        _ = featureFlagRefreshToken
+        return Self.isCodingAgentsPanelEnabled()
+    }
 
     var body: some View {
-        Group {
-            // Treat a `nil` size class as compact so that on iPhone cold start —
-            // where SwiftUI may report `horizontalSizeClass` as `nil` for one
-            // frame during initial environment resolution — we don't briefly
-            // mount `regularLayout` (i.e. `ConversationListView`). Its
-            // `.onAppear` consumes any pending selection request synchronously
-            // during layout, which would otherwise land a cold-start push-
-            // notification deep link in a transient `ConversationListView` that
-            // is immediately torn down when the size class resolves to
-            // `.compact`, silently dropping the selection.
-            if horizontalSizeClass == .regular {
-                regularLayout
-            } else {
-                compactLayout
-            }
-        }
-        // `onDismiss` resets `navigateToConnect` so that:
-        // (1) re-opening Settings via the drawer/toolbar doesn't auto-push
-        //     the Connect destination again, and
-        // (2) if `IOSRootNavigationView` is recreated (e.g. `ContentView`'s
-        //     `.id(client)` changes), `@State isSettingsPresented` resets to
-        //     `false` but the parent-owned `navigateToConnect` stays `true` —
-        //     which would otherwise cause the `.task` one-shot check below to
-        //     reopen the sheet automatically. Clearing the binding on dismiss
-        //     breaks that loop.
-        .sheet(isPresented: $isSettingsPresented, onDismiss: {
-            navigateToConnect = false
-        }) {
-            SettingsBottomSheet(
-                authManager: authManager,
-                conversationStore: store
-            )
-        }
-        // Coding Agents (ACP sessions) sheet. Driven from the terminal-icon
-        // toolbar entry on each top-level surface — see `compactEmptyRoot`,
-        // `ConversationChatView` (compact), and `ConversationListView` (iPad).
-        .sheet(isPresented: $isACPSessionsPresented) {
-            ACPSessionsView(
-                store: clientProvider.acpSessionStore,
-                onClose: { isACPSessionsPresented = false }
-            )
-        }
+        rootWithSheets
         .task {
             seedActiveConversationIfNeeded()
             applyPendingSelectionRequestIfNeeded()
@@ -109,15 +75,12 @@ struct IOSRootNavigationView: View {
             // link that was already set before this view appeared (e.g.
             // a launch path that wakes the app via the inline card)
             // would be missed by `.onChange` alone.
-            if clientProvider.acpSessionStore.selectedSessionId != nil
-                && !isACPSessionsPresented {
-                isACPSessionsPresented = true
-            }
+            reconcileACPSessionsPresentation()
         }
         .onChange(of: store.selectionRequest?.id) { _, _ in
             applyPendingSelectionRequestIfNeeded()
         }
-        .onChange(of: clientProvider.acpSessionStore.selectedSessionId) { _, newValue in
+        .onChange(of: clientProvider.acpSessionStore.selectedSessionId) { _, _ in
             // Inline `acp_spawn` taps (rendered by `ToolCallProgressBar`
             // on iOS) land here by setting the store's
             // `selectedSessionId`. We surface the Coding Agents sheet
@@ -125,8 +88,21 @@ struct IOSRootNavigationView: View {
             // observation tick — that's where the actual detail-view
             // push happens. Clearing the field here would race the
             // panel's consume helper, so we leave it alone.
-            if newValue != nil && !isACPSessionsPresented {
-                isACPSessionsPresented = true
+            reconcileACPSessionsPresentation()
+        }
+        .onChange(of: isCodingAgentsPanelEnabled) { _, _ in
+            reconcileACPSessionsPresentation()
+        }
+        .task {
+            let notifications = NotificationCenter.default.notifications(
+                named: Notification.Name("assistantFeatureFlagDidChange")
+            )
+            for await notification in notifications {
+                guard notification.userInfo?["key"] as? String == Self.codingAgentsPanelFeatureFlag else {
+                    continue
+                }
+                featureFlagRefreshToken += 1
+                reconcileACPSessionsPresentation()
             }
         }
         .onChange(of: store.conversations.map(\.id)) { _, _ in
@@ -161,6 +137,60 @@ struct IOSRootNavigationView: View {
             if shouldShow && !isSettingsPresented {
                 isSettingsPresented = true
             }
+        }
+    }
+
+    @ViewBuilder
+    private var rootWithSheets: some View {
+        if isCodingAgentsPanelEnabled {
+            rootWithSettingsSheet
+                // Coding Agents (ACP sessions) sheet. Driven from the terminal-icon
+                // toolbar entry on each top-level surface — see `compactEmptyRoot`,
+                // `ConversationChatView` (compact), and `ConversationListView` (iPad).
+                .sheet(isPresented: $isACPSessionsPresented) {
+                    ACPSessionsView(
+                        store: clientProvider.acpSessionStore,
+                        onClose: { isACPSessionsPresented = false }
+                    )
+                }
+        } else {
+            rootWithSettingsSheet
+        }
+    }
+
+    private var rootWithSettingsSheet: some View {
+        Group {
+            // Treat a `nil` size class as compact so that on iPhone cold start —
+            // where SwiftUI may report `horizontalSizeClass` as `nil` for one
+            // frame during initial environment resolution — we don't briefly
+            // mount `regularLayout` (i.e. `ConversationListView`). Its
+            // `.onAppear` consumes any pending selection request synchronously
+            // during layout, which would otherwise land a cold-start push-
+            // notification deep link in a transient `ConversationListView` that
+            // is immediately torn down when the size class resolves to
+            // `.compact`, silently dropping the selection.
+            if horizontalSizeClass == .regular {
+                regularLayout
+            } else {
+                compactLayout
+            }
+        }
+        // `onDismiss` resets `navigateToConnect` so that:
+        // (1) re-opening Settings via the drawer/toolbar doesn't auto-push
+        //     the Connect destination again, and
+        // (2) if `IOSRootNavigationView` is recreated (e.g. `ContentView`'s
+        //     `.id(client)` changes), `@State isSettingsPresented` resets to
+        //     `false` but the parent-owned `navigateToConnect` stays `true` —
+        //     which would otherwise cause the `.task` one-shot check below to
+        //     reopen the sheet automatically. Clearing the binding on dismiss
+        //     breaks that loop.
+        .sheet(isPresented: $isSettingsPresented, onDismiss: {
+            navigateToConnect = false
+        }) {
+            SettingsBottomSheet(
+                authManager: authManager,
+                conversationStore: store
+            )
         }
     }
 
@@ -253,7 +283,10 @@ struct IOSRootNavigationView: View {
                 onOpenDrawer: openDrawer,
                 onComposeNew: composeNewConversation,
                 onShowSettings: { isSettingsPresented = true },
-                onShowACPSessions: { isACPSessionsPresented = true }
+                onShowACPSessions: Self.codingAgentsPanelAction(
+                    isEnabled: isCodingAgentsPanelEnabled,
+                    action: { isACPSessionsPresented = true }
+                )
             )
             .task(id: id) {
                 store.loadHistoryIfNeeded(for: id)
@@ -322,13 +355,15 @@ struct IOSRootNavigationView: View {
                 .accessibilityLabel("Settings")
             }
             .hideSharedToolbarBackgroundIfAvailable()
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: { isACPSessionsPresented = true }) {
-                    VIconView(.terminal, size: 20)
+            if isCodingAgentsPanelEnabled {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { isACPSessionsPresented = true }) {
+                        VIconView(.terminal, size: 20)
+                    }
+                    .accessibilityLabel("Coding Agents")
                 }
-                .accessibilityLabel("Coding Agents")
+                .hideSharedToolbarBackgroundIfAvailable()
             }
-            .hideSharedToolbarBackgroundIfAvailable()
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: composeNewConversation) {
                     VIconView(.squarePen, size: 20)
@@ -345,7 +380,10 @@ struct IOSRootNavigationView: View {
         ConversationListView(
             store: store,
             onShowSettings: { isSettingsPresented = true },
-            onShowACPSessions: { isACPSessionsPresented = true },
+            onShowACPSessions: Self.codingAgentsPanelAction(
+                isEnabled: isCodingAgentsPanelEnabled,
+                action: { isACPSessionsPresented = true }
+            ),
             selectedConversationId: $activeConversationId
         )
     }
@@ -380,6 +418,37 @@ struct IOSRootNavigationView: View {
         activeConversationWasSeeded = false
         activeConversationId = conversation.id
         closeDrawer()
+    }
+
+    private func reconcileACPSessionsPresentation() {
+        isACPSessionsPresented = Self.resolvedACPSessionsPresentation(
+            isCodingAgentsPanelEnabled: isCodingAgentsPanelEnabled,
+            selectedSessionId: clientProvider.acpSessionStore.selectedSessionId,
+            isCurrentlyPresented: isACPSessionsPresented
+        )
+    }
+
+    static func isCodingAgentsPanelEnabled(
+        flagManager: MacOSClientFeatureFlagManager = .shared
+    ) -> Bool {
+        flagManager.isEnabled(codingAgentsPanelFeatureFlag)
+    }
+
+    static func codingAgentsPanelAction(
+        isEnabled: Bool,
+        action: @escaping () -> Void
+    ) -> (() -> Void)? {
+        isEnabled ? action : nil
+    }
+
+    static func resolvedACPSessionsPresentation(
+        isCodingAgentsPanelEnabled: Bool,
+        selectedSessionId: String?,
+        isCurrentlyPresented: Bool
+    ) -> Bool {
+        guard isCodingAgentsPanelEnabled else { return false }
+        if selectedSessionId != nil { return true }
+        return isCurrentlyPresented
     }
 
     /// Fallback after the user archives the currently active conversation from

--- a/clients/shared/Features/Chat/ToolCallProgressBar.swift
+++ b/clients/shared/Features/Chat/ToolCallProgressBar.swift
@@ -34,20 +34,15 @@ public struct ToolCallProgressBar: View {
     /// communicates state instead of forcing a fallback to the standard
     /// row. Returns `nil` when no `acpSessionId` can be extracted.
     private var acpSpawnDeepLink: (toolCall: ToolCallData, sessionId: String)? {
-        guard toolCalls.count == 1,
-              let toolCall = toolCalls.first,
-              toolCall.toolName == "acp_spawn",
-              let result = toolCall.result,
-              !result.isEmpty,
-              let sessionId = ToolCallProgressBar.extractAcpSessionId(from: result) else {
-            return nil
-        }
-        return (toolCall, sessionId)
+        Self.acpSpawnDeepLink(from: toolCalls)
     }
 
     public var body: some View {
         #if os(iOS)
-        if let deepLink = acpSpawnDeepLink {
+        if Self.shouldRenderACPSpawnDeepLinkCard(
+            toolCalls: toolCalls,
+            isCodingAgentsPanelEnabled: MacOSClientFeatureFlagManager.shared.isEnabled("coding-agents-panel")
+        ), let deepLink = acpSpawnDeepLink {
             ACPSpawnDeepLinkCard(toolCall: deepLink.toolCall, acpSessionId: deepLink.sessionId)
         } else {
             standardBody
@@ -109,6 +104,25 @@ public struct ToolCallProgressBar: View {
     }
 
     // MARK: - acp_spawn deep-link helpers
+
+    static func acpSpawnDeepLink(from toolCalls: [ToolCallData]) -> (toolCall: ToolCallData, sessionId: String)? {
+        guard toolCalls.count == 1,
+              let toolCall = toolCalls.first,
+              toolCall.toolName == "acp_spawn",
+              let result = toolCall.result,
+              !result.isEmpty,
+              let sessionId = ToolCallProgressBar.extractAcpSessionId(from: result) else {
+            return nil
+        }
+        return (toolCall, sessionId)
+    }
+
+    public static func shouldRenderACPSpawnDeepLinkCard(
+        toolCalls: [ToolCallData],
+        isCodingAgentsPanelEnabled: Bool
+    ) -> Bool {
+        isCodingAgentsPanelEnabled && acpSpawnDeepLink(from: toolCalls) != nil
+    }
 
     /// Best-effort JSON probe for the `acpSessionId` field in
     /// `acp_spawn`'s result payload — the daemon UUID
@@ -467,8 +481,12 @@ public struct ACPSpawnDeepLinkCard: View {
     /// onto its `NavigationStack`. A nil store is a no-op so callers
     /// can pass through the bridge result without a guard of their own.
     @MainActor
-    static func applyACPSessionDeepLink(id: String, store: ACPSessionStore?) {
-        guard let store else { return }
+    static func applyACPSessionDeepLink(
+        id: String,
+        store: ACPSessionStore?,
+        isCodingAgentsPanelEnabled: Bool = MacOSClientFeatureFlagManager.shared.isEnabled("coding-agents-panel")
+    ) {
+        guard isCodingAgentsPanelEnabled, let store else { return }
         store.selectedSessionId = id
     }
 }


### PR DESCRIPTION
## Summary
- Hide iOS Coding Agents sheet and toolbar entry points behind the coding-agents-panel client flag
- Fall back to ordinary ACP tool progress/results when the panel is disabled
- Add iOS regression coverage for disabled and enabled panel behavior

Apple refs checked (2026-05-01): SwiftUI View.task lifecycle and NotificationCenter async notifications.

Validation:
- xcodebuild test -project clients/ios/vellum-assistant-ios.xcodeproj -scheme VellumAssistantIOS -destination "platform=iOS Simulator,name=iPhone 17 Pro" -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:vellum-assistant-iosTests/ChatBubbleACPSpawnIOSTests -only-testing:vellum-assistant-iosTests/ACPSessionsViewIOSTests

Part of JARVIS-657.
Part of plan: coding-agents-panel.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
