### PR TITLE
feat: GA the `show-thinking-blocks` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -380,8 +380,7 @@ struct ChatBubble: View, Equatable {
                         )
                     } else if shouldShowBubble {
                         if !isUser,
-                           containsInlineThinkingTag(message.text),
-                           MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
+                           containsInlineThinkingTag(message.text) {
                             bubbleContentWithInlineThinking
                         } else {
                             bubbleContent

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -456,23 +456,21 @@ extension ChatBubble {
                     InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction, onRefetch: onSurfaceRefetch)
                 }
             case .thinking(let indices):
-                if MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
-                    let joined = indices
-                        .compactMap { i in
-                            i < message.thinkingSegments.count
-                                ? message.thinkingSegments[i]
-                                : nil
-                        }
-                        .filter { !$0.isEmpty }
-                        .joined(separator: "\n")
-                    if !joined.isEmpty {
-                        ThinkingBlockView(
-                            content: joined,
-                            isStreaming: message.isStreaming,
-                            expansionKey: "\(message.id.uuidString)-th\(indices.first ?? 0)",
-                            typographyGeneration: typographyGeneration
-                        )
+                let joined = indices
+                    .compactMap { i in
+                        i < message.thinkingSegments.count
+                            ? message.thinkingSegments[i]
+                            : nil
                     }
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n")
+                if !joined.isEmpty {
+                    ThinkingBlockView(
+                        content: joined,
+                        isStreaming: message.isStreaming,
+                        expansionKey: "\(message.id.uuidString)-th\(indices.first ?? 0)",
+                        typographyGeneration: typographyGeneration
+                    )
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -8,8 +8,7 @@ extension ChatBubble {
     /// For large messages (>500 chars) with a segment cache miss, renders plain text
     /// immediately and parses rich formatting asynchronously to avoid blocking scroll.
     ///
-    /// When the text contains inline `<thinking>...</thinking>` tags (and the
-    /// `show-thinking-blocks` feature flag is enabled for assistant messages),
+    /// When the text contains inline `<thinking>...</thinking>` tags,
     /// the tagged sections are lifted into collapsible `ThinkingBlockView`s
     /// rendered alongside text bubbles for the remaining content. This keeps
     /// the transformation entirely at the presentation layer — no changes to
@@ -17,8 +16,7 @@ extension ChatBubble {
     @ViewBuilder
     func textBubble(for segmentText: String, textGroupIndex: Int? = nil) -> some View {
         if !isUser,
-           containsInlineThinkingTag(segmentText),
-           MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
+           containsInlineThinkingTag(segmentText) {
             let chunks = parseInlineThinkingTags(segmentText)
             // Use a stable key prefix that doesn't change as segmentText grows
             // during streaming. The previous hash-based key caused thinking

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -194,7 +194,6 @@ final class ChatActionHandler {
             guard !vm.isCancelling else { break }
             guard !vm.isLoadingHistory else { break }
             guard !vm.isWorkspaceRefinementInFlight else { break }
-            guard MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") else { break }
             vm.thinkingDeltaBuffer += delta.thinking
             vm.scheduleThinkingFlush()
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -194,14 +194,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "show-thinking-blocks",
-      "scope": "client",
-      "key": "show-thinking-blocks",
-      "label": "Show Thinking Blocks",
-      "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
-      "defaultEnabled": true
-    },
-    {
       "id": "inline-skill-commands",
       "scope": "assistant",
       "key": "inline-skill-commands",


### PR DESCRIPTION
## Summary
- Remove the show-thinking-blocks feature flag from the registry
- Thinking blocks always displayed inline in chat messages
- Remove all flag checks from ChatActionHandler, ChatBubble, ChatBubbleInterleavedContent, ChatBubbleTextContent

Part of plan: ga-default-on-flags.md (PR 10 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
