### PR TITLE
fix(vbundle): harden promoteLegacyStagedFiles for symlinks + activate streaming round-trip test

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-symlink-streaming.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-symlink-streaming.test.ts
@@ -9,11 +9,9 @@
  *   code `"symlink_target_escapes_archive"`.
  * - `verifySymlinkEntry` rejects a manifest/tar disagreement with code
  *   `"link_target_mismatch"`.
- *
- * Round-trip via `buildVBundle({ files: [{ linkTarget }] })` is intentionally
- * `test.todo` — the in-memory builder symlink emit lands in PR 2 and the
- * walker lands in PR 4. Once both are merged we can assert end-to-end that
- * a symlink survives buildVBundle -> parseVBundleStream -> verifySymlinkEntry.
+ * - End-to-end round-trip via `buildVBundle({ files: [{ linkTarget }] })`:
+ *   the in-memory builder emits a typeflag-2 record that survives
+ *   `parseVBundleStream` and is accepted by `verifySymlinkEntry`.
  */
 
 import { createHash } from "node:crypto";
@@ -21,7 +19,9 @@ import { Readable } from "node:stream";
 import { gzipSync } from "node:zlib";
 import { describe, expect, test } from "bun:test";
 
+import { buildVBundle } from "../vbundle-builder.js";
 import {
+  readAndValidateManifest,
   StreamingValidationError,
   verifySymlinkEntry,
 } from "../vbundle-streaming-validator.js";
@@ -29,6 +29,7 @@ import {
   parseVBundleStream,
   type StreamedTarEntry,
 } from "../vbundle-tar-stream.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Hand-crafted tar fixture helpers
@@ -450,12 +451,65 @@ describe("verifySymlinkEntry — disagreement", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Round-trip via buildVBundle — gated on PR 2 + PR 4
+// Round-trip via buildVBundle
 // ---------------------------------------------------------------------------
 
-test.todo(
-  "round-trip: buildVBundle({ files: [{ linkTarget }] }) -> parseVBundleStream -> verifySymlinkEntry. Enable once PR 2 (buildVBundle symlink emit) and PR 4 (walker symlink collection) have landed.",
-  () => {
-    // no-op: see comment above.
-  },
-);
+describe("round-trip: buildVBundle -> parseVBundleStream -> verifySymlinkEntry", () => {
+  test("a symlink entry survives the full streaming pipeline", async () => {
+    const linkTarget = "bar.md";
+    const regularFileBytes = new TextEncoder().encode("regular file payload\n");
+
+    const { archive } = buildVBundle({
+      files: [
+        // The streaming importer requires data/db/assistant.db to be present;
+        // include a synthetic empty one so this fixture mirrors what
+        // production exports always carry.
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        // A regular file entry so we exercise both shapes through the parser.
+        { path: "workspace/regular.md", data: regularFileBytes },
+        // The symlink under test.
+        { path: "workspace/foo.md", data: new Uint8Array(), linkTarget },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const iter = parseVBundleStream(readableFromBuffer(archive));
+
+    // The manifest is the FIRST tar entry and must be drained before
+    // subsequent entries flow through.
+    const manifestEntry = await iter.next();
+    if (manifestEntry.done || !manifestEntry.value) {
+      throw new Error("archive contained no entries");
+    }
+    const { expected } = await readAndValidateManifest(manifestEntry.value);
+
+    // Drain the rest of the entries and capture the symlink entry.
+    let symlinkEntry: StreamedTarEntry | null = null;
+    for await (const entry of iter) {
+      if (entry.header.name === "workspace/foo.md") {
+        symlinkEntry = entry;
+        // Confirm the parser surfaced the typeflag-2 record correctly before
+        // handing it to verifySymlinkEntry (which would also resume() the
+        // body on its own paths).
+        expect(entry.header.type).toBe("symlink");
+        expect(entry.header.linkname).toBe(linkTarget);
+
+        const expectedEntry = expected.get("workspace/foo.md");
+        if (!expectedEntry) {
+          throw new Error("manifest expected map missing the symlink entry");
+        }
+        expect(expectedEntry.linkTarget).toBe(linkTarget);
+
+        // Asserts streaming-validator acceptance of a builder-produced entry.
+        expect(() =>
+          verifySymlinkEntry({ entry, expectedEntry }),
+        ).not.toThrow();
+      } else {
+        // Drain non-symlink bodies so the extractor advances.
+        entry.body.resume();
+      }
+    }
+
+    expect(symlinkEntry).not.toBeNull();
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -1327,10 +1327,37 @@ async function promoteLegacyStagedFiles(
 ): Promise<void> {
   for (const entry of staged) {
     // Backup before overwrite, matching commitImport.
+    //
+    // Use lstat (not existsSync) to detect a pre-existing entry: existsSync
+    // follows symlinks, so a dangling pre-existing symlink at livePath would
+    // report `false` and we'd skip the backup before later atomically
+    // replacing it via rename.
+    let preExisting: boolean;
+    try {
+      await lstat(entry.livePath);
+      preExisting = true;
+    } catch (err) {
+      if (isENOENT(err)) {
+        preExisting = false;
+      } else {
+        throw err;
+      }
+    }
+
     let backupPath: string | null = null;
-    if (existsSync(entry.livePath)) {
+    if (preExisting) {
       backupPath = generateBackupPath(entry.livePath);
-      await copyFile(entry.livePath, backupPath);
+      // copyFile follows symlinks and copies the resolved file's content, so
+      // backing up a pre-existing symlink with copyFile would lose the
+      // symlink shape. Recreate the link via readlink + symlink instead;
+      // fall back to copyFile for regular files.
+      const liveStat = await lstat(entry.livePath);
+      if (liveStat.isSymbolicLink()) {
+        const target = await readlink(entry.livePath);
+        await symlink(target, backupPath);
+      } else {
+        await copyFile(entry.livePath, backupPath);
+      }
     }
 
     await mkdir(dirname(entry.livePath), { recursive: true });
@@ -1364,6 +1391,11 @@ async function promoteLegacyStagedFiles(
         const srcStat = await lstat(entry.tempPath);
         if (srcStat.isSymbolicLink()) {
           const target = await readlink(entry.tempPath);
+          // Unlike rename (which atomically overwrites), fs.promises.symlink
+          // fails with EEXIST if the destination already exists. Remove any
+          // pre-existing entry at livePath first — the backup above
+          // preserved its contents.
+          await rm(entry.livePath, { force: true });
           await symlink(target, entry.livePath);
         } else {
           await copyFile(entry.tempPath, entry.livePath);


### PR DESCRIPTION
## Summary
Self-review remediation for the vbundle-symlinks plan (PRs #29201, #29213, #29214, #29217, #29218, #29221).
- **promoteLegacyStagedFiles**: existsSync to lstat, preserve symlink-shape on backup, rm before symlink in EXDEV fallback
- **vbundle-symlink-streaming.test.ts**: replace dead test.todo with real round-trip via buildVBundle

Plan: vbundle-symlinks.md (review remediation, round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
