### PR TITLE
feat(onboarding): explicit AI Data Sharing consent in macOS onboarding (Apple 5.1.2(i))

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -868,6 +868,10 @@ extension AppDelegate {
         AvatarAppearanceManager.shared.resetForDisconnect()
         OnboardingState.clearPersistedState()
         UserDefaults.standard.removeObject(forKey: "bootstrapState")
+        // Apple Guideline 5.1.2(i): AI Data Sharing consent must be re-collected
+        // on the next onboarding pass after a full retire. ToS is intentionally
+        // sticky and not cleared (matches web behavior).
+        UserDefaults.standard.removeObject(forKey: "aiDataConsent")
         SentryDeviceInfo.updateAssistantTag(nil)
         UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         SentryDeviceInfo.updateOrganizationTag(nil)

--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -67,6 +67,11 @@ public enum AppURLs {
         docsURL(path: "/privacy-policy")
     }
 
+    /// AI Data Sharing Policy docs — linked from the onboarding AI data consent checkbox.
+    public static var dataSharingDocs: URL {
+        docsURL(path: "/data-sharing")
+    }
+
     // MARK: - Helpers
 
     /// Build a docs URL by appending a path to the (possibly env-overridden) base.

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -352,18 +352,7 @@ struct HatchingStepView: View {
     private func goBack() {
         healthCheckTask?.cancel()
         isCheckingHealth = false
-        state.isHatching = false
-        state.isManagedHatch = false
-        state.hasExistingManagedAssistant = false
-        state.hatchFailed = false
-        state.hatchFailureReason = nil
-        state.hatchLogLines = []
-        state.hatchProgressTarget = 0.0
-        state.hatchProgressDisplay = 0.0
-        state.hatchStepLabel = nil
-        state.hatchTotalSteps = 1
-        state.hatchCurrentStep = 0
-        state.hatchProcessStarted = false
+        state.resetHatchTransientState()
         progressStartDate = nil
         segmentStartDate = nil
         segmentStartValue = 0

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -89,6 +89,32 @@ struct HatchingStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .opacity(showContent ? 1 : 0)
         .onAppear {
+            // Apple Guideline 5.1.2(i): AI Data Sharing consent must be explicitly
+            // checked by the user. If either consent flag is missing, bounce back
+            // to the privacy step (step 3) instead of starting the hatch.
+            let tosOk = UserDefaults.standard.bool(forKey: "tosAccepted")
+            let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
+            guard tosOk && aiOk else {
+                state.isHatching = false
+                // Mirror goBack()'s reset pattern so a subsequent retry with a
+                // different hosting mode doesn't get short-circuited by stale
+                // hatch state (e.g. isManagedHatch=true causing startHatching()
+                // to skip the CLI path).
+                state.isManagedHatch = false
+                state.hasExistingManagedAssistant = false
+                state.hatchFailed = false
+                state.hatchFailureReason = nil
+                state.hatchLogLines = []
+                state.hatchProgressTarget = 0.0
+                state.hatchProgressDisplay = 0.0
+                state.hatchStepLabel = nil
+                state.hatchTotalSteps = 1
+                state.hatchCurrentStep = 0
+                state.hatchProcessStarted = false
+                state.currentStep = 3
+                return
+            }
+
             // Eagerly initialize avatar traits so computed getters don't
             // mutate @Observable state during body evaluation.
             if state.hatchAvatarBodyShape == nil {

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -95,23 +95,7 @@ struct HatchingStepView: View {
             let tosOk = UserDefaults.standard.bool(forKey: "tosAccepted")
             let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
             guard tosOk && aiOk else {
-                state.isHatching = false
-                // Mirror goBack()'s reset pattern so a subsequent retry with a
-                // different hosting mode doesn't get short-circuited by stale
-                // hatch state (e.g. isManagedHatch=true causing startHatching()
-                // to skip the CLI path).
-                state.isManagedHatch = false
-                state.hasExistingManagedAssistant = false
-                state.hatchFailed = false
-                state.hatchFailureReason = nil
-                state.hatchLogLines = []
-                state.hatchProgressTarget = 0.0
-                state.hatchProgressDisplay = 0.0
-                state.hatchStepLabel = nil
-                state.hatchTotalSteps = 1
-                state.hatchCurrentStep = 0
-                state.hatchProcessStarted = false
-                state.currentStep = 3
+                state.bounceToConsentStep()
                 return
             }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -41,7 +41,7 @@ struct ImproveExperienceStepView: View {
             .padding(.bottom, VSpacing.xxl)
 
         VStack(spacing: 0) {
-            VStack(spacing: VSpacing.sm) {
+            VStack(spacing: 0) {
                 // Usage analytics toggle
                 VToggle(
                     isOn: $collectUsageData,
@@ -50,14 +50,9 @@ struct ImproveExperienceStepView: View {
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(VColor.surfaceLift)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .stroke(VColor.surfaceBase, lineWidth: 1)
-                        )
-                )
+
+                Divider()
+                    .background(VColor.surfaceBase)
 
                 // Diagnostics toggle
                 VToggle(
@@ -67,16 +62,11 @@ struct ImproveExperienceStepView: View {
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(VSpacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: VRadius.lg)
-                        .fill(VColor.surfaceLift)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: VRadius.lg)
-                                .stroke(VColor.surfaceBase, lineWidth: 1)
-                        )
-                )
 
-                // Privacy note bar
+                Divider()
+                    .background(VColor.surfaceBase)
+
+                // Privacy note
                 HStack(spacing: VSpacing.xs) {
                     VIconView(.eyeOff, size: 14)
                         .foregroundStyle(VColor.contentTertiary)
@@ -84,19 +74,26 @@ struct ImproveExperienceStepView: View {
                         .font(VFont.bodySmallDefault)
                         .foregroundStyle(VColor.contentTertiary)
                 }
-                .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(VColor.surfaceBase)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .padding(.bottom, VSpacing.sm)
-
-                // ToS consent checkbox
-                HStack(spacing: VSpacing.md) {
-                    tosCheckbox
-                    tosConsentText
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(VSpacing.md)
             }
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .fill(VColor.surfaceLift)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: VRadius.lg)
+                            .stroke(VColor.surfaceBase, lineWidth: 1)
+                    )
+            )
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+            .padding(.bottom, VSpacing.sm)
+
+            // ToS consent checkbox
+            HStack(spacing: VSpacing.md) {
+                tosCheckbox
+                tosConsentText
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             VStack(spacing: VSpacing.sm) {
                 VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: !tosAccepted) {

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -22,6 +22,7 @@ struct ImproveExperienceStepView: View {
     @AppStorage("collectUsageData") private var collectUsageData: Bool = true
     @AppStorage("sendDiagnostics") private var sendDiagnostics: Bool = true
     @AppStorage("tosAccepted") private var tosAccepted: Bool = false
+    @AppStorage("aiDataConsent") private var aiDataConsent: Bool = false
 
     var body: some View {
         Text("Before You Start")
@@ -88,15 +89,29 @@ struct ImproveExperienceStepView: View {
             .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
             .padding(.bottom, VSpacing.sm)
 
-            // ToS consent checkbox
-            HStack(spacing: VSpacing.md) {
-                tosCheckbox
-                tosConsentText
+            // Consent checkboxes (AI Data Sharing first, then ToS)
+            VStack(spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.md) {
+                    consentCheckbox(
+                        isChecked: $aiDataConsent,
+                        accessibilityLabel: "I agree to the AI Data Sharing Policy"
+                    )
+                    aiConsentText
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: VSpacing.md) {
+                    consentCheckbox(
+                        isChecked: $tosAccepted,
+                        accessibilityLabel: "I agree to the Terms of Service and Privacy Policy"
+                    )
+                    tosConsentText
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
 
             VStack(spacing: VSpacing.sm) {
-                VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: !tosAccepted) {
+                VButton(label: "Start", style: .primary, isFullWidth: true, isDisabled: !tosAccepted || !aiDataConsent) {
                     saveAndContinue()
                 }
 
@@ -139,22 +154,22 @@ struct ImproveExperienceStepView: View {
         }
     }
 
-    // MARK: - ToS Consent Checkbox
+    // MARK: - Consent Checkbox
 
-    private var tosCheckbox: some View {
+    private func consentCheckbox(isChecked: Binding<Bool>, accessibilityLabel: String) -> some View {
         Button {
             withAnimation(VAnimation.fast) {
-                tosAccepted.toggle()
+                isChecked.wrappedValue.toggle()
             }
         } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: VRadius.sm)
-                    .fill(tosAccepted ? VColor.primaryBase : Color.clear)
+                    .fill(isChecked.wrappedValue ? VColor.primaryBase : Color.clear)
 
                 RoundedRectangle(cornerRadius: VRadius.sm)
-                    .strokeBorder(tosAccepted ? Color.clear : VColor.borderElement, lineWidth: 1.5)
+                    .strokeBorder(isChecked.wrappedValue ? Color.clear : VColor.borderElement, lineWidth: 1.5)
 
-                if tosAccepted {
+                if isChecked.wrappedValue {
                     VIconView(.check, size: 12)
                         .foregroundStyle(VColor.contentInset)
                 }
@@ -163,8 +178,8 @@ struct ImproveExperienceStepView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Agree to Terms of Service and Privacy Policy")
-        .accessibilityValue(tosAccepted ? "Checked" : "Unchecked")
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(isChecked.wrappedValue ? "Checked" : "Unchecked")
         .accessibilityAddTraits(.isToggle)
     }
 
@@ -197,13 +212,42 @@ struct ImproveExperienceStepView: View {
         return str
     }
 
+    // MARK: - AI Data Sharing Consent Text
+
+    private var aiConsentText: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text(aiConsentAttributedString)
+                .font(VFont.bodyMediumLighter)
+                .foregroundStyle(VColor.contentSecondary)
+                .tint(VColor.primaryBase)
+                .environment(\.openURL, OpenURLAction { url in
+                    NSWorkspace.shared.open(url)
+                    return .handled
+                })
+        }
+    }
+
+    private var aiConsentAttributedString: AttributedString {
+        let markdown = "I agree to the [AI Data Sharing Policy](\(AppURLs.dataSharingDocs.absoluteString))"
+        guard var str = try? AttributedString(markdown: markdown) else {
+            return AttributedString("I agree to the AI Data Sharing Policy")
+        }
+        for run in str.runs where run.link != nil {
+            str[run.range].underlineStyle = .single
+        }
+        return str
+    }
+
     // MARK: - Actions
 
     private func saveAndContinue() {
-        // @AppStorage already persists collectUsageData, sendDiagnostics, and
-        // tosAccepted. Explicitly set tosAccepted = true here as a safeguard
-        // so acceptance is recorded even if the user somehow bypasses the toggle.
+        // @AppStorage already persists collectUsageData, sendDiagnostics,
+        // tosAccepted, and aiDataConsent. Explicitly set tosAccepted and
+        // aiDataConsent here as a safeguard so acceptance is recorded even if
+        // the user somehow bypasses the toggles. The Start button is only
+        // enabled when both checkboxes are checked, so this is a backstop.
         tosAccepted = true
+        aiDataConsent = true
 
         if sendDiagnostics {
             MetricKitManager.startSentry()

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -54,6 +54,7 @@ struct ImproveExperienceStepView: View {
 
                 Divider()
                     .background(VColor.surfaceBase)
+                    .accessibilityHidden(true)
 
                 // Diagnostics toggle
                 VToggle(
@@ -66,6 +67,7 @@ struct ImproveExperienceStepView: View {
 
                 Divider()
                     .background(VColor.surfaceBase)
+                    .accessibilityHidden(true)
 
                 // Privacy note
                 HStack(spacing: VSpacing.xs) {
@@ -96,7 +98,10 @@ struct ImproveExperienceStepView: View {
                         isChecked: $aiDataConsent,
                         accessibilityLabel: "I agree to the AI Data Sharing Policy"
                     )
-                    aiConsentText
+                    consentText(
+                        markdown: "I agree to the [AI Data Sharing Policy](\(AppURLs.dataSharingDocs.absoluteString))",
+                        fallback: "I agree to the AI Data Sharing Policy"
+                    )
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -105,7 +110,10 @@ struct ImproveExperienceStepView: View {
                         isChecked: $tosAccepted,
                         accessibilityLabel: "I agree to the Terms of Service and Privacy Policy"
                     )
-                    tosConsentText
+                    consentText(
+                        markdown: "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))",
+                        fallback: "I agree to the Terms of Service and Privacy Policy"
+                    )
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -183,11 +191,11 @@ struct ImproveExperienceStepView: View {
         .accessibilityAddTraits(.isToggle)
     }
 
-    // MARK: - ToS Consent Text
+    // MARK: - Consent Text
 
-    private var tosConsentText: some View {
+    private func consentText(markdown: String, fallback: String) -> some View {
         VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text(tosAttributedString)
+            Text(attributedString(from: markdown, fallback: fallback))
                 .font(VFont.bodyMediumLighter)
                 .foregroundStyle(VColor.contentSecondary)
                 .tint(VColor.primaryBase)
@@ -198,39 +206,12 @@ struct ImproveExperienceStepView: View {
         }
     }
 
-    private var tosAttributedString: AttributedString {
-        let markdown = "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))"
+    private func attributedString(from markdown: String, fallback: String) -> AttributedString {
         // Use `try?` with a plain-text fallback so a markdown parse failure
         // (e.g. unexpected interpolated content from VELLUM_DOCS_BASE_URL) degrades
         // gracefully instead of crashing the onboarding flow.
         guard var str = try? AttributedString(markdown: markdown) else {
-            return AttributedString("I agree to the Terms of Service and Privacy Policy")
-        }
-        for run in str.runs where run.link != nil {
-            str[run.range].underlineStyle = .single
-        }
-        return str
-    }
-
-    // MARK: - AI Data Sharing Consent Text
-
-    private var aiConsentText: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            Text(aiConsentAttributedString)
-                .font(VFont.bodyMediumLighter)
-                .foregroundStyle(VColor.contentSecondary)
-                .tint(VColor.primaryBase)
-                .environment(\.openURL, OpenURLAction { url in
-                    NSWorkspace.shared.open(url)
-                    return .handled
-                })
-        }
-    }
-
-    private var aiConsentAttributedString: AttributedString {
-        let markdown = "I agree to the [AI Data Sharing Policy](\(AppURLs.dataSharingDocs.absoluteString))"
-        guard var str = try? AttributedString(markdown: markdown) else {
-            return AttributedString("I agree to the AI Data Sharing Policy")
+            return AttributedString(fallback)
         }
         for run in str.runs where run.link != nil {
             str[run.range].underlineStyle = .single

--- a/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/ImproveExperienceStepView.swift
@@ -93,29 +93,17 @@ struct ImproveExperienceStepView: View {
 
             // Consent checkboxes (AI Data Sharing first, then ToS)
             VStack(spacing: VSpacing.sm) {
-                HStack(spacing: VSpacing.md) {
-                    consentCheckbox(
-                        isChecked: $aiDataConsent,
-                        accessibilityLabel: "I agree to the AI Data Sharing Policy"
-                    )
-                    consentText(
-                        markdown: "I agree to the [AI Data Sharing Policy](\(AppURLs.dataSharingDocs.absoluteString))",
-                        fallback: "I agree to the AI Data Sharing Policy"
-                    )
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                consentRow(
+                    isChecked: $aiDataConsent,
+                    markdown: "I agree to the [AI Data Sharing Policy](\(AppURLs.dataSharingDocs.absoluteString))",
+                    plainText: "I agree to the AI Data Sharing Policy"
+                )
 
-                HStack(spacing: VSpacing.md) {
-                    consentCheckbox(
-                        isChecked: $tosAccepted,
-                        accessibilityLabel: "I agree to the Terms of Service and Privacy Policy"
-                    )
-                    consentText(
-                        markdown: "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))",
-                        fallback: "I agree to the Terms of Service and Privacy Policy"
-                    )
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                consentRow(
+                    isChecked: $tosAccepted,
+                    markdown: "I agree to the [Terms of Service](\(AppURLs.termsOfUseDocs.absoluteString)) and [Privacy Policy](\(AppURLs.privacyPolicyDocs.absoluteString))",
+                    plainText: "I agree to the Terms of Service and Privacy Policy"
+                )
             }
 
             VStack(spacing: VSpacing.sm) {
@@ -160,6 +148,23 @@ struct ImproveExperienceStepView: View {
                 .onAppear { showCharacters = true }
                 .accessibilityHidden(true)
         }
+    }
+
+    // MARK: - Consent Row
+
+    /// A single consent row: checkbox + markdown link text. Uses `plainText` for
+    /// both the checkbox's accessibility label and the markdown-render fallback
+    /// so the two cannot drift apart.
+    private func consentRow(
+        isChecked: Binding<Bool>,
+        markdown: String,
+        plainText: String
+    ) -> some View {
+        HStack(spacing: VSpacing.md) {
+            consentCheckbox(isChecked: isChecked, accessibilityLabel: plainText)
+            consentText(markdown: markdown, fallback: plainText)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Consent Checkbox

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -359,8 +359,7 @@ struct OnboardingFlowView: View {
         let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
         guard tosOk && aiOk else {
             log.info("Managed bootstrap aborted: AI Data Sharing consent missing — bouncing to privacy step")
-            state.isHatching = false
-            state.currentStep = 3
+            state.bounceToConsentStep()
             return
         }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -349,6 +349,21 @@ struct OnboardingFlowView: View {
     /// `activateManagedAssistant()` surface in the same view via the shared
     /// `hatchFailed` / `hatchFailureReason` path that the health-poll uses.
     private func performManagedBootstrap() async {
+        // Apple Guideline 5.1.2(i): AI Data Sharing consent must be explicitly
+        // checked by the user. Bootstrap can be triggered via the auth-change
+        // path (line ~251) which doesn't route through onboarding step 3, so
+        // we re-check consent here as the load-bearing enforcement point.
+        // The HatchingStepView gate remains as defense-in-depth for non-managed
+        // (CLI) hatch flows.
+        let tosOk = UserDefaults.standard.bool(forKey: "tosAccepted")
+        let aiOk = UserDefaults.standard.bool(forKey: "aiDataConsent")
+        guard tosOk && aiOk else {
+            log.info("Managed bootstrap aborted: AI Data Sharing consent missing — bouncing to privacy step")
+            state.isHatching = false
+            state.currentStep = 3
+            return
+        }
+
         log.info("Beginning managed assistant bootstrap")
         state.hasExistingManagedAssistant = false
         state.hatchFailed = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -264,10 +264,19 @@ final class OnboardingState {
     /// bounce and the next consent re-check doesn't leave `onboarding.step`
     /// pointing at the now-aborted hatch step.
     func bounceToConsentStep() {
-        // Mirror HatchingStepView.goBack()'s reset pattern so a subsequent
-        // retry with a different hosting mode doesn't get short-circuited by
-        // stale hatch state (e.g. isManagedHatch=true causing startHatching()
-        // to skip the CLI path).
+        resetHatchTransientState()
+        currentStep = 3
+        if shouldPersist { persist() }
+    }
+
+    /// Clears the hatch-related transient state shared by `bounceToConsentStep()`
+    /// and `HatchingStepView.goBack()`. Both call sites need the same reset
+    /// before allowing a retry — without it, stale flags like `isManagedHatch`
+    /// can short-circuit `startHatching()` (e.g. skipping the CLI path).
+    /// Does NOT touch `hatchCompleted`, `hasHatched`, avatar traits, ToS/AI
+    /// consent, or any non-hatch credentials — see `resetForRetry()` for the
+    /// full reset.
+    func resetHatchTransientState() {
         isHatching = false
         isManagedHatch = false
         hasExistingManagedAssistant = false
@@ -280,8 +289,6 @@ final class OnboardingState {
         hatchTotalSteps = 1
         hatchCurrentStep = 0
         hatchProcessStarted = false
-        currentStep = 3
-        if shouldPersist { persist() }
     }
 
     static func clearPersistedState() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -257,6 +257,33 @@ final class OnboardingState {
         if shouldPersist { persist() }
     }
 
+    /// Bounces the user back to the privacy step (step 3) and clears any
+    /// in-flight hatch state. Used by the consent gates in `HatchingStepView`
+    /// and `performManagedBootstrap` to ensure a clean retry after the user
+    /// re-checks consent. Persists the step write so a force-quit between the
+    /// bounce and the next consent re-check doesn't leave `onboarding.step`
+    /// pointing at the now-aborted hatch step.
+    func bounceToConsentStep() {
+        // Mirror HatchingStepView.goBack()'s reset pattern so a subsequent
+        // retry with a different hosting mode doesn't get short-circuited by
+        // stale hatch state (e.g. isManagedHatch=true causing startHatching()
+        // to skip the CLI path).
+        isHatching = false
+        isManagedHatch = false
+        hasExistingManagedAssistant = false
+        hatchFailed = false
+        hatchFailureReason = nil
+        hatchLogLines = []
+        hatchProgressTarget = 0.0
+        hatchProgressDisplay = 0.0
+        hatchStepLabel = nil
+        hatchTotalSteps = 1
+        hatchCurrentStep = 0
+        hatchProcessStarted = false
+        currentStep = 3
+        if shouldPersist { persist() }
+    }
+
     static func clearPersistedState() {
         for key in ["onboarding.step", "onboarding.name", "onboarding.key", "onboarding.hatched", "onboarding.interviewCompleted", "onboarding.flowVersion", "onboarding.cloudProvider", "onboarding.skippedAPIKeyEntry", "onboarding.selectedHostingMode", "onboarding.variant", "onboarding.firstMeetingCrackProgress"] {
             UserDefaults.standard.removeObject(forKey: key)

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -220,6 +220,10 @@ final class OnboardingState {
         // Reset ToS acceptance so the user must re-accept on re-hatch
         UserDefaults.standard.set(false, forKey: "tosAccepted")
 
+        // Apple Guideline 5.1.2(i): clear AI Data Sharing consent so it must be
+        // explicitly re-checked on the next onboarding pass after a retry.
+        UserDefaults.standard.set(false, forKey: "aiDataConsent")
+
         // Clear API key for whichever provider was selected during onboarding
         let providerToDelete = selectedProvider
         if selectedProvider != "anthropic" {

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
@@ -2,6 +2,8 @@ import VellumAssistantShared
 import XCTest
 @testable import VellumAssistantLib
 
+private let aiConsentMustNotBeClobberedMessage = "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)"
+
 @MainActor
 final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
     private var tempDir: URL!
@@ -19,6 +21,10 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         defaultsSuiteName = "ManagedAssistantConnectionCoordinatorSwitchTests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: defaultsSuiteName)
         defaults.removePersistentDomain(forName: defaultsSuiteName)
+        // Seed `true` so a regression that writes/removes aiDataConsent flips
+        // the AI-consent assertions in tests below. setUp runs after the
+        // per-test UUID suite is created, so each test sees a fresh seed.
+        defaults.set(true, forKey: "aiDataConsent")
     }
 
     override func tearDown() {
@@ -150,8 +156,6 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         let bootstrap = MockBootstrap(
             outcome: .createdNew(PlatformAssistant(id: "managed-activate"))
         )
-        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
-        defaults.set(true, forKey: "aiDataConsent")
 
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: bootstrap,
@@ -171,7 +175,7 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), aiConsentMustNotBeClobberedMessage)
         // With no connection controller, bring-up must be a no-op.
         XCTAssertEqual(controller.teardownCount, 0)
         XCTAssertEqual(controller.bringUpCount, 0)

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
@@ -168,6 +168,7 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
+        XCTAssertFalse(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT auto-accept AI Data Sharing consent (Apple Guideline 5.1.2(i))")
         // With no connection controller, bring-up must be a no-op.
         XCTAssertEqual(controller.teardownCount, 0)
         XCTAssertEqual(controller.bringUpCount, 0)

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorSwitchTests.swift
@@ -150,6 +150,9 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         let bootstrap = MockBootstrap(
             outcome: .createdNew(PlatformAssistant(id: "managed-activate"))
         )
+        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
+        defaults.set(true, forKey: "aiDataConsent")
+
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: bootstrap,
             userDefaults: defaults,
@@ -168,7 +171,7 @@ final class ManagedAssistantConnectionCoordinatorSwitchTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertFalse(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT auto-accept AI Data Sharing consent (Apple Guideline 5.1.2(i))")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
         // With no connection controller, bring-up must be a no-op.
         XCTAssertEqual(controller.teardownCount, 0)
         XCTAssertEqual(controller.bringUpCount, 0)

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -40,6 +40,9 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         )
         var taggedAssistantId: String?
 
+        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
+        defaults.set(true, forKey: "aiDataConsent")
+
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: bootstrapService,
             userDefaults: defaults,
@@ -60,7 +63,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertFalse(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT auto-accept AI Data Sharing consent (Apple Guideline 5.1.2(i))")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
         XCTAssertEqual(taggedAssistantId, assistant.id)
 
         let data = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
@@ -75,6 +78,8 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
     func testActivateManagedAssistantPreservesExistingPrivacyOptOuts() async throws {
         defaults.set(false, forKey: "collectUsageData")
         defaults.set(false, forKey: "sendDiagnostics")
+        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
+        defaults.set(true, forKey: "aiDataConsent")
 
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: MockManagedAssistantBootstrapService(
@@ -92,7 +97,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertFalse(defaults.bool(forKey: "collectUsageData"))
         XCTAssertFalse(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertFalse(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT auto-accept AI Data Sharing consent (Apple Guideline 5.1.2(i))")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
     }
 
     func testActivateManagedAssistantRePopulatesOrgIdAfterCleared() async throws {

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -60,6 +60,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
+        XCTAssertFalse(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT auto-accept AI Data Sharing consent (Apple Guideline 5.1.2(i))")
         XCTAssertEqual(taggedAssistantId, assistant.id)
 
         let data = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
@@ -91,6 +92,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertFalse(defaults.bool(forKey: "collectUsageData"))
         XCTAssertFalse(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
+        XCTAssertFalse(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT auto-accept AI Data Sharing consent (Apple Guideline 5.1.2(i))")
     }
 
     func testActivateManagedAssistantRePopulatesOrgIdAfterCleared() async throws {

--- a/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedAssistantConnectionCoordinatorTests.swift
@@ -2,6 +2,8 @@ import VellumAssistantShared
 import XCTest
 @testable import VellumAssistantLib
 
+private let aiConsentMustNotBeClobberedMessage = "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)"
+
 @MainActor
 final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
     private var tempDir: URL!
@@ -19,6 +21,10 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         defaultsSuiteName = "ManagedAssistantConnectionCoordinatorTests.\(UUID().uuidString)"
         defaults = UserDefaults(suiteName: defaultsSuiteName)
         defaults.removePersistentDomain(forName: defaultsSuiteName)
+        // Seed `true` so a regression that writes/removes aiDataConsent flips
+        // the AI-consent assertions in tests below. setUp runs after the
+        // per-test UUID suite is created, so each test sees a fresh seed.
+        defaults.set(true, forKey: "aiDataConsent")
     }
 
     override func tearDown() {
@@ -40,9 +46,6 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         )
         var taggedAssistantId: String?
 
-        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
-        defaults.set(true, forKey: "aiDataConsent")
-
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: bootstrapService,
             userDefaults: defaults,
@@ -63,7 +66,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: "collectUsageData"))
         XCTAssertTrue(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), aiConsentMustNotBeClobberedMessage)
         XCTAssertEqual(taggedAssistantId, assistant.id)
 
         let data = try Data(contentsOf: URL(fileURLWithPath: lockfilePath))
@@ -78,8 +81,6 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
     func testActivateManagedAssistantPreservesExistingPrivacyOptOuts() async throws {
         defaults.set(false, forKey: "collectUsageData")
         defaults.set(false, forKey: "sendDiagnostics")
-        // Seed `true` so a regression that writes/removes aiDataConsent flips the assertion below.
-        defaults.set(true, forKey: "aiDataConsent")
 
         let coordinator = ManagedAssistantConnectionCoordinator(
             bootstrapService: MockManagedAssistantBootstrapService(
@@ -97,7 +98,7 @@ final class ManagedAssistantConnectionCoordinatorTests: XCTestCase {
         XCTAssertFalse(defaults.bool(forKey: "collectUsageData"))
         XCTAssertFalse(defaults.bool(forKey: "sendDiagnostics"))
         XCTAssertTrue(defaults.bool(forKey: "tosAccepted"))
-        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), "Managed coordinator must NOT clobber AI Data Sharing consent (Apple Guideline 5.1.2(i) — must remain user-controlled)")
+        XCTAssertTrue(defaults.bool(forKey: "aiDataConsent"), aiConsentMustNotBeClobberedMessage)
     }
 
     func testActivateManagedAssistantRePopulatesOrgIdAfterCleared() async throws {


### PR DESCRIPTION
## Summary

Adds an explicit "I agree to the AI Data Sharing Policy" checkbox to the macOS onboarding privacy step, consolidates the share-preferences UI into a single card matching the web UI in `vellum-assistant-platform`, gates hatching on explicit AI consent at two enforcement points, and clears AI consent on full retire. Satisfies Apple Guideline 5.1.2(i): AI data consent must be explicit and specific, never bundled with ToS or auto-accepted in code.

Reference web component: `vellum-assistant-platform/web/src/app/(app)/assistant/onboarding/privacy/PrivacyScreen.tsx`.

## Self-review result

Pass 2 (plan faithfulness) and Pass 3 (repo integration) both **PASS** after one round of gap remediation + one round of polish refactors. Pass 4 (slop/reuse) has remaining stylistic findings (Apple Guideline citation count, gate-read pattern duplication) deemed non-blocking.

## PRs merged into feature branch

**Feature implementation (Waves 1–3):**
- #29162: feat(onboarding): add AppURLs.dataSharingDocs for AI data sharing policy
- #29163: refactor(onboarding): combine share preferences and privacy note into single card
- #29164: feat(onboarding): add AI Data Sharing consent checkbox (Apple 5.1.2(i))
- #29183: feat(onboarding): gate hatching on explicit AI data consent (includes 2 in-PR fix commits addressing a Codex P1 bypass via `performManagedBootstrap` and a Devin edge case around residual hatch state)
- #29184: feat(auth): clear AI data consent on assistant retire

**Self-review remediation (round 1):**
- #29189: fix(onboarding): hide decorative dividers from VoiceOver + extract shared consent text helper
- #29190: fix(onboarding): extract shared consent-bounce helper that persists step write
- #29191: test: strengthen aiDataConsent preservation assertions

**Polish (round 2):**
- #29197: refactor(onboarding): consolidate consent row, hatch reset, test seed boilerplate

## Out of scope (deferred to follow-up PRs)

- Backfilling AI consent for existing users who already finished onboarding (separate follow-up PR)
- `SettingsPrivacyTab.swift` parity for AI consent revocation
- Re-consent on logout/re-login (current behavior: consent persists across logout, cleared on full retire — matches web)
- Promoting consent checkbox to a `VCheckbox` design-system component
- `clients/AGENTS.md` decorative-icon a11y review beyond `Divider()`

Part of plan: `.private/plans/onboarding-ai-consent.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
