### PR TITLE
fix: suppress unused variable warning in loadProviderRoutingSources

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2237,7 +2237,7 @@ public final class SettingsStore: ObservableObject {
     /// Fetches provider routing sources from the daemon debug endpoint and
     /// updates `providerRoutingSources`. Non-fatal — silently ignores errors.
     func loadProviderRoutingSources() {
-        guard let assistantId = cachedAssistantId else {
+        guard cachedAssistantId != nil else {
             providerRoutingSources = [:]
             return
         }


### PR DESCRIPTION
## Summary
- Replace `guard let assistantId = cachedAssistantId` with `guard cachedAssistantId != nil` in `loadProviderRoutingSources()` since the bound value was never used, causing a Swift compiler warning that broke the build.

## Original prompt
help fix this mac build error: unused variable warning on `assistantId` in `SettingsStore.swift:2240`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
