### PR TITLE
Fix post-hatch assistant switching

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -6,6 +6,18 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppDelegate+AuthLifecycle")
 
+enum ManagedSwitchAuthenticationGate {
+    static func shouldPromptForLogin(
+        assistant: LockfileAssistant,
+        isAuthenticated: Bool,
+        managedAuthenticationAlreadyVerified: Bool
+    ) -> Bool {
+        assistant.isManaged
+            && !isAuthenticated
+            && !managedAuthenticationAlreadyVerified
+    }
+}
+
 // MARK: - Auth lifecycle: login, logout, restart, retire, switch assistant
 
 extension AppDelegate {
@@ -632,9 +644,16 @@ extension AppDelegate {
     ///    the organization ID (cleared in step 3) before connecting
     /// 5. Reconfigure transport and reconnect
     /// 6. Resume credential bootstrap
-    func performSwitchAssistant(to assistant: LockfileAssistant) {
+    func performSwitchAssistant(
+        to assistant: LockfileAssistant,
+        managedAuthenticationAlreadyVerified: Bool = false
+    ) {
         // If switching to a managed assistant while logged out, prompt login first.
-        if assistant.isManaged && !authManager.isAuthenticated {
+        if ManagedSwitchAuthenticationGate.shouldPromptForLogin(
+            assistant: assistant,
+            isAuthenticated: authManager.isAuthenticated,
+            managedAuthenticationAlreadyVerified: managedAuthenticationAlreadyVerified
+        ) {
             // Persist the target so we can switch after login completes.
             UserDefaults.standard.set(assistant.assistantId, forKey: "pendingManagedSwitchAssistantId")
             showAuthWindow()

--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -958,21 +958,13 @@ extension AppDelegate {
             forAssistantId: platformAssistant.id
         )
 
-        let target = LockfileAssistant(
-            assistantId: platformAssistant.id,
-            runtimeUrl: VellumEnvironment.resolvedPlatformURL,
-            bearerToken: nil,
-            cloud: "vellum",
-            project: nil,
-            region: nil,
-            zone: nil,
-            instanceId: nil,
-            hatchedAt: platformAssistant.created_at ?? Date().iso8601String,
-            baseDataDir: nil,
-            gatewayPort: nil,
-            instanceDir: nil
+        guard let target = LockfileAssistant.loadByName(platformAssistant.id) else {
+            throw AssistantSwitcherError.lockfilePersistenceFailed
+        }
+        performSwitchAssistant(
+            to: target,
+            managedAuthenticationAlreadyVerified: true
         )
-        performSwitchAssistant(to: target)
     }
 
     /// Retire an assistant requested from the switcher. Today the switcher

--- a/clients/macos/vellum-assistantTests/AssistantSwitcherViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantSwitcherViewModelTests.swift
@@ -30,8 +30,14 @@ final class AssistantSwitcherViewModelTests: XCTestCase {
         // properties, which are covered by LockfileAssistantManagedTests —
         // here we exercise the filter predicate on a mocked loader so the
         // test stays pure.
-        let managedCurrent = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
-        let managedOther = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+        let managedCurrent = makeAssistant(
+            id: "managed-a",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
+        let managedOther = makeAssistant(
+            id: "managed-b",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
         let unmanaged = makeAssistant(id: "local-a", runtimeUrl: "", isLocal: true)
 
         let spy = SwitcherSpy()
@@ -50,8 +56,14 @@ final class AssistantSwitcherViewModelTests: XCTestCase {
     // MARK: - Select
 
     func testSelectInvokesSwitchHandlerWithCorrectId() async throws {
-        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
-        let managedB = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+        let managedA = makeAssistant(
+            id: "managed-a",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
+        let managedB = makeAssistant(
+            id: "managed-b",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
 
         let spy = SwitcherSpy()
         var activeId = "managed-a"
@@ -75,7 +87,10 @@ final class AssistantSwitcherViewModelTests: XCTestCase {
     }
 
     func testSelectIsNoOpWhenAlreadyActive() async throws {
-        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
+        let managedA = makeAssistant(
+            id: "managed-a",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
         let spy = SwitcherSpy()
         let vm = AssistantSwitcherViewModel(
             switchHandler: spy.switchHandler,
@@ -94,8 +109,14 @@ final class AssistantSwitcherViewModelTests: XCTestCase {
     // MARK: - Active change notification
 
     func testActiveAssistantDidChangeTriggersRefresh() {
-        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
-        let managedB = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+        let managedA = makeAssistant(
+            id: "managed-a",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
+        let managedB = makeAssistant(
+            id: "managed-b",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
 
         let spy = SwitcherSpy()
         var activeId: String? = "managed-a"
@@ -128,8 +149,14 @@ final class AssistantSwitcherViewModelTests: XCTestCase {
     // MARK: - Retire
 
     func testRetireRemovesAssistantFromListAfterHandlerCompletes() async throws {
-        let managedA = makeAssistant(id: "managed-a", runtimeUrl: "https://platform.example.com")
-        let managedB = makeAssistant(id: "managed-b", runtimeUrl: "https://platform.example.com")
+        let managedA = makeAssistant(
+            id: "managed-a",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
+        let managedB = makeAssistant(
+            id: "managed-b",
+            runtimeUrl: VellumEnvironment.resolvedPlatformURL
+        )
 
         var current: [LockfileAssistant] = [managedA, managedB]
         let spy = SwitcherSpy()
@@ -188,9 +215,13 @@ final class AssistantSwitcherViewModelTests: XCTestCase {
             let json: [String: Any] = [
                 "activeAssistant": id,
                 "assistants": [
-                    id: [
-                        "createdAt": "2024-01-01T00:00:00Z",
-                        "instanceDir": dir,
+                    [
+                        "assistantId": id,
+                        "cloud": "local",
+                        "hatchedAt": "2024-01-01T00:00:00Z",
+                        "resources": [
+                            "instanceDir": dir,
+                        ],
                     ]
                 ]
             ]

--- a/clients/macos/vellum-assistantTests/ManagedSwitchAuthenticationGateTests.swift
+++ b/clients/macos/vellum-assistantTests/ManagedSwitchAuthenticationGateTests.swift
@@ -1,0 +1,62 @@
+import VellumAssistantShared
+import XCTest
+@testable import VellumAssistantLib
+
+final class ManagedSwitchAuthenticationGateTests: XCTestCase {
+    func testManagedUnauthenticatedSwitchPromptsForLogin() {
+        XCTAssertTrue(
+            ManagedSwitchAuthenticationGate.shouldPromptForLogin(
+                assistant: makeAssistant(id: "managed-a", cloud: "vellum"),
+                isAuthenticated: false,
+                managedAuthenticationAlreadyVerified: false
+            )
+        )
+    }
+
+    func testPostHatchManagedSwitchDoesNotPromptWhenAuthenticationWasVerified() {
+        XCTAssertFalse(
+            ManagedSwitchAuthenticationGate.shouldPromptForLogin(
+                assistant: makeAssistant(id: "managed-a", cloud: "vellum"),
+                isAuthenticated: false,
+                managedAuthenticationAlreadyVerified: true
+            )
+        )
+    }
+
+    func testAuthenticatedManagedSwitchDoesNotPrompt() {
+        XCTAssertFalse(
+            ManagedSwitchAuthenticationGate.shouldPromptForLogin(
+                assistant: makeAssistant(id: "managed-a", cloud: "vellum"),
+                isAuthenticated: true,
+                managedAuthenticationAlreadyVerified: false
+            )
+        )
+    }
+
+    func testLocalSwitchDoesNotPrompt() {
+        XCTAssertFalse(
+            ManagedSwitchAuthenticationGate.shouldPromptForLogin(
+                assistant: makeAssistant(id: "local-a", cloud: "local"),
+                isAuthenticated: false,
+                managedAuthenticationAlreadyVerified: false
+            )
+        )
+    }
+
+    private func makeAssistant(id: String, cloud: String) -> LockfileAssistant {
+        LockfileAssistant(
+            assistantId: id,
+            runtimeUrl: cloud == "vellum" ? VellumEnvironment.resolvedPlatformURL : nil,
+            bearerToken: nil,
+            cloud: cloud,
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: "2026-05-01T12:00:00Z",
+            baseDataDir: nil,
+            gatewayPort: nil,
+            instanceDir: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- allow the post-hatch switch path to bypass the stale `AuthManager.isAuthenticated` UI gate, because hatch already proved the platform session token works
- switch newly hatched assistants using the persisted lockfile entry instead of a hand-built temporary value
- add focused coverage for the managed switch auth gate
- update assistant switcher view-model fixtures to use the current lockfile shape and current platform runtime URL

## Root Cause
After `New Assistant...` successfully hatched and persisted a managed assistant, it called the normal `performSwitchAssistant(to:)` path. That path prompts for login whenever `authManager.isAuthenticated` is false. If the auth manager state is stale even though the session token is valid, the post-hatch switch stops there: the new assistant is in the lockfile and can show in the switcher, but the app remains on the previous assistant.

The create path now passes an explicit `managedAuthenticationAlreadyVerified` flag because the hatch request just succeeded against the platform.

## Validation
- `swift test --package-path clients --filter ManagedSwitchAuthenticationGateTests`
- `swift test --package-path clients --filter AssistantSwitcherViewModelTests`
- pre-push Swift client build
- pre-push iOS simulator build
- pre-push design token guard