### PR TITLE
[codex] Use hatch create mode for explicit new-assistant flows

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -916,7 +916,8 @@ extension AppDelegate {
         }
         let result = try await AuthService.shared.hatchAssistant(
             organizationId: organizationId,
-            name: name
+            name: name,
+            mode: .create
         )
         let platformAssistant: PlatformAssistant
         switch result {

--- a/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
+++ b/clients/macos/vellum-assistant/App/ManagedAssistantConnectionCoordinator.swift
@@ -8,6 +8,12 @@ protocol ManagedAssistantBootstrapProviding {
         description: String?,
         anthropicApiKey: String?
     ) async throws -> ManagedBootstrapOutcome
+
+    func createManagedAssistant(
+        name: String?,
+        description: String?,
+        anthropicApiKey: String?
+    ) async throws -> ManagedBootstrapOutcome
 }
 
 extension ManagedAssistantBootstrapService: ManagedAssistantBootstrapProviding {}
@@ -114,6 +120,21 @@ final class ManagedAssistantConnectionCoordinator {
 
     func activateManagedAssistant() async throws -> ManagedAssistantConnectionResult {
         let outcome = try await bootstrapService.ensureManagedAssistant(
+            name: nil,
+            description: nil,
+            anthropicApiKey: nil
+        )
+        return try persistManagedAssistant(
+            outcome.assistant,
+            reusedExisting: outcome.reusedExisting
+        )
+    }
+
+    /// Create and activate an additional managed assistant for the current
+    /// account. Used by explicit "new assistant" UX where reusing the
+    /// currently selected assistant would be incorrect.
+    func activateNewManagedAssistant() async throws -> ManagedAssistantConnectionResult {
+        let outcome = try await bootstrapService.createManagedAssistant(
             name: nil,
             description: nil,
             anthropicApiKey: nil

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -363,7 +363,13 @@ struct OnboardingFlowView: View {
         state.isHatching = true
 
         do {
-            let activation = try await ManagedAssistantConnectionCoordinator().activateManagedAssistant()
+            let coordinator = ManagedAssistantConnectionCoordinator()
+            let activation: ManagedAssistantConnectionResult
+            if state.isRehatch {
+                activation = try await coordinator.activateNewManagedAssistant()
+            } else {
+                activation = try await coordinator.activateManagedAssistant()
+            }
             let assistant = activation.assistant
             state.hasExistingManagedAssistant = activation.reusedExisting
 

--- a/clients/macos/vellum-assistantTests/ManagedAssistantBootstrapServiceTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantBootstrapServiceTests.swift
@@ -214,8 +214,34 @@ final class ManagedAssistantBootstrapServiceTests: XCTestCase {
 
         // AND hatch is called as the first-run fallback
         XCTAssertEqual(auth.hatchCallCount, 1)
+        XCTAssertEqual(auth.hatchModes, [.ensure])
         if case .createdNew = outcome {
             // expected
+        } else {
+            XCTFail("Expected createdNew, got \(outcome)")
+        }
+    }
+
+    func testCreateManagedAssistantSkipsReuseLookupsAndUsesCreateMode() async throws {
+        let idStore = MockActiveAssistantIdStore(storedId: "current-managed")
+        let auth = MockBootstrapAuthService(
+            organizations: [PlatformOrganization(id: "org-test", name: "Org")],
+            listAssistantsResult: [PlatformAssistant(id: "existing-managed", name: "Existing")]
+        )
+        let service = ManagedAssistantBootstrapService(
+            authService: auth,
+            activeAssistantIdStore: idStore
+        )
+
+        let outcome = try await service.createManagedAssistant(name: "Nova")
+
+        XCTAssertEqual(idStore.clearCallCount, 0)
+        XCTAssertEqual(auth.getAssistantCallCount, 0)
+        XCTAssertEqual(auth.listAssistantsCallCount, 0)
+        XCTAssertEqual(auth.hatchCallCount, 1)
+        XCTAssertEqual(auth.hatchModes, [.create])
+        if case .createdNew(let assistant) = outcome {
+            XCTAssertEqual(assistant.id, "hatched-id")
         } else {
             XCTFail("Expected createdNew, got \(outcome)")
         }
@@ -284,6 +310,7 @@ private final class MockBootstrapAuthService: ManagedAssistantBootstrapAuthServi
     private(set) var getAssistantCallCount = 0
     private(set) var listAssistantsCallCount = 0
     private(set) var hatchCallCount = 0
+    private(set) var hatchModes: [HatchAssistantMode] = []
 
     init(
         organizations: [PlatformOrganization],
@@ -332,9 +359,11 @@ private final class MockBootstrapAuthService: ManagedAssistantBootstrapAuthServi
         organizationId: String,
         name: String?,
         description: String?,
-        anthropicApiKey: String?
+        anthropicApiKey: String?,
+        mode: HatchAssistantMode
     ) async throws -> HatchAssistantResult {
         hatchCallCount += 1
+        hatchModes.append(mode)
         return .createdNew(PlatformAssistant(id: "hatched-id"))
     }
 }

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
@@ -245,4 +245,12 @@ private final class MockBootstrap: ManagedAssistantBootstrapProviding {
     ) async throws -> ManagedBootstrapOutcome {
         outcome
     }
+
+    func createManagedAssistant(
+        name: String?,
+        description: String?,
+        anthropicApiKey: String?
+    ) async throws -> ManagedBootstrapOutcome {
+        outcome
+    }
 }

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -93,6 +93,33 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
     }
 
+    func testActivateNewManagedAssistantUsesCreatePath() async throws {
+        let assistant = PlatformAssistant(id: "managed-new", name: "New")
+        let bootstrapService = MockManagedAssistantBootstrapService(
+            outcome: .createdNew(assistant)
+        )
+
+        let coordinator = ManagedAssistantConnectionCoordinator(
+            bootstrapService: bootstrapService,
+            userDefaults: defaults,
+            runtimeURLProvider: { "https://platform.example.com" },
+            updateAssistantTag: { _ in },
+            lockfilePath: lockfilePath,
+            dateProvider: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        let result = try await coordinator.activateNewManagedAssistant()
+
+        XCTAssertEqual(result.assistant.id, assistant.id)
+        XCTAssertFalse(result.reusedExisting)
+        XCTAssertEqual(bootstrapService.ensureCallCount, 0)
+        XCTAssertEqual(bootstrapService.createCallCount, 1)
+        XCTAssertEqual(defaults.string(forKey: "connectedOrganizationId"), nil)
+        let lockfileData = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
+        let lockfileJson = try JSONSerialization.jsonObject(with: lockfileData) as? [String: Any]
+        XCTAssertEqual(lockfileJson?["activeAssistant"] as? String, assistant.id)
+    }
+
     func testActivateManagedAssistantRePopulatesOrgIdAfterCleared() async throws {
         // Simulate performSwitchAssistant clearing the org ID
         defaults.removeObject(forKey: "connectedOrganizationId")
@@ -158,6 +185,8 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
 private final class MockManagedAssistantBootstrapService: ManagedAssistantBootstrapProviding {
     private let outcome: ManagedBootstrapOutcome?
     private let onEnsureManagedAssistant: (() -> Void)?
+    private(set) var ensureCallCount = 0
+    private(set) var createCallCount = 0
 
     init(
         outcome: ManagedBootstrapOutcome? = nil,
@@ -172,9 +201,22 @@ private final class MockManagedAssistantBootstrapService: ManagedAssistantBootst
         description: String?,
         anthropicApiKey: String?
     ) async throws -> ManagedBootstrapOutcome {
+        ensureCallCount += 1
         onEnsureManagedAssistant?()
         guard let outcome else {
             fatalError("ensureManagedAssistant called without a configured outcome")
+        }
+        return outcome
+    }
+
+    func createManagedAssistant(
+        name: String?,
+        description: String?,
+        anthropicApiKey: String?
+    ) async throws -> ManagedBootstrapOutcome {
+        createCallCount += 1
+        guard let outcome else {
+            fatalError("createManagedAssistant called without a configured outcome")
         }
         return outcome
     }

--- a/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
+++ b/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
@@ -252,7 +252,8 @@ private final class MockAuthService: ManagedAssistantBootstrapAuthServicing {
     }
     func hatchAssistant(
         organizationId: String, name: String?, description: String?,
-        anthropicApiKey: String?
+        anthropicApiKey: String?,
+        mode: HatchAssistantMode
     ) async throws -> HatchAssistantResult {
         fatalError("Not used by ReturningUserRouter")
     }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -168,6 +168,12 @@ public struct HatchAssistantRequest: Codable, Sendable {
     }
 }
 
+/// Query mode for the platform hatch endpoint.
+public enum HatchAssistantMode: String, Codable, Sendable {
+    case ensure
+    case create
+}
+
 /// Result type for platform assistant lookups where 404/403 are normal outcomes.
 public enum PlatformAssistantResult: Sendable {
     case found(PlatformAssistant)

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -348,7 +348,8 @@ public final class AuthService {
         organizationId: String,
         name: String? = nil,
         description: String? = nil,
-        anthropicApiKey: String? = nil
+        anthropicApiKey: String? = nil,
+        mode: HatchAssistantMode = .ensure
     ) async throws -> HatchAssistantResult {
         let requestBody = HatchAssistantRequest(
             name: name,
@@ -356,9 +357,16 @@ public final class AuthService {
             anthropic_api_key: anthropicApiKey
         )
         let bodyData = try JSONEncoder().encode(requestBody)
+        let hatchPath: String
+        switch mode {
+        case .ensure:
+            hatchPath = "v1/assistants/hatch/"
+        case .create:
+            hatchPath = "v1/assistants/hatch/?mode=\(mode.rawValue)"
+        }
 
         let response = try await performPlatformRequest(
-            path: "v1/assistants/hatch/",
+            path: hatchPath,
             method: "POST",
             organizationId: organizationId,
             body: bodyData,

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -51,7 +51,8 @@ public protocol ManagedAssistantBootstrapAuthServicing: AnyObject {
         organizationId: String,
         name: String?,
         description: String?,
-        anthropicApiKey: String?
+        anthropicApiKey: String?,
+        mode: HatchAssistantMode
     ) async throws -> HatchAssistantResult
 }
 
@@ -171,13 +172,52 @@ public final class ManagedAssistantBootstrapService {
         // No selected assistant (or stale one was cleared) — hatch is idempotent
         // and will return the existing assistant if one exists.
         log.info("No stored assistant ID — calling idempotent hatch")
+        return try await hatchManagedAssistant(
+            organizationId: organizationId,
+            name: name,
+            description: description,
+            anthropicApiKey: anthropicApiKey,
+            mode: .ensure
+        )
+    }
+
+    /// Create an additional managed assistant for the current organization.
+    ///
+    /// Unlike `ensureManagedAssistant()`, this skips the stored-id lookup and
+    /// list-first reuse path. It directly opts into the platform's
+    /// multi-assistant hatch semantics (`mode=create`), which creates a new
+    /// assistant unless the backend is deduping an in-flight hatch.
+    public func createManagedAssistant(
+        name: String? = nil,
+        description: String? = nil,
+        anthropicApiKey: String? = nil
+    ) async throws -> ManagedBootstrapOutcome {
+        let organizationId = try await resolveOrganizationId()
+        log.info("Requesting additional managed assistant via create hatch mode")
+        return try await hatchManagedAssistant(
+            organizationId: organizationId,
+            name: name,
+            description: description,
+            anthropicApiKey: anthropicApiKey,
+            mode: .create
+        )
+    }
+
+    private func hatchManagedAssistant(
+        organizationId: String,
+        name: String?,
+        description: String?,
+        anthropicApiKey: String?,
+        mode: HatchAssistantMode
+    ) async throws -> ManagedBootstrapOutcome {
         let hatchResult: HatchAssistantResult
         do {
             hatchResult = try await authService.hatchAssistant(
                 organizationId: organizationId,
                 name: name,
                 description: description,
-                anthropicApiKey: anthropicApiKey
+                anthropicApiKey: anthropicApiKey,
+                mode: mode
             )
         } catch let error as PlatformAPIError {
             throw mapPlatformError(error)


### PR DESCRIPTION
## Summary
- add an explicit hatch mode to the shared platform auth client so callers can request either the legacy `ensure` flow or the new additive `create` flow
- route the menu-bar `New Assistant…` action and the managed re-hatch onboarding path through `mode=create`
- add bootstrap/coordinator test coverage so explicit new-assistant flows do not regress back to reusing the current assistant

## Why
The platform hatch endpoint now distinguishes between `ensure` and `create`. Our explicit new-assistant UX still used the idempotent hatch path, so it could reuse the user’s current assistant instead of creating an additional one.

## Impact
When a user explicitly asks for a new managed assistant, the macOS client now requests an additional assistant from the platform while leaving the default bootstrap path unchanged.

## Root Cause
The client only had a single hatch call shape, and both the onboarding re-hatch flow and the menu-bar new-assistant action were still using the legacy idempotent behavior.

## Validation
- `swift test --package-path clients --filter ManagedAssistantBootstrapServiceTests`
- `swift test --package-path clients --filter ManagedAssistantConnectionCoordinator`
- pre-push hook passed:
  - `clients/` Swift build
  - iOS debug build
  - design token guard