### PR TITLE
fix(macos): eliminate unused assistantId binding warnings in SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1372,7 +1372,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func fetchSlackChannelConfig() {
-        guard let assistantId = cachedAssistantId else { return }
+        guard cachedAssistantId != nil else { return }
         Task {
             do {
                 let (config, response): (SlackChannelConfigResponse?, _) = try await GatewayHTTPClient.get(
@@ -1409,7 +1409,7 @@ public final class SettingsStore: ObservableObject {
         guard !trimmedBot.isEmpty, !trimmedApp.isEmpty else { return }
         slackChannelSaveInProgress = true
         slackChannelError = nil
-        guard let assistantId = cachedAssistantId else {
+        guard cachedAssistantId != nil else {
             slackChannelSaveInProgress = false
             return
         }
@@ -1461,7 +1461,7 @@ public final class SettingsStore: ObservableObject {
     func clearSlackChannelConfig() {
         slackChannelSaveInProgress = true
         slackChannelError = nil
-        guard let assistantId = cachedAssistantId else {
+        guard cachedAssistantId != nil else {
             slackChannelSaveInProgress = false
             return
         }
@@ -1505,7 +1505,7 @@ public final class SettingsStore: ObservableObject {
         applyPhoneNumber: Bool = false,
         applyNumbers: Bool = false
     ) async {
-        guard let assistantId = cachedAssistantId else {
+        guard cachedAssistantId != nil else {
             twilioError = "No connected assistant"
             return
         }


### PR DESCRIPTION
## Summary
- Replace `guard let assistantId = cachedAssistantId` with `guard cachedAssistantId != nil` in four functions (`fetchSlackChannelConfig`, `saveSlackChannelConfig`, `clearSlackChannelConfig`, `performTwilioHTTPRequest`) where the bound value was never used
- Eliminates 5 Swift `#no-usage` build warnings

## Original prompt
Fix mac build warnings: value 'assistantId' was defined but never used in SettingsStore.swift at lines 1375, 1412, 1464, and 1508.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
