### PR TITLE
feat: GA the `ces-credential-backend` feature flag

### DIFF
--- a/assistant/src/credential-execution/feature-gates.ts
+++ b/assistant/src/credential-execution/feature-gates.ts
@@ -31,9 +31,6 @@ export const CES_GRANT_AUDIT_FLAG_KEY = "ces-grant-audit" as const;
 /** Gate for managed sidecar transport in containerized environments. */
 export const CES_MANAGED_SIDECAR_FLAG_KEY = "ces-managed-sidecar" as const;
 
-/** Gate for routing credential reads/writes through the CES process. */
-const CES_CREDENTIAL_BACKEND_FLAG_KEY = "ces-credential-backend" as const;
-
 // ---------------------------------------------------------------------------
 // Public API — predicate functions
 // ---------------------------------------------------------------------------
@@ -71,13 +68,4 @@ export function isCesGrantAuditEnabled(config: AssistantConfig): boolean {
  */
 export function isCesManagedSidecarEnabled(config: AssistantConfig): boolean {
   return isAssistantFeatureFlagEnabled(CES_MANAGED_SIDECAR_FLAG_KEY, config);
-}
-
-/**
- * Whether credential reads and writes should be routed through the CES process.
- */
-export function isCesCredentialBackendEnabled(
-  config: AssistantConfig,
-): boolean {
-  return isAssistantFeatureFlagEnabled(CES_CREDENTIAL_BACKEND_FLAG_KEY, config);
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -26,10 +26,6 @@ import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import {
-  isCesCredentialBackendEnabled,
-  isCesToolsEnabled,
-} from "../credential-execution/feature-gates.js";
-import {
   type CesProcessManager,
   CesUnavailableError,
   createCesProcessManager,
@@ -157,17 +153,6 @@ export interface CesStartupResult {
 async function startCesProcess(
   config: AssistantConfig,
 ): Promise<CesStartupResult> {
-  const shouldStartCes =
-    isCesToolsEnabled(config) || isCesCredentialBackendEnabled(config);
-  if (!shouldStartCes) {
-    return {
-      client: undefined,
-      processManager: undefined,
-      clientPromise: undefined,
-      abortController: undefined,
-    };
-  }
-
   const pm = createCesProcessManager({ assistantConfig: config });
   const abortController = new AbortController();
   let clientRef: CesClient | undefined;
@@ -524,86 +509,78 @@ export async function runDaemon(): Promise<void> {
     // bootstrap connection, so startup must happen at the process level.
     const cesStartupPromise = startCesProcess(config);
 
-    // When the credential backend flag is enabled, CES startup must complete
-    // BEFORE provider initialization so credential reads can go through CES.
-    // Block with a 20-second timeout — fall back to direct credential store
-    // on timeout.
-    if (isCesCredentialBackendEnabled(config)) {
-      const cesResult = await cesStartupPromise;
-      // startCesProcess() returns immediately — the actual handshake runs
-      // inside clientPromise. Await it (with a 20s timeout) so the CES client
-      // is available before provider initialization.
-      if (cesResult.clientPromise) {
-        const client = await awaitCesClientWithTimeout(
-          cesResult.clientPromise,
-          {
-            timeoutMs: DEFAULT_CES_STARTUP_TIMEOUT_MS,
-            onTimeout: () => {
-              log.warn(
-                "CES handshake timed out after 20s — falling back to direct credential store",
-              );
-            },
-          },
-        );
-        if (client) {
-          setCesClient(client);
-        }
+    // CES startup must complete BEFORE provider initialization so credential
+    // reads can go through CES. Block with a 20-second timeout — fall back to
+    // direct credential store on timeout.
+    const cesResult = await cesStartupPromise;
+    // startCesProcess() returns immediately — the actual handshake runs
+    // inside clientPromise. Await it (with a 20s timeout) so the CES client
+    // is available before provider initialization.
+    if (cesResult.clientPromise) {
+      const client = await awaitCesClientWithTimeout(cesResult.clientPromise, {
+        timeoutMs: DEFAULT_CES_STARTUP_TIMEOUT_MS,
+        onTimeout: () => {
+          log.warn(
+            "CES handshake timed out after 20s — falling back to direct credential store",
+          );
+        },
+      });
+      if (client) {
+        setCesClient(client);
       }
+    }
 
-      // Register CES reconnection callback so the credential layer can
-      // re-establish the connection when the transport dies, instead of
-      // falling back to the encrypted file store.
-      if (cesResult.processManager) {
-        const pm = cesResult.processManager;
+    // Register CES reconnection callback so the credential layer can
+    // re-establish the connection when the transport dies, instead of
+    // falling back to the encrypted file store.
+    if (cesResult.processManager) {
+      const pm = cesResult.processManager;
 
-        // Snapshot the managed-proxy context and assistant ID at CES startup
-        // so the reconnect closure below never calls back into
-        // `resolveManagedProxyContext()`. That function reads the assistant
-        // API key via `getSecureKeyAsync()`, which — once `setCesClient()`
-        // has resolved the backend to CES RPC — routes the read through CES
-        // itself. During a reconnect the old transport is dead and a new
-        // one is being set up by this very closure, so the nested credential
-        // read recursively awaits its own in-flight reconnection and
-        // deadlocks until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. That
-        // 45-second stall delays every CES restart and causes dependent
-        // credential reads (e.g. Meet's STT provider resolution) to return
-        // `undefined` during the window. API key rotation uses the
-        // `updateAssistantApiKey` RPC on the live client, not a reconnect,
-        // so caching at startup is safe.
-        const startupProxyCtx = await resolveManagedProxyContext();
-        const startupAssistantId = getPlatformAssistantId();
+      // Snapshot the managed-proxy context and assistant ID at CES startup
+      // so the reconnect closure below never calls back into
+      // `resolveManagedProxyContext()`. That function reads the assistant
+      // API key via `getSecureKeyAsync()`, which — once `setCesClient()`
+      // has resolved the backend to CES RPC — routes the read through CES
+      // itself. During a reconnect the old transport is dead and a new
+      // one is being set up by this very closure, so the nested credential
+      // read recursively awaits its own in-flight reconnection and
+      // deadlocks until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. That
+      // 45-second stall delays every CES restart and causes dependent
+      // credential reads (e.g. Meet's STT provider resolution) to return
+      // `undefined` during the window. API key rotation uses the
+      // `updateAssistantApiKey` RPC on the live client, not a reconnect,
+      // so caching at startup is safe.
+      const startupProxyCtx = await resolveManagedProxyContext();
+      const startupAssistantId = getPlatformAssistantId();
 
-        setCesReconnect(async () => {
-          try {
-            await pm.stop();
-            const transport = await pm.start();
-            const newClient = createCesClient(transport);
-            const { accepted, reason } = await newClient.handshake({
-              ...(startupProxyCtx.assistantApiKey
-                ? { assistantApiKey: startupProxyCtx.assistantApiKey }
-                : {}),
-              ...(startupAssistantId
-                ? { assistantId: startupAssistantId }
-                : {}),
-            });
-            if (accepted) {
-              log.info("CES reconnection handshake accepted");
-              return newClient;
-            }
-            log.warn({ reason }, "CES reconnection handshake rejected");
-            newClient.close();
-            await pm.stop().catch(() => {});
-            return undefined;
-          } catch (err) {
-            log.warn(
-              { error: err instanceof Error ? err.message : String(err) },
-              "CES reconnection attempt failed",
-            );
-            await pm.stop().catch(() => {});
-            return undefined;
+      setCesReconnect(async () => {
+        try {
+          await pm.stop();
+          const transport = await pm.start();
+          const newClient = createCesClient(transport);
+          const { accepted, reason } = await newClient.handshake({
+            ...(startupProxyCtx.assistantApiKey
+              ? { assistantApiKey: startupProxyCtx.assistantApiKey }
+              : {}),
+            ...(startupAssistantId ? { assistantId: startupAssistantId } : {}),
+          });
+          if (accepted) {
+            log.info("CES reconnection handshake accepted");
+            return newClient;
           }
-        });
-      }
+          log.warn({ reason }, "CES reconnection handshake rejected");
+          newClient.close();
+          await pm.stop().catch(() => {});
+          return undefined;
+        } catch (err) {
+          log.warn(
+            { error: err instanceof Error ? err.message : String(err) },
+            "CES reconnection attempt failed",
+          );
+          await pm.stop().catch(() => {});
+          return undefined;
+        }
+      });
     }
 
     // Populate the registry with user plugins from `~/.vellum/plugins/*`

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -114,14 +114,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "ces-credential-backend",
-      "scope": "assistant",
-      "key": "ces-credential-backend",
-      "label": "CES Credential Backend",
-      "description": "Route credential reads and writes through the CES process instead of accessing the encrypted store directly",
-      "defaultEnabled": true
-    },
-    {
       "id": "settings-billing",
       "scope": "client",
       "key": "settings-billing",


### PR DESCRIPTION
## Summary
- Remove the ces-credential-backend feature flag from the registry
- Remove isCesCredentialBackendEnabled function and constant
- CES process always started and awaited before provider initialization

Part of plan: ga-default-on-flags.md (PR 5 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
