### PR TITLE
feat(vbundle): commitImport recreates symlink entries via symlinkSync

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-importer.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Symlink-handling coverage for the buffer-mode `commitImport`.
+ *
+ * Scenarios:
+ *   1. Round-trip: a typeflag-2 manifest entry is recreated as a real symlink
+ *      under the workspace, points at its sibling regular file, and reads
+ *      back its target's contents through the link.
+ *   2. Defense-in-depth: a hand-built `preValidatedManifest` carrying a
+ *      `..`-traversal `link_target` is skipped (not written), with a
+ *      "escapes workspace" warning.
+ *   3. Defense-in-depth: an absolute `link_target` ("/etc/passwd") is
+ *      skipped with the same warning shape.
+ *   4. Overwrite: an existing regular file at the symlink's target path is
+ *      backed up, then replaced by the symlink. Backup contents match the
+ *      pre-existing file.
+ *   5. Symlink-overwrites-symlink: a different pre-existing symlink at the
+ *      target path is replaced cleanly without an EEXIST.
+ */
+
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { buildVBundle } from "../vbundle-builder.js";
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { commitImport } from "../vbundle-importer.js";
+import type { VBundleTarEntry } from "../vbundle-validator.js";
+import { buildTestManifest, defaultV1Options } from "./v1-test-helpers.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vbundle-symlink-importer-"));
+});
+
+afterEach(() => {
+  if (workspaceDir) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function makePathResolver(): DefaultPathResolver {
+  // Pass a stub guardian persona resolver to avoid the production lookup
+  // touching the real contact store during tests.
+  return new DefaultPathResolver(workspaceDir, undefined, () => null);
+}
+
+describe("commitImport — symlinks", () => {
+  test("round-trip: recreates a typeflag-2 entry as a real symlink", () => {
+    const files = [
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("db-bytes"),
+      },
+      {
+        path: "workspace/skills/bar.md",
+        data: new TextEncoder().encode("hello bar"),
+      },
+      {
+        path: "workspace/skills/foo.md",
+        data: new Uint8Array(0),
+        linkTarget: "bar.md",
+      },
+    ];
+    const { archive } = buildVBundle({ files, ...defaultV1Options() });
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: makePathResolver(),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const fooPath = join(workspaceDir, "skills/foo.md");
+    expect(lstatSync(fooPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(fooPath)).toBe("bar.md");
+    expect(readFileSync(fooPath, "utf8")).toBe("hello bar");
+
+    const fooReport = result.report.files.find(
+      (f) => f.path === "workspace/skills/foo.md",
+    );
+    expect(fooReport).toBeDefined();
+    expect(fooReport!.action).toBe("created");
+    expect(fooReport!.size).toBe(0);
+    expect(fooReport!.backup_path).toBeNull();
+  });
+
+  test("defense-in-depth: traversal link_target is skipped with warning", () => {
+    // Bypass `validateVBundle` (which would reject the traversal first) by
+    // handing `commitImport` a hand-built manifest + entries map.
+    const linkTarget = "../../../tmp/escape";
+    const archivePath = "workspace/skills/escape.md";
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: "0".repeat(64),
+          size_bytes: 8,
+        },
+        {
+          path: archivePath,
+          sha256: "0".repeat(64),
+          size_bytes: 0,
+          link_target: linkTarget,
+        },
+      ],
+    });
+    const entries = new Map<string, VBundleTarEntry>([
+      [
+        "workspace/data/db/assistant.db",
+        {
+          name: "workspace/data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+          size: 8,
+        },
+      ],
+      [
+        archivePath,
+        {
+          name: archivePath,
+          data: new Uint8Array(0),
+          size: 0,
+          linkname: linkTarget,
+        },
+      ],
+    ]);
+
+    const result = commitImport({
+      archiveData: new Uint8Array(0),
+      pathResolver: makePathResolver(),
+      preValidatedManifest: manifest,
+      preValidatedEntries: entries,
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const entry = result.report.files.find((f) => f.path === archivePath);
+    expect(entry).toBeDefined();
+    expect(entry!.action).toBe("skipped");
+    expect(
+      result.report.warnings.some((w) => w.includes("escapes workspace")),
+    ).toBe(true);
+
+    // Nothing should have landed on disk for the rejected entry.
+    expect(() => lstatSync(join(workspaceDir, "skills/escape.md"))).toThrow();
+  });
+
+  test("defense-in-depth: absolute link_target is skipped with warning", () => {
+    const linkTarget = "/etc/passwd";
+    const archivePath = "workspace/skills/abs.md";
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: "0".repeat(64),
+          size_bytes: 8,
+        },
+        {
+          path: archivePath,
+          sha256: "0".repeat(64),
+          size_bytes: 0,
+          link_target: linkTarget,
+        },
+      ],
+    });
+    const entries = new Map<string, VBundleTarEntry>([
+      [
+        "workspace/data/db/assistant.db",
+        {
+          name: "workspace/data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+          size: 8,
+        },
+      ],
+      [
+        archivePath,
+        {
+          name: archivePath,
+          data: new Uint8Array(0),
+          size: 0,
+          linkname: linkTarget,
+        },
+      ],
+    ]);
+
+    const result = commitImport({
+      archiveData: new Uint8Array(0),
+      pathResolver: makePathResolver(),
+      preValidatedManifest: manifest,
+      preValidatedEntries: entries,
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const entry = result.report.files.find((f) => f.path === archivePath);
+    expect(entry).toBeDefined();
+    expect(entry!.action).toBe("skipped");
+    expect(
+      result.report.warnings.some((w) => w.includes("escapes workspace")),
+    ).toBe(true);
+
+    expect(() => lstatSync(join(workspaceDir, "skills/abs.md"))).toThrow();
+  });
+
+  test("overwrite: pre-existing regular file is backed up and replaced", () => {
+    // Hand-build the manifest and skip `workspaceDir` so the workspace
+    // clear (Step 1b) doesn't wipe the regular file we plant below — that
+    // way we exercise the in-loop overwrite branch directly.
+    const archivePath = "workspace/skills/foo.md";
+    const linkTarget = "bar.md";
+
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: "0".repeat(64),
+          size_bytes: 8,
+        },
+        {
+          path: archivePath,
+          sha256: "0".repeat(64),
+          size_bytes: 0,
+          link_target: linkTarget,
+        },
+      ],
+    });
+    const entries = new Map<string, VBundleTarEntry>([
+      [
+        "workspace/data/db/assistant.db",
+        {
+          name: "workspace/data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+          size: 8,
+        },
+      ],
+      [
+        archivePath,
+        {
+          name: archivePath,
+          data: new Uint8Array(0),
+          size: 0,
+          linkname: linkTarget,
+        },
+      ],
+    ]);
+
+    // Pre-create the conflicting regular file at the resolved target.
+    const fooDiskPath = join(workspaceDir, "skills/foo.md");
+    mkdirSync(dirname(fooDiskPath), { recursive: true });
+    writeFileSync(fooDiskPath, "old");
+
+    const result = commitImport({
+      archiveData: new Uint8Array(0),
+      pathResolver: makePathResolver(),
+      preValidatedManifest: manifest,
+      preValidatedEntries: entries,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(lstatSync(fooDiskPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(fooDiskPath)).toBe("bar.md");
+
+    const report = result.report.files.find((f) => f.path === archivePath)!;
+    expect(report.action).toBe("overwritten");
+    expect(report.backup_path).not.toBeNull();
+
+    // A backup file matching the foo.md.backup-* glob should exist and
+    // contain the pre-existing regular-file bytes.
+    const skillsDir = join(workspaceDir, "skills");
+    const siblings = readdirSync(skillsDir);
+    const backups = siblings.filter((n) => n.startsWith("foo.md.backup-"));
+    expect(backups.length).toBeGreaterThan(0);
+    const backupContents = readFileSync(join(skillsDir, backups[0]), "utf8");
+    expect(backupContents).toBe("old");
+  });
+
+  test("symlink-overwrites-symlink: replaces an existing symlink without EEXIST", () => {
+    const archivePath = "workspace/skills/foo.md";
+    const linkTarget = "bar.md";
+
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: "0".repeat(64),
+          size_bytes: 8,
+        },
+        {
+          path: archivePath,
+          sha256: "0".repeat(64),
+          size_bytes: 0,
+          link_target: linkTarget,
+        },
+      ],
+    });
+    const entries = new Map<string, VBundleTarEntry>([
+      [
+        "workspace/data/db/assistant.db",
+        {
+          name: "workspace/data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+          size: 8,
+        },
+      ],
+      [
+        archivePath,
+        {
+          name: archivePath,
+          data: new Uint8Array(0),
+          size: 0,
+          linkname: linkTarget,
+        },
+      ],
+    ]);
+
+    // Pre-create a different symlink at the target path.
+    const fooDiskPath = join(workspaceDir, "skills/foo.md");
+    mkdirSync(dirname(fooDiskPath), { recursive: true });
+    symlinkSync("other.md", fooDiskPath);
+
+    const result = commitImport({
+      archiveData: new Uint8Array(0),
+      pathResolver: makePathResolver(),
+      preValidatedManifest: manifest,
+      preValidatedEntries: entries,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(lstatSync(fooDiskPath).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(fooDiskPath)).toBe("bar.md");
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-importer.test.ts
@@ -293,6 +293,104 @@ describe("commitImport — symlinks", () => {
     expect(backupContents).toBe("old");
   });
 
+  test("legacy prompts/USER.md symlink is skipped when guardian persona is already customized", () => {
+    // Bundle ships prompts/USER.md as a symlink. The destination workspace
+    // already has a customized guardian persona at users/<slug>.md, so the
+    // import must skip the entry rather than clobber the user's content.
+    // Hand-build the manifest and skip `workspaceDir` so the workspace
+    // clear (Step 1b) doesn't wipe the customized persona we plant below.
+    const archivePath = "prompts/USER.md";
+    const linkTarget = "../skills/something.md";
+
+    const customizedPersona = `_ Lines starting with _ are comments - they won't appear in the system prompt
+
+# User Profile
+
+- Preferred name/reference: Real User
+- Pronouns: she/her
+- Locale: en-US
+- Work role: Staff Engineer
+- Goals: Ship drop-user-md
+- Hobbies/fun: Reading papers
+- Daily tools: Terminal, Vellum
+`;
+
+    const guardianPath = join(workspaceDir, "users/captain.md");
+    mkdirSync(dirname(guardianPath), { recursive: true });
+    writeFileSync(guardianPath, customizedPersona, "utf-8");
+
+    const manifest = buildTestManifest({
+      contents: [
+        {
+          path: "workspace/data/db/assistant.db",
+          sha256: "0".repeat(64),
+          size_bytes: 8,
+        },
+        {
+          path: archivePath,
+          sha256: "0".repeat(64),
+          size_bytes: 0,
+          link_target: linkTarget,
+        },
+      ],
+    });
+    const entries = new Map<string, VBundleTarEntry>([
+      [
+        "workspace/data/db/assistant.db",
+        {
+          name: "workspace/data/db/assistant.db",
+          data: new TextEncoder().encode("db-bytes"),
+          size: 8,
+        },
+      ],
+      [
+        archivePath,
+        {
+          name: archivePath,
+          data: new Uint8Array(0),
+          size: 0,
+          linkname: linkTarget,
+        },
+      ],
+    ]);
+
+    // Resolver returns the customized guardian persona path for prompts/USER.md.
+    const resolver = new DefaultPathResolver(
+      workspaceDir,
+      undefined,
+      () => guardianPath,
+    );
+
+    const result = commitImport({
+      archiveData: new Uint8Array(0),
+      pathResolver: resolver,
+      preValidatedManifest: manifest,
+      preValidatedEntries: entries,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // The customized persona file must remain a regular file (NOT a symlink).
+    const stat = lstatSync(guardianPath);
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(stat.isFile()).toBe(true);
+    expect(readFileSync(guardianPath, "utf-8")).toBe(customizedPersona);
+
+    // The import report must record the entry as skipped.
+    const entry = result.report.files.find((f) => f.path === archivePath);
+    expect(entry).toBeDefined();
+    expect(entry!.action).toBe("skipped");
+
+    // Warning should mention the customized guardian persona.
+    expect(
+      result.report.warnings.some(
+        (w) =>
+          w.includes("guardian persona") && w.includes("already customized"),
+      ),
+    ).toBe(true);
+  });
+
   test("symlink-overwrites-symlink: replaces an existing symlink without EEXIST", () => {
     const archivePath = "workspace/skills/foo.md";
     const linkTarget = "bar.md";

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -16,13 +16,16 @@ import { createHash } from "node:crypto";
 import {
   copyFileSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 
 import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
@@ -152,6 +155,28 @@ function sha256Hex(data: Uint8Array): string {
 function generateBackupPath(diskPath: string): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   return `${diskPath}.backup-${timestamp}`;
+}
+
+/**
+ * Defense-in-depth: returns true if `linkTarget`, when resolved relative to
+ * the symlink's own directory (`dirname(diskPath)`), lands outside the
+ * supplied `workspaceDir`. The validator (`validateVBundle`) already enforces
+ * archive-relative containment, but we re-check here so the buffer importer
+ * is safe even if a caller passes a hand-built `preValidatedManifest`.
+ *
+ * Returns false when `workspaceDir` is undefined — the importer is permitted
+ * to write outside any workspace in that mode (e.g. legacy hooks-only
+ * imports).
+ */
+function isOutsideWorkspace(
+  diskPath: string,
+  linkTarget: string,
+  workspaceDir: string | undefined,
+): boolean {
+  if (!workspaceDir) return false;
+  const resolved = resolve(dirname(diskPath), linkTarget);
+  const ws = resolve(workspaceDir);
+  return resolved !== ws && !resolved.startsWith(ws + sep);
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +361,158 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
       warnings.push(
         `Skipped "${fileEntry.path}": no known disk target for this archive path`,
       );
+      continue;
+    }
+
+    // Symlink branch: recreate the entry on disk as a real symlink so the
+    // post-import workspace mirrors the source's link topology rather than
+    // duplicating bytes. The validator already enforces archive-relative
+    // containment, sha256-over-target, and size==0 — we still reapply
+    // absolute-target and workspace-escape gates here so a hand-built
+    // `preValidatedManifest` cannot bypass them.
+    if (fileEntry.link_target !== undefined) {
+      const archiveEntry = entryMap.get(fileEntry.path);
+      if (!archiveEntry) {
+        importedFiles.push({
+          path: fileEntry.path,
+          disk_path: diskPath,
+          action: "skipped",
+          size: 0,
+          sha256: fileEntry.sha256,
+          backup_path: null,
+        });
+        warnings.push(
+          `Skipped "${fileEntry.path}": declared in manifest but not found in archive`,
+        );
+        continue;
+      }
+
+      // Defense-in-depth path-traversal gate.
+      if (
+        fileEntry.link_target.startsWith("/") ||
+        isOutsideWorkspace(diskPath, fileEntry.link_target, workspaceDir)
+      ) {
+        importedFiles.push({
+          path: fileEntry.path,
+          disk_path: diskPath,
+          action: "skipped",
+          size: 0,
+          sha256: fileEntry.sha256,
+          backup_path: null,
+        });
+        warnings.push(
+          `Skipped "${fileEntry.path}": symlink target "${fileEntry.link_target}" escapes workspace`,
+        );
+        continue;
+      }
+
+      // Back up an existing entry at diskPath, if any. Use `lstatSync` so we
+      // detect a pre-existing dangling symlink (which `existsSync` reports
+      // as missing) — `symlinkSync` would otherwise fail with EEXIST. For
+      // regular files and resolvable symlinks we copy the file contents into
+      // the backup, matching the existing contract; for dangling symlinks
+      // we preserve the linkname via `readlinkSync`+`symlinkSync` so the
+      // original entry can be inspected after the import. The pre-existing
+      // entry is removed before `symlinkSync` so the new symlink can land.
+      let backupPath: string | null = null;
+      let action: ImportFileAction;
+      let preExistingEntry = false;
+      let preExistingIsSymlink = false;
+      try {
+        const stats = lstatSync(diskPath);
+        preExistingEntry = true;
+        preExistingIsSymlink = stats.isSymbolicLink();
+      } catch {
+        // ENOENT — no pre-existing entry at this path.
+      }
+      if (preExistingEntry) {
+        backupPath = generateBackupPath(diskPath);
+        try {
+          if (preExistingIsSymlink) {
+            const oldTarget = readlinkSync(diskPath);
+            symlinkSync(oldTarget, backupPath);
+          } else {
+            copyFileSync(diskPath, backupPath);
+          }
+          backupsCreated++;
+        } catch (err) {
+          return {
+            ok: false,
+            reason: "write_failed",
+            message: `Failed to back up "${diskPath}": ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            partial_report: buildPartialReport(
+              importedFiles,
+              manifest,
+              warnings,
+              backupsCreated,
+            ),
+          };
+        }
+        action = "overwritten";
+        try {
+          rmSync(diskPath, { force: true });
+        } catch {
+          /* best effort — symlinkSync below will surface the real error */
+        }
+      } else {
+        action = "created";
+      }
+
+      // Ensure parent directory exists.
+      const parentDir = dirname(diskPath);
+      if (!existsSync(parentDir)) {
+        try {
+          mkdirSync(parentDir, { recursive: true });
+        } catch (err) {
+          return {
+            ok: false,
+            reason: "write_failed",
+            message: `Failed to create directory "${parentDir}": ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            partial_report: buildPartialReport(
+              importedFiles,
+              manifest,
+              warnings,
+              backupsCreated,
+            ),
+          };
+        }
+      }
+
+      // Create the symlink. The target is stored verbatim — OS symlink
+      // semantics resolve it relative to the symlink's own directory at
+      // use time.
+      try {
+        symlinkSync(fileEntry.link_target, diskPath);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: "write_failed",
+          message: `Failed to create symlink "${diskPath}" -> "${fileEntry.link_target}": ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          partial_report: buildPartialReport(
+            importedFiles,
+            manifest,
+            warnings,
+            backupsCreated,
+          ),
+        };
+      }
+
+      importedFiles.push({
+        path: fileEntry.path,
+        disk_path: diskPath,
+        action,
+        size: 0,
+        sha256: fileEntry.sha256,
+        backup_path: backupPath,
+      });
+      // Skip the regular-file branches (and the post-write integrity check,
+      // which would dereference the symlink and read the target's bytes).
       continue;
     }
 

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -387,6 +387,33 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
         continue;
       }
 
+      // Legacy guardian persona (prompts/USER.md) is translated to the
+      // current guardian's users/<slug>.md by DefaultPathResolver. If the
+      // bundle ships USER.md as a symlink and the target already holds
+      // user-authored content, skip rather than clobber — mirrors the
+      // protection in the regular-file branch below.
+      if (
+        fileEntry.path === LEGACY_USER_MD_ARCHIVE_PATH &&
+        isGuardianPersonaCustomized(diskPath)
+      ) {
+        log.warn(
+          { archivePath: fileEntry.path, diskPath },
+          "Skipping legacy prompts/USER.md symlink import: guardian persona is already customized",
+        );
+        warnings.push(
+          `Skipped "${fileEntry.path}": guardian persona at "${diskPath}" is already customized`,
+        );
+        importedFiles.push({
+          path: fileEntry.path,
+          disk_path: diskPath,
+          action: "skipped",
+          size: 0,
+          sha256: fileEntry.sha256,
+          backup_path: null,
+        });
+        continue;
+      }
+
       // Defense-in-depth path-traversal gate.
       if (
         fileEntry.link_target.startsWith("/") ||


### PR DESCRIPTION
## Summary
- Buffer importer (`commitImport`) handles typeflag-2 manifest entries: validates link target stays inside workspace (rejects absolute paths and ../-escapes), backs up existing files, removes any pre-existing entry at the target path to avoid EEXIST, creates the symlink with `symlinkSync`
- Skips the post-write integrity check for symlinks (would otherwise follow the link and read the target file)
- Tests cover round-trip, defense-in-depth absolute and traversal rejection, regular-file overwrite, symlink-overwrites-symlink

Part of plan: vbundle-symlinks.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
