### PR TITLE
fix: read settings-developer-nav from client flag manager in PanelCoordinator and fix deep-link init

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -647,7 +647,7 @@ extension MainWindowView {
                         subagentId: subagentId,
                         viewModel: viewModel,
                         detailStore: viewModel.subagentDetailStore,
-                        showInspectButton: assistantFeatureFlagStore.isEnabled("settings-developer-nav"),
+                        showInspectButton: MacOSClientFeatureFlagManager.shared.isEnabled("settings-developer-nav"),
                         onAbort: { Task { await viewModel.abortSubagent(subagentId) } },
                         onRequestDetail: {
                             if let conversationId = viewModel.activeSubagents.first(where: { $0.id == subagentId })?.conversationId {
@@ -697,7 +697,7 @@ extension MainWindowView {
         if let viewModel = conversationManager.activeViewModel {
             let activeConversation = conversationManager.activeConversation
             let conversationStartersEnabled = true
-            let showInspectButton = assistantFeatureFlagStore.isEnabled(
+            let showInspectButton = MacOSClientFeatureFlagManager.shared.isEnabled(
                 "settings-developer-nav"
             )
             let isTTSEnabled = assistantFeatureFlagStore.isEnabled(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -112,15 +112,16 @@ struct SettingsPanel: View {
             // this synchronously via `isCurrentAssistantManaged` which is set
             // in `ConnectionSetup` before the settings view is presented.
             let debugEnabled = AppDelegate.shared?.isCurrentAssistantManaged ?? false
-            let visibleTabs = SettingsTab.sidebarTopTabs(
+            var visibleTabs = SettingsTab.sidebarTopTabs(
                 soundsEnabled: soundsEnabled,
                 debugEnabled: debugEnabled,
                 includeCompactionPlayground: false
             )
+            if developerEnabled { visibleTabs.append(.developer) }
             if visibleTabs.contains(pending) {
                 _selectedTab = State(initialValue: pending)
             } else if Self.deferredDeepLinkTabs.contains(pending) {
-                // Tab may become visible once feature flags load (e.g. .developer).
+                // Tab may become visible once feature flags load (e.g. .compactionPlayground).
                 // Preserve it for deferred evaluation in loadFeatureFlags().
                 _deferredDeepLinkTab = State(initialValue: pending)
             }


### PR DESCRIPTION
## Summary
- Fix PanelCoordinator reading `settings-developer-nav` via `assistantFeatureFlagStore` (which defaults to `true` for unknown client-scope keys) — now uses `MacOSClientFeatureFlagManager.shared.isEnabled()` matching SettingsPanel
- Fix developer tab deep-link dropped in init — append `.developer` to visible tabs when `developerEnabled` is true so deep-links aren't silently discarded
- Update stale comment referencing `.developer` as deferred

## Original prompt
Address review feedback from PR #29171: PanelCoordinator still reads developer flag via assistant-scope store (always true), and developer deep-links are dropped in init
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
