### PR TITLE
fix: remove incorrect unprefixed: true from clearAssistantCredentials

### DIFF
--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -348,7 +348,7 @@ public final class LocalAssistantBootstrapService {
             let body: [String: String] = ["type": "credential", "name": name]
             do {
                 let response = try await GatewayHTTPClient.delete(
-                    path: "secrets", json: body, timeout: 5, unprefixed: true
+                    path: "secrets", json: body, timeout: 5
                 )
                 if response.isSuccess || response.statusCode == 404 {
                     log.info("Cleared assistant credential: \(name, privacy: .public) (status \(response.statusCode))")


### PR DESCRIPTION
## Summary
Removes incorrectly applied `unprefixed: true` from the DELETE call in `clearAssistantCredentials`.

The original code used `assistants/{assistantId}/secrets` (assistant-scoped). The migration incorrectly added `unprefixed: true`, changing it to unscoped `/v1/secrets/`. The inject methods in the same file correctly use `unprefixed: true` because they were already unscoped — but `clearAssistantCredentials` was scoped.

Addresses Devin review feedback on PR #29178.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
