### PR TITLE
refactor(migrations): add vbundle-import-policy module (constants + predicates)

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the pure policy module shared by both vbundle importers.
+ *
+ * No `node:fs`, no temp dirs — every test exercises a constant or a
+ * predicate over strings.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONFIG_ARCHIVE_PATHS,
+  CREDENTIAL_METADATA_ARCHIVE_PATH,
+  isCarryForwardRelPath,
+  isConfigArchivePath,
+  isCredentialMetadataArchivePath,
+  isLegacyPersonaArchivePath,
+  isWorkspaceNamespacedArchivePath,
+  LEGACY_USER_MD_ARCHIVE_PATH,
+  partitionWorkspacePreserveSkipDirs,
+  WORKSPACE_PRESERVE_PATHS,
+} from "../vbundle-import-policy.js";
+
+describe("LEGACY_USER_MD_ARCHIVE_PATH", () => {
+  test("equals the legacy guardian persona archive path", () => {
+    expect(LEGACY_USER_MD_ARCHIVE_PATH).toBe("prompts/USER.md");
+  });
+});
+
+describe("CONFIG_ARCHIVE_PATHS", () => {
+  test("contains exactly the two known config archive paths", () => {
+    expect(CONFIG_ARCHIVE_PATHS.size).toBe(2);
+    expect(CONFIG_ARCHIVE_PATHS.has("workspace/config.json")).toBe(true);
+    expect(CONFIG_ARCHIVE_PATHS.has("config/settings.json")).toBe(true);
+  });
+});
+
+describe("CREDENTIAL_METADATA_ARCHIVE_PATH", () => {
+  test("equals the workspace-namespaced credential metadata path", () => {
+    expect(CREDENTIAL_METADATA_ARCHIVE_PATH).toBe(
+      "workspace/data/credentials/metadata.json",
+    );
+  });
+});
+
+describe("WORKSPACE_PRESERVE_PATHS", () => {
+  test("matches the literal 4-element ordered list", () => {
+    expect(WORKSPACE_PRESERVE_PATHS).toEqual([
+      "embedding-models",
+      "deprecated",
+      "data/db",
+      "data/qdrant",
+    ]);
+  });
+});
+
+describe("isWorkspaceNamespacedArchivePath", () => {
+  test("true for paths under workspace/", () => {
+    expect(isWorkspaceNamespacedArchivePath("workspace/foo")).toBe(true);
+    expect(isWorkspaceNamespacedArchivePath("workspace/data/db/x")).toBe(true);
+  });
+
+  test("false for non-workspace paths", () => {
+    expect(isWorkspaceNamespacedArchivePath("prompts/USER.md")).toBe(false);
+    expect(isWorkspaceNamespacedArchivePath("data/db/assistant.db")).toBe(
+      false,
+    );
+    expect(isWorkspaceNamespacedArchivePath("")).toBe(false);
+    expect(isWorkspaceNamespacedArchivePath("workspace")).toBe(false);
+  });
+});
+
+describe("isLegacyPersonaArchivePath", () => {
+  test("true only for the exact legacy path", () => {
+    expect(isLegacyPersonaArchivePath("prompts/USER.md")).toBe(true);
+  });
+
+  test("false for near-misses and unrelated paths", () => {
+    expect(isLegacyPersonaArchivePath("prompts/USER")).toBe(false);
+    expect(isLegacyPersonaArchivePath("workspace/prompts/USER.md")).toBe(false);
+    expect(isLegacyPersonaArchivePath("")).toBe(false);
+  });
+});
+
+describe("isConfigArchivePath", () => {
+  test("true for both members of CONFIG_ARCHIVE_PATHS", () => {
+    expect(isConfigArchivePath("workspace/config.json")).toBe(true);
+    expect(isConfigArchivePath("config/settings.json")).toBe(true);
+  });
+
+  test("false for non-members", () => {
+    expect(isConfigArchivePath("workspace/foo.json")).toBe(false);
+    expect(isConfigArchivePath("config/settings")).toBe(false);
+    expect(isConfigArchivePath("")).toBe(false);
+  });
+});
+
+describe("isCredentialMetadataArchivePath", () => {
+  test("true for the exact constant", () => {
+    expect(
+      isCredentialMetadataArchivePath(
+        "workspace/data/credentials/metadata.json",
+      ),
+    ).toBe(true);
+  });
+
+  test("false for the legacy non-prefixed form and empty string", () => {
+    expect(
+      isCredentialMetadataArchivePath("data/credentials/metadata.json"),
+    ).toBe(false);
+    expect(isCredentialMetadataArchivePath("")).toBe(false);
+  });
+});
+
+describe("isCarryForwardRelPath", () => {
+  test("true for each preserve-path", () => {
+    expect(isCarryForwardRelPath("embedding-models")).toBe(true);
+    expect(isCarryForwardRelPath("deprecated")).toBe(true);
+    expect(isCarryForwardRelPath("data/db")).toBe(true);
+    expect(isCarryForwardRelPath("data/qdrant")).toBe(true);
+  });
+
+  test("false for parents, descendants, unrelated, and empty", () => {
+    expect(isCarryForwardRelPath("data")).toBe(false);
+    expect(isCarryForwardRelPath("data/db/foo")).toBe(false);
+    expect(isCarryForwardRelPath("random")).toBe(false);
+    expect(isCarryForwardRelPath("")).toBe(false);
+  });
+});
+
+describe("partitionWorkspacePreserveSkipDirs", () => {
+  test("splits preserve-paths into top-level vs data-subdir skip sets", () => {
+    const { topLevelSkipDirs, dataSubdirSkipDirs } =
+      partitionWorkspacePreserveSkipDirs();
+
+    expect(topLevelSkipDirs.size).toBe(2);
+    expect(topLevelSkipDirs.has("embedding-models")).toBe(true);
+    expect(topLevelSkipDirs.has("deprecated")).toBe(true);
+
+    expect(dataSubdirSkipDirs.size).toBe(2);
+    expect(dataSubdirSkipDirs.has("db")).toBe(true);
+    expect(dataSubdirSkipDirs.has("qdrant")).toBe(true);
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared invariants and predicate functions consumed by both the buffer-
+ * based `commitImport` and the streaming `streamCommitImport`. These
+ * decisions must stay in lockstep across both importers — moving them
+ * here removes the parallel-implementation skew risk that would otherwise
+ * grow as either importer evolves.
+ *
+ * Pure: no `node:fs`, no I/O, no async. Functions over strings + manifest
+ * data shapes only.
+ */
+
+export const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
+
+export const CONFIG_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
+  "workspace/config.json",
+  "config/settings.json",
+]);
+
+export const CREDENTIAL_METADATA_ARCHIVE_PATH =
+  "workspace/data/credentials/metadata.json";
+
+export const WORKSPACE_PRESERVE_PATHS: readonly string[] = [
+  "embedding-models",
+  "deprecated",
+  "data/db",
+  "data/qdrant",
+];
+
+export function isWorkspaceNamespacedArchivePath(archivePath: string): boolean {
+  return archivePath.startsWith("workspace/");
+}
+
+export function isLegacyPersonaArchivePath(archivePath: string): boolean {
+  return archivePath === LEGACY_USER_MD_ARCHIVE_PATH;
+}
+
+export function isConfigArchivePath(archivePath: string): boolean {
+  return CONFIG_ARCHIVE_PATHS.has(archivePath);
+}
+
+export function isCredentialMetadataArchivePath(archivePath: string): boolean {
+  return archivePath === CREDENTIAL_METADATA_ARCHIVE_PATH;
+}
+
+export function isCarryForwardRelPath(relPath: string): boolean {
+  return WORKSPACE_PRESERVE_PATHS.includes(relPath);
+}
+
+export interface WorkspacePreserveSkipDirs {
+  topLevelSkipDirs: ReadonlySet<string>;
+  dataSubdirSkipDirs: ReadonlySet<string>;
+}
+
+/**
+ * Partition `WORKSPACE_PRESERVE_PATHS` into the two skip sets the buffer
+ * importer's selective-clear loop consumes:
+ *
+ * - `topLevelSkipDirs`: single-segment preserve-paths (e.g. "embedding-models").
+ * - `dataSubdirSkipDirs`: second segment of `data/<x>` preserve-paths
+ *   (e.g. "db" for "data/db").
+ *
+ * Stays in sync with WORKSPACE_PRESERVE_PATHS automatically — adding a
+ * new entry of either shape doesn't require touching the buffer importer.
+ * Multi-segment paths outside the `data/` subtree are intentionally
+ * unsupported here; the buffer importer's walk doesn't recurse into
+ * arbitrary subdirs. If a future preserve-path needs deeper coverage,
+ * widen this helper and the buffer importer's walk together.
+ */
+export function partitionWorkspacePreserveSkipDirs(): WorkspacePreserveSkipDirs {
+  const topLevelSkipDirs = new Set<string>();
+  const dataSubdirSkipDirs = new Set<string>();
+  for (const rel of WORKSPACE_PRESERVE_PATHS) {
+    const parts = rel.split("/");
+    if (parts.length === 1) {
+      topLevelSkipDirs.add(parts[0]!);
+    } else if (parts.length === 2 && parts[0] === "data") {
+      dataSubdirSkipDirs.add(parts[1]!);
+    }
+  }
+  return { topLevelSkipDirs, dataSubdirSkipDirs };
+}

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -28,59 +28,20 @@ import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
+import * as policy from "./vbundle-import-policy.js";
 import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
 
+// Re-export shared policy constants so `vbundle-streaming-importer.ts`
+// (and any other historical consumer) keeps compiling unchanged while
+// the policy module owns the source of truth. PR 5 will drop these
+// shims once both importers import directly from the policy module.
+export const LEGACY_USER_MD_ARCHIVE_PATH = policy.LEGACY_USER_MD_ARCHIVE_PATH;
+export const CONFIG_ARCHIVE_PATHS = policy.CONFIG_ARCHIVE_PATHS;
+export const WORKSPACE_PRESERVE_PATHS = policy.WORKSPACE_PRESERVE_PATHS;
+
 const log = getLogger("vbundle-importer");
-
-/** Archive path for the legacy guardian user persona file. */
-export const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
-
-/**
- * Archive paths recognized as JSON config files that must be run through
- * `sanitizeConfigForTransfer` before writing to disk. Exported so the
- * streaming importer can apply the same defense-in-depth treatment.
- */
-export const CONFIG_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
-  "workspace/config.json",
-  "config/settings.json",
-]);
-
-/**
- * Archive path for the credential metadata file. On import, bundle contents
- * must be merged with the target's live `vellum:*` entries so the gateway's
- * `readServiceCredentials` can still locate the platform API key after a
- * local→platform teleport. Both importers consult this constant.
- */
-const CREDENTIAL_METADATA_ARCHIVE_PATH =
-  "workspace/data/credentials/metadata.json";
-
-/**
- * Paths inside the workspace directory that must be preserved across an
- * import when the bundle does not carry entries for them.
- *
- * Each entry is a path RELATIVE to the workspace root. Two kinds of live
- * data warrant carry-over:
- *
- * - `embedding-models` / `deprecated`: large local caches / quarantine
- *   directories that are never shipped inside bundles but are expensive
- *   or impossible to reconstruct from an import.
- * - `data/db` / `data/qdrant`: user-critical state (SQLite assistant DB;
- *   Qdrant vector store). If the bundle omits them — e.g. a partial
- *   bundle covering only prompts/config — the live copies must survive.
- *
- * Both the buffer-based `commitImport` (which selectively clears the
- * workspace in place) and the streaming importer (which swaps the
- * workspace with a freshly-populated temp tree) consult this list so
- * their behavior stays in sync.
- */
-export const WORKSPACE_PRESERVE_PATHS: readonly string[] = [
-  "embedding-models",
-  "deprecated",
-  "data/db",
-  "data/qdrant",
-];
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -222,7 +183,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // carry-over logic and this in-place clear stay in sync.
   const WORKSPACE_SKIP_DIRS = new Set<string>();
   const DATA_SKIP_DIRS = new Set<string>();
