### PR TITLE
feat(auth): clear AI data consent on assistant retire

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -868,6 +868,10 @@ extension AppDelegate {
         AvatarAppearanceManager.shared.resetForDisconnect()
         OnboardingState.clearPersistedState()
         UserDefaults.standard.removeObject(forKey: "bootstrapState")
+        // Apple Guideline 5.1.2(i): AI Data Sharing consent must be re-collected
+        // on the next onboarding pass after a full retire. ToS is intentionally
+        // sticky and not cleared (matches web behavior).
+        UserDefaults.standard.removeObject(forKey: "aiDataConsent")
         SentryDeviceInfo.updateAssistantTag(nil)
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         SentryDeviceInfo.updateOrganizationTag(nil)


### PR DESCRIPTION
## Summary
- In finalizePostRetire (no-replacement / full-teardown path), clear the aiDataConsent UserDefaults key alongside existing removes
- tosAccepted stays sticky (matches web behavior)
- performLogout untouched (logout preserves assistant association, so consent persists)

Part of plan: onboarding-ai-consent.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
