### PR TITLE
feat: GA the `browser` feature flag

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -67,10 +67,12 @@ describe("isAssistantFeatureFlagEnabled", () => {
   });
 
   test("undeclared flag respects persisted override", () => {
-    _setOverridesForTesting({ browser: false });
+    _setOverridesForTesting({ "some-undeclared-flag": false });
     const config = {} as any;
 
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(false);
+    expect(isAssistantFeatureFlagEnabled("some-undeclared-flag", config)).toBe(
+      false,
+    );
   });
 });
 

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -168,18 +168,6 @@ describe("CES flags respect explicit false overrides", () => {
 // ---------------------------------------------------------------------------
 
 describe("CES flags do not affect unrelated flags", () => {
-  test("enabling all CES flags does not change browser flag (defaultEnabled: true)", () => {
-    const overrides: Record<string, boolean> = {};
-    for (const key of ALL_CES_FLAG_KEYS) {
-      overrides[key] = true;
-    }
-    _setOverridesForTesting(overrides);
-    const config = makeConfig();
-
-    // browser defaults to true in the registry and should stay true
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
-  });
-
   test("enabling all CES flags does not change sounds flag (defaultEnabled: true)", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -149,15 +149,11 @@ describe("isAssistantFeatureFlagEnabled", () => {
   });
 
   test("respects persisted overrides for undeclared keys", () => {
-    _setOverridesForTesting({ browser: false });
+    _setOverridesForTesting({ "some-undeclared-flag": false });
     const config = makeConfig();
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(false);
-  });
-
-  test("declared keys with no persisted override use registry default", () => {
-    const config = makeConfig();
-    // browser is declared in the registry with defaultEnabled: true
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
+    expect(isAssistantFeatureFlagEnabled("some-undeclared-flag", config)).toBe(
+      false,
+    );
   });
 
   test("app-builder-multifile defaults to enabled when no override is set", () => {
@@ -176,11 +172,15 @@ describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      browser: true,
+      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("browser", "bundled", "browser"),
+      makeSkill(
+        "app-builder-multifile",
+        "bundled",
+        APP_BUILDER_MULTIFILE_FLAG_KEY,
+      ),
     ];
     const config = makeConfig();
 
@@ -188,17 +188,21 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).not.toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("browser");
+    expect(ids).toContain("app-builder-multifile");
   });
 
   test("flag ON skill appears normally", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: true,
-      browser: true,
+      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("browser", "bundled", "browser"),
+      makeSkill(
+        "app-builder-multifile",
+        "bundled",
+        APP_BUILDER_MULTIFILE_FLAG_KEY,
+      ),
     ];
     const config = makeConfig();
 
@@ -206,7 +210,7 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("browser");
+    expect(ids).toContain("app-builder-multifile");
   });
 
   test("declared flag key defaults to registry value (true)", () => {
@@ -259,12 +263,16 @@ describe("resolveSkillStates with feature flags", () => {
   test("multiple skills with mixed flags — persisted overrides respected", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      browser: true,
+      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
       deploy: false,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("browser", "bundled", "browser"),
+      makeSkill(
+        "app-builder-multifile",
+        "bundled",
+        APP_BUILDER_MULTIFILE_FLAG_KEY,
+      ),
       makeSkill("deploy", "bundled", "deploy"),
     ];
     const config = makeConfig();
@@ -272,8 +280,8 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // sounds and deploy explicitly false; browser explicitly true
-    expect(ids).toEqual(["browser"]);
+    // sounds and deploy explicitly false; app-builder-multifile explicitly true
+    expect(ids).toEqual(["app-builder-multifile"]);
   });
 });
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -10,14 +10,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "browser",
-      "scope": "assistant",
-      "key": "browser",
-      "label": "Browser",
-      "description": "Enable browser skill prerequisites section in the system prompt",
-      "defaultEnabled": true
-    },
-    {
       "id": "user-hosted-enabled",
       "scope": "client",
       "key": "user-hosted-enabled",

--- a/skills/vellum-browser-use/SKILL.md
+++ b/skills/vellum-browser-use/SKILL.md
@@ -6,7 +6,6 @@ metadata:
   emoji: "🌐"
   vellum:
     display-name: "Browser"
-    feature-flag: "browser"
     activation-hints:
       - "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
 ---


### PR DESCRIPTION
## Summary
- Remove the browser feature flag from the registry and all test references
- Remove feature-flag frontmatter from browser skill SKILL.md
- Update tests to use different flag keys for override testing mechanics

Part of plan: ga-default-on-flags.md (PR 1 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
