### PR TITLE
feat: add exportDocumentPDF method to DocumentClient

### DIFF
--- a/clients/shared/Network/DocumentClient.swift
+++ b/clients/shared/Network/DocumentClient.swift
@@ -8,6 +8,7 @@ public protocol DocumentClientProtocol {
     func fetchList(conversationId: String?) async -> DocumentListResponse?
     func fetchDocument(surfaceId: String) async -> DocumentLoadResponse?
     func saveDocument(surfaceId: String, conversationId: String, title: String, content: String, wordCount: Int) async -> DocumentSaveResponse?
+    func exportDocumentPDF(surfaceId: String) async -> Data?
 }
 
 /// Gateway-backed implementation of ``DocumentClientProtocol``.
@@ -102,6 +103,23 @@ public struct DocumentClient: DocumentClientProtocol {
             )
         } catch {
             log.error("saveDocument error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func exportDocumentPDF(surfaceId: String) async -> Data? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/documents/\(surfaceId)/pdf",
+                timeout: 30
+            )
+            guard response.isSuccess else {
+                log.error("exportDocumentPDF failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return response.data
+        } catch {
+            log.error("exportDocumentPDF error: \(error.localizedDescription)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Adds exportDocumentPDF(surfaceId:) to DocumentClientProtocol and DocumentClient
- Calls GET assistants/{assistantId}/documents/{surfaceId}/pdf with 30s timeout
- Returns raw PDF Data on success, nil on failure

Part of plan: doc-pdf-export.md (PR 3 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
