### PR TITLE
refactor(onboarding): combine share preferences and privacy note into single card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -41,7 +41,7 @@ struct ImproveExperienceStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
         VStack(spacing: 0) {
-            VStack(spacing: VSpacing.sm) {
+            VStack(spacing: 0) {
                 // Usage analytics toggle
                 VToggle(
                     isOn: $collectUsageData,
@@ -50,14 +50,9 @@ struct ImproveExperienceStepView: View {
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(VColor.surfaceLift)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .stroke(VColor.surfaceBase, lineWidth: 1)
-                        )
-                )
+
+                Divider()
+                    .background(VColor.surfaceBase)
 
                 // Diagnostics toggle
                 VToggle(
@@ -67,16 +62,11 @@ struct ImproveExperienceStepView: View {
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(VColor.surfaceLift)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .stroke(VColor.surfaceBase, lineWidth: 1)
-                        )
-                )
 
-                // Privacy note bar
+                Divider()
+                    .background(VColor.surfaceBase)
+
+                // Privacy note
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.eyeOff, size: 14)
                         .foregroundStyle(VColor.contentTertiary)
@@ -84,19 +74,26 @@ struct ImproveExperienceStepView: View {
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
-                .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(VColor.surfaceBase)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .padding(.bottom, VSpacing.sm)
-
-                // ToS consent checkbox
-                HStack(spacing: VSpacing.md) {
-                    tosCheckbox
-                    tosConsentText
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(VSpacing.md)
             }
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(VColor.surfaceLift)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(VColor.surfaceBase, lineWidth: 1)
+                    )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            .padding(.bottom, VSpacing.sm)
+
+            // ToS consent checkbox
+            HStack(spacing: VSpacing.md) {
+                tosCheckbox
+                tosConsentText
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             VStack(spacing: VSpacing.sm) {
                 VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: !tosAccepted) {


### PR DESCRIPTION
## Summary
- Combine Share Analytics, Share Diagnostics, and the privacy note into a single card with 1pt dividers
- Matches the web UI structure in vellum-assistant-platform

Part of plan: onboarding-ai-consent.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
