### PR TITLE
fix(clients): recover stuck turn state via idle activity signal + isThinking watchdog

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -607,6 +607,17 @@ If the team adopts Xcode as the primary development environment and begins using
 
 ---
 
+## Daemon Event Recovery (Turn State)
+
+The daemon communicates turn lifecycle through SSE events on a single stream with no replay or delivery guarantee. Any event can be lost during stream gaps, reconnects, or internal filtering. **Every turn-state phase that disables an existing recovery mechanism must have its own equivalent recovery path.**
+
+- **`assistantActivityState("idle")` is the authoritative turn-completion signal.** When the daemon reports idle, the handler must clear all turn-progress indicators (`isSending`, `isThinking`, `isCompacting`, tool call spinners) — not just one flag.
+- **Watchdog parity.** If a new activity phase (e.g., "thinking") disables an existing watchdog (e.g., setting `isSending = false` to prevent the 60s watchdog from killing extended thinking), add an equivalent watchdog for the new phase.
+- **Preserve `currentAssistantMessageId` for `messageComplete`.** The daemon emits `idle` immediately before `messageComplete` on the same stream. Don't clear `currentAssistantMessageId` in the idle handler — use a short fallback timer that fires only if `messageComplete` never arrives.
+- **Cancel fallback timers in all state-reset paths.** Any deferred cleanup task (idle fallback, watchdog) must be cancelled in `handleTransportReconnect`, `startMessageLoop` error handler, `populateFromHistory`, and `handleMessageComplete` — anywhere that clears `currentAssistantMessageId` outside the normal idle → messageComplete flow.
+
+---
+
 ## Networking: GatewayHTTPClient
 
 All HTTP API calls go through `GatewayHTTPClient` (a stateless enum with static async methods).

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -509,6 +509,8 @@ final class ChatActionHandler {
         if (complete.messageId == nil || complete.source == "aux") && (vm.currentAssistantMessageId != nil || vm.isThinking) {
             return
         }
+        vm.idleFallbackTask?.cancel()
+        vm.idleFallbackTask = nil
         // Capture before dispatchPendingSendDirect clears the flag so we can
         // tell a real turn end from a cancel-acknowledgement completion.
         let wasCancelAck = vm.pendingSendDirectText != nil
@@ -1512,12 +1514,14 @@ final class ChatActionHandler {
                     vm.messages[idx].toolCalls[j].completedAt = Date()
                 }
             }
-            vm.currentAssistantMessageId = nil
-            vm.currentTurnUserText = nil
-            vm.currentAssistantHasText = false
             if vm.pendingQueuedCount == 0 {
                 vm.isSending = false
             }
