### PR TITLE
feat(onboarding): add AppURLs.dataSharingDocs for AI data sharing policy

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -67,6 +67,11 @@ public enum AppURLs {
         docsURL(path: "/privacy-policy")
     }
 
+    /// AI Data Sharing Policy docs — linked from the onboarding AI data consent checkbox.
+    public static var dataSharingDocs: URL {
+        docsURL(path: "/data-sharing")
+    }
+
     // MARK: - Helpers
 
     /// Build a docs URL by appending a path to the (possibly env-overridden) base.


### PR DESCRIPTION
## Summary
- Add `AppURLs.dataSharingDocs` getter pointing to `/data-sharing` for the AI Data Sharing Policy
- No callers yet — consumed by PR 3 (AI consent checkbox)

Part of plan: onboarding-ai-consent.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
