### PR TITLE
refactor(onboarding): consolidate consent row, hatch reset, test boilerplate

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -352,18 +352,7 @@ struct HatchingStepView: View {
     private func goBack() {
         healthCheckTask?.cancel()
         isCheckingHealth = false
-        state.isHatching = false
-        state.isManagedHatch = false
-        state.hasExistingManagedAssistant = false
-        state.hatchFailed = false
-        state.hatchFailureReason = nil
-        state.hatchLogLines = []
-        state.hatchProgressTarget = 0.0
-        state.hatchProgressDisplay = 0.0
-        state.hatchStepLabel = nil
-        state.hatchTotalSteps = 1
-        state.hatchCurrentStep = 0
-        state.hatchProcessStarted = false
+        state.resetHatchTransientState()
         progressStartDate = nil
         segmentStartDate = nil
         segmentStartValue = 0

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -93,29 +93,17 @@ struct ImproveExperienceStepView: View {
 
             // Consent checkboxes (AI Data Sharing first, then ToS)
             VStack(spacing: VSpacing.sm) {
-                HStack(spacing: VSpacing.md) {
-                    consentCheckbox(
-                        isChecked: $aiDataConsent,
-                        accessibilityLabel: "I agree to the AI Data Sharing Policy"
-                    )
-                    consentText(
-                        markdown: "I agree to the [AI Data Sharing Policy](\(AppURLs.dataSharingDocs.absoluteString))",
-                        fallback: "I agree to the AI Data Sharing Policy"
-                    )
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                consentRow(
+                    isChecked: $aiDataConsent,
+                    markdown: "I agree to the [AI Data Sharing Policy](\(AppURLs.dataSharingDocs.absoluteString))",
+                    plainText: "I agree to the AI Data Sharing Policy"
+                )
 
-                HStack(spacing: VSpacing.md) {
-                    consentCheckbox(
-                        isChecked: $tosAccepted,
-                        accessibilityLabel: "I agree to the Terms of Service and Privacy Policy"
-                    )
-                    consentText(
-                        markdown: "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))",
-                        fallback: "I agree to the Terms of Service and Privacy Policy"
-                    )
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                consentRow(
+                    isChecked: $tosAccepted,
+                    markdown: "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))",
+                    plainText: "I agree to the Terms of Service and Privacy Policy"
+                )
             }
 
             VStack(spacing: VSpacing.sm) {
@@ -160,6 +148,23 @@ struct ImproveExperienceStepView: View {
                 .onAppear { showCharacters = true }
                 .accessibilityHidden(true)
         }
+    }
+
+    // MARK: - Consent Row
+
+    /// A single consent row: checkbox + markdown link text. Uses `plainText` for
+    /// both the checkbox's accessibility label and the markdown-render fallback
+    /// so the two cannot drift apart.
+    private func consentRow(
+        isChecked: Binding<Bool>,
+        markdown: String,
+        plainText: String
+    ) -> some View {
+        HStack(spacing: VSpacing.md) {
+            consentCheckbox(isChecked: isChecked, accessibilityLabel: plainText)
+            consentText(markdown: markdown, fallback: plainText)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Consent Checkbox

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -264,10 +264,19 @@ final class OnboardingState {
     /// bounce and the next consent re-check doesn't leave `onboarding.step`
     /// pointing at the now-aborted hatch step.
     func bounceToConsentStep() {
-        // Mirror HatchingStepView.goBack()'s reset pattern so a subsequent
-        // retry with a different hosting mode doesn't get short-circuited by
-        // stale hatch state (e.g. isManagedHatch=true causing startHatching()
-        // to skip the CLI path).
+        resetHatchTransientState()
+        currentStep = 3
+        if shouldPersist { persist() }
+    }
+
+    /// Clears the hatch-related transient state shared by `bounceToConsentStep()`
+    /// and `HatchingStepView.goBack()`. Both call sites need the same reset
+    /// before allowing a retry — without it, stale flags like `isManagedHatch`
+    /// can short-circuit `startHatching()` (e.g. skipping the CLI path).
+    /// Does NOT touch `hatchCompleted`, `hasHatched`, avatar traits, ToS/AI
+    /// consent, or any non-hatch credentials — see `resetForRetry()` for the
+    /// full reset.
+    func resetHatchTransientState() {
         isHatching = false
         isManagedHatch = false
         hasExistingManagedAssistant = false
@@ -280,8 +289,6 @@ final class OnboardingState {
         hatchTotalSteps = 1
         hatchCurrentStep = 0
         hatchProcessStarted = false
-        currentStep = 3
-        if shouldPersist { persist() }
     }
 
     static func clearPersistedState() {

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
@@ -2,6 +2,8 @@ import VellumAssistantShared
 import XCTest
 @testable import VellumAssistantLib
 
+private let aiConsentMustNotBeClobberedMessage = "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)"
+
 @MainActor
 final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
     private var tempDir: URL!
@@ -19,6 +21,10 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         defaultsSuiteName = "ManagedAssistantConnectionCoordinatorSwitchTests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: defaultsSuiteName)
         defaults.removePersistentDomain(forName: defaultsSuiteName)
+        // Seed `true` so a regression that writes/removes aiDataConsent flips
+        // the AI-consent assertions in tests below. setUp runs after the
+        // per-test UUID suite is created, so each test sees a fresh seed.
+        defaults.set(true, forKey: "aiDataConsent")
     }
 
     override func tearDown() {
@@ -150,8 +156,6 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         let bootstrap = MockBootstrap(
             outcome: .createdNew(PlatformAssistant(id: "managed-activate"))
         )
-        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
-        defaults.set(true, forKey: "aiDataConsent")
 
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: bootstrap,
@@ -171,7 +175,7 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), aiConsentMustNotBeClobberedMessage)
         // With no connection controller, bring-up must be a no-op.
         XCTAssertEqual(controller.teardownCount, 0)
         XCTAssertEqual(controller.bringUpCount, 0)

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -2,6 +2,8 @@ import VellumAssistantShared
 import XCTest
 @testable import VellumAssistantLib
 
+private let aiConsentMustNotBeClobberedMessage = "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)"
+
 @MainActor
 final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
     private var tempDir: URL!
@@ -19,6 +21,10 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         defaultsSuiteName = "ManagedAssistantConnectionCoordinatorTests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: defaultsSuiteName)
         defaults.removePersistentDomain(forName: defaultsSuiteName)
+        // Seed `true` so a regression that writes/removes aiDataConsent flips
+        // the AI-consent assertions in tests below. setUp runs after the
+        // per-test UUID suite is created, so each test sees a fresh seed.
+        defaults.set(true, forKey: "aiDataConsent")
     }
 
     override func tearDown() {
@@ -40,9 +46,6 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         )
         var taggedAssistantId: String?
 
-        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
-        defaults.set(true, forKey: "aiDataConsent")
-
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: bootstrapService,
             userDefaults: defaults,
@@ -63,7 +66,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), aiConsentMustNotBeClobberedMessage)
         XCTAssertEqual(taggedAssistantId, assistant.id)
 
         let data = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
@@ -78,8 +81,6 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
     func testActivateManagedAssistantPreservesExistingPrivacyOptOuts() async throws {
         defaults.set(false, forKey: "collectUsageData")
         defaults.set(false, forKey: "sendDiagnostics")
-        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
-        defaults.set(true, forKey: "aiDataConsent")
 
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: MockManagedAssistantBootstrapService(
@@ -97,7 +98,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertFalse(defaults.bool(forKey: "collectUsageData"))
         XCTAssertFalse(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), aiConsentMustNotBeClobberedMessage)
     }
 
     func testActivateManagedAssistantRePopulatesOrgIdAfterCleared() async throws {


### PR DESCRIPTION
## Summary
Round-2 polish refactors from plan onboarding-ai-consent.md self-review:

- Extract `OnboardingState.resetHatchTransientState()` shared by `bounceToConsentStep()` and `HatchingStepView.goBack()` (was: 11-line reset block duplicated verbatim).
- Extract `consentRow(isChecked:markdown:plainText:)` helper used by both AI Data Sharing and ToS consent rows. Eliminates the footgun where `accessibilityLabel` and the plain-text `fallback` had to stay in sync as separate strings.
- Move `aiDataConsent = true` seed into test `setUp()`; hoist the duplicated assertion message into a file-scope `let`. Tests still verify the contract (managed coordinator must not clobber AI consent) — just less boilerplate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