-  for (const rel of WORKSPACE_PRESERVE_PATHS) {
+  for (const rel of policy.WORKSPACE_PRESERVE_PATHS) {
     const parts = rel.split("/");
     if (parts.length === 1) {
       WORKSPACE_SKIP_DIRS.add(parts[0]);
@@ -257,7 +218,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // (`vellum:*`) entries across the overwrite.
   let liveCredentialMetadataJson: string | null = null;
   const credentialMetadataDiskPath = pathResolver.resolve(
-    CREDENTIAL_METADATA_ARCHIVE_PATH,
+    policy.CREDENTIAL_METADATA_ARCHIVE_PATH,
   );
   if (credentialMetadataDiskPath && existsSync(credentialMetadataDiskPath)) {
     try {
@@ -450,7 +411,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     // would wipe them and break the gateway's vellum credential read.
     // We use the snapshot captured BEFORE the workspace clear because
     // Step 1b may have already removed the live file.
-    if (fileEntry.path === CREDENTIAL_METADATA_ARCHIVE_PATH) {
+    if (fileEntry.path === policy.CREDENTIAL_METADATA_ARCHIVE_PATH) {
       const bundleJson = new TextDecoder().decode(archiveEntry.data);
       const merged = mergeMetadataPreservingVellum(
         bundleJson,
@@ -537,7 +498,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // disk untouched — we must not rewrite it here or we would drop the
   // non-vellum entries the caller chose to keep.
   const bundleHadMetadata = manifest.contents.some(
-    (f) => f.path === CREDENTIAL_METADATA_ARCHIVE_PATH,
+    (f) => f.path === policy.CREDENTIAL_METADATA_ARCHIVE_PATH,
   );
   if (
     workspaceWasCleared &&

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -33,10 +33,9 @@ import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
 
-// Re-export shared policy constants so `vbundle-streaming-importer.ts`
-// (and any other historical consumer) keeps compiling unchanged while
-// the policy module owns the source of truth. PR 5 will drop these
-// shims once both importers import directly from the policy module.
+// Re-exported so consumers that import these constants from this module
+// (e.g. `vbundle-streaming-importer.ts`) keep compiling. The policy
+// module owns the source of truth.
 export const LEGACY_USER_MD_ARCHIVE_PATH = policy.LEGACY_USER_MD_ARCHIVE_PATH;
 export const CONFIG_ARCHIVE_PATHS = policy.CONFIG_ARCHIVE_PATHS;
 export const WORKSPACE_PRESERVE_PATHS = policy.WORKSPACE_PRESERVE_PATHS;


### PR DESCRIPTION
## Summary
- Adds `vbundle-import-policy.ts` with 4 shared constants, 5 predicate functions, and 1 partition helper. Pure module, no I/O.
- `vbundle-importer.ts` now imports from policy and re-exports the three constants the streaming importer consumes — temporary shim, removed in PR 5.
- Adds focused unit tests for every policy export.
- No predicate call sites changed yet; PRs 3 and 4 migrate the importers.

Part of plan: vbundle-import-policy.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
