### PR TITLE
feat: GA the `app-builder-multifile` feature flag

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -71,38 +71,7 @@ function mockStore(
 // ---------------------------------------------------------------------------
 
 describe("executeAppCreate", () => {
-  test("flag off: creates legacy app with root index.html", async () => {
-    const files: Record<string, string> = {};
-    let createdParams: Record<string, unknown> | undefined;
-    const app = makeLegacyApp();
-    const store: AppStore = {
-      ...mockStore(app, files),
-      createApp: (params) => {
-        createdParams = params as unknown as Record<string, unknown>;
-        return app;
-      },
-    };
-
-    const result = await executeAppCreate(
-      {
-        name: "Test App",
-        html: "<html><body>Hello</body></html>",
-      },
-      store,
-    );
-
-    expect(result.isError).toBe(false);
-    // Legacy path: no formatVersion set, htmlDefinition is the provided html
-    expect(createdParams?.formatVersion).toBeUndefined();
-    expect(createdParams?.htmlDefinition).toBe(
-      "<html><body>Hello</body></html>",
-    );
-    // No src/ files should be written
-    expect(files["src/index.html"]).toBeUndefined();
-    expect(files["src/main.tsx"]).toBeUndefined();
-  });
-
-  test("flag on: creates multifile app with src/ scaffold", async () => {
+  test("creates multifile app with src/ scaffold", async () => {
     const files: Record<string, string> = {};
     let createdParams: Record<string, unknown> | undefined;
     const app = makeMultifileApp({ name: "New App" });
@@ -117,7 +86,6 @@ describe("executeAppCreate", () => {
     const result = await executeAppCreate(
       {
         name: "New App",
-        featureFlags: { multifileEnabled: true },
       },
       store,
     );
@@ -136,7 +104,7 @@ describe("executeAppCreate", () => {
     expect(files["src/main.tsx"]).toContain('{"Hello, New App!"}');
   });
 
-  test("flag on with explicit html: uses provided html as src/index.html", async () => {
+  test("with explicit html: uses provided html as src/index.html", async () => {
     const files: Record<string, string> = {};
     const app = makeMultifileApp({ name: "Custom App" });
     const store: AppStore = {
@@ -150,7 +118,6 @@ describe("executeAppCreate", () => {
       {
         name: "Custom App",
         html: customHtml,
-        featureFlags: { multifileEnabled: true },
       },
       store,
     );

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -19,7 +19,6 @@ afterEach(() => {
 const DECLARED_FLAG_ID = "sounds";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 const DECLARED_SKILL_ID = "sounds";
-const APP_BUILDER_MULTIFILE_FLAG_KEY = "app-builder-multifile";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -158,13 +157,6 @@ describe("isAssistantFeatureFlagEnabled", () => {
     const config = makeConfig();
     // browser is declared in the registry with defaultEnabled: true
     expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
-  });
-
-  test("app-builder-multifile defaults to enabled when no override is set", () => {
-    const config = makeConfig();
-    expect(
-      isAssistantFeatureFlagEnabled(APP_BUILDER_MULTIFILE_FLAG_KEY, config),
-    ).toBe(true);
   });
 });
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -69,16 +69,7 @@ For `formatVersion: 2` apps, source files live under `src/` and compiled output 
 
 **Make creative decisions on behalf of the user.** They want to be delighted, not consulted. Pick the accent color. Choose between a dark moody aesthetic or a light airy one. Decide if cards should have glassmorphism or layered shadows. Add a background pattern or gradient. These are YOUR decisions as the designer.
 
-<!-- feature:app-builder-multifile:start -->
-
 **Prefer multi-file TSX projects** for any non-trivial app. They give you component reuse, TypeScript safety, and cleaner organization. Fall back to single-file HTML only for the simplest one-off pages.
-
-<!-- feature:app-builder-multifile:end -->
-<!-- feature:app-builder-multifile:alt -->
-
-**Always build single-file HTML apps.** Write a complete, self-contained HTML document with all CSS in `<style>` and all JavaScript in `<script>`. Do not use multi-file projects or TSX.
-
-<!-- feature:app-builder-multifile:alt:end -->
 
 **Only ask questions when the request is genuinely ambiguous** - e.g., "build me an app" with no indication of what kind. Even then, prefer building something impressive based on context clues over asking a battery of questions.
 
@@ -123,8 +114,6 @@ Example schema for a project tracker:
 ### 3. Build the App
 
 Apps are rendered inside a sandboxed WebView on macOS.
-
-<!-- feature:app-builder-multifile:start -->
 
 #### Multi-file TSX projects
 
@@ -262,23 +251,6 @@ app_refresh(app_id)
 - No external fonts, images, or resources - use system fonts and CSS/SVG for visuals
 - Design responsively. Apps render at fluid, user-resizable widths — avoid fixed-pixel layouts
 - The WebView blocks all navigation - links and form `action` attributes won't work
-<!-- feature:app-builder-multifile:end -->
-
-<!-- feature:app-builder-multifile:alt -->
-
-#### Single HTML file
-
-Write a complete, self-contained HTML document.
-
-**Technical constraints (single-file):**
-
-- Single HTML string - no external files, CDNs, or imports
-- All CSS in `<style>` in `<head>`, all JavaScript in `<script>` before `</body>`
-- No external fonts, images, or resources - use system fonts and CSS/SVG for visuals
-- Design responsively. Apps render at fluid, user-resizable widths — avoid fixed-pixel layouts
-- The WebView blocks all navigation - links and form `action` attributes won't work
-
-<!-- feature:app-builder-multifile:alt:end -->
 
 #### Injected design system
 
@@ -352,70 +324,7 @@ For handler conventions, examples, key rules, and frontend usage patterns, see *
 
 `localStorage` and `sessionStorage` are available for ephemeral UI state (filters, view modes, collapsed state, preferences, form drafts). Use custom routes for persistent app records, `localStorage` for UI preferences.
 
-<!-- feature:app-builder-multifile:alt -->
-
-#### JavaScript patterns
-
-Initialize apps with clean state management:
-
-```javascript
-document.addEventListener("DOMContentLoaded", async () => {
-  await loadRecords();
-});
-
-let allRecords = [];
-
-async function loadRecords() {
-  try {
-    const res = await window.vellum.fetch("/v1/x/records");
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    allRecords = await res.json();
-    render();
-  } catch (err) {
-    console.error("Failed to load:", err);
-  }
-}
-
-function render() {
-  // Re-render UI from allRecords
-}
-```
-
-**HTML escaping:** Always escape user-controlled data before inserting into the DOM via `innerHTML`:
-
-```javascript
-function esc(s) {
-  const d = document.createElement("div");
-  d.textContent = String(s);
-  return d.innerHTML;
-}
-```
-
-### 4. Single-Page App Views
-
-Apps run inside a sandboxed WebView that blocks all navigation. All apps are effectively single-page. When an app needs multiple views, use JavaScript to swap content:
-
-```javascript
-function showView(name) {
-  document.querySelectorAll(".view").forEach((v) => (v.hidden = true));
-  document.getElementById("view-" + name).hidden = false;
-  document
-    .querySelectorAll(".nav-link")
-    .forEach((btn) => btn.classList.remove("active"));
-  document
-    .querySelector(`[onclick="showView('${name}')"]`)
-    ?.classList.add("active");
-}
-```
-
-<!-- feature:app-builder-multifile:alt:end -->
-
-<!-- feature:app-builder-multifile:start -->
 ### 4. Create and Open the App
-<!-- feature:app-builder-multifile:end -->
-<!-- feature:app-builder-multifile:alt -->
-### 5. Create and Open the App
-<!-- feature:app-builder-multifile:alt:end -->
 
 Call `app_create` with:
 
@@ -428,12 +337,7 @@ Call `app_create` with:
 
 The app is NOT opened in a workspace panel automatically - users open it via the 'Open App' button on the inline card.
 
-<!-- feature:app-builder-multifile:start -->
 ### 5. Handle Iteration
-<!-- feature:app-builder-multifile:end -->
-<!-- feature:app-builder-multifile:alt -->
-### 6. Handle Iteration
-<!-- feature:app-builder-multifile:alt:end -->
 
 When the user requests changes, prefer **`file_edit`** over rewriting the entire file.
 

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -1,5 +1,3 @@
-import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
-import { getConfig } from "../../../../config/loader.js";
 import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppCreateInput } from "../../../../tools/apps/executors.js";
@@ -16,13 +14,6 @@ export async function run(
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
     setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
-  const multifileEnabled = isAssistantFeatureFlagEnabled(
-    "app-builder-multifile",
-    getConfig(),
-  );
-  const createInput: AppCreateInput = {
-    ...(input as unknown as AppCreateInput),
-    featureFlags: { multifileEnabled },
-  };
+  const createInput: AppCreateInput = input as unknown as AppCreateInput;
   return executeAppCreate(createInput, appStore, context.proxyToolResolver);
 }

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -78,11 +78,8 @@ export interface AppCreateInput {
   description?: string;
   schema_json?: string;
   html?: string;
-  pages?: Record<string, string>;
   auto_open?: boolean;
   preview?: Record<string, unknown>;
-  /** When provided, controls multifile scaffold behavior. */
-  featureFlags?: { multifileEnabled: boolean };
 }
 
 export async function executeAppCreate(
@@ -93,14 +90,9 @@ export async function executeAppCreate(
   const name = input.name;
   const description = input.description;
   const schemaJson = input.schema_json ?? "{}";
-  // Default to a minimal scaffold only when html is truly omitted; reject
-  // invalid types (e.g. object/number) so malformed tool calls surface errors.
-  let htmlDefinition: string;
-  if (typeof input.html === "string") {
-    htmlDefinition = input.html;
-  } else if (input.html == null) {
-    htmlDefinition = "<!DOCTYPE html><html><head></head><body></body></html>";
-  } else {
+  // Reject invalid html types (e.g. object/number) so malformed tool calls
+  // surface errors early.
+  if (input.html != null && typeof input.html !== "string") {
     return {
       content: JSON.stringify({
         error: `html must be a string, got ${typeof input.html}`,
@@ -108,7 +100,6 @@ export async function executeAppCreate(
       isError: true,
     };
   }
-  const pages = input.pages;
   const autoOpen = input.auto_open !== false; // default true
   const preview = input.preview;
 
@@ -121,49 +112,33 @@ export async function executeAppCreate(
       isError: true,
     };
   }
-  if (pages) {
-    for (const [filename, content] of Object.entries(pages)) {
-      if (typeof content !== "string") {
-        return {
-          content: JSON.stringify({
-            error: `pages["${filename}"] must be a string, got ${typeof content}`,
-          }),
-          isError: true,
-        };
-      }
-    }
-  }
 
   // Extract icon from preview if provided - only persist emoji-like values,
   // not URLs which would render as raw strings in UI and bundle manifests.
   const rawIcon = preview?.icon as string | undefined;
   const icon = rawIcon && !rawIcon.startsWith("http") ? rawIcon : undefined;
 
-  const multifileEnabled = input.featureFlags?.multifileEnabled === true;
-
   const app = store.createApp({
     name,
     description,
     icon,
     schemaJson,
-    htmlDefinition: multifileEnabled ? "" : htmlDefinition,
-    pages: multifileEnabled ? undefined : pages,
-    formatVersion: multifileEnabled ? 2 : undefined,
+    htmlDefinition: "",
+    formatVersion: 2,
   });
 
   // Scaffold multifile app with src/ files and compile to dist/
-  if (multifileEnabled) {
-    const htmlSafeName = name
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
-    const jsxSafeName = name.replace(/[<>{}&"']/g, "");
+  const htmlSafeName = name
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+  const jsxSafeName = name.replace(/[<>{}&"']/g, "");
 
-    const indexHtml =
-      typeof input.html === "string"
-        ? input.html
-        : `<!DOCTYPE html>
+  const indexHtml =
+    typeof input.html === "string"
+      ? input.html
+      : `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -175,7 +150,7 @@ export async function executeAppCreate(
 </body>
 </html>`;
 
-    const mainTsx = `import { render } from 'preact';
+  const mainTsx = `import { render } from 'preact';
 
 function App() {
   return <div>{"Hello, ${jsxSafeName}!"}</div>;
@@ -184,31 +159,30 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-    // Only write scaffold files when they don't already exist on disk.
-    // The LLM may have written custom source files via file_write before
-    // calling app_create, and overwriting them would destroy the real app
-    // content, leaving only the scaffold placeholder.
-    if (!store.appFileExists(app.id, "src/index.html")) {
-      store.writeAppFile(app.id, "src/index.html", indexHtml);
-    }
-    if (!store.appFileExists(app.id, "src/main.tsx")) {
-      store.writeAppFile(app.id, "src/main.tsx", mainTsx);
-    }
+  // Only write scaffold files when they don't already exist on disk.
+  // The LLM may have written custom source files via file_write before
+  // calling app_create, and overwriting them would destroy the real app
+  // content, leaving only the scaffold placeholder.
+  if (!store.appFileExists(app.id, "src/index.html")) {
+    store.writeAppFile(app.id, "src/index.html", indexHtml);
+  }
+  if (!store.appFileExists(app.id, "src/main.tsx")) {
+    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+  }
 
-    // Compile src/ → dist/
-    const appDir = getAppDirPath(app.id);
-    const compileResult = await compileApp(appDir);
-    if (!compileResult.ok) {
-      return {
-        content: JSON.stringify({
-          ...app,
-          compile_errors: compileResult.errors,
-          compile_warnings: compileResult.warnings,
-          compile_duration_ms: compileResult.durationMs,
-        }),
-        isError: false,
-      };
-    }
+  // Compile src/ → dist/
+  const appDir = getAppDirPath(app.id);
+  const compileResult = await compileApp(appDir);
+  if (!compileResult.ok) {
+    return {
+      content: JSON.stringify({
+        ...app,
+        compile_errors: compileResult.errors,
+        compile_warnings: compileResult.warnings,
+        compile_duration_ms: compileResult.durationMs,
+      }),
+      isError: false,
+    };
   }
 
   // Emit the inline preview card via the proxy without opening a workspace panel.

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -42,14 +42,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "app-builder-multifile",
-      "scope": "assistant",
-      "key": "app-builder-multifile",
-      "label": "App Builder Multi-file",
-      "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
-      "defaultEnabled": true
-    },
-    {
       "id": "mobile-pairing",
       "scope": "client",
       "key": "mobile-pairing",


### PR DESCRIPTION
## Summary
- Remove the app-builder-multifile feature flag from the registry
- Remove feature flag gating from app creation — always use multifile (format v2)
- Remove legacy single-file app creation code path
- Clean up featureFlags parameter from app create input
- Remove feature-gated sections from SKILL.md (keep multifile content, remove single-file alt)

Part of plan: ga-default-on-flags.md (PR 2 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
