### PR TITLE
feat: GA the `ces-managed-sidecar` feature flag

### DIFF
--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -17,12 +17,10 @@ import {
 import type { AssistantConfig } from "../config/schema.js";
 import {
   CES_GRANT_AUDIT_FLAG_KEY,
-  CES_MANAGED_SIDECAR_FLAG_KEY,
   CES_SECURE_INSTALL_FLAG_KEY,
   CES_SHELL_LOCKDOWN_FLAG_KEY,
   CES_TOOLS_FLAG_KEY,
   isCesGrantAuditEnabled,
-  isCesManagedSidecarEnabled,
   isCesSecureInstallEnabled,
   isCesShellLockdownEnabled,
   isCesToolsEnabled,
@@ -51,7 +49,6 @@ const ALL_CES_FLAG_KEYS = [
   CES_SHELL_LOCKDOWN_FLAG_KEY,
   CES_SECURE_INSTALL_FLAG_KEY,
   CES_GRANT_AUDIT_FLAG_KEY,
-  CES_MANAGED_SIDECAR_FLAG_KEY,
 ] as const;
 
 /** All CES predicate functions paired with their flag keys and expected defaults. */
@@ -79,12 +76,6 @@ const ALL_CES_PREDICATES = [
     fn: isCesGrantAuditEnabled,
     key: CES_GRANT_AUDIT_FLAG_KEY,
     defaultEnabled: false,
-  },
-  {
-    name: "isCesManagedSidecarEnabled",
-    fn: isCesManagedSidecarEnabled,
-    key: CES_MANAGED_SIDECAR_FLAG_KEY,
-    defaultEnabled: true,
   },
 ] as const;
 

--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -1,8 +1,8 @@
 /**
  * Managed CES contract and wiring tests.
  *
- * Validates the contract surface, behavioral invariants, and feature-flag
- * gating for the managed (three-container pod) CES sidecar integration:
+ * Validates the contract surface and behavioral invariants for the managed
+ * (three-container pod) CES sidecar integration:
  *
  * 1. Pod creation contract: well-known path constants match the
  *    stateful_template.yaml K8s spec (read-only mount + private PVC).
@@ -18,25 +18,11 @@
  *    (UpdateManagedCredential, MakeAuthenticatedRequest) validate expected
  *    payloads and reject malformed ones at the contract level.
  *
- * 5. Feature-flag rollback: when the `ces-managed-sidecar` flag is off,
- *    the process manager falls back to local discovery and never attempts
- *    the managed sidecar path.
- *
  * All tests use contract schemas and handle parsers to verify behavioral
  * contracts — no real CES process or socket dependencies are needed.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
-
-beforeEach(() => {
-  _setOverridesForTesting({});
-});
-
-afterEach(() => {
-  _setOverridesForTesting({});
-});
+import { describe, expect, test } from "bun:test";
 
 import {
   CES_PROTOCOL_VERSION,
@@ -53,25 +39,10 @@ import {
   UpdateManagedCredentialSchema,
 } from "@vellumai/service-contracts/credential-rpc";
 
-import type { AssistantConfig } from "../config/schema.js";
-import {
-  isCesManagedSidecarEnabled,
-  isCesToolsEnabled,
-} from "../credential-execution/feature-gates.js";
 import {
   CES_ASSISTANT_DATA_READONLY_MOUNT,
   CES_PRIVATE_DATA_DIR,
-  type CesProcessManagerConfig,
 } from "../credential-execution/process-manager.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Create a minimal AssistantConfig (flag overrides are now set via _setOverridesForTesting). */
-function makeConfig(): AssistantConfig {
-  return {} as AssistantConfig;
-}
 
 // ---------------------------------------------------------------------------
 // Well-known paths contract
@@ -438,104 +409,5 @@ describe("managed OAuth materialization through CES sidecar", () => {
         expect(parsed.handle.connectionId).toBe("conn_abc123");
       }
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Feature-flag rollback safety
-// ---------------------------------------------------------------------------
-
-describe("feature-flag rollback safety", () => {
-  test("managed sidecar flag defaults to true (enabled by default)", () => {
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(true);
-  });
-
-  test("managed sidecar flag can be explicitly enabled", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": true,
-    });
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(true);
-  });
-
-  test("managed sidecar flag can be explicitly disabled", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-    });
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(false);
-  });
-
-  test("enabling managed sidecar does not enable CES tools", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": true,
-    });
-    const config = makeConfig();
-    // CES tools flag should remain independently controlled
-    expect(isCesToolsEnabled(config)).toBe(false);
-  });
-
-  test("disabling managed sidecar does not affect other CES flags", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-      "ces-tools": true,
-    });
-    const config = makeConfig();
-    expect(isCesToolsEnabled(config)).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Process manager config wiring
-// ---------------------------------------------------------------------------
-
-describe("process manager config wiring", () => {
-  test("CesProcessManagerConfig accepts assistantConfig for flag gating", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": true,
-    });
-    const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig(),
-    };
-    expect(config.assistantConfig).toBeDefined();
-    expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(true);
-  });
-
-  test("CesProcessManagerConfig requires assistantConfig for feature-flag gate", () => {
-    const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig(),
-    };
-    expect(config.assistantConfig).toBeDefined();
-  });
-
-  test("when flag is off, managed discovery is skipped", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-    });
-    const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig(),
-    };
-    // The managed path should be gated
-    expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Non-CES internal consumers intact
-// ---------------------------------------------------------------------------
-
-describe("non-CES internal consumers intact when flag is off", () => {
-  test("existing non-agent flows are unaffected by managed sidecar flag", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-    });
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(false);
-  });
-
-  test("process manager without config allows managed mode (backward compat)", () => {
-    const config: CesProcessManagerConfig = {};
-    expect(config.assistantConfig).toBeUndefined();
   });
 });

