### PR TITLE
feat: GA the `settings-developer-nav` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -650,7 +650,7 @@ extension MainWindowView {
                         subagentId: subagentId,
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
-                        showInspectButton: assistantFeatureFlagStore.isEnabled("settings-developer-nav"),
+                        showInspectButton: true,
                         onAbort: { Task { await viewModel.abortSubagent(subagentId) } },
                         onRequestDetail: {
                             if let conversationId = viewModel.activeSubagents.first(where: { $0.id == subagentId })?.conversationId {
@@ -702,9 +702,7 @@ extension MainWindowView {
             let conversationStartersEnabled = assistantFeatureFlagStore.isEnabled(
                 Self.conversationStartersFeatureFlagKey
             )
-            let showInspectButton = assistantFeatureFlagStore.isEnabled(
-                "settings-developer-nav"
-            )
+            let showInspectButton = true
             let isTTSEnabled = assistantFeatureFlagStore.isEnabled(
                 "message-tts"
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -112,24 +112,24 @@ struct SettingsPanel: View {
             // so read connectedOrgId directly from UserDefaults.
             let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
             let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
-            // Contacts and developer flags load asynchronously, so default
-            // to false at init time — those tabs aren't visible yet.
-            // Compaction Playground is also deferred until flags load and
+            // Compaction Playground is deferred until flags load and
             // dev mode can be evaluated by the live sidebar visibility helper.
             // Debug tab is gated to managed assistants; `AppDelegate` publishes
             // this synchronously via `isCurrentAssistantManaged` which is set
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
-            let visibleTabs = SettingsTab.sidebarTopTabs(
+            var visibleTabs = SettingsTab.sidebarTopTabs(
                 billingEnabled: canShowBilling,
                 soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
             )
+            // Developer tab is always visible (no longer feature-flagged).
+            visibleTabs.append(.developer)
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else if Self.deferredDeepLinkTabs.contains(pending) {
-                // Tab may become visible once feature flags load (e.g. .developer).
+                // Tab may become visible once feature flags load (e.g. .compactionPlayground).
                 // Preserve it for deferred evaluation in loadFeatureFlags().
                 _deferredDeepLinkTab = State(initialValue: pending)
             }
@@ -155,23 +155,18 @@ struct SettingsPanel: View {
     @State private var deferredDeepLinkTab: SettingsTab?
     @State private var hasLoadedFeatureFlags: Bool = false
     @State private var isBillingEnabled: Bool = false
-    @State private var isDeveloperEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var isEmailChannelEnabled: Bool = false
-    @State private var showingDevUnlock: Bool = false
-    @State private var devUnlockText: String = ""
-    @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
     private static let billingFeatureFlagKey = "settings-billing"
-    private static let developerFeatureFlagKey = "settings-developer-nav"
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
-    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.developer, .compactionPlayground]
+    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.compactionPlayground]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -275,18 +270,13 @@ struct SettingsPanel: View {
         .onChange(of: isSoundsEnabled) { _, _ in
             handleSidebarVisibilityChanged()
         }
-        .onChange(of: isDeveloperEnabled) { _, _ in
-            handleSidebarVisibilityChanged()
-        }
         .onChange(of: isCompactionPlaygroundVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
-                if key == Self.developerFeatureFlagKey {
-                    isDeveloperEnabled = enabled
-                } else if key == Self.billingFeatureFlagKey {
+                if key == Self.billingFeatureFlagKey {
                     isBillingEnabled = enabled
                 } else if key == Self.compactionPlaygroundFeatureFlagKey {
                     isCompactionPlaygroundEnabled = enabled
@@ -314,56 +304,6 @@ struct SettingsPanel: View {
         .sheet(isPresented: $showingTrustRules, onDismiss: { connectionManager?.isTrustRulesSheetOpen = false }) {
             TrustRulesView(trustRuleClient: TrustRuleClient())
         }
-        .onAppear {
-            devUnlockMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-                if event.modifierFlags.contains(.command),
-                   event.charactersIgnoringModifiers == "d" {
-                    showingDevUnlock = true
-                    devUnlockText = ""
-                    return nil
-                }
-                return event
-            }
-        }
-        .onDisappear {
-            if let monitor = devUnlockMonitor {
-                NSEvent.removeMonitor(monitor)
-                devUnlockMonitor = nil
-            }
-        }
-        .popover(isPresented: $showingDevUnlock) {
-            VStack(spacing: VSpacing.md) {
-                Text("Enter passcode")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                VTextField(
-                    placeholder: "",
-                    text: $devUnlockText,
-                    isSecure: true,
-                    onSubmit: {
-                        if devUnlockText.lowercased() == "dev" {
-                            isDeveloperEnabled = true
-                            showingDevUnlock = false
-                            // Notify listeners (e.g. AssistantFeatureFlagStore) so UI updates globally
-                            NotificationCenter.default.post(
-                                name: .assistantFeatureFlagDidChange,
-                                object: nil,
-                                userInfo: ["key": Self.developerFeatureFlagKey, "enabled": true]
-                            )
-                            // Persist locally (cache) for optimistic UI + PATCH to gateway
-                            AssistantFeatureFlagResolver.mergeCachedFlag(key: Self.developerFeatureFlagKey, enabled: true)
-                            Task {
-                                try? await featureFlagClient.setFeatureFlag(key: Self.developerFeatureFlagKey, enabled: true)
-                            }
-                        }
-                        devUnlockText = ""
-                    },
-                    maxWidth: 160,
-                    font: VFont.bodyMediumDefault
-                )
-            }
-            .padding(VSpacing.lg)
-        }
     }
 
     private func scrollToPendingGeneralSection(using scrollProxy: ScrollViewProxy) {
@@ -382,9 +322,7 @@ struct SettingsPanel: View {
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
         var tabs = visibleSidebarTopTabs
-        if isDeveloperEnabled {
-            tabs.append(.developer)
-        }
+        tabs.append(.developer)
         return tabs
     }
 
@@ -411,7 +349,7 @@ struct SettingsPanel: View {
     }
 
     private var isCompactionPlaygroundVisible: Bool {
-        isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
+        isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
     }
 
     private var settingsNav: some View {
@@ -422,14 +360,12 @@ struct SettingsPanel: View {
                 }
             }
             Spacer(minLength: VSpacing.sm)
-            if isDeveloperEnabled {
-                VColor.surfaceBase
-                    .frame(height: 1)
-                    .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
-                    .padding(.trailing, VSpacing.md)
-                VNavItem(icon: SettingsTab.developer.icon.rawValue, label: "Developer", isActive: selectedTab == .developer) {
-                    selectVisibleTab(.developer)
-                }
+            VColor.surfaceBase
+                .frame(height: 1)
+                .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
+                .padding(.trailing, VSpacing.md)
+            VNavItem(icon: SettingsTab.developer.icon.rawValue, label: "Developer", isActive: selectedTab == .developer) {
+                selectVisibleTab(.developer)
             }
         }
         .padding(.top, VSpacing.lg)
@@ -725,9 +661,6 @@ struct SettingsPanel: View {
         if connectionManager != nil {
             do {
                 let flags = try await featureFlagClient.getFeatureFlags()
-                if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
-                    isDeveloperEnabled = developerFlag.enabled
-                }
                 if let playgroundFlag = flags.first(where: { $0.key == Self.compactionPlaygroundFeatureFlagKey }) {
                     isCompactionPlaygroundEnabled = playgroundFlag.enabled
                 }
@@ -752,9 +685,6 @@ struct SettingsPanel: View {
             registry: loadFeatureFlagRegistry()
         )
 
-        if let developerEnabled = resolved[Self.developerFeatureFlagKey] {
-            isDeveloperEnabled = developerEnabled
-        }
         if let playgroundEnabled = resolved[Self.compactionPlaygroundFeatureFlagKey] {
             isCompactionPlaygroundEnabled = playgroundEnabled
         }

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -57,7 +57,7 @@ public struct AssistantFeatureFlag: Decodable, Identifiable, Sendable, Equatable
     }
 
     /// Derive a human-readable name from the flag key.
-    /// e.g. "settings-developer-nav" -> "Settings Developer Nav"
+    /// e.g. "settings-billing" -> "Settings Billing"
     public var displayName: String {
         if let label = label { return label }
         return key

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -58,14 +58,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "settings-developer-nav",
-      "scope": "assistant",
-      "key": "settings-developer-nav",
-      "label": "Settings Developer Nav",
-      "description": "Control Developer nav visibility in macOS settings",
-      "defaultEnabled": true
-    },
-    {
       "id": "developer-menu-items",
       "scope": "client",
       "key": "developer-menu-items",


### PR DESCRIPTION
## Summary
- Remove the settings-developer-nav feature flag from the registry
- Make developer nav / inspect button unconditionally visible
- Remove flag key constant and notification handling from SettingsPanel
- Remove Cmd+D dev unlock popover (dead code since developer tab is always visible)
- Update comment example in FeatureFlagClient.swift to use a current flag

Part of plan: ga-default-on-flags.md (PR 3 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
