### PR TITLE
feat: GA all 18 default-on feature flags

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -71,38 +71,7 @@ function mockStore(
 // ---------------------------------------------------------------------------
 
 describe("executeAppCreate", () => {
-  test("flag off: creates legacy app with root index.html", async () => {
-    const files: Record<string, string> = {};
-    let createdParams: Record<string, unknown> | undefined;
-    const app = makeLegacyApp();
-    const store: AppStore = {
-      ...mockStore(app, files),
-      createApp: (params) => {
-        createdParams = params as unknown as Record<string, unknown>;
-        return app;
-      },
-    };
-
-    const result = await executeAppCreate(
-      {
-        name: "Test App",
-        html: "<html><body>Hello</body></html>",
-      },
-      store,
-    );
-
-    expect(result.isError).toBe(false);
-    // Legacy path: no formatVersion set, htmlDefinition is the provided html
-    expect(createdParams?.formatVersion).toBeUndefined();
-    expect(createdParams?.htmlDefinition).toBe(
-      "<html><body>Hello</body></html>",
-    );
-    // No src/ files should be written
-    expect(files["src/index.html"]).toBeUndefined();
-    expect(files["src/main.tsx"]).toBeUndefined();
-  });
-
-  test("flag on: creates multifile app with src/ scaffold", async () => {
+  test("creates multifile app with src/ scaffold", async () => {
     const files: Record<string, string> = {};
     let createdParams: Record<string, unknown> | undefined;
     const app = makeMultifileApp({ name: "New App" });
@@ -117,7 +86,6 @@ describe("executeAppCreate", () => {
     const result = await executeAppCreate(
       {
         name: "New App",
-        featureFlags: { multifileEnabled: true },
       },
       store,
     );
@@ -136,7 +104,7 @@ describe("executeAppCreate", () => {
     expect(files["src/main.tsx"]).toContain('{"Hello, New App!"}');
   });
 
-  test("flag on with explicit html: uses provided html as src/index.html", async () => {
+  test("with explicit html: uses provided html as src/index.html", async () => {
     const files: Record<string, string> = {};
     const app = makeMultifileApp({ name: "Custom App" });
     const store: AppStore = {
@@ -150,7 +118,6 @@ describe("executeAppCreate", () => {
       {
         name: "Custom App",
         html: customHtml,
-        featureFlags: { multifileEnabled: true },
       },
       store,
     );

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 // Test-scoped config state
 // ---------------------------------------------------------------------------
 
-const DECLARED_FLAG_ID = "sounds";
+const DECLARED_FLAG_ID = "email-channel";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 
 const { isAssistantFeatureFlagEnabled, _setOverridesForTesting } =
@@ -54,10 +54,12 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("missing persisted value falls back to defaults registry defaultEnabled", () => {
     // No explicit config at all — should fall back to defaults registry
-    // which has defaultEnabled: true for sounds
+    // which has defaultEnabled: false for email-channel
     const config = {} as any;
 
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
+      false,
+    );
   });
 
   test("unknown flag defaults to true when no persisted override", () => {
@@ -89,7 +91,7 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
     ).toBe(false);
   });
 
-  test("enabled when no override set (registry default is true)", () => {
+  test("disabled when no override set (registry default is false)", () => {
     const config = {} as any;
 
     expect(
@@ -97,6 +99,6 @@ describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
         config,
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -67,10 +67,12 @@ describe("isAssistantFeatureFlagEnabled", () => {
   });
 
   test("undeclared flag respects persisted override", () => {
-    _setOverridesForTesting({ browser: false });
+    _setOverridesForTesting({ "some-undeclared-flag": false });
     const config = {} as any;
 
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(false);
+    expect(isAssistantFeatureFlagEnabled("some-undeclared-flag", config)).toBe(
+      false,
+    );
   });
 });
 

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -159,7 +159,7 @@ describe("CES flags respect explicit false overrides", () => {
 // ---------------------------------------------------------------------------
 
 describe("CES flags do not affect unrelated flags", () => {
-  test("enabling all CES flags does not change sounds flag (defaultEnabled: true)", () => {
+  test("enabling all CES flags does not change browser flag (defaultEnabled: true)", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
@@ -167,7 +167,21 @@ describe("CES flags do not affect unrelated flags", () => {
     _setOverridesForTesting(overrides);
     const config = makeConfig();
 
-    // sounds defaults to true in the registry and should stay true
-    expect(isAssistantFeatureFlagEnabled("sounds", config)).toBe(true);
+    // browser defaults to true in the registry and should stay true
+    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
+  });
+
+  test("enabling all CES flags does not change app-builder-multifile flag (defaultEnabled: true)", () => {
+    const overrides: Record<string, boolean> = {};
+    for (const key of ALL_CES_FLAG_KEYS) {
+      overrides[key] = true;
+    }
+    _setOverridesForTesting(overrides);
+    const config = makeConfig();
+
+    // app-builder-multifile defaults to true in the registry and should stay true
+    expect(isAssistantFeatureFlagEnabled("app-builder-multifile", config)).toBe(
+      true,
+    );
   });
 });

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -168,18 +168,6 @@ describe("CES flags respect explicit false overrides", () => {
 // ---------------------------------------------------------------------------
 
 describe("CES flags do not affect unrelated flags", () => {
-  test("enabling all CES flags does not change browser flag (defaultEnabled: true)", () => {
-    const overrides: Record<string, boolean> = {};
-    for (const key of ALL_CES_FLAG_KEYS) {
-      overrides[key] = true;
-    }
-    _setOverridesForTesting(overrides);
-    const config = makeConfig();
-
-    // browser defaults to true in the registry and should stay true
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
-  });
-
   test("enabling all CES flags does not change sounds flag (defaultEnabled: true)", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -17,12 +17,10 @@ import {
 import type { AssistantConfig } from "../config/schema.js";
 import {
   CES_GRANT_AUDIT_FLAG_KEY,
-  CES_MANAGED_SIDECAR_FLAG_KEY,
   CES_SECURE_INSTALL_FLAG_KEY,
   CES_SHELL_LOCKDOWN_FLAG_KEY,
   CES_TOOLS_FLAG_KEY,
   isCesGrantAuditEnabled,
-  isCesManagedSidecarEnabled,
   isCesSecureInstallEnabled,
   isCesShellLockdownEnabled,
   isCesToolsEnabled,
@@ -51,7 +49,6 @@ const ALL_CES_FLAG_KEYS = [
   CES_SHELL_LOCKDOWN_FLAG_KEY,
   CES_SECURE_INSTALL_FLAG_KEY,
   CES_GRANT_AUDIT_FLAG_KEY,
-  CES_MANAGED_SIDECAR_FLAG_KEY,
 ] as const;
 
 /** All CES predicate functions paired with their flag keys and expected defaults. */
@@ -79,12 +76,6 @@ const ALL_CES_PREDICATES = [
     fn: isCesGrantAuditEnabled,
     key: CES_GRANT_AUDIT_FLAG_KEY,
     defaultEnabled: false,
-  },
-  {
-    name: "isCesManagedSidecarEnabled",
-    fn: isCesManagedSidecarEnabled,
-    key: CES_MANAGED_SIDECAR_FLAG_KEY,
-    defaultEnabled: true,
   },
 ] as const;
 

--- a/assistant/src/__tests__/credential-execution-managed-contract.test.ts
+++ b/assistant/src/__tests__/credential-execution-managed-contract.test.ts
@@ -1,8 +1,8 @@
 /**
  * Managed CES contract and wiring tests.
  *
- * Validates the contract surface, behavioral invariants, and feature-flag
- * gating for the managed (three-container pod) CES sidecar integration:
+ * Validates the contract surface and behavioral invariants for the managed
+ * (three-container pod) CES sidecar integration:
  *
  * 1. Pod creation contract: well-known path constants match the
  *    stateful_template.yaml K8s spec (read-only mount + private PVC).
@@ -18,25 +18,11 @@
  *    (UpdateManagedCredential, MakeAuthenticatedRequest) validate expected
  *    payloads and reject malformed ones at the contract level.
  *
- * 5. Feature-flag rollback: when the `ces-managed-sidecar` flag is off,
- *    the process manager falls back to local discovery and never attempts
- *    the managed sidecar path.
- *
  * All tests use contract schemas and handle parsers to verify behavioral
  * contracts — no real CES process or socket dependencies are needed.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
-
-beforeEach(() => {
-  _setOverridesForTesting({});
-});
-
-afterEach(() => {
-  _setOverridesForTesting({});
-});
+import { describe, expect, test } from "bun:test";
 
 import {
   CES_PROTOCOL_VERSION,
@@ -53,25 +39,10 @@ import {
   UpdateManagedCredentialSchema,
 } from "@vellumai/service-contracts/credential-rpc";
 
-import type { AssistantConfig } from "../config/schema.js";
-import {
-  isCesManagedSidecarEnabled,
-  isCesToolsEnabled,
-} from "../credential-execution/feature-gates.js";
 import {
   CES_ASSISTANT_DATA_READONLY_MOUNT,
   CES_PRIVATE_DATA_DIR,
-  type CesProcessManagerConfig,
 } from "../credential-execution/process-manager.js";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Create a minimal AssistantConfig (flag overrides are now set via _setOverridesForTesting). */
-function makeConfig(): AssistantConfig {
-  return {} as AssistantConfig;
-}
 
 // ---------------------------------------------------------------------------
 // Well-known paths contract
@@ -438,104 +409,5 @@ describe("managed OAuth materialization through CES sidecar", () => {
         expect(parsed.handle.connectionId).toBe("conn_abc123");
       }
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Feature-flag rollback safety
-// ---------------------------------------------------------------------------
-
-describe("feature-flag rollback safety", () => {
-  test("managed sidecar flag defaults to true (enabled by default)", () => {
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(true);
-  });
-
-  test("managed sidecar flag can be explicitly enabled", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": true,
-    });
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(true);
-  });
-
-  test("managed sidecar flag can be explicitly disabled", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-    });
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(false);
-  });
-
-  test("enabling managed sidecar does not enable CES tools", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": true,
-    });
-    const config = makeConfig();
-    // CES tools flag should remain independently controlled
-    expect(isCesToolsEnabled(config)).toBe(false);
-  });
-
-  test("disabling managed sidecar does not affect other CES flags", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-      "ces-tools": true,
-    });
-    const config = makeConfig();
-    expect(isCesToolsEnabled(config)).toBe(true);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Process manager config wiring
-// ---------------------------------------------------------------------------
-
-describe("process manager config wiring", () => {
-  test("CesProcessManagerConfig accepts assistantConfig for flag gating", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": true,
-    });
-    const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig(),
-    };
-    expect(config.assistantConfig).toBeDefined();
-    expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(true);
-  });
-
-  test("CesProcessManagerConfig requires assistantConfig for feature-flag gate", () => {
-    const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig(),
-    };
-    expect(config.assistantConfig).toBeDefined();
-  });
-
-  test("when flag is off, managed discovery is skipped", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-    });
-    const config: CesProcessManagerConfig = {
-      assistantConfig: makeConfig(),
-    };
-    // The managed path should be gated
-    expect(isCesManagedSidecarEnabled(config.assistantConfig!)).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Non-CES internal consumers intact
-// ---------------------------------------------------------------------------
-
-describe("non-CES internal consumers intact when flag is off", () => {
-  test("existing non-agent flows are unaffected by managed sidecar flag", () => {
-    _setOverridesForTesting({
-      "ces-managed-sidecar": false,
-    });
-    const config = makeConfig();
-    expect(isCesManagedSidecarEnabled(config)).toBe(false);
-  });
-
-  test("process manager without config allows managed mode (backward compat)", () => {
-    const config: CesProcessManagerConfig = {};
-    expect(config.assistantConfig).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -1,8 +1,7 @@
 /**
  * Tests for inline-command skill load permission handling.
  *
- * When a skill contains inline command expansions (!\`...\`) and the
- * inline-skill-commands flag is on, the permission
+ * When a skill contains inline command expansions (!\`...\`), the permission
  * system must:
  *
  * 1. Emit skill_load_dynamic:<id>@<hash> / skill_load_dynamic:<id> candidates
@@ -16,8 +15,6 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 
 // ── Mock setup (must be before any imports from the project) ──────────────
 
@@ -124,9 +121,6 @@ describe("inline-command skill_load permissions", () => {
       headless: "none",
     });
     testConfig.skills = { load: { extraDirs: [] } };
-    _setOverridesForTesting({
-      "inline-skill-commands": true,
-    });
     try {
       rmSync(join(testDir, "protected", "trust.json"));
     } catch {
@@ -188,28 +182,6 @@ describe("inline-command skill_load permissions", () => {
       );
       expect(result.decision).toBe("allow");
     });
-
-  });
-
-  // ── Feature flag disabled ────────────────────────────────────────────
-
-  describe("feature flag disabled", () => {
-    test("dynamic skill auto-allows when flag is off (low risk threshold)", async () => {
-      ensureSkillsDir();
-      writeDynamicSkill("dynamic-flag-off", "Dynamic Flag Off Skill");
-
-      // Disable the feature flag
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      const result = await check(
-        "skill_load",
-        { skill: "dynamic-flag-off" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("allow");
-    });
   });
 
   // ── Allowlist options ────────────────────────────────────────────────
@@ -253,5 +225,4 @@ describe("inline-command skill_load permissions", () => {
       }
     });
   });
-
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -19,7 +19,6 @@ afterEach(() => {
 const DECLARED_FLAG_ID = "sounds";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 const DECLARED_SKILL_ID = "sounds";
-const APP_BUILDER_MULTIFILE_FLAG_KEY = "app-builder-multifile";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -154,13 +153,6 @@ describe("isAssistantFeatureFlagEnabled", () => {
     expect(isAssistantFeatureFlagEnabled("some-undeclared-flag", config)).toBe(
       false,
     );
-  });
-
-  test("app-builder-multifile defaults to enabled when no override is set", () => {
-    const config = makeConfig();
-    expect(
-      isAssistantFeatureFlagEnabled(APP_BUILDER_MULTIFILE_FLAG_KEY, config),
-    ).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -16,9 +16,10 @@ afterEach(() => {
   _setOverridesForTesting({});
 });
 
-const DECLARED_FLAG_ID = "sounds";
+const DECLARED_FLAG_ID = "email-channel";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
-const DECLARED_SKILL_ID = "sounds";
+const DECLARED_SKILL_ID = "email-channel";
+const APP_BUILDER_MULTIFILE_FLAG_KEY = "app-builder-multifile";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -90,14 +91,14 @@ describe("skillFlagKey", () => {
 // ---------------------------------------------------------------------------
 
 describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
-  test("returns true when no flag overrides (registry default is true)", () => {
+  test("returns false when no flag overrides (registry default is false)", () => {
     const config = makeConfig();
     expect(
       isAssistantFeatureFlagEnabled(
         skillFlagKey({ featureFlag: DECLARED_FLAG_ID })!,
         config,
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("returns true when skill key is explicitly true", () => {
@@ -143,8 +144,10 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("falls back to registry default when no override", () => {
     const config = makeConfig();
-    // sounds defaults to true in the registry
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
+    // email-channel defaults to false in the registry
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
+      false,
+    );
   });
 
   test("respects persisted overrides for undeclared keys", () => {
@@ -205,14 +208,13 @@ describe("resolveSkillStates with feature flags", () => {
     expect(ids).toContain("app-builder-multifile");
   });
 
-  test("declared flag key defaults to registry value (true)", () => {
+  test("declared flag key defaults to registry value (false)", () => {
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // sounds registry default is true, so it passes through
-    expect(resolved.length).toBe(1);
-    expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
+    // email-channel registry default is false, so it is filtered out
+    expect(resolved.length).toBe(0);
   });
 
   test("skill without featureFlag is never flag-gated", () => {
@@ -272,7 +274,7 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // sounds and deploy explicitly false; app-builder-multifile explicitly true
+    // email-channel and deploy explicitly false; app-builder-multifile explicitly true
     expect(ids).toEqual(["app-builder-multifile"]);
   });
 });
@@ -282,15 +284,14 @@ describe("resolveSkillStates with feature flags", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveSkillStates with frontmatter featureFlag", () => {
-  test("skill with featureFlag (defaultEnabled: true) is included when no config override", () => {
-    // sounds has defaultEnabled: true in the registry
+  test("skill with featureFlag (defaultEnabled: false) is excluded when no config override", () => {
+    // email-channel has defaultEnabled: false in the registry
     const catalog = [makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    // No override, registry default is true → passes through
-    expect(resolved.length).toBe(1);
-    expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
+    // No override, registry default is false → filtered out
+    expect(resolved.length).toBe(0);
   });
 
   test("skill with featureFlag is included when override enables it", () => {

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -149,15 +149,11 @@ describe("isAssistantFeatureFlagEnabled", () => {
   });
 
   test("respects persisted overrides for undeclared keys", () => {
-    _setOverridesForTesting({ browser: false });
+    _setOverridesForTesting({ "some-undeclared-flag": false });
     const config = makeConfig();
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(false);
-  });
-
-  test("declared keys with no persisted override use registry default", () => {
-    const config = makeConfig();
-    // browser is declared in the registry with defaultEnabled: true
-    expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
+    expect(isAssistantFeatureFlagEnabled("some-undeclared-flag", config)).toBe(
+      false,
+    );
   });
 
   test("app-builder-multifile defaults to enabled when no override is set", () => {
@@ -176,11 +172,15 @@ describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      browser: true,
+      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("browser", "bundled", "browser"),
+      makeSkill(
+        "app-builder-multifile",
+        "bundled",
+        APP_BUILDER_MULTIFILE_FLAG_KEY,
+      ),
     ];
     const config = makeConfig();
 
@@ -188,17 +188,21 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).not.toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("browser");
+    expect(ids).toContain("app-builder-multifile");
   });
 
   test("flag ON skill appears normally", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: true,
-      browser: true,
+      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("browser", "bundled", "browser"),
+      makeSkill(
+        "app-builder-multifile",
+        "bundled",
+        APP_BUILDER_MULTIFILE_FLAG_KEY,
+      ),
     ];
     const config = makeConfig();
 
@@ -206,7 +210,7 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("browser");
+    expect(ids).toContain("app-builder-multifile");
   });
 
   test("declared flag key defaults to registry value (true)", () => {
@@ -259,12 +263,16 @@ describe("resolveSkillStates with feature flags", () => {
   test("multiple skills with mixed flags — persisted overrides respected", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      browser: true,
+      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
       deploy: false,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
-      makeSkill("browser", "bundled", "browser"),
+      makeSkill(
+        "app-builder-multifile",
+        "bundled",
+        APP_BUILDER_MULTIFILE_FLAG_KEY,
+      ),
       makeSkill("deploy", "bundled", "deploy"),
     ];
     const config = makeConfig();
@@ -272,8 +280,8 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // sounds and deploy explicitly false; browser explicitly true
-    expect(ids).toEqual(["browser"]);
+    // sounds and deploy explicitly false; app-builder-multifile explicitly true
+    expect(ids).toEqual(["app-builder-multifile"]);
   });
 });
 

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -12,8 +12,8 @@ const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 
 let currentConfig: Record<string, unknown> = {};
 
-const DECLARED_SKILL_ID = "sounds";
-const DECLARED_FLAG_KEY = "sounds";
+const DECLARED_SKILL_ID = "email-channel";
+const DECLARED_FLAG_KEY = "email-channel";
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {
   get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
@@ -99,8 +99,8 @@ describe("skill_load feature flag enforcement", () => {
   test("returns deterministic error for flag OFF skill", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Sounds",
-      "Toggle sounds behavior",
+      "Email Channel",
+      "Toggle email channel behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -120,8 +120,8 @@ describe("skill_load feature flag enforcement", () => {
   test("loads skill normally when flag is ON", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Sounds",
-      "Toggle sounds behavior",
+      "Email Channel",
+      "Toggle email channel behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -134,14 +134,14 @@ describe("skill_load feature flag enforcement", () => {
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
     expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Sounds");
+    expect(result.content).toContain("Skill: Email Channel");
   });
 
-  test("loads skill when flag key is absent (registry defaults to enabled)", async () => {
+  test("returns error when flag key is absent (registry defaults to disabled)", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
-      "Sounds",
-      "Toggle sounds behavior",
+      "Email Channel",
+      "Toggle email channel behavior",
       "Use the feature.",
     );
     writeFileSync(
@@ -153,8 +153,8 @@ describe("skill_load feature flag enforcement", () => {
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
-    // sounds is declared in the registry with defaultEnabled: true
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Sounds");
+    // email-channel is declared in the registry with defaultEnabled: false
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("disabled by feature flag");
   });
 });

--- a/assistant/src/__tests__/skill-load-inline-command.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-command.test.ts
@@ -4,8 +4,6 @@
  * Validates that:
  * - Root skills with `!\`command\`` tokens get those tokens expanded exactly
  *   once at skill_load time, wrapped in <inline_skill_command> XML tags.
- * - When the feature flag is off, skill_load returns an error instead of
- *   leaving unresolved live tokens in the prompt.
  * - When the skill source is "extra", skill_load rejects with a specific error.
  * - Render failures produce stable inline stubs rather than raw stderr.
  */
@@ -13,8 +11,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 
 // ── Test directory ────────────────────────────────────────────────────────────
 
@@ -163,10 +159,6 @@ describe("skill_load inline command expansion", () => {
       ) => mockRunInlineCommand(command, workingDir),
     }));
 
-    // Enable the feature flag
-    _setOverridesForTesting({
-      "inline-skill-commands": true,
-    });
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
@@ -252,48 +244,6 @@ describe("skill_load inline command expansion", () => {
       expect(result.content).not.toContain("inline_skill_command");
       // Runner should not be called
       expect(runInlineCommandCalls).toHaveLength(0);
-    });
-  });
-
-  // ── Feature flag off ─────────────────────────────────────────────────
-
-  describe("feature flag disabled", () => {
-    test("returns error when flag is off and skill has inline commands", async () => {
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      writeSkill(
-        "flagged-off-skill",
-        "Flagged Off Skill",
-        "Has inline commands",
-        "Data: !`echo hello`",
-      );
-
-      const result = await executeSkillLoad({ skill: "flagged-off-skill" });
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain(
-        "inline-skill-commands feature flag is disabled",
-      );
-      // Runner should not be called when flag is off
-      expect(runInlineCommandCalls).toHaveLength(0);
-    });
-
-    test("plain skill still loads when flag is off", async () => {
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      writeSkill(
-        "plain-flag-off",
-        "Plain Flag Off",
-        "No inline commands",
-        "Regular content.",
-      );
-
-      const result = await executeSkillLoad({ skill: "plain-flag-off" });
-      expect(result.isError).toBe(false);
-      expect(result.content).toContain("Regular content.");
     });
   });
 

--- a/assistant/src/__tests__/skill-load-inline-includes.test.ts
+++ b/assistant/src/__tests__/skill-load-inline-includes.test.ts
@@ -16,8 +16,6 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
-
 // ── Test directory ────────────────────────────────────────────────────────────
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
@@ -173,10 +171,6 @@ describe("skill_load inline command expansion for included skills", () => {
       ) => mockRunInlineCommand(command, workingDir),
     }));
 
-    // Enable the feature flag
-    _setOverridesForTesting({
-      "inline-skill-commands": true,
-    });
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
@@ -511,42 +505,6 @@ describe("skill_load inline command expansion for included skills", () => {
 
       // Root body intact
       expect(result.content).toContain("Root body.");
-    });
-  });
-
-  // ── Feature flag off for child inline commands ────────────────────────
-
-  describe("feature flag disabled for included skills", () => {
-    test("skill_load returns error when child has inline commands and flag is off", async () => {
-      _setOverridesForTesting({
-        "inline-skill-commands": false,
-      });
-
-      writeSkill(
-        "child-flag-off",
-        "Flag Off Child",
-        "Child with inline cmds",
-        "Data: !`echo hello`",
-      );
-      writeSkill(
-        "parent-flag-off",
-        "Parent Flag Off",
-        "Parent for flag-off test",
-        "Root content.",
-        { includes: ["child-flag-off"] },
-      );
-
-      const result = await executeSkillLoad({ skill: "parent-flag-off" });
-      // Fail closed: the entire skill_load must error when any included child
-      // has inline commands and the feature flag is off, matching the root
-      // skill behavior and the documented fail-closed contract.
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain("child-flag-off");
-      expect(result.content).toContain(
-        "inline-skill-commands feature flag is disabled",
-      );
-      // Runner should not be called
-      expect(runInlineCommandCalls).toHaveLength(0);
     });
   });
 

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -69,16 +69,7 @@ For `formatVersion: 2` apps, source files live under `src/` and compiled output 
 
 **Make creative decisions on behalf of the user.** They want to be delighted, not consulted. Pick the accent color. Choose between a dark moody aesthetic or a light airy one. Decide if cards should have glassmorphism or layered shadows. Add a background pattern or gradient. These are YOUR decisions as the designer.
 
-<!-- feature:app-builder-multifile:start -->
-
 **Prefer multi-file TSX projects** for any non-trivial app. They give you component reuse, TypeScript safety, and cleaner organization. Fall back to single-file HTML only for the simplest one-off pages.
-
-<!-- feature:app-builder-multifile:end -->
-<!-- feature:app-builder-multifile:alt -->
-
-**Always build single-file HTML apps.** Write a complete, self-contained HTML document with all CSS in `<style>` and all JavaScript in `<script>`. Do not use multi-file projects or TSX.
-
-<!-- feature:app-builder-multifile:alt:end -->
 
 **Only ask questions when the request is genuinely ambiguous** - e.g., "build me an app" with no indication of what kind. Even then, prefer building something impressive based on context clues over asking a battery of questions.
 
@@ -123,8 +114,6 @@ Example schema for a project tracker:
 ### 3. Build the App
 
 Apps are rendered inside a sandboxed WebView on macOS.
-
-<!-- feature:app-builder-multifile:start -->
 
 #### Multi-file TSX projects
 
@@ -262,23 +251,6 @@ app_refresh(app_id)
 - No external fonts, images, or resources - use system fonts and CSS/SVG for visuals
 - Design responsively. Apps render at fluid, user-resizable widths — avoid fixed-pixel layouts
 - The WebView blocks all navigation - links and form `action` attributes won't work
-<!-- feature:app-builder-multifile:end -->
-
-<!-- feature:app-builder-multifile:alt -->
-
-#### Single HTML file
-
-Write a complete, self-contained HTML document.
-
-**Technical constraints (single-file):**
-
-- Single HTML string - no external files, CDNs, or imports
-- All CSS in `<style>` in `<head>`, all JavaScript in `<script>` before `</body>`
-- No external fonts, images, or resources - use system fonts and CSS/SVG for visuals
-- Design responsively. Apps render at fluid, user-resizable widths — avoid fixed-pixel layouts
-- The WebView blocks all navigation - links and form `action` attributes won't work
-
-<!-- feature:app-builder-multifile:alt:end -->
 
 #### Injected design system
 
@@ -352,70 +324,7 @@ For handler conventions, examples, key rules, and frontend usage patterns, see *
 
 `localStorage` and `sessionStorage` are available for ephemeral UI state (filters, view modes, collapsed state, preferences, form drafts). Use custom routes for persistent app records, `localStorage` for UI preferences.
 
-<!-- feature:app-builder-multifile:alt -->
-
-#### JavaScript patterns
-
-Initialize apps with clean state management:
-
-```javascript
-document.addEventListener("DOMContentLoaded", async () => {
-  await loadRecords();
-});
-
-let allRecords = [];
-
-async function loadRecords() {
-  try {
-    const res = await window.vellum.fetch("/v1/x/records");
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    allRecords = await res.json();
-    render();
-  } catch (err) {
-    console.error("Failed to load:", err);
-  }
-}
-
-function render() {
-  // Re-render UI from allRecords
-}
-```
-
-**HTML escaping:** Always escape user-controlled data before inserting into the DOM via `innerHTML`:
-
-```javascript
-function esc(s) {
-  const d = document.createElement("div");
-  d.textContent = String(s);
-  return d.innerHTML;
-}
-```
-
-### 4. Single-Page App Views
-
-Apps run inside a sandboxed WebView that blocks all navigation. All apps are effectively single-page. When an app needs multiple views, use JavaScript to swap content:
-
-```javascript
-function showView(name) {
-  document.querySelectorAll(".view").forEach((v) => (v.hidden = true));
-  document.getElementById("view-" + name).hidden = false;
-  document
-    .querySelectorAll(".nav-link")
-    .forEach((btn) => btn.classList.remove("active"));
-  document
-    .querySelector(`[onclick="showView('${name}')"]`)
-    ?.classList.add("active");
-}
-```
-
-<!-- feature:app-builder-multifile:alt:end -->
-
-<!-- feature:app-builder-multifile:start -->
 ### 4. Create and Open the App
-<!-- feature:app-builder-multifile:end -->
-<!-- feature:app-builder-multifile:alt -->
-### 5. Create and Open the App
-<!-- feature:app-builder-multifile:alt:end -->
 
 Call `app_create` with:
 
@@ -428,12 +337,7 @@ Call `app_create` with:
 
 The app is NOT opened in a workspace panel automatically - users open it via the 'Open App' button on the inline card.
 
-<!-- feature:app-builder-multifile:start -->
 ### 5. Handle Iteration
-<!-- feature:app-builder-multifile:end -->
-<!-- feature:app-builder-multifile:alt -->
-### 6. Handle Iteration
-<!-- feature:app-builder-multifile:alt:end -->
 
 When the user requests changes, prefer **`file_edit`** over rewriting the entire file.
 

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -1,5 +1,3 @@
-import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
-import { getConfig } from "../../../../config/loader.js";
 import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppCreateInput } from "../../../../tools/apps/executors.js";
@@ -16,13 +14,6 @@ export async function run(
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
     setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
-  const multifileEnabled = isAssistantFeatureFlagEnabled(
-    "app-builder-multifile",
-    getConfig(),
-  );
-  const createInput: AppCreateInput = {
-    ...(input as unknown as AppCreateInput),
-    featureFlags: { multifileEnabled },
-  };
+  const createInput: AppCreateInput = input as unknown as AppCreateInput;
   return executeAppCreate(createInput, appStore, context.proxyToolResolver);
 }

--- a/assistant/src/credential-execution/feature-gates.ts
+++ b/assistant/src/credential-execution/feature-gates.ts
@@ -31,9 +31,6 @@ export const CES_GRANT_AUDIT_FLAG_KEY = "ces-grant-audit" as const;
 /** Gate for managed sidecar transport in containerized environments. */
 export const CES_MANAGED_SIDECAR_FLAG_KEY = "ces-managed-sidecar" as const;
 
-/** Gate for routing credential reads/writes through the CES process. */
-const CES_CREDENTIAL_BACKEND_FLAG_KEY = "ces-credential-backend" as const;
-
 // ---------------------------------------------------------------------------
 // Public API — predicate functions
 // ---------------------------------------------------------------------------
@@ -71,13 +68,4 @@ export function isCesGrantAuditEnabled(config: AssistantConfig): boolean {
  */
 export function isCesManagedSidecarEnabled(config: AssistantConfig): boolean {
   return isAssistantFeatureFlagEnabled(CES_MANAGED_SIDECAR_FLAG_KEY, config);
-}
-
-/**
- * Whether credential reads and writes should be routed through the CES process.
- */
-export function isCesCredentialBackendEnabled(
-  config: AssistantConfig,
-): boolean {
-  return isAssistantFeatureFlagEnabled(CES_CREDENTIAL_BACKEND_FLAG_KEY, config);
 }

--- a/assistant/src/credential-execution/feature-gates.ts
+++ b/assistant/src/credential-execution/feature-gates.ts
@@ -28,6 +28,9 @@ export const CES_SECURE_INSTALL_FLAG_KEY = "ces-secure-install" as const;
 /** Gate for credential grant and audit inspection surfaces. */
 export const CES_GRANT_AUDIT_FLAG_KEY = "ces-grant-audit" as const;
 
+/** Gate for routing credential reads/writes through the CES process. */
+const CES_CREDENTIAL_BACKEND_FLAG_KEY = "ces-credential-backend" as const;
+
 /** Gate for managed sidecar transport in containerized environments. */
 export const CES_MANAGED_SIDECAR_FLAG_KEY = "ces-managed-sidecar" as const;
 
@@ -61,6 +64,15 @@ export function isCesSecureInstallEnabled(config: AssistantConfig): boolean {
  */
 export function isCesGrantAuditEnabled(config: AssistantConfig): boolean {
   return isAssistantFeatureFlagEnabled(CES_GRANT_AUDIT_FLAG_KEY, config);
+}
+
+/**
+ * Whether credential reads and writes should be routed through the CES process.
+ */
+export function isCesCredentialBackendEnabled(
+  config: AssistantConfig,
+): boolean {
+  return isAssistantFeatureFlagEnabled(CES_CREDENTIAL_BACKEND_FLAG_KEY, config);
 }
 
 /**

--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -12,12 +12,6 @@
  * creates a socket-based CesTransport. The CES sidecar manages its own
  * lifecycle; the process manager only manages the transport connection.
  *
- * Feature-flag gate: Managed sidecar mode is controlled by the
- * `ces-managed-sidecar` feature flag (checked via the required
- * AssistantConfig). When the flag is off, the process manager skips
- * managed discovery even in containerized environments, ensuring
- * rollback safety.
- *
  * Managed env contract:
  * - CES_BOOTSTRAP_SOCKET  — Path to the bootstrap Unix socket (shared emptyDir)
  * - /assistant-data-ro     — Assistant data mounted read-only into the CES sidecar
@@ -42,7 +36,6 @@ import {
   type LocalSourceDiscoverySuccess,
   type ManagedDiscoverySuccess,
 } from "./executable-discovery.js";
-import { isCesManagedSidecarEnabled } from "./feature-gates.js";
 
 const log = getLogger("ces-process-manager");
 
@@ -71,10 +64,8 @@ export const CES_PRIVATE_DATA_DIR = "/ces-data";
 
 export interface CesProcessManagerConfig {
   /**
-   * Assistant configuration for feature-flag checks.
-   * The managed sidecar path is gated behind the `ces-managed-sidecar`
-   * feature flag via this config.  When omitted (e.g. CLI / admin
-   * callers), managed mode is allowed unconditionally.
+   * Assistant configuration.
+   * Reserved for future feature-flag checks or config-driven behavior.
    */
   assistantConfig?: AssistantConfig;
 }
@@ -87,10 +78,6 @@ export interface CesProcessManager {
   /**
    * Start the CES process (local) or connect to the sidecar (managed).
    * Returns a CesTransport ready for use with createCesClient().
-   *
-   * When the `ces-managed-sidecar` feature flag is off, managed mode
-   * is skipped even in containerized environments — the process manager
-   * falls back to local discovery.
    *
    * Throws if CES is unavailable.
    */
@@ -118,7 +105,7 @@ export interface CesProcessManager {
 // ---------------------------------------------------------------------------
 
 export function createCesProcessManager(
-  config: CesProcessManagerConfig,
+  _config: CesProcessManagerConfig,
 ): CesProcessManager {
   let childProcess: Subprocess | null = null;
   let managedSocket: Socket | null = null;
@@ -131,31 +118,15 @@ export function createCesProcessManager(
         throw new Error("CES process manager is already running");
       }
 
-      // Feature-flag gate: when the managed sidecar flag is off, skip
-      // managed discovery entirely. This ensures rollback safety —
-      // disabling the flag leaves existing non-agent platform consumers
-      // intact.
-      const managedAllowed = config.assistantConfig
-        ? isCesManagedSidecarEnabled(config.assistantConfig)
-        : true; // No config → allow managed mode unconditionally (CLI/admin callers)
-
-      if (managedAllowed) {
-        discoveryResult = await discoverCes();
-        if (discoveryResult.mode === "unavailable") {
-          // The managed sidecar bootstrap socket is not present — this happens
-          // when the flag is enabled by default but the instance pre-dates the
-          // socket volume mount (e.g. existing Docker configs without the
-          // ces-bootstrap volume). Warn and fall back to local discovery so
-          // these deployments don't fail on upgrade.
-          log.warn(
-            { reason: discoveryResult.reason },
-            "CES managed sidecar bootstrap socket unavailable — falling back to local CES discovery",
-          );
-          discoveryResult = discoverLocalCes();
-        }
-      } else {
-        log.info(
-          "CES managed sidecar feature flag is off — skipping managed discovery, falling back to local",
+      discoveryResult = await discoverCes();
+      if (discoveryResult.mode === "unavailable") {
+        // The managed sidecar bootstrap socket is not present — this happens
+        // when the instance pre-dates the socket volume mount (e.g. existing
+        // Docker configs without the ces-bootstrap volume). Warn and fall
+        // back to local discovery so these deployments don't fail on upgrade.
+        log.warn(
+          { reason: discoveryResult.reason },
+          "CES managed sidecar bootstrap socket unavailable — falling back to local CES discovery",
         );
         discoveryResult = discoverLocalCes();
       }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -24,7 +24,6 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
   contextWindowConfigFromEffective,
   resolveEffectiveContextWindow,
@@ -2619,34 +2618,29 @@ export async function runAgentLoopImpl(
 
     // Post-turn tool result truncation: save large results to disk and
     // replace in-context content with a prefix/suffix stub + file pointer.
-    if (isAssistantFeatureFlagEnabled("tool-result-truncation", config)) {
-      try {
-        const conv = getConversation(ctx.conversationId);
-        if (conv) {
-          const convDir = getResolvedConversationDirPath(
-            ctx.conversationId,
-            conv.createdAt,
-          );
-          const { messages: derefMessages, dereferencedCount } =
-            derefToolResultReReads(restoredHistory);
-          const { messages: truncatedMessages, truncatedCount } =
-            postTurnTruncateToolResults(derefMessages, {
-              conversationDir: convDir,
-            });
-          if (truncatedCount > 0 || dereferencedCount > 0) {
-            rlog.info(
-              { truncatedCount, dereferencedCount },
-              "Post-turn tool result truncation applied",
-            );
-          }
-          restoredHistory = truncatedMessages;
-        }
-      } catch (err) {
-        rlog.warn(
-          { err },
-          "Post-turn tool result truncation failed (non-fatal)",
+    try {
+      const conv = getConversation(ctx.conversationId);
+      if (conv) {
+        const convDir = getResolvedConversationDirPath(
+          ctx.conversationId,
+          conv.createdAt,
         );
+        const { messages: derefMessages, dereferencedCount } =
+          derefToolResultReReads(restoredHistory);
+        const { messages: truncatedMessages, truncatedCount } =
+          postTurnTruncateToolResults(derefMessages, {
+            conversationDir: convDir,
+          });
+        if (truncatedCount > 0 || dereferencedCount > 0) {
+          rlog.info(
+            { truncatedCount, dereferencedCount },
+            "Post-turn tool result truncation applied",
+          );
+        }
+        restoredHistory = truncatedMessages;
       }
+    } catch (err) {
+      rlog.warn({ err }, "Post-turn tool result truncation failed (non-fatal)");
     }
 
     // Persist injections in history: runtime-injected context stays on

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -26,10 +26,6 @@ import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import {
-  isCesCredentialBackendEnabled,
-  isCesToolsEnabled,
-} from "../credential-execution/feature-gates.js";
-import {
   type CesProcessManager,
   CesUnavailableError,
   createCesProcessManager,
@@ -157,17 +153,6 @@ export interface CesStartupResult {
 async function startCesProcess(
   config: AssistantConfig,
 ): Promise<CesStartupResult> {
-  const shouldStartCes =
-    isCesToolsEnabled(config) || isCesCredentialBackendEnabled(config);
-  if (!shouldStartCes) {
-    return {
-      client: undefined,
-      processManager: undefined,
-      clientPromise: undefined,
-      abortController: undefined,
-    };
-  }
-
   const pm = createCesProcessManager({ assistantConfig: config });
   const abortController = new AbortController();
   let clientRef: CesClient | undefined;
@@ -524,86 +509,78 @@ export async function runDaemon(): Promise<void> {
     // bootstrap connection, so startup must happen at the process level.
     const cesStartupPromise = startCesProcess(config);
 
-    // When the credential backend flag is enabled, CES startup must complete
-    // BEFORE provider initialization so credential reads can go through CES.
-    // Block with a 20-second timeout — fall back to direct credential store
-    // on timeout.
-    if (isCesCredentialBackendEnabled(config)) {
-      const cesResult = await cesStartupPromise;
-      // startCesProcess() returns immediately — the actual handshake runs
-      // inside clientPromise. Await it (with a 20s timeout) so the CES client
-      // is available before provider initialization.
-      if (cesResult.clientPromise) {
-        const client = await awaitCesClientWithTimeout(
-          cesResult.clientPromise,
-          {
-            timeoutMs: DEFAULT_CES_STARTUP_TIMEOUT_MS,
-            onTimeout: () => {
-              log.warn(
-                "CES handshake timed out after 20s — falling back to direct credential store",
-              );
-            },
-          },
-        );
-        if (client) {
-          setCesClient(client);
-        }
+    // CES startup must complete BEFORE provider initialization so credential
+    // reads can go through CES. Block with a 20-second timeout — fall back to
+    // direct credential store on timeout.
+    const cesResult = await cesStartupPromise;
+    // startCesProcess() returns immediately — the actual handshake runs
+    // inside clientPromise. Await it (with a 20s timeout) so the CES client
+    // is available before provider initialization.
+    if (cesResult.clientPromise) {
+      const client = await awaitCesClientWithTimeout(cesResult.clientPromise, {
+        timeoutMs: DEFAULT_CES_STARTUP_TIMEOUT_MS,
+        onTimeout: () => {
+          log.warn(
+            "CES handshake timed out after 20s — falling back to direct credential store",
+          );
+        },
+      });
+      if (client) {
+        setCesClient(client);
       }
+    }
 
-      // Register CES reconnection callback so the credential layer can
-      // re-establish the connection when the transport dies, instead of
-      // falling back to the encrypted file store.
-      if (cesResult.processManager) {
-        const pm = cesResult.processManager;
+    // Register CES reconnection callback so the credential layer can
+    // re-establish the connection when the transport dies, instead of
+    // falling back to the encrypted file store.
+    if (cesResult.processManager) {
+      const pm = cesResult.processManager;
 
-        // Snapshot the managed-proxy context and assistant ID at CES startup
-        // so the reconnect closure below never calls back into
-        // `resolveManagedProxyContext()`. That function reads the assistant
-        // API key via `getSecureKeyAsync()`, which — once `setCesClient()`
-        // has resolved the backend to CES RPC — routes the read through CES
-        // itself. During a reconnect the old transport is dead and a new
-        // one is being set up by this very closure, so the nested credential
-        // read recursively awaits its own in-flight reconnection and
-        // deadlocks until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. That
-        // 45-second stall delays every CES restart and causes dependent
-        // credential reads (e.g. Meet's STT provider resolution) to return
-        // `undefined` during the window. API key rotation uses the
-        // `updateAssistantApiKey` RPC on the live client, not a reconnect,
-        // so caching at startup is safe.
-        const startupProxyCtx = await resolveManagedProxyContext();
-        const startupAssistantId = getPlatformAssistantId();
+      // Snapshot the managed-proxy context and assistant ID at CES startup
+      // so the reconnect closure below never calls back into
+      // `resolveManagedProxyContext()`. That function reads the assistant
+      // API key via `getSecureKeyAsync()`, which — once `setCesClient()`
+      // has resolved the backend to CES RPC — routes the read through CES
+      // itself. During a reconnect the old transport is dead and a new
+      // one is being set up by this very closure, so the nested credential
+      // read recursively awaits its own in-flight reconnection and
+      // deadlocks until `CREDENTIAL_OP_TIMEOUT_MS` (45s) fires. That
+      // 45-second stall delays every CES restart and causes dependent
+      // credential reads (e.g. Meet's STT provider resolution) to return
+      // `undefined` during the window. API key rotation uses the
+      // `updateAssistantApiKey` RPC on the live client, not a reconnect,
+      // so caching at startup is safe.
+      const startupProxyCtx = await resolveManagedProxyContext();
+      const startupAssistantId = getPlatformAssistantId();
 
-        setCesReconnect(async () => {
-          try {
-            await pm.stop();
-            const transport = await pm.start();
-            const newClient = createCesClient(transport);
-            const { accepted, reason } = await newClient.handshake({
-              ...(startupProxyCtx.assistantApiKey
-                ? { assistantApiKey: startupProxyCtx.assistantApiKey }
-                : {}),
-              ...(startupAssistantId
-                ? { assistantId: startupAssistantId }
-                : {}),
-            });
-            if (accepted) {
-              log.info("CES reconnection handshake accepted");
-              return newClient;
-            }
-            log.warn({ reason }, "CES reconnection handshake rejected");
-            newClient.close();
-            await pm.stop().catch(() => {});
-            return undefined;
-          } catch (err) {
-            log.warn(
-              { error: err instanceof Error ? err.message : String(err) },
-              "CES reconnection attempt failed",
-            );
-            await pm.stop().catch(() => {});
-            return undefined;
+      setCesReconnect(async () => {
+        try {
+          await pm.stop();
+          const transport = await pm.start();
+          const newClient = createCesClient(transport);
+          const { accepted, reason } = await newClient.handshake({
+            ...(startupProxyCtx.assistantApiKey
+              ? { assistantApiKey: startupProxyCtx.assistantApiKey }
+              : {}),
+            ...(startupAssistantId ? { assistantId: startupAssistantId } : {}),
+          });
+          if (accepted) {
+            log.info("CES reconnection handshake accepted");
+            return newClient;
           }
-        });
-      }
+          log.warn({ reason }, "CES reconnection handshake rejected");
+          newClient.close();
+          await pm.stop().catch(() => {});
+          return undefined;
+        } catch (err) {
+          log.warn(
+            { error: err instanceof Error ? err.message : String(err) },
+            "CES reconnection attempt failed",
+          );
+          await pm.stop().catch(() => {});
+          return undefined;
+        }
+      });
     }
 
     // Populate the registry with user plugins from `~/.vellum/plugins/*`

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { loadSkillCatalog, resolveSkillSelector } from "../config/skills.js";
@@ -268,23 +267,17 @@ function resolveSkillMetadata(selector: string): SkillMetadata | undefined {
   const resolved = resolveSkillIdAndHash(selector);
   if (!resolved) return undefined;
 
-  const config = getConfig();
-  const inlineEnabled = isAssistantFeatureFlagEnabled(
-    "inline-skill-commands",
-    config,
-  );
   const inlineExpansions = hasInlineExpansions(resolved.id);
-  const isDynamic = inlineEnabled && inlineExpansions;
 
   return {
     skillId: resolved.id,
     selector,
     versionHash: resolved.versionHash ?? "",
-    transitiveHash: isDynamic
+    transitiveHash: inlineExpansions
       ? computeTransitiveHashSafe(resolved.id)
       : undefined,
     hasInlineExpansions: inlineExpansions,
-    isDynamic,
+    isDynamic: inlineExpansions,
   };
 }
 
@@ -726,14 +719,7 @@ function skillLoadAllowlistStrategy(
   if (rawSelector) {
     const resolved = resolveSkillIdAndHash(rawSelector);
 
-    // Check whether this is a dynamic (inline-command) skill load
-    const config = getConfig();
-    const inlineEnabled = isAssistantFeatureFlagEnabled(
-      "inline-skill-commands",
-      config,
-    );
-
-    if (resolved && inlineEnabled && hasInlineExpansions(resolved.id)) {
+    if (resolved && hasInlineExpansions(resolved.id)) {
       const transitiveHash = computeTransitiveHashSafe(resolved.id);
       const options: AllowlistOption[] = [];
       if (transitiveHash) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -442,7 +442,7 @@ export async function handleChannelInbound({
           `[Voice message received — ${transcribeResult.reason}]` +
           (trimmedContent ? `\n\n${trimmedContent}` : "");
         break;
-      // "no_audio", "disabled" — no action needed
+      // "no_audio" — no action needed
     }
   }
 

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.test.ts
@@ -7,7 +7,6 @@ import { SttError } from "../../../stt/types.js";
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-let mockFeatureFlagEnabled = true;
 let mockAttachments: Array<{
   id: string;
   mimeType: string;
@@ -19,14 +18,6 @@ let mockAttachments: Array<{
   createdAt: number;
 }> = [];
 let mockTranscriber: BatchTranscriber | null = null;
-
-mock.module("../../../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: () => mockFeatureFlagEnabled,
-}));
-
-mock.module("../../../config/loader.js", () => ({
-  getConfig: () => ({}),
-}));
 
 mock.module("../../../memory/attachments-store.js", () => ({
   getAttachmentsByIds: (ids: string[]) =>
@@ -115,7 +106,6 @@ function makeImageAttachment(id: string) {
 
 describe("tryTranscribeAudioAttachments", () => {
   beforeEach(() => {
-    mockFeatureFlagEnabled = true;
     mockAttachments = [];
     mockTranscriber = null;
   });
@@ -187,16 +177,6 @@ describe("tryTranscribeAudioAttachments", () => {
     expect((result as { reason: string }).reason).toBe(
       "API rate limit exceeded",
     );
-  });
-
-  test("feature flag disabled returns disabled", async () => {
-    mockFeatureFlagEnabled = false;
-    const audio = makeAudioAttachment("a1");
-    mockAttachments = [audio];
-
-    const result = await tryTranscribeAudioAttachments(["a1"]);
-
-    expect(result).toEqual({ status: "disabled" });
   });
 
   test("30-second timeout fires and returns error without blocking", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
+++ b/assistant/src/runtime/routes/inbound-stages/transcribe-audio.ts
@@ -2,21 +2,20 @@
  * Auto-transcribe audio attachments from channel inbound messages.
  *
  * Returns a discriminated result type so callers can handle each outcome
- * (transcribed, no audio, disabled, no provider, error) without exceptions.
+ * (transcribed, no audio, no provider, error) without exceptions.
  * Never throws — failures are represented as result variants so that message
  * delivery is never blocked by transcription issues.
  */
 
-import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
-import { getConfig } from "../../../config/loader.js";
-import { getAttachmentById, getAttachmentsByIds } from "../../../memory/attachments-store.js";
+import {
+  getAttachmentById,
+  getAttachmentsByIds,
+} from "../../../memory/attachments-store.js";
 import { resolveBatchTranscriber } from "../../../providers/speech-to-text/resolve.js";
 import { normalizeSttError } from "../../../stt/daemon-batch-transcriber.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("transcribe-audio");
-
-const VOICE_TRANSCRIPTION_FLAG_KEY = "channel-voice-transcription" as const;
 
 /** Timeout for the entire transcription pipeline (all attachments). */
 const TRANSCRIPTION_TIMEOUT_MS = 30_000;
@@ -28,7 +27,6 @@ const TRANSCRIPTION_TIMEOUT_MS = 30_000;
 export type TranscribeResult =
   | { status: "transcribed"; text: string }
   | { status: "no_audio" }
-  | { status: "disabled" }
   | { status: "no_provider"; reason: string }
   | { status: "error"; reason: string };
 
@@ -40,12 +38,6 @@ export async function tryTranscribeAudioAttachments(
   attachmentIds: string[],
 ): Promise<TranscribeResult> {
   try {
-    // Check feature flag
-    const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled(VOICE_TRANSCRIPTION_FLAG_KEY, config)) {
-      return { status: "disabled" };
-    }
-
     // Look up attachments and filter to audio MIME types
     const resolved = getAttachmentsByIds(attachmentIds);
     const audioAttachments = resolved.filter((a) =>

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -78,11 +78,8 @@ export interface AppCreateInput {
   description?: string;
   schema_json?: string;
   html?: string;
-  pages?: Record<string, string>;
   auto_open?: boolean;
   preview?: Record<string, unknown>;
-  /** When provided, controls multifile scaffold behavior. */
-  featureFlags?: { multifileEnabled: boolean };
 }
 
 export async function executeAppCreate(
@@ -93,14 +90,9 @@ export async function executeAppCreate(
   const name = input.name;
   const description = input.description;
   const schemaJson = input.schema_json ?? "{}";
-  // Default to a minimal scaffold only when html is truly omitted; reject
-  // invalid types (e.g. object/number) so malformed tool calls surface errors.
-  let htmlDefinition: string;
-  if (typeof input.html === "string") {
-    htmlDefinition = input.html;
-  } else if (input.html == null) {
-    htmlDefinition = "<!DOCTYPE html><html><head></head><body></body></html>";
-  } else {
+  // Reject invalid html types (e.g. object/number) so malformed tool calls
+  // surface errors early.
+  if (input.html != null && typeof input.html !== "string") {
     return {
       content: JSON.stringify({
         error: `html must be a string, got ${typeof input.html}`,
@@ -108,7 +100,6 @@ export async function executeAppCreate(
       isError: true,
     };
   }
-  const pages = input.pages;
   const autoOpen = input.auto_open !== false; // default true
   const preview = input.preview;
 
@@ -121,49 +112,33 @@ export async function executeAppCreate(
       isError: true,
     };
   }
-  if (pages) {
-    for (const [filename, content] of Object.entries(pages)) {
-      if (typeof content !== "string") {
-        return {
-          content: JSON.stringify({
-            error: `pages["${filename}"] must be a string, got ${typeof content}`,
-          }),
-          isError: true,
-        };
-      }
-    }
-  }
 
   // Extract icon from preview if provided - only persist emoji-like values,
   // not URLs which would render as raw strings in UI and bundle manifests.
   const rawIcon = preview?.icon as string | undefined;
   const icon = rawIcon && !rawIcon.startsWith("http") ? rawIcon : undefined;
 
-  const multifileEnabled = input.featureFlags?.multifileEnabled === true;
-
   const app = store.createApp({
     name,
     description,
     icon,
     schemaJson,
-    htmlDefinition: multifileEnabled ? "" : htmlDefinition,
-    pages: multifileEnabled ? undefined : pages,
-    formatVersion: multifileEnabled ? 2 : undefined,
+    htmlDefinition: "",
+    formatVersion: 2,
   });
 
   // Scaffold multifile app with src/ files and compile to dist/
-  if (multifileEnabled) {
-    const htmlSafeName = name
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
-    const jsxSafeName = name.replace(/[<>{}&"']/g, "");
+  const htmlSafeName = name
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+  const jsxSafeName = name.replace(/[<>{}&"']/g, "");
 
-    const indexHtml =
-      typeof input.html === "string"
-        ? input.html
-        : `<!DOCTYPE html>
+  const indexHtml =
+    typeof input.html === "string"
+      ? input.html
+      : `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -175,7 +150,7 @@ export async function executeAppCreate(
 </body>
 </html>`;
 
-    const mainTsx = `import { render } from 'preact';
+  const mainTsx = `import { render } from 'preact';
 
 function App() {
   return <div>{"Hello, ${jsxSafeName}!"}</div>;
@@ -184,31 +159,30 @@ function App() {
 render(<App />, document.getElementById('app')!);
 `;
 
-    // Only write scaffold files when they don't already exist on disk.
-    // The LLM may have written custom source files via file_write before
-    // calling app_create, and overwriting them would destroy the real app
-    // content, leaving only the scaffold placeholder.
-    if (!store.appFileExists(app.id, "src/index.html")) {
-      store.writeAppFile(app.id, "src/index.html", indexHtml);
-    }
-    if (!store.appFileExists(app.id, "src/main.tsx")) {
-      store.writeAppFile(app.id, "src/main.tsx", mainTsx);
-    }
+  // Only write scaffold files when they don't already exist on disk.
+  // The LLM may have written custom source files via file_write before
+  // calling app_create, and overwriting them would destroy the real app
+  // content, leaving only the scaffold placeholder.
+  if (!store.appFileExists(app.id, "src/index.html")) {
+    store.writeAppFile(app.id, "src/index.html", indexHtml);
+  }
+  if (!store.appFileExists(app.id, "src/main.tsx")) {
+    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+  }
 
-    // Compile src/ → dist/
-    const appDir = getAppDirPath(app.id);
-    const compileResult = await compileApp(appDir);
-    if (!compileResult.ok) {
-      return {
-        content: JSON.stringify({
-          ...app,
-          compile_errors: compileResult.errors,
-          compile_warnings: compileResult.warnings,
-          compile_duration_ms: compileResult.durationMs,
-        }),
-        isError: false,
-      };
-    }
+  // Compile src/ → dist/
+  const appDir = getAppDirPath(app.id);
+  const compileResult = await compileApp(appDir);
+  if (!compileResult.ok) {
+    return {
+      content: JSON.stringify({
+        ...app,
+        compile_errors: compileResult.errors,
+        compile_warnings: compileResult.warnings,
+        compile_duration_ms: compileResult.durationMs,
+      }),
+      isError: false,
+    };
   }
 
   // Emit the inline preview card via the proxy without opening a workspace panel.

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -29,9 +29,6 @@ import { getWorkspaceDirDisplay } from "../../util/platform.js";
 import { registerTool } from "../registry.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
-/** Canonical feature flag key for inline skill command expansion. */
-const INLINE_COMMANDS_FLAG_KEY = "inline-skill-commands";
-
 /** Skill sources eligible for inline command expansion in v1. */
 const INLINE_COMMAND_ELIGIBLE_SOURCES = new Set([
   "bundled",
@@ -300,20 +297,6 @@ export class SkillLoadTool implements Tool {
       skill.inlineCommandExpansions && skill.inlineCommandExpansions.length > 0;
 
     if (hasInlineCommands) {
-      const inlineFlagEnabled = isAssistantFeatureFlagEnabled(
-        INLINE_COMMANDS_FLAG_KEY,
-        config,
-      );
-
-      if (!inlineFlagEnabled) {
-        // Feature flag is off: fail closed instead of leaving live tokens in
-        // the prompt that the LLM might try to interpret.
-        return {
-          content: `Error: skill "${skill.id}" contains inline command expansions but the inline-skill-commands feature flag is disabled. Enable the flag to use this skill.`,
-          isError: true,
-        };
-      }
-
       if (skill.source === "extra") {
         // Third-party extra roots are out of scope for inline command
         // expansion in v1. Reject explicitly so the failure is clear.
@@ -391,21 +374,6 @@ export class SkillLoadTool implements Tool {
             childLoaded.skill.inlineCommandExpansions.length > 0;
 
           if (childHasInlineCommands) {
-            const childInlineFlagEnabled = isAssistantFeatureFlagEnabled(
-              INLINE_COMMANDS_FLAG_KEY,
-              config,
-            );
-
-            // Fail closed: if the flag is off, reject the entire skill_load
-            // just like we do for root skills. Leaving raw !`...` tokens in
-            // the prompt would violate the documented fail-closed contract.
-            if (!childInlineFlagEnabled) {
-              return {
-                content: `Error: included skill "${childId}" contains inline command expansions but the inline-skill-commands feature flag is disabled. Enable the flag to use skill "${skill.id}".`,
-                isError: true,
-              };
-            }
-
             if (childLoaded.skill.source === "extra") {
               return {
                 content: `Error: included skill "${childId}" contains inline command expansions but inline commands are not supported for third-party (extra) skill sources.`,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -380,8 +380,7 @@ struct ChatBubble: View, Equatable {
                         )
                     } else if shouldShowBubble {
                         if !isUser,
-                           containsInlineThinkingTag(message.text),
-                           MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
+                           containsInlineThinkingTag(message.text) {
                             bubbleContentWithInlineThinking
                         } else {
                             bubbleContent

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -456,23 +456,21 @@ extension ChatBubble {
                     InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction, onRefetch: onSurfaceRefetch)
                 }
             case .thinking(let indices):
-                if MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
-                    let joined = indices
-                        .compactMap { i in
-                            i < message.thinkingSegments.count
-                                ? message.thinkingSegments[i]
-                                : nil
-                        }
-                        .filter { !$0.isEmpty }
-                        .joined(separator: "\n")
-                    if !joined.isEmpty {
-                        ThinkingBlockView(
-                            content: joined,
-                            isStreaming: message.isStreaming,
-                            expansionKey: "\(message.id.uuidString)-th\(indices.first ?? 0)",
-                            typographyGeneration: typographyGeneration
-                        )
+                let joined = indices
+                    .compactMap { i in
+                        i < message.thinkingSegments.count
+                            ? message.thinkingSegments[i]
+                            : nil
                     }
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n")
+                if !joined.isEmpty {
+                    ThinkingBlockView(
+                        content: joined,
+                        isStreaming: message.isStreaming,
+                        expansionKey: "\(message.id.uuidString)-th\(indices.first ?? 0)",
+                        typographyGeneration: typographyGeneration
+                    )
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -8,8 +8,7 @@ extension ChatBubble {
     /// For large messages (>500 chars) with a segment cache miss, renders plain text
     /// immediately and parses rich formatting asynchronously to avoid blocking scroll.
     ///
-    /// When the text contains inline `<thinking>...</thinking>` tags (and the
-    /// `show-thinking-blocks` feature flag is enabled for assistant messages),
+    /// When the text contains inline `<thinking>...</thinking>` tags,
     /// the tagged sections are lifted into collapsible `ThinkingBlockView`s
     /// rendered alongside text bubbles for the remaining content. This keeps
     /// the transformation entirely at the presentation layer — no changes to
@@ -17,8 +16,7 @@ extension ChatBubble {
     @ViewBuilder
     func textBubble(for segmentText: String, textGroupIndex: Int? = nil) -> some View {
         if !isUser,
-           containsInlineThinkingTag(segmentText),
-           MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") {
+           containsInlineThinkingTag(segmentText) {
             let chunks = parseInlineThinkingTags(segmentText)
             // Use a stable key prefix that doesn't change as segmentText grows
             // during streaming. The previous hash-based key caused thinking

--- a/clients/macos/vellum-assistant/Features/Chat/MessageHeightCache.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageHeightCache.swift
@@ -1,18 +1,15 @@
 import Foundation
 import SwiftUI
-import VellumAssistantShared
 
 /// Per-conversation cache of each transcript row's measured height, keyed by
 /// the row's `TranscriptItem.id`. Written on every render via the geometry
 /// reader inside `CachedHeightRow`; read only by the scroll debug HUD today
 /// (and by future diagnostics that want a ground-truth height per row).
 ///
-/// The `message-height-cache` feature flag flips the stack from `LazyVStack`
-/// to a plain `VStack` inside `MessageListContentView`. That's what actually
-/// stabilises `scrollContentHeight` — `VStack` measures every cell, so the
-/// scroll view reports the true total height instead of `LazyVStack`'s
-/// drifting estimate. The cache itself is complementary: it records every
-/// row's measured height as a byproduct, useful for inspection.
+/// The transcript uses a plain `VStack` inside `MessageListContentView`,
+/// which measures every cell so the scroll view reports the true total height
+/// without estimator drift. The cache records every row's measured height as
+/// a byproduct, useful for inspection.
 ///
 /// Propagated through `EnvironmentValues.messageHeightCache` alongside the
 /// other transcript stores. Not annotated `@MainActor` because `EnvironmentKey`
@@ -59,56 +56,36 @@ extension EnvironmentValues {
 /// `MessageHeightCache`. Does NOT pin the row's frame — an earlier version
 /// applied `.frame(height: cached)` and produced catastrophic overlap when a
 /// row's content grew past its first-measured height (streaming, thinking
-/// block expanding). The row-height fix now lives at the stack level: the
-/// enclosing `MessageListContentView` swaps `LazyVStack` for a plain `VStack`
-/// when this flag is on, which eliminates the estimator that caused the
-/// jerky scroll in the first place.
-///
-/// When the flag is off the wrapper is a straight passthrough — no geometry
-/// reader, no cache writes — so off-state pays nothing.
+/// block expanding). The row-height fix lives at the stack level: the
+/// enclosing `MessageListContentView` uses a plain `VStack`, which
+/// eliminates the estimator that caused jerky scroll.
 struct CachedHeightRow<Content: View>: View {
     let itemId: UUID
     @ViewBuilder let content: () -> Content
     @Environment(\.messageHeightCache) private var heightCache
 
     var body: some View {
-        if MacOSClientFeatureFlagManager.shared.isEnabled("message-height-cache") {
-            content()
-                .onGeometryChange(for: CGFloat.self) { proxy in
-                    proxy.size.height
-                } action: { newHeight in
-                    heightCache.record(itemId, height: newHeight)
-                }
-        } else {
-            content()
-        }
+        content()
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                heightCache.record(itemId, height: newHeight)
+            }
     }
 }
 
 // MARK: - MessageTranscriptStack
 
-/// Container for the transcript's main content stack. When the
-/// `message-height-cache` flag is on, this is a plain `VStack` — every row
-/// is materialised eagerly, so `scrollContentHeight` equals the true sum of
-/// row heights with no estimator in the middle to drift. When the flag is
-/// off this is the original `LazyVStack`, preserving the existing laziness
-/// (and its estimation quirks) for conversations long enough that eager
-/// layout would be too expensive.
-///
-/// The flag toggle is a clean A/B: correctness vs. laziness.
+/// Container for the transcript's main content stack. Uses a plain `VStack`
+/// so every row is materialised eagerly and `scrollContentHeight` equals the
+/// true sum of row heights with no estimator in the middle to drift.
 struct MessageTranscriptStack<Content: View>: View {
     let spacing: CGFloat
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        if MacOSClientFeatureFlagManager.shared.isEnabled("message-height-cache") {
-            VStack(alignment: .leading, spacing: spacing) {
-                content()
-            }
-        } else {
-            LazyVStack(alignment: .leading, spacing: spacing) {
-                content()
-            }
+        VStack(alignment: .leading, spacing: spacing) {
+            content()
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -317,16 +317,11 @@ struct MessageListContentView: View, Equatable {
     // MARK: - Body
 
     var body: some View {
-        // WARNING: This LazyVStack uses .transaction { $0.animation = nil } to suppress
+        // WARNING: This VStack uses .transaction { $0.animation = nil } to suppress
         // all insertion/removal animations. Without this, SwiftUI calls motionVectors()
         // during any item insertion, which measures ALL children via sizeThatFits —
         // causing multi-minute hangs on long conversations. Do NOT remove the
         // .transaction modifier or wrap content changes in withAnimation.
-        //
-        // `MessageTranscriptStack` is `LazyVStack` by default, and swaps to a
-        // plain `VStack` when the `message-height-cache` flag is on — that's
-        // the experimental path for fixing contentH drift at the cost of
-        // eager layout. Same `.transaction` guard covers both.
         MessageTranscriptStack(spacing: VSpacing.md) {
             let _ = os_signpost(.event, log: stallLog, name: "MessageList.bodyEval")
             let isUnanchoredThinking = state.shouldShowThinkingIndicator && !state.rows.contains(where: \.isAnchoredThinkingRow)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -106,12 +106,11 @@ struct MessageListView: View {
     /// Owned here (same level as `thinkingBlockExpansionStore`) so the state
     /// survives view-tree destruction. See `FilePreviewExpansionStore.swift`.
     @State var filePreviewExpansionStore = FilePreviewExpansionStore()
-    /// Caches each transcript row's measured height so the LazyVStack reports
-    /// an accurate `contentSize` for off-screen cells. Gated on the
-    /// `message-height-cache` macOS feature flag. `.id(conversationId)` is
-    /// applied to the inner `ScrollView` (not `MessageListView`), so SwiftUI
-    /// preserves this `@State` across conversation switches — the cache must
-    /// be cleared explicitly in `handleConversationSwitched()` to avoid
+    /// Caches each transcript row's measured height so the VStack reports
+    /// an accurate `contentSize`. `.id(conversationId)` is applied to the
+    /// inner `ScrollView` (not `MessageListView`), so SwiftUI preserves
+    /// this `@State` across conversation switches — the cache must be
+    /// cleared explicitly in `handleConversationSwitched()` to avoid
     /// reusing heights keyed by fixed-sentinel UUIDs (e.g. queuedMarker)
     /// across conversations. Also reset on column-width and typography
     /// changes, which reflow every row.

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -11,9 +11,6 @@ private let panelCoordinatorLog = Logger(
 // MARK: - Panel Coordination Extension
 
 extension MainWindowView {
-    fileprivate static let conversationStartersFeatureFlagKey =
-        "conversation-starters"
-
     // MARK: - Config-Driven Slot Rendering
 
     @ViewBuilder
@@ -699,9 +696,7 @@ extension MainWindowView {
     var chatView: some View {
         if let viewModel = conversationManager.activeViewModel {
             let activeConversation = conversationManager.activeConversation
-            let conversationStartersEnabled = assistantFeatureFlagStore.isEnabled(
-                Self.conversationStartersFeatureFlagKey
-            )
+            let conversationStartersEnabled = true
             let showInspectButton = assistantFeatureFlagStore.isEnabled(
                 "settings-developer-nav"
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -647,7 +647,7 @@ extension MainWindowView {
                         subagentId: subagentId,
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
-                        showInspectButton: assistantFeatureFlagStore.isEnabled("settings-developer-nav"),
+                        showInspectButton: true,
                         onAbort: { Task { await viewModel.abortSubagent(subagentId) } },
                         onRequestDetail: {
                             if let conversationId = viewModel.activeSubagents.first(where: { $0.id == subagentId })?.conversationId {
@@ -697,9 +697,7 @@ extension MainWindowView {
         if let viewModel = conversationManager.activeViewModel {
             let activeConversation = conversationManager.activeConversation
             let conversationStartersEnabled = true
-            let showInspectButton = assistantFeatureFlagStore.isEnabled(
-                "settings-developer-nav"
-            )
+            let showInspectButton = true
             let isTTSEnabled = assistantFeatureFlagStore.isEnabled(
                 "message-tts"
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -33,7 +33,7 @@ enum SettingsTab: String {
     }
 
     static func sidebarTopTabs(
-        soundsEnabled: Bool = true,
+        billingEnabled: Bool = false,
         debugEnabled: Bool = false,
         includeCompactionPlayground: Bool = false
     ) -> [SettingsTab] {
@@ -43,8 +43,8 @@ enum SettingsTab: String {
         }
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
-        if soundsEnabled { tabs.append(.sounds) }
-        tabs.append(.billing)
+        tabs.append(.sounds)
+        if billingEnabled { tabs.append(.billing) }
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         tabs.append(.schedules)
@@ -89,10 +89,10 @@ struct SettingsPanel: View {
         self.onEnableIntegration = onEnableIntegration
         self.featureFlagClient = featureFlagClient
 
-        // Pre-compute the sounds flag so deep-link validation below uses
-        // the actual config value instead of the @State default (true).
-        let soundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
-        _isSoundsEnabled = State(initialValue: soundsEnabled)
+        // Pre-compute the billing flag so the first render already has the
+        // correct tab list in the sidebar nav.
+        let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
+        _isBillingEnabled = State(initialValue: billingEnabled)
 
         // Derive the initial tab from the pending deep-link at construction
         // time. Previous attempts set selectedTab in onAppear / onChange, but
@@ -114,7 +114,6 @@ struct SettingsPanel: View {
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
             var visibleTabs = SettingsTab.sidebarTopTabs(
                 billingEnabled: canShowBilling,
-                soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
             )
@@ -150,7 +149,6 @@ struct SettingsPanel: View {
     @State private var hasLoadedFeatureFlags: Bool = false
     @State private var isBillingEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
-    @State private var isSoundsEnabled: Bool = true
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var isEmailChannelEnabled: Bool = false
     @State private var bootstrapGeneration: Int = 0
@@ -159,7 +157,6 @@ struct SettingsPanel: View {
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
-    private static let soundsFeatureFlagKey = "sounds"
     private static let deferredDeepLinkTabs: Set<SettingsTab> = [.compactionPlayground]
 
     var body: some View {
@@ -226,7 +223,7 @@ struct SettingsPanel: View {
             await loadFeatureFlags()
         }
         .onAppear {
-            isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
+            isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -257,9 +254,6 @@ struct SettingsPanel: View {
         .onChange(of: isDebugVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
-        .onChange(of: isSoundsEnabled) { _, _ in
-            handleSidebarVisibilityChanged()
-        }
         .onChange(of: isCompactionPlaygroundVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
@@ -272,8 +266,6 @@ struct SettingsPanel: View {
                     isCompactionPlaygroundEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
-                } else if key == Self.soundsFeatureFlagKey {
-                    isSoundsEnabled = enabled
                 }
             }
         }
@@ -318,7 +310,7 @@ struct SettingsPanel: View {
 
     private var visibleSidebarTopTabs: [SettingsTab] {
         SettingsTab.sidebarTopTabs(
-            soundsEnabled: isSoundsEnabled,
+            billingEnabled: billingVisible,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
         )
@@ -654,9 +646,6 @@ struct SettingsPanel: View {
                 if let emailChannelFlag = flags.first(where: { $0.key == Self.emailChannelFeatureFlagKey }) {
                     isEmailChannelEnabled = emailChannelFlag.enabled
                 }
-                if let soundsFlag = flags.first(where: { $0.key == Self.soundsFeatureFlagKey }) {
-                    isSoundsEnabled = soundsFlag.enabled
-                }
                 handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
                 hasLoadedFeatureFlags = true
                 return
@@ -677,9 +666,6 @@ struct SettingsPanel: View {
         }
         if let emailChannelEnabled = resolved[Self.emailChannelFeatureFlagKey] {
             isEmailChannelEnabled = emailChannelEnabled
-        }
-        if let soundsEnabled = resolved[Self.soundsFeatureFlagKey] {
-            isSoundsEnabled = soundsEnabled
         }
         handleSidebarVisibilityChanged(clearDeferredIfHidden: true)
         hasLoadedFeatureFlags = true

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -33,7 +33,6 @@ enum SettingsTab: String {
     }
 
     static func sidebarTopTabs(
-        billingEnabled: Bool = false,
         debugEnabled: Bool = false,
         includeCompactionPlayground: Bool = false
     ) -> [SettingsTab] {
@@ -44,7 +43,7 @@ enum SettingsTab: String {
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
         tabs.append(.sounds)
-        if billingEnabled { tabs.append(.billing) }
+        tabs.append(.billing)
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         tabs.append(.schedules)
@@ -89,11 +88,6 @@ struct SettingsPanel: View {
         self.onEnableIntegration = onEnableIntegration
         self.featureFlagClient = featureFlagClient
 
-        // Pre-compute the billing flag so the first render already has the
-        // correct tab list in the sidebar nav.
-        let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
-        _isBillingEnabled = State(initialValue: billingEnabled)
-
         // Derive the initial tab from the pending deep-link at construction
         // time. Previous attempts set selectedTab in onAppear / onChange, but
         // those fire *after* the first render and are susceptible to timing
@@ -102,10 +96,7 @@ struct SettingsPanel: View {
         // first instance and leaves the second with .general).
         if let pending = store.pendingSettingsTab {
             // Validate that the deep-linked tab is actually visible before
-            // accepting it. @AppStorage isn't wired to UserDefaults in init,
-            // so read connectedOrgId directly from UserDefaults.
-            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
-            let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
+            // accepting it.
             // Compaction Playground is deferred until flags load and
             // dev mode can be evaluated by the live sidebar visibility helper.
             // Debug tab is gated to managed assistants; `AppDelegate` publishes
@@ -113,7 +104,6 @@ struct SettingsPanel: View {
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
             var visibleTabs = SettingsTab.sidebarTopTabs(
-                billingEnabled: canShowBilling,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
             )
@@ -147,13 +137,10 @@ struct SettingsPanel: View {
     /// Re-evaluated after loadFeatureFlags() completes.
     @State private var deferredDeepLinkTab: SettingsTab?
     @State private var hasLoadedFeatureFlags: Bool = false
-    @State private var isBillingEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var isEmailChannelEnabled: Bool = false
     @State private var bootstrapGeneration: Int = 0
-    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
-    private static let billingFeatureFlagKey = "settings-billing"
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
@@ -223,7 +210,6 @@ struct SettingsPanel: View {
             await loadFeatureFlags()
         }
         .onAppear {
-            isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
             if store.pendingSettingsTab != nil {
@@ -260,9 +246,7 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
-                if key == Self.billingFeatureFlagKey {
-                    isBillingEnabled = enabled
-                } else if key == Self.compactionPlaygroundFeatureFlagKey {
+                if key == Self.compactionPlaygroundFeatureFlagKey {
                     isCompactionPlaygroundEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
                     isEmbeddingProviderEnabled = enabled
@@ -310,7 +294,6 @@ struct SettingsPanel: View {
 
     private var visibleSidebarTopTabs: [SettingsTab] {
         SettingsTab.sidebarTopTabs(
-            billingEnabled: billingVisible,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
         )

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -33,7 +33,6 @@ enum SettingsTab: String {
     }
 
     static func sidebarTopTabs(
-        billingEnabled: Bool = false,
         soundsEnabled: Bool = true,
         debugEnabled: Bool = false,
         includeCompactionPlayground: Bool = false
@@ -45,7 +44,7 @@ enum SettingsTab: String {
         tabs.append(contentsOf: [.general, .modelsAndServices, .integrations])
         tabs.append(.voice)
         if soundsEnabled { tabs.append(.sounds) }
-        if billingEnabled { tabs.append(.billing) }
+        tabs.append(.billing)
         tabs.append(.permissionsAndPrivacy)
         tabs.append(.archivedConversations)
         tabs.append(.schedules)
@@ -90,11 +89,6 @@ struct SettingsPanel: View {
         self.onEnableIntegration = onEnableIntegration
         self.featureFlagClient = featureFlagClient
 
-        // Pre-compute the billing flag so the first render already has the
-        // correct tab list in the sidebar nav.
-        let billingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
-        _isBillingEnabled = State(initialValue: billingEnabled)
-
         // Pre-compute the sounds flag so deep-link validation below uses
         // the actual config value instead of the @State default (true).
         let soundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
@@ -108,11 +102,7 @@ struct SettingsPanel: View {
         // first instance and leaves the second with .general).
         if let pending = store.pendingSettingsTab {
             // Validate that the deep-linked tab is actually visible before
-            // accepting it. @AppStorage isn't wired to UserDefaults in init,
-            // so read connectedOrgId directly from UserDefaults.
-            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
-            let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
-            // Contacts and developer flags load asynchronously, so default
+            // accepting it. Contacts and developer flags load asynchronously, so default
             // to false at init time — those tabs aren't visible yet.
             // Compaction Playground is also deferred until flags load and
             // dev mode can be evaluated by the live sidebar visibility helper.
@@ -121,7 +111,6 @@ struct SettingsPanel: View {
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
             let visibleTabs = SettingsTab.sidebarTopTabs(
-                billingEnabled: canShowBilling,
                 soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
@@ -154,7 +143,6 @@ struct SettingsPanel: View {
     /// Re-evaluated after loadFeatureFlags() completes.
     @State private var deferredDeepLinkTab: SettingsTab?
     @State private var hasLoadedFeatureFlags: Bool = false
-    @State private var isBillingEnabled: Bool = false
     @State private var isDeveloperEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
@@ -164,8 +152,6 @@ struct SettingsPanel: View {
     @State private var devUnlockText: String = ""
     @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
-    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
-    private static let billingFeatureFlagKey = "settings-billing"
     private static let developerFeatureFlagKey = "settings-developer-nav"
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
@@ -237,7 +223,6 @@ struct SettingsPanel: View {
             await loadFeatureFlags()
         }
         .onAppear {
-            isBillingEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.billingFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
@@ -266,9 +251,6 @@ struct SettingsPanel: View {
                 selectVisibleTab(tab)
             }
         }
-        .onChange(of: billingVisible) { _, _ in
-            handleSidebarVisibilityChanged()
-        }
         .onChange(of: isDebugVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
@@ -286,8 +268,6 @@ struct SettingsPanel: View {
                let enabled = notification.userInfo?["enabled"] as? Bool {
                 if key == Self.developerFeatureFlagKey {
                     isDeveloperEnabled = enabled
-                } else if key == Self.billingFeatureFlagKey {
-                    isBillingEnabled = enabled
                 } else if key == Self.compactionPlaygroundFeatureFlagKey {
                     isCompactionPlaygroundEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
@@ -390,16 +370,10 @@ struct SettingsPanel: View {
 
     private var visibleSidebarTopTabs: [SettingsTab] {
         SettingsTab.sidebarTopTabs(
-            billingEnabled: billingVisible,
             soundsEnabled: isSoundsEnabled,
             debugEnabled: isDebugVisible,
             includeCompactionPlayground: isCompactionPlaygroundVisible
         )
-    }
-
-    private var billingVisible: Bool {
-        let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
-        return isBillingEnabled && authManager.isAuthenticated && connectedOrgId != nil
     }
 
     /// The Debug tab currently only hosts cloud-hosted assistant tooling

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -102,23 +102,28 @@ struct SettingsPanel: View {
         // first instance and leaves the second with .general).
         if let pending = store.pendingSettingsTab {
             // Validate that the deep-linked tab is actually visible before
-            // accepting it. Contacts and developer flags load asynchronously, so default
-            // to false at init time — those tabs aren't visible yet.
-            // Compaction Playground is also deferred until flags load and
+            // accepting it. @AppStorage isn't wired to UserDefaults in init,
+            // so read connectedOrgId directly from UserDefaults.
+            let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
+            let canShowBilling = billingEnabled && authManager.isAuthenticated && orgId != nil
+            // Compaction Playground is deferred until flags load and
             // dev mode can be evaluated by the live sidebar visibility helper.
             // Debug tab is gated to managed assistants; `AppDelegate` publishes
             // this synchronously via `isCurrentAssistantManaged` which is set
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
-            let visibleTabs = SettingsTab.sidebarTopTabs(
+            var visibleTabs = SettingsTab.sidebarTopTabs(
+                billingEnabled: canShowBilling,
                 soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
             )
+            // Developer tab is always visible (no longer feature-flagged).
+            visibleTabs.append(.developer)
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else if Self.deferredDeepLinkTabs.contains(pending) {
-                // Tab may become visible once feature flags load (e.g. .developer).
+                // Tab may become visible once feature flags load (e.g. .compactionPlayground).
                 // Preserve it for deferred evaluation in loadFeatureFlags().
                 _deferredDeepLinkTab = State(initialValue: pending)
             }
@@ -143,21 +148,19 @@ struct SettingsPanel: View {
     /// Re-evaluated after loadFeatureFlags() completes.
     @State private var deferredDeepLinkTab: SettingsTab?
     @State private var hasLoadedFeatureFlags: Bool = false
-    @State private var isDeveloperEnabled: Bool = false
+    @State private var isBillingEnabled: Bool = false
     @State private var isCompactionPlaygroundEnabled: Bool = false
     @State private var isSoundsEnabled: Bool = true
     @State private var isEmbeddingProviderEnabled: Bool = false
     @State private var isEmailChannelEnabled: Bool = false
-    @State private var showingDevUnlock: Bool = false
-    @State private var devUnlockText: String = ""
-    @State private var devUnlockMonitor: Any?
     @State private var bootstrapGeneration: Int = 0
-    private static let developerFeatureFlagKey = "settings-developer-nav"
+    @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
+    private static let billingFeatureFlagKey = "settings-billing"
     private static let compactionPlaygroundFeatureFlagKey = "compaction-playground"
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
-    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.developer, .compactionPlayground]
+    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.compactionPlayground]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -257,17 +260,14 @@ struct SettingsPanel: View {
         .onChange(of: isSoundsEnabled) { _, _ in
             handleSidebarVisibilityChanged()
         }
-        .onChange(of: isDeveloperEnabled) { _, _ in
-            handleSidebarVisibilityChanged()
-        }
         .onChange(of: isCompactionPlaygroundVisible) { _, _ in
             handleSidebarVisibilityChanged()
         }
         .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
             if let key = notification.userInfo?["key"] as? String,
                let enabled = notification.userInfo?["enabled"] as? Bool {
-                if key == Self.developerFeatureFlagKey {
-                    isDeveloperEnabled = enabled
+                if key == Self.billingFeatureFlagKey {
+                    isBillingEnabled = enabled
                 } else if key == Self.compactionPlaygroundFeatureFlagKey {
                     isCompactionPlaygroundEnabled = enabled
                 } else if key == Self.embeddingProviderFeatureFlagKey {
@@ -294,56 +294,6 @@ struct SettingsPanel: View {
         .sheet(isPresented: $showingTrustRules, onDismiss: { connectionManager?.isTrustRulesSheetOpen = false }) {
             TrustRulesView(trustRuleClient: TrustRuleClient())
         }
-        .onAppear {
-            devUnlockMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-                if event.modifierFlags.contains(.command),
-                   event.charactersIgnoringModifiers == "d" {
-                    showingDevUnlock = true
-                    devUnlockText = ""
-                    return nil
-                }
-                return event
-            }
-        }
-        .onDisappear {
-            if let monitor = devUnlockMonitor {
-                NSEvent.removeMonitor(monitor)
-                devUnlockMonitor = nil
-            }
-        }
-        .popover(isPresented: $showingDevUnlock) {
-            VStack(spacing: VSpacing.md) {
-                Text("Enter passcode")
-                    .font(VFont.bodySmallDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-                VTextField(
-                    placeholder: "",
-                    text: $devUnlockText,
-                    isSecure: true,
-                    onSubmit: {
-                        if devUnlockText.lowercased() == "dev" {
-                            isDeveloperEnabled = true
-                            showingDevUnlock = false
-                            // Notify listeners (e.g. AssistantFeatureFlagStore) so UI updates globally
-                            NotificationCenter.default.post(
-                                name: .assistantFeatureFlagDidChange,
-                                object: nil,
-                                userInfo: ["key": Self.developerFeatureFlagKey, "enabled": true]
-                            )
-                            // Persist locally (cache) for optimistic UI + PATCH to gateway
-                            AssistantFeatureFlagResolver.mergeCachedFlag(key: Self.developerFeatureFlagKey, enabled: true)
-                            Task {
-                                try? await featureFlagClient.setFeatureFlag(key: Self.developerFeatureFlagKey, enabled: true)
-                            }
-                        }
-                        devUnlockText = ""
-                    },
-                    maxWidth: 160,
-                    font: VFont.bodyMediumDefault
-                )
-            }
-            .padding(VSpacing.lg)
-        }
     }
 
     private func scrollToPendingGeneralSection(using scrollProxy: ScrollViewProxy) {
@@ -362,9 +312,7 @@ struct SettingsPanel: View {
     /// All currently visible tabs (top nav + gated bottom nav).
     private var allVisibleTabs: [SettingsTab] {
         var tabs = visibleSidebarTopTabs
-        if isDeveloperEnabled {
-            tabs.append(.developer)
-        }
+        tabs.append(.developer)
         return tabs
     }
 
@@ -385,7 +333,7 @@ struct SettingsPanel: View {
     }
 
     private var isCompactionPlaygroundVisible: Bool {
-        isDeveloperEnabled && isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
+        isCompactionPlaygroundEnabled && DevModeManager.shared.isDevMode
     }
 
     private var settingsNav: some View {
@@ -396,14 +344,12 @@ struct SettingsPanel: View {
                 }
             }
             Spacer(minLength: VSpacing.sm)
-            if isDeveloperEnabled {
-                VColor.surfaceBase
-                    .frame(height: 1)
-                    .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
-                    .padding(.trailing, VSpacing.md)
-                VNavItem(icon: SettingsTab.developer.icon.rawValue, label: "Developer", isActive: selectedTab == .developer) {
-                    selectVisibleTab(.developer)
-                }
+            VColor.surfaceBase
+                .frame(height: 1)
+                .padding(.vertical, SidebarLayoutMetrics.dividerVerticalPadding)
+                .padding(.trailing, VSpacing.md)
+            VNavItem(icon: SettingsTab.developer.icon.rawValue, label: "Developer", isActive: selectedTab == .developer) {
+                selectVisibleTab(.developer)
             }
         }
         .padding(.top, VSpacing.lg)
@@ -699,9 +645,6 @@ struct SettingsPanel: View {
         if connectionManager != nil {
             do {
                 let flags = try await featureFlagClient.getFeatureFlags()
-                if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
-                    isDeveloperEnabled = developerFlag.enabled
-                }
                 if let playgroundFlag = flags.first(where: { $0.key == Self.compactionPlaygroundFeatureFlagKey }) {
                     isCompactionPlaygroundEnabled = playgroundFlag.enabled
                 }
@@ -726,9 +669,6 @@ struct SettingsPanel: View {
             registry: loadFeatureFlagRegistry()
         )
 
-        if let developerEnabled = resolved[Self.developerFeatureFlagKey] {
-            isDeveloperEnabled = developerEnabled
-        }
         if let playgroundEnabled = resolved[Self.compactionPlaygroundFeatureFlagKey] {
             isCompactionPlaygroundEnabled = playgroundEnabled
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -20,7 +20,6 @@ struct DrawerMenuView: View {
     private var isBillingVisible: Bool {
         let _ = bootstrapGeneration  // Force recomputation when bootstrap completes
         return authManager.isAuthenticated &&
-        MacOSClientFeatureFlagManager.shared.isEnabled("settings-billing") &&
         connectedOrgId != nil
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -15,7 +15,6 @@ struct DrawerMenuView: View {
     @State private var isLowBalance = false
     @State private var isZeroBalance = false
     @State private var bootstrapGeneration: Int = 0
-    @State private var isReferralCodesEnabled: Bool = false
     @AppStorage("connectedOrganizationId") private var connectedOrgId: String?
 
     private var isBillingVisible: Bool {
@@ -26,7 +25,7 @@ struct DrawerMenuView: View {
     }
 
     private var isReferralVisible: Bool {
-        isBillingVisible && isReferralCodesEnabled
+        isBillingVisible
     }
 
     var body: some View {
@@ -89,15 +88,7 @@ struct DrawerMenuView: View {
         .onReceive(NotificationCenter.default.publisher(for: .localBootstrapCompleted)) { _ in
             bootstrapGeneration += 1
         }
-        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
-            if let key = notification.userInfo?["key"] as? String,
-               key == "referral-codes",
-               let enabled = notification.userInfo?["enabled"] as? Bool {
-                isReferralCodesEnabled = enabled
-            }
-        }
         .task {
-            isReferralCodesEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("referral-codes")
             await loadBalance()
         }
     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -29,9 +29,6 @@ struct HatchingStepView: View {
     private var hatchColor: AvatarColor {
         state.hatchAvatarColor ?? .allCases[0]
     }
-    private var managedSignInEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
-    }
     @State private var showFooterCharacters = false
     @State private var completionTask: Task<Void, Never>?
     @State private var healthCheckTask: Task<Void, Never>?
@@ -601,7 +598,7 @@ struct HatchingStepView: View {
         if !state.selectedModel.isEmpty {
             configValues["llm.default.model"] = state.selectedModel
         }
-        if managedSignInEnabled && !state.skippedAuth {
+        if !state.skippedAuth {
             configValues["services.inference.mode"] = "managed"
             configValues["services.image-generation.mode"] = "managed"
             configValues["services.web-search.mode"] = "managed"

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -23,10 +23,6 @@ struct OnboardingFlowView: View {
         NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
     }()
 
-    private var managedSignInEnabled: Bool {
-        MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
-    }
-
     private var preChatOnboardingEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("onboarding-pre-chat")
     }
@@ -106,7 +102,7 @@ struct OnboardingFlowView: View {
                     Group {
                         switch state.currentStep {
                             case 0:
-                                if managedSignInEnabled && authManager.isAuthenticated {
+                                if authManager.isAuthenticated {
                                     // Already authenticated — show a brief loading
                                     // state while the .task advances to Setup.
                                     HStack(spacing: VSpacing.sm) {
@@ -119,9 +115,9 @@ struct OnboardingFlowView: View {
                                 } else {
                                     WakeUpStepView(
                                         state: state,
-                                        authManager: managedSignInEnabled ? authManager : nil,
+                                        authManager: authManager,
                                         isAdvancing: isAdvancingFromWakeUp,
-                                        managedSignInEnabled: managedSignInEnabled,
+                                        managedSignInEnabled: true,
                                         onStartWithAPIKey: {
                                             guard !isAdvancingFromWakeUp else { return }
                                             isAdvancingFromWakeUp = true
@@ -197,14 +193,14 @@ struct OnboardingFlowView: View {
             if !authManager.isAuthenticated {
                 await authManager.checkSession()
             }
-            if managedSignInEnabled && authManager.isAuthenticated && state.currentStep == 0 {
+            if authManager.isAuthenticated && state.currentStep == 0 {
                 await continueManagedOnboardingAfterAuthentication()
             }
         }
         .onChange(of: state.currentStep) { _, newStep in
             if newStep == 0 {
                 isAdvancingFromWakeUp = false
-                if managedSignInEnabled && authManager.isAuthenticated {
+                if authManager.isAuthenticated {
                     Task {
                         await continueManagedOnboardingAfterAuthentication()
                     }
@@ -219,7 +215,7 @@ struct OnboardingFlowView: View {
             log.info(
                 "Observed auth state change in onboarding: isAuthenticated=\(isAuthenticated, privacy: .public) managedBootstrapEnabled=\(self.managedBootstrapEnabled, privacy: .public) lockfileAssistantId=\(currentAssistant?.assistantId ?? "<none>", privacy: .public)"
             )
-            if !isAuthenticated && managedSignInEnabled && state.currentStep > 0 {
+            if !isAuthenticated && state.currentStep > 0 {
                 log.info("User signed out during managed onboarding — returning to welcome screen")
                 completionDelayTask?.cancel()
                 didCallComplete = false
@@ -242,7 +238,7 @@ struct OnboardingFlowView: View {
             }
             if isAuthenticated {
                 if let assistant = currentAssistant {
-                    if assistant.isManaged && managedSignInEnabled && state.currentStep == 0 {
+                    if assistant.isManaged && state.currentStep == 0 {
                         log.info("Authenticated with managed assistant \(assistant.assistantId, privacy: .public); advancing to hosting selector")
                         state.advance()
                     } else if assistant.isManaged {
@@ -258,7 +254,7 @@ struct OnboardingFlowView: View {
                         onComplete()
                     }
                 } else if managedBootstrapEnabled {
-                    if managedSignInEnabled && state.currentStep == 0 {
+                    if state.currentStep == 0 {
                         Task {
                             await continueManagedOnboardingAfterAuthentication()
                         }
@@ -308,7 +304,6 @@ struct OnboardingFlowView: View {
 
     private func continueManagedOnboardingAfterAuthentication() async {
         guard managedBootstrapEnabled,
-              managedSignInEnabled,
               authManager.isAuthenticated,
               state.currentStep == 0,
               !isResolvingAssociatedManagedAssistant else {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -23,6 +23,10 @@ struct OnboardingFlowView: View {
         NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
     }()
 
+    private var managedSignInEnabled: Bool {
+        MacOSClientFeatureFlagManager.shared.isEnabled("managed-sign-in")
+    }
+
     private var preChatOnboardingEnabled: Bool {
         MacOSClientFeatureFlagManager.shared.isEnabled("onboarding-pre-chat")
     }
@@ -275,13 +279,9 @@ struct OnboardingFlowView: View {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     guard !Task.isCancelled else { return }
                     guard state.hatchCompleted else { return }
-                    if preChatOnboardingEnabled {
-                        PreChatOnboardingState.clearPersistedState()
-                        withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
-                            isShowingPreChat = true
-                        }
-                    } else {
-                        onComplete()
+                    PreChatOnboardingState.clearPersistedState()
+                    withAnimation(.spring(duration: 0.6, bounce: 0.15)) {
+                        isShowingPreChat = true
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -112,8 +112,7 @@ final class OnboardingState {
     var hatchTotalSteps: Int = 1
     var hatchCurrentStep: Int = 0
 
-    /// Pre-chat onboarding context collected after hatching when the
-    /// `onboarding-pre-chat` feature flag is enabled. Threaded through
+    /// Pre-chat onboarding context collected after hatching. Threaded through
     /// AppDelegate → ConversationManager → ChatViewModel so the first
     /// message POST includes it for assistant personalization.
     var preChatContext: PreChatOnboardingContext?

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -58,8 +58,8 @@ struct AssistantUpgradeSection: View {
     @State private var isTakingLongerThanExpected = false
     @State private var escalationTask: Task<Void, Never>?
     @State private var dockerUpgradeTask: Task<Void, Never>?
-    @State private var backwardReleasesEnabled = false
-    private let featureFlagClient = FeatureFlagClient()
+    @State private var backwardReleasesEnabled = true
+
 
     private var latestRelease: AssistantRelease? {
         availableReleases.first
@@ -381,11 +381,6 @@ struct AssistantUpgradeSection: View {
             }
         }
         .task { await loadReleases() }
-        .task {
-            if let flags = try? await featureFlagClient.getFeatureFlags() {
-                backwardReleasesEnabled = flags.first(where: { $0.key == "backward-releases" })?.enabled ?? false
-            }
-        }
         .onChange(of: currentVersion) { _, _ in
             Task { await loadReleasesQuietly() }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -21,7 +21,6 @@ struct SettingsBillingTab: View {
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
-    @State private var isReferralCodesEnabled: Bool = false
     @State private var showEarnCreditsModal: Bool = false
 
     var body: some View {
@@ -37,7 +36,6 @@ struct SettingsBillingTab: View {
             EarnCreditsModal()
         }
         .task {
-            isReferralCodesEnabled = MacOSClientFeatureFlagManager.shared.isEnabled("referral-codes")
             await loadSummary()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
@@ -48,13 +46,6 @@ struct SettingsBillingTab: View {
             }
         }
         .background(WindowReader(window: $hostWindow))
-        .onReceive(NotificationCenter.default.publisher(for: .assistantFeatureFlagDidChange)) { notification in
-            if let key = notification.userInfo?["key"] as? String,
-               key == "referral-codes",
-               let enabled = notification.userInfo?["enabled"] as? Bool {
-                isReferralCodesEnabled = enabled
-            }
-        }
     }
 
     // MARK: - Balance Card
@@ -63,15 +54,13 @@ struct SettingsBillingTab: View {
         SettingsCard(
             title: "Credit Balance",
             accessory: {
-                if isReferralCodesEnabled {
-                    VButton(
-                        label: "Earn credits",
-                        leftIcon: VIcon.gift.rawValue,
-                        style: .outlined,
-                        size: .compact
-                    ) {
-                        showEarnCreditsModal = true
-                    }
+                VButton(
+                    label: "Earn credits",
+                    leftIcon: VIcon.gift.rawValue,
+                    style: .outlined,
+                    size: .compact
+                ) {
+                    showEarnCreditsModal = true
                 }
             }
         ) {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -194,7 +194,6 @@ final class ChatActionHandler {
             guard !vm.isCancelling else { break }
             guard !vm.isLoadingHistory else { break }
             guard !vm.isWorkspaceRefinementInFlight else { break }
-            guard MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks") else { break }
             vm.thinkingDeltaBuffer += delta.thinking
             vm.scheduleThinkingFlush()
 

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -57,7 +57,7 @@ public struct AssistantFeatureFlag: Decodable, Identifiable, Sendable, Equatable
     }
 
     /// Derive a human-readable name from the flag key.
-    /// e.g. "settings-developer-nav" -> "Settings Developer Nav"
+    /// e.g. "settings-billing" -> "Settings Billing"
     public var displayName: String {
         if let label = label { return label }
         return key

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -488,12 +488,12 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     const handler = createFeatureFlagsPatchHandler();
     const res = await handler(
-      new Request("http://gateway.test/v1/feature-flags/browser", {
+      new Request("http://gateway.test/v1/feature-flags/email-channel", {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ enabled: true }),
       }),
-      "browser",
+      "email-channel",
     );
 
     expect(res.status).toBe(200);
@@ -501,7 +501,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
 
     clearFeatureFlagStoreCache();
     const persisted = readPersistedFeatureFlags();
-    expect(persisted["browser"]).toBe(true);
+    expect(persisted["email-channel"]).toBe(true);
   });
 
   // Validation tests

--- a/gateway/src/__tests__/remote-feature-flag-sync.test.ts
+++ b/gateway/src/__tests__/remote-feature-flag-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import type { CredentialCache } from "../credential-cache.js";
 
@@ -32,6 +33,37 @@ const { RemoteFeatureFlagSync } =
   await import("../remote-feature-flag-sync.js");
 const { readRemoteFeatureFlags, clearRemoteFeatureFlagStoreCache } =
   await import("../feature-flag-remote-store.js");
+const { resetFeatureFlagDefaultsCache, _setRegistryCandidateOverrides } =
+  await import("../feature-flag-defaults.js");
+
+// ---------------------------------------------------------------------------
+// Test-local registry with a GA flag (defaultEnabled: true) for the
+// "ignores remote false for GA flags" test. Written to an isolated temp path
+// so we never touch the committed registry file.
+// ---------------------------------------------------------------------------
+const testRegistryPath = join(protectedDir, "feature-flag-registry.json");
+
+const TEST_REGISTRY = {
+  version: 1,
+  flags: [
+    {
+      id: "test-ga-flag",
+      scope: "assistant",
+      key: "test-ga-flag",
+      label: "Test GA Flag",
+      description: "A test flag that is GA (defaultEnabled: true)",
+      defaultEnabled: true,
+    },
+    {
+      id: "email-channel",
+      scope: "assistant",
+      key: "email-channel",
+      label: "Email Channel",
+      description: "Email channel integration",
+      defaultEnabled: false,
+    },
+  ],
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -92,6 +124,10 @@ beforeEach(() => {
   delete process.env.VELLUM_PLATFORM_URL;
   delete process.env.PLATFORM_INTERNAL_API_KEY;
   mkdirSync(protectedDir, { recursive: true });
+  // Write the test registry and point resolution at it
+  writeFileSync(testRegistryPath, JSON.stringify(TEST_REGISTRY, null, 2));
+  _setRegistryCandidateOverrides([testRegistryPath]);
+  resetFeatureFlagDefaultsCache();
   clearRemoteFeatureFlagStoreCache();
   fetchMock = mock(async () => new Response());
 });
@@ -113,6 +149,8 @@ afterEach(() => {
   } catch {
     // best effort cleanup
   }
+  _setRegistryCandidateOverrides(null);
+  resetFeatureFlagDefaultsCache();
   clearRemoteFeatureFlagStoreCache();
 });
 
@@ -423,15 +461,17 @@ describe("RemoteFeatureFlagSync", () => {
     // The platform sends false for all flags it knows about (blanket-deny).
     // GA flags (defaultEnabled: true in the registry) should not be disabled
     // by remote overrides — only local persisted overrides can do that.
+    // Uses the test-local registry which defines test-ga-flag as GA
+    // (defaultEnabled: true) and email-channel as gated (defaultEnabled: false).
     fetchMock = mock(async () =>
       Response.json({
         flags: {
           // GA flag (defaultEnabled: true) — remote false should be dropped
-          "conversation-starters": false,
+          "test-ga-flag": false,
           // Gated flag (defaultEnabled: false) — remote false is kept
           "email-channel": false,
           // GA flag set to true — should be kept (redundant but harmless)
-          browser: true,
+          "test-ga-flag-true": true,
           // Unknown flag — remote false is kept (not in registry)
           "unknown-flag": false,
         },
@@ -446,12 +486,12 @@ describe("RemoteFeatureFlagSync", () => {
 
     clearRemoteFeatureFlagStoreCache();
     const cached = readRemoteFeatureFlags();
-    // conversation-starters (GA, remote false) should be absent
-    expect(cached["conversation-starters"]).toBeUndefined();
+    // test-ga-flag (GA, remote false) should be absent
+    expect(cached["test-ga-flag"]).toBeUndefined();
     // email-channel (gated, remote false) should be present
     expect(cached["email-channel"]).toBe(false);
-    // browser (GA, remote true) should be present
-    expect(cached.browser).toBe(true);
+    // test-ga-flag-true (unknown but true) should be present
+    expect(cached["test-ga-flag-true"]).toBe(true);
     // unknown-flag (not in registry, remote false) should be present
     expect(cached["unknown-flag"]).toBe(false);
   });

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -157,10 +157,7 @@ import {
 } from "./twilio/webhook-sync-trigger.js";
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
-import {
-  featureFlagRoutes,
-  getMergedFeatureFlags,
-} from "./ipc/feature-flag-handlers.js";
+import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
 import { capabilityTokenRoutes } from "./ipc/capability-token-handlers.js";
 import { riskClassificationRoutes } from "./ipc/risk-classification-handlers.js";
@@ -1907,12 +1904,7 @@ async function main() {
         );
       });
 
-      // Sync avatar to Slack bot profile on credential change (including
-      // initial startup). Gated behind channel-avatar-sync feature flag.
-      // Known limitation: if the flag is toggled off without a credential
-      // change, the syncer stays registered until the next credential
-      // change triggers this callback.
-      if (slackReady && getMergedFeatureFlags()["channel-avatar-sync"]) {
+      if (slackReady) {
         avatarChannelSyncer.register(new SlackAvatarSyncer(credentialCache));
         avatarChannelSyncer.syncToChannel("slack").catch((err) => {
           log.warn({ err }, "Initial Slack avatar sync failed");

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -258,14 +258,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "message-height-cache",
-      "scope": "client",
-      "key": "message-height-cache",
-      "label": "Message Height Cache",
-      "description": "Swap the transcript's LazyVStack for a plain VStack so scrollContentHeight is the true sum of row heights (no LazyVStack estimator drift). Row frames are not pinned \u2014 the earlier frame-pinning approach was removed because it caused overlap when rows grew past their first measurement (streaming, expanding thinking blocks). Tradeoff: eager layout \u2014 every row measures up-front, which can stall for many seconds to minutes on very long conversations.",
-      "defaultEnabled": true
-    },
-    {
       "id": "coding-agents-panel",
       "scope": "client",
       "key": "coding-agents-panel",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -114,14 +114,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "managed-sign-in",
-      "scope": "client",
-      "key": "managed-sign-in",
-      "label": "Managed Sign In",
-      "description": "Enable managed (organization-hosted) sign-in flow in the onboarding experience",
-      "defaultEnabled": true
-    },
-    {
       "id": "deploy-to-vercel",
       "scope": "assistant",
       "key": "deploy-to-vercel",
@@ -302,7 +294,7 @@
       "scope": "client",
       "key": "message-height-cache",
       "label": "Message Height Cache",
-      "description": "Swap the transcript's LazyVStack for a plain VStack so scrollContentHeight is the true sum of row heights (no LazyVStack estimator drift). Row frames are not pinned — the earlier frame-pinning approach was removed because it caused overlap when rows grew past their first measurement (streaming, expanding thinking blocks). Tradeoff: eager layout — every row measures up-front, which can stall for many seconds to minutes on very long conversations.",
+      "description": "Swap the transcript's LazyVStack for a plain VStack so scrollContentHeight is the true sum of row heights (no LazyVStack estimator drift). Row frames are not pinned \u2014 the earlier frame-pinning approach was removed because it caused overlap when rows grew past their first measurement (streaming, expanding thinking blocks). Tradeoff: eager layout \u2014 every row measures up-front, which can stall for many seconds to minutes on very long conversations.",
       "defaultEnabled": true
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -82,30 +82,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "ces-credential-backend",
-      "scope": "assistant",
-      "key": "ces-credential-backend",
-      "label": "CES Credential Backend",
-      "description": "Route credential reads and writes through the CES process instead of accessing the encrypted store directly",
-      "defaultEnabled": true
-    },
-    {
-      "id": "referral-codes",
-      "scope": "client",
-      "key": "referral-codes",
-      "label": "Referral Codes",
-      "description": "Surface the Earn Credits referral entry points (sidebar drawer row and Billing tab button) that open the referral modal",
-      "defaultEnabled": true
-    },
-    {
-      "id": "settings-billing",
-      "scope": "client",
-      "key": "settings-billing",
-      "label": "Billing Settings Tab",
-      "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
-      "defaultEnabled": true
-    },
-    {
       "id": "deploy-to-vercel",
       "scope": "assistant",
       "key": "deploy-to-vercel",
@@ -144,30 +120,6 @@
       "label": "Expand Completed Steps",
       "description": "Auto-expand completed tool call step groups instead of showing them collapsed",
       "defaultEnabled": false
-    },
-    {
-      "id": "show-thinking-blocks",
-      "scope": "client",
-      "key": "show-thinking-blocks",
-      "label": "Show Thinking Blocks",
-      "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
-      "defaultEnabled": true
-    },
-    {
-      "id": "inline-skill-commands",
-      "scope": "assistant",
-      "key": "inline-skill-commands",
-      "label": "Inline Skill Command Expansion",
-      "description": "Enable secure inline skill command expansion via !`command` syntax, with version-pinned approval and sandboxed execution at skill load time",
-      "defaultEnabled": true
-    },
-    {
-      "id": "channel-voice-transcription",
-      "scope": "assistant",
-      "key": "channel-voice-transcription",
-      "label": "Channel Voice Transcription",
-      "description": "Auto-transcribe voice/audio messages received from channels (Telegram, WhatsApp) before processing",
-      "defaultEnabled": true
     },
     {
       "id": "message-tts",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -130,14 +130,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "referral-codes",
-      "scope": "client",
-      "key": "referral-codes",
-      "label": "Referral Codes",
-      "description": "Surface the Earn Credits referral entry points (sidebar drawer row and Billing tab button) that open the referral modal",
-      "defaultEnabled": true
-    },
-    {
       "id": "managed-sign-in",
       "scope": "client",
       "key": "managed-sign-in",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -34,14 +34,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "app-builder-multifile",
-      "scope": "assistant",
-      "key": "app-builder-multifile",
-      "label": "App Builder Multi-file",
-      "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
-      "defaultEnabled": true
-    },
-    {
       "id": "mobile-pairing",
       "scope": "client",
       "key": "mobile-pairing",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -42,14 +42,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "settings-developer-nav",
-      "scope": "assistant",
-      "key": "settings-developer-nav",
-      "label": "Settings Developer Nav",
-      "description": "Control Developer nav visibility in macOS settings",
-      "defaultEnabled": true
-    },
-    {
       "id": "developer-menu-items",
       "scope": "client",
       "key": "developer-menu-items",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -106,14 +106,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "ces-credential-backend",
-      "scope": "assistant",
-      "key": "ces-credential-backend",
-      "label": "CES Credential Backend",
-      "description": "Route credential reads and writes through the CES process instead of accessing the encrypted store directly",
-      "defaultEnabled": true
-    },
-    {
       "id": "settings-billing",
       "scope": "client",
       "key": "settings-billing",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -138,14 +138,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "conversation-starters",
-      "scope": "assistant",
-      "key": "conversation-starters",
-      "label": "Recommended Starts",
-      "description": "Show a curated row of recommended starting actions on the empty conversation page, ordered by relevance as confident first-click options",
-      "defaultEnabled": true
-    },
-    {
       "id": "deploy-to-vercel",
       "scope": "assistant",
       "key": "deploy-to-vercel",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -218,14 +218,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "backward-releases",
-      "scope": "assistant",
-      "key": "backward-releases",
-      "label": "Backward Releases",
-      "description": "Show older versions in the version picker, allowing rollback to previous releases",
-      "defaultEnabled": true
-    },
-    {
       "id": "voice-mode",
       "scope": "assistant",
       "key": "voice-mode",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -242,14 +242,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "tool-result-truncation",
-      "scope": "assistant",
-      "key": "tool-result-truncation",
-      "label": "Post-Turn Tool Result Truncation",
-      "description": "Truncate large tool results after each assistant turn, persisting full content to disk for on-demand re-reads",
-      "defaultEnabled": true
-    },
-    {
       "id": "managed-gemini-embeddings-enabled",
       "scope": "assistant",
       "key": "managed-gemini-embeddings-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -82,15 +82,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "ces-managed-sidecar",
-      "scope": "assistant",
-      "key": "ces-managed-sidecar",
-      "label": "CES Managed Sidecar Transport",
-      "description": "Use managed sidecar transport for CES communication when running in a containerized environment",
-      "defaultEnabled": true
-    },
-    {
-<<<<<<< HEAD
       "id": "ces-credential-backend",
       "scope": "assistant",
       "key": "ces-credential-backend",
@@ -104,13 +95,14 @@
       "key": "referral-codes",
       "label": "Referral Codes",
       "description": "Surface the Earn Credits referral entry points (sidebar drawer row and Billing tab button) that open the referral modal",
-=======
+      "defaultEnabled": true
+    },
+    {
       "id": "settings-billing",
       "scope": "client",
       "key": "settings-billing",
       "label": "Billing Settings Tab",
       "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
->>>>>>> origin/noanflaherty/ga-default-on-flags
       "defaultEnabled": true
     },
     {
@@ -154,19 +146,19 @@
       "defaultEnabled": false
     },
     {
-<<<<<<< HEAD
       "id": "show-thinking-blocks",
       "scope": "client",
       "key": "show-thinking-blocks",
       "label": "Show Thinking Blocks",
       "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
-=======
+      "defaultEnabled": true
+    },
+    {
       "id": "inline-skill-commands",
       "scope": "assistant",
       "key": "inline-skill-commands",
       "label": "Inline Skill Command Expansion",
       "description": "Enable secure inline skill command expansion via !`command` syntax, with version-pinned approval and sandboxed execution at skill load time",
->>>>>>> origin/noanflaherty/ga-default-on-flags
       "defaultEnabled": true
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -266,14 +266,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "channel-avatar-sync",
-      "scope": "assistant",
-      "key": "channel-avatar-sync",
-      "label": "Channel Avatar Sync",
-      "description": "Automatically sync the assistant's avatar to connected channels (Slack) when the avatar changes or a new channel is connected",
-      "defaultEnabled": true
-    },
-    {
       "id": "meet",
       "scope": "assistant",
       "key": "meet",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -162,11 +162,11 @@
       "defaultEnabled": true
     },
     {
-      "id": "sounds",
+      "id": "channel-voice-transcription",
       "scope": "assistant",
-      "key": "sounds",
-      "label": "Sounds",
-      "description": "Enable the Sounds tab in Settings and all app sound playback (event sounds, random ambient sounds)",
+      "key": "channel-voice-transcription",
+      "label": "Channel Voice Transcription",
+      "description": "Auto-transcribe voice/audio messages received from channels (Telegram, WhatsApp) before processing",
       "defaultEnabled": true
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -250,14 +250,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "onboarding-pre-chat",
-      "scope": "client",
-      "key": "onboarding-pre-chat",
-      "label": "Pre-Chat Onboarding Flow",
-      "description": "Gates the 3-screen pre-chat onboarding flow (tools, tasks/tone, name exchange) shown before the first conversation",
-      "defaultEnabled": true
-    },
-    {
       "id": "home-tab",
       "scope": "client",
       "key": "home-tab",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -178,14 +178,6 @@
       "defaultEnabled": true
     },
     {
-      "id": "channel-voice-transcription",
-      "scope": "assistant",
-      "key": "channel-voice-transcription",
-      "label": "Channel Voice Transcription",
-      "description": "Auto-transcribe voice/audio messages received from channels (Telegram, WhatsApp) before processing",
-      "defaultEnabled": true
-    },
-    {
       "id": "sounds",
       "scope": "assistant",
       "key": "sounds",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -10,14 +10,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "browser",
-      "scope": "assistant",
-      "key": "browser",
-      "label": "Browser",
-      "description": "Enable browser skill prerequisites section in the system prompt",
-      "defaultEnabled": true
-    },
-    {
       "id": "user-hosted-enabled",
       "scope": "client",
       "key": "user-hosted-enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -170,14 +170,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "show-thinking-blocks",
-      "scope": "client",
-      "key": "show-thinking-blocks",
-      "label": "Show Thinking Blocks",
-      "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
-      "defaultEnabled": true
-    },
-    {
       "id": "inline-skill-commands",
       "scope": "assistant",
       "key": "inline-skill-commands",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -106,11 +106,27 @@
       "defaultEnabled": true
     },
     {
+<<<<<<< HEAD
+      "id": "ces-credential-backend",
+      "scope": "assistant",
+      "key": "ces-credential-backend",
+      "label": "CES Credential Backend",
+      "description": "Route credential reads and writes through the CES process instead of accessing the encrypted store directly",
+      "defaultEnabled": true
+    },
+    {
+      "id": "referral-codes",
+      "scope": "client",
+      "key": "referral-codes",
+      "label": "Referral Codes",
+      "description": "Surface the Earn Credits referral entry points (sidebar drawer row and Billing tab button) that open the referral modal",
+=======
       "id": "settings-billing",
       "scope": "client",
       "key": "settings-billing",
       "label": "Billing Settings Tab",
       "description": "Show the Billing tab in Settings when signed in, displaying credits balance and top-up",
+>>>>>>> origin/noanflaherty/ga-default-on-flags
       "defaultEnabled": true
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -162,11 +162,19 @@
       "defaultEnabled": false
     },
     {
+<<<<<<< HEAD
+      "id": "show-thinking-blocks",
+      "scope": "client",
+      "key": "show-thinking-blocks",
+      "label": "Show Thinking Blocks",
+      "description": "Display the assistant's thinking/reasoning inline in chat messages as collapsible blocks",
+=======
       "id": "inline-skill-commands",
       "scope": "assistant",
       "key": "inline-skill-commands",
       "label": "Inline Skill Command Expansion",
       "description": "Enable secure inline skill command expansion via !`command` syntax, with version-pinned approval and sandboxed execution at skill load time",
+>>>>>>> origin/noanflaherty/ga-default-on-flags
       "defaultEnabled": true
     },
     {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -174,7 +174,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-20T18:14:42-04:00"
+      "updatedAt": "2026-05-01T13:55:47-04:00"
     },
     {
       "id": "google-calendar",
@@ -244,7 +244,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-20T18:14:42-04:00"
+      "updatedAt": "2026-05-01T13:55:47-04:00"
     },
     {
       "id": "inbox-management",
@@ -271,7 +271,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-20T18:14:22-04:00"
+      "updatedAt": "2026-05-01T13:55:47-04:00"
     },
     {
       "id": "influencer",
@@ -360,7 +360,7 @@
           "feature-flag": "meet"
         }
       },
-      "updatedAt": "2026-04-30T17:02:02Z"
+      "updatedAt": "2026-05-01T11:27:13-04:00"
     },
     {
       "id": "meme-generator",
@@ -719,14 +719,13 @@
         "emoji": "🌐",
         "vellum": {
           "display-name": "Browser",
-          "feature-flag": "browser",
           "activation-hints": [
             "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-04-19T15:26:17-04:00"
+      "updatedAt": "2026-05-01T15:46:41-04:00"
     },
     {
       "id": "vellum-conversation-management",

--- a/skills/vellum-browser-use/SKILL.md
+++ b/skills/vellum-browser-use/SKILL.md
@@ -6,7 +6,6 @@ metadata:
   emoji: "🌐"
   vellum:
     display-name: "Browser"
-    feature-flag: "browser"
     activation-hints:
       - "Load first if you need to browse the web (navigating, clicking, extracting web content) via `assistant browser` commands"
 ---


### PR DESCRIPTION
## Summary
Remove all 18 feature flags that were already `defaultEnabled: true` from the registry and codebase, making each feature unconditionally enabled. Each flag's entry was removed from the canonical registry, all gating checks were eliminated, and dead code paths were cleaned up.

## Flags GA'd
| Flag | Scope | PR |
|------|-------|----|
| `browser` | assistant | #29139 |
| `app-builder-multifile` | assistant | #29149 |
| `settings-developer-nav` | assistant | #29147 |
| `ces-managed-sidecar` | assistant | #29150 |
| `ces-credential-backend` | assistant | #29141 |
| `settings-billing` | client | #29144 |
| `referral-codes` | client | #29136 |
| `managed-sign-in` | client | #29142 |
| `conversation-starters` | assistant | #29137 |
| `show-thinking-blocks` | client | #29140 |
| `inline-skill-commands` | assistant | #29154 |
| `channel-voice-transcription` | assistant | #29148 |
| `sounds` | assistant | #29153 |
| `backward-releases` | assistant | #29138 |
| `tool-result-truncation` | assistant | #29146 |
| `message-height-cache` | client | #29152 |
| `onboarding-pre-chat` | client | #29145 |
| `channel-avatar-sync` | assistant | #29143 |

## Fix PRs
- #29160: Fix missed backward-releases runtime reference in AssistantUpgradeSection.swift

## Self-review result
Gap found and fixed: backward-releases had a runtime reference in AssistantUpgradeSection.swift with a `?? false` fallback that would have changed behavior. Fixed by making it unconditionally `true`.

Part of plan: ga-default-on-flags.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
