### PR TITLE
perf(chat): use FixedWidthLayout for centeredChatColumn (LUM-1276)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -529,20 +529,16 @@ struct ChatView: View {
         )
     }
 
-    /// Centers chat chrome at the chat-column width without inducing a
-    /// SwiftUI alignment cascade.
+    /// Centers chat chrome at the chat-column width using `FixedWidthLayout`.
     ///
-    /// Uses `FixedWidthLayout` for the width constraint so `placeSubviews`
-    /// places the child via a `UnitPoint` anchor — never querying the
-    /// child subtree's `explicitAlignment` — instead of `_FrameLayout`,
-    /// which queries alignment guides on every descendant on every layout
-    /// pass. The inner `HStack { Spacer; content; Spacer }` reproduces the
-    /// horizontal `.center` positioning that `.frame(width:)` would have
-    /// applied to non-filling content; flexible content (anything with
-    /// `.frame(maxWidth: .infinity)` or an internal `Spacer`) collapses
-    /// the inner spacers to zero and occupies the full column width.
-    ///
-    /// Reference: [Layout.explicitAlignment](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu).
+    /// `FixedWidthLayout` returns `nil` from `explicitAlignment` and places its
+    /// child via a `UnitPoint` anchor rather than alignment guides, so it acts
+    /// as a barrier to parent-initiated alignment queries on the subtree. The
+    /// inner `HStack { Spacer; content; Spacer }` reproduces the horizontal
+    /// `.center` positioning that `.frame(width:)` applied to non-filling
+    /// content; flexible content (anything with `.frame(maxWidth: .infinity)`
+    /// or an internal `Spacer`) collapses the inner spacers to zero and
+    /// occupies the full column width.
     @ViewBuilder
     private func centeredChatColumn<Content: View>(
         width: CGFloat,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -529,8 +529,20 @@ struct ChatView: View {
         )
     }
 
-    /// Centers chat chrome to the same fixed transcript width using _FrameLayout
-    /// rather than nested max-width flex frames.
+    /// Centers chat chrome at the chat-column width without inducing a
+    /// SwiftUI alignment cascade.
+    ///
+    /// Uses `FixedWidthLayout` for the width constraint so `placeSubviews`
+    /// places the child via a `UnitPoint` anchor — never querying the
+    /// child subtree's `explicitAlignment` — instead of `_FrameLayout`,
+    /// which queries alignment guides on every descendant on every layout
+    /// pass. The inner `HStack { Spacer; content; Spacer }` reproduces the
+    /// horizontal `.center` positioning that `.frame(width:)` would have
+    /// applied to non-filling content; flexible content (anything with
+    /// `.frame(maxWidth: .infinity)` or an internal `Spacer`) collapses
+    /// the inner spacers to zero and occupies the full column width.
+    ///
+    /// Reference: [Layout.explicitAlignment](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu).
     @ViewBuilder
     private func centeredChatColumn<Content: View>(
         width: CGFloat,
@@ -538,8 +550,12 @@ struct ChatView: View {
     ) -> some View {
         HStack(spacing: 0) {
             Spacer(minLength: 0)
-            content()
-                .frame(width: width)
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                content()
+                Spacer(minLength: 0)
+            }
+            .fixedWidth(width)
             Spacer(minLength: 0)
         }
     }


### PR DESCRIPTION
## Prompt / plan

