### PR TITLE
feat: GA the `inline-skill-commands` feature flag

### DIFF
--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -1,8 +1,7 @@
 /**
  * Tests for inline-command skill load permission handling.
  *
- * When a skill contains inline command expansions (!\`...\`) and the
- * inline-skill-commands flag is on, the permission
+ * When a skill contains inline command expansions (!\`...\`), the permission
  * system must:
  *
  * 1. Emit skill_load_dynamic:<id>@<hash> / skill_load_dynamic:<id> candidates
@@ -16,8 +15,6 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 
 // ── Mock setup (must be before any imports from the project) ──────────────
 
@@ -124,9 +121,6 @@ describe("inline-command skill_load permissions", () => {
       headless: "none",
     });
     testConfig.skills = { load: { extraDirs: [] } };
-    _setOverridesForTesting({
-      "inline-skill-commands": true,
-    });
     try {
       rmSync(join(testDir, "protected", "trust.json"));
     } catch {
@@ -188,28 +182,6 @@ describe("inline-command skill_load permissions", () => {
       );
       expect(result.decision).toBe("allow");
     });
-
-  });
-
-  // ── Feature flag disabled ────────────────────────────────────────────
-
-  describe("feature flag disabled", () => {
-    test("dynamic skill auto-allows when flag is off (low risk threshold)", async () => {
-      ensureSkillsDir();
-      writeDynamicSkill("dynamic-flag-off", "Dynamic Flag Off Skill");
-
-      // Disable the feature flag
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      const result = await check(
-        "skill_load",
-        { skill: "dynamic-flag-off" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("allow");
-    });
   });
 
   // ── Allowlist options ────────────────────────────────────────────────
@@ -253,5 +225,4 @@ describe("inline-command skill_load permissions", () => {
       }
     });
   });
-
 });

--- a/assistant/src/__tests__/skill-load-inline-command.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-command.test.ts
@@ -4,8 +4,6 @@
  * Validates that:
  * - Root skills with `!\`command\`` tokens get those tokens expanded exactly
  *   once at skill_load time, wrapped in <inline_skill_command> XML tags.
- * - When the feature flag is off, skill_load returns an error instead of
- *   leaving unresolved live tokens in the prompt.
  * - When the skill source is "extra", skill_load rejects with a specific error.
  * - Render failures produce stable inline stubs rather than raw stderr.
  */
@@ -13,8 +11,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 
 // ── Test directory ────────────────────────────────────────────────────────────
 
@@ -163,10 +159,6 @@ describe("skill_load inline command expansion", () => {
       ) => mockRunInlineCommand(command, workingDir),
     }));
 
-    // Enable the feature flag
-    _setOverridesForTesting({
-      "inline-skill-commands": true,
-    });
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
@@ -252,48 +244,6 @@ describe("skill_load inline command expansion", () => {
       expect(result.content).not.toContain("inline_skill_command");
       // Runner should not be called
       expect(runInlineCommandCalls).toHaveLength(0);
-    });
-  });
-
-  // ── Feature flag off ─────────────────────────────────────────────────
-
-  describe("feature flag disabled", () => {
-    test("returns error when flag is off and skill has inline commands", async () => {
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      writeSkill(
-        "flagged-off-skill",
-        "Flagged Off Skill",
-        "Has inline commands",
-        "Data: !`echo hello`",
-      );
-
-      const result = await executeSkillLoad({ skill: "flagged-off-skill" });
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain(
-        "inline-skill-commands feature flag is disabled",
-      );
-      // Runner should not be called when flag is off
-      expect(runInlineCommandCalls).toHaveLength(0);
-    });
-
-    test("plain skill still loads when flag is off", async () => {
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      writeSkill(
-        "plain-flag-off",
-        "Plain Flag Off",
-        "No inline commands",
-        "Regular content.",
-      );
-
-      const result = await executeSkillLoad({ skill: "plain-flag-off" });
-      expect(result.isError).toBe(false);
-      expect(result.content).toContain("Regular content.");
     });
   });
 

--- a/assistant/src/__tests__/skill-load-inline-includes.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-includes.test.ts
@@ -16,8 +16,6 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
-
 // ── Test directory ────────────────────────────────────────────────────────────
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
@@ -173,10 +171,6 @@ describe("skill_load inline command expansion for included skills", () => {
       ) => mockRunInlineCommand(command, workingDir),
     }));
 
