### PR TITLE
feat: GA the `onboarding-pre-chat` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -27,10 +27,6 @@ struct OnboardingFlowView: View {
         MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
     }
 
-    private var preChatOnboardingEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("onboarding-pre-chat")
-    }
-
     private var maxOnboardingStep: Int {
         return 3
     }
@@ -279,13 +275,9 @@ struct OnboardingFlowView: View {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     guard !Task.isCancelled else { return }
                     guard state.hatchCompleted else { return }
-                    if preChatOnboardingEnabled {
-                        PreChatOnboardingState.clearPersistedState()
-                        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
-                            isShowingPreChat = true
-                        }
-                    } else {
-                        onComplete()
+                    PreChatOnboardingState.clearPersistedState()
+                    withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                        isShowingPreChat = true
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -112,8 +112,7 @@ final class OnboardingState {
     var hatchTotalSteps: Int = 1
     var hatchCurrentStep: Int = 0
 
-    /// Pre-chat onboarding context collected after hatching when the
-    /// `onboarding-pre-chat` feature flag is enabled. Threaded through
+    /// Pre-chat onboarding context collected after hatching. Threaded through
     /// AppDelegate → ConversationManager → ChatViewModel so the first
     /// message POST includes it for assistant personalization.
     var preChatContext: PreChatOnboardingContext?

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -306,14 +306,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "onboarding-pre-chat",
-      "scope": "client",
-      "key": "onboarding-pre-chat",
-      "label": "Pre-Chat Onboarding Flow",
-      "description": "Gates the 3-screen pre-chat onboarding flow (tools, tasks/tone, name exchange) shown before the first conversation",
-      "defaultEnabled": true
-    },
-    {
       "id": "home-tab",
       "scope": "client",
       "key": "home-tab",


### PR DESCRIPTION
## Summary
- Remove the onboarding-pre-chat feature flag from the registry
- Pre-chat onboarding flow always shown before first conversation
- Remove preChatOnboardingEnabled computed property and simplify conditionals

Part of plan: ga-default-on-flags.md (PR 17 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
