### PR TITLE
Fix assistant switcher create hatch mode

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -904,9 +904,10 @@ extension AppDelegate {
         )
     }
 
-    /// Hatch a new managed assistant against the platform and persist it to
-    /// the lockfile. Only succeeds for newly created assistants (reused ones are rejected).
-    /// After persisting, immediately switches to the newly created assistant.
+    /// Hatch a new managed assistant against the platform in explicit create
+    /// mode and persist it to the lockfile. A 200 response is accepted here
+    /// because create mode uses it to dedupe an in-flight hatch.
+    /// After persisting, immediately switches to the assistant.
     /// The organization id is read from UserDefaults — matching the path the
     /// onboarding flow and TeleportSection use. There is no centralized constant
     /// for this key yet; see TeleportSection for the other call site that reads it directly.
@@ -920,8 +921,17 @@ extension AppDelegate {
             name: name,
             mode: .create
         )
-        guard case .createdNew(let platformAssistant) = result else {
-            throw AssistantSwitcherError.assistantAlreadyExists
+        let platformAssistant: PlatformAssistant
+        let shouldBackfillName: Bool
+        switch result {
+        case .createdNew(let assistant):
+            platformAssistant = assistant
+            shouldBackfillName = true
+        case .reusedExisting(let assistant):
+            // In create mode, 200 means the platform deduped an in-flight
+            // hatch. Treat it as success and switch to that assistant.
+            platformAssistant = assistant
+            shouldBackfillName = false
         }
 
         let success = LockfileAssistant.ensureManagedEntry(
@@ -933,15 +943,20 @@ extension AppDelegate {
             throw AssistantSwitcherError.lockfilePersistenceFailed
         }
 
-        Task {
-            try? await AuthService.shared.updateAssistant(
-                id: platformAssistant.id,
-                organizationId: organizationId,
-                name: name
-            )
+        if shouldBackfillName {
+            Task {
+                try? await AuthService.shared.updateAssistant(
+                    id: platformAssistant.id,
+                    organizationId: organizationId,
+                    name: name
+                )
+            }
         }
 
-        IdentityInfo.seedCache(name: name, forAssistantId: platformAssistant.id)
+        IdentityInfo.seedCache(
+            name: platformAssistant.name ?? name,
+            forAssistantId: platformAssistant.id
+        )
 
         let target = LockfileAssistant(
             assistantId: platformAssistant.id,
@@ -1116,7 +1131,6 @@ enum AssistantSwitcherError: LocalizedError {
     case lockfilePersistenceFailed
     case retireNonActiveNotSupported
     case assistantNotFound(String)
-    case assistantAlreadyExists
 
     var errorDescription: String? {
         switch self {
@@ -1128,8 +1142,6 @@ enum AssistantSwitcherError: LocalizedError {
             return "Retiring a non-active assistant from the switcher isn't supported yet. Switch to the assistant first, then retire it."
         case .assistantNotFound(let id):
             return "Could not find assistant \(id) in the lockfile."
-        case .assistantAlreadyExists:
-            return "An assistant with this name already exists. Use the existing assistant or choose a different name."
         }
     }
 }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -168,7 +168,11 @@ public struct HatchAssistantRequest: Codable, Sendable {
     }
 }
 
-/// Query mode for the platform hatch endpoint.
+/// Hatch endpoint mode.
+///
+/// `ensure` preserves the legacy idempotent flow, returning an existing
+/// assistant when possible. `create` asks the platform to create an additional
+/// assistant when multi-assistant hatching is enabled.
 public enum HatchAssistantMode: String, Codable, Sendable {
     case ensure
     case create
@@ -181,7 +185,11 @@ public enum PlatformAssistantResult: Sendable {
     case accessDenied
 }
 
-/// Result type for the idempotent hatch endpoint (200 = existing, 201 = created).
+/// Result type for the hatch endpoint.
+///
+/// The platform returns 200 when reusing an existing assistant (legacy
+/// `ensure` mode) or deduping an in-flight create, and 201 for a newly
+/// created assistant.
 public enum HatchAssistantResult: Sendable {
     case reusedExisting(PlatformAssistant)
     case createdNew(PlatformAssistant)

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -342,8 +342,11 @@ public final class AuthService {
         return try response.decode(PaginatedPlatformAssistantsResponse.self).results
     }
 
-    /// Create or retrieve a managed assistant via the idempotent hatch endpoint.
-    /// Returns `.reusedExisting` on 200 (assistant already exists) or `.createdNew` on 201.
+    /// Create or retrieve a managed assistant via the hatch endpoint.
+    ///
+    /// Use `.ensure` for first-run/bootstrap flows that should reuse an
+    /// existing assistant. Use `.create` for explicit multi-assistant creation.
+    /// Returns `.reusedExisting` on 200 or `.createdNew` on 201.
     public func hatchAssistant(
         organizationId: String,
         name: String? = nil,

--- a/clients/shared/Tests/AuthServiceHatchModeTests.swift
+++ b/clients/shared/Tests/AuthServiceHatchModeTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+private final class HatchModeURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class AuthServiceHatchModeTests: XCTestCase {
+    private var previousToken: String?
+
+    override func setUp() {
+        super.setUp()
+        HatchModeURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(HatchModeURLProtocol.self)
+        previousToken = SessionTokenManager.getToken()
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(HatchModeURLProtocol.self)
+        HatchModeURLProtocol.requestHandler = nil
+        if let previousToken {
+            SessionTokenManager.setToken(previousToken)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+        super.tearDown()
+    }
+
+    func testCreateModeAppendsModeCreateQuery() async throws {
+        var sawRequest = false
+        HatchModeURLProtocol.requestHandler = { request in
+            sawRequest = true
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/v1/assistants/hatch")
+            XCTAssertEqual(queryValue("mode", in: request), "create")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Vellum-Organization-Id"), "org-123")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-Token"), "test-session-token")
+            return makeResponse(
+                for: request,
+                statusCode: 201,
+                body: """
+                {
+                  "id": "asst-created",
+                  "name": "Example Assistant",
+                  "created_at": "2026-05-01T12:00:00Z",
+                  "status": "initializing"
+                }
+                """
+            )
+        }
+
+        let result = try await AuthService.shared.hatchAssistant(
+            organizationId: "org-123",
+            name: "Example Assistant",
+            mode: .create
+        )
+
+        guard case .createdNew(let assistant) = result else {
+            XCTFail("Expected createdNew, got \(result)")
+            return
+        }
+        XCTAssertTrue(sawRequest)
+        XCTAssertEqual(assistant.id, "asst-created")
+    }
+
+    func testDefaultHatchModeOmitsModeQueryAndReusesExistingAssistant() async throws {
+        var sawRequest = false
+        HatchModeURLProtocol.requestHandler = { request in
+            sawRequest = true
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/v1/assistants/hatch")
+            XCTAssertNil(request.url?.query)
+            return makeResponse(
+                for: request,
+                statusCode: 200,
+                body: """
+                {
+                  "id": "asst-existing",
+                  "name": "Existing Assistant",
+                  "created_at": "2026-05-01T12:00:00Z",
+                  "status": "active"
+                }
+                """
+            )
+        }
+
+        let result = try await AuthService.shared.hatchAssistant(organizationId: "org-123")
+
+        guard case .reusedExisting(let assistant) = result else {
+            XCTFail("Expected reusedExisting, got \(result)")
+            return
+        }
+        XCTAssertTrue(sawRequest)
+        XCTAssertEqual(assistant.id, "asst-existing")
+    }
+}
+
+private func queryValue(_ name: String, in request: URLRequest) -> String? {
+    guard let url = request.url,
+          let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        return nil
+    }
+    return components.queryItems?.first { $0.name == name }?.value
+}
+
+private func makeResponse(
+    for request: URLRequest,
+    statusCode: Int,
+    body: String
+) -> (HTTPURLResponse, Data) {
+    let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: statusCode,
+        httpVersion: nil,
+        headerFields: ["Content-Type": "application/json"]
+    )!
+    return (response, Data(body.utf8))
+}


### PR DESCRIPTION
## Summary
- add explicit hatch modes to the shared `AuthService`
- have the macOS assistant switcher call hatch with `mode=create`
- treat create-mode `200` responses as in-flight hatch dedupe success instead of a duplicate-name failure
- add URLProtocol tests for create/default hatch-mode request URLs

## Root Cause
The switcher was using the default hatch endpoint mode. The platform default is the legacy idempotent `ensure` flow, where a successful `200` response maps to `reusedExisting`. The client then surfaced that successful response as "assistant already exists" even though the request itself completed.

## Follow-up
This PR only addresses the duplicate-name alert caused by using the wrong hatch mode. The separate post-create switch/refresh issue is intentionally left for PR 2.

## Validation
- `swift test --package-path clients --filter AuthServiceHatchModeTests`
- pre-push Swift client build
- pre-push design token guard