### PR TITLE
perf(chat): apply .fixedWidth() directly in centeredChatColumn (follow-up to #29231)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -399,10 +399,16 @@ struct ChatView: View {
 
             if let until = viewModel.compactionCircuitOpenUntil, until > Date() {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
-                    CompactionCircuitOpenBanner(
-                        openUntil: until,
-                        onExpired: { viewModel.compactionCircuitOpenUntil = nil }
-                    )
+                    // CompactionCircuitOpenBanner is natural-width; spacers center it
+                    // within the fixed column instead of leading-aligning it.
+                    HStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        CompactionCircuitOpenBanner(
+                            openUntil: until,
+                            onExpired: { viewModel.compactionCircuitOpenUntil = nil }
+                        )
+                        Spacer(minLength: 0)
+                    }
                 }
                 .padding(.bottom, -VSpacing.sm)
                 .animation(nil, value: queuedMessages.isEmpty)
@@ -529,16 +535,16 @@ struct ChatView: View {
         )
     }
 
-    /// Centers chat chrome at the chat-column width using `FixedWidthLayout`.
+    /// Centers a fixed-width column inside the available chat area.
     ///
-    /// `FixedWidthLayout` returns `nil` from `explicitAlignment` and places its
-    /// child via a `UnitPoint` anchor rather than alignment guides, so it acts
-    /// as a barrier to parent-initiated alignment queries on the subtree. The
-    /// inner `HStack { Spacer; content; Spacer }` reproduces the horizontal
-    /// `.center` positioning that `.frame(width:)` applied to non-filling
-    /// content; flexible content (anything with `.frame(maxWidth: .infinity)`
-    /// or an internal `Spacer`) collapses the inner spacers to zero and
-    /// occupies the full column width.
+    /// Sizes `content` with `FixedWidthLayout` so the column has a definite
+    /// width and `placeSubviews` does not query `explicitAlignment` on the
+    /// subtree. Flanking `Spacer`s split any remaining horizontal space to
+    /// keep the column horizontally centered on the page. The helper does
+    /// NOT center content within the column; callers that pass natural-width
+    /// content (no internal `Spacer`, no `.frame(maxWidth: .infinity)`) and
+    /// want it centered must wrap it themselves. See `MessageListView` for
+    /// the same pattern.
     @ViewBuilder
     private func centeredChatColumn<Content: View>(
         width: CGFloat,
@@ -546,12 +552,7 @@ struct ChatView: View {
     ) -> some View {
         HStack(spacing: 0) {
             Spacer(minLength: 0)
-            HStack(spacing: 0) {
-                Spacer(minLength: 0)
-                content()
-                Spacer(minLength: 0)
-            }
-            .fixedWidth(width)
+            content().fixedWidth(width)
             Spacer(minLength: 0)
         }
     }


### PR DESCRIPTION
## What

Drops the inner `HStack { Spacer; content; Spacer }` wrapper from `centeredChatColumn`, applying `.fixedWidth(width)` directly to `content()` — matching the established pattern in `MessageListView.swift:147-182`. Adds an explicit centering wrap at `CompactionCircuitOpenBanner`'s call site, the only natural-width caller.

## Why

Follow-up to #29231. The previous shape was:

```swift
HStack(spacing: 0) {
    Spacer(minLength: 0)
    HStack(spacing: 0) {                      // inner centering layer
        Spacer(minLength: 0)
        content()
        Spacer(minLength: 0)
    }
    .fixedWidth(width)
    Spacer(minLength: 0)
}
```

Inside the inner `.fixedWidth(width)` HStack, content with `.frame(maxWidth: .infinity)` or an internal `Spacer` is layout-flexible. `Spacer` is also flexible. SwiftUI's HStack distributes the proposed `width` among children sorted by flexibility; with two `Spacer(minLength: 0)` siblings sharing the proposal alongside flexible content, the result is order-dependent and not a documented invariant. The previous claim — "inner spacers collapse to zero and content fills the full column" — relies on undocumented HStack distribution behavior.

`MessageListView.swift:147-182` already solved the same problem differently: apply `.fixedWidth(W)` directly to the content (`scrollViewContent.fixedWidth(widths.chatColumnWidth)`), and rely on `FixedWidthLayout`'s contract — `sizeThatFits` returns exactly `W`, and `placeSubviews` proposes `(W, height)` to the single child. The child either fills `W` (flexible) or sits at top-leading (natural-width). No competition with sibling Spacers.

This PR adopts the MessageListView pattern in `centeredChatColumn`. Of the six callers, five are already horizontally flexible and fill the column on their own:

- `CreditsExhaustedBanner` — inner VStack `.frame(maxWidth: .infinity, alignment: .leading)` (`ChatErrorToastView.swift:223`)
- `DiskPressureBanner` — `Spacer(minLength: VSpacing.lg)` between content and buttons (`ChatErrorToastView.swift:263`)
- `MissingApiKeyBanner` — `VButton.frame(maxWidth: .infinity)` (`ChatErrorToastView.swift:405`)
- `RecoveryModeBanner` — inner VStack `.frame(maxWidth: .infinity, alignment: .leading)` (`RecoveryModeBanner.swift:55`)
- `ComposerSection` — `ComposerView.frame(maxWidth: .infinity)`
- Read-only sentinel — `HStack { Spacer; Icon; Text; Spacer }` (already self-centers)

`CompactionCircuitOpenBanner` is the lone natural-width caller — a tight pill with icon + text and no horizontal flex (`ChatErrorToastView.swift:339`). The previous `.frame(width:)` semantics centered it implicitly; under `FixedWidthLayout`'s `topLeading` placement it would render flush-left within the column. The fix wraps it explicitly at its call site so it stays centered — a more honest expression of the intent.

## Benefits

- **Removes a layout subtlety.** `MessageListView` and `centeredChatColumn` now use the same shape — `Spacer + content.fixedWidth(W) + Spacer` for page-level centering, with internal positioning handled at each call site as needed.
- **No reliance on Spacer-vs-flexible-content distribution.** `FixedWidthLayout` proposes exactly `width` to its single child; the result is determined by the child's own size policy.
- **Helper docstring matches behavior.** It centers the column on the page, not the content within the column.

## Safety

- Five flexible callers: behavior unchanged. Both old and new shapes propose `width` to content that fills horizontally.
- `CompactionCircuitOpenBanner`: now wrapped at call site with `HStack { Spacer; banner; Spacer }`. Banner is non-flexible, Spacers split surplus, banner stays centered. Visually identical to pre-#29231 behavior.
- No additional `_FrameLayout` or `_FlexFrameLayout` introduced.

## Alternatives considered

- **Make `FixedWidthLayout` accept a placement anchor parameter.** Adds API surface to a primitive that intentionally exposes only width. Doesn't help: natural-width content centered inside a wider region would still need spacers somewhere. Rejected.
- **Add `.frame(maxWidth: .infinity)` to `CompactionCircuitOpenBanner`'s outer HStack.** Creates `_FlexFrameLayout` — the exact anti-pattern this layout family is replacing per [`clients/macos/AGENTS.md`](https://github.com/vellum-ai/vellum-assistant/blob/main/clients/macos/AGENTS.md) lines 304-309. Rejected.
- **Push centering into `CompactionCircuitOpenBanner` itself.** Would change its visual from "tight pill at center" to "bar that spans the column with content leading-aligned." Different design intent. Rejected.

## References

- [`Layout.placeSubviews`](https://developer.apple.com/documentation/swiftui/layout/placesubviews(in:proposal:subviews:cache:)) — single-child placement contract.
- [`Layout.explicitAlignment`](https://developer.apple.com/documentation/swiftui/layout/explicitalignment(of:in:proposal:subviews:cache:)-8ofeu) — returning `nil` opts out of alignment-guide cascade.
- `clients/shared/DesignSystem/Modifiers/FixedWidthLayout.swift` — reference implementation.
- `clients/macos/vellum-assistant/Features/Chat/MessageListView.swift:147-182` — established pattern.

## Root cause analysis

1. **How did the code get into this state?** #29231 replaced `.frame(width:)` with `.fixedWidth(...)` inside `centeredChatColumn`, then added an inner `HStack { Spacer; content; Spacer }` to preserve the implicit `.center` alignment that `.frame(width:)` provided. The chosen shape works for fixed-size content but introduces an order-dependent behavior for flexible content.
2. **What mistakes or decisions led to it?** Treating `.frame(width:)`'s alignment-as-default as needing direct reproduction inside the helper, instead of pushing it to the one caller that actually needed it. The existing `MessageListView` pattern (direct `.fixedWidth()`) was visible but not followed.
3. **Were there warning signs we missed?** Yes — five of six callers were already self-filling, so the inner centering layer was load-bearing for exactly one banner. That asymmetry is a smell.
4. **What can we do to prevent this pattern from recurring?** Use `MessageListView`'s pattern as the canonical shape for chat-column wrappers. When introducing a Layout primitive, keep its contract narrow (one input, one output) and push positioning concerns to call sites.
5. **AGENTS.md update?** No new rule needed. `clients/macos/AGENTS.md` lines 304-309 already prescribe `.fixedWidth()` over `.frame(width:)`. The fix is to apply that rule consistently, not add more text.

## Prompt / plan

Follow-up to PR #29231 addressing review feedback flagging the inner-Spacer competition with flexible content.

## Test plan

- Visual diff of all six `centeredChatColumn` call sites (5 flexible banners + composer + sentinel + natural-width `CompactionCircuitOpenBanner`).
- Local Xcode build (no macOS CI runner).
- Monitor MACOS-Q9 / MACOS-H7 fingerprints post-v0.7.1+.

Link to Devin session: https://app.devin.ai/sessions/9a108e31a87d4ebcb19aeefaff7f529a
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->