### PR TITLE
Remove unused assistantId binding in TerminalAPIClient

### DIFF
--- a/clients/macos/vellum-assistant/Features/Terminal/TerminalAPIClient.swift
+++ b/clients/macos/vellum-assistant/Features/Terminal/TerminalAPIClient.swift
@@ -88,7 +88,6 @@ final class TerminalAPIClient {
     ) -> (stream: AsyncThrowingStream<TerminalOutputEvent, Error>, cancel: () -> Void) {
         let task = UncheckedSendableBox<Task<Void, Never>?>(nil)
 
-        let assistantId = self.assistantId
         let stream = AsyncThrowingStream<TerminalOutputEvent, Error> { continuation in
             let sseTask = Task { @MainActor in
                 do {


### PR DESCRIPTION
## Summary
- Drop the `let assistantId = self.assistantId` capture in `subscribeEvents` — it was never referenced inside the SSE task, producing a build warning.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Terminal/TerminalAPIClient.swift:91:13: warning: initialization of immutable value 'assistantId' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
 89 |         let task = UncheckedSendableBox<Task<Void, Never>?>(nil)
 90 |
 91 |         let assistantId = self.assistantId
    |             `- warning: initialization of immutable value 'assistantId' was never used; consider replacing with assignment to '_' or removing it [#no-usage]
 92 |         let stream = AsyncThrowingStream<TerminalOutputEvent, Error> { continuation in
 93 |             let sseTask = Task { @MainActor in
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->