### PR TITLE
refactor(migrations): drop unused policy scaffolding

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, test } from "bun:test";
 import {
   CONFIG_ARCHIVE_PATHS,
   CREDENTIAL_METADATA_ARCHIVE_PATH,
-  isCarryForwardRelPath,
   isConfigArchivePath,
   isCredentialMetadataArchivePath,
   isLegacyPersonaArchivePath,
@@ -108,22 +107,6 @@ describe("isCredentialMetadataArchivePath", () => {
       isCredentialMetadataArchivePath("data/credentials/metadata.json"),
     ).toBe(false);
     expect(isCredentialMetadataArchivePath("")).toBe(false);
-  });
-});
-
-describe("isCarryForwardRelPath", () => {
-  test("true for each preserve-path", () => {
-    expect(isCarryForwardRelPath("embedding-models")).toBe(true);
-    expect(isCarryForwardRelPath("deprecated")).toBe(true);
-    expect(isCarryForwardRelPath("data/db")).toBe(true);
-    expect(isCarryForwardRelPath("data/qdrant")).toBe(true);
-  });
-
-  test("false for parents, descendants, unrelated, and empty", () => {
-    expect(isCarryForwardRelPath("data")).toBe(false);
-    expect(isCarryForwardRelPath("data/db/foo")).toBe(false);
-    expect(isCarryForwardRelPath("random")).toBe(false);
-    expect(isCarryForwardRelPath("")).toBe(false);
   });
 });
 

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -42,15 +42,6 @@ export function isCredentialMetadataArchivePath(archivePath: string): boolean {
   return archivePath === CREDENTIAL_METADATA_ARCHIVE_PATH;
 }
 
-export function isCarryForwardRelPath(relPath: string): boolean {
-  return WORKSPACE_PRESERVE_PATHS.includes(relPath);
-}
-
-export interface WorkspacePreserveSkipDirs {
-  topLevelSkipDirs: ReadonlySet<string>;
-  dataSubdirSkipDirs: ReadonlySet<string>;
-}
-
 /**
  * Partition `WORKSPACE_PRESERVE_PATHS` into the two skip sets the buffer
  * importer's selective-clear loop consumes:
@@ -66,7 +57,10 @@ export interface WorkspacePreserveSkipDirs {
  * arbitrary subdirs. If a future preserve-path needs deeper coverage,
  * widen this helper and the buffer importer's walk together.
  */
-export function partitionWorkspacePreserveSkipDirs(): WorkspacePreserveSkipDirs {
+export function partitionWorkspacePreserveSkipDirs(): {
+  topLevelSkipDirs: ReadonlySet<string>;
+  dataSubdirSkipDirs: ReadonlySet<string>;
+} {
   const topLevelSkipDirs = new Set<string>();
   const dataSubdirSkipDirs = new Set<string>();
   for (const rel of WORKSPACE_PRESERVE_PATHS) {


### PR DESCRIPTION
## Summary
Self-review found two unused exports in `vbundle-import-policy.ts`:

- `isCarryForwardRelPath` — predicate exported and unit-tested but no production caller. Both importers iterate `WORKSPACE_PRESERVE_PATHS` directly or via `partitionWorkspacePreserveSkipDirs()` instead.
- `WorkspacePreserveSkipDirs` interface — named return type that no consumer imports by name. Inlined.

Pure deletion. No production behavior change. All existing tests pass.

Fixes gap identified during plan review for vbundle-import-policy.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
