### PR TITLE
fix: collapse dead health ternary and add unprefixed: true in GatewayConnectionManager

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -357,12 +357,7 @@ public final class GatewayConnectionManager {
     }
 
     private func performHealthCheck() async throws {
-        let healthPath: String
-        #if os(macOS)
-        healthPath = (cachedAssistant?.isManaged ?? false) ? "health" : "health"
-        #else
-        healthPath = ((try? GatewayHTTPClient.isConnectionManaged()) ?? false) ? "health" : "health"
-        #endif
+        let healthPath = "health"
 
         // Run the HTTP GET + JSON decode off the main actor. `GatewayHTTPClient`
         // is nonisolated but, when called from a `@MainActor` context, its
@@ -385,7 +380,8 @@ public final class GatewayConnectionManager {
             let response = try await GatewayHTTPClient.get(
                 path: healthPath,
                 timeout: 10,
-                quiet: true
+                quiet: true,
+                unprefixed: true
             )
             let version: String? = response.isSuccess
                 ? (try? JSONDecoder().decode(HealthVersionResponse.self, from: response.data))?.version


### PR DESCRIPTION
## Summary
Fixes gap: GatewayConnectionManager health path dead ternary and missing unprefixed.

**Gap:** Dead ternary + inconsistent health path
**What was expected:** Health check should use unprefixed path like HealthCheckClient
**What was found:** Dead ternary and auto-prefix changing behavior for non-managed connections
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
