### PR TITLE
feat(vbundle): in-memory tar emit/parse/validate for symlink entries

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-tar.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-tar.test.ts
@@ -7,12 +7,16 @@
  * tampered `link_target` field, and a tampered `sha256` digest.
  */
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { describe, expect, test } from "bun:test";
 
 import { buildVBundle } from "../vbundle-builder.js";
-import { canonicalizeJson, validateVBundle } from "../vbundle-validator.js";
+import {
+  canonicalizeJson,
+  computeManifestChecksum,
+  validateVBundle,
+} from "../vbundle-validator.js";
 import { defaultV1Options } from "./v1-test-helpers.js";
 
 function sha256Hex(data: Uint8Array | string): string {
@@ -163,6 +167,36 @@ describe("vbundle symlink tar — emit / parse / validate", () => {
     expect(traversal!.path).toBe("workspace/skills/foo.md");
   });
 
+  test("absolute symlink target is rejected as escaping the archive root", () => {
+    // An absolute target like "/etc/passwd" is unconstrained by the bundle
+    // root: the prior `posix.normalize(posix.join(dirname, target))` guard
+    // returns "/etc/passwd" unchanged, which does not start with "../" and
+    // would otherwise pass. The validator must catch absolute targets up
+    // front and surface them with the same SYMLINK_TARGET_ESCAPES_ARCHIVE
+    // code as `..`-based escapes.
+    const files = [
+      {
+        path: "workspace/skills/foo.md",
+        data: new Uint8Array(0),
+        linkTarget: "/etc/passwd",
+      },
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("db-bytes"),
+      },
+    ];
+
+    const { archive } = buildVBundle({ files, ...defaultV1Options() });
+    const result = validateVBundle(archive);
+
+    expect(result.is_valid).toBe(false);
+    const traversal = result.errors.find(
+      (e) => e.code === "SYMLINK_TARGET_ESCAPES_ARCHIVE",
+    );
+    expect(traversal).toBeDefined();
+    expect(traversal!.path).toBe("workspace/skills/foo.md");
+  });
+
   test("manifest link_target tampered to a different value surfaces LINK_TARGET_MISMATCH", () => {
     const files = [
       {
@@ -199,6 +233,172 @@ describe("vbundle symlink tar — emit / parse / validate", () => {
     );
     expect(mismatch).toBeDefined();
     expect(mismatch!.path).toBe("workspace/skills/foo.md");
+  });
+
+  test("typeflag-2 entry whose tar header declares a non-zero size surfaces FILE_SIZE_MISMATCH", () => {
+    // Hand-craft a bundle so we can violate an invariant the buildVBundle
+    // emit path enforces: a symlink header that lies about its size.
+    //
+    // The validator's downstream check `archiveEntry.size !== 0` only fires
+    // if `parseTar` propagates the tar-declared size for typeflag-2 entries
+    // — not if it forces 0. This regression test pins that contract.
+    //
+    // Layout:
+    //   - manifest.json header + body
+    //   - foo.md symlink header (typeflag '2', linkname=bar.md, size=0o123)
+    //   - end-of-archive (two zero blocks)
+
+    const BLOCK = 512;
+    const enc = new TextEncoder();
+
+    function buildHeader(opts: {
+      name: string;
+      size: number;
+      typeflag: string;
+      linkname?: string;
+    }): Uint8Array {
+      const h = new Uint8Array(BLOCK);
+      const nameBytes = enc.encode(opts.name);
+      h.set(nameBytes.subarray(0, 100), 0);
+      const writeOctal = (off: number, len: number, value: number) => {
+        const s = value.toString(8).padStart(len - 1, "0");
+        for (let i = 0; i < s.length; i++) h[off + i] = s.charCodeAt(i);
+        h[off + len - 1] = 0;
+      };
+      writeOctal(100, 8, 0o644);
+      writeOctal(108, 8, 0);
+      writeOctal(116, 8, 0);
+      writeOctal(124, 12, opts.size);
+      writeOctal(136, 12, Math.floor(Date.now() / 1000));
+      h[156] = opts.typeflag.charCodeAt(0);
+      if (opts.linkname) {
+        const lk = enc.encode(opts.linkname);
+        h.set(lk.subarray(0, 100), 157);
+      }
+      const magic = enc.encode("ustar\0");
+      h.set(magic, 257);
+      h[263] = "0".charCodeAt(0);
+      h[264] = "0".charCodeAt(0);
+      // Checksum field starts as eight spaces per spec
+      for (let i = 148; i < 156; i++) h[i] = 0x20;
+      let sum = 0;
+      for (let i = 0; i < BLOCK; i++) sum += h[i];
+      const cksum = sum.toString(8).padStart(6, "0");
+      for (let i = 0; i < 6; i++) h[148 + i] = cksum.charCodeAt(i);
+      h[154] = 0;
+      h[155] = 0x20;
+      return h;
+    }
+
+    function padBlock(data: Uint8Array): Uint8Array {
+      const rem = data.length % BLOCK;
+      if (rem === 0) return data;
+      const padded = new Uint8Array(data.length + (BLOCK - rem));
+      padded.set(data);
+      return padded;
+    }
+
+    // Build manifest declaring foo.md as a symlink with size_bytes 0,
+    // sha256 over the link target string. That matches what buildVBundle
+    // would emit; the discrepancy lives in the tar header alone.
+    const linkTarget = "bar.md";
+    const symlinkSha = sha256Hex(linkTarget);
+    const manifest = {
+      schema_version: 1,
+      bundle_id: randomUUID(),
+      created_at: new Date().toISOString(),
+      assistant: { id: "self", name: "Test", runtime_version: "0.0.0-test" },
+      origin: { mode: "self-hosted-local" },
+      compatibility: {
+        min_runtime_version: "0.0.0-test",
+        max_runtime_version: null,
+      },
+      contents: [
+        {
+          path: "workspace/skills/foo.md",
+          sha256: symlinkSha,
+          size_bytes: 0,
+          link_target: linkTarget,
+        },
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: sha256Hex(enc.encode("db-bytes")),
+          size_bytes: 8,
+        },
+      ],
+      checksum: "",
+      secrets_redacted: false,
+      export_options: {
+        include_logs: false,
+        include_browser_state: false,
+        include_memory_vectors: false,
+      },
+    };
+    manifest.checksum = computeManifestChecksum(manifest);
+
+    const manifestBytes = enc.encode(JSON.stringify(manifest));
+    const manifestHeader = buildHeader({
+      name: "manifest.json",
+      size: manifestBytes.length,
+      typeflag: "0",
+    });
+    const manifestPart = new Uint8Array(BLOCK + padBlock(manifestBytes).length);
+    manifestPart.set(manifestHeader, 0);
+    manifestPart.set(padBlock(manifestBytes), BLOCK);
+
+    // Symlink header: declares size=0o123 (= 83 decimal). parseTar must
+    // propagate this 83 so the FILE_SIZE_MISMATCH check fires; if it forces
+    // 0, the bug is silent. We pad one block of zero body bytes after the
+    // header (the `Math.ceil(83/512) = 1` blocks parseTar will skip) so the
+    // following DB entry header lands at the correct block boundary.
+    const symlinkHeader = buildHeader({
+      name: "workspace/skills/foo.md",
+      size: 0o123,
+      typeflag: "2",
+      linkname: linkTarget,
+    });
+    const symlinkBodyPadding = new Uint8Array(BLOCK);
+    const symlinkPart = new Uint8Array(
+      symlinkHeader.length + symlinkBodyPadding.length,
+    );
+    symlinkPart.set(symlinkHeader, 0);
+    symlinkPart.set(symlinkBodyPadding, symlinkHeader.length);
+
+    // Regular file body for the DB entry so the manifest's required-DB
+    // refine is satisfied.
+    const dbBytes = enc.encode("db-bytes");
+    const dbHeader = buildHeader({
+      name: "workspace/data/db/assistant.db",
+      size: dbBytes.length,
+      typeflag: "0",
+    });
+    const dbPart = new Uint8Array(BLOCK + padBlock(dbBytes).length);
+    dbPart.set(dbHeader, 0);
+    dbPart.set(padBlock(dbBytes), BLOCK);
+
+    const eoa = new Uint8Array(BLOCK * 2);
+
+    const total =
+      manifestPart.length + symlinkPart.length + dbPart.length + eoa.length;
+    const tar = new Uint8Array(total);
+    let off = 0;
+    tar.set(manifestPart, off);
+    off += manifestPart.length;
+    tar.set(symlinkPart, off);
+    off += symlinkPart.length;
+    tar.set(dbPart, off);
+    off += dbPart.length;
+    tar.set(eoa, off);
+
+    const archive = gzipSync(tar);
+    const result = validateVBundle(archive);
+
+    expect(result.is_valid).toBe(false);
+    const sizeMismatch = result.errors.find(
+      (e) =>
+        e.code === "FILE_SIZE_MISMATCH" && e.path === "workspace/skills/foo.md",
+    );
+    expect(sizeMismatch).toBeDefined();
   });
 
   test("manifest sha256 tampered for a symlink entry surfaces FILE_CHECKSUM_MISMATCH", () => {

--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-tar.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-tar.test.ts
@@ -1,0 +1,237 @@
+/**
+ * In-memory tar emit / parse / validate coverage for the typeflag-2 symlink
+ * entry shape introduced in the vbundle-symlinks plan (PR 2).
+ *
+ * These tests exercise the round-trip through `buildVBundle` →
+ * `validateVBundle` plus three negative paths: traversal rejection, a
+ * tampered `link_target` field, and a tampered `sha256` digest.
+ */
+
+import { createHash } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../vbundle-builder.js";
+import { canonicalizeJson, validateVBundle } from "../vbundle-validator.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
+
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Decode the manifest from a built archive, run the supplied mutator, recompute
+ * the manifest checksum, and rebuild the archive. Mirrors the
+ * `dropFromManifestAndRepack` pattern from `vbundle-streaming-importer.test.ts`.
+ *
+ * Assumes the manifest is the first tar entry and has no PAX prefix.
+ */
+function mutateManifestAndRepack(
+  archive: Uint8Array,
+  mutate: (
+    contents: Array<{
+      path: string;
+      sha256: string;
+      size_bytes: number;
+      link_target?: string;
+    }>,
+  ) => void,
+): Uint8Array {
+  const raw = gunzipSync(archive);
+  const sizeStr = new TextDecoder()
+    .decode(raw.subarray(124, 136))
+    .replace(/\0.*$/, "")
+    .trim();
+  const origSize = parseInt(sizeStr, 8);
+  const manifestJson = new TextDecoder().decode(
+    raw.subarray(512, 512 + origSize),
+  );
+  const manifest = JSON.parse(manifestJson) as {
+    contents: Array<{
+      path: string;
+      sha256: string;
+      size_bytes: number;
+      link_target?: string;
+    }>;
+    checksum: string;
+    [k: string]: unknown;
+  };
+
+  mutate(manifest.contents);
+
+  // Recompute the v1 checksum: empty-string placeholder, then canonicalize.
+  const withEmptyChecksum: Record<string, unknown> = {
+    ...manifest,
+    checksum: "",
+  };
+  manifest.checksum = sha256Hex(canonicalizeJson(withEmptyChecksum));
+
+  const newJson = JSON.stringify(manifest);
+  const newBytes = new TextEncoder().encode(newJson);
+
+  const header = new Uint8Array(512);
+  header.set(raw.subarray(0, 512), 0);
+  const newSizeOctal = newBytes.length.toString(8).padStart(11, "0");
+  for (let i = 0; i < 11; i++) {
+    header[124 + i] = newSizeOctal.charCodeAt(i);
+  }
+  header[135] = 0;
+  for (let i = 148; i < 156; i++) header[i] = 0x20;
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += header[i];
+  const cksum = sum.toString(8).padStart(6, "0");
+  for (let i = 0; i < 6; i++) header[148 + i] = cksum.charCodeAt(i);
+  header[154] = 0;
+  header[155] = 0x20;
+
+  const oldPaddedLen = 512 + Math.ceil(origSize / 512) * 512;
+  const newPadded = Math.ceil(newBytes.length / 512) * 512;
+  const out = new Uint8Array(
+    header.length + newPadded + (raw.length - oldPaddedLen),
+  );
+  out.set(header, 0);
+  out.set(newBytes, 512);
+  out.set(raw.subarray(oldPaddedLen), 512 + newPadded);
+  return gzipSync(out);
+}
+
+describe("vbundle symlink tar — emit / parse / validate", () => {
+  test("round-trip: regular files and a typeflag-2 symlink validate cleanly", () => {
+    const files = [
+      {
+        path: "workspace/skills/bar.md",
+        data: new TextEncoder().encode("hello"),
+      },
+      {
+        path: "workspace/skills/foo.md",
+        data: new Uint8Array(0),
+        linkTarget: "bar.md",
+      },
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("db-bytes"),
+      },
+    ];
+
+    const { archive, manifest } = buildVBundle({
+      files,
+      ...defaultV1Options(),
+    });
+    const result = validateVBundle(archive);
+
+    expect(result.is_valid).toBe(true);
+    expect(result.errors).toEqual([]);
+
+    const symlinkEntry = result.entries!.get("workspace/skills/foo.md");
+    expect(symlinkEntry).toBeDefined();
+    expect(symlinkEntry!.linkname).toBe("bar.md");
+    expect(symlinkEntry!.size).toBe(0);
+
+    const symlinkContent = manifest.contents.find(
+      (c) => c.path === "workspace/skills/foo.md",
+    )!;
+    expect(symlinkContent.link_target).toBe("bar.md");
+    expect(symlinkContent.size_bytes).toBe(0);
+    expect(symlinkContent.sha256).toBe(sha256Hex("bar.md"));
+
+    // Regular file entries should NOT carry a linkname.
+    const regularEntry = result.entries!.get("workspace/skills/bar.md");
+    expect(regularEntry!.linkname).toBeUndefined();
+  });
+
+  test("symlink target that escapes the archive root is rejected", () => {
+    const files = [
+      {
+        path: "workspace/skills/foo.md",
+        data: new Uint8Array(0),
+        linkTarget: "../../../etc/passwd",
+      },
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("db-bytes"),
+      },
+    ];
+
+    const { archive } = buildVBundle({ files, ...defaultV1Options() });
+    const result = validateVBundle(archive);
+
+    expect(result.is_valid).toBe(false);
+    const traversal = result.errors.find(
+      (e) => e.code === "SYMLINK_TARGET_ESCAPES_ARCHIVE",
+    );
+    expect(traversal).toBeDefined();
+    expect(traversal!.path).toBe("workspace/skills/foo.md");
+  });
+
+  test("manifest link_target tampered to a different value surfaces LINK_TARGET_MISMATCH", () => {
+    const files = [
+      {
+        path: "workspace/skills/bar.md",
+        data: new TextEncoder().encode("hello"),
+      },
+      {
+        path: "workspace/skills/foo.md",
+        data: new Uint8Array(0),
+        linkTarget: "bar.md",
+      },
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("db-bytes"),
+      },
+    ];
+
+    const { archive } = buildVBundle({ files, ...defaultV1Options() });
+
+    // Mutate the manifest entry so it points at a different target than the
+    // one carried in the tar header. Recompute sha256 over the new target so
+    // the checksum check passes and we exercise the linkname-mismatch branch.
+    const tampered = mutateManifestAndRepack(archive, (contents) => {
+      const entry = contents.find((c) => c.path === "workspace/skills/foo.md")!;
+      const newTarget = "different.md";
+      entry.link_target = newTarget;
+      entry.sha256 = sha256Hex(newTarget);
+    });
+
+    const result = validateVBundle(tampered);
+    expect(result.is_valid).toBe(false);
+    const mismatch = result.errors.find(
+      (e) => e.code === "LINK_TARGET_MISMATCH",
+    );
+    expect(mismatch).toBeDefined();
+    expect(mismatch!.path).toBe("workspace/skills/foo.md");
+  });
+
+  test("manifest sha256 tampered for a symlink entry surfaces FILE_CHECKSUM_MISMATCH", () => {
+    const files = [
+      {
+        path: "workspace/skills/bar.md",
+        data: new TextEncoder().encode("hello"),
+      },
+      {
+        path: "workspace/skills/foo.md",
+        data: new Uint8Array(0),
+        linkTarget: "bar.md",
+      },
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("db-bytes"),
+      },
+    ];
+
+    const { archive } = buildVBundle({ files, ...defaultV1Options() });
+
+    const wrongDigest = "0".repeat(64);
+    const tampered = mutateManifestAndRepack(archive, (contents) => {
+      const entry = contents.find((c) => c.path === "workspace/skills/foo.md")!;
+      entry.sha256 = wrongDigest;
+    });
+
+    const result = validateVBundle(tampered);
+    expect(result.is_valid).toBe(false);
+    const checksum = result.errors.find(
+      (e) => e.code === "FILE_CHECKSUM_MISMATCH",
+    );
+    expect(checksum).toBeDefined();
+    expect(checksum!.path).toBe("workspace/skills/foo.md");
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -247,7 +247,11 @@ function createPaxPathEntry(name: string): Uint8Array {
   return result;
 }
 
-function createTarEntry(name: string, data: Uint8Array): Uint8Array {
+function createTarEntry(
+  name: string,
+  data: Uint8Array,
+  linkTarget?: string,
+): Uint8Array {
   const encoder = new TextEncoder();
   const nameBytes = encoder.encode(name);
 
@@ -255,6 +259,14 @@ function createTarEntry(name: string, data: Uint8Array): Uint8Array {
   // so that the full path is preserved in the archive.
   const needsPax = nameBytes.length > 100;
   const paxEntry = needsPax ? createPaxPathEntry(name) : null;
+
+  const isSymlink = linkTarget !== undefined;
+  const linkTargetBytes = isSymlink ? encoder.encode(linkTarget) : null;
+  if (linkTargetBytes && linkTargetBytes.length > 100) {
+    throw new Error(
+      `Symlink target "${linkTarget}" is ${linkTargetBytes.length} bytes, exceeding the ustar linkname-field 100-byte limit. The walker should guard against this case before calling createTarEntry.`,
+    );
+  }
 
   const header = new Uint8Array(BLOCK_SIZE);
 
@@ -270,14 +282,19 @@ function createTarEntry(name: string, data: Uint8Array): Uint8Array {
   // Group ID (116-123)
   writeOctal(header, 116, 8, 0);
 
-  // File size (124-135)
-  writeOctal(header, 124, 12, data.length);
+  // File size (124-135) — symlink entries always carry size 0
+  writeOctal(header, 124, 12, isSymlink ? 0 : data.length);
 
   // Modification time (136-147)
   writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
 
-  // Type flag (156): regular file
-  header[156] = "0".charCodeAt(0);
+  // Type flag (156): regular file ("0") or symlink ("2")
+  header[156] = (isSymlink ? "2" : "0").charCodeAt(0);
+
+  // Linkname (157-256) — only set for symlinks; null-padded by default
+  if (linkTargetBytes) {
+    header.set(linkTargetBytes, 157);
+  }
 
   // USTAR magic (257-262)
   const magic = encoder.encode("ustar\0");
@@ -287,16 +304,22 @@ function createTarEntry(name: string, data: Uint8Array): Uint8Array {
   header[263] = "0".charCodeAt(0);
   header[264] = "0".charCodeAt(0);
 
-  // Compute and write checksum (148-155)
+  // Compute and write checksum (148-155) — must be last so the linkname
+  // (and every other field) contributes to the sum.
   const checksum = computeHeaderChecksum(header);
   writeOctal(header, 148, 7, checksum);
   header[155] = 0x20; // trailing space
 
-  // Combine header + padded data
-  const paddedData = padToBlock(data);
-  const fileEntry = new Uint8Array(header.length + paddedData.length);
-  fileEntry.set(header, 0);
-  fileEntry.set(paddedData, header.length);
+  // Symlink entries are header-only — no body, no padding.
+  const fileEntry = isSymlink
+    ? header
+    : (() => {
+        const paddedData = padToBlock(data);
+        const combined = new Uint8Array(header.length + paddedData.length);
+        combined.set(header, 0);
+        combined.set(paddedData, header.length);
+        return combined;
+      })();
 
   if (paxEntry) {
     const result = new Uint8Array(paxEntry.length + fileEntry.length);
@@ -309,11 +332,11 @@ function createTarEntry(name: string, data: Uint8Array): Uint8Array {
 }
 
 function createTarArchive(
-  entries: Array<{ name: string; data: Uint8Array }>,
+  entries: Array<{ name: string; data: Uint8Array; linkTarget?: string }>,
 ): Uint8Array {
   const parts: Uint8Array[] = [];
   for (const entry of entries) {
-    parts.push(createTarEntry(entry.name, entry.data));
+    parts.push(createTarEntry(entry.name, entry.data, entry.linkTarget));
   }
   // End-of-archive: two zero blocks
   parts.push(new Uint8Array(BLOCK_SIZE * 2));
@@ -387,12 +410,22 @@ export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {
     secretsRedacted,
   } = options;
 
-  // Build file entries for the manifest
-  const fileEntries: ManifestFileEntryType[] = files.map((f) => ({
-    path: f.path,
-    sha256: sha256Hex(f.data),
-    size_bytes: f.data.length,
-  }));
+  // Build file entries for the manifest. Symlink entries hash the link target
+  // string (not the empty data buffer) and declare size_bytes: 0.
+  const fileEntries: ManifestFileEntryType[] = files.map((f) =>
+    f.linkTarget !== undefined
+      ? {
+          path: f.path,
+          sha256: sha256Hex(f.linkTarget),
+          size_bytes: 0,
+          link_target: f.linkTarget,
+        }
+      : {
+          path: f.path,
+          sha256: sha256Hex(f.data),
+          size_bytes: f.data.length,
+        },
+  );
 
   const { manifest, manifestData } = buildManifestObject({
     contents: fileEntries,
@@ -404,10 +437,16 @@ export function buildVBundle(options: BuildVBundleOptions): BuildVBundleResult {
     now: new Date(),
   });
 
-  // Build tar entries: manifest first, then all files
+  // Build tar entries: manifest first, then all files. Symlink entries forward
+  // `linkTarget` so createTarEntry emits a typeflag-2 header; `data` is unused
+  // in that branch but must still be a valid Uint8Array.
   const tarEntries = [
     { name: "manifest.json", data: manifestData },
-    ...files.map((f) => ({ name: f.path, data: f.data })),
+    ...files.map((f) =>
+      f.linkTarget !== undefined
+        ? { name: f.path, data: new Uint8Array(0), linkTarget: f.linkTarget }
+        : { name: f.path, data: f.data },
+    ),
   ];
 
   const tar = createTarArchive(tarEntries);

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -291,13 +291,18 @@ function parseTar(buffer: Uint8Array): TarEntry[] {
     }
 
     // Symlink (type '2') — empty body regardless of declared size; the link
-    // target lives in the ustar linkname field (157..256).
+    // target lives in the ustar linkname field (157..256). We preserve the
+    // tar-declared `size` here (rather than forcing it to 0) so the
+    // downstream `archiveEntry.size !== 0` check can surface
+    // `FILE_SIZE_MISMATCH` on malformed symlink headers. The body itself is
+    // always an empty buffer — symlinks have no data body even if the
+    // header lies about it.
     if (typeFlag === "2") {
       const linkname = decodeNullTerminated(header, 157, 100);
       entries.push({
         name: normalizePath(name),
         data: new Uint8Array(0),
-        size: 0,
+        size,
         linkname,
       });
       offset = dataStart + dataBlocks * BLOCK_SIZE;
@@ -577,15 +582,33 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
         });
       }
 
-      const normalized = posix.normalize(
-        posix.join(posix.dirname(fileEntry.path), fileEntry.link_target),
-      );
-      if (normalized.startsWith("../") || normalized === "..") {
+      // Absolute POSIX targets are unconstrained by the bundle root — reject
+      // them up front. The `posix.normalize` guard below only catches
+      // `..`-based escapes; an absolute path like `/etc/passwd` survives
+      // normalization unchanged and would otherwise pass.
+      if (fileEntry.link_target.startsWith("/")) {
         errors.push({
           code: "SYMLINK_TARGET_ESCAPES_ARCHIVE",
-          message: `Symlink target escapes archive root for ${fileEntry.path}: target=${fileEntry.link_target}, normalized=${normalized}`,
+          message: `Symlink target is absolute, which escapes the archive root for ${fileEntry.path}: target=${fileEntry.link_target}`,
           path: fileEntry.path,
         });
+      } else {
+        const normalized = posix.normalize(
+          posix.join(posix.dirname(fileEntry.path), fileEntry.link_target),
+        );
+        // Defense-in-depth: also reject if the joined+normalized path is
+        // absolute, in case `dirname` ever resolves to an absolute root.
+        if (
+          normalized.startsWith("../") ||
+          normalized === ".." ||
+          normalized.startsWith("/")
+        ) {
+          errors.push({
+            code: "SYMLINK_TARGET_ESCAPES_ARCHIVE",
+            message: `Symlink target escapes archive root for ${fileEntry.path}: target=${fileEntry.link_target}, normalized=${normalized}`,
+            path: fileEntry.path,
+          });
+        }
       }
       continue;
     }

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -14,6 +14,7 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
+import { posix } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 import { z } from "zod";
@@ -202,6 +203,9 @@ export interface VBundleTarEntry {
   name: string;
   data: Uint8Array;
   size: number;
+  /** Set when the tar entry is typeflag-2 (symlink); carries the link target
+   *  decoded from the ustar linkname field. */
+  linkname?: string;
 }
 
 export interface VBundleValidationResult {
@@ -221,6 +225,9 @@ interface TarEntry {
   name: string;
   data: Uint8Array;
   size: number;
+  /** Set when the tar entry is typeflag-2 (symlink); carries the link target
+   *  decoded from the ustar linkname field. */
+  linkname?: string;
 }
 
 /**
@@ -279,6 +286,20 @@ function parseTar(buffer: Uint8Array): TarEntry[] {
       if (pathMatch) {
         longName = pathMatch[1];
       }
+      offset = dataStart + dataBlocks * BLOCK_SIZE;
+      continue;
+    }
+
+    // Symlink (type '2') — empty body regardless of declared size; the link
+    // target lives in the ustar linkname field (157..256).
+    if (typeFlag === "2") {
+      const linkname = decodeNullTerminated(header, 157, 100);
+      entries.push({
+        name: normalizePath(name),
+        data: new Uint8Array(0),
+        size: 0,
+        linkname,
+      });
       offset = dataStart + dataBlocks * BLOCK_SIZE;
       continue;
     }
@@ -505,6 +526,75 @@ export function validateVBundle(data: Uint8Array): VBundleValidationResult {
       errors.push({
         code: "MISSING_DECLARED_FILE",
         message: `File declared in manifest not found in archive: ${fileEntry.path}`,
+        path: fileEntry.path,
+      });
+      continue;
+    }
+
+    if (fileEntry.link_target !== undefined) {
+      // Symlink branch: typeflag agreement, linkname agreement, sha over the
+      // link target string, size==0 on both sides, and path-traversal rejection.
+      if (archiveEntry.linkname === undefined) {
+        errors.push({
+          code: "SYMLINK_TYPEFLAG_MISMATCH",
+          message: `Manifest declares symlink for ${fileEntry.path} but tar entry is not typeflag-2`,
+          path: fileEntry.path,
+        });
+        continue;
+      }
+
+      if (archiveEntry.linkname !== fileEntry.link_target) {
+        errors.push({
+          code: "LINK_TARGET_MISMATCH",
+          message: `Symlink linkname mismatch for ${fileEntry.path}: manifest declares "${fileEntry.link_target}", tar carries "${archiveEntry.linkname}"`,
+          path: fileEntry.path,
+        });
+        continue;
+      }
+
+      if (archiveEntry.size !== 0) {
+        errors.push({
+          code: "FILE_SIZE_MISMATCH",
+          message: `Size mismatch for ${fileEntry.path}: manifest declares ${fileEntry.size_bytes} bytes, archive has ${archiveEntry.size} bytes`,
+          path: fileEntry.path,
+        });
+      }
+
+      if (fileEntry.size_bytes !== 0) {
+        errors.push({
+          code: "FILE_SIZE_MISMATCH",
+          message: `Size mismatch for ${fileEntry.path}: manifest declares ${fileEntry.size_bytes} bytes, archive has ${archiveEntry.size} bytes`,
+          path: fileEntry.path,
+        });
+      }
+
+      const expected = sha256Hex(fileEntry.link_target);
+      if (expected !== fileEntry.sha256) {
+        errors.push({
+          code: "FILE_CHECKSUM_MISMATCH",
+          message: `Checksum mismatch for ${fileEntry.path}: expected ${fileEntry.sha256}, computed ${expected}`,
+          path: fileEntry.path,
+        });
+      }
+
+      const normalized = posix.normalize(
+        posix.join(posix.dirname(fileEntry.path), fileEntry.link_target),
+      );
+      if (normalized.startsWith("../") || normalized === "..") {
+        errors.push({
+          code: "SYMLINK_TARGET_ESCAPES_ARCHIVE",
+          message: `Symlink target escapes archive root for ${fileEntry.path}: target=${fileEntry.link_target}, normalized=${normalized}`,
+          path: fileEntry.path,
+        });
+      }
+      continue;
+    }
+
+    if (archiveEntry.linkname !== undefined) {
+      // Tar carries a typeflag-2 entry but manifest declares a regular file.
+      errors.push({
+        code: "SYMLINK_NOT_DECLARED",
+        message: `Tar entry ${fileEntry.path} is typeflag-2 but manifest does not declare link_target`,
         path: fileEntry.path,
       });
       continue;


### PR DESCRIPTION
## Summary
- `createTarEntry`/`createTarArchive` emit tar typeflag-2 headers when `linkTarget` is set
- `parseTar` recognizes typeflag-2, decodes `linkname`
- `validateVBundle` validates symlink entries: linkname/manifest agreement, sha256 over link target, size=0, and path-traversal rejection
- Tests cover round-trip, traversal rejection, linkname/manifest mismatch, sha mismatch

Part of plan: vbundle-symlinks.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
