### PR TITLE
Add PDF Export to Document Writer

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4520,6 +4520,22 @@ paths:
           required: true
           schema:
             type: string
+  /v1/documents/{id}/pdf:
+    get:
+      operationId: documents_by_id_pdf_get
+      summary: Export a document as PDF
+      description: Render a document to PDF and return the binary content.
+      tags:
+        - documents
+      responses:
+        "200":
+          description: Successful response
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
   /v1/events:
     get:
       operationId: events_get

--- a/assistant/src/runtime/routes/document-pdf-renderer.ts
+++ b/assistant/src/runtime/routes/document-pdf-renderer.ts
@@ -1,0 +1,186 @@
+/**
+ * Markdown to PDF renderer for document export.
+ *
+ * Converts markdown content to styled HTML via `marked`, then renders
+ * the HTML to a PDF buffer using Playwright headless Chromium.
+ * The HTML template uses print-friendly styling that matches the
+ * document editor typography.
+ */
+
+import { marked } from "marked";
+
+import { importPlaywright } from "../../tools/browser/runtime-check.js";
+
+// ---------------------------------------------------------------------------
+// marked configuration
+// ---------------------------------------------------------------------------
+
+marked.setOptions({
+  gfm: true,
+  breaks: true,
+});
+
+// ---------------------------------------------------------------------------
+// Print template
+// ---------------------------------------------------------------------------
+
+const FONT_STACK = `"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+
+function wrapInPrintTemplate(title: string, innerHtml: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: ${FONT_STACK};
+    font-size: 14px;
+    line-height: 1.7;
+    color: #1a1a1a;
+    background: #ffffff;
+    padding: 0;
+  }
+
+  h1 { font-size: 28px; font-weight: 600; margin-top: 32px; margin-bottom: 12px; }
+  h2 { font-size: 22px; font-weight: 600; margin-top: 28px; margin-bottom: 10px; }
+  h3 { font-size: 18px; font-weight: 600; margin-top: 24px; margin-bottom: 8px; }
+  h4, h5, h6 { font-size: 16px; font-weight: 600; margin-top: 20px; margin-bottom: 8px; }
+
+  p {
+    margin-bottom: 12px;
+  }
+
+  pre {
+    background: #f5f5f5;
+    border-radius: 8px;
+    padding: 12px 16px;
+    overflow-x: auto;
+    margin-bottom: 12px;
+  }
+
+  code {
+    font-family: "DM Mono", "SF Mono", monospace;
+    font-size: 13px;
+    background: #f5f5f5;
+    border-radius: 4px;
+    padding: 2px 5px;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    border-radius: 0;
+  }
+
+  blockquote {
+    border-left: 3px solid #6366f1;
+    padding-left: 16px;
+    margin: 12px 0;
+    color: #555555;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 12px 0;
+  }
+
+  th, td {
+    border: 1px solid #e0e0e0;
+    padding: 8px 12px;
+    text-align: left;
+  }
+
+  th {
+    background: #f5f5f5;
+    font-weight: 600;
+  }
+
+  ul, ol {
+    margin: 12px 0;
+    padding-left: 24px;
+  }
+
+  li {
+    margin-bottom: 4px;
+  }
+
+  a {
+    color: #6366f1;
+    text-decoration: none;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid #e0e0e0;
+    margin: 24px 0;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  .document-title {
+    margin-top: 0;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #e0e0e0;
+  }
+</style>
+</head>
+<body>
+<h1 class="document-title">${escapeHtml(title)}</h1>
+${innerHtml}
+</body>
+</html>`;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a markdown string to a PDF buffer.
+ *
+ * Parses markdown to HTML via `marked`, wraps it in a print-friendly
+ * template, then renders to PDF using Playwright headless Chromium.
+ * The browser is always closed in a `finally` block.
+ */
+export async function renderMarkdownToPDF(
+  title: string,
+  markdown: string,
+): Promise<Buffer> {
+  const innerHtml = marked.parse(markdown) as string;
+  const fullHtml = wrapInPrintTemplate(title, innerHtml);
+
+  const pw = await importPlaywright();
+  const browser = await pw.chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent(fullHtml, { waitUntil: "networkidle" });
+    const pdfBuffer = await page.pdf({
+      format: "A4",
+      margin: {
+        top: "0.75in",
+        bottom: "0.75in",
+        left: "0.75in",
+        right: "0.75in",
+      },
+      printBackground: true,
+    });
+    return Buffer.from(pdfBuffer);
+  } finally {
+    await browser.close();
+  }
+}

