### PR TITLE
fix: pin assistant target in deferred credential sync tasks

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1324,7 +1324,9 @@ public final class SettingsStore: ObservableObject {
         let body: [String: String] = ["type": "credential", "name": name, "value": value]
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
         Task {
-            _ = try? await GatewayHTTPClient.post(path: "secrets", body: bodyData)
+            _ = try? await GatewayHTTPClient.withAssistant(assistantId) {
+                try await GatewayHTTPClient.post(path: "secrets", body: bodyData)
+            }
         }
     }
 
@@ -1336,7 +1338,9 @@ public final class SettingsStore: ObservableObject {
         let body: [String: String] = ["type": "credential", "name": name]
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return false }
         Task {
-            _ = try? await GatewayHTTPClient.delete(path: "secrets", body: bodyData)
+            _ = try? await GatewayHTTPClient.withAssistant(assistantId) {
+                try await GatewayHTTPClient.delete(path: "secrets", body: bodyData)
+            }
         }
         return true
     }


### PR DESCRIPTION
## Summary
Wraps `syncCredentialToDaemon` and `deleteCredentialFromDaemon` in `GatewayHTTPClient.withAssistant(assistantId)` to pin the target assistant.

Addresses Codex review feedback: the captured `assistantId` was unused after auto-prefix migration, so deferred Tasks could write credentials to the wrong assistant if the user switched assistants.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
