### PR TITLE
fix: update stale doc comment examples in GatewayHTTPClient

### DIFF
--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -405,7 +405,7 @@ public enum GatewayHTTPClient {
     /// Performs an authenticated DELETE request against the gateway.
     ///
     /// - Parameters:
-    ///   - path: Path segment after `/v1/` (e.g. `"assistants/{id}/secrets"`).
+    ///   - path: Path segment after `/v1/` (e.g. `"secrets"`).
     ///   - body: Optional HTTP body data.
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
@@ -834,9 +834,9 @@ public enum GatewayHTTPClient {
     /// ``post(path:body:timeout:)``.
     ///
     /// - Parameters:
-    ///   - path: Path segment after `/v1/` (e.g. `"assistants/{assistantId}/workspace/file/content"`).
+    ///   - path: Path segment after `/v1/` (e.g. `"workspace/file/content"`).
     ///   - params: Optional query parameters.
-    /// - Returns: The fully-qualified URL with `{assistantId}` resolved.
+    /// - Returns: The fully-qualified URL.
     /// - Throws: `ClientError` if the connection cannot be resolved or the URL is invalid.
     public static func buildURL(path: String, params: [String: String]? = nil, unprefixed: Bool = false) throws -> URL {
         let connection = try resolveConnection()


### PR DESCRIPTION
## Summary
Fixes stale doc comments that still showed prefixed path examples.

**Gap:** Stale doc comment examples
**What was expected:** Examples should show unprefixed paths
**What was found:** Two doc comments still referenced assistants/{id}/... paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
