### PR TITLE
refactor(clients): consolidate turn-state cleanup into shared helpers

### DIFF
--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -706,9 +706,7 @@ final class ChatActionHandler {
                 completedToolCalls = toolCalls
             }
         }
-        vm.currentAssistantMessageId = nil
-        vm.currentTurnUserText = nil
-        vm.currentAssistantHasText = false
+        vm.clearCurrentTurnTracking()
         // Reset processing messages to sent and drop attachment base64 data
         // for lazy-loadable attachments (sizeBytes != nil means the daemon can
         // re-serve them). Locally-added attachments (sizeBytes == nil) keep their
@@ -766,9 +764,7 @@ final class ChatActionHandler {
         if let lastUserIndex = vm.messages.lastIndex(where: { $0.role == .user }) {
             vm.messages.removeSubrange((lastUserIndex + 1)...)
         }
-        vm.currentAssistantMessageId = nil
-        vm.currentTurnUserText = nil
-        vm.currentAssistantHasText = false
+        vm.clearCurrentTurnTracking()
         vm.discardStreamingBuffer()
         vm.discardPartialOutputBuffer()
     }
@@ -810,31 +806,16 @@ final class ChatActionHandler {
             vm.isSending = false
         }
         vm.messageManager.batchUpdateMessages { msgs in
-            if let existingId = vm.currentAssistantMessageId,
-               let index = msgs.firstIndex(where: { $0.id == existingId }) {
-                msgs[index].isStreaming = false
-                msgs[index].streamingCodePreview = nil
-                msgs[index].streamingCodeToolName = nil
-                // Mark preview-only tool calls (have toolUseId, not complete, no inputRawDict)
-                // as complete/cancelled so they don't remain in a dangling incomplete state.
-                for tcIdx in msgs[index].toolCalls.indices {
-                    let tc = msgs[index].toolCalls[tcIdx]
-                    if tc.toolUseId != nil && !tc.isComplete && tc.inputRawDict == nil {
-                        msgs[index].toolCalls[tcIdx].isComplete = true
-                        msgs[index].toolCalls[tcIdx].completedAt = Date()
-                    }
-                }
+            if let existingId = vm.currentAssistantMessageId {
+                msgs.finalizeStreamingMessage(id: existingId, completeToolCalls: .previewOnly)
             }
-            // Reset processing messages to sent
             for i in msgs.indices {
                 if msgs[i].role == .user && msgs[i].status == .processing {
                     msgs[i].status = .sent
                 }
             }
         }
-        vm.currentAssistantMessageId = nil
-        vm.currentTurnUserText = nil
-        vm.currentAssistantHasText = false
+        vm.clearCurrentTurnTracking()
         vm.discardStreamingBuffer()
         vm.flushPartialOutputBuffer()
         vm.dispatchPendingSendDirect()
@@ -968,15 +949,10 @@ final class ChatActionHandler {
         if msg.runStillActive != true {
             vm.flushStreamingBuffer()
             vm.flushPartialOutputBuffer()
-            if let existingId = vm.currentAssistantMessageId,
-               let index = vm.messages.firstIndex(where: { $0.id == existingId }) {
-                vm.messages[index].isStreaming = false
-                vm.messages[index].streamingCodePreview = nil
-                vm.messages[index].streamingCodeToolName = nil
+            if let existingId = vm.currentAssistantMessageId {
+                vm.messages.finalizeStreamingMessage(id: existingId, completeToolCalls: .none)
             }
-            vm.currentAssistantMessageId = nil
-            vm.currentTurnUserText = nil
-            vm.currentAssistantHasText = false
+            vm.clearCurrentTurnTracking()
         }
         if msg.runStillActive != true && vm.pendingQueuedCount == 0 {
             vm.isSending = false
@@ -997,20 +973,16 @@ final class ChatActionHandler {
         // Must run before currentAssistantMessageId is cleared so attachments land on the right message
         vm.ingestAssistantAttachments(handoff.attachments)
         // Keep isSending = true — daemon is handing off to next queued message
-        if let existingId = vm.currentAssistantMessageId,
-           let index = vm.messages.firstIndex(where: { $0.id == existingId }) {
+        if let existingId = vm.currentAssistantMessageId {
             // Backfill the daemon's persisted message ID so fork, inspect,
             // TTS, and other daemon-anchored actions work without a history reload.
-            if let messageId = handoff.messageId {
+            if let messageId = handoff.messageId,
+               let index = vm.messages.firstIndex(where: { $0.id == existingId }) {
                 vm.messages[index].daemonMessageId = messageId
             }
-            vm.messages[index].isStreaming = false
-            vm.messages[index].streamingCodePreview = nil
-            vm.messages[index].streamingCodeToolName = nil
+            vm.messages.finalizeStreamingMessage(id: existingId, completeToolCalls: .none)
         }
-        vm.currentAssistantMessageId = nil
-        vm.currentTurnUserText = nil
-        vm.currentAssistantHasText = false
+        vm.clearCurrentTurnTracking()
         // Reset processing messages to sent and clear attachment binary payloads.
         // Only clear for lazy-loadable attachments (sizeBytes != nil); locally-created
         // attachments (sizeBytes == nil) can't be re-fetched and need their data preserved.
@@ -1061,20 +1033,8 @@ final class ChatActionHandler {
         // complete, reset processing statuses, and handle secret_blocked
         // removal — all in a single batch to avoid per-mutation overhead.
         vm.messageManager.batchUpdateMessages { msgs in
-            // Mark current assistant message as no longer streaming
-            if let existingId = vm.currentAssistantMessageId,
-               let index = msgs.firstIndex(where: { $0.id == existingId }) {
-                msgs[index].isStreaming = false
-                msgs[index].streamingCodePreview = nil
-                msgs[index].streamingCodeToolName = nil
-                // Mark preview-only tool calls as complete on terminal error
-                for tcIdx in msgs[index].toolCalls.indices {
-                    let tc = msgs[index].toolCalls[tcIdx]
-                    if tc.toolUseId != nil && !tc.isComplete && tc.inputRawDict == nil {
-                        msgs[index].toolCalls[tcIdx].isComplete = true
-                        msgs[index].toolCalls[tcIdx].completedAt = Date()
-                    }
-                }
+            if let existingId = vm.currentAssistantMessageId {
+                msgs.finalizeStreamingMessage(id: existingId, completeToolCalls: .previewOnly)
             }
             if !wasCancelling && err.category == "secret_blocked" {
                 let normalizedTurnText = savedTurnUserText?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1115,9 +1075,7 @@ final class ChatActionHandler {
                 }
             }
         }
-        vm.currentAssistantMessageId = nil
-        vm.currentTurnUserText = nil
-        vm.currentAssistantHasText = false
+        vm.clearCurrentTurnTracking()
         if !wasCancelling {
             vm.errorText = err.message
             // When the backend blocks a message for containing secrets,
@@ -1308,19 +1266,8 @@ final class ChatActionHandler {
         // Finalize assistant message, remove empty trailing assistant bubble,
         // insert inline error, reset processing/queued statuses — single batch.
         vm.messageManager.batchUpdateMessages { msgs in
-            if let existingId = vm.currentAssistantMessageId,
-               let index = msgs.firstIndex(where: { $0.id == existingId }) {
-                msgs[index].isStreaming = false
-                msgs[index].streamingCodePreview = nil
-                msgs[index].streamingCodeToolName = nil
-                // Mark preview-only tool calls as complete on conversation error
-                for tcIdx in msgs[index].toolCalls.indices {
-                    let tc = msgs[index].toolCalls[tcIdx]
-                    if tc.toolUseId != nil && !tc.isComplete && tc.inputRawDict == nil {
-                        msgs[index].toolCalls[tcIdx].isComplete = true
-                        msgs[index].toolCalls[tcIdx].completedAt = Date()
-                    }
-                }
+            if let existingId = vm.currentAssistantMessageId {
+                msgs.finalizeStreamingMessage(id: existingId, completeToolCalls: .previewOnly)
             }
             if !wasCancelling {
                 // Remove empty assistant message left over from the interrupted stream
@@ -1349,9 +1296,7 @@ final class ChatActionHandler {
                 }
             }
         }
-        vm.currentAssistantMessageId = nil
-        vm.currentTurnUserText = nil
-        vm.currentAssistantHasText = false
+        vm.clearCurrentTurnTracking()
         vm.flushPartialOutputBuffer()
         // When the user intentionally cancelled, suppress the error.
         // Otherwise, set error state so the UI shows the error banner.
@@ -1499,20 +1444,10 @@ final class ChatActionHandler {
             vm.isThinking = false
             vm.isCompacting = false
             vm.isCancelling = false
-            // Flush buffered text before clearing the message reference.
             vm.flushStreamingBuffer()
             vm.flushPartialOutputBuffer()
-            // Mark the current assistant message as no longer streaming and
-            // complete any in-flight tool calls so progress indicators clear.
-            if let assistantId = vm.currentAssistantMessageId,
-               let idx = vm.messages.firstIndex(where: { $0.id == assistantId }) {
-                vm.messages[idx].isStreaming = false
-                vm.messages[idx].streamingCodePreview = nil
-                vm.messages[idx].streamingCodeToolName = nil
-                for j in vm.messages[idx].toolCalls.indices where !vm.messages[idx].toolCalls[j].isComplete {
-                    vm.messages[idx].toolCalls[j].isComplete = true
-                    vm.messages[idx].toolCalls[j].completedAt = Date()
-                }
+            if let assistantId = vm.currentAssistantMessageId {
+                vm.messages.finalizeStreamingMessage(id: assistantId)
             }
             if vm.pendingQueuedCount == 0 {
                 vm.isSending = false

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1901,3 +1901,48 @@ public struct ChatMessage: Identifiable, Equatable {
         isContentStripped = true
     }
 }
+
+// MARK: - Streaming message finalization
+
+/// Controls which tool calls are marked complete when finalizing a streaming message.
+public enum ToolCallCompletionMode {
+    /// Complete all incomplete tool calls (recovery paths: idle handler, watchdogs).
+    case all
+    /// Only complete preview-only tool calls — those with a `toolUseId` but no
+    /// `inputRawDict`, indicating the daemon hadn't started executing them
+    /// (cancellation/error paths).
+    case previewOnly
+    /// Don't touch tool calls.
+    case none
+}
+
+extension Array where Element == ChatMessage {
+    /// Mark a specific assistant message as no longer streaming, clear code preview
+    /// state, and optionally complete tool calls based on the specified mode.
+    mutating func finalizeStreamingMessage(
+        id: UUID,
+        completeToolCalls: ToolCallCompletionMode = .all
+    ) {
+        guard let index = firstIndex(where: { $0.id == id }) else { return }
+        self[index].isStreaming = false
+        self[index].streamingCodePreview = nil
+        self[index].streamingCodeToolName = nil
+        switch completeToolCalls {
+        case .all:
+            for j in self[index].toolCalls.indices where !self[index].toolCalls[j].isComplete {
+                self[index].toolCalls[j].isComplete = true
+                self[index].toolCalls[j].completedAt = Date()
+            }
+        case .previewOnly:
+            for j in self[index].toolCalls.indices {
+                let tc = self[index].toolCalls[j]
+                if tc.toolUseId != nil && !tc.isComplete && tc.inputRawDict == nil {
+                    self[index].toolCalls[j].isComplete = true
+                    self[index].toolCalls[j].completedAt = Date()
+                }
+            }
+        case .none:
+            break
+        }
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -247,20 +247,11 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     self.assistantStatusText = nil
                     let assistantId = self.currentAssistantMessageId
                     self.messageManager.batchUpdateMessages { msgs in
-                        if let existingId = assistantId,
-                           let index = msgs.firstIndex(where: { $0.id == existingId }) {
-                            msgs[index].isStreaming = false
-                            msgs[index].streamingCodePreview = nil
-                            msgs[index].streamingCodeToolName = nil
-                            for j in msgs[index].toolCalls.indices where !msgs[index].toolCalls[j].isComplete {
-                                msgs[index].toolCalls[j].isComplete = true
-                                msgs[index].toolCalls[j].completedAt = Date()
-                            }
+                        if let existingId = assistantId {
+                            msgs.finalizeStreamingMessage(id: existingId)
                         }
                     }
-                    self.currentAssistantMessageId = nil
-                    self.currentTurnUserText = nil
-                    self.currentAssistantHasText = false
+                    self.clearCurrentTurnTracking()
                     self.discardStreamingBuffer()
                     self.discardPartialOutputBuffer()
                     self.messageManager.isSending = false
@@ -284,10 +275,19 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
             guard !Task.isCancelled, let self else { return }
             guard self.currentAssistantMessageId == messageId else { return }
             log.warning("idle fallback: messageComplete not received within 5s — clearing currentAssistantMessageId")
-            self.currentAssistantMessageId = nil
-            self.currentTurnUserText = nil
-            self.currentAssistantHasText = false
+            self.clearCurrentTurnTracking()
         }
+    }
+
+    /// Cancel any pending idle fallback and clear per-message turn tracking state.
+    /// Every code path that sets `currentAssistantMessageId = nil` should call this
+    /// instead to ensure the idle fallback timer is always cancelled.
+    func clearCurrentTurnTracking() {
+        idleFallbackTask?.cancel()
+        idleFallbackTask = nil
+        currentAssistantMessageId = nil
+        currentTurnUserText = nil
+        currentAssistantHasText = false
     }
 
     /// Whether the assistant is actively working on a response — covers sending,
@@ -358,15 +358,8 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                     // to emit a single Combine notification.
                     let assistantId = self.currentAssistantMessageId
                     self.messageManager.batchUpdateMessages { msgs in
-                        if let existingId = assistantId,
-                           let index = msgs.firstIndex(where: { $0.id == existingId }) {
-                            msgs[index].isStreaming = false
-                            msgs[index].streamingCodePreview = nil
-                            msgs[index].streamingCodeToolName = nil
-                            for j in msgs[index].toolCalls.indices where !msgs[index].toolCalls[j].isComplete {
-                                msgs[index].toolCalls[j].isComplete = true
-                                msgs[index].toolCalls[j].completedAt = Date()
-                            }
+                        if let existingId = assistantId {
+                            msgs.finalizeStreamingMessage(id: existingId)
                         }
                         for i in msgs.indices {
                             if case .queued = msgs[i].status, msgs[i].role == .user {
@@ -376,9 +369,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                             }
                         }
                     }
-                    self.currentAssistantMessageId = nil
-                    self.currentTurnUserText = nil
-                    self.currentAssistantHasText = false
+                    self.clearCurrentTurnTracking()
                     self.discardStreamingBuffer()
                     self.discardPartialOutputBuffer()
                     // Voice state
@@ -1512,14 +1503,10 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
                 self?.isThinking = false
                 self?.isSending = false
                 self?.isCancelling = false
-                // Mark current assistant message as no longer streaming
-                if let existingId = self?.currentAssistantMessageId,
-                   let index = self?.messages.firstIndex(where: { $0.id == existingId }) {
-                    self?.messages[index].isStreaming = false
+                if let existingId = self?.currentAssistantMessageId {
+                    self?.messages.finalizeStreamingMessage(id: existingId, completeToolCalls: .none)
                 }
-                self?.idleFallbackTask?.cancel()
-                self?.idleFallbackTask = nil
-                self?.currentAssistantMessageId = nil
+                self?.clearCurrentTurnTracking()
                 self?.discardStreamingBuffer()
                 self?.discardPartialOutputBuffer()
                 // If a send-direct was pending when the stream dropped,
@@ -2287,10 +2274,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         discardStreamingBuffer()
         discardPartialOutputBuffer()
         surfaceRefetchCoordinator.cancelRefetchTasks()
-        idleFallbackTask?.cancel()
-        idleFallbackTask = nil
-        currentAssistantMessageId = nil
-        currentAssistantHasText = false
+        clearCurrentTurnTracking()
 
         if needsReconnectCatchUp {
             // Reconnect catch-up: the SSE stream dropped while a run was
@@ -2436,9 +2420,7 @@ public final class ChatViewModel: MessageSendCoordinatorDelegate {
         if isThinking || isSending || currentAssistantMessageId != nil {
             isThinking = false
             isSending = false
-            idleFallbackTask?.cancel()
-            idleFallbackTask = nil
-            currentAssistantMessageId = nil
+            clearCurrentTurnTracking()
             discardStreamingBuffer()
             discardPartialOutputBuffer()
             reconnectDebounceTask?.cancel()

--- a/clients/shared/Features/Chat/MessageSendCoordinator.swift
+++ b/clients/shared/Features/Chat/MessageSendCoordinator.swift
@@ -67,6 +67,7 @@ protocol MessageSendCoordinatorDelegate: AnyObject {
     func discardStreamingBuffer()
     func discardPartialOutputBuffer()
     func flushStreamingBuffer()
+    func clearCurrentTurnTracking()
 
     // MARK: - Callbacks
     var onFork: (() -> Void)? { get }
@@ -690,15 +691,8 @@ final class MessageSendCoordinator {
         // in a single batch to avoid O(n) synchronous Combine pipeline evaluations.
         let assistantId = delegate.currentAssistantMessageId
         messageManager.batchUpdateMessages { msgs in
-            if let existingId = assistantId,
-               let index = msgs.firstIndex(where: { $0.id == existingId }) {
-                msgs[index].isStreaming = false
-                msgs[index].streamingCodePreview = nil
-                msgs[index].streamingCodeToolName = nil
-                for j in msgs[index].toolCalls.indices where !msgs[index].toolCalls[j].isComplete {
-                    msgs[index].toolCalls[j].isComplete = true
-                    msgs[index].toolCalls[j].completedAt = Date()
-                }
+            if let existingId = assistantId {
+                msgs.finalizeStreamingMessage(id: existingId)
             }
             for i in msgs.indices {
                 if case .queued = msgs[i].status, msgs[i].role == .user {
@@ -708,9 +702,7 @@ final class MessageSendCoordinator {
                 }
             }
         }
-        delegate.currentAssistantMessageId = nil
-        delegate.currentTurnUserText = nil
-        delegate.currentAssistantHasText = false
+        delegate.clearCurrentTurnTracking()
         delegate.discardStreamingBuffer()
         delegate.discardPartialOutputBuffer()
         messageManager.pendingQueuedCount = 0

--- a/clients/shared/Tests/ClearCurrentTurnTrackingTests.swift
+++ b/clients/shared/Tests/ClearCurrentTurnTrackingTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class ClearCurrentTurnTrackingTests: XCTestCase {
+
+    private var connectionManager: GatewayConnectionManager!
+    private var viewModel: ChatViewModel!
+
+    override func setUp() {
+        super.setUp()
+        connectionManager = GatewayConnectionManager()
+        connectionManager.isConnected = true
+        viewModel = ChatViewModel(connectionManager: connectionManager, eventStreamClient: connectionManager.eventStreamClient)
+        viewModel.conversationId = "sess-1"
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        connectionManager = nil
+        super.tearDown()
+    }
+
+    func testClearsAllTrackingProperties() {
+        viewModel.currentAssistantMessageId = UUID()
+        viewModel.currentTurnUserText = "hello"
+        viewModel.currentAssistantHasText = true
+
+        viewModel.clearCurrentTurnTracking()
+
+        XCTAssertNil(viewModel.currentAssistantMessageId)
+        XCTAssertNil(viewModel.currentTurnUserText)
+        XCTAssertFalse(viewModel.currentAssistantHasText)
+    }
+
+    func testCancelsIdleFallbackTask() {
+        viewModel.currentAssistantMessageId = UUID()
+        viewModel.scheduleIdleFallbackCleanup()
+        XCTAssertNotNil(viewModel.idleFallbackTask, "Precondition: fallback task should be scheduled")
+
+        viewModel.clearCurrentTurnTracking()
+
+        XCTAssertNil(viewModel.idleFallbackTask, "Idle fallback task should be cancelled and nil'd")
+    }
+
+    func testIsIdempotent() {
+        viewModel.clearCurrentTurnTracking()
+        viewModel.clearCurrentTurnTracking()
+
+        XCTAssertNil(viewModel.currentAssistantMessageId)
+        XCTAssertNil(viewModel.currentTurnUserText)
+        XCTAssertFalse(viewModel.currentAssistantHasText)
+        XCTAssertNil(viewModel.idleFallbackTask)
+    }
+
+    func testDoesNotAffectOtherTurnState() {
+        viewModel.isSending = true
+        viewModel.isThinking = true
+        viewModel.isCompacting = true
+        viewModel.currentAssistantMessageId = UUID()
+
+        viewModel.clearCurrentTurnTracking()
+
+        XCTAssertTrue(viewModel.isSending, "isSending should not be cleared by clearCurrentTurnTracking")
+        XCTAssertTrue(viewModel.isCompacting, "isCompacting should not be cleared by clearCurrentTurnTracking")
+        // isThinking uses a setter that may schedule/cancel watchdogs, so just verify
+        // the method doesn't crash when other turn state is set.
+    }
+}

--- a/clients/shared/Tests/FinalizeStreamingMessageTests.swift
+++ b/clients/shared/Tests/FinalizeStreamingMessageTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class FinalizeStreamingMessageTests: XCTestCase {
+
+    // MARK: - .all mode
+
+    func testAllModeMarksNotStreamingAndClearsCodePreview() {
+        var msg = ChatMessage(role: .assistant, text: "Hello", isStreaming: true)
+        msg.streamingCodePreview = "let x = 1"
+        msg.streamingCodeToolName = "bash"
+        var messages = [msg]
+
+        messages.finalizeStreamingMessage(id: msg.id)
+
+        XCTAssertFalse(messages[0].isStreaming)
+        XCTAssertNil(messages[0].streamingCodePreview)
+        XCTAssertNil(messages[0].streamingCodeToolName)
+    }
+
+    func testAllModeCompletesAllIncompleteToolCalls() {
+        var msg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [
+            ToolCallData(toolName: "bash", inputSummary: "ls"),
+            ToolCallData(toolName: "file_read", inputSummary: "/tmp/a.txt"),
+        ])
+        msg.toolCalls[0].isComplete = true
+        msg.toolCalls[0].completedAt = Date()
+        var messages = [msg]
+
+        messages.finalizeStreamingMessage(id: msg.id)
+
+        XCTAssertTrue(messages[0].toolCalls[0].isComplete, "Already-complete tool call stays complete")
+        XCTAssertTrue(messages[0].toolCalls[1].isComplete, "Incomplete tool call should be completed")
+        XCTAssertNotNil(messages[0].toolCalls[1].completedAt)
+    }
+
+    // MARK: - .previewOnly mode
+
+    func testPreviewOnlyCompletesOnlyPreviewToolCalls() {
+        var msg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [
+            ToolCallData(toolName: "bash", inputSummary: "ls"),
+            ToolCallData(toolName: "file_read", inputSummary: "/tmp/a.txt"),
+        ])
+        // First tool call: has toolUseId, no inputRawDict → preview-only, should be completed
+        msg.toolCalls[0].toolUseId = "tool-1"
+        msg.toolCalls[0].inputRawDict = nil
+        // Second tool call: has toolUseId AND inputRawDict → daemon started executing, should NOT be completed
+        msg.toolCalls[1].toolUseId = "tool-2"
+        msg.toolCalls[1].inputRawDict = ["path": AnyCodable("/tmp/a.txt")]
+        var messages = [msg]
+
+        messages.finalizeStreamingMessage(id: msg.id, completeToolCalls: .previewOnly)
+
+        XCTAssertTrue(messages[0].toolCalls[0].isComplete, "Preview-only tool call should be completed")
+        XCTAssertNotNil(messages[0].toolCalls[0].completedAt)
+        XCTAssertFalse(messages[0].toolCalls[1].isComplete, "Tool call with inputRawDict should NOT be completed in previewOnly mode")
+    }
+
+    func testPreviewOnlySkipsToolCallsWithoutToolUseId() {
+        var msg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [
+            ToolCallData(toolName: "bash", inputSummary: "ls"),
+        ])
+        // No toolUseId → not preview-only, should not be completed
+        msg.toolCalls[0].toolUseId = nil
+        msg.toolCalls[0].inputRawDict = nil
+        var messages = [msg]
+
+        messages.finalizeStreamingMessage(id: msg.id, completeToolCalls: .previewOnly)
+
+        XCTAssertFalse(messages[0].toolCalls[0].isComplete, "Tool call without toolUseId should not be completed in previewOnly mode")
+    }
+
+    // MARK: - .none mode
+
+    func testNoneModeDoesNotTouchToolCalls() {
+        var msg = ChatMessage(role: .assistant, text: "", isStreaming: true, toolCalls: [
+            ToolCallData(toolName: "bash", inputSummary: "ls"),
+        ])
+        var messages = [msg]
+
+        messages.finalizeStreamingMessage(id: msg.id, completeToolCalls: .none)
+
+        XCTAssertFalse(messages[0].isStreaming, "isStreaming should still be cleared")
+        XCTAssertFalse(messages[0].toolCalls[0].isComplete, "Tool calls should not be touched in .none mode")
+    }
+
+    // MARK: - Edge cases
+
+    func testNonexistentIdIsNoOp() {
+        var msg = ChatMessage(role: .assistant, text: "Hello", isStreaming: true)
+        var messages = [msg]
+        let bogusId = UUID()
+
+        messages.finalizeStreamingMessage(id: bogusId)
+
+        XCTAssertTrue(messages[0].isStreaming, "Message should be unchanged when ID doesn't match")
+    }
+
+    func testOnlyTargetedMessageIsAffected() {
+        var msg1 = ChatMessage(role: .assistant, text: "First", isStreaming: true)
+        var msg2 = ChatMessage(role: .assistant, text: "Second", isStreaming: true)
+        var messages = [msg1, msg2]
+
+        messages.finalizeStreamingMessage(id: msg1.id)
+
+        XCTAssertFalse(messages[0].isStreaming, "Targeted message should be finalized")
+        XCTAssertTrue(messages[1].isStreaming, "Other message should be untouched")
+    }
+}


### PR DESCRIPTION
Extracts two shared helpers to consolidate duplicated turn-state cleanup logic across 14+ call sites in ChatActionHandler, ChatViewModel, and MessageSendCoordinator. Adding a new turn-state flag now means updating one place instead of hunting through every recovery path — the same class of oversight that caused the stuck "Finalizing your response" bug.

---

- Requested by: @ashleetiw
- Session: https://app.devin.ai/sessions/5641e74ed74a44b686f5c24e8d209a4c

Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