--- a/assistant/src/runtime/routes/document-pdf-renderer.ts
+++ b/assistant/src/runtime/routes/document-pdf-renderer.ts
@@ -12,15 +12,6 @@ import { marked } from "marked";
 import { importPlaywright } from "../../tools/browser/runtime-check.js";
 
 // ---------------------------------------------------------------------------
-// marked configuration
-// ---------------------------------------------------------------------------
-
-marked.setOptions({
-  gfm: true,
-  breaks: true,
-});
-
-// ---------------------------------------------------------------------------
 // Print template
 // ---------------------------------------------------------------------------
 
@@ -161,7 +152,10 @@ export async function renderMarkdownToPDF(
   title: string,
   markdown: string,
 ): Promise<Buffer> {
-  const innerHtml = marked.parse(markdown) as string;
+  const innerHtml = marked.parse(markdown, {
+    gfm: true,
+    breaks: true,
+  }) as string;
   const fullHtml = wrapInPrintTemplate(title, innerHtml);
 
   const pw = await importPlaywright();

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -8,8 +8,10 @@ import { z } from "zod";
 
 import { rawAll, rawGet, rawRun } from "../../memory/raw-query.js";
 import { getLogger } from "../../util/logger.js";
+import { renderMarkdownToPDF } from "./document-pdf-renderer.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
+import { RouteResponse } from "./types.js";
 
 const log = getLogger("documents-routes");
 
@@ -310,6 +312,34 @@ export const ROUTES: RouteDefinition[] = [
         throw new InternalError(result.error);
       }
       return result;
+    },
+  },
+
+  {
+    operationId: "exportDocumentPDF",
+    endpoint: "documents/:id/pdf",
+    method: "GET",
+    policyKey: "documents",
+    requirePolicyEnforcement: true,
+    summary: "Export a document as PDF",
+    description: "Render a document to PDF and return the binary content.",
+    tags: ["documents"],
+    handler: async ({ pathParams }) => {
+      const result = loadDocument(pathParams!.id);
+      if (!result.success) {
+        throw new NotFoundError(result.error);
+      }
+      const pdfBuffer = await renderMarkdownToPDF(result.title, result.content);
+      const filename =
+        result.title
+          .replace(/[^a-zA-Z0-9_-]/g, "-")
+          .replace(/-+/g, "-")
+          .replace(/^-|-$/g, "") || "document";
+      return new RouteResponse(pdfBuffer, {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${filename}.pdf"`,
+        "Content-Length": String(pdfBuffer.length),
+      });
     },
   },
 ];

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -335,7 +335,7 @@ export const ROUTES: RouteDefinition[] = [
           .replace(/[^a-zA-Z0-9_-]/g, "-")
           .replace(/-+/g, "-")
           .replace(/^-|-$/g, "") || "document";
-      return new RouteResponse(pdfBuffer, {
+      return new RouteResponse(new Uint8Array(pdfBuffer), {
         "Content-Type": "application/pdf",
         "Content-Disposition": `attachment; filename="${filename}.pdf"`,
         "Content-Length": String(pdfBuffer.length),

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -160,11 +160,22 @@ final class DocumentManager {
     }
 
     func exportToPDF() {
-        guard let surfaceId = surfaceId else { return }
-        save()
+        guard let surfaceId = surfaceId,
+              let conversationId = conversationId else { return }
         let titleForFile = title
+        let contentToSave = currentContent ?? ""
+        let wordCountToSave = wordCount
+        let client = documentClient
         Task {
-            guard let pdfData = await documentClient.exportDocumentPDF(surfaceId: surfaceId) else {
+            // Await the save so the server has the latest content before rendering
+            _ = await client.saveDocument(
+                surfaceId: surfaceId,
+                conversationId: conversationId,
+                title: titleForFile,
+                content: contentToSave,
+                wordCount: wordCountToSave
+            )
+            guard let pdfData = await client.exportDocumentPDF(surfaceId: surfaceId) else {
                 log.error("PDF export failed: no data returned")
                 return
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -159,6 +159,29 @@ final class DocumentManager {
         }
     }
 
+    func exportToPDF() {
+        guard let surfaceId = surfaceId else { return }
+        save()
+        let titleForFile = title
+        Task {
+            guard let pdfData = await documentClient.exportDocumentPDF(surfaceId: surfaceId) else {
+                log.error("PDF export failed: no data returned")
+                return
+            }
+            await MainActor.run {
+                let panel = NSSavePanel()
+                panel.nameFieldStringValue = sanitizedFilename(from: titleForFile) + ".pdf"
+                panel.canCreateDirectories = true
+                panel.begin { response in
+                    guard response == .OK, let url = panel.url else { return }
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        try? pdfData.write(to: url)
+                    }
+                }
+            }
+        }
+    }
+
     private func sanitizedFilename(from title: String) -> String {
         let replaced = title.replacingOccurrences(of: " ", with: "-")
         let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DocumentEditorPanel.swift
@@ -24,8 +24,15 @@ struct DocumentEditorPanelView: View {
                 if documentManager.isSaving {
                     ProgressView().controlSize(.small).scaleEffect(0.7)
                 } else {
-                    VButton(label: "Export", iconOnly: VIcon.arrowDownToLine.rawValue, style: .ghost) {
-                        documentManager.exportToFile()
+                    VSplitButton(
+                        label: "Export",
+                        icon: VIcon.arrowDownToLine.rawValue,
+                        style: .ghost,
+                        action: { documentManager.exportToFile() }
+                    ) {
+                        VMenuItem(label: "Export as PDF") {
+                            documentManager.exportToPDF()
+                        }
                     }
                 }
                 VButton(label: "Close", iconOnly: VIcon.x.rawValue, style: .ghost, action: onClose)

--- a/clients/shared/Network/DocumentClient.swift
+++ b/clients/shared/Network/DocumentClient.swift
@@ -8,6 +8,7 @@ public protocol DocumentClientProtocol {
     func fetchList(conversationId: String?) async -> DocumentListResponse?
     func fetchDocument(surfaceId: String) async -> DocumentLoadResponse?
     func saveDocument(surfaceId: String, conversationId: String, title: String, content: String, wordCount: Int) async -> DocumentSaveResponse?
+    func exportDocumentPDF(surfaceId: String) async -> Data?
 }
 
 /// Gateway-backed implementation of ``DocumentClientProtocol``.
@@ -102,6 +103,23 @@ public struct DocumentClient: DocumentClientProtocol {
             )
         } catch {
             log.error("saveDocument error: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    public func exportDocumentPDF(surfaceId: String) async -> Data? {
+        do {
+            let response = try await GatewayHTTPClient.get(
+                path: "assistants/{assistantId}/documents/\(surfaceId)/pdf",
+                timeout: 30
+            )
+            guard response.isSuccess else {
+                log.error("exportDocumentPDF failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return response.data
+        } catch {
+            log.error("exportDocumentPDF error: \(error.localizedDescription)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary
Adds a PDF export option to the document editor. The Export button is now a VSplitButton — clicking the main area exports markdown (unchanged behavior), and the dropdown menu offers "Export as PDF". PDF rendering happens server-side: markdown is converted to styled HTML via `marked`, then rendered to PDF using Playwright headless Chromium.

## PRs merged into feature branch
- #29165: feat: add markdown-to-PDF renderer using marked + Playwright
- #29166: feat: add exportDocumentPDF method to DocumentClient
- #29170: feat: add PDF export endpoint for documents
- #29175: feat: add PDF export option to document editor VSplitButton

## Self-review result
All PRs reviewed by Codex. One actionable finding (save document before PDF export to avoid stale content) was addressed in PR #29175.

Part of plan: doc-pdf-export.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