+            // Leave currentAssistantMessageId for messageComplete — it needs
+            // it for daemonMessageId backfill, attachment ingestion, and voice
+            // callbacks. Schedule a short fallback to clear it if messageComplete
+            // never arrives (lost event).
+            vm.scheduleIdleFallbackCleanup()
         case "awaiting_confirmation":
             vm.isThinking = false
             vm.isSending = false

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1495,6 +1495,29 @@ final class ChatActionHandler {
             vm.isThinking = false
         case "idle":
             vm.isThinking = false
+            vm.isCompacting = false
+            vm.isCancelling = false
+            // Flush buffered text before clearing the message reference.
+            vm.flushStreamingBuffer()
+            vm.flushPartialOutputBuffer()
+            // Mark the current assistant message as no longer streaming and
+            // complete any in-flight tool calls so progress indicators clear.
+            if let assistantId = vm.currentAssistantMessageId,
+               let idx = vm.messages.firstIndex(where: { $0.id == assistantId }) {
+                vm.messages[idx].isStreaming = false
+                vm.messages[idx].streamingCodePreview = nil
+                vm.messages[idx].streamingCodeToolName = nil
+                for j in vm.messages[idx].toolCalls.indices where !vm.messages[idx].toolCalls[j].isComplete {
+                    vm.messages[idx].toolCalls[j].isComplete = true
+                    vm.messages[idx].toolCalls[j].completedAt = Date()
+                }
+            }
+            vm.currentAssistantMessageId = nil
+            vm.currentTurnUserText = nil
+            vm.currentAssistantHasText = false
+            if vm.pendingQueuedCount == 0 {
+                vm.isSending = false
+            }
         case "awaiting_confirmation":
             vm.isThinking = false
             vm.isSending = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1517,6 +1517,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                    let index = self?.messages.firstIndex(where: { $0.id == existingId }) {
                     self?.messages[index].isStreaming = false
                 }
+                self?.idleFallbackTask?.cancel()
+                self?.idleFallbackTask = nil
                 self?.currentAssistantMessageId = nil
                 self?.discardStreamingBuffer()
                 self?.discardPartialOutputBuffer()
@@ -2285,6 +2287,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         discardStreamingBuffer()
         discardPartialOutputBuffer()
         surfaceRefetchCoordinator.cancelRefetchTasks()
+        idleFallbackTask?.cancel()
+        idleFallbackTask = nil
         currentAssistantMessageId = nil
         currentAssistantHasText = false
 
@@ -2432,6 +2436,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         if isThinking || isSending || currentAssistantMessageId != nil {
             isThinking = false
             isSending = false
+            idleFallbackTask?.cancel()
+            idleFallbackTask = nil
             currentAssistantMessageId = nil
             discardStreamingBuffer()
             discardPartialOutputBuffer()

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -184,6 +184,12 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// send-in-progress indicator gets stuck.
     @ObservationIgnored private var sendingWatchdogTask: Task<Void, Never>?
 
+    /// Watchdog task that fires when `isThinking` has been `true` for more than
+    /// 90 seconds without being reset.  The "thinking" activity phase disables
+    /// the `isSending` watchdog, so this provides equivalent auto-recovery when
+    /// both `assistantActivityState(idle)` and `messageComplete` are lost.
+    @ObservationIgnored private var thinkingWatchdogTask: Task<Void, Never>?
+
     /// Per-requestId safety-net timeouts that clear the submitting spinner if
     /// a guardian decision HTTP response takes longer than 15 seconds.  Keyed
     /// by requestId so concurrent submissions each get an independent timeout.
@@ -219,7 +225,49 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     }
     public var isThinking: Bool {
         get { messageManager.isThinking }
-        set { messageManager.isThinking = newValue }
+        set {
+            messageManager.isThinking = newValue
+            if newValue {
+                thinkingWatchdogTask?.cancel()
+                thinkingWatchdogTask = Task { @MainActor [weak self] in
+                    try? await Task.sleep(for: .seconds(90))
+                    guard !Task.isCancelled, let self, self.isThinking else { return }
+                    log.error("isThinking watchdog: still true after 90s — auto-recovering, conversationId=\(self.conversationId ?? "nil")")
+                    self.messageManager.isThinking = false
+                    self.isCancelling = false
+                    self.isCompacting = false
+                    self.assistantActivityPhase = "idle"
+                    self.assistantActivityAnchor = "global"
+                    self.assistantActivityReason = nil
+                    self.assistantStatusText = nil
+                    let assistantId = self.currentAssistantMessageId
+                    self.messageManager.batchUpdateMessages { msgs in
+                        if let existingId = assistantId,
+                           let index = msgs.firstIndex(where: { $0.id == existingId }) {
+                            msgs[index].isStreaming = false
+                            msgs[index].streamingCodePreview = nil
+                            msgs[index].streamingCodeToolName = nil
+                            for j in msgs[index].toolCalls.indices where !msgs[index].toolCalls[j].isComplete {
+                                msgs[index].toolCalls[j].isComplete = true
+                                msgs[index].toolCalls[j].completedAt = Date()
+                            }
+                        }
+                    }
+                    self.currentAssistantMessageId = nil
+                    self.currentTurnUserText = nil
+                    self.currentAssistantHasText = false
+                    self.discardStreamingBuffer()
+                    self.discardPartialOutputBuffer()
+                    self.messageManager.isSending = false
+                    self.sendingWatchdogTask?.cancel()
+                    self.sendingWatchdogTask = nil
+                    self.thinkingWatchdogTask = nil
+                }
+            } else {
+                thinkingWatchdogTask?.cancel()
+                thinkingWatchdogTask = nil
+            }
+        }
     }
     /// Whether the assistant is actively working on a response — covers sending,
     /// extended-thinking, any in-progress assistant message, and orphaned tool
@@ -2449,6 +2497,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         // btwTask cancellation is handled by ChatBtwState's deinit.
         greetingState.cancelAll()
         sendingWatchdogTask?.cancel()
+        thinkingWatchdogTask?.cancel()
         guardianDecisionTimeoutTasks.values.forEach { $0.cancel() }
         if let token = memoryPressureListener {
             MemoryPressureMonitor.shared.removeListener(token)

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -278,11 +278,11 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// `messageComplete` never arrives after the daemon reported idle.
     func scheduleIdleFallbackCleanup() {
         idleFallbackTask?.cancel()
-        guard currentAssistantMessageId != nil else { return }
+        guard let messageId = currentAssistantMessageId else { return }
         idleFallbackTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(5))
             guard !Task.isCancelled, let self else { return }
-            guard self.currentAssistantMessageId != nil else { return }
+            guard self.currentAssistantMessageId == messageId else { return }
             log.warning("idle fallback: messageComplete not received within 5s — clearing currentAssistantMessageId")
             self.currentAssistantMessageId = nil
             self.currentTurnUserText = nil

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -190,6 +190,11 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
     /// both `assistantActivityState(idle)` and `messageComplete` are lost.
     @ObservationIgnored private var thinkingWatchdogTask: Task<Void, Never>?
 
+    /// Fallback task scheduled by the `assistantActivityState("idle")` handler.
+    /// Clears `currentAssistantMessageId` after 5 seconds if `messageComplete`
+    /// hasn't arrived to do it. Cancelled by `handleMessageComplete`.
+    @ObservationIgnored var idleFallbackTask: Task<Void, Never>?
+
     /// Per-requestId safety-net timeouts that clear the submitting spinner if
     /// a guardian decision HTTP response takes longer than 15 seconds.  Keyed
     /// by requestId so concurrent submissions each get an independent timeout.
@@ -269,6 +274,22 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             }
         }
     }
