### PR TITLE
refactor(migrations): single-source-of-truth vbundle import policy module

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-parity.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-parity.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Buffer-vs-streaming `.vbundle` import parity suite.
+ *
+ * Pins the existing disk-outcome equivalence between `commitImport`
+ * (buffer-based) and `streamCommitImport` (streaming) as a regression net
+ * BEFORE any production code is migrated to a shared policy module.
+ *
+ * Each test builds one archive, mkdtemps two sibling workspaces, seeds them
+ * identically, runs each importer against its own workspace, and asserts the
+ * post-import disk trees are byte-for-byte identical:
+ *
+ *   expect(walkDiskTree(streamWs)).toEqual(walkDiskTree(bufferWs))
+ *
+ * Per-case invariants (carry-forward markers survive, persona lands at the
+ * right disk path, traversal entries do not erase the workspace, etc.) are
+ * asserted on top of disk-tree equality.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../vbundle-builder.js";
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { commitImport } from "../vbundle-importer.js";
+import { streamCommitImport } from "../vbundle-streaming-importer.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Allocate a fresh workspace path under a temp parent dir we own. The parent
+ * is realpath-resolved so macOS `/var` → `/private/var` symlink mismatches
+ * don't trip the streaming importer's `rebaseOntoTempWorkspace` containment
+ * check (which compares `resolve(diskPath)` against `resolve(workspaceDir)`).
+ *
+ * Returns `<parent>/workspace`. The directory itself is NOT created — tests
+ * that need it pre-existing call `mkdirSync` themselves.
+ */
+function freshWorkspace(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "vbundle-import-parity-")),
+  );
+  return join(parent, "workspace");
+}
+
+/** Best-effort cleanup of a workspace's parent dir. */
+function cleanupWorkspaceParent(workspaceDir: string): void {
+  try {
+    rmSync(join(workspaceDir, ".."), { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+function sha256Hex(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Recursively walk `root` and return a `Map<relPath, sha256Hex>` for every
+ * regular file. Skips dot-prefixed scratch dirs the streaming importer may
+ * leave behind on failure paths (`.import-*`, `.pre-import-*`) plus the
+ * import marker file — the buffer importer never produces these, so they'd
+ * spuriously break parity if included.
+ *
+ * Two importers are parity-equivalent for a given input iff the maps they
+ * produce on identically-seeded sibling workspaces are equal.
+ */
+function walkDiskTree(root: string): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!existsSync(root)) return out;
+
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      // Skip streaming-importer scratch artifacts so they don't show up as
+      // false negatives in the parity comparison.
+      if (
+        entry.name.startsWith(".import-") ||
+        entry.name.startsWith(".pre-import-") ||
+        entry.name === ".import-marker.json"
+      ) {
+        continue;
+      }
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(abs);
+      } else if (entry.isFile()) {
+        const rel = relative(root, abs);
+        out.set(rel, sha256Hex(readFileSync(abs)));
+      }
+    }
+  }
+  return out;
+}
+
+interface SeedFile {
+  relPath: string;
+  content: string | Uint8Array;
+}
+
+/** Mkdir parents and write each file to `workspaceDir`. */
+function seedLiveWorkspace(workspaceDir: string, files: SeedFile[]): void {
+  mkdirSync(workspaceDir, { recursive: true });
+  for (const { relPath, content } of files) {
+    const abs = join(workspaceDir, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+}
+
+function runBufferImport(workspaceDir: string, archive: Uint8Array): void {
+  const result = commitImport({
+    archiveData: archive,
+    pathResolver: new DefaultPathResolver(workspaceDir),
+    workspaceDir,
+  });
+  if (!result.ok) {
+    throw new Error(
+      `buffer commitImport unexpectedly failed: ${JSON.stringify(result)}`,
+    );
+  }
+}
+
+async function runStreamImport(
+  workspaceDir: string,
+  archive: Uint8Array,
+  importCredentials?: (
+    credentials: Array<{ account: string; value: string }>,
+  ) => Promise<void>,
+): Promise<void> {
+  const result = await streamCommitImport({
+    source: Readable.from([Buffer.from(archive)]),
+    pathResolver: new DefaultPathResolver(workspaceDir),
+    workspaceDir,
+    importCredentials,
+  });
+  if (!result.ok) {
+    throw new Error(
+      `streamCommitImport unexpectedly failed: ${JSON.stringify(result)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parity tests
+// ---------------------------------------------------------------------------
+
+describe("vbundle import parity (buffer vs streaming)", () => {
+  let bufferWs: string;
+  let streamWs: string;
+
+  beforeEach(() => {
+    bufferWs = freshWorkspace();
+    streamWs = freshWorkspace();
+  });
+
+  afterEach(() => {
+    cleanupWorkspaceParent(bufferWs);
+    cleanupWorkspaceParent(streamWs);
+  });
+
+  test("A — full workspace + credentials: identical disk outcome", async () => {
+    const dbBytes = new Uint8Array(16);
+    for (let i = 0; i < dbBytes.length; i++) dbBytes[i] = (i * 17) & 0xff;
+
+    const configJson = JSON.stringify({ version: 1 });
+    const metadataJson = JSON.stringify({
+      version: 5,
+      credentials: [
+        {
+          credentialId: "id-openai-api_key",
+          service: "openai",
+          field: "api_key",
+          allowedTools: [],
+          allowedDomains: [],
+          createdAt: 1700000000000,
+          updatedAt: 1700000000000,
+        },
+      ],
+    });
+
+    const openaiKey = new Uint8Array(16);
+    for (let i = 0; i < openaiKey.length; i++) openaiKey[i] = (i + 5) & 0xff;
+    const anthropicKey = new TextEncoder().encode("sk-ant-test");
+
+    const { archive } = buildVBundle({
+      files: [
+        { path: "workspace/data/db/assistant.db", data: dbBytes },
+        {
+          path: "workspace/config.json",
+          data: new TextEncoder().encode(configJson),
+        },
+        {
+          path: "workspace/data/credentials/metadata.json",
+          data: new TextEncoder().encode(metadataJson),
+        },
+        { path: "credentials/openai-key", data: openaiKey },
+        { path: "credentials/anthropic-key", data: anthropicKey },
+      ],
+      ...defaultV1Options(),
+    });
+
+    // Pre-create both workspaces (streaming importer expects to operate
+    // against an existing dir and the atomic-swap path requires it).
+    mkdirSync(bufferWs, { recursive: true });
+    mkdirSync(streamWs, { recursive: true });
+
+    runBufferImport(bufferWs, archive);
+    await runStreamImport(streamWs, archive, async () => {
+      // parity test: credentials are intercepted but not persisted
+    });
+
+    const bufferMap = walkDiskTree(bufferWs);
+    const streamMap = walkDiskTree(streamWs);
+
+    expect(streamMap).toEqual(bufferMap);
+
+    // Sanity: the three workspace-bound files we expect both importers to
+    // land are present in the parity map.
+    expect(bufferMap.has("data/db/assistant.db")).toBe(true);
+    expect(bufferMap.has("config.json")).toBe(true);
+    expect(bufferMap.has("data/credentials/metadata.json")).toBe(true);
+  });
+
+  test("B — config-only partial bundle: live preserved paths survive on both sides", async () => {
+    const seeds: SeedFile[] = [
+      { relPath: "data/db/marker", content: "db-marker" },
+      { relPath: "data/qdrant/marker", content: "qdrant-marker" },
+      { relPath: "embedding-models/marker", content: "embedding-marker" },
+      { relPath: "deprecated/marker", content: "deprecated-marker" },
+    ];
+
+    seedLiveWorkspace(bufferWs, seeds);
+    seedLiveWorkspace(streamWs, seeds);
+
+    const configJson = JSON.stringify({ version: 1 });
+    const { archive } = buildVBundle({
+      files: [
+        // Validator requires the DB entry (legacy or workspace-prefixed).
+        // It's not the focus of this case — config.json is — but it must
+        // be present for the bundle to validate.
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "workspace/config.json",
+          data: new TextEncoder().encode(configJson),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    runBufferImport(bufferWs, archive);
+    await runStreamImport(streamWs, archive);
+
+    const bufferMap = walkDiskTree(bufferWs);
+    const streamMap = walkDiskTree(streamWs);
+
+    expect(streamMap).toEqual(bufferMap);
+
+    // Each carry-forward marker must still be on disk.
+    for (const seed of seeds) {
+      expect(bufferMap.has(seed.relPath)).toBe(true);
+      expect(streamMap.has(seed.relPath)).toBe(true);
+    }
+  });
+
+  test("C — legacy prompts/USER.md: both importers land it at users/<slug>.md", async () => {
+    const personaBody = `_ Lines starting with _ are comments - they won't appear in the system prompt
+
+# User Profile
+
+- Preferred name/reference: Captain Parity
+- Pronouns: they/them
+- Locale: en-US
+- Work role: Quartermaster
+- Goals: Verify importer parity
+- Hobbies/fun: Diff'ing trees
+- Daily tools: Terminal
+`;
+
+    // Pre-create users/ in both workspaces so the resolver's containment
+    // check has a real on-disk parent to anchor against.
+    mkdirSync(join(bufferWs, "users"), { recursive: true });
+    mkdirSync(join(streamWs, "users"), { recursive: true });
+
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "prompts/USER.md",
+          data: new TextEncoder().encode(personaBody),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const bufferGuardianPath = join(bufferWs, "users", "captain.md");
+    const streamGuardianPath = join(streamWs, "users", "captain.md");
+
+    const bufferResolver = new DefaultPathResolver(
+      bufferWs,
+      undefined,
+      () => bufferGuardianPath,
+    );
+    const streamResolver = new DefaultPathResolver(
+      streamWs,
+      undefined,
+      () => streamGuardianPath,
+    );
+
+    const bufferResult = commitImport({
+      archiveData: archive,
+      pathResolver: bufferResolver,
+      workspaceDir: bufferWs,
+    });
+    expect(bufferResult.ok).toBe(true);
+
+    const streamResult = await streamCommitImport({
+      source: Readable.from([Buffer.from(archive)]),
+      pathResolver: streamResolver,
+      workspaceDir: streamWs,
+    });
+    expect(streamResult.ok).toBe(true);
+
+    const bufferMap = walkDiskTree(bufferWs);
+    const streamMap = walkDiskTree(streamWs);
+
+    expect(streamMap).toEqual(bufferMap);
+
+    expect(existsSync(bufferGuardianPath)).toBe(true);
+    expect(existsSync(streamGuardianPath)).toBe(true);
+    expect(readFileSync(bufferGuardianPath, "utf-8")).toBe(personaBody);
+    expect(readFileSync(streamGuardianPath, "utf-8")).toBe(personaBody);
+  });
+
+  test("D — no workspace entries at all: legacy bundle leaves seeded files in place", async () => {
+    const seeds: SeedFile[] = [
+      { relPath: "unrelated.txt", content: "stay" },
+      { relPath: "custom-dir/note.md", content: "# note" },
+    ];
+
+    seedLiveWorkspace(bufferWs, seeds);
+    seedLiveWorkspace(streamWs, seeds);
+
+    const dbBytes = new TextEncoder().encode("legacy-db-payload");
+    const { archive } = buildVBundle({
+      files: [{ path: "data/db/assistant.db", data: dbBytes }],
+      ...defaultV1Options(),
+    });
+
+    runBufferImport(bufferWs, archive);
+    await runStreamImport(streamWs, archive);
+
+    const bufferMap = walkDiskTree(bufferWs);
+    const streamMap = walkDiskTree(streamWs);
+
+    expect(streamMap).toEqual(bufferMap);
+
+    for (const seed of seeds) {
+      expect(bufferMap.has(seed.relPath)).toBe(true);
+      expect(streamMap.has(seed.relPath)).toBe(true);
+    }
+  });
+
+  test("E — path-traversal workspace entry: both importers refuse to clear", async () => {
+    seedLiveWorkspace(bufferWs, [{ relPath: "marker.txt", content: "keep" }]);
+    seedLiveWorkspace(streamWs, [{ relPath: "marker.txt", content: "keep" }]);
+
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "workspace/../../etc/passwd",
+          data: new TextEncoder().encode("nope"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    runBufferImport(bufferWs, archive);
+    await runStreamImport(streamWs, archive);
+
+    const bufferMap = walkDiskTree(bufferWs);
+    const streamMap = walkDiskTree(streamWs);
+
+    expect(streamMap).toEqual(bufferMap);
+
+    expect(bufferMap.has("marker.txt")).toBe(true);
+    expect(streamMap.has("marker.txt")).toBe(true);
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, test } from "bun:test";
 import {
   CONFIG_ARCHIVE_PATHS,
   CREDENTIAL_METADATA_ARCHIVE_PATH,
-  isCarryForwardRelPath,
   isConfigArchivePath,
   isCredentialMetadataArchivePath,
   isLegacyPersonaArchivePath,
@@ -108,22 +107,6 @@ describe("isCredentialMetadataArchivePath", () => {
       isCredentialMetadataArchivePath("data/credentials/metadata.json"),
     ).toBe(false);
     expect(isCredentialMetadataArchivePath("")).toBe(false);
-  });
-});
-
-describe("isCarryForwardRelPath", () => {
-  test("true for each preserve-path", () => {
-    expect(isCarryForwardRelPath("embedding-models")).toBe(true);
-    expect(isCarryForwardRelPath("deprecated")).toBe(true);
-    expect(isCarryForwardRelPath("data/db")).toBe(true);
-    expect(isCarryForwardRelPath("data/qdrant")).toBe(true);
-  });
-
-  test("false for parents, descendants, unrelated, and empty", () => {
-    expect(isCarryForwardRelPath("data")).toBe(false);
-    expect(isCarryForwardRelPath("data/db/foo")).toBe(false);
-    expect(isCarryForwardRelPath("random")).toBe(false);
-    expect(isCarryForwardRelPath("")).toBe(false);
   });
 });
 

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the pure policy module shared by both vbundle importers.
+ *
+ * No `node:fs`, no temp dirs — every test exercises a constant or a
+ * predicate over strings.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONFIG_ARCHIVE_PATHS,
+  CREDENTIAL_METADATA_ARCHIVE_PATH,
+  isCarryForwardRelPath,
+  isConfigArchivePath,
+  isCredentialMetadataArchivePath,
+  isLegacyPersonaArchivePath,
+  isWorkspaceNamespacedArchivePath,
+  LEGACY_USER_MD_ARCHIVE_PATH,
+  partitionWorkspacePreserveSkipDirs,
+  WORKSPACE_PRESERVE_PATHS,
+} from "../vbundle-import-policy.js";
+
+describe("LEGACY_USER_MD_ARCHIVE_PATH", () => {
+  test("equals the legacy guardian persona archive path", () => {
+    expect(LEGACY_USER_MD_ARCHIVE_PATH).toBe("prompts/USER.md");
+  });
+});
+
+describe("CONFIG_ARCHIVE_PATHS", () => {
+  test("contains exactly the two known config archive paths", () => {
+    expect(CONFIG_ARCHIVE_PATHS.size).toBe(2);
+    expect(CONFIG_ARCHIVE_PATHS.has("workspace/config.json")).toBe(true);
+    expect(CONFIG_ARCHIVE_PATHS.has("config/settings.json")).toBe(true);
+  });
+});
+
+describe("CREDENTIAL_METADATA_ARCHIVE_PATH", () => {
+  test("equals the workspace-namespaced credential metadata path", () => {
+    expect(CREDENTIAL_METADATA_ARCHIVE_PATH).toBe(
+      "workspace/data/credentials/metadata.json",
+    );
+  });
+});
+
+describe("WORKSPACE_PRESERVE_PATHS", () => {
+  test("matches the literal 4-element ordered list", () => {
+    expect(WORKSPACE_PRESERVE_PATHS).toEqual([
+      "embedding-models",
+      "deprecated",
+      "data/db",
+      "data/qdrant",
+    ]);
+  });
+});
+
+describe("isWorkspaceNamespacedArchivePath", () => {
+  test("true for paths under workspace/", () => {
+    expect(isWorkspaceNamespacedArchivePath("workspace/foo")).toBe(true);
+    expect(isWorkspaceNamespacedArchivePath("workspace/data/db/x")).toBe(true);
+  });
+
+  test("false for non-workspace paths", () => {
+    expect(isWorkspaceNamespacedArchivePath("prompts/USER.md")).toBe(false);
+    expect(isWorkspaceNamespacedArchivePath("data/db/assistant.db")).toBe(
+      false,
+    );
+    expect(isWorkspaceNamespacedArchivePath("")).toBe(false);
+    expect(isWorkspaceNamespacedArchivePath("workspace")).toBe(false);
+  });
+});
+
+describe("isLegacyPersonaArchivePath", () => {
+  test("true only for the exact legacy path", () => {
+    expect(isLegacyPersonaArchivePath("prompts/USER.md")).toBe(true);
+  });
+
+  test("false for near-misses and unrelated paths", () => {
+    expect(isLegacyPersonaArchivePath("prompts/USER")).toBe(false);
+    expect(isLegacyPersonaArchivePath("workspace/prompts/USER.md")).toBe(false);
+    expect(isLegacyPersonaArchivePath("")).toBe(false);
+  });
+});
+
+describe("isConfigArchivePath", () => {
+  test("true for both members of CONFIG_ARCHIVE_PATHS", () => {
+    expect(isConfigArchivePath("workspace/config.json")).toBe(true);
+    expect(isConfigArchivePath("config/settings.json")).toBe(true);
+  });
+
+  test("false for non-members", () => {
+    expect(isConfigArchivePath("workspace/foo.json")).toBe(false);
+    expect(isConfigArchivePath("config/settings")).toBe(false);
+    expect(isConfigArchivePath("")).toBe(false);
+  });
+});
+
+describe("isCredentialMetadataArchivePath", () => {
+  test("true for the exact constant", () => {
+    expect(
+      isCredentialMetadataArchivePath(
+        "workspace/data/credentials/metadata.json",
+      ),
+    ).toBe(true);
+  });
+
+  test("false for the legacy non-prefixed form and empty string", () => {
+    expect(
+      isCredentialMetadataArchivePath("data/credentials/metadata.json"),
+    ).toBe(false);
+    expect(isCredentialMetadataArchivePath("")).toBe(false);
+  });
+});
+
+describe("isCarryForwardRelPath", () => {
+  test("true for each preserve-path", () => {
+    expect(isCarryForwardRelPath("embedding-models")).toBe(true);
+    expect(isCarryForwardRelPath("deprecated")).toBe(true);
+    expect(isCarryForwardRelPath("data/db")).toBe(true);
+    expect(isCarryForwardRelPath("data/qdrant")).toBe(true);
+  });
+
+  test("false for parents, descendants, unrelated, and empty", () => {
+    expect(isCarryForwardRelPath("data")).toBe(false);
+    expect(isCarryForwardRelPath("data/db/foo")).toBe(false);
+    expect(isCarryForwardRelPath("random")).toBe(false);
+    expect(isCarryForwardRelPath("")).toBe(false);
+  });
+});
+
+describe("partitionWorkspacePreserveSkipDirs", () => {
+  test("splits preserve-paths into top-level vs data-subdir skip sets", () => {
+    const { topLevelSkipDirs, dataSubdirSkipDirs } =
+      partitionWorkspacePreserveSkipDirs();
+
+    expect(topLevelSkipDirs.size).toBe(2);
+    expect(topLevelSkipDirs.has("embedding-models")).toBe(true);
+    expect(topLevelSkipDirs.has("deprecated")).toBe(true);
+
+    expect(dataSubdirSkipDirs.size).toBe(2);
+    expect(dataSubdirSkipDirs.has("db")).toBe(true);
+    expect(dataSubdirSkipDirs.has("qdrant")).toBe(true);
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared invariants and predicate functions consumed by both the buffer-
+ * based `commitImport` and the streaming `streamCommitImport`. These
+ * decisions must stay in lockstep across both importers — moving them
+ * here removes the parallel-implementation skew risk that would otherwise
+ * grow as either importer evolves.
+ *
+ * Pure: no `node:fs`, no I/O, no async. Functions over strings + manifest
+ * data shapes only.
+ */
+
+export const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
+
+export const CONFIG_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
+  "workspace/config.json",
+  "config/settings.json",
+]);
+
+export const CREDENTIAL_METADATA_ARCHIVE_PATH =
+  "workspace/data/credentials/metadata.json";
+
+export const WORKSPACE_PRESERVE_PATHS: readonly string[] = [
+  "embedding-models",
+  "deprecated",
+  "data/db",
+  "data/qdrant",
+];
+
+export function isWorkspaceNamespacedArchivePath(archivePath: string): boolean {
+  return archivePath.startsWith("workspace/");
+}
+
+export function isLegacyPersonaArchivePath(archivePath: string): boolean {
+  return archivePath === LEGACY_USER_MD_ARCHIVE_PATH;
+}
+
+export function isConfigArchivePath(archivePath: string): boolean {
+  return CONFIG_ARCHIVE_PATHS.has(archivePath);
+}
+
+export function isCredentialMetadataArchivePath(archivePath: string): boolean {
+  return archivePath === CREDENTIAL_METADATA_ARCHIVE_PATH;
+}
+
+export function isCarryForwardRelPath(relPath: string): boolean {
+  return WORKSPACE_PRESERVE_PATHS.includes(relPath);
+}
+
+export interface WorkspacePreserveSkipDirs {
+  topLevelSkipDirs: ReadonlySet<string>;
+  dataSubdirSkipDirs: ReadonlySet<string>;
+}
+
+/**
+ * Partition `WORKSPACE_PRESERVE_PATHS` into the two skip sets the buffer
+ * importer's selective-clear loop consumes:
+ *
+ * - `topLevelSkipDirs`: single-segment preserve-paths (e.g. "embedding-models").
+ * - `dataSubdirSkipDirs`: second segment of `data/<x>` preserve-paths
+ *   (e.g. "db" for "data/db").
+ *
+ * Stays in sync with WORKSPACE_PRESERVE_PATHS automatically — adding a
+ * new entry of either shape doesn't require touching the buffer importer.
+ * Multi-segment paths outside the `data/` subtree are intentionally
+ * unsupported here; the buffer importer's walk doesn't recurse into
+ * arbitrary subdirs. If a future preserve-path needs deeper coverage,
+ * widen this helper and the buffer importer's walk together.
+ */
+export function partitionWorkspacePreserveSkipDirs(): WorkspacePreserveSkipDirs {
+  const topLevelSkipDirs = new Set<string>();
+  const dataSubdirSkipDirs = new Set<string>();
+  for (const rel of WORKSPACE_PRESERVE_PATHS) {
+    const parts = rel.split("/");
+    if (parts.length === 1) {
+      topLevelSkipDirs.add(parts[0]!);
+    } else if (parts.length === 2 && parts[0] === "data") {
+      dataSubdirSkipDirs.add(parts[1]!);
+    }
+  }
+  return { topLevelSkipDirs, dataSubdirSkipDirs };
+}

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -42,15 +42,6 @@ export function isCredentialMetadataArchivePath(archivePath: string): boolean {
   return archivePath === CREDENTIAL_METADATA_ARCHIVE_PATH;
 }
 
-export function isCarryForwardRelPath(relPath: string): boolean {
-  return WORKSPACE_PRESERVE_PATHS.includes(relPath);
-}
-
-export interface WorkspacePreserveSkipDirs {
-  topLevelSkipDirs: ReadonlySet<string>;
-  dataSubdirSkipDirs: ReadonlySet<string>;
-}
-
 /**
  * Partition `WORKSPACE_PRESERVE_PATHS` into the two skip sets the buffer
  * importer's selective-clear loop consumes:
@@ -66,7 +57,10 @@ export interface WorkspacePreserveSkipDirs {
  * arbitrary subdirs. If a future preserve-path needs deeper coverage,
  * widen this helper and the buffer importer's walk together.
  */
-export function partitionWorkspacePreserveSkipDirs(): WorkspacePreserveSkipDirs {
+export function partitionWorkspacePreserveSkipDirs(): {
+  topLevelSkipDirs: ReadonlySet<string>;
+  dataSubdirSkipDirs: ReadonlySet<string>;
+} {
   const topLevelSkipDirs = new Set<string>();
   const dataSubdirSkipDirs = new Set<string>();
   for (const rel of WORKSPACE_PRESERVE_PATHS) {

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -33,13 +33,6 @@ import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
 
-// Re-exported so consumers that import these constants from this module
-// (e.g. `vbundle-streaming-importer.ts`) keep compiling. The policy
-// module owns the source of truth.
-export const LEGACY_USER_MD_ARCHIVE_PATH = policy.LEGACY_USER_MD_ARCHIVE_PATH;
-export const CONFIG_ARCHIVE_PATHS = policy.CONFIG_ARCHIVE_PATHS;
-export const WORKSPACE_PRESERVE_PATHS = policy.WORKSPACE_PRESERVE_PATHS;
-
 const log = getLogger("vbundle-importer");
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -180,16 +180,8 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // Directories to preserve when clearing the workspace. Derived from the
   // shared WORKSPACE_PRESERVE_PATHS list so the streaming importer's
   // carry-over logic and this in-place clear stay in sync.
-  const WORKSPACE_SKIP_DIRS = new Set<string>();
-  const DATA_SKIP_DIRS = new Set<string>();
-  for (const rel of policy.WORKSPACE_PRESERVE_PATHS) {
-    const parts = rel.split("/");
-    if (parts.length === 1) {
-      WORKSPACE_SKIP_DIRS.add(parts[0]);
-    } else if (parts.length === 2 && parts[0] === "data") {
-      DATA_SKIP_DIRS.add(parts[1]);
-    }
-  }
+  const { topLevelSkipDirs, dataSubdirSkipDirs } =
+    policy.partitionWorkspacePreserveSkipDirs();
 
   // Step 1b: Clear the workspace directory before restore if the bundle
   // contains new-format workspace/ entries. This ensures an exact-match
@@ -207,7 +199,9 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // "workspace/../../etc/passwd") from triggering a workspace purge while
   // resolving to nothing.
   const hasWorkspaceEntries = manifest.contents.some(
-    (f) => f.path.startsWith("workspace/") && !!pathResolver.resolve(f.path),
+    (f) =>
+      policy.isWorkspaceNamespacedArchivePath(f.path) &&
+      !!pathResolver.resolve(f.path),
   );
 
   // Capture the target's credential metadata BEFORE the workspace clear
@@ -239,7 +233,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       // Clear workspace contents selectively, preserving skip dirs
       const topEntries = readdirSync(workspaceDir, { withFileTypes: true });
       for (const entry of topEntries) {
-        if (WORKSPACE_SKIP_DIRS.has(entry.name)) continue;
+        if (topLevelSkipDirs.has(entry.name)) continue;
 
         const entryPath = join(workspaceDir, entry.name);
         if (entry.name === "data" && entry.isDirectory()) {
@@ -247,7 +241,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
           // (critical user data) but clear everything else
           const dataEntries = readdirSync(entryPath, { withFileTypes: true });
           for (const dataEntry of dataEntries) {
-            if (DATA_SKIP_DIRS.has(dataEntry.name)) continue;
+            if (dataSubdirSkipDirs.has(dataEntry.name)) continue;
             rmSync(join(entryPath, dataEntry.name), {
               recursive: true,
               force: true,
@@ -323,7 +317,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     // than clobber — the user has curated their persona since the
     // bundle was exported.
     if (
-      fileEntry.path === LEGACY_USER_MD_ARCHIVE_PATH &&
+      policy.isLegacyPersonaArchivePath(fileEntry.path) &&
       isGuardianPersonaCustomized(diskPath)
     ) {
       log.warn(
@@ -398,7 +392,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
 
     // Sanitize config files to strip environment-specific fields (defense-in-depth)
     let dataToWrite: Uint8Array = archiveEntry.data;
-    if (CONFIG_ARCHIVE_PATHS.has(fileEntry.path)) {
+    if (policy.isConfigArchivePath(fileEntry.path)) {
       const configJson = new TextDecoder().decode(archiveEntry.data);
       const sanitized = sanitizeConfigForTransfer(configJson);
       dataToWrite = new TextEncoder().encode(sanitized);
@@ -410,7 +404,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     // would wipe them and break the gateway's vellum credential read.
     // We use the snapshot captured BEFORE the workspace clear because
     // Step 1b may have already removed the live file.
-    if (fileEntry.path === policy.CREDENTIAL_METADATA_ARCHIVE_PATH) {
+    if (policy.isCredentialMetadataArchivePath(fileEntry.path)) {
       const bundleJson = new TextDecoder().decode(archiveEntry.data);
       const merged = mergeMetadataPreservingVellum(
         bundleJson,
@@ -496,8 +490,8 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // run (e.g. workspaceDir unset) the live metadata.json is still on
   // disk untouched — we must not rewrite it here or we would drop the
   // non-vellum entries the caller chose to keep.
-  const bundleHadMetadata = manifest.contents.some(
-    (f) => f.path === policy.CREDENTIAL_METADATA_ARCHIVE_PATH,
+  const bundleHadMetadata = manifest.contents.some((f) =>
+    policy.isCredentialMetadataArchivePath(f.path),
   );
   if (
     workspaceWasCleared &&

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -28,59 +28,19 @@ import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
+import * as policy from "./vbundle-import-policy.js";
 import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
 import { validateVBundle } from "./vbundle-validator.js";
 
+// Re-exported so consumers that import these constants from this module
+// (e.g. `vbundle-streaming-importer.ts`) keep compiling. The policy
+// module owns the source of truth.
+export const LEGACY_USER_MD_ARCHIVE_PATH = policy.LEGACY_USER_MD_ARCHIVE_PATH;
+export const CONFIG_ARCHIVE_PATHS = policy.CONFIG_ARCHIVE_PATHS;
+export const WORKSPACE_PRESERVE_PATHS = policy.WORKSPACE_PRESERVE_PATHS;
+
 const log = getLogger("vbundle-importer");
-
-/** Archive path for the legacy guardian user persona file. */
-export const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
-
-/**
- * Archive paths recognized as JSON config files that must be run through
- * `sanitizeConfigForTransfer` before writing to disk. Exported so the
- * streaming importer can apply the same defense-in-depth treatment.
- */
-export const CONFIG_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
-  "workspace/config.json",
-  "config/settings.json",
-]);
-
-/**
- * Archive path for the credential metadata file. On import, bundle contents
- * must be merged with the target's live `vellum:*` entries so the gateway's
- * `readServiceCredentials` can still locate the platform API key after a
- * local→platform teleport. Both importers consult this constant.
- */
-const CREDENTIAL_METADATA_ARCHIVE_PATH =
-  "workspace/data/credentials/metadata.json";
-
-/**
- * Paths inside the workspace directory that must be preserved across an
- * import when the bundle does not carry entries for them.
- *
- * Each entry is a path RELATIVE to the workspace root. Two kinds of live
- * data warrant carry-over:
- *
- * - `embedding-models` / `deprecated`: large local caches / quarantine
- *   directories that are never shipped inside bundles but are expensive
- *   or impossible to reconstruct from an import.
- * - `data/db` / `data/qdrant`: user-critical state (SQLite assistant DB;
- *   Qdrant vector store). If the bundle omits them — e.g. a partial
- *   bundle covering only prompts/config — the live copies must survive.
- *
- * Both the buffer-based `commitImport` (which selectively clears the
- * workspace in place) and the streaming importer (which swaps the
- * workspace with a freshly-populated temp tree) consult this list so
- * their behavior stays in sync.
- */
-export const WORKSPACE_PRESERVE_PATHS: readonly string[] = [
-  "embedding-models",
-  "deprecated",
-  "data/db",
-  "data/qdrant",
-];
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -222,7 +182,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // carry-over logic and this in-place clear stay in sync.
   const WORKSPACE_SKIP_DIRS = new Set<string>();
   const DATA_SKIP_DIRS = new Set<string>();
-  for (const rel of WORKSPACE_PRESERVE_PATHS) {
+  for (const rel of policy.WORKSPACE_PRESERVE_PATHS) {
     const parts = rel.split("/");
     if (parts.length === 1) {
       WORKSPACE_SKIP_DIRS.add(parts[0]);
@@ -257,7 +217,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // (`vellum:*`) entries across the overwrite.
   let liveCredentialMetadataJson: string | null = null;
   const credentialMetadataDiskPath = pathResolver.resolve(
-    CREDENTIAL_METADATA_ARCHIVE_PATH,
+    policy.CREDENTIAL_METADATA_ARCHIVE_PATH,
   );
   if (credentialMetadataDiskPath && existsSync(credentialMetadataDiskPath)) {
     try {
@@ -450,7 +410,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     // would wipe them and break the gateway's vellum credential read.
     // We use the snapshot captured BEFORE the workspace clear because
     // Step 1b may have already removed the live file.
-    if (fileEntry.path === CREDENTIAL_METADATA_ARCHIVE_PATH) {
+    if (fileEntry.path === policy.CREDENTIAL_METADATA_ARCHIVE_PATH) {
       const bundleJson = new TextDecoder().decode(archiveEntry.data);
       const merged = mergeMetadataPreservingVellum(
         bundleJson,
@@ -537,7 +497,7 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
   // disk untouched — we must not rewrite it here or we would drop the
   // non-vellum entries the caller chose to keep.
   const bundleHadMetadata = manifest.contents.some(
-    (f) => f.path === CREDENTIAL_METADATA_ARCHIVE_PATH,
+    (f) => f.path === policy.CREDENTIAL_METADATA_ARCHIVE_PATH,
   );
   if (
     workspaceWasCleared &&

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -53,14 +53,12 @@ import { resetDb } from "../../memory/db-connection.js";
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
-import {
-  CONFIG_ARCHIVE_PATHS,
-  type ImportCommitReport,
-  type ImportCommitResult,
-  type ImportedFileReport,
-  type ImportFileAction,
-  LEGACY_USER_MD_ARCHIVE_PATH,
-  WORKSPACE_PRESERVE_PATHS,
+import * as policy from "./vbundle-import-policy.js";
+import type {
+  ImportCommitReport,
+  ImportCommitResult,
+  ImportedFileReport,
+  ImportFileAction,
 } from "./vbundle-importer.js";
 import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import {
@@ -510,7 +508,7 @@ export async function streamCommitImport(
       // bundle was exported. We check against the LIVE workspace path
       // (diskPath) because the swap hasn't happened yet.
       if (
-        archivePath === LEGACY_USER_MD_ARCHIVE_PATH &&
+        policy.isLegacyPersonaArchivePath(archivePath) &&
         isGuardianPersonaCustomized(diskPath)
       ) {
         log.warn(
@@ -591,14 +589,15 @@ export async function streamCommitImport(
       // Classify the entry as `workspace/*` (namespaced) vs legacy format.
       // Namespaced entries flip the swap-gate flag; legacy entries are
       // staged for an in-place promote after the stream completes.
-      const isWorkspaceNamespaced = archivePath.startsWith("workspace/");
+      const isWorkspaceNamespaced =
+        policy.isWorkspaceNamespacedArchivePath(archivePath);
 
       // Config files need sanitization before writing to strip
       // environment-specific fields (defense-in-depth; matches commitImport).
       // Configs are small (KB-scale) so buffering them is fine. Hash
       // verification still runs on the RAW bytes — the manifest declares the
       // sha/size of the archive content, not the sanitized output.
-      if (CONFIG_ARCHIVE_PATHS.has(archivePath)) {
+      if (policy.isConfigArchivePath(archivePath)) {
         const rawBytes = await collectHashVerified(entry.body, {
           sha256: expectedEntry.sha256,
           size: expectedEntry.size,
@@ -1346,7 +1345,7 @@ async function planCarryOverPreservedPaths(
   tempWorkspaceDir: string,
 ): Promise<CarriedPath[]> {
   const plan: CarriedPath[] = [];
-  for (const rel of WORKSPACE_PRESERVE_PATHS) {
+  for (const rel of policy.WORKSPACE_PRESERVE_PATHS) {
     const livePath = join(realWorkspaceDir, rel);
     const tempPath = join(tempWorkspaceDir, rel);
 


### PR DESCRIPTION
## Summary

Pure refactor that lifts shared invariants and predicate logic out of the two `.vbundle` import paths (`vbundle-importer.ts` buffer-based, `vbundle-streaming-importer.ts` atomic-swap) into a new pure-policy module `vbundle-import-policy.ts`. Eliminates the parallel-implementation skew theme that produced earlier orphaned import-commit serializers.

Behavior parity holds: every existing migration test passes unchanged, plus a new buffer-vs-streaming parity test suite locks in disk-outcome equivalence as a regression net.

## What changed

- **New**: `assistant/src/runtime/migrations/vbundle-import-policy.ts` — 4 shared constants (`LEGACY_USER_MD_ARCHIVE_PATH`, `CONFIG_ARCHIVE_PATHS`, `CREDENTIAL_METADATA_ARCHIVE_PATH`, `WORKSPACE_PRESERVE_PATHS`), 4 predicates (`isWorkspaceNamespacedArchivePath`, `isLegacyPersonaArchivePath`, `isConfigArchivePath`, `isCredentialMetadataArchivePath`), 1 partition helper (`partitionWorkspacePreserveSkipDirs`). Pure module — no `node:fs`, no I/O.
- **New**: focused unit tests for every policy export (`__tests__/vbundle-import-policy.test.ts`).
- **New**: buffer-vs-streaming parity test suite (`__tests__/vbundle-import-parity.test.ts`) covering 5 disk-outcome equivalence cases (full workspace + credentials, config-only partial, legacy `prompts/USER.md`, no workspace entries, path-traversal refusal).
- **Modified**: `vbundle-importer.ts` consumes `policy.*` predicates and `policy.partitionWorkspacePreserveSkipDirs()`; no inline duplications remain.
- **Modified**: `vbundle-streaming-importer.ts` consumes `policy.*` predicates; constant imports moved off `vbundle-importer.ts` (only type imports remain).

## Self-review result

Round 1: 6 findings across 4 review passes. 2 accepted and fixed (unused `isCarryForwardRelPath` predicate + `WorkspacePreserveSkipDirs` interface). 4 declined with documented justification (each anchored in the plan's explicit out-of-scope sections or the user's brief).

Round 2: 4 review passes complete. 3 PASS. 1 finding (third copy of `LEGACY_USER_MD_ARCHIVE_PATH` in `vbundle-import-analyzer.ts:41`) is explicitly named in the plan's "Out of scope" section and ruled out by the user's brief — declined.

## PRs merged into feature branch

- #29202: test(migrations): add buffer-vs-streaming vbundle import parity suite
- #29200: refactor(migrations): add vbundle-import-policy module (constants + predicates)
- #29204: refactor(migrations): commitImport consumes vbundle-import-policy predicates
- #29206: refactor(migrations): streamCommitImport consumes vbundle-import-policy predicates
- #29208: chore(migrations): drop transitional re-export shims from vbundle-importer

## Fix PRs

- #29209: refactor(migrations): drop unused policy scaffolding (isCarryForwardRelPath, WorkspacePreserveSkipDirs)

## Out-of-scope follow-ups (separate workstream)

- `vbundle-import-analyzer.ts:41` privately re-declares `LEGACY_USER_MD_ARCHIVE_PATH`. Could consume the policy module's constant/predicate to remove the third copy.
- Streaming importer's `data/credentials/metadata.json` disk-path joins (lines ~864–875) hardcode the path string instead of deriving from `policy.CREDENTIAL_METADATA_ARCHIVE_PATH`.

## Test plan

- [x] `bun test src/runtime/migrations/__tests__/` — 151 / 151 pass
- [x] `bun test src/__tests__/migration-*.test.ts src/__tests__/rebind-secrets-screen.test.ts src/__tests__/transfer-progress-screen.test.ts` — full migration surface green
- [x] `bun test src/runtime/migrations/__tests__/vbundle-import-parity.test.ts` — 5 / 5 buffer-vs-streaming parity cases green
- [x] `bunx tsc --noEmit` — clean
- [x] Crash-safety machinery untouched (`swapWorkspaceContents`, `recoverInterruptedImport`, marker, EXDEV fallback)
- [x] `WORKSPACE_PRESERVE_PATHS` contents unchanged
- [x] Manifest schema, builder, validators untouched

Part of plan: vbundle-import-policy.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
