### PR TITLE
feat: GA the `referral-codes` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -15,7 +15,6 @@ struct DrawerMenuView: View {
     @State private var isLowBalance = false
     @State private var isZeroBalance = false
     @State private var bootstrapGeneration: Int = 0
-    @State private var isReferralCodesEnabled: Bool = false
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
 
     private var isBillingVisible: Bool {
@@ -26,7 +25,7 @@ struct DrawerMenuView: View {
     }
 
     private var isReferralVisible: Bool {
-        isBillingVisible && isReferralCodesEnabled
+        isBillingVisible
     }
 
     var body: some View {
@@ -89,15 +88,7 @@ struct DrawerMenuView: View {
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }
-        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
-            if let key = notification.userInfo?["key"] as? String,
-               key == "referral-codes",
-               let enabled = notification.userInfo?["enabled"] as? Bool {
-                isReferralCodesEnabled = enabled
-            }
-        }
         .task {
-            isReferralCodesEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("referral-codes")
             await loadBalance()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -21,7 +21,6 @@ struct SettingsBillingTab: View {
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
-    @State private var isReferralCodesEnabled: Bool = false
     @State private var showEarnCreditsModal: Bool = false
 
     var body: some View {
@@ -37,7 +36,6 @@ struct SettingsBillingTab: View {
             EarnCreditsModal()
         }
         .task {
-            isReferralCodesEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("referral-codes")
             await loadSummary()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
@@ -48,13 +46,6 @@ struct SettingsBillingTab: View {
             }
         }
         .background(WindowReader(window: $hostWindow))
-        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
-            if let key = notification.userInfo?["key"] as? String,
-               key == "referral-codes",
-               let enabled = notification.userInfo?["enabled"] as? Bool {
-                isReferralCodesEnabled = enabled
-            }
-        }
     }
 
     // MARK: - Balance Card
@@ -63,15 +54,13 @@ struct SettingsBillingTab: View {
         SettingsCard(
             title: "Credit Balance",
             accessory: {
-                if isReferralCodesEnabled {
-                    VButton(
-                        label: "Earn credits",
-                        leftIcon: VIcon.gift.rawValue,
-                        style: .outlined,
-                        size: .compact
-                    ) {
-                        showEarnCreditsModal = true
-                    }
+                VButton(
+                    label: "Earn credits",
+                    leftIcon: VIcon.gift.rawValue,
+                    style: .outlined,
+                    size: .compact
+                ) {
+                    showEarnCreditsModal = true
                 }
             }
         ) {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -130,14 +130,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "referral-codes",
-      "scope": "client",
-      "key": "referral-codes",
-      "label": "Referral Codes",
-      "description": "Surface the Earn Credits referral entry points (sidebar drawer row and Billing tab button) that open the referral modal",
-      "defaultEnabled": true
-    },
-    {
       "id": "managed-sign-in",
       "scope": "client",
       "key": "managed-sign-in",


### PR DESCRIPTION
## Summary
- Remove the referral-codes feature flag from the registry
- Referral entry points always visible in sidebar and billing tab
- Remove flag checks and notification listeners

Part of plan: ga-default-on-flags.md (PR 7 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
