### PR TITLE
chore(migrations): drop transitional re-export shims from vbundle-importer

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -33,13 +33,6 @@ import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
 
-// Re-exported so consumers that import these constants from this module
-// (e.g. `vbundle-streaming-importer.ts`) keep compiling. The policy
-// module owns the source of truth.
-export const LEGACY_USER_MD_ARCHIVE_PATH = policy.LEGACY_USER_MD_ARCHIVE_PATH;
-export const CONFIG_ARCHIVE_PATHS = policy.CONFIG_ARCHIVE_PATHS;
-export const WORKSPACE_PRESERVE_PATHS = policy.WORKSPACE_PRESERVE_PATHS;
-
 const log = getLogger("vbundle-importer");
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes the three transitional re-exports from `vbundle-importer.ts`. The policy module is the single source of truth for the four shared constants.
- Both importers now consume `vbundle-import-policy.ts` directly.

Part of plan: vbundle-import-policy.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
