### PR TITLE
Fix iOS managed assistant reconnect handling

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -51,14 +51,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Ensure ripgrep is available
-        run: |
-          if ! command -v rg >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y ripgrep
-          fi
-          rg --version | head -1
-
       - name: FlexFrame guard
         run: bash clients/scripts/check-flexframe.sh
 

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -31,14 +31,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Ensure ripgrep is available
-        run: |
-          if ! command -v rg >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y ripgrep
-          fi
-          rg --version | head -1
-
       - name: FlexFrame guard
         run: bash clients/scripts/check-flexframe.sh
 

--- a/clients/scripts/check-flexframe.sh
+++ b/clients/scripts/check-flexframe.sh
@@ -73,15 +73,15 @@ PATTERN='\.frame\(\s*(max|min|ideal)(Width|Height)\s*:'
 
 cd "$REPO_ROOT"
 
+if ! command -v rg >/dev/null 2>&1 && ! command -v perl >/dev/null 2>&1; then
+  echo "ERROR: flexframe lint requires either ripgrep (rg) or perl in PATH." >&2
+  exit 2
+fi
+
 collect_raw_hits() {
   if command -v rg >/dev/null 2>&1; then
     rg -U --multiline-dotall -n --no-heading "$PATTERN" "${SCAN_DIRS[@]}" 2>/dev/null
     return
-  fi
-
-  if ! command -v perl >/dev/null 2>&1; then
-    echo "ERROR: flexframe lint requires either ripgrep (rg) or perl in PATH." >&2
-    exit 2
   fi
 
   find "${SCAN_DIRS[@]}" -type f -name '*.swift' -print0 2>/dev/null \

--- a/clients/scripts/check-flexframe.sh
+++ b/clients/scripts/check-flexframe.sh
@@ -73,12 +73,42 @@ PATTERN='\.frame\(\s*(max|min|ideal)(Width|Height)\s*:'
 
 cd "$REPO_ROOT"
 
-if ! command -v rg >/dev/null 2>&1; then
-  echo "ERROR: ripgrep (rg) is required but not found in PATH." >&2
-  echo "  macOS: brew install ripgrep" >&2
-  echo "  Ubuntu: apt-get install ripgrep" >&2
-  exit 2
-fi
+collect_raw_hits() {
+  if command -v rg >/dev/null 2>&1; then
+    rg -U --multiline-dotall -n --no-heading "$PATTERN" "${SCAN_DIRS[@]}" 2>/dev/null
+    return
+  fi
+
+  if ! command -v perl >/dev/null 2>&1; then
+    echo "ERROR: flexframe lint requires either ripgrep (rg) or perl in PATH." >&2
+    exit 2
+  fi
+
+  find "${SCAN_DIRS[@]}" -type f -name '*.swift' -print0 2>/dev/null \
+    | perl -0ne '
+        chomp;
+        my $file = $_;
+        open my $fh, "<", $file or next;
+        local $/;
+        my $content = <$fh>;
+        close $fh;
+
+        my @lines = split /\n/, $content, -1;
+        my %printed;
+        while ($content =~ /\.frame\(\s*(?:(?:max|min|ideal)(?:Width|Height))\s*:/sg) {
+          my $start_line = substr($content, 0, $-[0]) =~ tr/\n//;
+          my $end_line = substr($content, 0, $+[0]) =~ tr/\n//;
+          for my $idx ($start_line .. $end_line) {
+            next if $idx > $#lines;
+            my $line_no = $idx + 1;
+            my $line = $lines[$idx];
+            my $key = "$line_no:$line";
+            next if $printed{$key}++;
+            print "$file:$line_no:$line\n";
+          }
+        }
+      '
+}
 
 # Collect raw hits with line numbers, then drop comment-only lines
 # (lines whose first non-whitespace is `//` or `///`). AGENTS.md-style
@@ -89,11 +119,10 @@ fi
 # across lines (opening paren on one line, `maxWidth:` on the next) is
 # caught. Without this, code formatted as `.frame(\n    maxWidth: …\n)`
 # bypasses the lint silently — a real escape already present at
-# ChatLoadingSkeleton.swift before this PR. ripgrep reports only the
-# START line of a multiline match, so the comment filter (which only
-# inspects that line) stays correct: the outer `.frame(` never itself
-# starts with `//`.
-RAW_HITS=$(rg -U --multiline-dotall -n --no-heading "$PATTERN" "${SCAN_DIRS[@]}" 2>/dev/null \
+# ChatLoadingSkeleton.swift before this PR. The fallback scanner mirrors
+# ripgrep's line-oriented output for multiline matches so the allowlist remains
+# stable when CI hosts do not have `rg` preinstalled.
+RAW_HITS=$(collect_raw_hits \
   | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//' \
   || true)
 

--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -92,7 +92,7 @@ public final class GatewayConnectionManager {
         #if os(macOS)
         return cachedAssistant?.isManaged ?? false
         #else
-        return false
+        return (try? GatewayHTTPClient.isConnectionManaged()) ?? false
         #endif
     }
 
@@ -359,7 +359,7 @@ public final class GatewayConnectionManager {
     private func performHealthCheck() async throws {
         let healthPath = "health"
         let useUnprefixedHealthPath = HealthCheckClient.usesUnprefixedGatewayHealth(
-            forManagedConnection: isManagedConnectionForHealthCheck()
+            forManagedConnection: isManaged
         )
 
         // Run the HTTP GET + JSON decode off the main actor. `GatewayHTTPClient`
@@ -448,14 +448,6 @@ public final class GatewayConnectionManager {
             log.info("Health check passed")
         }
         setConnected(true)
-    }
-
-    private func isManagedConnectionForHealthCheck() -> Bool {
-        #if os(macOS)
-        return cachedAssistant?.isManaged ?? false
-        #else
-        return (try? GatewayHTTPClient.isConnectionManaged()) ?? false
-        #endif
     }
 
     /// Reconciles `isAuthFailed` against the tracker's current state and logs
@@ -692,12 +684,7 @@ public final class GatewayConnectionManager {
     // MARK: - 401 Recovery
 
     private func handleAuthenticationFailure() {
-        #if os(macOS)
-        let managedConnection = cachedAssistant?.isManaged ?? false
-        #else
-        let managedConnection = (try? GatewayHTTPClient.isConnectionManaged()) ?? false
-        #endif
-        if managedConnection {
+        if isManaged {
             log.warning("401 in managed mode — session token may be expired")
             eventStreamClient.broadcastMessage(.conversationError(ConversationErrorMessage(
                 conversationId: "",
@@ -875,7 +862,7 @@ public final class GatewayConnectionManager {
     // MARK: - Background Reconnection Loop
 
     /// Retries connection with increasing delays after the initial `connect()` fails.
-    /// Applies to local and managed assistants on macOS. Uses health checks and auto-wake
+    /// Applies to local assistants and managed assistants. Uses health checks and auto-wake
     /// (local only) to reconnect without calling `connectImpl()` (which would interfere via
     /// `disconnectInternal()`). Cancelled on explicit `disconnect()` or `reconfigure()`.
     private func startReconnectionLoop() {


### PR DESCRIPTION
## Summary
- Treat iOS managed platform connections as managed in GatewayConnectionManager instead of only during health path selection.
- Reuse that shared managed-state check for health routing and auth/404 recovery paths.
- Keep the managed reconnection loop eligible on iOS after managed health checks move to assistant-scoped routes.
- Make FlexFrame lint independent of apt-installed ripgrep so CI can run on runners with temporary Ubuntu mirror DNS failures.

## Original prompt
could you use /do to address feedback in the PR if its valid https://github.com/vellum-ai/vellum-assistant/pull/29216