### PR TITLE
fix: remove dead approvalPath method from InteractionClient

### DIFF
--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -41,9 +41,8 @@ public struct InteractionClient: InteractionClientProtocol {
             if let selectedPattern { body["selectedPattern"] = selectedPattern }
             if let selectedScope { body["selectedScope"] = selectedScope }
 
-            let path = try Self.approvalPath(endpoint: "confirm")
             log.info("[confirm-flow] Sending POST /confirm: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
-            let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "confirm", json: body, timeout: 10)
             if response.isSuccess {
                 return .success
             }
@@ -72,8 +71,7 @@ public struct InteractionClient: InteractionClientProtocol {
             body["value"] = value ?? ""
             if let delivery { body["delivery"] = delivery }
 
-            let path = try Self.approvalPath(endpoint: "secret")
-            let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "secret", json: body, timeout: 10)
             if !response.isSuccess {
                 log.error("sendSecretResponse failed (HTTP \(response.statusCode))")
                 return false
@@ -83,18 +81,5 @@ public struct InteractionClient: InteractionClientProtocol {
             log.error("sendSecretResponse error: \(error.localizedDescription)")
             return false
         }
-    }
-
-    // MARK: - Path Resolution
-
-    /// Returns the appropriate request path for an approval endpoint based on
-    /// the current connection type.
-    ///
-    /// Managed connections route through the platform proxy which expects
-    /// `assistants/{assistantId}/<endpoint>`. Non-managed connections (local
-    /// gateway or direct remote runtime) use flat `<endpoint>` paths.
-    private static func approvalPath(endpoint: String) throws -> String {
-        let managed = try GatewayHTTPClient.isConnectionManaged()
-        return managed ? "\(endpoint)" : endpoint
     }
 }


### PR DESCRIPTION
## Summary
Removes the now-dead `approvalPath` method and inlines endpoint strings.

**Gap:** approvalPath became a no-op identity function after prefix stripping
**What was expected:** Method either does something useful or is removed
**What was found:** Both branches return the same value after the auto-prefix migration
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
