### PR TITLE
fix: add unprefixed: true to LogExporter logs/export call

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -632,7 +632,7 @@ enum LogExporter {
         }
 
         do {
-            let response = try await GatewayHTTPClient.post(path: "logs/export", json: body, timeout: 60)
+            let response = try await GatewayHTTPClient.post(path: "logs/export", json: body, timeout: 60, unprefixed: true)
             guard response.isSuccess else {
                 log.warning("Export API failed with status \(response.statusCode)")
                 writeExportErrorLog(


### PR DESCRIPTION
## Summary
Adds missing `unprefixed: true` to the `logs/export` call in LogExporter.swift.

**Gap:** LogExporter logs/export path would be auto-prefixed, breaking the route
**What was expected:** logs/export is a global endpoint that needs unprefixed
**What was found:** The call was missing unprefixed: true
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
