### PR TITLE
fix: make backward-releases unconditionally enabled in AssistantUpgradeSection

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -58,8 +58,8 @@ struct AssistantUpgradeSection: View {
     @State private var isTakingLongerThanExpected = false
     @State private var escalationTask: Task<Void, Never>?
     @State private var dockerUpgradeTask: Task<Void, Never>?
-    @State private var backwardReleasesEnabled = false
-    private let featureFlagClient = FeatureFlagClient()
+    @State private var backwardReleasesEnabled = true
+
 
     private var latestRelease: AssistantRelease? {
         availableReleases.first
@@ -381,11 +381,6 @@ struct AssistantUpgradeSection: View {
             }
         }
         .task { await loadReleases() }
-        .task {
-            if let flags = try? await featureFlagClient.getFeatureFlags() {
-                backwardReleasesEnabled = flags.first(where: { $0.key == "backward-releases" })?.enabled ?? false
-            }
-        }
         .onChange(of: currentVersion) { _, _ in
             Task { await loadReleasesQuietly() }
         }


### PR DESCRIPTION
## Summary
- Fix missed runtime reference to backward-releases flag in AssistantUpgradeSection.swift
- Set backwardReleasesEnabled default to true and remove the flag lookup task
- Remove unused featureFlagClient property

Part of plan: ga-default-on-flags.md (gap fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