--- a/assistant/src/credential-execution/feature-gates.ts
+++ b/assistant/src/credential-execution/feature-gates.ts
@@ -28,9 +28,6 @@ export const CES_SECURE_INSTALL_FLAG_KEY = "ces-secure-install" as const;
 /** Gate for credential grant and audit inspection surfaces. */
 export const CES_GRANT_AUDIT_FLAG_KEY = "ces-grant-audit" as const;
 
-/** Gate for managed sidecar transport in containerized environments. */
-export const CES_MANAGED_SIDECAR_FLAG_KEY = "ces-managed-sidecar" as const;
-
 /** Gate for routing credential reads/writes through the CES process. */
 const CES_CREDENTIAL_BACKEND_FLAG_KEY = "ces-credential-backend" as const;
 
@@ -64,13 +61,6 @@ export function isCesSecureInstallEnabled(config: AssistantConfig): boolean {
  */
 export function isCesGrantAuditEnabled(config: AssistantConfig): boolean {
   return isAssistantFeatureFlagEnabled(CES_GRANT_AUDIT_FLAG_KEY, config);
-}
-
-/**
- * Whether managed sidecar transport should be used for CES communication.
- */
-export function isCesManagedSidecarEnabled(config: AssistantConfig): boolean {
-  return isAssistantFeatureFlagEnabled(CES_MANAGED_SIDECAR_FLAG_KEY, config);
 }
 
 /**

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -12,12 +12,6 @@
  * creates a socket-based CesTransport. The CES sidecar manages its own
  * lifecycle; the process manager only manages the transport connection.
  *
- * Feature-flag gate: Managed sidecar mode is controlled by the
- * `ces-managed-sidecar` feature flag (checked via the required
- * AssistantConfig). When the flag is off, the process manager skips
- * managed discovery even in containerized environments, ensuring
- * rollback safety.
- *
  * Managed env contract:
  * - CES_BOOTSTRAP_SOCKET  — Path to the bootstrap Unix socket (shared emptyDir)
  * - /assistant-data-ro     — Assistant data mounted read-only into the CES sidecar
@@ -42,7 +36,6 @@ import {
   type LocalSourceDiscoverySuccess,
   type ManagedDiscoverySuccess,
 } from "./executable-discovery.js";
-import { isCesManagedSidecarEnabled } from "./feature-gates.js";
 
 const log = getLogger("ces-process-manager");
 
@@ -71,10 +64,8 @@ export const CES_PRIVATE_DATA_DIR = "/ces-data";
 
 export interface CesProcessManagerConfig {
   /**
-   * Assistant configuration for feature-flag checks.
-   * The managed sidecar path is gated behind the `ces-managed-sidecar`
-   * feature flag via this config.  When omitted (e.g. CLI / admin
-   * callers), managed mode is allowed unconditionally.
+   * Assistant configuration.
+   * Reserved for future feature-flag checks or config-driven behavior.
    */
   assistantConfig?: AssistantConfig;
 }
