### PR TITLE
fix: change settings-developer-nav to client scope for UserDefaults persistence

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -89,8 +89,11 @@ struct SettingsPanel: View {
         self.onEnableIntegration = onEnableIntegration
         self.featureFlagClient = featureFlagClient
 
-        // Pre-compute the sounds flag so deep-link validation below uses
-        // the actual config value instead of the @State default (true).
+        // Pre-compute client flags so deep-link validation below uses
+        // the actual config values instead of the @State defaults.
+        let developerEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.developerFeatureFlagKey)
+        _isDeveloperEnabled = State(initialValue: developerEnabled)
+
         let soundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
         _isSoundsEnabled = State(initialValue: soundsEnabled)
 
@@ -156,7 +159,7 @@ struct SettingsPanel: View {
     private static let embeddingProviderFeatureFlagKey = "settings-embedding-provider"
     private static let emailChannelFeatureFlagKey = "email-channel"
     private static let soundsFeatureFlagKey = "sounds"
-    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.developer, .compactionPlayground]
+    private static let deferredDeepLinkTabs: Set<SettingsTab> = [.compactionPlayground]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -222,6 +225,7 @@ struct SettingsPanel: View {
             await loadFeatureFlags()
         }
         .onAppear {
+            isDeveloperEnabled = MacOSClientFeatureFlagManager.shared.isEnabled(Self.developerFeatureFlagKey)
             isSoundsEnabled = assistantFeatureFlagStore.isEnabled(Self.soundsFeatureFlagKey)
             // The init already consumed pendingSettingsTab into selectedTab.
             // Clear the store value so it doesn't leak into future navigations.
@@ -329,11 +333,8 @@ struct SettingsPanel: View {
                                 object: nil,
                                 userInfo: ["key": Self.developerFeatureFlagKey, "enabled": true]
                             )
-                            // Persist locally (cache) for optimistic UI + PATCH to gateway
-                            AssistantFeatureFlagResolver.mergeCachedFlag(key: Self.developerFeatureFlagKey, enabled: true)
-                            Task {
-                                try? await featureFlagClient.setFeatureFlag(key: Self.developerFeatureFlagKey, enabled: true)
-                            }
+                            // Persist via client flag manager (UserDefaults)
+                            MacOSClientFeatureFlagManager.shared.setOverride(Self.developerFeatureFlagKey, enabled: true)
                         }
                         devUnlockText = ""
                     },
@@ -698,9 +699,6 @@ struct SettingsPanel: View {
         if connectionManager != nil {
             do {
                 let flags = try await featureFlagClient.getFeatureFlags()
-                if let developerFlag = flags.first(where: { $0.key == Self.developerFeatureFlagKey }) {
-                    isDeveloperEnabled = developerFlag.enabled
-                }
                 if let playgroundFlag = flags.first(where: { $0.key == Self.compactionPlaygroundFeatureFlagKey }) {
                     isCompactionPlaygroundEnabled = playgroundFlag.enabled
                 }
@@ -725,9 +723,6 @@ struct SettingsPanel: View {
             registry: loadFeatureFlagRegistry()
         )
 
-        if let developerEnabled = resolved[Self.developerFeatureFlagKey] {
-            isDeveloperEnabled = developerEnabled
-        }
         if let playgroundEnabled = resolved[Self.compactionPlaygroundFeatureFlagKey] {
             isCompactionPlaygroundEnabled = playgroundEnabled
         }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -43,7 +43,7 @@
     },
     {
       "id": "settings-developer-nav",
-      "scope": "assistant",
+      "scope": "client",
       "key": "settings-developer-nav",
       "label": "Settings Developer Nav",
       "description": "Control Developer nav visibility in macOS settings",


### PR DESCRIPTION
## Summary
- Change `settings-developer-nav` scope from `assistant` to `client` in the registry so it's not dependent on the gateway
- Use `MacOSClientFeatureFlagManager` (UserDefaults) for persistence instead of gateway PATCH, fixing the bug where the developer tab state was lost between settings opens
- Read the flag from `MacOSClientFeatureFlagManager.shared.isEnabled()` on init/onAppear instead of waiting for `loadFeatureFlags()` gateway fetch
- Remove developer flag from `loadFeatureFlags()` network and local paths since it's now a client-side concern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
