### PR TITLE
feat: GA the `tool-result-truncation` feature flag

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -24,7 +24,6 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   contextWindowConfigFromEffective,
   resolveEffectiveContextWindow,
@@ -2619,34 +2618,29 @@ export async function runAgentLoopImpl(
 
     // Post-turn tool result truncation: save large results to disk and
     // replace in-context content with a prefix/suffix stub + file pointer.
-    if (isAssistantFeatureFlagEnabled("tool-result-truncation", config)) {
-      try {
-        const conv = getConversation(ctx.conversationId);
-        if (conv) {
-          const convDir = getResolvedConversationDirPath(
-            ctx.conversationId,
-            conv.createdAt,
-          );
-          const { messages: derefMessages, dereferencedCount } =
-            derefToolResultReReads(restoredHistory);
-          const { messages: truncatedMessages, truncatedCount } =
-            postTurnTruncateToolResults(derefMessages, {
-              conversationDir: convDir,
-            });
-          if (truncatedCount > 0 || dereferencedCount > 0) {
-            rlog.info(
-              { truncatedCount, dereferencedCount },
-              "Post-turn tool result truncation applied",
-            );
-          }
-          restoredHistory = truncatedMessages;
-        }
-      } catch (err) {
-        rlog.warn(
-          { err },
-          "Post-turn tool result truncation failed (non-fatal)",
+    try {
+      const conv = getConversation(ctx.conversationId);
+      if (conv) {
+        const convDir = getResolvedConversationDirPath(
+          ctx.conversationId,
+          conv.createdAt,
         );
+        const { messages: derefMessages, dereferencedCount } =
+          derefToolResultReReads(restoredHistory);
+        const { messages: truncatedMessages, truncatedCount } =
+          postTurnTruncateToolResults(derefMessages, {
+            conversationDir: convDir,
+          });
+        if (truncatedCount > 0 || dereferencedCount > 0) {
+          rlog.info(
+            { truncatedCount, dereferencedCount },
+            "Post-turn tool result truncation applied",
+          );
+        }
+        restoredHistory = truncatedMessages;
       }
+    } catch (err) {
+      rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
     }
 
     // Persist injections in history: runtime-injected context stays on

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -282,14 +282,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "tool-result-truncation",
-      "scope": "assistant",
-      "key": "tool-result-truncation",
-      "label": "Post-Turn Tool Result Truncation",
-      "description": "Truncate large tool results after each assistant turn, persisting full content to disk for on-demand re-reads",
-      "defaultEnabled": true
-    },
-    {
       "id": "managed-gemini-embeddings-enabled",
       "scope": "assistant",
       "key": "managed-gemini-embeddings-enabled",


### PR DESCRIPTION
## Summary
- Remove the tool-result-truncation feature flag from the registry
- Post-turn tool result truncation always runs unconditionally
- Remove flag check wrapper, keep truncation logic intact

Part of plan: ga-default-on-flags.md (PR 15 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
