### PR TITLE
fix(onboarding): extract shared consent-bounce helper + persist step

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -95,23 +95,7 @@ struct HatchingStepView: View {
             let tosOk = UserDefaults.standard.bool(forKey: "tosAccepted")
             let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
             guard tosOk && aiOk else {
-                state.isHatching = false
-                // Mirror goBack()'s reset pattern so a subsequent retry with a
-                // different hosting mode doesn't get short-circuited by stale
-                // hatch state (e.g. isManagedHatch=true causing startHatching()
-                // to skip the CLI path).
-                state.isManagedHatch = false
-                state.hasExistingManagedAssistant = false
-                state.hatchFailed = false
-                state.hatchFailureReason = nil
-                state.hatchLogLines = []
-                state.hatchProgressTarget = 0.0
-                state.hatchProgressDisplay = 0.0
-                state.hatchStepLabel = nil
-                state.hatchTotalSteps = 1
-                state.hatchCurrentStep = 0
-                state.hatchProcessStarted = false
-                state.currentStep = 3
+                state.bounceToConsentStep()
                 return
             }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -359,8 +359,7 @@ struct OnboardingFlowView: View {
         let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
         guard tosOk && aiOk else {
             log.info("Managed bootstrap aborted: AI Data Sharing consent missing — bouncing to privacy step")
-            state.isHatching = false
-            state.currentStep = 3
+            state.bounceToConsentStep()
             return
         }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -257,6 +257,33 @@ final class OnboardingState {
         if shouldPersist { persist() }
     }
 
+    /// Bounces the user back to the privacy step (step 3) and clears any
+    /// in-flight hatch state. Used by the consent gates in `HatchingStepView`
+    /// and `performManagedBootstrap` to ensure a clean retry after the user
+    /// re-checks consent. Persists the step write so a force-quit between the
+    /// bounce and the next consent re-check doesn't leave `onboarding.step`
+    /// pointing at the now-aborted hatch step.
+    func bounceToConsentStep() {
+        // Mirror HatchingStepView.goBack()'s reset pattern so a subsequent
+        // retry with a different hosting mode doesn't get short-circuited by
+        // stale hatch state (e.g. isManagedHatch=true causing startHatching()
+        // to skip the CLI path).
+        isHatching = false
+        isManagedHatch = false
+        hasExistingManagedAssistant = false
+        hatchFailed = false
+        hatchFailureReason = nil
+        hatchLogLines = []
+        hatchProgressTarget = 0.0
+        hatchProgressDisplay = 0.0
+        hatchStepLabel = nil
+        hatchTotalSteps = 1
+        hatchCurrentStep = 0
+        hatchProcessStarted = false
+        currentStep = 3
+        if shouldPersist { persist() }
+    }
+
     static func clearPersistedState() {
         for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.skippedAPIKeyEntry", "onboarding.selectedHostingMode", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
             UserDefaults.standard.removeObject(forKey: key)


### PR DESCRIPTION
## Summary
- Add `OnboardingState.bounceToConsentStep()` helper that resets in-flight hatch state, sets currentStep=3, and persists the step write
- Replace inline reset blocks in `HatchingStepView.onAppear` consent guard and `OnboardingFlowView.performManagedBootstrap` consent guard with the shared call
- Symmetrizes the two enforcement points (managed-bootstrap gate previously only reset 2 fields; now matches HatchingStepView's full reset)
- Closes a force-quit-between-bounce-and-recheck desync that could leave `onboarding.step` stale in UserDefaults

Fixes self-review gaps from plan onboarding-ai-consent.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