`centeredChatColumn` (used six times inside `ChatView.activeConversationContent` for chrome banners, the read-only sentinel, and the composer) wraps its content in `.frame(width: width)`. `clients/macos/AGENTS.md` § "No `_FlexFrameLayout` inside LazyVStack/LazyHStack/LazyVGrid cell hierarchy" already documents that `.frame(width:)` "queries child alignment via `commonPlacement → ViewDimensions[guide]`" during `placeSubviews` and is "not safe as a cascade barrier" when the subtree contains a `LazyVStack` or deep view hierarchy — recommending `.fixedWidth()` instead. The `MessageListView` work in [#29212](https://github.com/vellum-ai/vellum-assistant/pull/29212) and the `PinnedLatestTurnSection` change in [#29199](https://github.com/vellum-ai/vellum-assistant/pull/29199) applied that rule to the message-list ScrollView ancestor chain. This PR applies the same rule to the chat-chrome ancestor chain, which is the wrapper for `MessageListView` and the chrome banners. Tracking ticket: [LUM-1276](https://linear.app/vellum/issue/LUM-1276) ([Sentry MACOS-Q9](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-MACOS-Q9), 1 event on macOS 26 beta — `_FlexFrameLayout` ancestor chain reaching `CreditsExhaustedBanner`).

## Test plan

CI does not run an Xcode build for this repo, so Swift typechecking and visual verification need to happen locally in Xcode. `.fixedWidth(_:)` and `FixedWidthLayout` are already public in `clients/shared/DesignSystem/Modifiers/FixedWidthLayout.swift` and used elsewhere in `MessageListView.swift` and `MessageCellView`.

Visual checks to verify locally:

- All five chrome banners (`CreditsExhaustedBanner`, `DiskPressureBanner`, `MissingApiKeyBanner`, `CompactionCircuitOpenBanner`, `RecoveryModeBanner`) render at the same width and centering as before.
- `CompactionCircuitOpenBanner` (the only banner with natural-width content and no internal `Spacer`) stays horizontally centered inside the chat column.
- Composer column and the read-only sentinel are unchanged.

---

## What changed

```swift
// before
HStack(spacing: 0) {
    Spacer(minLength: 0)
    content().frame(width: width)
    Spacer(minLength: 0)
}

// after
HStack(spacing: 0) {
    Spacer(minLength: 0)
    HStack(spacing: 0) {
        Spacer(minLength: 0)
        content()
        Spacer(minLength: 0)
    }
    .fixedWidth(width)
    Spacer(minLength: 0)
}
```

The outer `HStack { Spacer; …; Spacer }` continues to center the column inside the available width. The inner `HStack { Spacer; content; Spacer }` reproduces the visual centering that `.frame(width:)`'s default `.center` alignment used to apply to non-filling content (for filling content, the inner spacers collapse to zero and have no layout effect).

## Why this change is needed

`FixedWidthLayout` is a [`Layout`-protocol](https://developer.apple.com/documentation/swiftui/layout) wrapper used elsewhere in the codebase (`MessageListView.swift:150`, `:183`, `:199`, and across `MessageCellView`). Compared to `.frame(width:)`:

- `sizeThatFits` returns the same width — identical visual sizing.
- `placeSubviews` calls [`place(at:bounds.origin, anchor: .topLeading, …)`](https://developer.apple.com/documentation/swiftui/layoutsubview/place(at:anchor:proposal:)) — `UnitPoint`-based placement that does not query alignment guides on the child subtree.
- Both [`explicitAlignment`](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu) overloads return `nil`, blocking parent-initiated alignment queries from propagating through the subtree.

This makes the helper a true cascade barrier for the chat-column subtree, which contains `MessageListView` (a `LazyVStack`-backed deep hierarchy) and chrome banners that themselves have nested layout.

## Why it's safe

`FixedWidthLayout` returns the same width as `.frame(width:)` from `sizeThatFits`, so column width is unchanged. The inner `HStack { Spacer; content; Spacer }` reproduces `.frame(width:)`'s default `.center` alignment for content that does not fill its proposal:

| Banner | Fills horizontally? | Behavior under `.fixedWidth` + inner Spacers |
|---|---|---|
| `CreditsExhaustedBanner` | Yes (`VStack.frame(maxWidth: .infinity, alignment: .leading)`) | Spacers collapse to 0; identical |
| `DiskPressureBanner` | Yes (interior `Spacer(minLength:)`) | Spacers collapse to 0; identical |
| `MissingApiKeyBanner` | Yes (`VButton.frame(maxWidth: .infinity)`) | Spacers collapse to 0; identical |
| `RecoveryModeBanner` | Yes (`.frame(maxWidth: .infinity, alignment: .leading)`) | Spacers collapse to 0; identical |
| `CompactionCircuitOpenBanner` | No (natural-width `HStack`) | Inner spacers split remainder, content is centered — matches previous `.frame(width:)` `.center` default |
| `ComposerSection` | Yes (`ComposerView.frame(maxWidth: .infinity)`) | Spacers collapse to 0; identical |
| Read-only sentinel | Yes (interior `Spacer(minLength: 0)` on both sides) | Spacers collapse to 0; identical |

Because `FixedWidthLayout` returns `nil` from both `explicitAlignment` overloads, the OUTER `HStack { Spacer; centeredColumn; Spacer }` (column-centering wrapper) continues to work — it computes its own positioning and never queries the inner subtree's alignment.

## Alternatives NOT taken

1. **Add `.frame(maxWidth: .infinity)` inside each banner.** Reintroduces `_FlexFrameLayout`, which is the explicit anti-pattern enforced by `clients/scripts/check-flexframe.sh` and `clients/macos/AGENTS.md`. Wrong direction.
2. **Drop the inner `HStack { Spacer; content; Spacer }` wrapper.** `CompactionCircuitOpenBanner`'s natural-width `HStack` would shift from center to leading inside the chat column — visible regression. The inner spacers add zero layout cost when content fills (Spacers collapse to 0), so the wrapper is strictly safer than not having it.
3. **Wrap each banner site individually instead of changing the helper.** Six near-identical call-site rewrites versus one helper change. The helper is the architectural source.
4. **Hoist the column-centering `HStack` into `FixedWidthLayout` directly (e.g. a new `CenteredFixedWidthLayout`).** Possible, but would add a new shared `Layout` type for one consumer. Defer until a second consumer needs it.

## Root cause analysis

1. **How did the code get into this state?** `centeredChatColumn` predates the design-system migration that introduced `FixedWidthLayout` and the cascade-barrier rule. When `.fixedWidth()` was applied to the inner ScrollView positions in `MessageListView` ([#29212](https://github.com/vellum-ai/vellum-assistant/pull/29212), `MessageListView.swift:150`, `:183`, `:199`), the chat-chrome wrapper that hosts those scroll surfaces was not on the radar.
2. **What mistakes or decisions led to it?** `.frame(width:)` looks like an unambiguous "constrain to a width" primitive; `_FrameLayout`'s placement-time alignment query is not surfaced in its public API. The cascade-vs-not distinction was learned incrementally as the chat surfaces hit production hangs, rather than being an upfront design choice. Once the rule was articulated, retroactive sweeps fixed the message-list and pinned-turn ancestor chains but not the chrome-banner wrapper.
3. **Were there warning signs we missed?** Yes — the prior cascade fixes ([#28870](https://github.com/vellum-ai/vellum-assistant/pull/28870), [#29199](https://github.com/vellum-ai/vellum-assistant/pull/29199), [#29212](https://github.com/vellum-ai/vellum-assistant/pull/29212)) all targeted the same family of width-constraint helpers. A grep for `.frame(width:` in `clients/macos/vellum-assistant/Features/Chat/` would have surfaced this helper at any of those points.
4. **What can we do to prevent this pattern from recurring?** The substantive rule already exists in `clients/macos/AGENTS.md` § "No `_FlexFrameLayout` …" (line 304–309), including the explicit warning that `.frame(width:)` is "not safe as a cascade barrier". The lint script `clients/scripts/check-flexframe.sh` mechanically enforces the `_FlexFrameLayout` half of the rule (`.frame(maxWidth:)`, `.frame(minHeight:)`, etc.) but does not flag `.frame(width:)` because the modifier is fine in most contexts and only problematic when used as a cascade barrier above a deep subtree. Extending the lint to flag `.frame(width:)` inside `clients/macos/vellum-assistant/Features/Chat/` (the directory where deep-hierarchy cascade barriers live) would close the gap; doing it more broadly would generate false positives.
5. **Should we add/remove/change a guideline to AGENTS.md?** No new rule needed — the existing rule at `clients/macos/AGENTS.md` line 304–309 already says exactly what this PR implements. The improvement is in tooling/manual-review reach, not docs. (If a follow-up PR extends `check-flexframe.sh` to flag `.frame(width:)` inside chat directories, that would be a concrete next step, but is intentionally out of scope here.)

Closes LUM-1276

Link to Devin session: https://app.devin.ai/sessions/9a108e31a87d4ebcb19aeefaff7f529a
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->