### PR TITLE
feat(vbundle): walkDirectory and walkDirectoryForMetadata emit symlink entries

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-walker.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-walker.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the symlink-aware directory walkers used by vbundle export.
+ *
+ * Two walkers exist (`walkDirectory` for the buffered path,
+ * `walkDirectoryForMetadata` for the streaming path) and they must classify
+ * symlinks identically: bundleable in-workspace targets become typeflag-2
+ * entries, while broken / directory / outside-workspace / inside-skipDir
+ * targets are dropped and reported. Each scenario below is exercised against
+ * both walkers via describe.each so any drift between them fails loudly.
+ *
+ * One additional integration test drives `buildExportVBundle` end-to-end and
+ * checks both that the dropped paths are summarized in a single aggregated
+ * `log.warn` call and that a class-1 round-trip survives `validateVBundle`.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const mockLogWarn = mock((_obj: unknown, _msg: string) => {});
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => ({
+    warn: mockLogWarn,
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+  }),
+}));
+
+const { buildExportVBundle, walkDirectory, walkDirectoryForMetadata } =
+  await import("../vbundle-builder.js");
+const { validateVBundle } = await import("../vbundle-validator.js");
+const { defaultV1Options } = await import("./v1-test-helpers.js");
+
+// ---------------------------------------------------------------------------
+// Workspace fixtures
+// ---------------------------------------------------------------------------
+
+const cleanupQueue: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  // Resolve to the canonical path so walker comparisons (which call
+  // realpathSync on the symlink target) line up with the workspace root on
+  // platforms where tmpdir() is itself a symlink (macOS: /var → /private/var).
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  cleanupQueue.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (cleanupQueue.length > 0) {
+    const dir = cleanupQueue.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  mockLogWarn.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Walker adapters — normalize both walker shapes to a common surface so the
+// parametrized tests below can assert the same fields against either one.
+// ---------------------------------------------------------------------------
+
+interface NormalizedSymlinkEntry {
+  archivePath: string;
+  linkTarget: string;
+}
+
+interface NormalizedWalkResult {
+  fileArchivePaths: string[];
+  symlinks: NormalizedSymlinkEntry[];
+  droppedSymlinks: string[];
+}
+
+interface WalkerAdapter {
+  name: string;
+  walk: (
+    dir: string,
+    prefix: string,
+    skipDirs: string[],
+  ) => NormalizedWalkResult;
+}
+
+const walkers: WalkerAdapter[] = [
+  {
+    name: "walkDirectory",
+    walk: (dir, prefix, skipDirs) => {
+      const result = walkDirectory(dir, prefix, {
+        includeBinary: true,
+        skipDirs,
+      });
+      return {
+        fileArchivePaths: result.files
+          .filter((f) => f.linkTarget === undefined)
+          .map((f) => f.path),
+        symlinks: result.files
+          .filter((f) => f.linkTarget !== undefined)
+          .map((f) => ({ archivePath: f.path, linkTarget: f.linkTarget! })),
+        droppedSymlinks: result.droppedSymlinks,
+      };
+    },
+  },
+  {
+    name: "walkDirectoryForMetadata",
+    walk: (dir, prefix, skipDirs) => {
+      const result = walkDirectoryForMetadata(dir, prefix, {
+        includeBinary: true,
+        skipDirs,
+      });
+      return {
+        fileArchivePaths: result.files.map((f) => f.archivePath),
+        symlinks: result.symlinks.map((s) => ({
+          archivePath: s.archivePath,
+          linkTarget: s.linkTarget,
+        })),
+        droppedSymlinks: result.droppedSymlinks,
+      };
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Per-walker classification tests
+// ---------------------------------------------------------------------------
+
+describe.each(walkers)("$name — symlink classification", ({ walk }) => {
+  test("class 1: in-workspace symlink is emitted with relative linkTarget", () => {
+    const root = makeTempDir("vbundle-walker-class1-");
+    mkdirSync(join(root, "skills"), { recursive: true });
+    writeFileSync(join(root, "skills", "bar.md"), "bar contents");
+    symlinkSync("bar.md", join(root, "skills", "foo.md"));
+
+    const result = walk(root, "workspace", []);
+
+    expect(result.droppedSymlinks).toEqual([]);
+    expect(result.fileArchivePaths).toContain("workspace/skills/bar.md");
+    expect(result.symlinks).toEqual([
+      {
+        archivePath: "workspace/skills/foo.md",
+        linkTarget: "bar.md",
+      },
+    ]);
+  });
+
+  test("class 2: symlink targeting a path outside the workspace is dropped", () => {
+    const root = makeTempDir("vbundle-walker-class2-");
+    const outside = makeTempDir("vbundle-walker-outside-");
+    mkdirSync(join(root, "skills"), { recursive: true });
+    const outsideTarget = join(outside, "external.md");
+    writeFileSync(outsideTarget, "external contents");
+    symlinkSync(outsideTarget, join(root, "skills", "dev"));
+
+    const result = walk(root, "workspace", []);
+
+    expect(result.symlinks).toEqual([]);
+    expect(result.droppedSymlinks).toContain(join("skills", "dev"));
+  });
+
+  test("class 3: symlink targeting a skipDir is dropped", () => {
+    const root = makeTempDir("vbundle-walker-class3-");
+    mkdirSync(join(root, "embedding-models"), { recursive: true });
+    mkdirSync(join(root, "skills"), { recursive: true });
+    writeFileSync(join(root, "embedding-models", "x.bin"), "blob");
+    symlinkSync(
+      join(root, "embedding-models", "x.bin"),
+      join(root, "skills", "cache"),
+    );
+
+    const result = walk(root, "workspace", ["embedding-models"]);
+
+    expect(result.symlinks).toEqual([]);
+    expect(result.droppedSymlinks).toContain(join("skills", "cache"));
+    // The skipDir itself is not walked, so its files are not emitted either.
+    expect(result.fileArchivePaths).not.toContain(
+      "workspace/embedding-models/x.bin",
+    );
+  });
+
+  test("directory targets are out of scope and dropped", () => {
+    const root = makeTempDir("vbundle-walker-dirtarget-");
+    mkdirSync(join(root, "skills", "sub-dir"), { recursive: true });
+    writeFileSync(join(root, "skills", "sub-dir", "nested.md"), "nested");
+    symlinkSync(
+      join(root, "skills", "sub-dir"),
+      join(root, "skills", "dir-link"),
+    );
+
+    const result = walk(root, "workspace", []);
+
+    expect(result.symlinks).toEqual([]);
+    expect(result.droppedSymlinks).toContain(join("skills", "dir-link"));
+    // The real sub-dir is still walked through normally.
+    expect(result.fileArchivePaths).toContain(
+      "workspace/skills/sub-dir/nested.md",
+    );
+  });
+
+  test("broken symlinks are dropped without throwing", () => {
+    const root = makeTempDir("vbundle-walker-broken-");
+    mkdirSync(join(root, "skills"), { recursive: true });
+    symlinkSync(
+      join(root, "skills", "does-not-exist.md"),
+      join(root, "skills", "broken"),
+    );
+
+    const result = walk(root, "workspace", []);
+
+    expect(result.symlinks).toEqual([]);
+    expect(result.droppedSymlinks).toContain(join("skills", "broken"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aggregated warning + round-trip integration
+// ---------------------------------------------------------------------------
+
+describe("buildExportVBundle aggregated symlink warning", () => {
+  test("emits a single warn call covering every dropped symlink", () => {
+    const root = makeTempDir("vbundle-walker-agg-");
+    const outsideA = makeTempDir("vbundle-walker-agg-outA-");
+    const outsideB = makeTempDir("vbundle-walker-agg-outB-");
+    // Required workspace fixture so the walker has at least one regular file.
+    writeFileSync(join(root, "config.json"), JSON.stringify({ test: true }));
+    mkdirSync(join(root, "data", "db"), { recursive: true });
+    writeFileSync(join(root, "data", "db", "assistant.db"), "fake-db");
+
+    mkdirSync(join(root, "skills"), { recursive: true });
+    mkdirSync(join(root, "embedding-models"), { recursive: true });
+    writeFileSync(join(root, "embedding-models", "blob.bin"), "blob");
+
+    const externalA = join(outsideA, "ext.md");
+    const externalB = join(outsideB, "ext.md");
+    writeFileSync(externalA, "ext-a");
+    writeFileSync(externalB, "ext-b");
+
+    symlinkSync(externalA, join(root, "skills", "ext-a"));
+    symlinkSync(externalB, join(root, "skills", "ext-b"));
+    symlinkSync(
+      join(root, "embedding-models", "blob.bin"),
+      join(root, "skills", "cache"),
+    );
+
+    buildExportVBundle({
+      workspaceDir: root,
+      ...defaultV1Options(),
+    });
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [meta, msg] = mockLogWarn.mock.calls[0];
+    expect(meta).toMatchObject({ count: 3 });
+    expect((meta as { paths: string[] }).paths.sort()).toEqual(
+      [
+        join("skills", "cache"),
+        join("skills", "ext-a"),
+        join("skills", "ext-b"),
+      ].sort(),
+    );
+    expect(typeof msg).toBe("string");
+  });
+
+  test("class-1 symlink survives buildExportVBundle round-trip via validateVBundle", () => {
+    const root = makeTempDir("vbundle-walker-rt-");
+    writeFileSync(join(root, "config.json"), JSON.stringify({ test: true }));
+    mkdirSync(join(root, "data", "db"), { recursive: true });
+    writeFileSync(join(root, "data", "db", "assistant.db"), "fake-db");
+    mkdirSync(join(root, "skills"), { recursive: true });
+    writeFileSync(join(root, "skills", "bar.md"), "bar contents");
+    symlinkSync("bar.md", join(root, "skills", "foo.md"));
+
+    const result = buildExportVBundle({
+      workspaceDir: root,
+      ...defaultV1Options(),
+    });
+
+    const validation = validateVBundle(result.archive);
+    expect(validation.errors).toEqual([]);
+    expect(validation.is_valid).toBe(true);
+
+    const symlinkEntry = result.manifest.contents.find(
+      (f) => f.path === "workspace/skills/foo.md",
+    );
+    expect(symlinkEntry).toBeDefined();
+    expect(symlinkEntry?.link_target).toBe("bar.md");
+    expect(symlinkEntry?.size_bytes).toBe(0);
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-walker.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-walker.test.ts
@@ -218,6 +218,29 @@ describe.each(walkers)("$name — symlink classification", ({ walk }) => {
     expect(result.symlinks).toEqual([]);
     expect(result.droppedSymlinks).toContain(join("skills", "broken"));
   });
+
+  test("class 1: in-workspace symlink is emitted when walk root is a non-canonical path with symlinked prefix", () => {
+    // Intentionally NOT canonicalized — on macOS this stays as
+    // /var/folders/... while realpathSync canonicalizes to
+    // /private/var/folders/.... Without the realpathSync(walkRoot) fix in
+    // classifySymlink, the containment check misclassifies in-workspace
+    // symlinks as "outside workspace" and silently drops them.
+    const ws = mkdtempSync(join(tmpdir(), "vbundle-walker-noncanon-"));
+    cleanupQueue.push(ws);
+    mkdirSync(join(ws, "skills"), { recursive: true });
+    writeFileSync(join(ws, "skills", "bar.md"), "hello");
+    symlinkSync("bar.md", join(ws, "skills", "foo.md"));
+
+    const result = walk(ws, "workspace", []);
+
+    expect(result.droppedSymlinks).toEqual([]);
+    expect(result.symlinks).toEqual([
+      {
+        archivePath: "workspace/skills/foo.md",
+        linkTarget: "bar.md",
+      },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -509,7 +509,12 @@ function classifySymlink(args: {
     return { kind: "drop", reason: "target is not a regular file" };
   }
 
-  const dirAbs = resolve(walkRoot);
+  let dirAbs: string;
+  try {
+    dirAbs = realpathSync(walkRoot);
+  } catch {
+    dirAbs = resolve(walkRoot);
+  }
   const targetAbs = resolve(absoluteTarget);
   const insideWorkspace =
     targetAbs === dirAbs || targetAbs.startsWith(dirAbs + sep);
@@ -527,7 +532,18 @@ function classifySymlink(args: {
     return { kind: "drop", reason: "target inside skipDir" };
   }
 
-  const linkTarget = relative(dirname(fullPath), absoluteTarget);
+  // Canonicalize the symlink's parent directory so the relative linkTarget
+  // computation lines up with `absoluteTarget` (which is canonical from
+  // realpathSync). On macOS, walking through /var/folders/... and resolving
+  // the target through /private/var/folders/... would otherwise produce a
+  // long ../../../private/... path that exceeds the 100-byte ustar limit.
+  let parentAbs: string;
+  try {
+    parentAbs = realpathSync(dirname(fullPath));
+  } catch {
+    parentAbs = resolve(dirname(fullPath));
+  }
+  const linkTarget = relative(parentAbs, absoluteTarget);
   if (new TextEncoder().encode(linkTarget).length > 100) {
     return {
       kind: "drop",

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -19,15 +19,17 @@ import {
   readdirSync,
   readFileSync,
   readSync,
+  realpathSync,
 } from "node:fs";
 import { stat, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, relative } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGzip, gzipSync } from "node:zlib";
 
 import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
+import { getLogger } from "../../util/logger.js";
 import type { VBundleOriginMode } from "./origin-mode.js";
 import type {
   ManifestFileEntryType,
@@ -467,28 +469,120 @@ interface WalkDirectoryOptions {
 }
 
 /**
- * Recursively walk a directory and return all non-symlink files as
- * VBundleFileEntry objects with paths prefixed by `archivePrefix`.
+ * Resolve and classify a symlink encountered during a walk.
+ *
+ * Returns one of:
+ *   { kind: "class1", linkTarget } — emit as a tar typeflag-2 entry whose
+ *     `linkname` field holds `linkTarget` (the symlink target encoded as a
+ *     POSIX path relative to the symlink's own directory).
+ *   { kind: "drop", reason }       — drop the symlink. Reasons cover broken
+ *     links, targets outside the workspace (class 2), targets inside a
+ *     skipped directory (class 3), directory targets (out of scope), and
+ *     link targets whose UTF-8 encoding exceeds the 100-byte ustar
+ *     `linkname` field limit.
+ */
+type SymlinkClassification =
+  | { kind: "class1"; linkTarget: string }
+  | { kind: "drop"; reason: string };
+
+function classifySymlink(args: {
+  fullPath: string;
+  walkRoot: string;
+  skipDirs: readonly string[];
+}): SymlinkClassification {
+  const { fullPath, walkRoot, skipDirs } = args;
+
+  let absoluteTarget: string;
+  try {
+    absoluteTarget = realpathSync(fullPath);
+  } catch {
+    return { kind: "drop", reason: "broken symlink (realpath failed)" };
+  }
+
+  let targetStat;
+  try {
+    targetStat = lstatSync(absoluteTarget);
+  } catch {
+    return { kind: "drop", reason: "broken symlink (target stat failed)" };
+  }
+  if (!targetStat.isFile()) {
+    return { kind: "drop", reason: "target is not a regular file" };
+  }
+
+  const dirAbs = resolve(walkRoot);
+  const targetAbs = resolve(absoluteTarget);
+  const insideWorkspace =
+    targetAbs === dirAbs || targetAbs.startsWith(dirAbs + sep);
+  if (!insideWorkspace) {
+    return { kind: "drop", reason: "target outside workspace" };
+  }
+
+  const targetRelToWorkspace = relative(dirAbs, targetAbs);
+  if (
+    skipDirs.some(
+      (s) =>
+        targetRelToWorkspace === s || targetRelToWorkspace.startsWith(s + "/"),
+    )
+  ) {
+    return { kind: "drop", reason: "target inside skipDir" };
+  }
+
+  const linkTarget = relative(dirname(fullPath), absoluteTarget);
+  if (new TextEncoder().encode(linkTarget).length > 100) {
+    return {
+      kind: "drop",
+      reason: "encoded link target exceeds 100-byte ustar limit",
+    };
+  }
+
+  return { kind: "class1", linkTarget };
+}
+
+/**
+ * Recursively walk a directory and return all regular files (and bundleable
+ * symlinks) as VBundleFileEntry objects with paths prefixed by
+ * `archivePrefix`. Symlinks that resolve to a regular file inside the walk
+ * root and outside any skipDir are emitted as typeflag-2 entries (data
+ * empty, `linkTarget` populated). All other symlinks (broken, directory
+ * target, target outside workspace, target inside skipDir, encoded
+ * linkTarget over 100 bytes) are reported via the returned `droppedSymlinks`
+ * array as workspace-relative paths of the symlink itself.
  *
  * By default, binary files (detected via null-byte heuristic in the first
  * 8 KB) are skipped. Pass `includeBinary: true` to include them.
  */
-function walkDirectory(
+export function walkDirectory(
   dir: string,
   archivePrefix: string,
   options: WalkDirectoryOptions = {},
-): VBundleFileEntry[] {
+): { files: VBundleFileEntry[]; droppedSymlinks: string[] } {
   const { includeBinary = false, skipDirs = [] } = options;
   const entries: VBundleFileEntry[] = [];
+  const droppedSymlinks: string[] = [];
 
   function walk(currentDir: string): void {
     const dirEntries = readdirSync(currentDir, { withFileTypes: true });
     for (const entry of dirEntries) {
       const fullPath = join(currentDir, entry.name);
 
-      // Skip symlinks
       const stat = lstatSync(fullPath);
-      if (stat.isSymbolicLink()) continue;
+      if (stat.isSymbolicLink()) {
+        const classification = classifySymlink({
+          fullPath,
+          walkRoot: dir,
+          skipDirs,
+        });
+        if (classification.kind === "class1") {
+          entries.push({
+            path: `${archivePrefix}/${relative(dir, fullPath)}`,
+            data: new Uint8Array(0),
+            linkTarget: classification.linkTarget,
+          });
+        } else {
+          droppedSymlinks.push(relative(dir, fullPath));
+        }
+        continue;
+      }
 
       if (stat.isDirectory()) {
         // Check skip list against the relative path from the walk root
@@ -534,7 +628,7 @@ function walkDirectory(
   }
 
   walk(dir);
-  return entries;
+  return { files: entries, droppedSymlinks };
 }
 
 // ---------------------------------------------------------------------------
@@ -613,12 +707,21 @@ export function buildExportVBundle(
     existsSync(workspaceDir) &&
     lstatSync(workspaceDir).isDirectory()
   ) {
-    files.push(
-      ...walkDirectory(workspaceDir, "workspace", {
+    const { files: walkedFiles, droppedSymlinks } = walkDirectory(
+      workspaceDir,
+      "workspace",
+      {
         includeBinary: true,
         skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
-      }),
+      },
     );
+    files.push(...walkedFiles);
+    if (droppedSymlinks.length > 0) {
+      getLogger("vbundle-builder").warn(
+        { count: droppedSymlinks.length, paths: droppedSymlinks },
+        `Dropped ${droppedSymlinks.length} symlinks pointing outside workspace or into skipped directories`,
+      );
+    }
   }
 
   // Sanitize workspace/config.json to strip environment-specific fields
@@ -653,26 +756,48 @@ export function buildExportVBundle(
 
 /**
  * Walk a directory tree and collect file metadata (paths + sizes) without
- * reading file contents into memory. Uses the same filtering logic as
- * `walkDirectory` (symlink skip, SQLite auxiliary skip, binary detection,
- * skip dirs).
+ * reading file contents into memory. Mirrors `walkDirectory`'s filtering
+ * logic (SQLite auxiliary skip, binary detection, skipDirs) and symlink
+ * classification — bundleable symlinks are emitted as `SymlinkMetadata`
+ * entries; non-bundleable symlinks are reported via `droppedSymlinks`.
  */
-function walkDirectoryForMetadata(
+export function walkDirectoryForMetadata(
   dir: string,
   archivePrefix: string,
   options: WalkDirectoryOptions = {},
-): FileMetadata[] {
+): {
+  files: FileMetadata[];
+  symlinks: SymlinkMetadata[];
+  droppedSymlinks: string[];
+} {
   const { includeBinary = false, skipDirs = [] } = options;
   const entries: FileMetadata[] = [];
+  const symlinks: SymlinkMetadata[] = [];
+  const droppedSymlinks: string[] = [];
 
   function walk(currentDir: string): void {
     const dirEntries = readdirSync(currentDir, { withFileTypes: true });
     for (const entry of dirEntries) {
       const fullPath = join(currentDir, entry.name);
 
-      // Skip symlinks
       const fileStat = lstatSync(fullPath);
-      if (fileStat.isSymbolicLink()) continue;
+      if (fileStat.isSymbolicLink()) {
+        const classification = classifySymlink({
+          fullPath,
+          walkRoot: dir,
+          skipDirs,
+        });
+        if (classification.kind === "class1") {
+          symlinks.push({
+            archivePath: `${archivePrefix}/${relative(dir, fullPath)}`,
+            linkTarget: classification.linkTarget,
+            size: 0,
+          });
+        } else {
+          droppedSymlinks.push(relative(dir, fullPath));
+        }
+        continue;
+      }
 
       if (fileStat.isDirectory()) {
         // Check skip list against the relative path from the walk root
@@ -725,7 +850,7 @@ function walkDirectoryForMetadata(
   }
 
   walk(dir);
-  return entries;
+  return { files: entries, symlinks, droppedSymlinks };
 }
 
 /**
@@ -976,6 +1101,7 @@ export async function streamExportVBundle(
   }
 
   const allFileMetadata: FileMetadata[] = [];
+  const symlinkEntries: SymlinkMetadata[] = [];
 
   // Walk the entire workspace directory, including binary files
   if (
@@ -983,12 +1109,22 @@ export async function streamExportVBundle(
     existsSync(workspaceDir) &&
     lstatSync(workspaceDir).isDirectory()
   ) {
-    allFileMetadata.push(
-      ...walkDirectoryForMetadata(workspaceDir, "workspace", {
-        includeBinary: true,
-        skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
-      }),
-    );
+    const {
+      files: walkedFiles,
+      symlinks: walkedSymlinks,
+      droppedSymlinks,
+    } = walkDirectoryForMetadata(workspaceDir, "workspace", {
+      includeBinary: true,
+      skipDirs: ["embedding-models", "data/qdrant", "signals", "deprecated"],
+    });
+    allFileMetadata.push(...walkedFiles);
+    symlinkEntries.push(...walkedSymlinks);
+    if (droppedSymlinks.length > 0) {
+      getLogger("vbundle-builder").warn(
+        { count: droppedSymlinks.length, paths: droppedSymlinks },
+        `Dropped ${droppedSymlinks.length} symlinks pointing outside workspace or into skipped directories`,
+      );
+    }
   }
 
   // Sanitize workspace/config.json: read from disk, sanitize, and replace the
@@ -1026,11 +1162,6 @@ export async function streamExportVBundle(
       });
     }
   }
-
-  // Symlink entries — populated by the walker in PR 4. For now this slice
-  // is always empty; downstream wiring (manifest emit + tar emit) is in
-  // place so the walker can append entries without further plumbing.
-  const symlinkEntries: SymlinkMetadata[] = [];
 
   // ------------------------------------------------------------------
   // Pass 1: Compute SHA-256 checksums to build the manifest


### PR DESCRIPTION
## Summary
- Both walkers now classify symlinks into three cases: in-workspace bundleable (emit as VBundleFileEntry/SymlinkMetadata with linkTarget relative-to-symlink-dir), outside workspace (drop), inside skipDir (drop)
- Directory-target and broken symlinks dropped (out of scope per plan)
- Encoded linkTarget > 100 bytes dropped (ustar linkname-field limit)
- Single aggregated warning log per build via existing logger
- Tests cover all classification cases for both walkers plus the aggregated-warning behavior

Part of plan: vbundle-symlinks.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
