### PR TITLE
feat(clients): enforce assistants/{assistantId}/ prefix in GatewayHTTPClient

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -150,7 +150,7 @@ enum APIKeyManager {
         do {
             let body: [String: Any] = ["type": "api_key", "name": provider]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/secrets/read", json: body, timeout: 5
+                path: "secrets/read", json: body, timeout: 5
             )
             guard response.isSuccess,
                   let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
@@ -191,7 +191,7 @@ enum APIKeyManager {
         do {
             let body: [String: Any] = ["type": "api_key", "name": provider, "value": key]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/secrets", json: body, timeout: 5
+                path: "secrets", json: body, timeout: 5
             )
             if response.isSuccess {
                 return SetKeyResult(success: true, error: nil, isTransient: false)
@@ -220,7 +220,7 @@ enum APIKeyManager {
         do {
             let body: [String: Any] = ["type": "api_key", "name": provider]
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/secrets", json: body, timeout: 5
+                path: "secrets", json: body, timeout: 5
             )
             return response.isSuccess
         } catch {
@@ -255,7 +255,7 @@ enum APIKeyManager {
         do {
             let body: [String: Any] = ["type": "credential", "name": "\(service):\(field)"]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/secrets/read", json: body, timeout: 5
+                path: "secrets/read", json: body, timeout: 5
             )
             guard response.isSuccess,
                   let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
@@ -287,7 +287,7 @@ enum APIKeyManager {
         do {
             let body: [String: Any] = ["type": "credential", "name": "\(service):\(field)", "value": value]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/secrets", json: body, timeout: 5
+                path: "secrets", json: body, timeout: 5
             )
             if response.isSuccess {
                 return SetKeyResult(success: true, error: nil, isTransient: false)
@@ -310,7 +310,7 @@ enum APIKeyManager {
         do {
             let body: [String: Any] = ["type": "credential", "name": "\(service):\(field)"]
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/secrets", json: body, timeout: 5
+                path: "secrets", json: body, timeout: 5
             )
             return response.isSuccess
         } catch {

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -803,7 +803,7 @@ extension AppDelegate {
         for name in APIKeyManager.allSyncableProviders {
             guard let key = APIKeyManager.getKey(for: name), !key.isEmpty else { continue }
             let body: [String: Any] = ["type": "api_key", "name": name, "value": key]
-            _ = try? await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", json: body, timeout: 5)
+            _ = try? await GatewayHTTPClient.post(path: "secrets", json: body, timeout: 5)
         }
 
         log.info("syncApiKeysViaGateway: pushed API keys for \(assistantId, privacy: .public)")

--- a/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+ConnectionSetup.swift
@@ -506,7 +506,7 @@ extension AppDelegate {
                 let publicKey = try await SigningIdentityManager.shared.getPublicKey()
 
                 _ = try? await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/sign-bundle-response",
+                    path: "sign-bundle-response",
                     json: [
                         "requestId": msg.requestId,
                         "signature": signature.base64EncodedString(),
@@ -517,7 +517,7 @@ extension AppDelegate {
             } catch {
                 log.error("Failed to sign bundle payload: \(error.localizedDescription)")
                 _ = try? await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/sign-bundle-response",
+                    path: "sign-bundle-response",
                     json: [
                         "requestId": msg.requestId,
                         "error": error.localizedDescription
@@ -535,7 +535,7 @@ extension AppDelegate {
                 let publicKey = try await SigningIdentityManager.shared.getPublicKey()
 
                 _ = try? await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/signing-identity-response",
+                    path: "signing-identity-response",
                     json: [
                         "requestId": msg.requestId,
                         "keyId": keyId,
@@ -545,7 +545,7 @@ extension AppDelegate {
             } catch {
                 log.error("Failed to get signing identity: \(error.localizedDescription)")
                 _ = try? await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/signing-identity-response",
+                    path: "signing-identity-response",
                     json: [
                         "requestId": msg.requestId,
                         "error": error.localizedDescription

--- a/clients/macos/vellum-assistant/App/ManagedAssistantIdentityInjection.swift
+++ b/clients/macos/vellum-assistant/App/ManagedAssistantIdentityInjection.swift
@@ -84,7 +84,7 @@ enum ManagedAssistantIdentityInjection {
         ]
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/\(assistantId)/secrets",
+                path: "secrets",
                 json: body,
                 timeout: 10
             )

--- a/clients/macos/vellum-assistant/App/UpdateManager.swift
+++ b/clients/macos/vellum-assistant/App/UpdateManager.swift
@@ -220,7 +220,7 @@ public final class UpdateManager: NSObject, SPUUpdaterDelegate {
 
             // Fetch the current service group version from health endpoint.
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
+                path: "healthz",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
 

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -186,7 +186,7 @@ final class AvatarAppearanceManager {
     private func fetchAvatarViaHTTP() async {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/workspace/file/content",
+                path: "workspace/file/content",
                 params: ["path": "data/avatar/avatar-image.png"],
                 timeout: 10
             )
@@ -225,7 +225,7 @@ final class AvatarAppearanceManager {
     private func fetchTraitsViaHTTP() async {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/workspace/file/content",
+                path: "workspace/file/content",
                 params: ["path": "data/avatar/character-traits.json"],
                 timeout: 10
             )
@@ -425,7 +425,7 @@ final class AvatarAppearanceManager {
         for attempt in 1...3 {
             do {
                 let response = try await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/avatar/render-from-traits",
+                    path: "avatar/render-from-traits",
                     json: json,
                     timeout: 15
                 )

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentService.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarComponentService.swift
@@ -69,7 +69,7 @@ final class AvatarComponentService {
     static func fetch() async -> ComponentsResponse? {
         do {
             let (decoded, response): (ComponentsResponse?, GatewayHTTPClient.Response) =
-                try await GatewayHTTPClient.get(path: "assistants/{assistantId}/avatar/character-components", timeout: 10)
+                try await GatewayHTTPClient.get(path: "avatar/character-components", timeout: 10)
             guard response.isSuccess else {
                 log.warning("character-components fetch failed with status \(response.statusCode)")
                 return nil

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteViewModel.swift
@@ -170,7 +170,7 @@ final class CommandPaletteViewModel {
 
         do {
             let (decoded, response): (GlobalSearchResponse?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/search/global",
+                path: "search/global",
                 params: params,
                 timeout: deep ? 10 : 5
             )

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -23,7 +23,7 @@ struct ConversationClient: ConversationClientProtocol {
 
     func deleteConversation(_ conversationId: String) async {
         let response = try? await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/conversations/\(conversationId)", timeout: 10
+            path: "conversations/\(conversationId)", timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Delete conversation \(conversationId) failed (HTTP \(statusCode))")
@@ -32,7 +32,7 @@ struct ConversationClient: ConversationClientProtocol {
 
     func archiveConversation(_ conversationId: String) async {
         let response = try? await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/conversations/\(conversationId)/archive", timeout: 10
+            path: "conversations/\(conversationId)/archive", timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Archive conversation \(conversationId) failed (HTTP \(statusCode))")
@@ -41,7 +41,7 @@ struct ConversationClient: ConversationClientProtocol {
 
     func unarchiveConversation(_ conversationId: String) async {
         let response = try? await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/conversations/\(conversationId)/unarchive", timeout: 10
+            path: "conversations/\(conversationId)/unarchive", timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Unarchive conversation \(conversationId) failed (HTTP \(statusCode))")

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -395,7 +395,7 @@ struct HatchingStepView: View {
             if Task.isCancelled { return false }
             do {
                 let (_, response): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                    path: "assistants/{assistantId}/health",
+                    path: "health",
                     timeout: 5
                 ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
                 if response.isSuccess { return true }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -423,7 +423,7 @@ struct OnboardingFlowView: View {
         while clock.now < deadline {
             do {
                 let (_, response): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                    path: "assistants/{assistantId}/health",
+                    path: "health",
                     timeout: 5
                 ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
                 if response.isSuccess {

--- a/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AboutVellumWindow.swift
@@ -331,7 +331,7 @@ struct AboutVellumView: View {
         guard !selectedAssistantId.isEmpty else { return }
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
+                path: "healthz",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
             healthz = decoded ?? DaemonHealthz()

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantBackupsSection.swift
@@ -543,7 +543,7 @@ struct AssistantBackupsSection: View {
         defer { isExporting = false }
 
         do {
-            let response = try await GatewayHTTPClient.post(path: "migrations/export", timeout: 3600)
+            let response = try await GatewayHTTPClient.post(path: "migrations/export", timeout: 3600, unprefixed: true)
 
             guard response.isSuccess else {
                 errorMessage = "Export failed (HTTP \(response.statusCode))"
@@ -620,7 +620,7 @@ struct AssistantBackupsSection: View {
 
         do {
             let (decoded, _): (ManagedBackupsResponse?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/\(assistant.assistantId)/backups"
+                path: "backups"
             )
             guard let decoded else {
                 errorMessage = "Failed to load backups"
@@ -640,7 +640,7 @@ struct AssistantBackupsSection: View {
         defer { isCreatingBackup = false }
 
         do {
-            let response = try await GatewayHTTPClient.post(path: "assistants/\(assistant.assistantId)/backups")
+            let response = try await GatewayHTTPClient.post(path: "backups")
             if response.isSuccess {
                 successMessage = "Backup created successfully"
                 await loadManagedBackupsQuietly()
@@ -666,7 +666,7 @@ struct AssistantBackupsSection: View {
 
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/\(assistant.assistantId)/backups/\(backup.snapshotName)/restore"
+                path: "backups/\(backup.snapshotName)/restore"
             )
             if response.isSuccess {
                 successMessage = "Restore initiated. The assistant may be briefly unavailable."
@@ -693,7 +693,7 @@ struct AssistantBackupsSection: View {
             // overload on `GatewayHTTPClient.get<T>` is convenient but its
             // `configure` closure parameter is not `@Sendable`, which conflicts
             // with strict concurrency when called from @MainActor code.
-            let response = try await GatewayHTTPClient.get(path: "backups", timeout: 15)
+            let response = try await GatewayHTTPClient.get(path: "backups", timeout: 15, unprefixed: true)
             guard response.isSuccess else {
                 errorMessage = "Failed to load backups (HTTP \(response.statusCode))"
                 return
@@ -836,7 +836,8 @@ extension AssistantBackupsSection {
             let response = try await GatewayHTTPClient.post(
                 path: "backups/restore",
                 json: ["path": path],
-                timeout: 120
+                timeout: 120,
+                unprefixed: true
             )
             if response.isSuccess {
                 handleRestoreSuccess(message: "Backup restored. Restarting assistant...")
@@ -862,7 +863,8 @@ extension AssistantBackupsSection {
                 path: "migrations/import",
                 body: fileData,
                 contentType: "application/octet-stream",
-                timeout: 3600
+                timeout: 3600,
+                unprefixed: true
             )
 
             if response.isSuccess {

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantTransferSection.swift
@@ -228,7 +228,7 @@ struct AssistantTransferSection: View {
         do {
             // Step 1 — Initiate export
             currentStep = "Requesting cloud export..."
-            let exportResponse = try await GatewayHTTPClient.post(path: "migrations/export")
+            let exportResponse = try await GatewayHTTPClient.post(path: "migrations/export", unprefixed: true)
             guard exportResponse.isSuccess else {
                 throw TransferError.exportFailed(statusCode: exportResponse.statusCode)
             }
@@ -246,7 +246,8 @@ struct AssistantTransferSection: View {
             while Date().timeIntervalSince(exportPollStart) < exportPollTimeout {
                 try Task.checkCancellation()
                 let (statusResult, statusResponse): (ExportStatusResponse?, _) = try await GatewayHTTPClient.get(
-                    path: "migrations/export/\(jobId)/status"
+                    path: "migrations/export/\(jobId)/status",
+                    unprefixed: true
                 ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
                 guard statusResponse.isSuccess, let statusResult else {
                     throw TransferError.exportFailed(statusCode: statusResponse.statusCode)
@@ -320,7 +321,8 @@ struct AssistantTransferSection: View {
                     path: "migrations/import",
                     body: bundleData,
                     contentType: "application/octet-stream",
-                    timeout: 3600
+                    timeout: 3600,
+                    unprefixed: true
                 )
             }
             guard importResponse.isSuccess else {
@@ -342,7 +344,7 @@ struct AssistantTransferSection: View {
             do {
                 let retireResponse = try await GatewayHTTPClient.withAssistant(managedAssistantId) {
                     try await GatewayHTTPClient.delete(
-                        path: "assistants/{assistantId}/retire",
+                        path: "retire",
                         timeout: 30
                     )
                 }
@@ -365,7 +367,8 @@ struct AssistantTransferSection: View {
     private func exportAssistantBundle() async throws -> Data {
         let response = try await GatewayHTTPClient.post(
             path: "migrations/export",
-            timeout: 3600
+            timeout: 3600,
+            unprefixed: true
         )
         guard response.isSuccess else {
             throw TransferError.exportFailed(statusCode: response.statusCode)
@@ -387,7 +390,7 @@ struct AssistantTransferSection: View {
                 try Task.checkCancellation()
 
                 if let response = try? await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/guardian/init",
+                    path: "guardian/init",
                     json: body,
                     timeout: 15
                 ), response.isSuccess,

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -389,7 +389,7 @@ struct SettingsDeveloperTab: View {
     private func fetchHealthz() async {
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
+                path: "healthz",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
             healthz = decoded ?? DaemonHealthz()
@@ -642,7 +642,7 @@ struct SettingsDeveloperTab: View {
     }
 
     private func performManagedRestart() async {
-        _ = try? await GatewayHTTPClient.post(path: "assistants/\(selectedAssistantId)/restart")
+        _ = try? await GatewayHTTPClient.post(path: "restart")
     }
 
     private func performLocalRestart() async {
@@ -825,7 +825,7 @@ struct SettingsDeveloperTab: View {
         let body: [String: String] = ["type": "credential", "name": "vellum:assistant_api_key"]
         do {
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/secrets", json: body, timeout: 10
+                path: "secrets", json: body, timeout: 10
             )
             if response.isSuccess || response.statusCode == 404 {
                 // Clear the locally-cached credential so the key is not

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -188,7 +188,7 @@ struct SettingsGeneralTab: View {
         defer { isRefreshingHealthz = false }
         do {
             let (decoded, _): (DaemonHealthz?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/healthz",
+                path: "healthz",
                 timeout: 10
             ) { $0.keyDecodingStrategy = .convertFromSnakeCase }
             healthz = decoded ?? DaemonHealthz()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1324,7 +1324,7 @@ public final class SettingsStore: ObservableObject {
         let body: [String: String] = ["type": "credential", "name": name, "value": value]
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
         Task {
-            _ = try? await GatewayHTTPClient.post(path: "assistants/\(assistantId)/secrets", body: bodyData)
+            _ = try? await GatewayHTTPClient.post(path: "secrets", body: bodyData)
         }
     }
 
@@ -1336,7 +1336,7 @@ public final class SettingsStore: ObservableObject {
         let body: [String: String] = ["type": "credential", "name": name]
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return false }
         Task {
-            _ = try? await GatewayHTTPClient.delete(path: "assistants/\(assistantId)/secrets", body: bodyData)
+            _ = try? await GatewayHTTPClient.delete(path: "secrets", body: bodyData)
         }
         return true
     }
@@ -1372,7 +1372,7 @@ public final class SettingsStore: ObservableObject {
         Task {
             do {
                 let (config, response): (SlackChannelConfigResponse?, _) = try await GatewayHTTPClient.get(
-                    path: "assistants/\(assistantId)/integrations/slack/channel/config",
+                    path: "integrations/slack/channel/config",
                     timeout: 10
                 )
                 if response.statusCode == 200, let config {
@@ -1417,7 +1417,7 @@ public final class SettingsStore: ObservableObject {
         Task {
             do {
                 let response = try await GatewayHTTPClient.post(
-                    path: "assistants/\(assistantId)/integrations/slack/channel/config",
+                    path: "integrations/slack/channel/config",
                     body: bodyData,
                     timeout: 10
                 )
@@ -1464,7 +1464,7 @@ public final class SettingsStore: ObservableObject {
         Task {
             do {
                 let response = try await GatewayHTTPClient.delete(
-                    path: "assistants/\(assistantId)/integrations/slack/channel/config",
+                    path: "integrations/slack/channel/config",
                     timeout: 10
                 )
                 if response.isSuccess {
@@ -1506,7 +1506,7 @@ public final class SettingsStore: ObservableObject {
             return
         }
 
-        let gatewayPath = "assistants/\(assistantId)/\(path)"
+        let gatewayPath = path
         let bodyData: Data?
         if let body {
             bodyData = try? JSONSerialization.data(withJSONObject: body)
@@ -2240,7 +2240,7 @@ public final class SettingsStore: ObservableObject {
         Task {
             do {
                 let response = try await GatewayHTTPClient.get(
-                    path: "assistants/\(assistantId)/debug",
+                    path: "debug",
                     timeout: 10
                 )
                 guard response.isSuccess else { return }
@@ -2404,7 +2404,7 @@ public final class SettingsStore: ObservableObject {
             do {
                 let (decoded, response): (OAuthProvidersListResponse?, _) =
                     try await GatewayHTTPClient.get(
-                        path: "assistants/{assistantId}/oauth/providers",
+                        path: "oauth/providers",
                         params: ["supports_managed_mode": "true"],
                         timeout: 10
                     )
@@ -2809,7 +2809,7 @@ public final class SettingsStore: ObservableObject {
         Task {
             do {
                 let (decoded, response): (YourOwnOAuthAppsResponse?, _) = try await GatewayHTTPClient.get(
-                    path: "assistants/{assistantId}/oauth/apps",
+                    path: "oauth/apps",
                     params: ["provider_key": providerKey],
                     timeout: 10
                 )
@@ -2842,7 +2842,7 @@ public final class SettingsStore: ObservableObject {
     func fetchYourOwnOAuthConnections(appId: String) async {
         do {
             let (decoded, response): (YourOwnOAuthConnectionsResponse?, _) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/oauth/apps/\(appId)/connections",
+                path: "oauth/apps/\(appId)/connections",
                 timeout: 10
             )
             if response.isSuccess, let decoded {
@@ -2863,7 +2863,7 @@ public final class SettingsStore: ObservableObject {
         let secretKey = "client" + "_secret"
         body[secretKey] = clientSecret
         do {
-            let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/oauth/apps", json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "oauth/apps", json: body, timeout: 10)
             if response.isSuccess {
                 self.fetchYourOwnOAuthApps(providerKey: providerKey)
             } else {
@@ -2885,7 +2885,7 @@ public final class SettingsStore: ObservableObject {
     func deleteYourOwnOAuthApp(id: String, providerKey: String) async {
         yourOwnOAuthError[providerKey] = nil
         do {
-            let response = try await GatewayHTTPClient.delete(path: "assistants/{assistantId}/oauth/apps/\(id)", timeout: 10)
+            let response = try await GatewayHTTPClient.delete(path: "oauth/apps/\(id)", timeout: 10)
             if response.isSuccess {
                 self.yourOwnOAuthApps[providerKey]?.removeAll { $0.id == id }
                 self.yourOwnOAuthConnectionsByApp.removeValue(forKey: id)
@@ -2909,7 +2909,7 @@ public final class SettingsStore: ObservableObject {
         let providerKey = yourOwnOAuthApps.first(where: { $0.value.contains(where: { $0.id == appId }) })?.key
         if let providerKey { yourOwnOAuthError[providerKey] = nil }
         do {
-            let response = try await GatewayHTTPClient.delete(path: "assistants/{assistantId}/oauth/connections/\(id)", timeout: 10)
+            let response = try await GatewayHTTPClient.delete(path: "oauth/connections/\(id)", timeout: 10)
             if response.isSuccess {
                 await self.fetchYourOwnOAuthConnections(appId: appId)
             } else {
@@ -2940,7 +2940,7 @@ public final class SettingsStore: ObservableObject {
         if let providerKey { yourOwnOAuthError[providerKey] = nil }
         Task {
             do {
-                let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/oauth/apps/\(appId)/connect", json: [:], timeout: 10)
+                let response = try await GatewayHTTPClient.post(path: "oauth/apps/\(appId)/connect", json: [:], timeout: 10)
                 guard response.isSuccess else {
                     let errorMsg: String
                     if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1324,7 +1324,9 @@ public final class SettingsStore: ObservableObject {
         let body: [String: String] = ["type": "credential", "name": name, "value": value]
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
         Task {
-            _ = try? await GatewayHTTPClient.post(path: "secrets", body: bodyData)
+            _ = try? await GatewayHTTPClient.withAssistant(assistantId) {
+                try await GatewayHTTPClient.post(path: "secrets", body: bodyData)
+            }
         }
     }
 
@@ -1336,7 +1338,9 @@ public final class SettingsStore: ObservableObject {
         let body: [String: String] = ["type": "credential", "name": name]
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return false }
         Task {
-            _ = try? await GatewayHTTPClient.delete(path: "secrets", body: bodyData)
+            _ = try? await GatewayHTTPClient.withAssistant(assistantId) {
+                try await GatewayHTTPClient.delete(path: "secrets", body: bodyData)
+            }
         }
         return true
     }

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -276,7 +276,7 @@ struct TeleportSection: View {
                     do {
                         let response = try await GatewayHTTPClient.withAssistant(oldId) {
                             try await GatewayHTTPClient.delete(
-                                path: "assistants/{assistantId}/retire",
+                                path: "retire",
                                 timeout: 30
                             )
                         }
@@ -498,7 +498,8 @@ struct TeleportSection: View {
                 path: "migrations/import",
                 body: bundleData,
                 contentType: "application/octet-stream",
-                timeout: 3600
+                timeout: 3600,
+                unprefixed: true
             )
         }
         guard importResponse.isSuccess else {
@@ -658,12 +659,14 @@ struct TeleportSection: View {
             response = try await GatewayHTTPClient.post(
                 path: "migrations/export",
                 timeout: 3600,
+                unprefixed: true,
                 onProgress: onProgress
             )
         } else {
             response = try await GatewayHTTPClient.post(
                 path: "migrations/export",
-                timeout: 3600
+                timeout: 3600,
+                unprefixed: true
             )
         }
         guard response.isSuccess else {
@@ -749,7 +752,7 @@ struct TeleportSection: View {
                 try Task.checkCancellation()
 
                 if let response = try? await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/guardian/init",
+                    path: "guardian/init",
                     json: body,
                     timeout: 15
                 ), response.isSuccess,

--- a/clients/macos/vellum-assistant/Features/Terminal/TerminalAPIClient.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/TerminalAPIClient.swift
@@ -23,7 +23,7 @@ final class TerminalAPIClient {
     /// Creates a new terminal session and returns the session ID.
     func createSession() async throws -> String {
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/\(assistantId)/terminal/sessions",
+            path: "terminal/sessions",
             timeout: 30
         )
         guard response.isSuccess else {
@@ -43,7 +43,7 @@ final class TerminalAPIClient {
     /// Destroys an existing terminal session. Errors are swallowed (best-effort).
     func destroySession(sessionId: String) async {
         _ = try? await GatewayHTTPClient.delete(
-            path: "assistants/\(assistantId)/terminal/sessions/\(sessionId)",
+            path: "terminal/sessions/\(sessionId)",
             timeout: 10
         )
     }
@@ -54,7 +54,7 @@ final class TerminalAPIClient {
     func sendInput(sessionId: String, data: String) async throws {
         let body = try JSONSerialization.data(withJSONObject: ["data": data])
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/\(assistantId)/terminal/sessions/\(sessionId)/input",
+            path: "terminal/sessions/\(sessionId)/input",
             body: body,
             timeout: 10
         )
@@ -67,7 +67,7 @@ final class TerminalAPIClient {
     func resize(sessionId: String, cols: Int, rows: Int) async throws {
         let body = try JSONSerialization.data(withJSONObject: ["cols": cols, "rows": rows] as [String: Any])
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/\(assistantId)/terminal/sessions/\(sessionId)/resize",
+            path: "terminal/sessions/\(sessionId)/resize",
             body: body,
             timeout: 10
         )
@@ -93,7 +93,7 @@ final class TerminalAPIClient {
             let sseTask = Task { @MainActor in
                 do {
                     let (bytes, urlResponse) = try await GatewayHTTPClient.stream(
-                        path: "assistants/\(assistantId)/terminal/sessions/\(sessionId)/events",
+                        path: "terminal/sessions/\(sessionId)/events",
                         timeout: .infinity
                     )
 

--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -632,7 +632,7 @@ enum LogExporter {
         }
 
         do {
-            let response = try await GatewayHTTPClient.post(path: "logs/export", json: body, timeout: 60)
+            let response = try await GatewayHTTPClient.post(path: "logs/export", json: body, timeout: 60, unprefixed: true)
             guard response.isSuccess else {
                 log.warning("Export API failed with status \(response.statusCode)")
                 writeExportErrorLog(

--- a/clients/shared/App/Auth/ActorCredentialRefresher.swift
+++ b/clients/shared/App/Auth/ActorCredentialRefresher.swift
@@ -37,7 +37,8 @@ public class ActorCredentialRefresher {
                 path: "guardian/refresh",
                 json: body,
                 timeout: 15,
-                skipRetry: true
+                skipRetry: true,
+                unprefixed: true
             )
 
             if response.isSuccess {

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -254,7 +254,8 @@ public final class LocalAssistantBootstrapService {
         let response = try await GatewayHTTPClient.post(
             path: "secrets",
             json: ["type": "credential", "name": "vellum:assistant_api_key", "value": key],
-            timeout: 10
+            timeout: 10,
+            unprefixed: true
         )
         guard response.isSuccess else {
             log.error("Failed to inject API key into assistant: status=\(response.statusCode, privacy: .public) body=\(String(data: response.data, encoding: .utf8) ?? "<non-utf8>", privacy: .public)")
@@ -267,7 +268,8 @@ public final class LocalAssistantBootstrapService {
         let response = try await GatewayHTTPClient.post(
             path: "secrets",
             json: ["type": "credential", "name": "vellum:platform_base_url", "value": url],
-            timeout: 10
+            timeout: 10,
+            unprefixed: true
         )
         guard response.isSuccess else {
             throw LocalBootstrapError.assistantInjectionFailed
@@ -279,7 +281,8 @@ public final class LocalAssistantBootstrapService {
         let response = try await GatewayHTTPClient.post(
             path: "secrets",
             json: ["type": "credential", "name": "vellum:platform_assistant_id", "value": id],
-            timeout: 10
+            timeout: 10,
+            unprefixed: true
         )
         guard response.isSuccess else {
             throw LocalBootstrapError.assistantInjectionFailed
@@ -291,7 +294,8 @@ public final class LocalAssistantBootstrapService {
         let response = try await GatewayHTTPClient.post(
             path: "secrets",
             json: ["type": "credential", "name": "vellum:platform_organization_id", "value": id],
-            timeout: 10
+            timeout: 10,
+            unprefixed: true
         )
         guard response.isSuccess else {
             throw LocalBootstrapError.assistantInjectionFailed
@@ -303,7 +307,8 @@ public final class LocalAssistantBootstrapService {
         let response = try await GatewayHTTPClient.post(
             path: "secrets",
             json: ["type": "credential", "name": "vellum:platform_user_id", "value": id],
-            timeout: 10
+            timeout: 10,
+            unprefixed: true
         )
         guard response.isSuccess else {
             throw LocalBootstrapError.assistantInjectionFailed
@@ -315,7 +320,8 @@ public final class LocalAssistantBootstrapService {
         let response = try await GatewayHTTPClient.post(
             path: "secrets",
             json: ["type": "credential", "name": "vellum:webhook_secret", "value": secret],
-            timeout: 10
+            timeout: 10,
+            unprefixed: true
         )
         guard response.isSuccess else {
             throw LocalBootstrapError.assistantInjectionFailed
@@ -342,7 +348,7 @@ public final class LocalAssistantBootstrapService {
             let body: [String: String] = ["type": "credential", "name": name]
             do {
                 let response = try await GatewayHTTPClient.delete(
-                    path: "assistants/{assistantId}/secrets", json: body, timeout: 5
+                    path: "secrets", json: body, timeout: 5, unprefixed: true
                 )
                 if response.isSuccess || response.statusCode == 404 {
                     log.info("Cleared assistant credential: \(name, privacy: .public) (status \(response.statusCode))")

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -348,7 +348,7 @@ public final class LocalAssistantBootstrapService {
             let body: [String: String] = ["type": "credential", "name": name]
             do {
                 let response = try await GatewayHTTPClient.delete(
-                    path: "secrets", json: body, timeout: 5, unprefixed: true
+                    path: "secrets", json: body, timeout: 5
                 )
                 if response.isSuccess || response.statusCode == 404 {
                     log.info("Cleared assistant credential: \(name, privacy: .public) (status \(response.statusCode))")

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -52,7 +52,7 @@ struct ConversationStarterClient: ConversationStarterClientProtocol {
 
     func fetchConversationStarters(limit: Int) async -> ConversationStartersResponse? {
         guard let response = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/conversation-starters",
+            path: "conversation-starters",
             params: ["limit": String(limit)]
         ), response.isSuccess else { return nil }
         return try? JSONDecoder().decode(ConversationStartersResponse.self, from: response.data)
@@ -60,7 +60,7 @@ struct ConversationStarterClient: ConversationStarterClientProtocol {
 
     func deleteConversationStarter(id: String) async -> Bool {
         guard let response = try? await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/conversation-starters/\(Self.pathEscape(id))"
+            path: "conversation-starters/\(Self.pathEscape(id))"
         ) else { return false }
         return response.isSuccess || response.statusCode == 404
     }
@@ -97,7 +97,7 @@ public struct SurfaceClient: SurfaceClientProtocol {
 
     public func fetchSurfaceData(surfaceId: String, conversationId: String) async -> SurfaceData? {
         let response = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/surfaces/\(surfaceId)", params: ["conversationId": conversationId], timeout: 10
+            path: "surfaces/\(surfaceId)", params: ["conversationId": conversationId], timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Fetch surface \(surfaceId) failed (HTTP \(statusCode))")
@@ -111,7 +111,7 @@ public struct SurfaceClient: SurfaceClientProtocol {
     /// reconstructing a `UiSurfaceShowMessage` to re-open ephemeral surfaces.
     public func fetchSurfaceContent(surfaceId: String, conversationId: String) async -> SurfaceContentResponse? {
         let response = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/surfaces/\(surfaceId)", params: ["conversationId": conversationId], timeout: 10
+            path: "surfaces/\(surfaceId)", params: ["conversationId": conversationId], timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Fetch surface content \(surfaceId) failed (HTTP \(statusCode))")

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -43,7 +43,7 @@ public struct UsageClient: UsageClientProtocol {
 
     public func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
         let result: (UsageTotalsResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/usage/totals?from=\(from)&to=\(to)", timeout: 10
+            path: "usage/totals?from=\(from)&to=\(to)", timeout: 10
         )
         return result?.0
     }
@@ -51,7 +51,7 @@ public struct UsageClient: UsageClientProtocol {
     public func fetchUsageDaily(from: Int, to: Int, granularity: String = "daily", tz: String) async -> UsageDailyResponse? {
         let encodedTz = tz.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? tz
         let result: (UsageDailyResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/usage/daily?from=\(from)&to=\(to)&granularity=\(granularity)&tz=\(encodedTz)", timeout: 10
+            path: "usage/daily?from=\(from)&to=\(to)&granularity=\(granularity)&tz=\(encodedTz)", timeout: 10
         )
         return result?.0
     }
@@ -60,7 +60,7 @@ public struct UsageClient: UsageClientProtocol {
         let encodedGroupBy = groupBy.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? groupBy
         let encodedTz = tz.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? tz
         let result: (UsageSeriesResponse?, GatewayHTTPClient.Response)? = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/usage/series?from=\(from)&to=\(to)&granularity=\(granularity)&groupBy=\(encodedGroupBy)&tz=\(encodedTz)", timeout: 10
+            path: "usage/series?from=\(from)&to=\(to)&granularity=\(granularity)&groupBy=\(encodedGroupBy)&tz=\(encodedTz)", timeout: 10
         )
         return result?.0
     }
@@ -69,7 +69,7 @@ public struct UsageClient: UsageClientProtocol {
         let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? groupBy
         do {
             let result: (UsageBreakdownResponse?, GatewayHTTPClient.Response) = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/usage/breakdown?from=\(from)&to=\(to)&groupBy=\(encoded)", timeout: 10
+                path: "usage/breakdown?from=\(from)&to=\(to)&groupBy=\(encoded)", timeout: 10
             )
             return UsageFetchResult(value: result.0, statusCode: result.1.statusCode)
         } catch {

--- a/clients/shared/Network/ACPClient.swift
+++ b/clients/shared/Network/ACPClient.swift
@@ -55,7 +55,7 @@ public enum ACPClient {
         let response: GatewayHTTPClient.Response
         do {
             response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/acp/sessions",
+                path: "acp/sessions",
                 params: params,
                 timeout: 15
             )
@@ -90,7 +90,7 @@ public enum ACPClient {
         id: String
     ) async -> Result<Bool, ACPClientError> {
         return await postExpectingAck(
-            path: "assistants/{assistantId}/acp/\(id)/cancel",
+            path: "acp/\(id)/cancel",
             body: [:],
             label: "cancelSession"
         )
@@ -109,7 +109,7 @@ public enum ACPClient {
         instruction: String
     ) async -> Result<Bool, ACPClientError> {
         return await postExpectingAck(
-            path: "assistants/{assistantId}/acp/\(id)/steer",
+            path: "acp/\(id)/steer",
             body: ["instruction": instruction],
             label: "steerSession"
         )
@@ -133,7 +133,7 @@ public enum ACPClient {
         id: String
     ) async -> Result<Bool, ACPClientError> {
         return await deleteExpectingPayload(
-            path: "assistants/{assistantId}/acp/sessions/\(id)",
+            path: "acp/sessions/\(id)",
             timeout: 10,
             as: DeleteSessionResponse.self,
             label: "deleteSession"
@@ -151,7 +151,7 @@ public enum ACPClient {
     ///   `.failure` on transport, decoding, or non-2xx responses.
     public static func clearCompleted() async -> Result<Int, ACPClientError> {
         return await deleteExpectingPayload(
-            path: "assistants/{assistantId}/acp/sessions?status=completed",
+            path: "acp/sessions?status=completed",
             timeout: 15,
             as: ClearCompletedResponse.self,
             label: "clearCompleted"

--- a/clients/shared/Network/AppsClient.swift
+++ b/clients/shared/Network/AppsClient.swift
@@ -139,7 +139,7 @@ public struct AppsClient: AppsClientProtocol {
             if let conversationId { params["conversationId"] = conversationId }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/apps",
+                path: "apps",
                 params: params.isEmpty ? nil : params,
                 timeout: 10
             )
@@ -183,7 +183,7 @@ public struct AppsClient: AppsClientProtocol {
     public func openApp(id: String) async -> AppOpenResult? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/apps/\(id)/open", timeout: 10
+                path: "apps/\(id)/open", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("openApp failed (HTTP \(response.statusCode))")
@@ -220,7 +220,7 @@ public struct AppsClient: AppsClientProtocol {
     public func deleteApp(id: String) async -> AppDeleteResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/apps/\(id)/delete", timeout: 10
+                path: "apps/\(id)/delete", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("deleteApp failed (HTTP \(response.statusCode))")
@@ -237,7 +237,7 @@ public struct AppsClient: AppsClientProtocol {
     public func fetchAppPreview(appId: String) async -> AppPreviewResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/apps/\(appId)/preview", timeout: 10
+                path: "apps/\(appId)/preview", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchAppPreview failed (HTTP \(response.statusCode))")
@@ -255,7 +255,7 @@ public struct AppsClient: AppsClientProtocol {
         do {
             let body: [String: Any] = ["preview": preview]
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/apps/\(appId)/preview", json: body, timeout: 10
+                path: "apps/\(appId)/preview", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("updateAppPreview failed (HTTP \(response.statusCode))")
@@ -272,7 +272,7 @@ public struct AppsClient: AppsClientProtocol {
     public func bundleApp(appId: String) async -> BundleAppResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/apps/\(appId)/bundle", timeout: 10
+                path: "apps/\(appId)/bundle", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("bundleApp failed (HTTP \(response.statusCode))")
@@ -290,7 +290,7 @@ public struct AppsClient: AppsClientProtocol {
         do {
             let body: [String: Any] = ["filePath": filePath]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/apps/open-bundle", json: body, timeout: 10
+                path: "apps/open-bundle", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("openBundle failed (HTTP \(response.statusCode))")
@@ -310,7 +310,7 @@ public struct AppsClient: AppsClientProtocol {
             if let limit { params["limit"] = String(limit) }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/apps/\(appId)/history",
+                path: "apps/\(appId)/history",
                 params: params.isEmpty ? nil : params,
                 timeout: 10
             )
@@ -332,7 +332,7 @@ public struct AppsClient: AppsClientProtocol {
             if let toCommit { params["toCommit"] = toCommit }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/apps/\(appId)/diff",
+                path: "apps/\(appId)/diff",
                 params: params,
                 timeout: 10
             )
@@ -352,7 +352,7 @@ public struct AppsClient: AppsClientProtocol {
         do {
             let body: [String: Any] = ["commitHash": commitHash]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/apps/\(appId)/restore", json: body, timeout: 10
+                path: "apps/\(appId)/restore", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("restoreApp failed (HTTP \(response.statusCode))")
@@ -371,7 +371,7 @@ public struct AppsClient: AppsClientProtocol {
     public func fetchSharedAppsList() async -> SharedAppsListResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/apps/shared", timeout: 10
+                path: "apps/shared", timeout: 10
             )
             if response.statusCode == 404 {
                 // Older assistants may not expose the shared-apps route yet.
@@ -417,7 +417,7 @@ public struct AppsClient: AppsClientProtocol {
     public func deleteSharedApp(uuid: String) async -> SharedAppDeleteResponse? {
         do {
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/apps/shared/\(uuid)", timeout: 10
+                path: "apps/shared/\(uuid)", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("deleteSharedApp failed (HTTP \(response.statusCode))")
@@ -435,7 +435,7 @@ public struct AppsClient: AppsClientProtocol {
         do {
             let body: [String: Any] = ["uuid": uuid]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/apps/fork", json: body, timeout: 10
+                path: "apps/fork", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("forkSharedApp failed (HTTP \(response.statusCode))")
@@ -452,7 +452,7 @@ public struct AppsClient: AppsClientProtocol {
     public func shareAppCloud(appId: String) async -> ShareAppCloudResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/apps/\(appId)/share-cloud", timeout: 10
+                path: "apps/\(appId)/share-cloud", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("shareAppCloud failed (HTTP \(response.statusCode))")
@@ -477,7 +477,7 @@ public struct AppsClient: AppsClientProtocol {
                 var params: [String: String] = ["method": method]
                 if let recordId { params["recordId"] = recordId }
                 response = try await GatewayHTTPClient.get(
-                    path: "assistants/{assistantId}/apps/\(appId)/data",
+                    path: "apps/\(appId)/data",
                     params: params,
                     timeout: 10
                 )
@@ -492,7 +492,7 @@ public struct AppsClient: AppsClientProtocol {
                     body["data"] = rawData
                 }
                 response = try await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/apps/\(appId)/data",
+                    path: "apps/\(appId)/data",
                     json: body,
                     timeout: 10
                 )

--- a/clients/shared/Network/AttachmentContentClient.swift
+++ b/clients/shared/Network/AttachmentContentClient.swift
@@ -17,7 +17,7 @@ public enum AttachmentContentClient {
     /// - Returns: The raw attachment bytes.
     /// - Throws: ``GatewayHTTPClient/ClientError`` or network errors.
     public static func fetchContent(attachmentId: String) async throws -> Data {
-        let path = "assistants/{assistantId}/attachments/\(attachmentId)/content"
+        let path = "attachments/\(attachmentId)/content"
         let response = try await GatewayHTTPClient.get(path: path, timeout: 120)
         guard response.isSuccess else {
             log.error("Attachment fetch failed with HTTP \(response.statusCode) for \(attachmentId)")

--- a/clients/shared/Network/BtwClient.swift
+++ b/clients/shared/Network/BtwClient.swift
@@ -47,7 +47,7 @@ public struct BtwClient: BtwClientProtocol {
         defer { session.invalidateAndCancel() }
 
         let (bytes, response) = try await GatewayHTTPClient.streamPostWithRetry(
-            path: "assistants/{assistantId}/btw",
+            path: "btw",
             body: bodyData,
             timeout: 120,
             session: session

--- a/clients/shared/Network/ChannelClient.swift
+++ b/clients/shared/Network/ChannelClient.swift
@@ -68,7 +68,7 @@ public struct ChannelClient: ChannelClientProtocol {
     public func fetchChannelReadiness() async -> [String: ChannelReadinessInfo] {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/channels/readiness", timeout: 10
+                path: "channels/readiness", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchChannelReadiness failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/CompactionPlaygroundClient.swift
+++ b/clients/shared/Network/CompactionPlaygroundClient.swift
@@ -44,7 +44,7 @@ public struct CompactionPlaygroundClient: CompactionPlaygroundClientProtocol {
     // MARK: - Compaction actions (conversation-scoped)
 
     public func forceCompact(conversationId: String) async throws -> CompactionForceResponse {
-        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/compact"
+        let path = "conversations/\(conversationId)/playground/compact"
         let response = try await GatewayHTTPClient.post(path: path, json: [:], timeout: 120)
         try throwIfUnsuccessful(response, path: path)
         return try JSONDecoder().decode(CompactionForceResponse.self, from: response.data)
@@ -55,7 +55,7 @@ public struct CompactionPlaygroundClient: CompactionPlaygroundClientProtocol {
         consecutiveFailures: Int?,
         circuitOpenForMs: Int?
     ) async throws {
-        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/inject-compaction-failures"
+        let path = "conversations/\(conversationId)/playground/inject-compaction-failures"
         let body = InjectFailuresRequest(
             consecutiveFailures: consecutiveFailures,
             circuitOpenForMs: circuitOpenForMs
@@ -69,13 +69,13 @@ public struct CompactionPlaygroundClient: CompactionPlaygroundClientProtocol {
     }
 
     public func resetCircuit(conversationId: String) async throws {
-        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/reset-compaction-circuit"
+        let path = "conversations/\(conversationId)/playground/reset-compaction-circuit"
         let response = try await GatewayHTTPClient.post(path: path, json: [:], timeout: 15)
         try throwIfUnsuccessful(response, path: path)
     }
 
     public func getState(conversationId: String) async throws -> CompactionStateResponse {
-        let path = "assistants/{assistantId}/conversations/\(conversationId)/playground/compaction-state"
+        let path = "conversations/\(conversationId)/playground/compaction-state"
         let response = try await GatewayHTTPClient.get(path: path, timeout: 15)
         try throwIfUnsuccessful(response, path: path)
         return try JSONDecoder().decode(CompactionStateResponse.self, from: response.data)
@@ -88,7 +88,7 @@ public struct CompactionPlaygroundClient: CompactionPlaygroundClientProtocol {
         avgTokensPerTurn: Int?,
         title: String?
     ) async throws -> SeedConversationResponse {
-        let path = "assistants/{assistantId}/playground/seed-conversation"
+        let path = "playground/seed-conversation"
         let body = SeedConversationRequest(
             turns: turns,
             avgTokensPerTurn: avgTokensPerTurn,
@@ -104,21 +104,21 @@ public struct CompactionPlaygroundClient: CompactionPlaygroundClientProtocol {
     }
 
     public func listSeededConversations() async throws -> SeededConversationsListResponse {
-        let path = "assistants/{assistantId}/playground/seeded-conversations"
+        let path = "playground/seeded-conversations"
         let response = try await GatewayHTTPClient.get(path: path, timeout: 15)
         try throwIfUnsuccessful(response, path: path)
         return try JSONDecoder().decode(SeededConversationsListResponse.self, from: response.data)
     }
 
     public func deleteSeededConversation(id: String) async throws -> DeleteSeededConversationsResponse {
-        let path = "assistants/{assistantId}/playground/seeded-conversations/\(id)"
+        let path = "playground/seeded-conversations/\(id)"
         let response = try await GatewayHTTPClient.delete(path: path, timeout: 15)
         try throwIfUnsuccessful(response, path: path)
         return try JSONDecoder().decode(DeleteSeededConversationsResponse.self, from: response.data)
     }
 
     public func deleteAllSeededConversations() async throws -> DeleteSeededConversationsResponse {
-        let path = "assistants/{assistantId}/playground/seeded-conversations"
+        let path = "playground/seeded-conversations"
         let response = try await GatewayHTTPClient.delete(path: path, timeout: 30)
         try throwIfUnsuccessful(response, path: path)
         return try JSONDecoder().decode(DeleteSeededConversationsResponse.self, from: response.data)

--- a/clients/shared/Network/ComputerUseClient.swift
+++ b/clients/shared/Network/ComputerUseClient.swift
@@ -17,7 +17,7 @@ public struct ComputerUseClient: ComputerUseClientProtocol {
         do {
             let body = try JSONEncoder().encode(msg)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/computer-use/watch",
+                path: "computer-use/watch",
                 body: body,
                 timeout: 10
             )
@@ -36,7 +36,7 @@ public struct ComputerUseClient: ComputerUseClientProtocol {
         do {
             let body = try JSONEncoder().encode(msg)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/recordings/status",
+                path: "recordings/status",
                 body: body,
                 timeout: 10
             )

--- a/clients/shared/Network/ConsolidationClient.swift
+++ b/clients/shared/Network/ConsolidationClient.swift
@@ -19,7 +19,7 @@ public struct ConsolidationClient: ConsolidationClientProtocol {
     public func fetchConfig() async -> ConsolidationConfigResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/consolidation/config", timeout: 10
+                path: "consolidation/config", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchConfig failed (HTTP \(response.statusCode))")
@@ -36,7 +36,7 @@ public struct ConsolidationClient: ConsolidationClientProtocol {
     public func runNow() async -> ConsolidationRunNowResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/consolidation/run-now", timeout: 30
+                path: "consolidation/run-now", timeout: 30
             )
             guard response.isSuccess else {
                 log.error("runNow failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/ContactClient.swift
+++ b/clients/shared/Network/ContactClient.swift
@@ -105,7 +105,7 @@ public struct ContactClient: ContactClientProtocol {
         if let notes { body["notes"] = notes }
 
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/contacts", json: body, timeout: 10
+            path: "contacts", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("updateContact failed (HTTP \(response.statusCode))")
@@ -128,7 +128,7 @@ public struct ContactClient: ContactClientProtocol {
         }
 
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/contacts", json: body, timeout: 10
+            path: "contacts", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("createContact failed (HTTP \(response.statusCode))")
@@ -157,7 +157,7 @@ public struct ContactClient: ContactClientProtocol {
         if let guardianName { body["guardianName"] = guardianName }
 
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/contacts/invites", json: body, timeout: 10
+            path: "contacts/invites", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("createInvite failed (HTTP \(response.statusCode))")
@@ -178,7 +178,7 @@ public struct ContactClient: ContactClientProtocol {
 
     public func triggerInviteCall(inviteId: String) async throws -> Bool {
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/contacts/invites/\(inviteId)/call", json: [:], timeout: 10
+            path: "contacts/invites/\(inviteId)/call", json: [:], timeout: 10
         )
         guard response.isSuccess else {
             log.error("triggerInviteCall failed (HTTP \(response.statusCode))")
@@ -204,7 +204,7 @@ public struct ContactClient: ContactClientProtocol {
         if let role { params["role"] = role }
 
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/contacts", params: params, timeout: 10
+            path: "contacts", params: params, timeout: 10
         )
         guard response.isSuccess else {
             log.error("fetchContactsList failed (HTTP \(response.statusCode))")
@@ -215,7 +215,7 @@ public struct ContactClient: ContactClientProtocol {
 
     public func fetchContact(contactId: String) async throws -> ContactPayload? {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/contacts/\(contactId)", timeout: 10
+            path: "contacts/\(contactId)", timeout: 10
         )
         guard response.isSuccess else {
             log.error("fetchContact failed (HTTP \(response.statusCode))")
@@ -226,7 +226,7 @@ public struct ContactClient: ContactClientProtocol {
 
     public func deleteContact(contactId: String) async throws -> Bool {
         let response = try await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/contacts/\(contactId)", timeout: 10
+            path: "contacts/\(contactId)", timeout: 10
         )
         guard response.isSuccess || response.statusCode == 204 else {
             log.error("deleteContact failed (HTTP \(response.statusCode))")
@@ -247,7 +247,7 @@ public struct ContactClient: ContactClientProtocol {
         if let reason { body["reason"] = reason }
 
         let response = try await GatewayHTTPClient.patch(
-            path: "assistants/{assistantId}/contact-channels/\(channelId)", json: body, timeout: 10
+            path: "contact-channels/\(channelId)", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("updateContactChannel failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/ConversationAnalysisClient.swift
+++ b/clients/shared/Network/ConversationAnalysisClient.swift
@@ -15,7 +15,7 @@ public struct ConversationAnalysisClient: ConversationAnalysisClientProtocol {
     public func analyzeConversation(conversationId: String) async -> ConversationListResponseItem? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/\(conversationId)/analyze",
+                path: "conversations/\(conversationId)/analyze",
                 json: [:],
                 timeout: 30
             )

--- a/clients/shared/Network/ConversationClient.swift
+++ b/clients/shared/Network/ConversationClient.swift
@@ -16,7 +16,7 @@ public struct ConversationClient: ConversationClientProtocol {
         do {
             let encoded = messageId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? messageId
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/messages/\(encoded)/content",
+                path: "messages/\(encoded)/content",
                 params: ["conversationId": conversationId],
                 timeout: 10
             )

--- a/clients/shared/Network/ConversationDetailClient.swift
+++ b/clients/shared/Network/ConversationDetailClient.swift
@@ -15,7 +15,7 @@ public struct ConversationDetailClient: ConversationDetailClientProtocol {
     public func fetchConversation(conversationId: String) async -> ConversationListResponseItem? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/conversations/\(conversationId)",
+                path: "conversations/\(conversationId)",
                 timeout: 15
             )
             guard response.isSuccess else {

--- a/clients/shared/Network/ConversationForkClient.swift
+++ b/clients/shared/Network/ConversationForkClient.swift
@@ -20,7 +20,7 @@ public struct ConversationForkClient: ConversationForkClientProtocol {
             }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/fork",
+                path: "conversations/fork",
                 json: body,
                 timeout: 15
             )

--- a/clients/shared/Network/ConversationHistoryClient.swift
+++ b/clients/shared/Network/ConversationHistoryClient.swift
@@ -30,7 +30,7 @@ public struct ConversationHistoryClient: ConversationHistoryClientProtocol {
             if let maxToolResultChars { params["maxToolResultChars"] = "\(maxToolResultChars)" }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/messages", params: params, timeout: 15
+                path: "messages", params: params, timeout: 15
             )
             guard response.isSuccess else {
                 log.error("fetchHistory failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/ConversationInferenceProfileClient.swift
+++ b/clients/shared/Network/ConversationInferenceProfileClient.swift
@@ -38,7 +38,7 @@ public struct ConversationInferenceProfileClient: ConversationInferenceProfileCl
         let body: [String: Any] = ["profile": profile ?? NSNull()]
         do {
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/conversations/\(conversationId)/inference-profile",
+                path: "conversations/\(conversationId)/inference-profile",
                 json: body
             )
             guard response.isSuccess else {

--- a/clients/shared/Network/ConversationListClient.swift
+++ b/clients/shared/Network/ConversationListClient.swift
@@ -30,7 +30,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
             if let conversationType { params["conversationType"] = conversationType }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/conversations", params: params, timeout: 15
+                path: "conversations", params: params, timeout: 15
             )
             guard response.isSuccess else {
                 let body = String(data: response.data.prefix(512), encoding: .utf8) ?? "<non-utf8>"
@@ -76,7 +76,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func switchConversation(conversationId: String) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/switch",
+                path: "conversations/switch",
                 json: ["conversationId": conversationId],
                 timeout: 10
             )
@@ -94,7 +94,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func renameConversation(conversationId: String, name: String) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/conversations/\(conversationId)/name",
+                path: "conversations/\(conversationId)/name",
                 json: ["name": name],
                 timeout: 10
             )
@@ -112,7 +112,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func clearAllConversations() async -> Bool {
         do {
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/conversations",
+                path: "conversations",
                 timeout: 10
             )
             guard response.isSuccess || response.statusCode == 204 else {
@@ -129,7 +129,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func cancelGeneration(conversationId: String) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/\(conversationId)/cancel",
+                path: "conversations/\(conversationId)/cancel",
                 json: [:] as [String: String],
                 timeout: 10
             )
@@ -148,7 +148,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func undoLastMessage(conversationId: String) async -> Int? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/\(conversationId)/undo",
+                path: "conversations/\(conversationId)/undo",
                 json: [:] as [String: String],
                 timeout: 10
             )
@@ -174,7 +174,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
             if let maxMessagesPerConversation { params["maxMessagesPerConversation"] = "\(maxMessagesPerConversation)" }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/conversations/search",
+                path: "conversations/search",
                 params: params,
                 timeout: 15
             )
@@ -212,7 +212,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
                 }
             ]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/reorder",
+                path: "conversations/reorder",
                 json: body,
                 timeout: 10
             )
@@ -232,7 +232,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func fetchGroups() async -> [ConversationGroupResponse]? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/groups",
+                path: "groups",
                 timeout: 15
             )
             guard response.isSuccess else {
@@ -253,7 +253,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func createGroup(name: String) async -> ConversationGroupResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/groups",
+                path: "groups",
                 json: ["name": name],
                 timeout: 10
             )
@@ -275,7 +275,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
             if let sortPosition { body["sortPosition"] = sortPosition }
 
             let response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/groups/\(groupId)",
+                path: "groups/\(groupId)",
                 json: body,
                 timeout: 10
             )
@@ -293,7 +293,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
     public func deleteGroup(groupId: String) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/groups/\(groupId)",
+                path: "groups/\(groupId)",
                 timeout: 10
             )
             guard response.isSuccess || response.statusCode == 204 else {
@@ -316,7 +316,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
                 ] as [String: Any] }
             ]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/groups/reorder",
+                path: "groups/reorder",
                 json: body,
                 timeout: 10
             )
@@ -348,7 +348,7 @@ public struct ConversationListClient: ConversationListClientProtocol {
             }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/seen",
+                path: "conversations/seen",
                 json: body,
                 timeout: 10
             )

--- a/clients/shared/Network/ConversationQueueClient.swift
+++ b/clients/shared/Network/ConversationQueueClient.swift
@@ -16,7 +16,7 @@ public struct ConversationQueueClient: ConversationQueueClientProtocol {
         do {
             let encoded = requestId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? requestId
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/messages/queued/\(encoded)?conversationId=\(conversationId)",
+                path: "messages/queued/\(encoded)?conversationId=\(conversationId)",
                 timeout: 10
             )
             guard response.isSuccess else {

--- a/clients/shared/Network/ConversationUnreadClient.swift
+++ b/clients/shared/Network/ConversationUnreadClient.swift
@@ -43,7 +43,7 @@ public struct ConversationUnreadClient: ConversationUnreadClientProtocol {
         }
 
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/conversations/unread",
+            path: "conversations/unread",
             json: body,
             timeout: 10
         )

--- a/clients/shared/Network/DiagnosticsClient.swift
+++ b/clients/shared/Network/DiagnosticsClient.swift
@@ -15,7 +15,7 @@ public struct DiagnosticsClient: DiagnosticsClientProtocol {
     public func fetchEnvVars() async -> EnvVarsResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/diagnostics/env-vars", timeout: 10
+                path: "diagnostics/env-vars", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchEnvVars failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/DictationClient.swift
+++ b/clients/shared/Network/DictationClient.swift
@@ -38,7 +38,7 @@ public struct DictationClient: DictationClientProtocol {
         do {
             let encodedRequest = try JSONEncoder().encode(request)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/dictation",
+                path: "dictation",
                 body: encodedRequest,
                 timeout: Self.requestTimeout
             )

--- a/clients/shared/Network/DocumentClient.swift
+++ b/clients/shared/Network/DocumentClient.swift
@@ -20,7 +20,7 @@ public struct DocumentClient: DocumentClientProtocol {
             if let conversationId { params["conversationId"] = conversationId }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/documents",
+                path: "documents",
                 params: params.isEmpty ? nil : params,
                 timeout: 10
             )
@@ -52,7 +52,7 @@ public struct DocumentClient: DocumentClientProtocol {
     public func fetchDocument(surfaceId: String) async -> DocumentLoadResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/documents/\(surfaceId)", timeout: 10
+                path: "documents/\(surfaceId)", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchDocument failed (HTTP \(response.statusCode))")
@@ -87,7 +87,7 @@ public struct DocumentClient: DocumentClientProtocol {
                 "wordCount": wordCount,
             ]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/documents", json: body, timeout: 10
+                path: "documents", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("saveDocument failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -397,7 +397,7 @@ public final class EventStreamClient {
             do {
                 await self.sseHandshakeDiagnostics.reset()
                 let (bytes, response) = try await GatewayHTTPClient.stream(
-                    path: "assistants/{assistantId}/events",
+                    path: "events",
                     timeout: .infinity,
                     session: session
                 )

--- a/clients/shared/Network/FeatureFlagClient.swift
+++ b/clients/shared/Network/FeatureFlagClient.swift
@@ -99,7 +99,7 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
 
     public func getFeatureFlags() async throws -> [AssistantFeatureFlag] {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/feature-flags", timeout: 10
+            path: "feature-flags", timeout: 10
         )
         guard response.isSuccess else {
             log.error("getFeatureFlags failed (HTTP \(response.statusCode))")
@@ -137,7 +137,7 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
 
     public func setFeatureFlag(key: String, enabled: Bool) async throws {
         let response = try await GatewayHTTPClient.patch(
-            path: "assistants/{assistantId}/feature-flags/\(key)",
+            path: "feature-flags/\(key)",
             json: ["enabled": enabled],
             timeout: 10
         )
@@ -149,7 +149,7 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
 
     public func getPrivacyConfig() async throws -> PrivacyConfig {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/config/privacy",
+            path: "config/privacy",
             timeout: 10
         )
         guard response.isSuccess else {
@@ -176,7 +176,7 @@ public struct FeatureFlagClient: FeatureFlagClientProtocol {
         }
 
         let response = try await GatewayHTTPClient.patch(
-            path: "assistants/{assistantId}/config/privacy",
+            path: "config/privacy",
             json: body,
             timeout: 10
         )

--- a/clients/shared/Network/FilingClient.swift
+++ b/clients/shared/Network/FilingClient.swift
@@ -18,7 +18,7 @@ public struct FilingClient: FilingClientProtocol {
     public func fetchConfig() async -> FilingConfigResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/filing/config", timeout: 10
+                path: "filing/config", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchConfig failed (HTTP \(response.statusCode))")
@@ -35,7 +35,7 @@ public struct FilingClient: FilingClientProtocol {
     public func runNow() async -> FilingRunNowResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/filing/run-now", timeout: 120
+                path: "filing/run-now", timeout: 120
             )
             guard response.isSuccess else {
                 log.error("runNow failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -359,9 +359,9 @@ public final class GatewayConnectionManager {
     private func performHealthCheck() async throws {
         let healthPath: String
         #if os(macOS)
-        healthPath = (cachedAssistant?.isManaged ?? false) ? "assistants/{assistantId}/health" : "health"
+        healthPath = (cachedAssistant?.isManaged ?? false) ? "health" : "health"
         #else
-        healthPath = ((try? GatewayHTTPClient.isConnectionManaged()) ?? false) ? "assistants/{assistantId}/health" : "health"
+        healthPath = ((try? GatewayHTTPClient.isConnectionManaged()) ?? false) ? "health" : "health"
         #endif
 
         // Run the HTTP GET + JSON decode off the main actor. `GatewayHTTPClient`

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -357,12 +357,7 @@ public final class GatewayConnectionManager {
     }
 
     private func performHealthCheck() async throws {
-        let healthPath: String
-        #if os(macOS)
-        healthPath = (cachedAssistant?.isManaged ?? false) ? "health" : "health"
-        #else
-        healthPath = ((try? GatewayHTTPClient.isConnectionManaged()) ?? false) ? "health" : "health"
-        #endif
+        let healthPath = "health"
 
         // Run the HTTP GET + JSON decode off the main actor. `GatewayHTTPClient`
         // is nonisolated but, when called from a `@MainActor` context, its
@@ -385,7 +380,8 @@ public final class GatewayConnectionManager {
             let response = try await GatewayHTTPClient.get(
                 path: healthPath,
                 timeout: 10,
-                quiet: true
+                quiet: true,
+                unprefixed: true
             )
             let version: String? = response.isSuccess
                 ? (try? JSONDecoder().decode(HealthVersionResponse.self, from: response.data))?.version

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -405,7 +405,7 @@ public enum GatewayHTTPClient {
     /// Performs an authenticated DELETE request against the gateway.
     ///
     /// - Parameters:
-    ///   - path: Path segment after `/v1/` (e.g. `"assistants/{id}/secrets"`).
+    ///   - path: Path segment after `/v1/` (e.g. `"secrets"`).
     ///   - body: Optional HTTP body data.
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
@@ -834,9 +834,9 @@ public enum GatewayHTTPClient {
     /// ``post(path:body:timeout:)``.
     ///
     /// - Parameters:
-    ///   - path: Path segment after `/v1/` (e.g. `"assistants/{assistantId}/workspace/file/content"`).
+    ///   - path: Path segment after `/v1/` (e.g. `"workspace/file/content"`).
     ///   - params: Optional query parameters.
-    /// - Returns: The fully-qualified URL with `{assistantId}` resolved.
+    /// - Returns: The fully-qualified URL.
     /// - Throws: `ClientError` if the connection cannot be resolved or the URL is invalid.
     public static func buildURL(path: String, params: [String: String]? = nil, unprefixed: Bool = false) throws -> URL {
         let connection = try resolveConnection()

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -160,7 +160,7 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 60.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func postMultipart(path: String, parts: [MultipartPart], timeout: TimeInterval = 60, unprefixed: Bool = false) async throws -> Response {
+    public static func postMultipart(path: String, parts: [MultipartPart], timeout: TimeInterval = 60) async throws -> Response {
         let boundary = UUID().uuidString
         var body = Data()
 
@@ -185,7 +185,7 @@ public enum GatewayHTTPClient {
 
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
 
-        return try await executeWithRetry(path: path, method: "POST", timeout: timeout, unprefixed: unprefixed) { request in
+        return try await executeWithRetry(path: path, method: "POST", timeout: timeout) { request in
             request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
             request.httpBody = body
         }
@@ -344,8 +344,8 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func patch(path: String, body: Data? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
-        return try await executeWithRetry(path: path, method: "PATCH", timeout: timeout, unprefixed: unprefixed) { request in
+    public static func patch(path: String, body: Data? = nil, timeout: TimeInterval = 30) async throws -> Response {
+        return try await executeWithRetry(path: path, method: "PATCH", timeout: timeout) { request in
             request.httpBody = body
         }
     }
@@ -358,9 +358,9 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, serialization errors, or network errors.
-    public static func patch(path: String, json: [String: Any], timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
+    public static func patch(path: String, json: [String: Any], timeout: TimeInterval = 30) async throws -> Response {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await patch(path: path, body: body, timeout: timeout, unprefixed: unprefixed)
+        return try await patch(path: path, body: body, timeout: timeout)
     }
 
     /// Performs an authenticated PUT request against the gateway.
@@ -375,8 +375,8 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func put(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
-        return try await executeWithRetry(path: path, params: params, method: "PUT", timeout: timeout, unprefixed: unprefixed) { request in
+    public static func put(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> Response {
+        return try await executeWithRetry(path: path, params: params, method: "PUT", timeout: timeout) { request in
             request.httpBody = body
             if let contentType {
                 request.setValue(contentType, forHTTPHeaderField: "Content-Type")
@@ -397,9 +397,9 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, serialization errors, or network errors.
-    public static func put(path: String, json: [String: Any], timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
+    public static func put(path: String, json: [String: Any], timeout: TimeInterval = 30) async throws -> Response {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await put(path: path, body: body, timeout: timeout, unprefixed: unprefixed)
+        return try await put(path: path, body: body, timeout: timeout)
     }
 
     /// Performs an authenticated DELETE request against the gateway.
@@ -453,9 +453,9 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A ``DownloadResponse`` with the local file URL and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func download(path: String, params: [String: String]? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> DownloadResponse {
+    public static func download(path: String, params: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> DownloadResponse {
         let connection = try resolveConnection()
-        let request = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: connection, unprefixed: unprefixed)
+        let request = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: connection)
         let response = try await executeDownload(request)
 
         guard response.statusCode == 401, !connection.isManaged else {
@@ -470,7 +470,7 @@ public enum GatewayHTTPClient {
         try? FileManager.default.removeItem(at: response.fileURL)
 
         let freshConnection = try resolveConnection()
-        let retryRequest = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: freshConnection, unprefixed: unprefixed)
+        let retryRequest = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: freshConnection)
         return try await executeDownload(retryRequest)
     }
 
@@ -488,9 +488,9 @@ public enum GatewayHTTPClient {
     ///     in `AsyncBytes`).
     /// - Returns: A tuple of `(URLSession.AsyncBytes, URLResponse)` for streaming consumption.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func stream(path: String, timeout: TimeInterval = 30, session: URLSession = .shared, unprefixed: Bool = false) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func stream(path: String, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: nil, method: "GET", timeout: timeout, connection: connection, unprefixed: unprefixed)
+        var request = try buildRequest(path: path, params: nil, method: "GET", timeout: timeout, connection: connection)
         request.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         request.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -517,9 +517,9 @@ public enum GatewayHTTPClient {
     ///     in `AsyncBytes`).
     /// - Returns: A tuple of `(URLSession.AsyncBytes, URLResponse)` for streaming consumption.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func streamPost(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared, unprefixed: Bool = false) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func streamPost(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection, unprefixed: unprefixed)
+        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection)
         request.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         request.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -551,9 +551,9 @@ public enum GatewayHTTPClient {
     /// - Throws: `ClientError` if the request cannot be constructed,
     ///   `URLError(.userAuthenticationRequired)` if credential refresh fails,
     ///   or network errors from `URLSession`.
-    public static func streamPostWithRetry(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared, unprefixed: Bool = false) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func streamPostWithRetry(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection, unprefixed: unprefixed)
+        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection)
         request.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         request.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -582,7 +582,7 @@ public enum GatewayHTTPClient {
 
         // Rebuild with fresh credentials from the credential store.
         let freshConnection = try resolveConnection()
-        var retryRequest = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: freshConnection, unprefixed: unprefixed)
+        var retryRequest = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: freshConnection)
         retryRequest.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         retryRequest.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         retryRequest.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -838,9 +838,9 @@ public enum GatewayHTTPClient {
     ///   - params: Optional query parameters.
     /// - Returns: The fully-qualified URL.
     /// - Throws: `ClientError` if the connection cannot be resolved or the URL is invalid.
-    public static func buildURL(path: String, params: [String: String]? = nil, unprefixed: Bool = false) throws -> URL {
+    public static func buildURL(path: String, params: [String: String]? = nil) throws -> URL {
         let connection = try resolveConnection()
-        return try constructURL(path: path, params: params, connection: connection, unprefixed: unprefixed)
+        return try constructURL(path: path, params: params, connection: connection)
     }
 
     // MARK: - WebSocket Helpers

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -14,8 +14,12 @@ public enum MultipartPart {
 /// Consolidates URL construction, auth headers, org-id injection, and
 /// request execution so callers can simply write:
 ///
-///     let response = try await GatewayHTTPClient.get(path: "health")
-///     let response = try await GatewayHTTPClient.post(path: "assistants/upgrade")
+///     let response = try await GatewayHTTPClient.get(path: "health", unprefixed: true)
+///     let response = try await GatewayHTTPClient.post(path: "restart")
+///
+/// All paths are automatically prepended with `assistants/{assistantId}/` unless
+/// the caller passes `unprefixed: true` (for routes that operate outside assistant
+/// scope, e.g. `health`, `guardian/*`, `secrets`).
 public enum GatewayHTTPClient {
     private static let sseAcceptHeader = "text/event-stream, application/json"
 
@@ -66,8 +70,8 @@ public enum GatewayHTTPClient {
     ///   - quiet: When `true`, suppresses HTTP request/response logging for this request.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func get(path: String, params: [String: String]? = nil, timeout: TimeInterval = 30, quiet: Bool = false) async throws -> Response {
-        return try await executeWithRetry(path: path, params: params, method: "GET", timeout: timeout, quiet: quiet)
+    public static func get(path: String, params: [String: String]? = nil, timeout: TimeInterval = 30, quiet: Bool = false, unprefixed: Bool = false) async throws -> Response {
+        return try await executeWithRetry(path: path, params: params, method: "GET", timeout: timeout, quiet: quiet, unprefixed: unprefixed)
     }
 
     /// Performs an authenticated GET request and decodes the JSON response into the given type.
@@ -90,9 +94,10 @@ public enum GatewayHTTPClient {
         path: String,
         params: [String: String]? = nil,
         timeout: TimeInterval = 30,
+        unprefixed: Bool = false,
         configure: ((_ decoder: JSONDecoder) -> Void)? = nil
     ) async throws -> (T?, Response) {
-        let response = try await get(path: path, params: params, timeout: timeout)
+        let response = try await get(path: path, params: params, timeout: timeout, unprefixed: unprefixed)
         guard response.isSuccess else { return (nil, response) }
         let decoder = JSONDecoder()
         configure?(decoder)
@@ -110,8 +115,8 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func post(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, timeout: TimeInterval = 30) async throws -> Response {
-        return try await executeWithRetry(path: path, params: params, method: "POST", timeout: timeout) { request in
+    public static func post(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
+        return try await executeWithRetry(path: path, params: params, method: "POST", timeout: timeout, unprefixed: unprefixed) { request in
             request.httpBody = body
             if let contentType {
                 request.setValue(contentType, forHTTPHeaderField: "Content-Type")
@@ -130,9 +135,9 @@ public enum GatewayHTTPClient {
     ///     the credential refresh endpoint to prevent recursive refresh loops.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, serialization errors, or network errors.
-    public static func post(path: String, json: [String: Any], extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30, skipRetry: Bool = false) async throws -> Response {
+    public static func post(path: String, json: [String: Any], extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30, skipRetry: Bool = false, unprefixed: Bool = false) async throws -> Response {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await executeWithRetry(path: path, method: "POST", timeout: timeout, skipRetry: skipRetry) { request in
+        return try await executeWithRetry(path: path, method: "POST", timeout: timeout, skipRetry: skipRetry, unprefixed: unprefixed) { request in
             request.httpBody = body
             if let extraHeaders {
                 for (key, value) in extraHeaders {
@@ -155,7 +160,7 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 60.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func postMultipart(path: String, parts: [MultipartPart], timeout: TimeInterval = 60) async throws -> Response {
+    public static func postMultipart(path: String, parts: [MultipartPart], timeout: TimeInterval = 60, unprefixed: Bool = false) async throws -> Response {
         let boundary = UUID().uuidString
         var body = Data()
 
@@ -180,7 +185,7 @@ public enum GatewayHTTPClient {
 
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
 
-        return try await executeWithRetry(path: path, method: "POST", timeout: timeout) { request in
+        return try await executeWithRetry(path: path, method: "POST", timeout: timeout, unprefixed: unprefixed) { request in
             request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
             request.httpBody = body
         }
@@ -212,10 +217,11 @@ public enum GatewayHTTPClient {
         params: [String: String]? = nil,
         contentType: String? = nil,
         timeout: TimeInterval = 30,
+        unprefixed: Bool = false,
         onProgress: @escaping @MainActor (Double) -> Void
     ) async throws -> Response {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: connection)
+        var request = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: connection, unprefixed: unprefixed)
         request.httpBody = body
         if let contentType {
             request.setValue(contentType, forHTTPHeaderField: "Content-Type")
@@ -228,7 +234,7 @@ public enum GatewayHTTPClient {
         if result.statusCode == 401, !connection.isManaged {
             if await refreshBearerCredentials(connection: connection) {
                 let freshConnection = try resolveConnection()
-                var retryRequest = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: freshConnection)
+                var retryRequest = try buildRequest(path: path, params: params, method: "POST", timeout: timeout, connection: freshConnection, unprefixed: unprefixed)
                 retryRequest.httpBody = body
                 if let contentType {
                     retryRequest.setValue(contentType, forHTTPHeaderField: "Content-Type")
@@ -338,8 +344,8 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func patch(path: String, body: Data? = nil, timeout: TimeInterval = 30) async throws -> Response {
-        return try await executeWithRetry(path: path, method: "PATCH", timeout: timeout) { request in
+    public static func patch(path: String, body: Data? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
+        return try await executeWithRetry(path: path, method: "PATCH", timeout: timeout, unprefixed: unprefixed) { request in
             request.httpBody = body
         }
     }
@@ -352,9 +358,9 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, serialization errors, or network errors.
-    public static func patch(path: String, json: [String: Any], timeout: TimeInterval = 30) async throws -> Response {
+    public static func patch(path: String, json: [String: Any], timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await patch(path: path, body: body, timeout: timeout)
+        return try await patch(path: path, body: body, timeout: timeout, unprefixed: unprefixed)
     }
 
     /// Performs an authenticated PUT request against the gateway.
@@ -369,8 +375,8 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func put(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> Response {
-        return try await executeWithRetry(path: path, params: params, method: "PUT", timeout: timeout) { request in
+    public static func put(path: String, body: Data? = nil, params: [String: String]? = nil, contentType: String? = nil, extraHeaders: [String: String]? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
+        return try await executeWithRetry(path: path, params: params, method: "PUT", timeout: timeout, unprefixed: unprefixed) { request in
             request.httpBody = body
             if let contentType {
                 request.setValue(contentType, forHTTPHeaderField: "Content-Type")
@@ -391,9 +397,9 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, serialization errors, or network errors.
-    public static func put(path: String, json: [String: Any], timeout: TimeInterval = 30) async throws -> Response {
+    public static func put(path: String, json: [String: Any], timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await put(path: path, body: body, timeout: timeout)
+        return try await put(path: path, body: body, timeout: timeout, unprefixed: unprefixed)
     }
 
     /// Performs an authenticated DELETE request against the gateway.
@@ -404,8 +410,8 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func delete(path: String, body: Data? = nil, timeout: TimeInterval = 30) async throws -> Response {
-        return try await executeWithRetry(path: path, method: "DELETE", timeout: timeout) { request in
+    public static func delete(path: String, body: Data? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
+        return try await executeWithRetry(path: path, method: "DELETE", timeout: timeout, unprefixed: unprefixed) { request in
             request.httpBody = body
         }
     }
@@ -418,9 +424,9 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A `Response` with the raw data and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, serialization errors, or network errors.
-    public static func delete(path: String, json: [String: Any], timeout: TimeInterval = 30) async throws -> Response {
+    public static func delete(path: String, json: [String: Any], timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> Response {
         let body = try JSONSerialization.data(withJSONObject: json)
-        return try await delete(path: path, body: body, timeout: timeout)
+        return try await delete(path: path, body: body, timeout: timeout, unprefixed: unprefixed)
     }
 
     /// Result of an authenticated download-to-disk request.
@@ -447,9 +453,9 @@ public enum GatewayHTTPClient {
     ///   - timeout: Request timeout in seconds. Defaults to 30.
     /// - Returns: A ``DownloadResponse`` with the local file URL and HTTP status code.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func download(path: String, params: [String: String]? = nil, timeout: TimeInterval = 30) async throws -> DownloadResponse {
+    public static func download(path: String, params: [String: String]? = nil, timeout: TimeInterval = 30, unprefixed: Bool = false) async throws -> DownloadResponse {
         let connection = try resolveConnection()
-        let request = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: connection)
+        let request = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: connection, unprefixed: unprefixed)
         let response = try await executeDownload(request)
 
         guard response.statusCode == 401, !connection.isManaged else {
@@ -464,7 +470,7 @@ public enum GatewayHTTPClient {
         try? FileManager.default.removeItem(at: response.fileURL)
 
         let freshConnection = try resolveConnection()
-        let retryRequest = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: freshConnection)
+        let retryRequest = try buildRequest(path: path, params: params, method: "GET", timeout: timeout, connection: freshConnection, unprefixed: unprefixed)
         return try await executeDownload(retryRequest)
     }
 
@@ -482,9 +488,9 @@ public enum GatewayHTTPClient {
     ///     in `AsyncBytes`).
     /// - Returns: A tuple of `(URLSession.AsyncBytes, URLResponse)` for streaming consumption.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func stream(path: String, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func stream(path: String, timeout: TimeInterval = 30, session: URLSession = .shared, unprefixed: Bool = false) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: nil, method: "GET", timeout: timeout, connection: connection)
+        var request = try buildRequest(path: path, params: nil, method: "GET", timeout: timeout, connection: connection, unprefixed: unprefixed)
         request.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         request.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -511,9 +517,9 @@ public enum GatewayHTTPClient {
     ///     in `AsyncBytes`).
     /// - Returns: A tuple of `(URLSession.AsyncBytes, URLResponse)` for streaming consumption.
     /// - Throws: `ClientError` if the request cannot be constructed, or network errors from `URLSession`.
-    public static func streamPost(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func streamPost(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared, unprefixed: Bool = false) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection)
+        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection, unprefixed: unprefixed)
         request.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         request.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -545,9 +551,9 @@ public enum GatewayHTTPClient {
     /// - Throws: `ClientError` if the request cannot be constructed,
     ///   `URLError(.userAuthenticationRequired)` if credential refresh fails,
     ///   or network errors from `URLSession`.
-    public static func streamPostWithRetry(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared) async throws -> (URLSession.AsyncBytes, URLResponse) {
+    public static func streamPostWithRetry(path: String, body: Data, timeout: TimeInterval = 30, session: URLSession = .shared, unprefixed: Bool = false) async throws -> (URLSession.AsyncBytes, URLResponse) {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection)
+        var request = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: connection, unprefixed: unprefixed)
         request.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         request.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -576,7 +582,7 @@ public enum GatewayHTTPClient {
 
         // Rebuild with fresh credentials from the credential store.
         let freshConnection = try resolveConnection()
-        var retryRequest = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: freshConnection)
+        var retryRequest = try buildRequest(path: path, params: nil, method: "POST", timeout: timeout, connection: freshConnection, unprefixed: unprefixed)
         retryRequest.setValue(sseAcceptHeader, forHTTPHeaderField: "Accept")
         retryRequest.setValue(DeviceIdStore.getOrCreate(), forHTTPHeaderField: "X-Vellum-Client-Id")
         retryRequest.setValue(clientInterfaceId, forHTTPHeaderField: "X-Vellum-Interface-Id")
@@ -832,9 +838,9 @@ public enum GatewayHTTPClient {
     ///   - params: Optional query parameters.
     /// - Returns: The fully-qualified URL with `{assistantId}` resolved.
     /// - Throws: `ClientError` if the connection cannot be resolved or the URL is invalid.
-    public static func buildURL(path: String, params: [String: String]? = nil) throws -> URL {
+    public static func buildURL(path: String, params: [String: String]? = nil, unprefixed: Bool = false) throws -> URL {
         let connection = try resolveConnection()
-        return try constructURL(path: path, params: params, connection: connection)
+        return try constructURL(path: path, params: params, connection: connection, unprefixed: unprefixed)
     }
 
     // MARK: - WebSocket Helpers
@@ -852,7 +858,7 @@ public enum GatewayHTTPClient {
     ///   - params: Additional query parameters to include in the URL.
     /// - Returns: A `URLRequest` configured for a WebSocket upgrade with auth.
     /// - Throws: `ClientError` if the connection cannot be resolved or the URL is invalid.
-    public static func buildWebSocketRequest(path: String, params: [String: String]? = nil) throws -> URLRequest {
+    public static func buildWebSocketRequest(path: String, params: [String: String]? = nil, unprefixed: Bool = false) throws -> URLRequest {
         let connection = try resolveConnection()
 
         // Merge auth token into query params — WebSocket upgrades cannot carry
@@ -867,7 +873,7 @@ public enum GatewayHTTPClient {
             }
         }
 
-        let httpURL = try constructURL(path: path, params: mergedParams, connection: connection)
+        let httpURL = try constructURL(path: path, params: mergedParams, connection: connection, unprefixed: unprefixed)
 
         // Convert http(s) scheme to ws(s) for the WebSocket transport.
         guard var components = URLComponents(url: httpURL, resolvingAgainstBaseURL: false) else {
@@ -902,9 +908,17 @@ public enum GatewayHTTPClient {
     private static func constructURL(
         path: String,
         params: [String: String]?,
-        connection: ConnectionInfo
+        connection: ConnectionInfo,
+        unprefixed: Bool = false
     ) throws -> URL {
-        var resolvedPath = path.replacingOccurrences(of: "{assistantId}", with: connection.assistantId)
+        var resolvedPath = path
+
+        // Auto-prepend the assistant scope unless the caller explicitly opts out.
+        if !unprefixed && !resolvedPath.hasPrefix("assistants/") {
+            resolvedPath = "assistants/{assistantId}/\(resolvedPath)"
+        }
+
+        resolvedPath = resolvedPath.replacingOccurrences(of: "{assistantId}", with: connection.assistantId)
         // QR-mode connections have an empty assistantId — collapse the empty scope
         // prefix so e.g. "assistants//trace-events" falls back to "trace-events".
         if connection.assistantId.isEmpty {
@@ -947,9 +961,10 @@ public enum GatewayHTTPClient {
         params: [String: String]?,
         method: String,
         timeout: TimeInterval,
-        connection: ConnectionInfo
+        connection: ConnectionInfo,
+        unprefixed: Bool = false
     ) throws -> URLRequest {
-        let url = try constructURL(path: path, params: params, connection: connection)
+        let url = try constructURL(path: path, params: params, connection: connection, unprefixed: unprefixed)
 
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -1025,10 +1040,11 @@ public enum GatewayHTTPClient {
         timeout: TimeInterval,
         quiet: Bool = false,
         skipRetry: Bool = false,
+        unprefixed: Bool = false,
         configure: ((_ request: inout URLRequest) -> Void)? = nil
     ) async throws -> Response {
         let connection = try resolveConnection()
-        var request = try buildRequest(path: path, params: params, method: method, timeout: timeout, connection: connection)
+        var request = try buildRequest(path: path, params: params, method: method, timeout: timeout, connection: connection, unprefixed: unprefixed)
         configure?(&request)
         let response = try await execute(request, quiet: quiet)
 
@@ -1042,7 +1058,7 @@ public enum GatewayHTTPClient {
 
         // Rebuild with fresh credentials from the credential store.
         let freshConnection = try resolveConnection()
-        var retryRequest = try buildRequest(path: path, params: params, method: method, timeout: timeout, connection: freshConnection)
+        var retryRequest = try buildRequest(path: path, params: params, method: method, timeout: timeout, connection: freshConnection, unprefixed: unprefixed)
         configure?(&retryRequest)
         return try await execute(retryRequest, quiet: quiet)
     }

--- a/clients/shared/Network/GuardianClient.swift
+++ b/clients/shared/Network/GuardianClient.swift
@@ -18,7 +18,7 @@ public struct GuardianClient: GuardianClientProtocol {
     public func fetchPendingActions(conversationId: String) async -> GuardianActionsPendingResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/guardian-actions/pending",
+                path: "guardian-actions/pending",
                 params: ["conversationId": conversationId],
                 timeout: 10
             )
@@ -46,7 +46,7 @@ public struct GuardianClient: GuardianClientProtocol {
             if let conversationId { body["conversationId"] = conversationId }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/guardian-actions/decision", json: body, timeout: 10
+                path: "guardian-actions/decision", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("submitDecision failed (HTTP \(response.statusCode))")
@@ -90,7 +90,7 @@ public struct GuardianClient: GuardianClientProtocol {
 
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "guardian/init", json: body, extraHeaders: extraHeaders, timeout: 15
+                path: "guardian/init", json: body, extraHeaders: extraHeaders, timeout: 15, unprefixed: true
             )
 
             guard response.isSuccess else {
@@ -124,7 +124,7 @@ public struct GuardianClient: GuardianClientProtocol {
     public func resetBootstrap() async -> Bool {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "guardian/reset-bootstrap", json: [:], timeout: 5
+                path: "guardian/reset-bootstrap", json: [:], timeout: 5, unprefixed: true
             )
             guard response.isSuccess else {
                 log.error("Reset bootstrap failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/HealthCheckClient.swift
+++ b/clients/shared/Network/HealthCheckClient.swift
@@ -16,7 +16,8 @@ public enum HealthCheckClient {
             let response = try await GatewayHTTPClient.get(
                 path: "health",
                 timeout: timeout,
-                quiet: true
+                quiet: true,
+                unprefixed: true
             )
             return response.isSuccess
         } catch {
@@ -48,7 +49,8 @@ public enum HealthCheckClient {
                 let response = try await GatewayHTTPClient.get(
                     path: "health",
                     timeout: timeout,
-                    quiet: true
+                    quiet: true,
+                    unprefixed: true
                 )
                 return response.isSuccess
             } catch {

--- a/clients/shared/Network/HeartbeatClient.swift
+++ b/clients/shared/Network/HeartbeatClient.swift
@@ -23,7 +23,7 @@ public struct HeartbeatClient: HeartbeatClientProtocol {
     public func fetchConfig() async -> HeartbeatConfigResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/heartbeat/config", timeout: 10
+                path: "heartbeat/config", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchConfig failed (HTTP \(response.statusCode))")
@@ -46,7 +46,7 @@ public struct HeartbeatClient: HeartbeatClientProtocol {
             if let activeHoursEnd { body["activeHoursEnd"] = activeHoursEnd }
 
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/heartbeat/config", json: body, timeout: 10
+                path: "heartbeat/config", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("updateConfig failed (HTTP \(response.statusCode))")
@@ -66,7 +66,7 @@ public struct HeartbeatClient: HeartbeatClientProtocol {
             if let limit { params["limit"] = String(limit) }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/heartbeat/runs",
+                path: "heartbeat/runs",
                 params: params.isEmpty ? nil : params,
                 timeout: 10
             )
@@ -85,7 +85,7 @@ public struct HeartbeatClient: HeartbeatClientProtocol {
     public func runNow() async -> HeartbeatRunNowResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/heartbeat/run-now", timeout: 10
+                path: "heartbeat/run-now", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("runNow failed (HTTP \(response.statusCode))")
@@ -102,7 +102,7 @@ public struct HeartbeatClient: HeartbeatClientProtocol {
     public func fetchChecklist() async -> HeartbeatChecklistResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/heartbeat/checklist", timeout: 10
+                path: "heartbeat/checklist", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchChecklist failed (HTTP \(response.statusCode))")
@@ -120,7 +120,7 @@ public struct HeartbeatClient: HeartbeatClientProtocol {
         do {
             let body: [String: Any] = ["content": content]
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/heartbeat/checklist", json: body, timeout: 10
+                path: "heartbeat/checklist", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("writeChecklist failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/HomeFeedClient.swift
+++ b/clients/shared/Network/HomeFeedClient.swift
@@ -96,7 +96,7 @@ public struct DefaultHomeFeedClient: HomeFeedClient {
         let response: GatewayHTTPClient.Response
         do {
             response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/home/feed",
+                path: "home/feed",
                 params: ["timeAwaySeconds": String(seconds)],
                 timeout: 10
             )
@@ -125,7 +125,7 @@ public struct DefaultHomeFeedClient: HomeFeedClient {
         let response: GatewayHTTPClient.Response
         do {
             response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/home/feed/\(Self.pathEscape(itemId))",
+                path: "home/feed/\(Self.pathEscape(itemId))",
                 json: ["status": status.rawValue],
                 timeout: 10
             )
@@ -154,7 +154,7 @@ public struct DefaultHomeFeedClient: HomeFeedClient {
         let response: GatewayHTTPClient.Response
         do {
             response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/home/feed/\(Self.pathEscape(itemId))/actions/\(Self.pathEscape(actionId))",
+                path: "home/feed/\(Self.pathEscape(itemId))/actions/\(Self.pathEscape(actionId))",
                 json: [:],
                 timeout: 10
             )

--- a/clients/shared/Network/HomeStateClient.swift
+++ b/clients/shared/Network/HomeStateClient.swift
@@ -42,7 +42,7 @@ public struct DefaultHomeStateClient: HomeStateClient {
         let response: GatewayHTTPClient.Response
         do {
             response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/home/state", timeout: 10
+                path: "home/state", timeout: 10
             )
         } catch {
             log.error("fetchRelationshipState transport error: \(error.localizedDescription)")

--- a/clients/shared/Network/HostProxyClient.swift
+++ b/clients/shared/Network/HostProxyClient.swift
@@ -22,7 +22,7 @@ public struct HostProxyClient: HostProxyClientProtocol {
         do {
             let body = try JSONEncoder().encode(result)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/host-bash-result",
+                path: "host-bash-result",
                 body: body,
                 timeout: 30
             )
@@ -46,7 +46,7 @@ public struct HostProxyClient: HostProxyClientProtocol {
                 ? max(30, TimeInterval(body.count) / (1024 * 1024) * 5 + 30)
                 : 30
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/host-file-result",
+                path: "host-file-result",
                 body: body,
                 timeout: timeout
             )
@@ -65,7 +65,7 @@ public struct HostProxyClient: HostProxyClientProtocol {
         do {
             let body = try JSONEncoder().encode(result)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/host-cu-result",
+                path: "host-cu-result",
                 body: body,
                 timeout: 30
             )
@@ -84,7 +84,7 @@ public struct HostProxyClient: HostProxyClientProtocol {
         do {
             let body = try JSONEncoder().encode(result)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/host-browser-result",
+                path: "host-browser-result",
                 body: body,
                 timeout: 30
             )
@@ -105,7 +105,7 @@ public struct HostProxyClient: HostProxyClientProtocol {
             // Scale timeout based on payload size for large transfer results.
             let timeout: TimeInterval = max(30, TimeInterval(body.count) / (1024 * 1024) * 5 + 30)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/host-transfer-result",
+                path: "host-transfer-result",
                 body: body,
                 timeout: timeout
             )
@@ -123,7 +123,7 @@ public struct HostProxyClient: HostProxyClientProtocol {
     public func pullTransferContent(transferId: String) async throws -> Data {
         // Use a generous timeout — large files may take a while to download.
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/transfers/\(transferId)/content",
+            path: "transfers/\(transferId)/content",
             timeout: 300
         )
         guard response.isSuccess else {
@@ -136,7 +136,7 @@ public struct HostProxyClient: HostProxyClientProtocol {
         // Scale timeout by data size: ~5s per MB with a 30s minimum.
         let timeout: TimeInterval = max(30, TimeInterval(data.count) / (1024 * 1024) * 5 + 30)
         let response = try await GatewayHTTPClient.put(
-            path: "assistants/{assistantId}/transfers/\(transferId)/content",
+            path: "transfers/\(transferId)/content",
             body: data,
             params: ["sourcePath": sourcePath],
             contentType: "application/octet-stream",

--- a/clients/shared/Network/IdentityClient.swift
+++ b/clients/shared/Network/IdentityClient.swift
@@ -43,7 +43,7 @@ public struct IdentityClient: IdentityClientProtocol {
     public func fetchRemoteIdentity() async -> RemoteIdentityInfo? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/identity", timeout: 10
+                path: "identity", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchRemoteIdentity failed (HTTP \(response.statusCode))")
@@ -59,7 +59,7 @@ public struct IdentityClient: IdentityClientProtocol {
     public func fetchIdentity() async -> IdentityGetResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/identity", timeout: 10
+                path: "identity", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchIdentity failed (HTTP \(response.statusCode))")
@@ -76,7 +76,7 @@ public struct IdentityClient: IdentityClientProtocol {
     public func fetchIdentityIntro() async -> String? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/identity/intro", timeout: 10
+                path: "identity/intro", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchIdentityIntro failed (HTTP \(response.statusCode))")
@@ -95,7 +95,7 @@ public struct IdentityClient: IdentityClientProtocol {
         do {
             let body: [String: Any] = ["type": "generate_avatar", "description": description]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/settings/avatar/generate", json: body, timeout: 30
+                path: "settings/avatar/generate", json: body, timeout: 30
             )
             guard response.isSuccess else {
                 log.error("generateAvatar failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/IntegrationClient.swift
+++ b/clients/shared/Network/IntegrationClient.swift
@@ -23,7 +23,7 @@ public struct IntegrationClient: IntegrationClientProtocol {
     public func fetchIntegrationsStatus() async -> IntegrationsStatusResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/integrations/status", timeout: 5
+                path: "integrations/status", timeout: 5
             )
             guard response.isSuccess else {
                 log.error("fetchIntegrationsStatus failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -95,6 +95,6 @@ public struct InteractionClient: InteractionClientProtocol {
     /// gateway or direct remote runtime) use flat `<endpoint>` paths.
     private static func approvalPath(endpoint: String) throws -> String {
         let managed = try GatewayHTTPClient.isConnectionManaged()
-        return managed ? "assistants/{assistantId}/\(endpoint)" : endpoint
+        return managed ? "\(endpoint)" : endpoint
     }
 }

--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -41,9 +41,8 @@ public struct InteractionClient: InteractionClientProtocol {
             if let selectedPattern { body["selectedPattern"] = selectedPattern }
             if let selectedScope { body["selectedScope"] = selectedScope }
 
-            let path = try Self.approvalPath(endpoint: "confirm")
             log.info("[confirm-flow] Sending POST /confirm: requestId=\(requestId, privacy: .public) decision=\(decision, privacy: .public)")
-            let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "confirm", json: body, timeout: 10)
             if response.isSuccess {
                 return .success
             }
@@ -72,8 +71,7 @@ public struct InteractionClient: InteractionClientProtocol {
             body["value"] = value ?? ""
             if let delivery { body["delivery"] = delivery }
 
-            let path = try Self.approvalPath(endpoint: "secret")
-            let response = try await GatewayHTTPClient.post(path: path, json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "secret", json: body, timeout: 10)
             if !response.isSuccess {
                 log.error("sendSecretResponse failed (HTTP \(response.statusCode))")
                 return false
@@ -83,18 +81,5 @@ public struct InteractionClient: InteractionClientProtocol {
             log.error("sendSecretResponse error: \(error.localizedDescription)")
             return false
         }
-    }
-
-    // MARK: - Path Resolution
-
-    /// Returns the appropriate request path for an approval endpoint based on
-    /// the current connection type.
-    ///
-    /// Managed connections route through the platform proxy which expects
-    /// `assistants/{assistantId}/<endpoint>`. Non-managed connections (local
-    /// gateway or direct remote runtime) use flat `<endpoint>` paths.
-    private static func approvalPath(endpoint: String) throws -> String {
-        let managed = try GatewayHTTPClient.isConnectionManaged()
-        return managed ? "\(endpoint)" : endpoint
     }
 }

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -714,7 +714,7 @@ public struct LLMContextClient: LLMContextClientProtocol {
         do {
             try Task.checkCancellation()
             response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/messages/\(messageId)/llm-context",
+                path: "messages/\(messageId)/llm-context",
                 timeout: 15
             )
             try Task.checkCancellation()
@@ -774,7 +774,7 @@ public struct LLMContextClient: LLMContextClientProtocol {
     public func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/llm-request-logs/\(logId)/payload",
+                path: "llm-request-logs/\(logId)/payload",
                 timeout: 30
             )
             guard response.isSuccess else {

--- a/clients/shared/Network/LiveVoiceChannelClient.swift
+++ b/clients/shared/Network/LiveVoiceChannelClient.swift
@@ -184,7 +184,7 @@ public final class LiveVoiceChannelClient: LiveVoiceChannelClientProtocol {
     public convenience init() {
         self.init(
             requestBuilder: {
-                try GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params: nil)
+                try GatewayHTTPClient.buildWebSocketRequest(path: "live-voice", params: nil, unprefixed: true)
             },
             webSocketFactory: { request in
                 URLSession.shared.webSocketTask(with: request)

--- a/clients/shared/Network/MemoryItemClient.swift
+++ b/clients/shared/Network/MemoryItemClient.swift
@@ -62,7 +62,7 @@ public struct MemoryItemClient: MemoryItemClientProtocol {
 
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/memory-items", params: params, timeout: 10
+                path: "memory-items", params: params, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchMemoryItems failed (HTTP \(response.statusCode))")
@@ -78,7 +78,7 @@ public struct MemoryItemClient: MemoryItemClientProtocol {
     public func fetchMemoryItem(id: String) async -> MemoryItemPayload? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/memory-items/\(id)", timeout: 10
+                path: "memory-items/\(id)", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchMemoryItem failed (HTTP \(response.statusCode))")
@@ -107,7 +107,7 @@ public struct MemoryItemClient: MemoryItemClientProtocol {
 
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/memory-items", json: body, timeout: 10
+                path: "memory-items", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("createMemoryItem failed (HTTP \(response.statusCode))")
@@ -140,7 +140,7 @@ public struct MemoryItemClient: MemoryItemClientProtocol {
 
         do {
             let response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/memory-items/\(id)", json: body, timeout: 10
+                path: "memory-items/\(id)", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("updateMemoryItem failed (HTTP \(response.statusCode))")
@@ -157,7 +157,7 @@ public struct MemoryItemClient: MemoryItemClientProtocol {
     public func deleteMemoryItem(id: String) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/memory-items/\(id)", timeout: 10
+                path: "memory-items/\(id)", timeout: 10
             )
             return response.statusCode == 204
         } catch {

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -92,7 +92,7 @@ public struct MessageClient: MessageClientProtocol {
 
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/attachments",
+                path: "attachments",
                 json: body,
                 timeout: 60
             )
@@ -139,7 +139,7 @@ public struct MessageClient: MessageClientProtocol {
 
         do {
             let response = try await GatewayHTTPClient.postMultipart(
-                path: "assistants/{assistantId}/attachments",
+                path: "attachments",
                 parts: parts,
                 timeout: 60
             )
@@ -233,7 +233,7 @@ public struct MessageClient: MessageClientProtocol {
 
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/messages",
+                path: "messages",
                 json: body,
                 timeout: 30
             )

--- a/clients/shared/Network/NotificationClient.swift
+++ b/clients/shared/Network/NotificationClient.swift
@@ -22,7 +22,7 @@ public struct NotificationClient: NotificationClientProtocol {
             if let errorCode { body["errorCode"] = errorCode }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/notification-intent-result", json: body, timeout: 10
+                path: "notification-intent-result", json: body, timeout: 10
             )
             if !response.isSuccess {
                 log.error("sendIntentResult failed (HTTP \(response.statusCode)) for deliveryId \(deliveryId)")

--- a/clients/shared/Network/PairingClient.swift
+++ b/clients/shared/Network/PairingClient.swift
@@ -33,7 +33,7 @@ public struct PairingClient: PairingClientProtocol {
             "decision": decision,
         ]
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/pairing/register", json: body, timeout: 10
+            path: "pairing/register", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("sendPairingApprovalResponse failed (HTTP \(response.statusCode))")
@@ -44,7 +44,7 @@ public struct PairingClient: PairingClientProtocol {
 
     public func fetchApprovedDevices() async throws -> [ApprovedDevicesListResponseMessage.Device] {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/pairing/register", timeout: 10
+            path: "pairing/register", timeout: 10
         )
         guard response.isSuccess else {
             throw PairingClientError.httpError(statusCode: response.statusCode)
@@ -59,7 +59,7 @@ public struct PairingClient: PairingClientProtocol {
             "hashedDeviceId": hashedDeviceId,
         ]
         let response = try await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/pairing/register", json: body, timeout: 10
+            path: "pairing/register", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("removeApprovedDevice failed (HTTP \(response.statusCode))")
@@ -70,7 +70,7 @@ public struct PairingClient: PairingClientProtocol {
 
     public func clearApprovedDevices() async throws -> Bool {
         let response = try await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/pairing/register", timeout: 10
+            path: "pairing/register", timeout: 10
         )
         guard response.isSuccess else {
             log.error("clearApprovedDevices failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/PublishClient.swift
+++ b/clients/shared/Network/PublishClient.swift
@@ -19,7 +19,7 @@ public struct PublishClient: PublishClientProtocol {
         if let appId { body["appId"] = appId }
 
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/publish", json: body, timeout: 30
+            path: "publish", json: body, timeout: 30
         )
         guard response.isSuccess else {
             log.error("publishPage failed (HTTP \(response.statusCode))")
@@ -33,7 +33,7 @@ public struct PublishClient: PublishClientProtocol {
         do {
             let body: [String: Any] = ["type": "unpublish_page", "deploymentId": deploymentId]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/unpublish", json: body, timeout: 10
+                path: "unpublish", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("unpublishPage failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/RegenerateClient.swift
+++ b/clients/shared/Network/RegenerateClient.swift
@@ -17,7 +17,7 @@ public struct RegenerateClient: RegenerateClientProtocol {
     public func regenerate(conversationId: String) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/conversations/\(conversationId)/regenerate",
+                path: "conversations/\(conversationId)/regenerate",
                 timeout: 15
             )
             guard response.isSuccess else {

--- a/clients/shared/Network/STTClient.swift
+++ b/clients/shared/Network/STTClient.swift
@@ -50,7 +50,7 @@ public struct STTClient: STTClientProtocol {
         do {
             let json = Self.buildRequestBody(audioData: audioData, contentType: contentType)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/stt/transcribe",
+                path: "stt/transcribe",
                 json: json,
                 timeout: Self.requestTimeout
             )

--- a/clients/shared/Network/STTStreamingClient.swift
+++ b/clients/shared/Network/STTStreamingClient.swift
@@ -159,7 +159,8 @@ public final class STTStreamingClient: STTStreamingClientProtocol {
         do {
             let request = try GatewayHTTPClient.buildWebSocketRequest(
                 path: "stt/stream",
-                params: params
+                params: params,
+                unprefixed: true
             )
             log.info("Opening STT stream WebSocket: mimeType=\(mimeType), sampleRate=\(sampleRate.map(String.init) ?? "nil")")
 

--- a/clients/shared/Network/ScheduleClient.swift
+++ b/clients/shared/Network/ScheduleClient.swift
@@ -34,7 +34,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func fetchSchedulesList() async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/schedules", timeout: 10
+            path: "schedules", timeout: 10
         )
         guard response.isSuccess else {
             log.error("fetchSchedulesList failed (HTTP \(response.statusCode))")
@@ -45,7 +45,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func toggleSchedule(id: String, enabled: Bool) async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/schedules/\(id)/toggle",
+            path: "schedules/\(id)/toggle",
             json: ["enabled": enabled],
             timeout: 10
         )
@@ -58,7 +58,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func deleteSchedule(id: String) async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/schedules/\(id)", timeout: 10
+            path: "schedules/\(id)", timeout: 10
         )
         guard response.isSuccess else {
             log.error("deleteSchedule failed (HTTP \(response.statusCode))")
@@ -69,7 +69,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func cancelSchedule(id: String) async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/schedules/\(id)/cancel",
+            path: "schedules/\(id)/cancel",
             json: [:],
             timeout: 10
         )
@@ -82,7 +82,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func runNow(id: String) async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/schedules/\(id)/run",
+            path: "schedules/\(id)/run",
             json: [:],
             timeout: 120
         )
@@ -95,7 +95,7 @@ public struct ScheduleClient: ScheduleClientProtocol {
 
     public func updateSchedule(id: String, updates: [String: Any]) async throws -> [ScheduleItem] {
         let response = try await GatewayHTTPClient.patch(
-            path: "assistants/{assistantId}/schedules/\(id)",
+            path: "schedules/\(id)",
             json: updates,
             timeout: 10
         )

--- a/clients/shared/Network/SettingsClient.swift
+++ b/clients/shared/Network/SettingsClient.swift
@@ -63,7 +63,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchVercelConfig() async -> VercelApiConfigResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "integrations/vercel/config", timeout: 10
+                path: "integrations/vercel/config", timeout: 10, unprefixed: true
             )
             guard response.isSuccess else {
                 log.error("fetchVercelConfig failed (HTTP \(response.statusCode))")
@@ -81,7 +81,7 @@ public struct SettingsClient: SettingsClientProtocol {
         do {
             let body: [String: Any] = ["type": "vercel_api_config", "action": "set", "apiToken": apiToken]
             let response = try await GatewayHTTPClient.post(
-                path: "integrations/vercel/config", json: body, timeout: 10
+                path: "integrations/vercel/config", json: body, timeout: 10, unprefixed: true
             )
             guard response.isSuccess else {
                 log.error("saveVercelConfig failed (HTTP \(response.statusCode))")
@@ -99,7 +99,7 @@ public struct SettingsClient: SettingsClientProtocol {
         do {
             let body: [String: Any] = ["type": "vercel_api_config", "action": "delete"]
             let response = try await GatewayHTTPClient.post(
-                path: "integrations/vercel/config", json: body, timeout: 10
+                path: "integrations/vercel/config", json: body, timeout: 10, unprefixed: true
             )
             guard response.isSuccess else {
                 log.error("deleteVercelConfig failed (HTTP \(response.statusCode))")
@@ -116,7 +116,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchModelInfo() async -> ModelInfoMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/model", timeout: 10
+                path: "model", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchModelInfo failed (HTTP \(response.statusCode))")
@@ -135,7 +135,7 @@ public struct SettingsClient: SettingsClientProtocol {
             var body: [String: Any] = ["modelId": model]
             if let provider { body["provider"] = provider }
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/model", json: body, timeout: 10
+                path: "model", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setModel failed (HTTP \(response.statusCode))")
@@ -152,7 +152,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func setImageGenModel(modelId: String) async -> ModelInfoMessage? {
         do {
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/model/image-gen", json: ["modelId": modelId], timeout: 10
+                path: "model/image-gen", json: ["modelId": modelId], timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setImageGenModel failed (HTTP \(response.statusCode))")
@@ -169,7 +169,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchEmbeddingConfig() async -> EmbeddingConfigMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/config/embeddings", timeout: 10
+                path: "config/embeddings", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchEmbeddingConfig failed (HTTP \(response.statusCode))")
@@ -187,7 +187,7 @@ public struct SettingsClient: SettingsClientProtocol {
             var body: [String: Any] = ["provider": provider]
             if let model { body["model"] = model }
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/config/embeddings", json: body, timeout: 10
+                path: "config/embeddings", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setEmbeddingConfig failed (HTTP \(response.statusCode))")
@@ -203,7 +203,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchTelegramConfig() async -> TelegramConfigResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/integrations/telegram/config", timeout: 10
+                path: "integrations/telegram/config", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchTelegramConfig failed (HTTP \(response.statusCode))")
@@ -232,11 +232,11 @@ public struct SettingsClient: SettingsClientProtocol {
             let response: GatewayHTTPClient.Response
             if method == "DELETE" {
                 response = try await GatewayHTTPClient.delete(
-                    path: "assistants/{assistantId}/integrations/telegram/config", timeout: 10
+                    path: "integrations/telegram/config", timeout: 10
                 )
             } else {
                 response = try await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/integrations/telegram/config", json: body, timeout: 10
+                    path: "integrations/telegram/config", json: body, timeout: 10
                 )
             }
             guard response.isSuccess else {
@@ -257,7 +257,7 @@ public struct SettingsClient: SettingsClientProtocol {
             if let webhookUrl { body["webhookUrl"] = webhookUrl }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/integrations/slack/config", json: body, timeout: 10
+                path: "integrations/slack/config", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setSlackWebhookConfig failed (HTTP \(response.statusCode))")
@@ -275,7 +275,8 @@ public struct SettingsClient: SettingsClientProtocol {
             let response = try await GatewayHTTPClient.get(
                 path: "channel-verification-sessions/status",
                 params: ["channel": channel],
-                timeout: 10
+                timeout: 10,
+                unprefixed: true
             )
             guard response.isSuccess else {
                 log.error("fetchChannelVerificationStatus(\(channel, privacy: .public)) failed (HTTP \(response.statusCode))")
@@ -313,19 +314,19 @@ public struct SettingsClient: SettingsClientProtocol {
             switch action {
             case "cancel_session":
                 response = try await GatewayHTTPClient.delete(
-                    path: "assistants/{assistantId}/channel-verification-sessions", json: body, timeout: 10
+                    path: "channel-verification-sessions", json: body, timeout: 10
                 )
             case "revoke":
                 response = try await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/channel-verification-sessions/revoke", json: body, timeout: 10
+                    path: "channel-verification-sessions/revoke", json: body, timeout: 10
                 )
             case "resend_session":
                 response = try await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/channel-verification-sessions/resend", json: body, timeout: 10
+                    path: "channel-verification-sessions/resend", json: body, timeout: 10
                 )
             default:
                 response = try await GatewayHTTPClient.post(
-                    path: "assistants/{assistantId}/channel-verification-sessions", json: body, timeout: 10
+                    path: "channel-verification-sessions", json: body, timeout: 10
                 )
             }
 
@@ -369,7 +370,7 @@ public struct SettingsClient: SettingsClientProtocol {
         do {
             let body = try JSONEncoder().encode(config)
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/settings/voice",
+                path: "settings/voice",
                 body: body,
                 timeout: 10
             )
@@ -388,7 +389,7 @@ public struct SettingsClient: SettingsClientProtocol {
         do {
             let body = try JSONEncoder().encode(request)
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/oauth/start",
+                path: "oauth/start",
                 body: body,
                 timeout: 10
             )
@@ -411,7 +412,7 @@ public struct SettingsClient: SettingsClientProtocol {
                 "platform": platform
             ]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/device-token",
+                path: "device-token",
                 json: body,
                 timeout: 10
             )
@@ -429,7 +430,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchIngressConfig() async -> IngressConfigResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/integrations/ingress/config",
+                path: "integrations/ingress/config",
                 timeout: 10
             )
             guard response.isSuccess else {
@@ -450,7 +451,7 @@ public struct SettingsClient: SettingsClientProtocol {
             if let publicBaseUrl { body["publicBaseUrl"] = publicBaseUrl }
             if let enabled { body["enabled"] = enabled }
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/integrations/ingress/config",
+                path: "integrations/ingress/config",
                 json: body,
                 timeout: 10
             )
@@ -469,7 +470,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchSuggestion(conversationId: String, requestId: String) async -> SuggestionResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/suggestion",
+                path: "suggestion",
                 params: ["conversationKey": conversationId],
                 timeout: 15
             )
@@ -493,7 +494,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchPlatformConfig() async -> PlatformConfigResponseMessage? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/config/platform", timeout: 10
+                path: "config/platform", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchPlatformConfig failed (HTTP \(response.statusCode))")
@@ -511,7 +512,7 @@ public struct SettingsClient: SettingsClientProtocol {
         do {
             let body: [String: Any] = ["baseUrl": baseUrl]
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/config/platform", json: body, timeout: 10
+                path: "config/platform", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("setPlatformConfig failed (HTTP \(response.statusCode))")
@@ -528,7 +529,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func patchConfig(_ partial: [String: Any]) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/config", json: partial, timeout: 10
+                path: "config", json: partial, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("patchConfig failed (HTTP \(response.statusCode))")
@@ -545,7 +546,7 @@ public struct SettingsClient: SettingsClientProtocol {
         do {
             let encodedName = Self.encodePath(name)
             let response = try await GatewayHTTPClient.put(
-                path: "assistants/{assistantId}/config/llm/profiles/\(encodedName)",
+                path: "config/llm/profiles/\(encodedName)",
                 json: fragment,
                 timeout: 10
             )
@@ -563,7 +564,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchConfig() async -> [String: Any]? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/config", timeout: 10
+                path: "config", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchConfig failed (HTTP \(response.statusCode))")
@@ -585,7 +586,7 @@ public struct SettingsClient: SettingsClientProtocol {
         do {
             let body: [String: Any] = ["type": "api_key", "name": provider]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/secrets/read", json: body, timeout: 5
+                path: "secrets/read", json: body, timeout: 5
             )
             guard response.isSuccess,
                   let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
@@ -604,7 +605,7 @@ public struct SettingsClient: SettingsClientProtocol {
     public func fetchCallSiteCatalog() async -> CallSiteCatalogResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/config/llm/call-sites", timeout: 10
+                path: "config/llm/call-sites", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchCallSiteCatalog failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/SkillsClient.swift
+++ b/clients/shared/Network/SkillsClient.swift
@@ -48,7 +48,7 @@ public struct SkillsClient: SkillsClientProtocol {
             if let query, !query.isEmpty { params["q"] = query }
             if let category { params["category"] = category }
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills", params: params.isEmpty ? nil : params, timeout: 10
+                path: "skills", params: params.isEmpty ? nil : params, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchSkillsList failed (HTTP \(response.statusCode))")
@@ -65,7 +65,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func enableSkill(name: String) async -> SkillOperationResult? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(name))/enable", timeout: 10
+                path: "skills/\(Self.encodePath(name))/enable", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("enableSkill failed (HTTP \(response.statusCode))")
@@ -84,7 +84,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func disableSkill(name: String) async -> SkillOperationResult? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(name))/disable", timeout: 10
+                path: "skills/\(Self.encodePath(name))/disable", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("disableSkill failed (HTTP \(response.statusCode))")
@@ -114,7 +114,7 @@ public struct SkillsClient: SkillsClientProtocol {
             }
 
             let response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(name))/config", json: body, timeout: 10
+                path: "skills/\(Self.encodePath(name))/config", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("configureSkill failed (HTTP \(response.statusCode))")
@@ -136,7 +136,7 @@ public struct SkillsClient: SkillsClientProtocol {
             if let version { body["version"] = version }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills/install", json: body, timeout: 120
+                path: "skills/install", json: body, timeout: 120
             )
             guard response.isSuccess else {
                 log.error("installSkill failed (HTTP \(response.statusCode))")
@@ -157,7 +157,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func uninstallSkill(name: String) async -> SkillOperationResult? {
         do {
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(name))", timeout: 10
+                path: "skills/\(Self.encodePath(name))", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("uninstallSkill failed (HTTP \(response.statusCode))")
@@ -176,7 +176,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func updateSkill(name: String) async -> SkillOperationResult? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(name))/update", timeout: 10
+                path: "skills/\(Self.encodePath(name))/update", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("updateSkill failed (HTTP \(response.statusCode))")
@@ -195,7 +195,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func checkSkillUpdates() async -> SkillOperationResult? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills/check-updates", timeout: 10
+                path: "skills/check-updates", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("checkSkillUpdates failed (HTTP \(response.statusCode))")
@@ -214,7 +214,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func searchSkills(query: String) async -> SkillSearchResult? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills/search",
+                path: "skills/search",
                 params: ["q": query],
                 timeout: 10
             )
@@ -239,7 +239,7 @@ public struct SkillsClient: SkillsClientProtocol {
         do {
             let body: [String: Any] = ["sourceText": sourceText]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills/draft", json: body, timeout: 30
+                path: "skills/draft", json: body, timeout: 30
             )
             guard response.isSuccess else {
                 log.error("draftSkill failed (HTTP \(response.statusCode))")
@@ -265,7 +265,7 @@ public struct SkillsClient: SkillsClientProtocol {
             if let overwrite { body["overwrite"] = overwrite }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/skills", json: body, timeout: 10
+                path: "skills", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("createSkill failed (HTTP \(response.statusCode))")
@@ -284,7 +284,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func fetchSkillDetail(skillId: String) async -> SkillDetailHTTPResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(skillId))", timeout: 10
+                path: "skills/\(Self.encodePath(skillId))", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchSkillDetail failed (HTTP \(response.statusCode))")
@@ -311,7 +311,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func fetchSkillFiles(skillId: String) async -> SkillDetailFilesHTTPResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(skillId))/files", timeout: 15
+                path: "skills/\(Self.encodePath(skillId))/files", timeout: 15
             )
             guard response.isSuccess else {
                 log.error("fetchSkillFiles failed (HTTP \(response.statusCode))")
@@ -331,7 +331,7 @@ public struct SkillsClient: SkillsClientProtocol {
     public func fetchSkillFileContent(skillId: String, path: String) async -> SkillFileContentResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/skills/\(Self.encodePath(skillId))/files/content",
+                path: "skills/\(Self.encodePath(skillId))/files/content",
                 params: ["path": path],
                 timeout: 15
             )

--- a/clients/shared/Network/SubagentClient.swift
+++ b/clients/shared/Network/SubagentClient.swift
@@ -40,7 +40,7 @@ public struct SubagentClient: SubagentClientProtocol {
             if let conversationId { body["conversationId"] = conversationId }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/subagents/\(subagentId)/abort",
+                path: "subagents/\(subagentId)/abort",
                 json: body,
                 timeout: 10
             )
@@ -65,7 +65,7 @@ public struct SubagentClient: SubagentClientProtocol {
         do {
             let params: [String: String] = ["conversationId": conversationId]
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/subagents/\(subagentId)",
+                path: "subagents/\(subagentId)",
                 params: params,
                 timeout: 10
             )
@@ -90,7 +90,7 @@ public struct SubagentClient: SubagentClientProtocol {
             if let conversationId { body["conversationId"] = conversationId }
 
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/subagents/\(subagentId)/message",
+                path: "subagents/\(subagentId)/message",
                 json: body,
                 timeout: 30
             )

--- a/clients/shared/Network/SurfaceActionClient.swift
+++ b/clients/shared/Network/SurfaceActionClient.swift
@@ -56,7 +56,7 @@ public struct SurfaceActionClient: SurfaceActionClientProtocol {
                 body["data"] = data.mapValues { $0.value }
             }
 
-            let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/surface-actions", json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "surface-actions", json: body, timeout: 10)
             if !response.isSuccess {
                 logSurfaceActionFailure(operation: "sendSurfaceAction", statusCode: response.statusCode, data: response.data)
             }
@@ -71,7 +71,7 @@ public struct SurfaceActionClient: SurfaceActionClientProtocol {
                 "conversationId": conversationId,
                 "surfaceId": surfaceId,
             ]
-            let response = try await GatewayHTTPClient.post(path: "assistants/{assistantId}/surfaces/\(surfaceId)/undo", json: body, timeout: 10)
+            let response = try await GatewayHTTPClient.post(path: "surfaces/\(surfaceId)/undo", json: body, timeout: 10)
             if !response.isSuccess {
                 logSurfaceActionFailure(operation: "sendSurfaceUndo", statusCode: response.statusCode, data: response.data)
             }

--- a/clients/shared/Network/TTSClient.swift
+++ b/clients/shared/Network/TTSClient.swift
@@ -33,7 +33,7 @@ public struct TTSClient: TTSClientProtocol {
     public func synthesize(messageId: String, conversationId: String?) async -> TTSResult {
         do {
             let encoded = messageId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? messageId
-            let path = "assistants/{assistantId}/messages/\(encoded)/tts"
+            let path = "messages/\(encoded)/tts"
             var params: [String: String]? = nil
             if let conversationId, !conversationId.isEmpty {
                 params = ["conversationId": conversationId]
@@ -57,7 +57,7 @@ public struct TTSClient: TTSClientProtocol {
                 json["conversationId"] = conversationId
             }
 
-            let path = "assistants/{assistantId}/tts/synthesize"
+            let path = "tts/synthesize"
             let response = try await GatewayHTTPClient.post(path: path, json: json, timeout: 60)
             return Self.mapResponse(response)
         } catch {

--- a/clients/shared/Network/TelemetryClient.swift
+++ b/clients/shared/Network/TelemetryClient.swift
@@ -18,7 +18,7 @@ public struct TelemetryClient: TelemetryClientProtocol {
         let body: [String: Any] = ["event_name": eventName]
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/telemetry/lifecycle",
+                path: "telemetry/lifecycle",
                 json: body,
                 timeout: 10
             )

--- a/clients/shared/Network/ThresholdClient.swift
+++ b/clients/shared/Network/ThresholdClient.swift
@@ -90,7 +90,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
 
     public func getGlobalThresholds() async throws -> GlobalThresholds {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/permissions/thresholds", timeout: 10
+            path: "permissions/thresholds", timeout: 10
         )
         guard response.isSuccess else {
             log.error("getGlobalThresholds failed (HTTP \(response.statusCode))")
@@ -105,7 +105,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
             "autonomous": thresholds.autonomous,
         ]
         let response = try await GatewayHTTPClient.put(
-            path: "assistants/{assistantId}/permissions/thresholds", json: body, timeout: 10
+            path: "permissions/thresholds", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("setGlobalThresholds failed (HTTP \(response.statusCode))")
@@ -115,7 +115,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
 
     public func getConversationOverride(conversationId: String) async throws -> String? {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/permissions/thresholds/conversations/\(conversationId)", timeout: 10
+            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
         )
         if response.statusCode == 404 {
             return nil
@@ -131,7 +131,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
     public func setConversationOverride(conversationId: String, threshold: String) async throws {
         let body: [String: Any] = ["threshold": threshold]
         let response = try await GatewayHTTPClient.put(
-            path: "assistants/{assistantId}/permissions/thresholds/conversations/\(conversationId)", json: body, timeout: 10
+            path: "permissions/thresholds/conversations/\(conversationId)", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("setConversationOverride failed (HTTP \(response.statusCode))")
@@ -141,7 +141,7 @@ public struct ThresholdClient: ThresholdClientProtocol {
 
     public func deleteConversationOverride(conversationId: String) async throws {
         let response = try await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/permissions/thresholds/conversations/\(conversationId)", timeout: 10
+            path: "permissions/thresholds/conversations/\(conversationId)", timeout: 10
         )
         guard response.isSuccess else {
             log.error("deleteConversationOverride failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/ToolClient.swift
+++ b/clients/shared/Network/ToolClient.swift
@@ -31,7 +31,7 @@ public struct ToolClient: ToolClientProtocol {
 
     public func fetchToolNamesList() async throws -> ToolNamesListResponseMessage {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/tools", timeout: 10
+            path: "tools", timeout: 10
         )
         guard response.isSuccess else {
             log.error("fetchToolNamesList failed (HTTP \(response.statusCode))")
@@ -62,7 +62,7 @@ public struct ToolClient: ToolClientProtocol {
         if let isInteractive { body["isInteractive"] = isInteractive }
 
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/tools/simulate-permission", json: body, timeout: 10
+            path: "tools/simulate-permission", json: body, timeout: 10
         )
         guard response.isSuccess else {
             log.error("simulateToolPermission failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/TraceEventClient.swift
+++ b/clients/shared/Network/TraceEventClient.swift
@@ -14,7 +14,7 @@ public struct TraceEventClient: TraceEventClientProtocol {
 
     public func fetchHistory(conversationId: String) async throws -> [TraceEventMessage] {
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/trace-events",
+            path: "trace-events",
             params: ["conversationId": conversationId],
             timeout: 10
         )

--- a/clients/shared/Network/TrustRuleClient.swift
+++ b/clients/shared/Network/TrustRuleClient.swift
@@ -99,7 +99,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
         if let includeDeleted { params["include_deleted"] = String(includeDeleted) }
 
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/trust-rules", params: params, timeout: 10
+            path: "trust-rules", params: params, timeout: 10
         )
         guard response.isSuccess else {
             log.error("listRules failed (HTTP \(response.statusCode))")
@@ -117,7 +117,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
             "scope": scope,
         ]
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/trust-rules", json: body, timeout: 10
+            path: "trust-rules", json: body, timeout: 10
         )
         if response.statusCode == 403 {
             throw TrustRuleClientError.featureDisabled
@@ -136,7 +136,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
 
         let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
         let response = try await GatewayHTTPClient.patch(
-            path: "assistants/{assistantId}/trust-rules/\(encoded)", json: body, timeout: 10
+            path: "trust-rules/\(encoded)", json: body, timeout: 10
         )
         if response.statusCode == 404 {
             throw TrustRuleClientError.notFound
@@ -154,7 +154,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
     public func deleteRule(id: String) async throws {
         let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
         let response = try await GatewayHTTPClient.delete(
-            path: "assistants/{assistantId}/trust-rules/\(encoded)", timeout: 10
+            path: "trust-rules/\(encoded)", timeout: 10
         )
         if response.statusCode == 404 {
             throw TrustRuleClientError.notFound
@@ -171,7 +171,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
     public func resetRule(id: String) async throws -> TrustRule {
         let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/trust-rules/\(encoded)/reset", json: [:], timeout: 10
+            path: "trust-rules/\(encoded)/reset", json: [:], timeout: 10
         )
         if response.statusCode == 404 {
             throw TrustRuleClientError.notFound
@@ -216,7 +216,7 @@ public struct TrustRuleClient: TrustRuleClientProtocol {
             ]
         }
         let response = try await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/trust-rules/suggest", json: body, timeout: 30
+            path: "trust-rules/suggest", json: body, timeout: 30
         )
         if response.statusCode == 403 {
             throw TrustRuleClientError.featureDisabled

--- a/clients/shared/Network/WorkItemClient.swift
+++ b/clients/shared/Network/WorkItemClient.swift
@@ -29,7 +29,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
             if let status { params["status"] = status }
 
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/work-items",
+                path: "work-items",
                 params: params.isEmpty ? nil : params,
                 timeout: 10
             )
@@ -48,7 +48,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
     public func complete(id: String) async -> Bool {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/work-items/\(id)/complete", timeout: 10
+                path: "work-items/\(id)/complete", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("complete failed (HTTP \(response.statusCode))")
@@ -64,7 +64,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
     public func delete(id: String) async -> WorkItemDeleteResponse? {
         do {
             let response = try await GatewayHTTPClient.delete(
-                path: "assistants/{assistantId}/work-items/\(id)", timeout: 10
+                path: "work-items/\(id)", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("delete failed (HTTP \(response.statusCode))")
@@ -81,7 +81,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
     public func runTask(id: String) async -> WorkItemRunTaskResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/work-items/\(id)/run", timeout: 10
+                path: "work-items/\(id)/run", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("runTask failed (HTTP \(response.statusCode))")
@@ -98,7 +98,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
     public func fetchOutput(id: String) async -> WorkItemOutputResponse? {
         do {
             let response = try await GatewayHTTPClient.get(
-                path: "assistants/{assistantId}/work-items/\(id)/output", timeout: 10
+                path: "work-items/\(id)/output", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("fetchOutput failed (HTTP \(response.statusCode))")
@@ -122,7 +122,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
             if let sortIndex { body["sortIndex"] = sortIndex }
 
             let response = try await GatewayHTTPClient.patch(
-                path: "assistants/{assistantId}/work-items/\(id)", json: body, timeout: 10
+                path: "work-items/\(id)", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("update failed (HTTP \(response.statusCode))")
@@ -139,7 +139,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
     public func preflight(id: String) async -> WorkItemPreflightResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/work-items/\(id)/preflight", timeout: 10
+                path: "work-items/\(id)/preflight", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("preflight failed (HTTP \(response.statusCode))")
@@ -157,7 +157,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
         do {
             let body: [String: Any] = ["approvedTools": approvedTools]
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/work-items/\(id)/approve-permissions", json: body, timeout: 10
+                path: "work-items/\(id)/approve-permissions", json: body, timeout: 10
             )
             guard response.isSuccess else {
                 log.error("approvePermissions failed (HTTP \(response.statusCode))")
@@ -174,7 +174,7 @@ public struct WorkItemClient: WorkItemClientProtocol {
     public func cancel(id: String) async -> WorkItemCancelResponse? {
         do {
             let response = try await GatewayHTTPClient.post(
-                path: "assistants/{assistantId}/work-items/\(id)/cancel", timeout: 10
+                path: "work-items/\(id)/cancel", timeout: 10
             )
             guard response.isSuccess else {
                 log.error("cancel failed (HTTP \(response.statusCode))")

--- a/clients/shared/Network/WorkspaceClient.swift
+++ b/clients/shared/Network/WorkspaceClient.swift
@@ -33,7 +33,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
         if showHidden { params["showHidden"] = "true" }
 
         let response = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/workspace/tree", params: params, timeout: 10
+            path: "workspace/tree", params: params, timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Fetch workspace tree failed (HTTP \(statusCode))")
@@ -48,7 +48,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
         if showHidden { params["showHidden"] = "true" }
 
         let response = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/workspace/file", params: params, timeout: 10
+            path: "workspace/file", params: params, timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Fetch workspace file failed (HTTP \(statusCode))")
@@ -65,7 +65,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
     /// present — so the UI doesn't need to hardcode which files to look for.
     public func fetchWorkspaceFilesList() async -> WorkspaceFilesListResponse? {
         let response = try? await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/workspace-files", timeout: 10
+            path: "workspace-files", timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Fetch workspace files list failed (HTTP \(statusCode))")
@@ -77,7 +77,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
 
     public func deleteWorkspaceItem(path: String) async -> Bool {
         let response = try? await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/workspace/delete", json: ["path": path], timeout: 10
+            path: "workspace/delete", json: ["path": path], timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Delete workspace item failed (HTTP \(statusCode))")
@@ -96,7 +96,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
         }
 
         let response = try? await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/workspace/write", json: body, timeout: 10
+            path: "workspace/write", json: body, timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Write workspace file failed (HTTP \(statusCode))")
@@ -107,7 +107,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
 
     public func createWorkspaceDirectory(path: String) async -> Bool {
         let response = try? await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/workspace/mkdir", json: ["path": path], timeout: 10
+            path: "workspace/mkdir", json: ["path": path], timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Create workspace directory failed (HTTP \(statusCode))")
@@ -118,7 +118,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
 
     public func renameWorkspaceItem(oldPath: String, newPath: String) async -> Bool {
         let response = try? await GatewayHTTPClient.post(
-            path: "assistants/{assistantId}/workspace/rename", json: ["oldPath": oldPath, "newPath": newPath], timeout: 10
+            path: "workspace/rename", json: ["oldPath": oldPath, "newPath": newPath], timeout: 10
         )
         if let statusCode = response?.statusCode, !(200..<300).contains(statusCode) {
             log.error("Rename workspace item failed (HTTP \(statusCode))")
@@ -136,7 +136,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
         var params: [String: String] = ["path": path]
         if showHidden { params["showHidden"] = "true" }
         let response = try await GatewayHTTPClient.get(
-            path: "assistants/{assistantId}/workspace/file/content", params: params, timeout: 120
+            path: "workspace/file/content", params: params, timeout: 120
         )
         if response.statusCode == 404 {
             throw WorkspaceFileError.notFound
@@ -157,7 +157,7 @@ public struct WorkspaceClient: WorkspaceClientProtocol {
         var params: [String: String] = ["path": path]
         if showHidden { params["showHidden"] = "true" }
         let response = try await GatewayHTTPClient.download(
-            path: "assistants/{assistantId}/workspace/file/content", params: params, timeout: 120
+            path: "workspace/file/content", params: params, timeout: 120
         )
         guard response.isSuccess else {
             try? FileManager.default.removeItem(at: response.fileURL)

--- a/clients/shared/Utilities/STTProviderRegistry.swift
+++ b/clients/shared/Utilities/STTProviderRegistry.swift
@@ -155,7 +155,7 @@ public func loadSTTProviderRegistry() -> STTProviderRegistry {
 public func refreshSTTProviderRegistry() async {
     do {
         let (registry, _): (STTProviderRegistry?, GatewayHTTPClient.Response) =
-            try await GatewayHTTPClient.get(path: "assistants/{assistantId}/stt/providers")
+            try await GatewayHTTPClient.get(path: "stt/providers")
         if let registry, !registry.providers.isEmpty {
             cachedSTTProviderRegistry.withLock { $0 = registry }
             log.info("Loaded \(registry.providers.count) STT providers from API")


### PR DESCRIPTION
## Summary
Makes it much harder to accidentally introduce gateway API paths without the `assistants/{assistantId}/` prefix. `GatewayHTTPClient` now auto-prepends the prefix to all paths by default. Exception call sites explicitly opt out with `unprefixed: true`.

## Self-review result
GAPS FOUND — 5 gaps fixed across 5 fix PRs

## PRs merged into feature branch
- #29168: feat(clients): auto-prepend assistants/{assistantId}/ prefix in GatewayHTTPClient
- #29172: fix: add unprefixed: true to STTStreamingClient WebSocket path
- #29173: fix: update stale doc comment examples in GatewayHTTPClient
- #29174: fix: collapse dead health ternary and add unprefixed: true in GatewayConnectionManager
- #29176: fix: remove dead approvalPath method from InteractionClient
- #29177: fix: remove unused unprefixed parameter from 10 GatewayHTTPClient methods

### Fix PRs (self-review gaps)
- #29172: STTStreamingClient WebSocket path silently changed
- #29173: Stale doc comment examples
- #29174: GatewayConnectionManager dead ternary + missing unprefixed
- #29176: InteractionClient.approvalPath dead code
- #29177: Unused unprefixed parameter on 10 methods

Part of plan: gateway-prefix-enforcement.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
