### PR TITLE
feat: GA the `conversation-starters` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -11,9 +11,6 @@ private let panelCoordinatorLog = Logger(
 // MARK: - Panel Coordination Extension
 
 extension MainWindowView {
-    fileprivate static let conversationStartersFeatureFlagKey =
-        "conversation-starters"
-
     // MARK: - Config-Driven Slot Rendering
 
     @ViewBuilder
@@ -699,9 +696,7 @@ extension MainWindowView {
     var chatView: some View {
         if let viewModel = conversationManager.activeViewModel {
             let activeConversation = conversationManager.activeConversation
-            let conversationStartersEnabled = assistantFeatureFlagStore.isEnabled(
-                Self.conversationStartersFeatureFlagKey
-            )
+            let conversationStartersEnabled = true
             let showInspectButton = assistantFeatureFlagStore.isEnabled(
                 "settings-developer-nav"
             )

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -146,14 +146,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "conversation-starters",
-      "scope": "assistant",
-      "key": "conversation-starters",
-      "label": "Recommended Starts",
-      "description": "Show a curated row of recommended starting actions on the empty conversation page, ordered by relevance as confident first-click options",
-      "defaultEnabled": true
-    },
-    {
       "id": "deploy-to-vercel",
       "scope": "assistant",
       "key": "deploy-to-vercel",


### PR DESCRIPTION
## Summary
- Remove the conversation-starters feature flag from the registry
- Conversation starters always shown on empty conversation page
- Remove conversationStartersFeatureFlagKey constant and flag check

Part of plan: ga-default-on-flags.md (PR 9 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
