### PR TITLE
feat(vbundle): streaming tar emit/parse/validate for symlink entries

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-streaming.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-streaming.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Tests for streaming-side symlink support in vbundle:
+ *
+ * - `parseVBundleStream` surfaces a hand-crafted typeflag-2 entry as
+ *   `{ type: "symlink", linkname }`.
+ * - `verifySymlinkEntry` accepts a well-formed symlink entry whose manifest
+ *   declared a matching `link_target`.
+ * - `verifySymlinkEntry` rejects a target that escapes the archive root with
+ *   code `"symlink_target_escapes_archive"`.
+ * - `verifySymlinkEntry` rejects a manifest/tar disagreement with code
+ *   `"link_target_mismatch"`.
+ *
+ * Round-trip via `buildVBundle({ files: [{ linkTarget }] })` is intentionally
+ * `test.todo` — the in-memory builder symlink emit lands in PR 2 and the
+ * walker lands in PR 4. Once both are merged we can assert end-to-end that
+ * a symlink survives buildVBundle -> parseVBundleStream -> verifySymlinkEntry.
+ */
+
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { gzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+
+import {
+  StreamingValidationError,
+  verifySymlinkEntry,
+} from "../vbundle-streaming-validator.js";
+import {
+  parseVBundleStream,
+  type StreamedTarEntry,
+} from "../vbundle-tar-stream.js";
+
+// ---------------------------------------------------------------------------
+// Hand-crafted tar fixture helpers
+// ---------------------------------------------------------------------------
+
+const BLOCK_SIZE = 512;
+
+function writeOctal(
+  buf: Uint8Array,
+  offset: number,
+  length: number,
+  value: number,
+): void {
+  const str = value.toString(8).padStart(length - 1, "0");
+  for (let i = 0; i < str.length; i++) {
+    buf[offset + i] = str.charCodeAt(i);
+  }
+  buf[offset + length - 1] = 0;
+}
+
+/**
+ * Build a single 512-byte tar header block with typeflag-2 (symlink). The
+ * link target is written into the linkname field (header[157..256]). Body
+ * size is always 0 for symlink entries so no content blocks follow.
+ */
+function buildSymlinkHeaderBlock(name: string, linkTarget: string): Uint8Array {
+  const encoder = new TextEncoder();
+  const nameBytes = encoder.encode(name);
+  const linkBytes = encoder.encode(linkTarget);
+  if (nameBytes.length > 100) {
+    throw new Error(`fixture: name too long (${nameBytes.length} bytes)`);
+  }
+  if (linkBytes.length > 100) {
+    throw new Error(`fixture: linkTarget too long (${linkBytes.length} bytes)`);
+  }
+
+  const header = new Uint8Array(BLOCK_SIZE);
+  header.set(nameBytes, 0);
+  writeOctal(header, 100, 8, 0o644);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, 0); // size=0
+  writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
+  header[156] = "2".charCodeAt(0); // typeflag = symlink
+  header.set(linkBytes, 157); // linkname
+
+  const magic = encoder.encode("ustar\0");
+  header.set(magic, 257);
+  header[263] = "0".charCodeAt(0);
+  header[264] = "0".charCodeAt(0);
+
+  // Checksum: sum of all bytes with the checksum field treated as 8 ASCII spaces.
+  let sum = 0;
+  for (let i = 0; i < BLOCK_SIZE; i++) {
+    sum += i >= 148 && i < 156 ? 0x20 : header[i];
+  }
+  writeOctal(header, 148, 7, sum);
+  header[155] = 0x20;
+
+  return header;
+}
+
+/** Concatenate a list of byte chunks into a single Uint8Array. */
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+/**
+ * Build a minimal gzipped tar archive containing a single typeflag-2 entry
+ * followed by the standard two-block end-of-archive marker. Used for
+ * exercising the parser without depending on `buildVBundle` symlink emit
+ * (which lands in PR 2).
+ */
+function buildGzippedSymlinkOnlyTar(
+  name: string,
+  linkTarget: string,
+): Uint8Array {
+  const tar = concatBytes([
+    buildSymlinkHeaderBlock(name, linkTarget),
+    new Uint8Array(BLOCK_SIZE * 2), // EOA marker
+  ]);
+  return gzipSync(tar);
+}
+
+function readableFromBuffer(buf: Uint8Array): Readable {
+  return Readable.from([Buffer.from(buf)]);
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Build a synthetic `StreamedTarEntry` for use with `verifySymlinkEntry`.
+ * The body is empty (`Readable.from([])`) since symlink entries declare
+ * size=0 and never carry payload bytes.
+ */
+function makeSymlinkEntry(input: {
+  name: string;
+  linkname: string;
+  size?: number;
+}): StreamedTarEntry {
+  return {
+    header: {
+      name: input.name,
+      size: input.size ?? 0,
+      type: "symlink",
+      linkname: input.linkname,
+    },
+    body: Readable.from([]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseVBundleStream — surfaces typeflag-2 entries
+// ---------------------------------------------------------------------------
+
+describe("parseVBundleStream — symlink entries", () => {
+  test("surfaces a typeflag-2 entry as { type: 'symlink', linkname }", async () => {
+    const archive = buildGzippedSymlinkOnlyTar("workspace/foo.md", "bar.md");
+
+    const seen: { name: string; type: string; linkname?: string }[] = [];
+    for await (const entry of parseVBundleStream(readableFromBuffer(archive))) {
+      seen.push({
+        name: entry.header.name,
+        type: entry.header.type,
+        linkname: entry.header.linkname,
+      });
+      // Drain the (zero-byte) body so the extractor advances.
+      entry.body.resume();
+    }
+
+    expect(seen.length).toBe(1);
+    expect(seen[0]?.name).toBe("workspace/foo.md");
+    expect(seen[0]?.type).toBe("symlink");
+    expect(seen[0]?.linkname).toBe("bar.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifySymlinkEntry — happy path
+// ---------------------------------------------------------------------------
+
+describe("verifySymlinkEntry — accepts a valid symlink", () => {
+  test("does not throw when manifest and tar agree and target stays in archive", () => {
+    const linkTarget = "bar.md";
+    const entry = makeSymlinkEntry({
+      name: "workspace/foo.md",
+      linkname: linkTarget,
+    });
+
+    expect(() =>
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex(linkTarget),
+          size: 0,
+          linkTarget,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts a target that resolves to a sibling at the archive root", () => {
+    const linkTarget = "sibling.md";
+    const entry = makeSymlinkEntry({
+      name: "workspace/notes/foo.md",
+      linkname: linkTarget,
+    });
+
+    expect(() =>
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex(linkTarget),
+          size: 0,
+          linkTarget,
+        },
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifySymlinkEntry — path traversal rejection
+// ---------------------------------------------------------------------------
+
+describe("verifySymlinkEntry — path traversal", () => {
+  test("rejects a target that escapes the archive root with code symlink_target_escapes_archive", () => {
+    const escapingTarget = "../../../etc/passwd";
+    const entry = makeSymlinkEntry({
+      name: "workspace/foo.md",
+      linkname: escapingTarget,
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex(escapingTarget),
+          size: 0,
+          linkTarget: escapingTarget,
+        },
+      });
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("symlink_target_escapes_archive");
+    expect(err?.archivePath).toBe("workspace/foo.md");
+  });
+
+  test("rejects a target that escapes the archive root from a top-level symlink", () => {
+    // Symlink at "foo.md" (no parent dir inside the archive); a `..` target
+    // resolves above the archive root.
+    const escapingTarget = "..";
+    const entry = makeSymlinkEntry({
+      name: "foo.md",
+      linkname: escapingTarget,
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex(escapingTarget),
+          size: 0,
+          linkTarget: escapingTarget,
+        },
+      });
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("symlink_target_escapes_archive");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifySymlinkEntry — manifest/tar disagreement
+// ---------------------------------------------------------------------------
+
+describe("verifySymlinkEntry — disagreement", () => {
+  test("throws link_target_mismatch when tar linkname differs from manifest link_target", () => {
+    const entry = makeSymlinkEntry({
+      name: "workspace/foo.md",
+      linkname: "bar.md",
+    });
+    const manifestTarget = "qux.md";
+
+    let err: StreamingValidationError | null = null;
+    try {
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex(manifestTarget),
+          size: 0,
+          linkTarget: manifestTarget,
+        },
+      });
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("link_target_mismatch");
+    expect(err?.archivePath).toBe("workspace/foo.md");
+  });
+
+  test("throws symlink_not_declared when manifest entry has no link_target", () => {
+    const entry = makeSymlinkEntry({
+      name: "workspace/foo.md",
+      linkname: "bar.md",
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex("bar.md"),
+          size: 0,
+          linkTarget: null,
+        },
+      });
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("symlink_not_declared");
+  });
+
+  test("throws entry_size when symlink header declares non-zero size", () => {
+    const entry = makeSymlinkEntry({
+      name: "workspace/foo.md",
+      linkname: "bar.md",
+      size: 5,
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex("bar.md"),
+          size: 0,
+          linkTarget: "bar.md",
+        },
+      });
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("entry_size");
+  });
+
+  test("throws entry_hash when manifest sha256 doesn't match link target digest", () => {
+    const linkTarget = "bar.md";
+    const entry = makeSymlinkEntry({
+      name: "workspace/foo.md",
+      linkname: linkTarget,
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          // Wrong digest — manifest declared a different content than what's
+          // hashable from the link target.
+          sha256:
+            "0000000000000000000000000000000000000000000000000000000000000000",
+          size: 0,
+          linkTarget,
+        },
+      });
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("entry_hash");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip via buildVBundle — gated on PR 2 + PR 4
+// ---------------------------------------------------------------------------
+
+test.todo(
+  "round-trip: buildVBundle({ files: [{ linkTarget }] }) -> parseVBundleStream -> verifySymlinkEntry. Enable once PR 2 (buildVBundle symlink emit) and PR 4 (walker symlink collection) have landed.",
+  () => {
+    // no-op: see comment above.
+  },
+);

--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-streaming.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-streaming.test.ts
@@ -250,6 +250,37 @@ describe("verifySymlinkEntry — path traversal", () => {
     expect(err?.archivePath).toBe("workspace/foo.md");
   });
 
+  test("verifySymlinkEntry rejects absolute symlink targets", () => {
+    // Regression: `posix.join("workspace", "/etc/passwd")` normalizes the
+    // leading slash away and returns `"workspace/etc/passwd"`, so without
+    // an explicit absolute-target guard an attacker could ship a manifest
+    // with `link_target: "/etc/passwd"` that passes the `..` traversal
+    // check and is later realized by `fs.symlink("/etc/passwd", ...)`.
+    const absoluteTarget = "/etc/passwd";
+    const entry = makeSymlinkEntry({
+      name: "workspace/skills/foo.md",
+      linkname: absoluteTarget,
+    });
+
+    let err: StreamingValidationError | null = null;
+    try {
+      verifySymlinkEntry({
+        entry,
+        expectedEntry: {
+          sha256: sha256Hex(absoluteTarget),
+          size: 0,
+          linkTarget: absoluteTarget,
+        },
+      });
+    } catch (e) {
+      err = e as StreamingValidationError;
+    }
+
+    expect(err).toBeInstanceOf(StreamingValidationError);
+    expect(err?.code).toBe("symlink_target_escapes_archive");
+    expect(err?.archivePath).toBe("workspace/skills/foo.md");
+  });
+
   test("rejects a target that escapes the archive root from a top-level symlink", () => {
     // Symlink at "foo.md" (no parent dir inside the archive); a `..` target
     // resolves above the archive root.

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -712,8 +712,18 @@ async function computeFileSha256(
 /**
  * Create just the 512-byte tar header block for a regular file entry.
  * Extracted from `createTarEntry` logic — does NOT include data or padding.
+ *
+ * When `linkTarget` is provided, the header is emitted as a tar typeflag-2
+ * (symlink) record: typeflag is "2", the link target is written into the
+ * `linkname` field (header[157..256], 100-byte limit), and `size` is forced
+ * to 0 in the header field. Caller is responsible for not yielding any body
+ * or padding bytes for symlink entries.
  */
-function createTarHeaderBlock(name: string, size: number): Uint8Array {
+function createTarHeaderBlock(
+  name: string,
+  size: number,
+  linkTarget?: string,
+): Uint8Array {
   const encoder = new TextEncoder();
   const nameBytes = encoder.encode(name);
 
@@ -731,14 +741,26 @@ function createTarHeaderBlock(name: string, size: number): Uint8Array {
   // Group ID (116-123)
   writeOctal(header, 116, 8, 0);
 
-  // File size (124-135)
-  writeOctal(header, 124, 12, size);
+  // File size (124-135) — symlink entries always declare size=0
+  writeOctal(header, 124, 12, linkTarget !== undefined ? 0 : size);
 
   // Modification time (136-147)
   writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
 
-  // Type flag (156): regular file
-  header[156] = "0".charCodeAt(0);
+  // Type flag (156): regular file ("0") or symlink ("2")
+  header[156] =
+    linkTarget !== undefined ? "2".charCodeAt(0) : "0".charCodeAt(0);
+
+  // Linkname (157-256, 100 bytes) — only set for symlink entries
+  if (linkTarget !== undefined) {
+    const linkBytes = encoder.encode(linkTarget);
+    if (linkBytes.length > 100) {
+      throw new Error(
+        `symlink target exceeds 100-byte ustar linkname limit (${linkBytes.length} bytes): ${linkTarget}`,
+      );
+    }
+    header.set(linkBytes, 157);
+  }
 
   // USTAR magic (257-262)
   const magic = encoder.encode("ustar\0");
@@ -748,7 +770,8 @@ function createTarHeaderBlock(name: string, size: number): Uint8Array {
   header[263] = "0".charCodeAt(0);
   header[264] = "0".charCodeAt(0);
 
-  // Compute and write checksum (148-155)
+  // Compute and write checksum (148-155). Must run AFTER linkname is set
+  // so the checksum covers the symlink target bytes.
   const checksum = computeHeaderChecksum(header);
   writeOctal(header, 148, 7, checksum);
   header[155] = 0x20; // trailing space
@@ -760,13 +783,21 @@ function createTarHeaderBlock(name: string, size: number): Uint8Array {
  * If name exceeds 100 bytes, returns the PAX extended header entry
  * concatenated with the regular header block. Otherwise returns just
  * the header block.
+ *
+ * `linkTarget` is forwarded to `createTarHeaderBlock` so symlink entries
+ * still get a PAX path header for long names while emitting a typeflag-2
+ * ustar block.
  */
-function createPaxAndHeaderBlocks(name: string, size: number): Uint8Array {
+function createPaxAndHeaderBlocks(
+  name: string,
+  size: number,
+  linkTarget?: string,
+): Uint8Array {
   const encoder = new TextEncoder();
   const nameBytes = encoder.encode(name);
   const needsPax = nameBytes.length > 100;
 
-  const header = createTarHeaderBlock(name, size);
+  const header = createTarHeaderBlock(name, size, linkTarget);
 
   if (needsPax) {
     const paxEntry = createPaxPathEntry(name);
@@ -804,12 +835,18 @@ async function* generateTarStream(
 
   // File entries
   for (const file of files) {
+    if (isSymlinkEntry(file)) {
+      // Symlink entry: typeflag-2 header carries the linkname; no body, no
+      // padding. Skip the entrySize/body/padding logic entirely so the
+      // surrounding stream stays block-aligned.
+      yield createPaxAndHeaderBlocks(file.archivePath, 0, file.linkTarget);
+      continue;
+    }
+
     const entrySize = file.size;
     yield createPaxAndHeaderBlocks(file.archivePath, entrySize);
 
-    if (isSymlinkEntry(file)) {
-      // Symlink entry — empty body; the link target lives in the tar header.
-    } else if (isInMemoryEntry(file)) {
+    if (isInMemoryEntry(file)) {
       // In-memory entry — yield data directly
       if (file.size > 0) {
         yield file.data;
@@ -951,6 +988,11 @@ export async function streamExportVBundle(
     }
   }
 
+  // Symlink entries — populated by the walker in PR 4. For now this slice
+  // is always empty; downstream wiring (manifest emit + tar emit) is in
+  // place so the walker can append entries without further plumbing.
+  const symlinkEntries: SymlinkMetadata[] = [];
+
   // ------------------------------------------------------------------
   // Pass 1: Compute SHA-256 checksums to build the manifest
   // ------------------------------------------------------------------
@@ -975,6 +1017,19 @@ export async function streamExportVBundle(
     });
   }
 
+  // Add symlink entries to the manifest. The sha256 is computed over the
+  // link target string (UTF-8 encoded) so the streaming validator can
+  // verify the manifest declared the same target the tar header carries.
+  // size_bytes is always 0 for symlink entries.
+  for (const entry of symlinkEntries) {
+    fileEntries.push({
+      path: entry.archivePath,
+      sha256: sha256Hex(entry.linkTarget),
+      size_bytes: 0,
+      link_target: entry.linkTarget,
+    });
+  }
+
   const { manifest, manifestData } = buildManifestObject({
     contents: fileEntries,
     assistant,
@@ -995,6 +1050,7 @@ export async function streamExportVBundle(
     ...allFileMetadata,
     ...sanitizedConfigEntries,
     ...inMemoryEntries,
+    ...symlinkEntries,
   ];
   const tarGenerator = generateTarStream(manifestData, allEntries);
   const tarReadable = Readable.from(tarGenerator);

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -285,14 +285,37 @@ export function verifySymlinkEntry(input: {
     );
   }
 
+  // Absolute targets escape the archive root unconditionally — and would
+  // bypass the resolution check below because `posix.join("workspace",
+  // "/etc/passwd")` normalizes the leading `/` away and returns
+  // `"workspace/etc/passwd"`. Reject these explicitly before resolution so
+  // a symlink with target `/etc/passwd` cannot be imported as a real
+  // host-filesystem symlink.
+  if (expectedEntry.linkTarget.startsWith("/")) {
+    entry.body.resume();
+    throw new StreamingValidationError(
+      "symlink_target_escapes_archive",
+      `Symlink ${archivePath} has absolute target ${JSON.stringify(
+        expectedEntry.linkTarget,
+      )}, which escapes the archive root`,
+      archivePath,
+    );
+  }
+
   // Path traversal: resolve the symlink target relative to the symlink's own
   // directory inside the archive. If the resolved path escapes the archive
   // root (begins with `..` or equals `..`), the target points outside the
-  // bundle — refuse to import.
+  // bundle — refuse to import. Also reject a resolved path that is itself
+  // absolute as defense-in-depth (dirname could in theory yield an absolute
+  // path; cheap to guard).
   const resolved = posix.normalize(
     posix.join(posix.dirname(archivePath), expectedEntry.linkTarget),
   );
-  if (resolved === ".." || resolved.startsWith("../")) {
+  if (
+    resolved === ".." ||
+    resolved.startsWith("../") ||
+    resolved.startsWith("/")
+  ) {
     entry.body.resume();
     throw new StreamingValidationError(
       "symlink_target_escapes_archive",

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -20,6 +20,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { posix } from "node:path";
 import { Transform, type TransformCallback } from "node:stream";
 
 import type { StreamedTarEntry } from "./vbundle-tar-stream.js";
@@ -38,8 +39,16 @@ import {
 
 export interface ManifestReadResult {
   manifest: ManifestType;
-  /** Fast lookup from archive path -> expected sha256 + size (from manifest.contents). */
-  expected: Map<string, { sha256: string; size: number }>;
+  /**
+   * Fast lookup from archive path -> expected sha256 + size + linkTarget
+   * (from manifest.contents). `linkTarget` is non-null only for symlink
+   * entries — regular file entries carry `null` so callers can branch on
+   * type without a separate map.
+   */
+  expected: Map<
+    string,
+    { sha256: string; size: number; linkTarget: string | null }
+  >;
 }
 
 /**
@@ -177,7 +186,10 @@ export async function readAndValidateManifest(
     manifest = translateLegacyManifest(legacy);
   }
 
-  const expected = new Map<string, { sha256: string; size: number }>();
+  const expected = new Map<
+    string,
+    { sha256: string; size: number; linkTarget: string | null }
+  >();
   for (const file of manifest.contents) {
     if (expected.has(file.path)) {
       throw new StreamingValidationError(
@@ -185,10 +197,114 @@ export async function readAndValidateManifest(
         `Manifest contains duplicate entry for path: ${file.path}`,
       );
     }
-    expected.set(file.path, { sha256: file.sha256, size: file.size_bytes });
+    expected.set(file.path, {
+      sha256: file.sha256,
+      size: file.size_bytes,
+      linkTarget: file.link_target ?? null,
+    });
   }
 
   return { manifest, expected };
+}
+
+// ---------------------------------------------------------------------------
+// Symlink entry verifier
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hex digest of UTF-8 bytes / Uint8Array — local mirror of the helper in vbundle-streaming-importer.ts. */
+function sha256Hex(data: Uint8Array | string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+/**
+ * Verify a streaming tar entry whose manifest declared it as a symlink.
+ *
+ * Throws `StreamingValidationError` with stable codes for each failure mode:
+ *   - `entry_size`: tar header declared a non-zero size (symlink bodies must be empty).
+ *   - `symlink_not_declared`: manifest entry didn't carry a `link_target` so the
+ *     tar typeflag-2 record is unauthorized.
+ *   - `link_target_mismatch`: tar header `linkname` doesn't equal the manifest's
+ *     declared `link_target`. Either the bundle was tampered with or the producer
+ *     and writer disagreed.
+ *   - `entry_hash`: manifest's declared sha256 does not match the sha256 of the
+ *     declared link target string. Catches manifest tampering where the attacker
+ *     adjusted `link_target` but forgot to recompute the digest.
+ *   - `symlink_target_escapes_archive`: the resolved link target points outside
+ *     the archive root (e.g. `../../etc/passwd`). Importer would otherwise
+ *     follow the symlink to a privileged path on the host.
+ *
+ * On success, drains the entry body via `entry.body.resume()` so the tar
+ * extractor's `next` callback fires and the parser can advance to the next
+ * entry — symlink bodies are size=0, but `tar-stream` still emits a Readable
+ * that needs to be consumed.
+ */
+export function verifySymlinkEntry(input: {
+  entry: StreamedTarEntry;
+  expectedEntry: { sha256: string; size: number; linkTarget: string | null };
+}): void {
+  const { entry, expectedEntry } = input;
+  const archivePath = entry.header.name;
+
+  if (entry.header.size !== 0) {
+    entry.body.resume();
+    throw new StreamingValidationError(
+      "entry_size",
+      `Symlink entry ${archivePath} declared size ${entry.header.size}; symlink bodies must be empty`,
+      archivePath,
+    );
+  }
+
+  if (expectedEntry.linkTarget == null) {
+    entry.body.resume();
+    throw new StreamingValidationError(
+      "symlink_not_declared",
+      `Tar entry ${archivePath} is a symlink but the manifest did not declare a link_target`,
+      archivePath,
+    );
+  }
+
+  const tarLinkname = entry.header.linkname;
+  if (tarLinkname !== expectedEntry.linkTarget) {
+    entry.body.resume();
+    throw new StreamingValidationError(
+      "link_target_mismatch",
+      `Symlink target mismatch for ${archivePath}: tar header linkname=${JSON.stringify(
+        tarLinkname,
+      )}, manifest link_target=${JSON.stringify(expectedEntry.linkTarget)}`,
+      archivePath,
+    );
+  }
+
+  const computedSha = sha256Hex(expectedEntry.linkTarget);
+  if (computedSha !== expectedEntry.sha256) {
+    entry.body.resume();
+    throw new StreamingValidationError(
+      "entry_hash",
+      `Symlink hash mismatch for ${archivePath}: manifest sha256=${expectedEntry.sha256}, computed over link_target=${computedSha}`,
+      archivePath,
+    );
+  }
+
+  // Path traversal: resolve the symlink target relative to the symlink's own
+  // directory inside the archive. If the resolved path escapes the archive
+  // root (begins with `..` or equals `..`), the target points outside the
+  // bundle — refuse to import.
+  const resolved = posix.normalize(
+    posix.join(posix.dirname(archivePath), expectedEntry.linkTarget),
+  );
+  if (resolved === ".." || resolved.startsWith("../")) {
+    entry.body.resume();
+    throw new StreamingValidationError(
+      "symlink_target_escapes_archive",
+      `Symlink ${archivePath} target ${JSON.stringify(
+        expectedEntry.linkTarget,
+      )} resolves to ${resolved}, which escapes the archive root`,
+      archivePath,
+    );
+  }
+
+  // All checks pass — drain the (empty) body so the tar extractor advances.
+  entry.body.resume();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Streaming tar primitives (`createTarHeaderBlock`, `createPaxAndHeaderBlocks`, `generateTarStream`) emit typeflag-2 entries when given a symlink entry
- Streaming validator's manifest `expected` map carries optional `linkTarget`; new `verifySymlinkEntry` helper enforces sha/linkname agreement, size=0, and path-traversal rejection
- Tests cover symlink verification, traversal rejection, and manifest/tar disagreement

Part of plan: vbundle-symlinks.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
