### PR TITLE
feat: GA the `managed-sign-in` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -29,9 +29,6 @@ struct HatchingStepView: View {
     private var hatchColor: AvatarColor {
         state.hatchAvatarColor ?? .allCases[0]
     }
-    private var managedSignInEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
-    }
     @State private var showFooterCharacters = false
     @State private var completionTask: Task<Void, Never>?
     @State private var healthCheckTask: Task<Void, Never>?
@@ -601,7 +598,7 @@ struct HatchingStepView: View {
         if !state.selectedModel.isEmpty {
             configValues["llm.default.model"] = state.selectedModel
         }
-        if managedSignInEnabled && !state.skippedAuth {
+        if !state.skippedAuth {
             configValues["services.inference.mode"] = "managed"
             configValues["services.image-generation.mode"] = "managed"
             configValues["services.web-search.mode"] = "managed"

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -23,10 +23,6 @@ struct OnboardingFlowView: View {
         NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
     }()
 
-    private var managedSignInEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
-    }
-
     private var preChatOnboardingEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("onboarding-pre-chat")
     }
@@ -106,7 +102,7 @@ struct OnboardingFlowView: View {
                     Group {
                         switch state.currentStep {
                             case 0:
-                                if managedSignInEnabled && authManager.isAuthenticated {
+                                if authManager.isAuthenticated {
                                     // Already authenticated — show a brief loading
                                     // state while the .task advances to Setup.
                                     HStack(spacing: VSpacing.sm) {
@@ -119,9 +115,9 @@ struct OnboardingFlowView: View {
                                 } else {
                                     WakeUpStepView(
                                         state: state,
-                                        authManager: managedSignInEnabled ? authManager : nil,
+                                        authManager: authManager,
                                         isAdvancing: isAdvancingFromWakeUp,
-                                        managedSignInEnabled: managedSignInEnabled,
+                                        managedSignInEnabled: true,
                                         onStartWithAPIKey: {
                                             guard !isAdvancingFromWakeUp else { return }
                                             isAdvancingFromWakeUp = true
@@ -197,14 +193,14 @@ struct OnboardingFlowView: View {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()
             }
-            if managedSignInEnabled && authManager.isAuthenticated && state.currentStep == 0 {
+            if authManager.isAuthenticated && state.currentStep == 0 {
                 await continueManagedOnboardingAfterAuthentication()
             }
         }
         .onChange(of: state.currentStep) { _, newStep in
             if newStep == 0 {
                 isAdvancingFromWakeUp = false
-                if managedSignInEnabled && authManager.isAuthenticated {
+                if authManager.isAuthenticated {
                     Task {
                         await continueManagedOnboardingAfterAuthentication()
                     }
@@ -219,7 +215,7 @@ struct OnboardingFlowView: View {
             log.info(
                 "Observed auth state change in onboarding: isAuthenticated=\(isAuthenticated, privacy: .public) managedBootstrapEnabled=\(self.managedBootstrapEnabled, privacy: .public) lockfileAssistantId=\(currentAssistant?.assistantId ?? "<none>", privacy: .public)"
             )
-            if !isAuthenticated && managedSignInEnabled && state.currentStep > 0 {
+            if !isAuthenticated && state.currentStep > 0 {
                 log.info("User signed out during managed onboarding — returning to welcome screen")
                 completionDelayTask?.cancel()
                 didCallComplete = false
@@ -242,7 +238,7 @@ struct OnboardingFlowView: View {
             }
             if isAuthenticated {
                 if let assistant = currentAssistant {
-                    if assistant.isManaged && managedSignInEnabled && state.currentStep == 0 {
+                    if assistant.isManaged && state.currentStep == 0 {
                         log.info("Authenticated with managed assistant \(assistant.assistantId, privacy: .public); advancing to hosting selector")
                         state.advance()
                     } else if assistant.isManaged {
@@ -258,7 +254,7 @@ struct OnboardingFlowView: View {
                         onComplete()
                     }
                 } else if managedBootstrapEnabled {
-                    if managedSignInEnabled && state.currentStep == 0 {
+                    if state.currentStep == 0 {
                         Task {
                             await continueManagedOnboardingAfterAuthentication()
                         }
@@ -308,7 +304,6 @@ struct OnboardingFlowView: View {
 
     private func continueManagedOnboardingAfterAuthentication() async {
         guard managedBootstrapEnabled,
-              managedSignInEnabled,
               authManager.isAuthenticated,
               state.currentStep == 0,
               !isResolvingAssociatedManagedAssistant else {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -138,14 +138,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "managed-sign-in",
-      "scope": "client",
-      "key": "managed-sign-in",
-      "label": "Managed Sign In",
-      "description": "Enable managed (organization-hosted) sign-in flow in the onboarding experience",
-      "defaultEnabled": true
-    },
-    {
       "id": "conversation-starters",
       "scope": "assistant",
       "key": "conversation-starters",


### PR DESCRIPTION
## Summary
- Remove the managed-sign-in feature flag from the registry
- Managed sign-in always available in onboarding flow
- Remove flag checks from HatchingStepView and OnboardingFlowView

Part of plan: ga-default-on-flags.md (PR 8 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