+    /// Schedule a 5-second fallback to clear `currentAssistantMessageId` if
+    /// `messageComplete` never arrives after the daemon reported idle.
+    func scheduleIdleFallbackCleanup() {
+        idleFallbackTask?.cancel()
+        guard currentAssistantMessageId != nil else { return }
+        idleFallbackTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, let self else { return }
+            guard self.currentAssistantMessageId != nil else { return }
+            log.warning("idle fallback: messageComplete not received within 5s — clearing currentAssistantMessageId")
+            self.currentAssistantMessageId = nil
+            self.currentTurnUserText = nil
+            self.currentAssistantHasText = false
+        }
+    }
+
     /// Whether the assistant is actively working on a response — covers sending,
     /// extended-thinking, any in-progress assistant message, and orphaned tool
     /// calls that haven't received their `tool_result` event yet (e.g. tool
@@ -2498,6 +2519,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         greetingState.cancelAll()
         sendingWatchdogTask?.cancel()
         thinkingWatchdogTask?.cancel()
+        idleFallbackTask?.cancel()
         guardianDecisionTimeoutTasks.values.forEach { $0.cancel() }
         if let token = memoryPressureListener {
             MemoryPressureMonitor.shared.removeListener(token)


### PR DESCRIPTION
Fixes the macOS app's stuck "Finalizing your response" indicator by making `assistantActivityState("idle")` a full turn recovery path and adding a 90-second `isThinking` watchdog. Previously, if the daemon's `messageComplete` event was lost or filtered while the app was in the thinking phase, the turn state would remain stuck indefinitely with no recovery mechanism.

---

## Why this is needed

The daemon communicates turn lifecycle through SSE events on a single stream with no replay or delivery guarantee. If any terminal event (`messageComplete`, `assistantActivityState("idle")`) is lost — during a stream gap, reconnect, or internal filtering — the client's turn state diverges permanently from reality. The existing 60-second `isSending` watchdog provided auto-recovery, but only when `isSending` was true. The "thinking" activity phase sets `isSending = false` (to prevent the watchdog from killing legitimate extended thinking), which meant `isThinking = true` had **no** timeout and no recovery path.

## What changed

**1. `assistantActivityState("idle")` handler now clears full turn state** (`ChatActionHandler.swift`)

When the daemon reports idle, the turn is definitively over. The handler now clears `isThinking`, `isCompacting`, `isCancelling`, flushes streaming/partial output buffers, marks the current assistant message as `isStreaming = false`, completes in-flight tool calls, and clears `isSending`. It intentionally preserves `currentAssistantMessageId` for `messageComplete` (which arrives milliseconds later on the same stream) and schedules a 5-second fallback to clear it if `messageComplete` never arrives.

**2. 90-second `isThinking` watchdog** (`ChatViewModel.swift`)

Mirrors the existing `isSending` watchdog pattern. When `isThinking` is set to `true`, a 90-second timer starts. If `isThinking` is still `true` when it fires (both `idle` and `messageComplete` were lost), it performs a comprehensive state reset. Uses the backing store (`messageManager.isThinking = false`) to avoid re-triggering the setter. 90 seconds was chosen to exceed the longest observed extended thinking durations while remaining responsive enough for recovery.

**3. `scheduleIdleFallbackCleanup()` with captured message ID** (`ChatViewModel.swift`)

The idle handler can't clear `currentAssistantMessageId` immediately because `messageComplete` needs it for daemonMessageId backfill, attachment ingestion, and voice callbacks. Instead, a 5-second fallback task captures the specific `currentAssistantMessageId` when scheduled and only clears it if the same ID is still current when the timer fires. This prevents cross-turn clearing if the user sends a quick follow-up. The fallback is cancelled by `handleMessageComplete` on entry, and also cancelled in all state-reset paths (`handleTransportReconnect`, `startMessageLoop` error handler, `populateFromHistory`).

## Why this is safe

- **`idle` is always terminal.** The daemon only emits it with reasons `message_complete`, `generation_cancelled`, or `error_terminal` — never mid-turn.
- **`activityVersion` guard** prevents stale idle events from clearing a later turn's state.
- **`messageComplete` still runs its full cleanup** (suggestions, daemonMessageId backfill, attachments, voice callbacks) because `currentAssistantMessageId` is preserved until `messageComplete` arrives or the 5-second fallback fires.
- **The idle fallback captures the specific message ID** so a stale fallback from Turn A cannot clear Turn B's `currentAssistantMessageId` if the user sends a quick follow-up.
- **The `isThinking` watchdog uses the backing store** (`messageManager.isThinking = false`) to avoid re-triggering its own setter, and cancels the `sendingWatchdogTask` to prevent double-recovery.
- **Additive changes only.** No existing event handler behavior is removed. The idle handler previously only set `isThinking = false`; it now additionally clears the other turn flags that were already being cleared by `messageComplete`.

## Alternatives not taken

| Alternative | Why rejected |
|---|---|
| **Remove `messageId == nil` from the `messageComplete` filter** | `recording.ts` and `wake-target-adapter.ts` in the daemon emit `message_complete` with no `messageId` and no `source: "aux"`. Removing the check would let recording events reset active main turns. The correct upstream fix is adding `source: "aux"` to those emitters, but that's a daemon change outside this PR's scope. |
| **Add periodic reconciliation (like the web app's visibility handler)** | The macOS app is a menu bar app with no visibility change events. Periodic polling would add server load for an always-"visible" app. The idle handler + watchdog provide equivalent recovery. |
| **Full refactor to a pure turn state reducer** | The right long-term architecture, but ~4000 lines of intertwined imperative state management in `ChatActionHandler` + `ChatViewModel` make this a multi-week effort. The targeted idle handler + watchdog close the specific recovery gaps without the blast radius. |
| **Derive turn state from message `isStreaming` flag** | Would lose the thinking indicator, tool call tracking, queue depth, and other state the turn flags carry. The imperative state exists for good reasons. |
| **Shorten the `isSending` watchdog from 60s to cover thinking too** | Would kill legitimate extended thinking responses (>60s of thinking with no SSE events is normal for complex reasoning). The separate 90s `isThinking` watchdog allows longer thinking while still recovering from lost events. |

## Root cause analysis

### How the code got into this state

1. The 60-second `isSending` watchdog was added as auto-recovery for stuck turns when `messageComplete` was lost.
2. Extended thinking support set `isSending = false` when the daemon reported `phase: "thinking"`, to prevent the watchdog from killing legitimate long-thinking responses. This was the correct fix for that bug.
3. But `isThinking = true` was left with **no** equivalent watchdog. The only recovery mechanism for the turn was just disabled during the thinking phase.
4. The `assistantActivityState("idle")` handler only set `isThinking = false` — it didn't clear the other turn flags (`isSending`, `currentAssistantMessageId`, tool call state). This meant that even when the daemon correctly signaled "I'm idle," the client's turn could remain stuck.

### What decisions led to it

- Each stuck-UI bug was fixed with a targeted self-heal for that specific indicator (compacting, subagents, reconnect state), rather than making `idle` a universal recovery signal. This created a pattern where the generic turn state flags (`isSending`, `isThinking`, `currentAssistantMessageId`) had weaker recovery than newer, more specific indicators.
- The `isSending` watchdog's interaction with extended thinking was a case where fixing one bug (watchdog killing thinking) created a gap in another (no recovery during thinking). The fix was local and didn't consider the broader invariant: "every stuck-turn path needs a recovery mechanism."

### Warning signs we missed

- The `assistantActivityState("idle")` handler doing almost nothing (just `isThinking = false`) should have been a red flag — if the daemon says "I'm idle," the client should agree.
- The asymmetry between `isSending` (has watchdog) and `isThinking` (no watchdog) should have been caught when the thinking-disables-watchdog behavior was added.

### Preventing recurrence

When adding new "activity phases" or modifying how phases interact with recovery mechanisms, verify: **does every phase that disables an existing recovery path have its own equivalent recovery?** The new `isThinking` watchdog and enhanced idle handler establish this pattern.

## References

- [Apple — Structured concurrency: Task cancellation](https://developer.apple.com/documentation/swift/task/cancel()) — pattern used for watchdog and fallback task cancellation
- [Apple — Task.sleep(for:)](https://developer.apple.com/documentation/swift/task/sleep(for:tolerance:clock:)) — timeout mechanism for watchdogs
- Daemon `conversation-agent-loop.ts` lines 2776-2785: `emitActivityState("idle")` is always sent before `messageComplete` on terminal paths

---

- Requested by: @ashleeradka
- Session: https://app.devin.ai/sessions/5641e74ed74a44b686f5c24e8d209a4c
