### PR TITLE
feat: GA the `sounds` feature flag

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 // Test-scoped config state
 // ---------------------------------------------------------------------------
 
-const DECLARED_FLAG_ID = "sounds";
+const DECLARED_FLAG_ID = "email-channel";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 
 const { isAssistantFeatureFlagEnabled, _setOverridesForTesting } =
@@ -54,10 +54,12 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("missing persisted value falls back to defaults registry defaultEnabled", () => {
     // No explicit config at all — should fall back to defaults registry
-    // which has defaultEnabled: true for sounds
+    // which has defaultEnabled: false for email-channel
     const config = {} as any;
 
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
+      false,
+    );
   });
 
   test("unknown flag defaults to true when no persisted override", () => {
@@ -87,7 +89,7 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
     ).toBe(false);
   });
 
-  test("enabled when no override set (registry default is true)", () => {
+  test("disabled when no override set (registry default is false)", () => {
     const config = {} as any;
 
     expect(
@@ -95,6 +97,6 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
         config,
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -180,7 +180,7 @@ describe("CES flags do not affect unrelated flags", () => {
     expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
   });
 
-  test("enabling all CES flags does not change sounds flag (defaultEnabled: true)", () => {
+  test("enabling all CES flags does not change app-builder-multifile flag (defaultEnabled: true)", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
@@ -188,7 +188,9 @@ describe("CES flags do not affect unrelated flags", () => {
     _setOverridesForTesting(overrides);
     const config = makeConfig();
 
-    // sounds defaults to true in the registry and should stay true
-    expect(isAssistantFeatureFlagEnabled("sounds", config)).toBe(true);
+    // app-builder-multifile defaults to true in the registry and should stay true
+    expect(isAssistantFeatureFlagEnabled("app-builder-multifile", config)).toBe(
+      true,
+    );
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -16,9 +16,9 @@ afterEach(() => {
   _setOverridesForTesting({});
 });
 
-const DECLARED_FLAG_ID = "sounds";
+const DECLARED_FLAG_ID = "email-channel";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
-const DECLARED_SKILL_ID = "sounds";
+const DECLARED_SKILL_ID = "email-channel";
 const APP_BUILDER_MULTIFILE_FLAG_KEY = "app-builder-multifile";
 // ---------------------------------------------------------------------------
 // Helpers
@@ -91,14 +91,14 @@ describe("skillFlagKey", () => {
 // ---------------------------------------------------------------------------
 
 describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
-  test("returns true when no flag overrides (registry default is true)", () => {
+  test("returns false when no flag overrides (registry default is false)", () => {
     const config = makeConfig();
     expect(
       isAssistantFeatureFlagEnabled(
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
         config,
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("returns true when skill key is explicitly true", () => {
@@ -144,8 +144,10 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("falls back to registry default when no override", () => {
     const config = makeConfig();
-    // sounds defaults to true in the registry
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
+    // email-channel defaults to false in the registry
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
+      false,
+    );
   });
 
   test("respects persisted overrides for undeclared keys", () => {
@@ -209,14 +211,13 @@ describe("resolveSkillStates with feature flags", () => {
     expect(ids).toContain("browser");
   });
 
-  test("declared flag key defaults to registry value (true)", () => {
+  test("declared flag key defaults to registry value (false)", () => {
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // sounds registry default is true, so it passes through
-    expect(resolved.length).toBe(1);
-    expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
+    // email-channel registry default is false, so it is filtered out
+    expect(resolved.length).toBe(0);
   });
 
   test("skill without featureFlag is never flag-gated", () => {
@@ -272,7 +273,7 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // sounds and deploy explicitly false; browser explicitly true
+    // email-channel and deploy explicitly false; browser explicitly true
     expect(ids).toEqual(["browser"]);
   });
 });
@@ -282,15 +283,14 @@ describe("resolveSkillStates with feature flags", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveSkillStates with frontmatter featureFlag", () => {
-  test("skill with featureFlag (defaultEnabled: true) is included when no config override", () => {
-    // sounds has defaultEnabled: true in the registry
+  test("skill with featureFlag (defaultEnabled: false) is excluded when no config override", () => {
+    // email-channel has defaultEnabled: false in the registry
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // No override, registry default is true → passes through
-    expect(resolved.length).toBe(1);
-    expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
+    // No override, registry default is false → filtered out
+    expect(resolved.length).toBe(0);
   });
 
   test("skill with featureFlag is included when override enables it", () => {

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -12,8 +12,8 @@ const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 
 let currentConfig: Record<string, unknown> = {};
 
-const DECLARED_SKILL_ID = "sounds";
-const DECLARED_FLAG_KEY = "sounds";
+const DECLARED_SKILL_ID = "email-channel";
+const DECLARED_FLAG_KEY = "email-channel";
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {
   get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
@@ -99,8 +99,8 @@ describe("skill_load feature flag enforcement", () => {
   test("returns deterministic error for flag OFF skill", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Sounds",
-      "Toggle sounds behavior",
+      "Email Channel",
+      "Toggle email channel behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -120,8 +120,8 @@ describe("skill_load feature flag enforcement", () => {
   test("loads skill normally when flag is ON", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Sounds",
-      "Toggle sounds behavior",
+      "Email Channel",
+      "Toggle email channel behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -134,14 +134,14 @@ describe("skill_load feature flag enforcement", () => {
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Sounds");
+    expect(result.content).toContain("Skill: Email Channel");
   });
 
-  test("loads skill when flag key is absent (registry defaults to enabled)", async () => {
+  test("returns error when flag key is absent (registry defaults to disabled)", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Sounds",
-      "Toggle sounds behavior",
+      "Email Channel",
+      "Toggle email channel behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -153,8 +153,8 @@ describe("skill_load feature flag enforcement", () => {
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
-    // sounds is declared in the registry with defaultEnabled: true
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Sounds");
+    // email-channel is declared in the registry with defaultEnabled: false
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("disabled by feature flag");
   });
 });

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -34,7 +34,6 @@ enum SettingsTab: String {
 
     static func sidebarTopTabs(
         billingEnabled: Bool = false,
-        soundsEnabled: Bool = true,
         debugEnabled: Bool = false,
         includeCompactionPlayground: Bool = false
     ) -> [SettingsTab] {
@@ -44,7 +43,7 @@ enum SettingsTab: String {
         }
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
-        if soundsEnabled { tabs.append(.sounds) }
+        tabs.append(.sounds)
         if billingEnabled { tabs.append(.billing) }
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
@@ -95,11 +94,6 @@ struct SettingsPanel: View {
         let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
         _isBillingEnabled = State(initialValue: billingEnabled)
 
-        // Pre-compute the sounds flag so deep-link validation below uses
-        // the actual config value instead of the @State default (true).
-        let soundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
-        _isSoundsEnabled = State(initialValue: soundsEnabled)
-
         // Derive the initial tab from the pending deep-link at construction
         // time. Previous attempts set selectedTab in onAppear / onChange, but
         // those fire *after* the first render and are susceptible to timing
@@ -122,7 +116,6 @@ struct SettingsPanel: View {
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
             let visibleTabs = SettingsTab.sidebarTopTabs(
                 billingEnabled: canShowBilling,
-                soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
             )
@@ -157,7 +150,6 @@ struct SettingsPanel: View {
     @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
-    @State private var isSoundsEnabled: Bool = true
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var isEmailChannelEnabled: Bool = false
     @State private var showingDevUnlock: Bool = false
@@ -170,7 +162,6 @@ struct SettingsPanel: View {
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
-    private static let soundsFeatureFlagKey = "sounds"
     private static let deferredDeepLinkTabs: Set<SettingsTab> = [.developer, .compactionPlayground]
 
     var body: some View {
@@ -238,7 +229,6 @@ struct SettingsPanel: View {
         }
         .onAppear {
             isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
-            isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -272,9 +262,6 @@ struct SettingsPanel: View {
         .onChange(of: isDebugVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
-        .onChange(of: isSoundsEnabled) { _, _ in
-            handleSidebarVisibilityChanged()
-        }
         .onChange(of: isDeveloperEnabled) { _, _ in
             handleSidebarVisibilityChanged()
         }
@@ -292,8 +279,6 @@ struct SettingsPanel: View {
                     isCompactionPlaygroundEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
-                } else if key == Self.soundsFeatureFlagKey {
-                    isSoundsEnabled = enabled
                 }
             }
         }
@@ -391,7 +376,6 @@ struct SettingsPanel: View {
     private var visibleSidebarTopTabs: [SettingsTab] {
         SettingsTab.sidebarTopTabs(
             billingEnabled: billingVisible,
-            soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
         )
@@ -737,9 +721,6 @@ struct SettingsPanel: View {
                 if let emailChannelFlag = flags.first(where: { $0.key == Self.emailChannelFeatureFlagKey }) {
                     isEmailChannelEnabled = emailChannelFlag.enabled
                 }
-                if let soundsFlag = flags.first(where: { $0.key == Self.soundsFeatureFlagKey }) {
-                    isSoundsEnabled = soundsFlag.enabled
-                }
                 handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
                 hasLoadedFeatureFlags = true
                 return
@@ -763,9 +744,6 @@ struct SettingsPanel: View {
         }
         if let emailChannelEnabled = resolved[Self.emailChannelFeatureFlagKey] {
             isEmailChannelEnabled = emailChannelEnabled
-        }
-        if let soundsEnabled = resolved[Self.soundsFeatureFlagKey] {
-            isSoundsEnabled = soundsEnabled
         }
         handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
         hasLoadedFeatureFlags = true

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -218,14 +218,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "sounds",
-      "scope": "assistant",
-      "key": "sounds",
-      "label": "Sounds",
-      "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
-      "defaultEnabled": true
-    },
-    {
       "id": "message-tts",
       "scope": "assistant",
       "key": "message-tts",


### PR DESCRIPTION
## Summary
- Remove the sounds feature flag from the registry
- Sounds tab always visible in settings sidebar
- Remove soundsEnabled parameter from sidebarTopTabs()
- Update test fixtures to use a different flag for testing mechanics

Part of plan: ga-default-on-flags.md (PR 13 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