@@ -87,10 +78,6 @@ export interface CesProcessManager {
   /**
    * Start the CES process (local) or connect to the sidecar (managed).
    * Returns a CesTransport ready for use with createCesClient().
-   *
-   * When the `ces-managed-sidecar` feature flag is off, managed mode
-   * is skipped even in containerized environments — the process manager
-   * falls back to local discovery.
    *
    * Throws if CES is unavailable.
    */
@@ -118,7 +105,7 @@ export interface CesProcessManager {
 // ---------------------------------------------------------------------------
 
 export function createCesProcessManager(
-  config: CesProcessManagerConfig,
+  _config: CesProcessManagerConfig,
 ): CesProcessManager {
   let childProcess: Subprocess | null = null;
   let managedSocket: Socket | null = null;
@@ -131,31 +118,15 @@ export function createCesProcessManager(
         throw new Error("CES process manager is already running");
       }
 
-      // Feature-flag gate: when the managed sidecar flag is off, skip
-      // managed discovery entirely. This ensures rollback safety —
-      // disabling the flag leaves existing non-agent platform consumers
-      // intact.
-      const managedAllowed = config.assistantConfig
-        ? isCesManagedSidecarEnabled(config.assistantConfig)
-        : true; // No config → allow managed mode unconditionally (CLI/admin callers)
-
-      if (managedAllowed) {
-        discoveryResult = await discoverCes();
-        if (discoveryResult.mode === "unavailable") {
-          // The managed sidecar bootstrap socket is not present — this happens
-          // when the flag is enabled by default but the instance pre-dates the
-          // socket volume mount (e.g. existing Docker configs without the
-          // ces-bootstrap volume). Warn and fall back to local discovery so
-          // these deployments don't fail on upgrade.
-          log.warn(
-            { reason: discoveryResult.reason },
-            "CES managed sidecar bootstrap socket unavailable — falling back to local CES discovery",
-          );
-          discoveryResult = discoverLocalCes();
-        }
-      } else {
-        log.info(
-          "CES managed sidecar feature flag is off — skipping managed discovery, falling back to local",
+      discoveryResult = await discoverCes();
+      if (discoveryResult.mode === "unavailable") {
+        // The managed sidecar bootstrap socket is not present — this happens
+        // when the instance pre-dates the socket volume mount (e.g. existing
+        // Docker configs without the ces-bootstrap volume). Warn and fall
+        // back to local discovery so these deployments don't fail on upgrade.
+        log.warn(
+          { reason: discoveryResult.reason },
+          "CES managed sidecar bootstrap socket unavailable — falling back to local CES discovery",
         );
         discoveryResult = discoverLocalCes();
       }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -106,14 +106,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "ces-managed-sidecar",
-      "scope": "assistant",
-      "key": "ces-managed-sidecar",
-      "label": "CES Managed Sidecar Transport",
-      "description": "Use managed sidecar transport for CES communication when running in a containerized environment",
-      "defaultEnabled": true
-    },
-    {
       "id": "ces-credential-backend",
       "scope": "assistant",
       "key": "ces-credential-backend",


### PR DESCRIPTION
## Summary
- Remove the ces-managed-sidecar feature flag from the registry
- Remove isCesManagedSidecarEnabled function and constant
- Always allow managed sidecar discovery, remove local-only fallback
- Remove feature-flag rollback tests

Part of plan: ga-default-on-flags.md (PR 4 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
