### PR TITLE
Cherry-pick fixes onto release/v0.7.1

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -52,10 +52,10 @@ struct InferenceServiceCard: View {
     /// Whether the API keys management sheet is presented.
     @State private var showAPIKeysSheet = false
     /// Per-provider key-exists status. Loaded async on appear and refreshed
-    /// after the API keys sheet is dismissed.
-    /// Tri-state key status per provider: `true` = key present, `false` = key absent,
-    /// `nil` = not yet loaded or fetch failed. `nil` is treated as "unknown" so a
-    /// transient daemon error never triggers the auto-reset to managed mode.
+    /// after the API keys sheet is dismissed. Used to drive `hasUsableProvider`
+    /// and the API keys section summary.
+    /// Tri-state: `true` = key present, `false` = key absent, `nil` = not yet
+    /// loaded or fetch failed.
     @State private var providerKeyStatuses: [String: Bool?] = [:]
     /// Monotonically increasing counter bumped every time the API keys
     /// sheet is dismissed. Drives `.task(id:)` to re-fetch key statuses
@@ -184,20 +184,6 @@ struct InferenceServiceCard: View {
         }
         .task(id: apiKeysRefreshToken) {
             await loadProviderKeyStatuses()
-            guard !Task.isCancelled else { return }
-            let requiresKey = store.dynamicProviderApiKeyPlaceholder(draftProvider) != nil
-            let isManagedCapable = store.isManagedCapable(draftProvider)
-            // Flatten Bool?? → Bool? so nil-valued entries (fetch error) compare
-            // as truly unknown rather than as a present-but-nil outer optional.
-            // A [String: Bool?] subscript returns Bool?? where .some(.none) means
-            // "key exists in dict, value is nil" — `?? nil` collapses that to nil.
-            let flatStatus = providerKeyStatuses[draftProvider] ?? nil
-            let keyStatusKnown = flatStatus != nil
-            let hasConfiguredKey = flatStatus == true
-            if isLoggedIn && draftMode == "your-own" && isManagedCapable && requiresKey && keyStatusKnown && !hasConfiguredKey {
-                draftMode = "managed"
-                store.setInferenceMode("managed")
-            }
         }
         .onAppear {
             draftMode = store.inferenceMode
@@ -217,9 +203,8 @@ struct InferenceServiceCard: View {
                 }
             }
 
-            // The task(id: apiKeysRefreshToken) block handles the "logged-in +
-            // your-own + no key configured" auto-reset using daemon-sourced
-            // key statuses. The task fires automatically on initial appearance.
+            // The task(id: apiKeysRefreshToken) fires automatically on
+            // initial appearance to populate providerKeyStatuses.
         }
         .onChange(of: store.inferenceMode) { _, newValue in
             // Sync draft when external changes arrive (e.g. daemon reload),
@@ -243,8 +228,8 @@ struct InferenceServiceCard: View {
                 // mode that onAppear may have temporarily overridden.
                 draftMode = "managed"
             } else if isAuthenticated && store.inferenceMode == "your-own" {
-                // Trigger the task to re-fetch daemon-sourced key statuses and
-                // apply the auto-reset check with accurate data.
+                // Re-fetch key statuses now that auth is available so
+                // hasUsableProvider and the API keys section reflect reality.
                 apiKeysRefreshToken += 1
             }
         }

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedInferenceSelectionTests.swift
@@ -236,36 +236,6 @@ final class SettingsStoreManagedInferenceSelectionTests: XCTestCase {
         XCTAssertFalse(store.isNativeWebSearchCapable("openrouter", model: "openai/gpt-5"))
     }
 
-    // MARK: - BYOK Auto-Reset Condition
-
-    func testAutoResetDoesNotFireWhenDaemonReportsKeyConfigured() {
-        // Verify the task-block auto-reset condition for gemini in "your-own"
-        // mode when the daemon reports a key is configured. The reset guard
-        // evaluates !hasConfiguredKey, so the reset must NOT fire here.
-        let requiresKey = store.dynamicProviderApiKeyPlaceholder("gemini") != nil
-        let isManagedCapable = store.isManagedCapable("gemini")
-        let hasConfiguredKey = true  // daemon reports key present
-
-        XCTAssertTrue(requiresKey, "gemini requires an API key")
-        XCTAssertTrue(isManagedCapable, "gemini supports managed mode")
-
-        let wouldResetToManaged = isManagedCapable && requiresKey && !hasConfiguredKey
-        XCTAssertFalse(wouldResetToManaged,
-            "auto-reset must not fire when daemon reports key is configured")
-    }
-
-    func testAutoResetFiresWhenDaemonReportsNoKeyConfigured() {
-        // Verify the task-block auto-reset condition fires when the daemon
-        // reports no key is configured for a managed-capable, key-required provider.
-        let requiresKey = store.dynamicProviderApiKeyPlaceholder("gemini") != nil
-        let isManagedCapable = store.isManagedCapable("gemini")
-        let hasConfiguredKey = false  // daemon reports key absent
-
-        let wouldResetToManaged = isManagedCapable && requiresKey && !hasConfiguredKey
-        XCTAssertTrue(wouldResetToManaged,
-            "auto-reset must fire when daemon reports no key is configured for managed-capable provider")
-    }
-
     // MARK: - Model Validation Against Selected Provider
 
     func testOpenAIModelsAreAvailableForOpenAIProvider() {


### PR DESCRIPTION
## Summary
- Cherry-pick `c2c21a3` — fix(macos): strip Your Own mode auto-revert — respect explicit user saves (#29205)
- `c136e16` and `a79debc` were already on the release branch from prior cherry-picks (skipped as empty)

## Test plan
- [ ] Verify iOS build passes in CI
- [ ] Confirm Your Own mode settings persist after explicit save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
