### PR TITLE
feat: GA the `message-height-cache` feature flag

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageHeightCache.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageHeightCache.swift
@@ -1,18 +1,15 @@
 import Foundation
 import SwiftUI
-import VellumAssistantShared
 
 /// Per-conversation cache of each transcript row's measured height, keyed by
 /// the row's `TranscriptItem.id`. Written on every render via the geometry
 /// reader inside `CachedHeightRow`; read only by the scroll debug HUD today
 /// (and by future diagnostics that want a ground-truth height per row).
 ///
-/// The `message-height-cache` feature flag flips the stack from `LazyVStack`
-/// to a plain `VStack` inside `MessageListContentView`. That's what actually
-/// stabilises `scrollContentHeight` — `VStack` measures every cell, so the
-/// scroll view reports the true total height instead of `LazyVStack`'s
-/// drifting estimate. The cache itself is complementary: it records every
-/// row's measured height as a byproduct, useful for inspection.
+/// The transcript uses a plain `VStack` inside `MessageListContentView`,
+/// which measures every cell so the scroll view reports the true total height
+/// without estimator drift. The cache records every row's measured height as
+/// a byproduct, useful for inspection.
 ///
 /// Propagated through `EnvironmentValues.messageHeightCache` alongside the
 /// other transcript stores. Not annotated `@MainActor` because `EnvironmentKey`
@@ -59,56 +56,36 @@ extension EnvironmentValues {
 /// `MessageHeightCache`. Does NOT pin the row's frame — an earlier version
 /// applied `.frame(height: cached)` and produced catastrophic overlap when a
 /// row's content grew past its first-measured height (streaming, thinking
-/// block expanding). The row-height fix now lives at the stack level: the
-/// enclosing `MessageListContentView` swaps `LazyVStack` for a plain `VStack`
-/// when this flag is on, which eliminates the estimator that caused the
-/// jerky scroll in the first place.
-///
-/// When the flag is off the wrapper is a straight passthrough — no geometry
-/// reader, no cache writes — so off-state pays nothing.
+/// block expanding). The row-height fix lives at the stack level: the
+/// enclosing `MessageListContentView` uses a plain `VStack`, which
+/// eliminates the estimator that caused jerky scroll.
 struct CachedHeightRow<Content: View>: View {
     let itemId: UUID
     @ViewBuilder let content: () -> Content
     @Environment(\.messageHeightCache) private var heightCache
 
     var body: some View {
-        if MacOSClientFeatureFlagManager.shared.isEnabled("message-height-cache") {
-            content()
-                .onGeometryChange(for: CGFloat.self) { proxy in
-                    proxy.size.height
-                } action: { newHeight in
-                    heightCache.record(itemId, height: newHeight)
-                }
-        } else {
-            content()
-        }
+        content()
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                heightCache.record(itemId, height: newHeight)
+            }
     }
 }
 
 // MARK: - MessageTranscriptStack
 
-/// Container for the transcript's main content stack. When the
-/// `message-height-cache` flag is on, this is a plain `VStack` — every row
-/// is materialised eagerly, so `scrollContentHeight` equals the true sum of
-/// row heights with no estimator in the middle to drift. When the flag is
-/// off this is the original `LazyVStack`, preserving the existing laziness
-/// (and its estimation quirks) for conversations long enough that eager
-/// layout would be too expensive.
-///
-/// The flag toggle is a clean A/B: correctness vs. laziness.
+/// Container for the transcript's main content stack. Uses a plain `VStack`
+/// so every row is materialised eagerly and `scrollContentHeight` equals the
+/// true sum of row heights with no estimator in the middle to drift.
 struct MessageTranscriptStack<Content: View>: View {
     let spacing: CGFloat
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        if MacOSClientFeatureFlagManager.shared.isEnabled("message-height-cache") {
-            VStack(alignment: .leading, spacing: spacing) {
-                content()
-            }
-        } else {
-            LazyVStack(alignment: .leading, spacing: spacing) {
-                content()
-            }
+        VStack(alignment: .leading, spacing: spacing) {
+            content()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -317,16 +317,11 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Body
 
     var body: some View {
-        // WARNING: This LazyVStack uses .transaction { $0.animation = nil } to suppress
+        // WARNING: This VStack uses .transaction { $0.animation = nil } to suppress
         // all insertion/removal animations. Without this, SwiftUI calls motionVectors()
         // during any item insertion, which measures ALL children via sizeThatFits —
         // causing multi-minute hangs on long conversations. Do NOT remove the
         // .transaction modifier or wrap content changes in withAnimation.
-        //
-        // `MessageTranscriptStack` is `LazyVStack` by default, and swaps to a
-        // plain `VStack` when the `message-height-cache` flag is on — that's
-        // the experimental path for fixing contentH drift at the cost of
-        // eager layout. Same `.transaction` guard covers both.
         MessageTranscriptStack(spacing: VSpacing.md) {
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -106,12 +106,11 @@ struct MessageListView: View {
     /// Owned here (same level as `thinkingBlockExpansionStore`) so the state
     /// survives view-tree destruction. See `FilePreviewExpansionStore.swift`.
     @State var filePreviewExpansionStore = FilePreviewExpansionStore()
-    /// Caches each transcript row's measured height so the LazyVStack reports
-    /// an accurate `contentSize` for off-screen cells. Gated on the
-    /// `message-height-cache` macOS feature flag. `.id(conversationId)` is
-    /// applied to the inner `ScrollView` (not `MessageListView`), so SwiftUI
-    /// preserves this `@State` across conversation switches — the cache must
-    /// be cleared explicitly in `handleConversationSwitched()` to avoid
+    /// Caches each transcript row's measured height so the VStack reports
+    /// an accurate `contentSize`. `.id(conversationId)` is applied to the
+    /// inner `ScrollView` (not `MessageListView`), so SwiftUI preserves
+    /// this `@State` across conversation switches — the cache must be
+    /// cleared explicitly in `handleConversationSwitched()` to avoid
     /// reusing heights keyed by fixed-sentinel UUIDs (e.g. queuedMarker)
     /// across conversations. Also reset on column-width and typography
     /// changes, which reflow every row.

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -346,14 +346,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "message-height-cache",
-      "scope": "client",
-      "key": "message-height-cache",
-      "label": "Message Height Cache",
-      "description": "Swap the transcript's LazyVStack for a plain VStack so scrollContentHeight is the true sum of row heights (no LazyVStack estimator drift). Row frames are not pinned — the earlier frame-pinning approach was removed because it caused overlap when rows grew past their first measurement (streaming, expanding thinking blocks). Tradeoff: eager layout — every row measures up-front, which can stall for many seconds to minutes on very long conversations.",
-      "defaultEnabled": true
-    },
-    {
       "id": "coding-agents-panel",
       "scope": "client",
       "key": "coding-agents-panel",


### PR DESCRIPTION
## Summary
- Remove the message-height-cache feature flag from the registry
- Always use VStack (remove LazyVStack fallback)
- Always record geometry changes for height caching
- Remove flag-related comments

Part of plan: ga-default-on-flags.md (PR 16 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
