### PR TITLE
feat: GA the `channel-avatar-sync` feature flag

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -157,10 +157,7 @@ import {
 } from "./twilio/webhook-sync-trigger.js";
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
-import {
-  featureFlagRoutes,
-  getMergedFeatureFlags,
-} from "./ipc/feature-flag-handlers.js";
+import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
 import { capabilityTokenRoutes } from "./ipc/capability-token-handlers.js";
 import { riskClassificationRoutes } from "./ipc/risk-classification-handlers.js";
@@ -1907,12 +1904,7 @@ async function main() {
         );
       });
 
-      // Sync avatar to Slack bot profile on credential change (including
-      // initial startup). Gated behind channel-avatar-sync feature flag.
-      // Known limitation: if the flag is toggled off without a credential
-      // change, the syncer stays registered until the next credential
-      // change triggers this callback.
-      if (slackReady && getMergedFeatureFlags()["channel-avatar-sync"]) {
+      if (slackReady) {
         avatarChannelSyncer.register(new SlackAvatarSyncer(credentialCache));
         avatarChannelSyncer.syncToChannel("slack").catch((err) => {
           log.warn({ err }, "Initial Slack avatar sync failed");

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -322,14 +322,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "channel-avatar-sync",
-      "scope": "assistant",
-      "key": "channel-avatar-sync",
-      "label": "Channel Avatar Sync",
-      "description": "Automatically sync the assistant's avatar to connected channels (Slack) when the avatar changes or a new channel is connected",
-      "defaultEnabled": true
-    },
-    {
       "id": "meet",
       "scope": "assistant",
       "key": "meet",


### PR DESCRIPTION
## Summary
- Remove the channel-avatar-sync feature flag from the registry
- Avatar sync always registered when Slack is ready
- Remove flag check and unregister-on-flag-off path

Part of plan: ga-default-on-flags.md (PR 18 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
