### PR TITLE
feat: GA the `backward-releases` feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -234,14 +234,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "backward-releases",
-      "scope": "assistant",
-      "key": "backward-releases",
-      "label": "Backward Releases",
-      "description": "Show older versions in the version picker, allowing rollback to previous releases",
-      "defaultEnabled": true
-    },
-    {
       "id": "voice-mode",
       "scope": "assistant",
       "key": "voice-mode",


### PR DESCRIPTION
## Summary
- Remove the backward-releases feature flag from the registry
- Flag had no runtime checks — registry-only removal

Part of plan: ga-default-on-flags.md (PR 14 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