-    // Enable the feature flag
-    _setOverridesForTesting({
-      "inline-skill-commands": true,
-    });
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
@@ -511,42 +505,6 @@ describe("skill_load inline command expansion for included skills", () => {
 
       // Root body intact
       expect(result.content).toContain("Root body.");
-    });
-  });
-
-  // ── Feature flag off for child inline commands ────────────────────────
-
-  describe("feature flag disabled for included skills", () => {
-    test("skill_load returns error when child has inline commands and flag is off", async () => {
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      writeSkill(
-        "child-flag-off",
-        "Flag Off Child",
-        "Child with inline cmds",
-        "Data: !`echo hello`",
-      );
-      writeSkill(
-        "parent-flag-off",
-        "Parent Flag Off",
-        "Parent for flag-off test",
-        "Root content.",
-        { includes: ["child-flag-off"] },
-      );
-
-      const result = await executeSkillLoad({ skill: "parent-flag-off" });
-      // Fail closed: the entire skill_load must error when any included child
-      // has inline commands and the feature flag is off, matching the root
-      // skill behavior and the documented fail-closed contract.
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain("child-flag-off");
-      expect(result.content).toContain(
-        "inline-skill-commands feature flag is disabled",
-      );
-      // Runner should not be called
-      expect(runInlineCommandCalls).toHaveLength(0);
     });
   });
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
@@ -268,23 +267,17 @@ function resolveSkillMetadata(selector: string): SkillMetadata | undefined {
   const resolved = resolveSkillIdAndHash(selector);
   if (!resolved) return undefined;
 
-  const config = getConfig();
-  const inlineEnabled = isAssistantFeatureFlagEnabled(
-    "inline-skill-commands",
-    config,
-  );
   const inlineExpansions = hasInlineExpansions(resolved.id);
-  const isDynamic = inlineEnabled && inlineExpansions;
 
   return {
     skillId: resolved.id,
     selector,
     versionHash: resolved.versionHash ?? "",
-    transitiveHash: isDynamic
+    transitiveHash: inlineExpansions
       ? computeTransitiveHashSafe(resolved.id)
       : undefined,
     hasInlineExpansions: inlineExpansions,
-    isDynamic,
+    isDynamic: inlineExpansions,
   };
 }
 
@@ -726,14 +719,7 @@ function skillLoadAllowlistStrategy(
   if (rawSelector) {
     const resolved = resolveSkillIdAndHash(rawSelector);
 
-    // Check whether this is a dynamic (inline-command) skill load
-    const config = getConfig();
-    const inlineEnabled = isAssistantFeatureFlagEnabled(
-      "inline-skill-commands",
-      config,
-    );
-
-    if (resolved && inlineEnabled && hasInlineExpansions(resolved.id)) {
+    if (resolved && hasInlineExpansions(resolved.id)) {
       const transitiveHash = computeTransitiveHashSafe(resolved.id);
       const options: AllowlistOption[] = [];
       if (transitiveHash) {

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -29,9 +29,6 @@ import { getWorkspaceDirDisplay } from "../../util/platform.js";
 import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
-/** Canonical feature flag key for inline skill command expansion. */
-const INLINE_COMMANDS_FLAG_KEY = "inline-skill-commands";
-
 /** Skill sources eligible for inline command expansion in v1. */
 const INLINE_COMMAND_ELIGIBLE_SOURCES = new Set([
   "bundled",
@@ -300,20 +297,6 @@ export class SkillLoadTool implements Tool {
       skill.inlineCommandExpansions && skill.inlineCommandExpansions.length > 0;
 
     if (hasInlineCommands) {
-      const inlineFlagEnabled = isAssistantFeatureFlagEnabled(
-        INLINE_COMMANDS_FLAG_KEY,
-        config,
-      );
-
-      if (!inlineFlagEnabled) {
-        // Feature flag is off: fail closed instead of leaving live tokens in
-        // the prompt that the LLM might try to interpret.
-        return {
-          content: `Error: skill "${skill.id}" contains inline command expansions but the inline-skill-commands feature flag is disabled. Enable the flag to use this skill.`,
-          isError: true,
-        };
-      }
-
       if (skill.source === "extra") {
         // Third-party extra roots are out of scope for inline command
         // expansion in v1. Reject explicitly so the failure is clear.
@@ -391,21 +374,6 @@ export class SkillLoadTool implements Tool {
             childLoaded.skill.inlineCommandExpansions.length > 0;
 
           if (childHasInlineCommands) {
-            const childInlineFlagEnabled = isAssistantFeatureFlagEnabled(
-              INLINE_COMMANDS_FLAG_KEY,
-              config,
-            );
-
-            // Fail closed: if the flag is off, reject the entire skill_load
-            // just like we do for root skills. Leaving raw !`...` tokens in
-            // the prompt would violate the documented fail-closed contract.
-            if (!childInlineFlagEnabled) {
-              return {
-                content: `Error: included skill "${childId}" contains inline command expansions but the inline-skill-commands feature flag is disabled. Enable the flag to use skill "${skill.id}".`,
-                isError: true,
-              };
-            }
-
             if (childLoaded.skill.source === "extra") {
               return {
                 content: `Error: included skill "${childId}" contains inline command expansions but inline commands are not supported for third-party (extra) skill sources.`,

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -202,14 +202,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "inline-skill-commands",
-      "scope": "assistant",
-      "key": "inline-skill-commands",
-      "label": "Inline Skill Command Expansion",
-      "description": "Enable secure inline skill command expansion via !`command` syntax, with version-pinned approval and sandboxed execution at skill load time",
-      "defaultEnabled": true
-    },
-    {
       "id": "channel-voice-transcription",
       "scope": "assistant",
       "key": "channel-voice-transcription",


### PR DESCRIPTION
## Summary
- Remove the inline-skill-commands feature flag from the registry
- Inline command expansion always enabled, remove flag checks from load.ts and checker.ts
- Remove flag-off test scenarios from skill load tests

Part of plan: ga-default-on-flags.md (PR 11 of 18)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
