### PR TITLE
refactor(vbundle): introduce optional symlink fields on entry/manifest/tar header types

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-validator-v1-schema.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-validator-v1-schema.test.ts
@@ -19,9 +19,10 @@ import {
   canonicalizeJson,
   computeLegacyManifestSha256,
   computeManifestChecksum,
+  ManifestSchema,
   validateVBundle,
 } from "../vbundle-validator.js";
-import { defaultV1Options } from "./v1-test-helpers.js";
+import { buildTestManifest, defaultV1Options } from "./v1-test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Tar helpers — minimum-viable to wrap a manifest object into a vbundle.
@@ -350,6 +351,55 @@ describe("ManifestSchema — legacy fallback (backwards compatibility)", () => {
     expect(result.errors.some((e) => e.code === "FILE_CHECKSUM_MISMATCH")).toBe(
       true,
     );
+  });
+});
+
+describe("ManifestFileEntry — link_target field", () => {
+  test("accepts manifest entry with link_target", () => {
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: sha256Hex(DB_BYTES),
+          size_bytes: 1,
+          link_target: "bar.md",
+        },
+      ],
+    });
+    const result = ManifestSchema.safeParse(manifest);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contents[0]?.link_target).toBe("bar.md");
+    }
+  });
+
+  test("accepts manifest entry without link_target (backwards-compat)", () => {
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: sha256Hex(DB_BYTES),
+          size_bytes: 1,
+        },
+      ],
+    });
+    const result = ManifestSchema.safeParse(manifest);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects manifest entry with empty link_target", () => {
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: sha256Hex(DB_BYTES),
+          size_bytes: 1,
+          link_target: "",
+        },
+      ],
+    });
+    const result = ManifestSchema.safeParse(manifest);
+    expect(result.success).toBe(false);
   });
 });
 

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -41,6 +41,8 @@ import type {
 export interface VBundleFileEntry {
   path: string;
   data: Uint8Array;
+  /** When set, `data` is ignored: the entry is emitted as a tar typeflag-2 (symlink) record with empty body, and `linkTarget` is the symlink target encoded relative to the symlink's own directory inside the archive. */
+  linkTarget?: string;
 }
 
 /** v1 manifest `assistant` block. */
@@ -109,11 +111,22 @@ interface InMemoryEntry {
   size: number;
 }
 
-/** Union of disk-backed and in-memory tar stream entries. */
-type TarStreamEntry = FileMetadata | InMemoryEntry;
+/** Symlink entry — emitted as a tar typeflag-2 record with empty body. */
+interface SymlinkMetadata {
+  archivePath: string;
+  linkTarget: string;
+  size: 0;
+}
+
+/** Union of disk-backed, in-memory, and symlink tar stream entries. */
+type TarStreamEntry = FileMetadata | InMemoryEntry | SymlinkMetadata;
 
 function isInMemoryEntry(entry: TarStreamEntry): entry is InMemoryEntry {
   return "data" in entry;
+}
+
+function isSymlinkEntry(entry: TarStreamEntry): entry is SymlinkMetadata {
+  return "linkTarget" in entry;
 }
 
 // ---------------------------------------------------------------------------
@@ -791,10 +804,12 @@ async function* generateTarStream(
 
   // File entries
   for (const file of files) {
-    const entrySize = isInMemoryEntry(file) ? file.size : file.size;
+    const entrySize = file.size;
     yield createPaxAndHeaderBlocks(file.archivePath, entrySize);
 
-    if (isInMemoryEntry(file)) {
+    if (isSymlinkEntry(file)) {
+      // Symlink entry — empty body; the link target lives in the tar header.
+    } else if (isInMemoryEntry(file)) {
       // In-memory entry — yield data directly
       if (file.size > 0) {
         yield file.data;

--- a/assistant/src/runtime/migrations/vbundle-tar-stream.ts
+++ b/assistant/src/runtime/migrations/vbundle-tar-stream.ts
@@ -25,7 +25,9 @@ import { extract as tarExtract } from "tar-stream";
 export interface StreamedTarHeader {
   name: string;
   size: number;
-  type: "file" | "directory" | "pax-header" | "other";
+  type: "file" | "directory" | "pax-header" | "symlink" | "other";
+  /** Populated only when `type === "symlink"`; the symlink's target string from the tar header. */
+  linkname?: string;
 }
 
 export interface StreamedTarEntry {
@@ -57,6 +59,8 @@ function normalizeHeaderType(
       return "directory";
     case "pax-header":
       return "pax-header";
+    case "symlink":
+      return "symlink";
     default:
       return "other";
   }
@@ -125,12 +129,17 @@ export async function* parseVBundleStream(
     // Avoid unhandled "error" on body streams destroyed mid-flight; the
     // extractor itself propagates the real error to its "error" listener.
     body.on("error", () => {});
+    const normalizedType = normalizeHeaderType(header.type);
+    const surfaced: StreamedTarHeader = {
+      name: header.name,
+      size: header.size,
+      type: normalizedType,
+    };
+    if (normalizedType === "symlink" && header.linkname) {
+      surfaced.linkname = header.linkname;
+    }
     pushEntry({
-      header: {
-        name: header.name,
-        size: header.size,
-        type: normalizeHeaderType(header.type),
-      },
+      header: surfaced,
       body,
       next,
     });

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -26,6 +26,7 @@ const ManifestFileEntry = z.object({
   path: z.string().min(1),
   sha256: z.string().regex(/^[0-9a-f]{64}$/),
   size_bytes: z.number().int().nonnegative(),
+  link_target: z.string().min(1).optional(),
 });
 
 const AssistantInfo = z.object({


### PR DESCRIPTION
## Summary
- Add optional `linkTarget` to `VBundleFileEntry` and a `SymlinkMetadata` variant for the streaming tar entry union
- Add optional `link_target` to the v1 manifest `ManifestFileEntry` schema (backwards-compat with bundles that don't carry symlinks)
- Extend `StreamedTarHeader` with a `"symlink"` type and optional `linkname` for the streaming tar parser

No behavior change yet — these types are consumed by PRs 2 onward.

Part of plan: vbundle-symlinks.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
