### PR TITLE
fix: await save before PDF export to prevent stale content race

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/DocumentManager.swift
@@ -160,11 +160,22 @@ final class DocumentManager {
     }
 
     func exportToPDF() {
-        guard let surfaceId = surfaceId else { return }
-        save()
+        guard let surfaceId = surfaceId,
+              let conversationId = conversationId else { return }
         let titleForFile = title
+        let contentToSave = currentContent ?? ""
+        let wordCountToSave = wordCount
+        let client = documentClient
         Task {
-            guard let pdfData = await documentClient.exportDocumentPDF(surfaceId: surfaceId) else {
+            // Await the save so the server has the latest content before rendering
+            _ = await client.saveDocument(
+                surfaceId: surfaceId,
+                conversationId: conversationId,
+                title: titleForFile,
+                content: contentToSave,
+                wordCount: wordCountToSave
+            )
+            guard let pdfData = await client.exportDocumentPDF(surfaceId: surfaceId) else {
                 log.error("PDF export failed: no data returned")
                 return
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for doc-pdf-export.md.

**Gap:** save() is fire-and-forget but PDF export depends on it completing
**What was expected:** PDF export should render the latest editor content
**What was found:** save() launches an unstructured Task internally and returns immediately, so the PDF export request could reach the server before the save completes

Fix: Inline the save call directly in exportToPDF() within the same Task so it can be awaited before requesting the PDF.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
