### PR TITLE
feat: GA the `settings-billing` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -33,7 +33,6 @@ enum SettingsTab: String {
     }
 
     static func sidebarTopTabs(
-        billingEnabled: Bool = false,
         soundsEnabled: Bool = true,
         debugEnabled: Bool = false,
         includeCompactionPlayground: Bool = false
@@ -45,7 +44,7 @@ enum SettingsTab: String {
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
         if soundsEnabled { tabs.append(.sounds) }
-        if billingEnabled { tabs.append(.billing) }
+        tabs.append(.billing)
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         tabs.append(.schedules)
@@ -90,11 +89,6 @@ struct SettingsPanel: View {
         self.onEnableIntegration = onEnableIntegration
         self.featureFlagClient = featureFlagClient
 
-        // Pre-compute the billing flag so the first render already has the
-        // correct tab list in the sidebar nav.
-        let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
-        _isBillingEnabled = State(initialValue: billingEnabled)
-
         // Pre-compute the sounds flag so deep-link validation below uses
         // the actual config value instead of the @State default (true).
         let soundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
@@ -108,11 +102,7 @@ struct SettingsPanel: View {
         // first instance and leaves the second with .general).
         if let pending = store.pendingSettingsTab {
             // Validate that the deep-linked tab is actually visible before
-            // accepting it. @AppStorage isn't wired to UserDefaults in init,
-            // so read connectedOrgId directly from UserDefaults.
-            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
-            let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
-            // Contacts and developer flags load asynchronously, so default
+            // accepting it. Contacts and developer flags load asynchronously, so default
             // to false at init time — those tabs aren't visible yet.
             // Compaction Playground is also deferred until flags load and
             // dev mode can be evaluated by the live sidebar visibility helper.
@@ -121,7 +111,6 @@ struct SettingsPanel: View {
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
             let visibleTabs = SettingsTab.sidebarTopTabs(
-                billingEnabled: canShowBilling,
                 soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
@@ -154,7 +143,6 @@ struct SettingsPanel: View {
     /// Re-evaluated after loadFeatureFlags() completes.
     @State private var deferredDeepLinkTab: SettingsTab?
     @State private var hasLoadedFeatureFlags: Bool = false
-    @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
@@ -164,8 +152,6 @@ struct SettingsPanel: View {
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
-    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
-    private static let billingFeatureFlagKey = "settings-billing"
     private static let developerFeatureFlagKey = "settings-developer-nav"
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
@@ -237,7 +223,6 @@ struct SettingsPanel: View {
             await loadFeatureFlags()
         }
         .onAppear {
-            isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
@@ -266,9 +251,6 @@ struct SettingsPanel: View {
                 selectVisibleTab(tab)
             }
         }
-        .onChange(of: billingVisible) { _, _ in
-            handleSidebarVisibilityChanged()
-        }
         .onChange(of: isDebugVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
@@ -286,8 +268,6 @@ struct SettingsPanel: View {
                let enabled = notification.userInfo?["enabled"] as? Bool {
                 if key == Self.developerFeatureFlagKey {
                     isDeveloperEnabled = enabled
-                } else if key == Self.billingFeatureFlagKey {
-                    isBillingEnabled = enabled
                 } else if key == Self.compactionPlaygroundFeatureFlagKey {
                     isCompactionPlaygroundEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
@@ -390,16 +370,10 @@ struct SettingsPanel: View {
 
     private var visibleSidebarTopTabs: [SettingsTab] {
         SettingsTab.sidebarTopTabs(
-            billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
         )
-    }
-
-    private var billingVisible: Bool {
-        let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
-        return isBillingEnabled && authManager.isAuthenticated && connectedOrgId != nil
     }
 
     /// The Debug tab currently only hosts cloud-hosted assistant tooling

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -21,7 +21,6 @@ struct DrawerMenuView: View {
     private var isBillingVisible: Bool {
         let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
         return authManager.isAuthenticated &&
-        MacOSClientFeatureFlagManager.shared.isEnabled("settings-billing") &&
         connectedOrgId != nil
     }
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -122,14 +122,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "settings-billing",
-      "scope": "client",
-      "key": "settings-billing",
-      "label": "Billing Settings Tab",
-      "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
-      "defaultEnabled": true
-    },
-    {
       "id": "referral-codes",
       "scope": "client",
       "key": "referral-codes",


### PR DESCRIPTION
## Summary
- Remove the settings-billing feature flag from the registry
- Billing tab always visible in settings sidebar
- Remove billingEnabled parameter from sidebarTopTabs()
- Clean up all flag resolution and notification handling

Part of plan: ga-default-on-flags.md (PR 6 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
