### PR TITLE
fix: add unprefixed: true to STTStreamingClient WebSocket path

### DIFF
--- a/clients/shared/Network/STTStreamingClient.swift
+++ b/clients/shared/Network/STTStreamingClient.swift
@@ -159,7 +159,8 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
         do {
             let request = try GatewayHTTPClient.buildWebSocketRequest(
                 path: "stt/stream",
-                params: params
+                params: params,
+                unprefixed: true
             )
             log.info("Opening STT stream WebSocket: mimeType=\(mimeType), sampleRate=\(sampleRate.map(String.init) ?? "nil")")
 


### PR DESCRIPTION
## Summary
Fixes gap: STTStreamingClient WebSocket path was silently changed by auto-prefix.

**Gap:** STTStreamingClient WebSocket path silently changed
**What was expected:** The old path was unprefixed (/v1/stt/stream/)
**What was found:** Auto-prefix now makes it /v1/assistants/{id}/stt/stream/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
