### PR TITLE
perf(chat): extract ChatSearchOverlay into standalone View for narrow observation scope (LUM-1280)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Standalone search overlay for ChatView. Creates its own observation scope
+/// so that reading `viewModel.messages` (needed for match filtering) only
+/// invalidates this view — not the parent ChatView outer body.
+struct ChatSearchOverlay: View {
+    var viewModel: ChatViewModel
+    @Binding var isSearchActive: Bool
+    @Binding var anchorMessageId: UUID?
+
+    @State private var searchText = ""
+    @State private var currentMatchIndex = 0
+
+    private var searchMatches: [UUID] {
+        guard isSearchActive, !searchText.isEmpty else { return [] }
+        let query = searchText.lowercased()
+        return viewModel.messages.filter { $0.text.lowercased().contains(query) }.map(\.id)
+    }
+
+    var body: some View {
+        Group {
+            if isSearchActive {
+                ChatSearchBar(
+                    searchText: $searchText,
+                    matchCount: searchMatches.count,
+                    currentMatchIndex: currentMatchIndex,
+                    onPrevious: { navigateMatch(delta: -1) },
+                    onNext: { navigateMatch(delta: 1) },
+                    onDismiss: { isSearchActive = false }
+                )
+                .padding(.trailing, VSpacing.xl)
+                .padding(.top, VSpacing.sm)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+                .layoutHangSignpost("chat.searchOverlay")
+            }
+        }
+        .onChange(of: searchText) {
+            currentMatchIndex = 0
+            scrollToCurrentMatch()
+        }
+        .onChange(of: searchMatches.count) {
+            let count = searchMatches.count
+            if currentMatchIndex >= count {
+                currentMatchIndex = max(count - 1, 0)
+            }
+        }
+        .onChange(of: isSearchActive) { _, active in
+            if !active {
+                searchText = ""
+                currentMatchIndex = 0
+            }
+        }
+    }
+
+    private func navigateMatch(delta: Int) {
+        let matches = searchMatches
+        guard !matches.isEmpty else { return }
+        currentMatchIndex = (currentMatchIndex + delta + matches.count) % matches.count
+        scrollToCurrentMatch()
+    }
+
+    private func scrollToCurrentMatch() {
+        let matches = searchMatches
+        guard !matches.isEmpty, currentMatchIndex < matches.count else { return }
+        anchorMessageId = matches[currentMatchIndex]
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -104,8 +104,6 @@ struct ChatView: View {
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
-    @State private var searchText = ""
-    @State private var currentMatchIndex = 0
     @State private var showSkeleton = false
     @State private var skeletonDebounceTask: Task<Void, Never>? = nil
     @State private var diskPressureDismissalRefreshToken = 0
@@ -117,13 +115,6 @@ struct ChatView: View {
 
     private var shouldShowSkeleton: Bool {
         viewModel.isPaginatedEmpty && !viewModel.isHistoryLoaded
-    }
-
-    /// Message IDs whose text contains the search query, ordered chronologically.
-    private var searchMatches: [UUID] {
-        guard isSearchActive, !searchText.isEmpty else { return [] }
-        let query = searchText.lowercased()
-        return viewModel.messages.filter { $0.text.lowercased().contains(query) }.map(\.id)
     }
 
     private var currentConversation: ConversationModel? {
@@ -185,32 +176,13 @@ struct ChatView: View {
             return .handled
         }
         .overlay(alignment: .topTrailing) {
-            if isSearchActive {
-                ChatSearchBar(
-                    searchText: $searchText,
-                    matchCount: searchMatches.count,
-                    currentMatchIndex: currentMatchIndex,
-                    onPrevious: { navigateMatch(delta: -1) },
-                    onNext: { navigateMatch(delta: 1) },
-                    onDismiss: { dismissSearch() }
-                )
-                .padding(.trailing, VSpacing.xl)
-                .padding(.top, VSpacing.sm)
-                .transition(.opacity.combined(with: .move(edge: .top)))
-                .layoutHangSignpost("chat.searchBar")
-            }
+            ChatSearchOverlay(
+                viewModel: viewModel,
+                isSearchActive: $isSearchActive,
+                anchorMessageId: $anchorMessageId
+            )
         }
         .animation(VAnimation.fast, value: isSearchActive)
-        .onChange(of: searchText) {
-            currentMatchIndex = 0
-            scrollToCurrentMatch()
-        }
-        .onChange(of: searchMatches.count) {
-            let count = searchMatches.count
-            if currentMatchIndex >= count {
-                currentMatchIndex = max(count - 1, 0)
-            }
-        }
         .onReceive(NotificationCenter.default.publisher(for: .activateChatSearch)) { notification in
             if let targetId = notification.object as? UUID, targetId != conversationId {
                 return
@@ -740,21 +712,6 @@ struct ChatView: View {
 
     private func dismissSearch() {
         isSearchActive = false
-        searchText = ""
-        currentMatchIndex = 0
-    }
-
-    private func navigateMatch(delta: Int) {
-        let matches = searchMatches
-        guard !matches.isEmpty else { return }
-        currentMatchIndex = (currentMatchIndex + delta + matches.count) % matches.count
-        scrollToCurrentMatch()
-    }
-
-    private func scrollToCurrentMatch() {
-        let matches = searchMatches
-        guard !matches.isEmpty, currentMatchIndex < matches.count else { return }
-        anchorMessageId = matches[currentMatchIndex]
     }
 }
 


### PR DESCRIPTION
Extracts search overlay (Cmd+F match logic) into a standalone `ChatSearchOverlay` View struct, creating its own observation scope so that reading `viewModel.messages` during search only invalidates the search view — not the outer `ChatView.body`. Fixes Sentry hang MACOS-QB (LUM-1280).

**Why needed:** When search was active, `.onChange(of: searchMatches.count)` in the outer `ChatView.body` evaluated `searchMatches` — a computed property that reads `viewModel.messages` and runs an O(n) `.lowercased().contains()` filter. This registered an observation dependency on the messages array in the outer scope. During streaming with active search: every token → messages mutation → outer body invalidation → O(n) string filter on all messages, synchronously on the main thread. Sentry captured this as a 2s+ hang.

**Benefits:** The outer `ChatView.body` no longer observes `viewModel.messages`. That dependency is now confined to `ChatSearchOverlay.body` (a standalone View struct with its own observation scope). During streaming with search active, only the lightweight search overlay re-evaluates — not the full outer body with its GeometryReader, ZStack, ~12 modifiers, and ObservationBoundaryView reconstruction.

**Safety:** The extraction is purely structural — identical behavior, same `ChatSearchBar` component, same match navigation logic, same scroll-to-match behavior. The standalone View struct pattern is already used in this file for the same purpose (`BtwOverlayView`). `ChatSearchOverlay` resets its internal `@State` (searchText, currentMatchIndex) via `.onChange(of: isSearchActive)` when the parent dismisses search, matching the previous `dismissSearch()` behavior exactly.

**References:**
- [WWDC23 — Discover Observation in SwiftUI](https://developer.apple.com/videos/play/wwdc2023/10149/) — standalone View structs create independent observation tracking scopes
- [WWDC23 — Demystify SwiftUI performance](https://developer.apple.com/videos/play/wwdc2023/10160/) — narrowing invalidation surfaces to avoid unnecessary body re-evaluations
- `clients/AGENTS.md` § "Scope observation narrowly" — documents that private `@ViewBuilder` functions do NOT create separate observation scopes; standalone `View` structs do

**Alternatives NOT taken:**
- *Wrap search overlay in `ObservationBoundaryView`* — Would isolate rendering reads inside the boundary, but `.onChange(of: searchMatches.count)` is a modifier on the parent view — it can't be placed inside the boundary closure. The `.onChange` is the primary observation leak site, so the boundary would not solve the problem.
- *Cache searchMatches as @State updated via .task(id:)* — Would require a stable trigger value that doesn't itself register an observation dependency. Using `messagesRevision` as the task ID would re-register the dependency in the outer scope (it changes on every token). Debounce-based alternatives add user-visible latency to search result updates without fully solving the scope issue.
- *Move `.onChange(of: searchMatches.count)` inside the conditional `if isSearchActive` branch* — Not architecturally possible: `.onChange` is a SwiftUI view modifier that must be applied to a view in the modifier chain, not placed inside a `@ViewBuilder` conditional branch.

**Root cause analysis:**

1. *How did the code get into this state?* — The Cmd+F search feature was added as inline computed properties (`searchMatches`) and modifiers (`.onChange(of: searchMatches.count)`) directly in `ChatView`'s outer body. At the time, `ChatView` used `ObservableObject` (whole-object publishing via `objectWillChange`), where observation granularity wasn't a concern — re-evaluation happened regardless of which property changed. After migration to `@Observable`, property-level tracking made this an observation over-dependency.

2. *What decisions led to it?* — The `searchMatches` computed property has a guard (`guard isSearchActive, !searchText.isEmpty else { return [] }`) that short-circuits without reading `viewModel.messages` when search is inactive. This masked the observation dependency during normal use — developers and review tooling couldn't tell that activating search would introduce a new high-frequency observation dependency into the outer body.

3. *Were there warning signs?* — Yes. The existing AGENTS.md guideline ("Scope observation narrowly… extract logical sections into standalone child View structs") already recommended this extraction. The search overlay is a self-contained "logical section" (own state, own interaction logic, conditionally visible). The warning sign was that it remained inline despite being a natural extraction candidate.

4. *What prevents recurrence?* — The existing `clients/AGENTS.md` guidelines already cover this pattern:
   - "Scope observation narrowly" recommends extracting logical sections into standalone View structs
   - "Cache derived booleans from high-frequency collections" calls out `.onChange(of:)` as a hidden observation registration site
   
   No additional AGENTS.md update needed. The issue was that these guidelines weren't applied when the search feature was originally added (pre-`@Observable` migration, so the risk wasn't obvious). The migration to `@Observable` surfaced latent observation coupling that didn't matter under `ObservableObject`.

5. *Systemic observation:* When migrating from `ObservableObject` to `@Observable`, audit all computed properties that conditionally read `@Observable` stored properties. A guard that short-circuits during normal operation masks observation dependencies that become active under specific user actions (search, filters, sort toggles). If the dependent property mutates at high frequency, the conditional code path creates a latent performance cliff.

---

- Requested by: @ashleeradka
- Session: https://app.devin.ai/sessions/c7ff076105f540abb4b1717864c12bcf
