### PR TITLE
Fix managed assistant desktop reconnect after hatch

### DIFF
--- a/clients/macos/vellum-assistantTests/HealthCheckClientTests.swift
+++ b/clients/macos/vellum-assistantTests/HealthCheckClientTests.swift
@@ -232,4 +232,18 @@ final class HealthCheckClientTests: XCTestCase {
         )
         XCTAssertTrue(assistant.isRemote)
     }
+
+    func testManagedAssistantGatewayHealthUsesAssistantScopedPath() {
+        XCTAssertFalse(
+            HealthCheckClient.usesUnprefixedGatewayHealth(forManagedConnection: true),
+            "Managed assistants route through the platform proxy and must keep the assistants/{id} health scope"
+        )
+    }
+
+    func testNonManagedAssistantGatewayHealthUsesFlatPath() {
+        XCTAssertTrue(
+            HealthCheckClient.usesUnprefixedGatewayHealth(forManagedConnection: false),
+            "Local and non-managed remote assistants expose health at the flat gateway path"
+        )
+    }
 }

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -358,6 +358,9 @@ public final class GatewayConnectionManager {
 
     private func performHealthCheck() async throws {
         let healthPath = "health"
+        let useUnprefixedHealthPath = HealthCheckClient.usesUnprefixedGatewayHealth(
+            forManagedConnection: isManagedConnectionForHealthCheck()
+        )
 
         // Run the HTTP GET + JSON decode off the main actor. `GatewayHTTPClient`
         // is nonisolated but, when called from a `@MainActor` context, its
@@ -381,7 +384,7 @@ public final class GatewayConnectionManager {
                 path: healthPath,
                 timeout: 10,
                 quiet: true,
-                unprefixed: true
+                unprefixed: useUnprefixedHealthPath
             )
             let version: String? = response.isSuccess
                 ? (try? JSONDecoder().decode(HealthVersionResponse.self, from: response.data))?.version
@@ -445,6 +448,14 @@ public final class GatewayConnectionManager {
             log.info("Health check passed")
         }
         setConnected(true)
+    }
+
+    private func isManagedConnectionForHealthCheck() -> Bool {
+        #if os(macOS)
+        return cachedAssistant?.isManaged ?? false
+        #else
+        return (try? GatewayHTTPClient.isConnectionManaged()) ?? false
+        #endif
     }
 
     /// Reconciles `isAuthFailed` against the tracker's current state and logs

--- a/clients/shared/Network/GatewayHTTPClient.swift
+++ b/clients/shared/Network/GatewayHTTPClient.swift
@@ -14,12 +14,12 @@ public enum MultipartPart {
 /// Consolidates URL construction, auth headers, org-id injection, and
 /// request execution so callers can simply write:
 ///
-///     let response = try await GatewayHTTPClient.get(path: "health", unprefixed: true)
+///     let response = try await GatewayHTTPClient.get(path: "health")
 ///     let response = try await GatewayHTTPClient.post(path: "restart")
 ///
 /// All paths are automatically prepended with `assistants/{assistantId}/` unless
 /// the caller passes `unprefixed: true` (for routes that operate outside assistant
-/// scope, e.g. `health`, `guardian/*`, `secrets`).
+/// scope, e.g. `healthz`, `guardian/*`, `secrets`).
 public enum GatewayHTTPClient {
     private static let sseAcceptHeader = "text/event-stream, application/json"
 

--- a/clients/shared/Network/HealthCheckClient.swift
+++ b/clients/shared/Network/HealthCheckClient.swift
@@ -10,14 +10,21 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Healt
 /// `GatewayHTTPClient` which handles URL resolution, authentication, and 401 retry.
 public enum HealthCheckClient {
 
+    /// Managed platform health is assistant-scoped; flat gateway health is
+    /// only for non-managed runtimes.
+    static func usesUnprefixedGatewayHealth(forManagedConnection isManaged: Bool) -> Bool {
+        !isManaged
+    }
+
     /// Check whether the currently connected assistant is reachable.
     public static func isReachable(timeout: TimeInterval = 3) async -> Bool {
+        let isManagedConnection = (try? GatewayHTTPClient.isConnectionManaged()) ?? false
         do {
             let response = try await GatewayHTTPClient.get(
                 path: "health",
                 timeout: timeout,
                 quiet: true,
-                unprefixed: true
+                unprefixed: usesUnprefixedGatewayHealth(forManagedConnection: isManagedConnection)
             )
             return response.isSuccess
         } catch {
@@ -50,7 +57,7 @@ public enum HealthCheckClient {
                     path: "health",
                     timeout: timeout,
                     quiet: true,
-                    unprefixed: true
+                    unprefixed: usesUnprefixedGatewayHealth(forManagedConnection: assistant.isManaged)
                 )
                 return response.isSuccess
             } catch {


### PR DESCRIPTION
## Summary
- Keep managed assistant health checks on the assistant-scoped platform route after hatch.
- Share the managed-vs-flat health route decision with reachability checks.
- Add regression coverage for managed and non-managed health route selection.

## Original prompt
finish up this pr
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
