### PR TITLE
Increase hatch timeout to 300s in CLI and macOS app

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -32,7 +32,7 @@ export type { PollResult, WatchHatchingResult } from "../lib/gcp";
 const INSTALL_SCRIPT_REMOTE_PATH = "/tmp/vellum-install.sh";
 
 const HATCH_TIMEOUT_MS: Record<Species, number> = {
-  vellum: 2 * 60 * 1000,
+  vellum: 5 * 60 * 1000,
   openclaw: 10 * 60 * 1000,
 };
 const DEFAULT_SPECIES: Species = "vellum";

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -468,6 +468,7 @@ export async function hatchAssistant(
     method: "POST",
     headers: await authHeaders(token, platformUrl),
     body: JSON.stringify({}),
+    signal: AbortSignal.timeout(300_000),
   });
 
   if (response.ok) {

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -362,7 +362,7 @@ public final class AuthService {
             method: "POST",
             organizationId: organizationId,
             body: bodyData,
-            timeoutInterval: 30
+            timeoutInterval: 300
         )
 
         if response.statusCode == 401 {


### PR DESCRIPTION
Increases hatch timeouts to 300s to match the platform backend and vembda timeouts, preventing premature client-side timeouts during slow provisioning.

- CLI: vellum species `HATCH_TIMEOUT_MS` raised from 120s to 300s
- CLI: `hatchAssistant` fetch now has explicit 300s `AbortSignal.timeout`
- macOS AuthService: `hatchAssistant` HTTP timeout raised from 30s to 300s

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/728facfa7f0945f090dc0059c10102e2

## Test plan
- CI lint checks pass (no macOS build in CI)
- Manual verification: hatch flow should tolerate up to 5 minutes of provisioning time
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
