### PR TITLE
feat: add PDF export option to document editor VSplitButton

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -159,6 +159,28 @@ final class DocumentManager {
         }
     }
 
+    func exportToPDF() {
+        guard let surfaceId = surfaceId else { return }
+        let titleForFile = title
+        Task {
+            guard let pdfData = await documentClient.exportDocumentPDF(surfaceId: surfaceId) else {
+                log.error("PDF export failed: no data returned")
+                return
+            }
+            await MainActor.run {
+                let panel = NSSavePanel()
+                panel.nameFieldStringValue = sanitizedFilename(from: titleForFile) + ".pdf"
+                panel.canCreateDirectories = true
+                panel.begin { response in
+                    guard response == .OK, let url = panel.url else { return }
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        try? pdfData.write(to: url)
+                    }
+                }
+            }
+        }
+    }
+
     private func sanitizedFilename(from title: String) -> String {
         let replaced = title.replacingOccurrences(of: " ", with: "-")
         let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -161,6 +161,7 @@ final class DocumentManager {
 
     func exportToPDF() {
         guard let surfaceId = surfaceId else { return }
+        save()
         let titleForFile = title
         Task {
             guard let pdfData = await documentClient.exportDocumentPDF(surfaceId: surfaceId) else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -24,8 +24,15 @@ struct DocumentEditorPanelView: View {
                 if documentManager.isSaving {
                     ProgressView().controlSize(.small).scaleEffect(0.7)
                 } else {
-                    VButton(label: "Export", iconOnly: VIcon.arrowDownToLine.rawValue, style: .ghost) {
-                        documentManager.exportToFile()
+                    VSplitButton(
+                        label: "Export",
+                        icon: VIcon.arrowDownToLine.rawValue,
+                        style: .ghost,
+                        action: { documentManager.exportToFile() }
+                    ) {
+                        VMenuItem(label: "Export as PDF") {
+                            documentManager.exportToPDF()
+                        }
                     }
                 }
                 VButton(label: "Close", iconOnly: VIcon.x.rawValue, style: .ghost, action: onClose)


### PR DESCRIPTION
## Summary
- Adds `exportToPDF()` method to `DocumentManager` that calls the server PDF endpoint via `documentClient.exportDocumentPDF(surfaceId:)` and presents an `NSSavePanel` with a `.pdf` filename
- Replaces the `VButton` export button with a `VSplitButton` offering both `.md` and `.pdf` export options
- Primary action exports markdown (unchanged behavior), dropdown menu offers "Export as PDF"

Part of plan: doc-pdf-export.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
