### PR TITLE
feat: GA the `channel-voice-transcription` feature flag

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -442,7 +442,7 @@ export async function handleChannelInbound({
           `[Voice message received — ${transcribeResult.reason}]` +
           (trimmedContent ? `\n\n${trimmedContent}` : "");
         break;
-      // "no_audio", "disabled" — no action needed
+      // "no_audio" — no action needed
     }
   }
 

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
@@ -7,7 +7,6 @@ import { SttError } from "../../../stt/types.js";
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-let mockFeatureFlagEnabled = true;
 let mockAttachments: Array<{
   id: string;
   mimeType: string;
@@ -19,14 +18,6 @@ let mockAttachments: Array<{
   createdAt: number;
 }> = [];
 let mockTranscriber: BatchTranscriber | null = null;
-
-mock.module("../../../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: () => mockFeatureFlagEnabled,
-}));
-
-mock.module("../../../config/loader.js", () => ({
-  getConfig: () => ({}),
-}));
 
 mock.module("../../../memory/attachments-store.js", () => ({
   getAttachmentsByIds: (ids: string[]) =>
@@ -115,7 +106,6 @@ function makeImageAttachment(id: string) {
 
 describe("tryTranscribeAudioAttachments", () => {
   beforeEach(() => {
-    mockFeatureFlagEnabled = true;
     mockAttachments = [];
     mockTranscriber = null;
   });
@@ -187,16 +177,6 @@ describe("tryTranscribeAudioAttachments", () => {
     expect((result as { reason: string }).reason).toBe(
       "API rate limit exceeded",
     );
-  });
-
-  test("feature flag disabled returns disabled", async () => {
-    mockFeatureFlagEnabled = false;
-    const audio = makeAudioAttachment("a1");
-    mockAttachments = [audio];
-
-    const result = await tryTranscribeAudioAttachments(["a1"]);
-
-    expect(result).toEqual({ status: "disabled" });
   });
 
   test("30-second timeout fires and returns error without blocking", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
@@ -2,21 +2,20 @@
  * Auto-transcribe audio attachments from channel inbound messages.
  *
  * Returns a discriminated result type so callers can handle each outcome
- * (transcribed, no audio, disabled, no provider, error) without exceptions.
+ * (transcribed, no audio, no provider, error) without exceptions.
  * Never throws — failures are represented as result variants so that message
  * delivery is never blocked by transcription issues.
  */
 
-import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
-import { getConfig } from "../../../config/loader.js";
-import { getAttachmentById, getAttachmentsByIds } from "../../../memory/attachments-store.js";
+import {
+  getAttachmentById,
+  getAttachmentsByIds,
+} from "../../../memory/attachments-store.js";
 import { resolveBatchTranscriber } from "../../../providers/speech-to-text/resolve.js";
 import { normalizeSttError } from "../../../stt/daemon-batch-transcriber.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("transcribe-audio");
-
-const VOICE_TRANSCRIPTION_FLAG_KEY = "channel-voice-transcription" as const;
 
 /** Timeout for the entire transcription pipeline (all attachments). */
 const TRANSCRIPTION_TIMEOUT_MS = 30_000;
@@ -28,7 +27,6 @@ const TRANSCRIPTION_TIMEOUT_MS = 30_000;
 export type TranscribeResult =
   | { status: "transcribed"; text: string }
   | { status: "no_audio" }
-  | { status: "disabled" }
   | { status: "no_provider"; reason: string }
   | { status: "error"; reason: string };
 
@@ -40,12 +38,6 @@ export async function tryTranscribeAudioAttachments(
   attachmentIds: string[],
 ): Promise<TranscribeResult> {
   try {
-    // Check feature flag
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(VOICE_TRANSCRIPTION_FLAG_KEY, config)) {
-      return { status: "disabled" };
-    }
-
     // Look up attachments and filter to audio MIME types
     const resolved = getAttachmentsByIds(attachmentIds);
     const audioAttachments = resolved.filter((a) =>

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -210,14 +210,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "channel-voice-transcription",
-      "scope": "assistant",
-      "key": "channel-voice-transcription",
-      "label": "Channel Voice Transcription",
-      "description": "Auto-transcribe voice/audio messages received from channels (Telegram, WhatsApp) before processing",
-      "defaultEnabled": true
-    },
-    {
       "id": "sounds",
       "scope": "assistant",
       "key": "sounds",


### PR DESCRIPTION
## Summary
- Remove the channel-voice-transcription feature flag from the registry
- Audio transcription always runs for channel voice messages
- Remove flag check and disabled status return

Part of plan: ga-default-on-flags.md (PR 12 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
