### PR TITLE
feat(onboarding): gate hatching on explicit AI data consent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -96,6 +96,21 @@ struct HatchingStepView: View {
             let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
             guard tosOk && aiOk else {
                 state.isHatching = false
+                // Mirror goBack()'s reset pattern so a subsequent retry with a
+                // different hosting mode doesn't get short-circuited by stale
+                // hatch state (e.g. isManagedHatch=true causing startHatching()
+                // to skip the CLI path).
+                state.isManagedHatch = false
+                state.hasExistingManagedAssistant = false
+                state.hatchFailed = false
+                state.hatchFailureReason = nil
+                state.hatchLogLines = []
+                state.hatchProgressTarget = 0.0
+                state.hatchProgressDisplay = 0.0
+                state.hatchStepLabel = nil
+                state.hatchTotalSteps = 1
+                state.hatchCurrentStep = 0
+                state.hatchProcessStarted = false
                 state.currentStep = 3
                 return
             }

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -89,6 +89,17 @@ struct HatchingStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .opacity(showContent ? 1 : 0)
         .onAppear {
+            // Apple Guideline 5.1.2(i): AI Data Sharing consent must be explicitly
+            // checked by the user. If either consent flag is missing, bounce back
+            // to the privacy step (step 3) instead of starting the hatch.
+            let tosOk = UserDefaults.standard.bool(forKey: "tosAccepted")
+            let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
+            guard tosOk && aiOk else {
+                state.isHatching = false
+                state.currentStep = 3
+                return
+            }
+
             // Eagerly initialize avatar traits so computed getters don't
             // mutate @Observable state during body evaluation.
             if state.hatchAvatarBodyShape == nil {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -349,6 +349,21 @@ struct OnboardingFlowView: View {
     /// `activateManagedAssistant()` surface in the same view via the shared
     /// `hatchFailed` / `hatchFailureReason` path that the health-poll uses.
     private func performManagedBootstrap() async {
+        // Apple Guideline 5.1.2(i): AI Data Sharing consent must be explicitly
+        // checked by the user. Bootstrap can be triggered via the auth-change
+        // path (line ~251) which doesn't route through onboarding step 3, so
+        // we re-check consent here as the load-bearing enforcement point.
+        // The HatchingStepView gate remains as defense-in-depth for non-managed
+        // (CLI) hatch flows.
+        let tosOk = UserDefaults.standard.bool(forKey: "tosAccepted")
+        let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
+        guard tosOk && aiOk else {
+            log.info("Managed bootstrap aborted: AI Data Sharing consent missing — bouncing to privacy step")
+            state.isHatching = false
+            state.currentStep = 3
+            return
+        }
+
         log.info("Beginning managed assistant bootstrap")
         state.hasExistingManagedAssistant = false
         state.hatchFailed = false


### PR DESCRIPTION
## Summary
- Add guard at top of HatchingStepView.onAppear that bounces to onboarding step 3 if either tosAccepted or aiDataConsent is false
- Single enforcement point for Apple Guideline 5.1.2(i) — AI Data Sharing consent must be explicit, never bypassed

Part of plan: onboarding-ai-consent.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
