### PR TITLE
mem(v2): retrieval polish and stale-page telemetry

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -16,6 +16,7 @@ describe("MemoryV2ConfigSchema", () => {
       k: 0.5,
       hops: 2,
       top_k: 20,
+      ann_candidate_limit: null,
       top_k_skills: 5,
       epsilon: 0.01,
       dense_weight: 0.7,

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -87,6 +87,15 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Number of top-activation concept pages considered for injection per turn",
       ),
+    ann_candidate_limit: z
+      .number({ error: "memory.v2.ann_candidate_limit must be a number" })
+      .int("memory.v2.ann_candidate_limit must be an integer")
+      .positive("memory.v2.ann_candidate_limit must be a positive integer")
+      .nullable()
+      .default(null)
+      .describe(
+        "Per-channel cap on the unrestricted ANN candidate query (dense and sparse each return up to this many hits before they are unioned and fed into the activation pipeline). `null` = unlimited (every page in the v2 collection is eligible). Increase or null this out to surface more candidates at the cost of higher per-turn embedding/scoring work.",
+      ),
     top_k_skills: z
       .number({ error: "memory.v2.top_k_skills must be a number" })
       .int()

--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -62,11 +62,12 @@ export function isMemoryV2ReadActive(config: AssistantConfig): boolean {
 const log = getLogger("context-search-memory-v2-source");
 
 /**
- * Top-K size for the un-restricted ANN candidate query against the v2
- * concept-page collection. Larger than the per-call recall limit so spreading
- * has neighbors to pull in.
+ * Sentinel passed to Qdrant when `config.memory.v2.ann_candidate_limit` is
+ * `null` (unlimited). Qdrant's query API requires an explicit numeric
+ * `limit`, so unlimited is represented as a number large enough that any
+ * realistic concept-page collection is returned in full.
  */
-const MEMORY_V2_ANN_CANDIDATE_LIMIT = 50;
+const UNLIMITED_ANN_CANDIDATE_LIMIT = Number.MAX_SAFE_INTEGER;
 
 /** Cap individual concept-page files we are willing to read for lexical scan. */
 const MEMORY_V2_LEXICAL_MAX_FILE_SIZE_BYTES = 256 * 1024;
@@ -181,10 +182,13 @@ async function activationEvidence(
   if (!denseVector || denseVector.length === 0) return [];
   const sparseVector = generateSparseEmbedding(trimmedQuery);
 
+  const annLimit =
+    context.config.memory.v2.ann_candidate_limit ??
+    UNLIMITED_ANN_CANDIDATE_LIMIT;
   const hits = await hybridQueryConceptPages(
     denseVector,
     sparseVector,
-    MEMORY_V2_ANN_CANDIDATE_LIMIT,
+    annLimit,
   );
   if (hits.length === 0) return [];
 

--- a/assistant/src/memory/memory-v2-activation-log-store.ts
+++ b/assistant/src/memory/memory-v2-activation-log-store.ts
@@ -14,7 +14,7 @@ export interface MemoryV2ConceptRowRecord {
   simNow: number;
   spreadContribution: number;
   source: "prior_state" | "ann_top50" | "both";
-  status: "in_context" | "injected" | "not_injected";
+  status: "in_context" | "injected" | "not_injected" | "page_missing";
 }
 
 export interface MemoryV2SkillRowRecord {

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -193,6 +193,7 @@ function makeConfig(
     epsilon: number;
     dense_weight: number;
     sparse_weight: number;
+    ann_candidate_limit: number | null;
   }> = {},
 ): AssistantConfig {
   return {
@@ -205,6 +206,7 @@ function makeConfig(
         epsilon: 0.01,
         dense_weight: 1.0,
         sparse_weight: 0.0,
+        ann_candidate_limit: null,
         ...overrides,
       },
     },
@@ -342,7 +344,9 @@ describe("selectCandidates", () => {
     expect(out.fromAnn).toEqual(new Set(["alice-vscode", "delta-recipe"]));
   });
 
-  test("ANN top-K limit equals 50 and runs without slug restriction", async () => {
+  test("ANN candidate query honors `config.memory.v2.ann_candidate_limit` and runs without slug restriction", async () => {
+    // Default `ann_candidate_limit: null` → unlimited, so a sentinel large
+    // enough to return every page is passed to Qdrant.
     stageHybridResponse([{ slug: "alpha", denseScore: 0.5, sparseScore: 1 }]);
     await selectCandidates({
       priorState: null,
@@ -351,10 +355,25 @@ describe("selectCandidates", () => {
       nowText: "",
       config: makeConfig(),
     });
-    // Both channels (dense + sparse) ran with limit=50 and no filter.
     expect(state.queryCalls).toHaveLength(2);
     for (const call of state.queryCalls) {
-      expect(call.limit).toBe(50);
+      expect(call.limit).toBe(Number.MAX_SAFE_INTEGER);
+      expect(call.filter).toBeUndefined();
+    }
+
+    // Explicit override flows through both channels verbatim.
+    state.queryCalls.length = 0;
+    stageHybridResponse([{ slug: "beta", denseScore: 0.5, sparseScore: 1 }]);
+    await selectCandidates({
+      priorState: null,
+      userText: "hello",
+      assistantText: "",
+      nowText: "",
+      config: makeConfig({ ann_candidate_limit: 25 }),
+    });
+    expect(state.queryCalls).toHaveLength(2);
+    for (const call of state.queryCalls) {
+      expect(call.limit).toBe(25);
       expect(call.filter).toBeUndefined();
     }
   });
@@ -682,15 +701,59 @@ describe("spreadActivation", () => {
     expect(out.final.get("bob")).toBeCloseTo(0.9, 6);
   });
 
-  test("missing predecessor activation contributes 0 to the numerator", () => {
-    // Edge alice→bob: bob has predecessor alice. alice is not in
-    // `ownActivation`, so it contributes 0 to the numerator while the
-    // denominator still counts the structural predecessor.
+  test("predecessors not in the candidate set are dropped from both numerator and denominator", () => {
+    // Edge alice→bob: bob has structural predecessor alice, but alice is not
+    // in `ownActivation`. With the new formula she contributes nothing —
+    // hop1 has no active predecessors so the whole hop drops out of both
+    // sides of the ratio. Bob therefore stays at his own activation.
     const edges = buildEdgeIndex([["alice", "bob"]]);
     const own = new Map([["bob", 0.6]]);
     const out = spreadActivation(own, edges, 0.5, 2);
-    // numerator = 0.6 + 0.5*0 = 0.6. denominator = 1 + 0.5*1 = 1.5.
-    expect(out.final.get("bob")).toBeCloseTo(0.4, 6);
+    expect(out.final.get("bob")).toBeCloseTo(0.6, 6);
+  });
+
+  test("L_2 norm over multiple active predecessors rewards strong outliers more than avg would", () => {
+    // bob has 4 predecessors in the candidate set: one strong, three weak.
+    // L_2 = √((0.8² + 0.1² + 0.1² + 0.1²) / 4) = √(0.1675) ≈ 0.40927
+    // Plain avg of the same set = 0.275, so L_2 lifts bob more than avg
+    // would — the design goal of preferring quality over quantity.
+    const edges = buildEdgeIndex([
+      ["a1", "bob"],
+      ["a2", "bob"],
+      ["a3", "bob"],
+      ["a4", "bob"],
+    ]);
+    const own = new Map([
+      ["a1", 0.8],
+      ["a2", 0.1],
+      ["a3", 0.1],
+      ["a4", 0.1],
+      ["bob", 0.0],
+    ]);
+    const out = spreadActivation(own, edges, 0.5, 2);
+    const rms = Math.sqrt((0.8 * 0.8 + 3 * 0.1 * 0.1) / 4);
+    // numerator   = 0 + 0.5 · rms
+    // denominator = 1 + 0.5
+    expect(out.final.get("bob")).toBeCloseTo((0.5 * rms) / 1.5, 6);
+  });
+
+  test("high-in-degree hub with mostly-inactive predecessors stays near A_o", () => {
+    // 100 structural predecessors point at hub; only one (`pred0`) is in
+    // the candidate set. The old formula would crush hub by the structural
+    // count (denominator ≈ 51); the new formula folds the empty bulk out
+    // and the L_2 averages over the single active predecessor only.
+    const rawEdges: Array<[string, string]> = [];
+    for (let i = 0; i < 100; i++) rawEdges.push([`pred${i}`, "hub"]);
+    const edges = buildEdgeIndex(rawEdges);
+    const own = new Map([
+      ["hub", 0.6],
+      ["pred0", 0.5],
+    ]);
+    const out = spreadActivation(own, edges, 0.5, 2);
+    // hop1 active = {pred0}, L_2([0.5]) = 0.5.
+    //   numerator   = 0.6 + 0.5 · 0.5 = 0.85
+    //   denominator = 1 + 0.5         = 1.5
+    expect(out.final.get("hub")).toBeCloseTo(0.85 / 1.5, 6);
   });
 
   test("empty own-activation map returns empty result", () => {

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -331,6 +331,13 @@ function stageTurn(
   hits: Array<{ slug: string; denseScore?: number; sparseScore?: number }>,
   channels = 4,
 ): void {
+  // Clear any leftovers from a prior turn before staging this one so unused
+  // staged responses can't bleed into the next injection. The activation
+  // pipeline now skips the embedding round-trip for empty texts (turn 1's
+  // assistantMessage), so consumed-channel counts vary per turn — staging
+  // exclusively is the only way multi-turn tests stay aligned.
+  state.queryResponses.dense.length = 0;
+  state.queryResponses.sparse.length = 0;
   for (let i = 0; i < channels; i++) {
     state.queryResponses.dense.push({
       points: hits
@@ -652,6 +659,17 @@ describe("injectMemoryV2Block", () => {
     expect(persisted!.everInjected).toEqual([
       { slug: "phantom-slug", turn: 1 },
     ]);
+
+    // Activation log marks the slug `page_missing` (not `injected`) so a
+    // stale Qdrant / edge-index entry pointing at a vanished page is
+    // visible in telemetry instead of masquerading as a successful inject.
+    expect(telemetryState.recordCalls.length).toBe(1);
+    const row = telemetryState.recordCalls[0] as {
+      concepts: Array<{ slug: string; status: string }>;
+    };
+    const phantom = row.concepts.find((c) => c.slug === "phantom-slug");
+    expect(phantom).toBeDefined();
+    expect(phantom!.status).toBe("page_missing");
   });
 
   // ---------------------------------------------------------------------------

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -247,6 +247,24 @@ describe("simBatch", () => {
     expect(state.queryCalls).toHaveLength(0);
   });
 
+  test("empty text returns empty map without touching backends", async () => {
+    // Turn 1 has no prior assistant message, so `computeOwnActivation` calls
+    // `simBatch("", slugs, config)`. Gemini rejects empty content with HTTP
+    // 400 — short-circuit here so the activation pipeline doesn't crash.
+    const config = configWithWeights(0.7, 0.3);
+
+    for (const text of ["", "   ", "\n\n"]) {
+      state.embedCalls.length = 0;
+      state.sparseCalls.length = 0;
+      state.queryCalls.length = 0;
+      const out = await simBatch(text, ["alice-vscode"], config);
+      expect(out.size).toBe(0);
+      expect(state.embedCalls).toHaveLength(0);
+      expect(state.sparseCalls).toHaveLength(0);
+      expect(state.queryCalls).toHaveLength(0);
+    }
+  });
+
   test("identical text yields ~1.0 when both channels max out", async () => {
     const config = configWithWeights(0.7, 0.3);
     stageHybridResponse([
@@ -423,6 +441,21 @@ describe("simSkillBatch", () => {
     expect(state.embedCalls).toHaveLength(0);
     expect(state.sparseCalls).toHaveLength(0);
     expect(state.queryCalls).toHaveLength(0);
+  });
+
+  test("empty text returns empty map without touching backends", async () => {
+    const config = configWithWeights(0.7, 0.3);
+
+    for (const text of ["", "   ", "\n\n"]) {
+      state.embedCalls.length = 0;
+      state.sparseCalls.length = 0;
+      state.queryCalls.length = 0;
+      const out = await simSkillBatch(text, ["example-skill-a"], config);
+      expect(out.size).toBe(0);
+      expect(state.embedCalls).toHaveLength(0);
+      expect(state.sparseCalls).toHaveLength(0);
+      expect(state.queryCalls).toHaveLength(0);
+    }
   });
 
   test("queries the dedicated skills collection and forwards an id-IN filter", async () => {

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -44,12 +44,12 @@ import { hybridQuerySkills } from "./skill-qdrant.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
 /**
- * Top-K size for the un-restricted ANN candidate query against the v2
- * concept-page collection. The design doc fixes this at 50 — small enough to
- * keep the per-turn round-trip cheap, large enough to surface relevant pages
- * outside the prior active set.
+ * Sentinel passed to Qdrant when `config.memory.v2.ann_candidate_limit` is
+ * `null` (unlimited). Qdrant's query API requires an explicit numeric
+ * `limit`, so unlimited is represented as a number large enough that any
+ * realistic concept-page collection is returned in full.
  */
-const ANN_CANDIDATE_LIMIT = 50;
+const UNLIMITED_ANN_CANDIDATE_LIMIT = Number.MAX_SAFE_INTEGER;
 
 // ---------------------------------------------------------------------------
 // Candidate selection
@@ -120,11 +120,9 @@ export async function selectCandidates(
     const denseResult = await embedWithBackend(config, [annQueryText]);
     const dense = denseResult.vectors[0];
     const sparse = generateSparseEmbedding(annQueryText);
-    const hits = await hybridQueryConceptPages(
-      dense,
-      sparse,
-      ANN_CANDIDATE_LIMIT,
-    );
+    const limit =
+      config.memory.v2.ann_candidate_limit ?? UNLIMITED_ANN_CANDIDATE_LIMIT;
+    const hits = await hybridQueryConceptPages(dense, sparse, limit);
     for (const hit of hits) fromAnn.add(hit.slug);
   }
 
@@ -239,20 +237,25 @@ export interface SpreadActivationResult {
  * Apply 2-hop spreading activation with neighborhood normalization. Edges are
  * directed: an edge A→B means A's activation contributes to B's final value.
  *
- *   A(n) = [ A_o(n) + k · Σ_{m∈in1(n)} A_o(m) + k² · Σ_{m∈in2(n)} A_o(m) ]
- *        / (1 + k · #in1(n) + k² · #in2(n))
+ *   A(n) = [ A_o(n) + Σ_{r: |active_inR(n)| > 0} k^r · L2(active_inR(n)) ]
+ *        / [ 1     + Σ_{r: |active_inR(n)| > 0} k^r ]
  *
- * For each candidate slug `n`, BFS walks `incoming` adjacency to gather
- * predecessors at distance 1, 2 (i.e. nodes from which a directed path of
- * that length leads into `n`). The denominator counts those structural
- * predecessors at each hop (whether or not they appear in `ownActivation`)
- * so a pure source — no incoming edges — collapses to `A == A_o`. Missing
- * predecessors contribute 0 to the numerator.
+ * `active_inR(n)` is the subset of structural predecessors at hop `r` that
+ * also appear in `ownActivation` (i.e. made the candidate set). `L2(.)` is
+ * the quadratic mean √(mean(A_o²)) — a mild bias toward strong outliers
+ * compared to the arithmetic mean, without letting a single high-cosine
+ * predecessor dominate the way `max` would.
  *
- * Bounded in [0, 1]: with `A_o ∈ [0, 1]` and `k ∈ [0, 1]`, the numerator is
- * at most `1 + k · #in1 + k² · #in2` — exactly the denominator — so the
- * ratio is at most 1. `clampUnitInterval` guards against numerical drift
- * and out-of-range inputs.
+ * Hops with **no** active predecessors are dropped from BOTH numerator and
+ * denominator so a high-in-degree hub with mostly-inactive neighbors stays
+ * near `A_o` instead of being crushed by the structural count. A pure
+ * source (no incoming edges, or every edge points at a non-candidate)
+ * collapses to `A == A_o`.
+ *
+ * Bounded in [0, 1]: every `L2` term ≤ max active A_o ≤ 1, so the numerator
+ * is at most `1 + Σ k^r` — exactly the denominator — so the ratio is at most
+ * 1. `clampUnitInterval` guards against numerical drift and out-of-range
+ * inputs.
  *
  * Pure function — no I/O. Reads the precomputed `incoming` map from
  * `edgeIndex` and runs a per-source BFS bounded by `hops`.
@@ -282,22 +285,28 @@ export function spreadActivation(
     // hop-0 only via `numerator = ownValue`.
     const distance = bfsPredecessorDistances(edgeIndex.incoming, slug, hops);
 
+    // Bucket only predecessors that are in `ownActivation` (the candidate
+    // set). Structural predecessors that didn't make the cut contribute
+    // nothing — neither to the numerator nor the denominator — so hub
+    // in-degree alone never penalizes a node.
+    const ringActiveCounts: number[] = new Array(hops + 1).fill(0);
+    const ringSquareSums: number[] = new Array(hops + 1).fill(0);
+    for (const [predecessor, hop] of distance) {
+      const predValue = ownActivation.get(predecessor);
+      if (predValue === undefined) continue;
+      ringActiveCounts[hop] += 1;
+      ringSquareSums[hop] += predValue * predValue;
+    }
+
     let numerator = ownValue;
     let denominator = 1;
     let kPow = 1;
-    // Accumulate per-hop contributions in a single pass. We need per-hop
-    // counts to weight by k^r, so bucket as we go.
-    const ringCounts: number[] = new Array(hops + 1).fill(0);
-    const ringSums: number[] = new Array(hops + 1).fill(0);
-    for (const [predecessor, hop] of distance) {
-      ringCounts[hop] += 1;
-      ringSums[hop] += ownActivation.get(predecessor) ?? 0;
-    }
     for (let r = 1; r <= hops; r++) {
       kPow *= k;
-      if (ringCounts[r] === 0) continue;
-      numerator += kPow * ringSums[r];
-      denominator += kPow * ringCounts[r];
+      if (ringActiveCounts[r] === 0) continue;
+      const rms = Math.sqrt(ringSquareSums[r] / ringActiveCounts[r]);
+      numerator += kPow * rms;
+      denominator += kPow;
     }
 
     const finalValue = clampUnitInterval(numerator / denominator);

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -241,9 +241,30 @@ export async function injectMemoryV2Block(
 
   await save(database, conversationId, nextActivationState);
 
-  // Record per-turn activation telemetry. This runs *before* the cache-stable
-  // empty-block return so we capture diagnostics even on no-op turns. Failures
-  // are warn-logged and never block memory injection.
+  // Render before recording telemetry so the activation log can mark slugs
+  // whose backing file is gone — those are no-op renders that would otherwise
+  // be indistinguishable from successful "injected" rows in the log.
+  // `renderInjectionBlock` itself short-circuits on empty inputs.
+  const { block, missingSlugs } = await renderInjectionBlock(
+    workspaceDir,
+    slugsToRender,
+    topSkillIds,
+  );
+  const missingSlugSet = new Set(missingSlugs);
+  if (missingSlugs.length > 0) {
+    log.warn(
+      {
+        conversationId,
+        turn: currentTurn,
+        missingSlugs,
+        renderedCount: slugsToRender.length - missingSlugs.length,
+      },
+      "Memory v2 injection skipped slugs whose page was missing on disk — Qdrant index may be stale; consider reembed",
+    );
+  }
+
+  // Record per-turn activation telemetry. Failures are warn-logged and never
+  // block memory injection.
   const toInjectSet = new Set(toInject);
   const renderedSet = new Set(slugsToRender);
   const topSkillIdSet = new Set(topSkillIds);
@@ -260,6 +281,10 @@ export async function injectMemoryV2Block(
       //   - per-turn: cached attachments from prior turns are still on the
       //     user message, so prior-everInjected slugs are `in_context` and
       //     the delta (`toInject`) is `injected`.
+      // `page_missing` overrides any "would-have-been-injected" status when
+      // `readPage` returned null for the slug — telemetry surfaces stale
+      // ANN/edge entries instead of silently masquerading as a successful
+      // injection.
       let status: MemoryV2ConceptRowRecord["status"];
       if (mode === "context-load") {
         status = renderedSet.has(slug) ? "injected" : "not_injected";
@@ -269,6 +294,9 @@ export async function injectMemoryV2Block(
         status = "injected";
       } else {
         status = "not_injected";
+      }
+      if (status === "injected" && missingSlugSet.has(slug)) {
+        status = "page_missing";
       }
       return {
         slug,
@@ -327,23 +355,6 @@ export async function injectMemoryV2Block(
     );
   }
 
-  // (7) Cache-stable empty path: nothing to render AND no ranked skills.
-  if (slugsToRender.length === 0 && topSkillIds.length === 0) {
-    return { block: null, toInject: [] };
-  }
-
-  // (8) Render. Both `topNow` and `toInject` are activation-descending
-  // (selectInjections sorts before slicing), so `slugsToRender` doubles as
-  // the render order. Per-turn: only the new slugs render (prior turns'
-  // attachments stay cached on prior user messages). Context-load: full
-  // top-K renders so the fresh user message gets a complete activation dump.
-  // Skills are appended after concept-page sections.
-  const block = await renderInjectionBlock(
-    workspaceDir,
-    slugsToRender,
-    topSkillIds,
-  );
-
   return { block, toInject: newlyInjected };
 }
 
@@ -351,14 +362,32 @@ export async function injectMemoryV2Block(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+interface RenderInjectionBlockResult {
+  /**
+   * Rendered `<memory>` block, or `null` when both the concept-page list
+   * and the skill list collapse to empty after cache misses (no on-disk
+   * pages, no resolvable skill ids). The caller falls through to its
+   * empty-block path instead of attaching an empty `<memory>` wrapper.
+   */
+  block: string | null;
+  /**
+   * Slugs that `readPage` returned null for. Surfaced so the caller can
+   * mark them in the activation log (`status: "page_missing"`) and emit
+   * a warning — silent drops here previously masked stale Qdrant /
+   * edge-index entries that pointed at pages no longer on disk.
+   */
+  missingSlugs: string[];
+}
+
 /**
  * Render the `<memory>` block for a list of slugs and a list of
  * ranked skill ids.
  *
  * Concept pages are read in parallel via `readPage`. Pages whose file has
  * gone missing between selection and render (e.g. consolidation deleted
- * them) are silently dropped — the activation state still records them in
- * `everInjected` so we don't keep re-attempting on every turn.
+ * them, folder reorg renamed the slug) are dropped from the rendered
+ * block but reported back via `missingSlugs` so callers can surface the
+ * divergence.
  *
  * Skill ids are looked up via `getSkillCapability`. Ids that the cache no
  * longer knows (e.g. uninstalled mid-run) are silently dropped, mirroring
@@ -391,27 +420,29 @@ export async function injectMemoryV2Block(
  *   - <skill-1 content>
  *   - <skill-2 content>
  *   </memory>
- *
- * Returns `null` when both lists collapse to empty after cache misses so
- * the caller can fall through to its empty-block path instead of attaching
- * an empty `<memory>` wrapper.
  */
 async function renderInjectionBlock(
   workspaceDir: string,
   slugs: string[],
   skillIds: string[],
-): Promise<string | null> {
+): Promise<RenderInjectionBlockResult> {
   const pages = await Promise.all(
     slugs.map(async (slug) => {
       const page = await readPage(workspaceDir, slug);
-      return page ? { slug, content: renderPageContent(page).trim() } : null;
+      return { slug, page };
     }),
   );
 
   const sections: string[] = [];
-  for (const entry of pages) {
-    if (!entry || entry.content.length === 0) continue;
-    sections.push(`### ${entry.slug}\n${entry.content}`);
+  const missingSlugs: string[] = [];
+  for (const { slug, page } of pages) {
+    if (!page) {
+      missingSlugs.push(slug);
+      continue;
+    }
+    const content = renderPageContent(page).trim();
+    if (content.length === 0) continue;
+    sections.push(`### ${slug}\n${content}`);
   }
 
   // v2's skills collection is skills-only, so the activation suffix always applies.
@@ -425,7 +456,10 @@ async function renderInjectionBlock(
     sections.push(`### Skills You Can Use\n${skillLines.join("\n")}`);
   }
 
-  if (sections.length === 0) return null;
+  if (sections.length === 0) return { block: null, missingSlugs };
 
-  return `<memory>\n${sections.join("\n\n")}\n</memory>`;
+  return {
+    block: `<memory>\n${sections.join("\n\n")}\n</memory>`,
+    missingSlugs,
+  };
 }

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -236,6 +236,7 @@ export async function hybridQueryConceptPages(
   sparse: SparseEmbedding,
   limit: number,
   restrictToSlugs?: readonly string[],
+  options?: { skipSparse?: boolean },
 ): Promise<ConceptPageQueryResult[]> {
   if (restrictToSlugs && restrictToSlugs.length === 0) {
     // An empty restriction means "no candidates"; skip the round-trip.
@@ -248,6 +249,13 @@ export async function hybridQueryConceptPages(
   const filter = restrictToSlugs
     ? { must: [{ key: "slug", match: { any: [...restrictToSlugs] } }] }
     : undefined;
+
+  // When the caller weighted sparse to zero, skip the round-trip entirely.
+  // The downstream fuser (`fuseHit` in `sim.ts`) already treats a missing
+  // sparse score as a 0 contribution, so omitting the query is a pure
+  // optimization — and it's also the kill switch operators use to dodge a
+  // Qdrant 1.13.x sparse-index crash that we've reproduced in the wild.
+  const skipSparse = options?.skipSparse ?? false;
 
   const denseQuery = () =>
     client.query(MEMORY_V2_COLLECTION, {
@@ -267,7 +275,14 @@ export async function hybridQueryConceptPages(
     });
 
   // Run both queries concurrently — they hit independent named vectors.
-  const runQueries = async () => Promise.all([denseQuery(), sparseQuery()]);
+  // When sparse is gated off we still resolve a Promise so the destructuring
+  // below stays uniform; the empty `points: []` matches the shape of a
+  // no-hit Qdrant response.
+  const emptyResult = {
+    points: [] as Array<{ payload?: unknown; score?: number }>,
+  };
+  const runQueries = async () =>
+    Promise.all([denseQuery(), skipSparse ? emptyResult : sparseQuery()]);
 
   let denseResults;
   let sparseResults;

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -63,8 +63,13 @@ export const clamp01 = clampUnitInterval;
  * Edge cases:
  *   - Empty `candidateSlugs` → returns an empty map without touching Qdrant
  *     or the embedding backend.
- *   - Empty query text or all-zero sparse vector → still queries (dense may
- *     still hit), and the sparse contribution to fusion is zero.
+ *   - Empty / whitespace-only `text` → returns an empty map without touching
+ *     Qdrant or the embedding backend. The Gemini embedding API rejects empty
+ *     content with HTTP 400, and short-circuiting here prevents the failure
+ *     from cascading through `Promise.all` in `computeOwnActivation` (e.g.
+ *     turn 1 has no prior assistant message, so its `simBatch` channel is
+ *     called with `""`). Treating the channel's contribution as 0 is the
+ *     same outcome a no-hit query would produce.
  */
 export async function simBatch(
   text: string,
@@ -72,6 +77,9 @@ export async function simBatch(
   config: AssistantConfig,
 ): Promise<Map<string, number>> {
   if (candidateSlugs.length === 0) {
+    return new Map();
+  }
+  if (text.trim().length === 0) {
     return new Map();
   }
 
@@ -122,8 +130,12 @@ export async function simBatch(
  * Edge cases:
  *   - Empty `ids` → returns an empty map without touching Qdrant or the
  *     embedding backend.
- *   - Empty query text → still queries (dense may still hit), and the sparse
- *     contribution is zero.
+ *   - Empty / whitespace-only `text` → returns an empty map without touching
+ *     Qdrant or the embedding backend. Same rationale as {@link simBatch}:
+ *     Gemini rejects empty content with HTTP 400, so the activation pipeline
+ *     would otherwise fail on turn 1 (where the assistant-text channel is
+ *     `""`). Treating the channel's contribution as 0 matches a no-hit
+ *     query.
  */
 export async function simSkillBatch(
   text: string,
@@ -131,6 +143,9 @@ export async function simSkillBatch(
   config: AssistantConfig,
 ): Promise<Map<string, number>> {
   if (ids.length === 0) {
+    return new Map();
+  }
+  if (text.trim().length === 0) {
     return new Map();
   }
 

--- a/assistant/src/memory/v2/skill-qdrant.ts
+++ b/assistant/src/memory/v2/skill-qdrant.ts
@@ -286,6 +286,7 @@ export async function hybridQuerySkills(
   sparse: SparseEmbedding,
   limit: number,
   restrictToIds?: readonly string[],
+  options?: { skipSparse?: boolean },
 ): Promise<SkillQueryResult[]> {
   if (restrictToIds && restrictToIds.length === 0) {
     // An empty restriction means "no candidates"; skip the round-trip.
@@ -298,6 +299,11 @@ export async function hybridQuerySkills(
   const filter = restrictToIds
     ? { must: [{ key: "id", match: { any: [...restrictToIds] } }] }
     : undefined;
+
+  // Same opt-in short-circuit as `hybridQueryConceptPages`: skip the sparse
+  // round-trip entirely so we sidestep the Qdrant 1.13.x sparse-index OOM
+  // crash when operators flip sparse off via `sparse_weight: 0`.
+  const skipSparse = options?.skipSparse ?? false;
 
   const denseQuery = () =>
     client.query(MEMORY_V2_SKILLS_COLLECTION, {
@@ -317,7 +323,11 @@ export async function hybridQuerySkills(
     });
 
   // Run both queries concurrently — they hit independent named vectors.
-  const runQueries = async () => Promise.all([denseQuery(), sparseQuery()]);
+  const emptyResult = {
+    points: [] as Array<{ payload?: unknown; score?: number }>,
+  };
+  const runQueries = async () =>
+    Promise.all([denseQuery(), skipSparse ? emptyResult : sparseQuery()]);
 
   let denseResults;
   let sparseResults;

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -17,7 +17,11 @@ import {
   totalEdgeCount,
   validateEdgeTargets,
 } from "../../memory/v2/edge-index.js";
-import { listPages, readPage } from "../../memory/v2/page-store.js";
+import {
+  listPages,
+  readPage,
+  renderPageContent,
+} from "../../memory/v2/page-store.js";
 import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { RouteError } from "./errors.js";
@@ -113,6 +117,45 @@ async function handleValidate({
   };
 }
 
+// ── Get concept page ────────────────────────────────────────────────────
+
+const MemoryV2GetConceptPageParams = z
+  .object({
+    slug: z.string().min(1),
+  })
+  .strict();
+
+export type MemoryV2GetConceptPageResult = {
+  slug: string;
+  /** Frontmatter + body, exactly as `renderInjectionBlock` would format it. */
+  rendered: string;
+};
+
+async function handleGetConceptPage({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV2GetConceptPageResult> {
+  const { slug } = MemoryV2GetConceptPageParams.parse(body);
+  const workspaceDir = getWorkspaceDir();
+  let page;
+  try {
+    page = await readPage(workspaceDir, slug);
+  } catch (err) {
+    throw new RouteError(
+      `Failed to read concept page '${slug}': ${err instanceof Error ? err.message : String(err)}`,
+      "MEMORY_V2_PAGE_READ_FAILED",
+      400,
+    );
+  }
+  if (!page) {
+    throw new RouteError(
+      `Concept page '${slug}' not found on disk`,
+      "MEMORY_V2_PAGE_NOT_FOUND",
+      404,
+    );
+  }
+  return { slug, rendered: renderPageContent(page) };
+}
+
 // ── Reembed skills ──────────────────────────────────────────────────────
 
 const MemoryV2ReembedSkillsParams = z.object({}).strict();
@@ -173,6 +216,17 @@ export const ROUTES: RouteDefinition[] = [
       "Read-only structural validation of the v2 workspace — reports orphan edges, oversized pages, and parse failures.",
     tags: ["memory"],
     requestBody: MemoryV2ValidateParams,
+  },
+  {
+    operationId: "memory_v2_get_concept_page",
+    method: "POST",
+    endpoint: "memory/v2/concept-page",
+    handler: handleGetConceptPage,
+    summary: "Read a single memory v2 concept page",
+    description:
+      "Returns the rendered (frontmatter + body) markdown for a slug. 404 when the slug has no on-disk page — the activation log inspector uses this to show what got injected.",
+    tags: ["memory"],
+    requestBody: MemoryV2GetConceptPageParams,
   },
   {
     operationId: "memory_v2_reembed_skills",

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
@@ -421,7 +421,17 @@ private struct ActivationRowConfig {
 
 private struct ActivationRowView: View {
     let config: ActivationRowConfig
+    /// Optional trailing content rendered inside the expanded disclosure
+    /// after the breakdown rows. Concept rows pass a `ConceptPageContentView`
+    /// here so the raw page markdown shows up alongside the activation
+    /// breakdown; skill rows pass nil.
+    let expandedTrailing: AnyView?
     @State private var isExpanded = false
+
+    init(config: ActivationRowConfig, expandedTrailing: AnyView? = nil) {
+        self.config = config
+        self.expandedTrailing = expandedTrailing
+    }
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
@@ -430,6 +440,9 @@ private struct ActivationRowView: View {
                     activationBreakdownRow(label: row.label, value: row.value)
                 }
                 activationBreakdownRow(label: "status", value: config.statusLabel)
+                if let expandedTrailing {
+                    expandedTrailing
+                }
             }
             .padding(.top, VSpacing.xs)
             .padding(.leading, VSpacing.md)
@@ -488,15 +501,83 @@ private struct ConceptRowView: View {
             breakdownRows.append(.init(label: "source", value: row.source))
         }
 
-        return ActivationRowView(config: ActivationRowConfig(
-            id: row.slug,
-            activation: row.finalActivation,
-            activationLabel: row.finalActivationLabel,
-            statusColor: statusColor(row.status),
-            sourceBadge: isCustomSource ? row.source : nil,
-            breakdownRows: breakdownRows,
-            statusLabel: statusLabel(row.status)
-        ))
+        return ActivationRowView(
+            config: ActivationRowConfig(
+                id: row.slug,
+                activation: row.finalActivation,
+                activationLabel: row.finalActivationLabel,
+                statusColor: statusColor(row.status),
+                sourceBadge: isCustomSource ? row.source : nil,
+                breakdownRows: breakdownRows,
+                statusLabel: statusLabel(row.status)
+            ),
+            expandedTrailing: AnyView(ConceptPageContentView(slug: row.slug))
+        )
+    }
+}
+
+// MARK: - Concept page content (lazy-loaded on row expand)
+
+private struct ConceptPageContentView: View {
+    let slug: String
+    @State private var state: LoadState = .idle
+
+    enum LoadState: Equatable {
+        case idle
+        case loading
+        case missing
+        case loaded(String)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Text("page content")
+                .font(VFont.labelSmall)
+                .foregroundStyle(VColor.contentSecondary)
+                .padding(.top, VSpacing.sm)
+
+            content
+        }
+        .task(id: slug) {
+            // SwiftUI fires `.task` when this view first renders inside
+            // the disclosed disclosure body — i.e., on first expand. The
+            // load runs once per slug; cached `state` is reused across
+            // subsequent collapses+re-expands of the same row.
+            guard state == .idle else { return }
+            state = .loading
+            let client = LLMContextClient()
+            if let rendered = await client.fetchConceptPage(slug: slug) {
+                state = .loaded(rendered)
+            } else {
+                state = .missing
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .idle, .loading:
+            HStack(spacing: VSpacing.xs) {
+                ProgressView().controlSize(.small)
+                Text("Loading…")
+                    .font(VFont.labelSmall)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+        case .missing:
+            Text("Page not found on disk — slug may reference a stale Qdrant entry.")
+                .font(VFont.labelSmall)
+                .foregroundStyle(VColor.contentTertiary)
+        case .loaded(let text):
+            Text(text)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(VColor.contentDefault)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(VSpacing.sm)
+                .background(VColor.surfaceBase)
+                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+        }
     }
 }
 

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -687,6 +687,12 @@ public protocol LLMContextClientProtocol {
     func fetchContext(messageId: String) async -> LLMContextResponse?
     func fetchContextResult(messageId: String) async throws -> LLMContextFetchResult
     func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse?
+    /// Reads the raw rendered (frontmatter + body) markdown for a single
+    /// memory v2 concept page. `nil` when the page has no on-disk file
+    /// (e.g. stale activation log row referencing a deleted slug) or when
+    /// the daemon is unreachable. The activation-log inspector lazy-fetches
+    /// this on disclosure-row expansion.
+    func fetchConceptPage(slug: String) async -> String?
 }
 
 /// Gateway-backed implementation of ``LLMContextClientProtocol``.
@@ -787,6 +793,36 @@ public struct LLMContextClient: LLMContextClientProtocol {
             return nil
         }
     }
+
+    public func fetchConceptPage(slug: String) async -> String? {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "memory/v2/concept-page",
+                json: ["slug": slug],
+                timeout: 15
+            )
+            // 404 = page no longer on disk (stale slug). Surface as nil so
+            // the inspector can render a "page missing" affordance instead
+            // of treating it as a transport error.
+            if response.statusCode == 404 { return nil }
+            guard response.isSuccess else {
+                log.error("fetchConceptPage failed (HTTP \(response.statusCode)) for slug \(slug)")
+                return nil
+            }
+            let decoded = try JSONDecoder().decode(ConceptPageResponse.self, from: response.data)
+            return decoded.rendered
+        } catch is CancellationError {
+            return nil
+        } catch {
+            log.error("fetchConceptPage error for slug \(slug): \(error.localizedDescription)")
+            return nil
+        }
+    }
+}
+
+private struct ConceptPageResponse: Decodable {
+    let slug: String
+    let rendered: String
 }
 
 public extension LLMContextClientProtocol {
@@ -799,6 +835,10 @@ public extension LLMContextClientProtocol {
     }
 
     func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse? {
+        nil
+    }
+
+    func fetchConceptPage(slug: String) async -> String? {
         nil
     }
 }


### PR DESCRIPTION
## Summary

- Configurable `ann_candidate_limit` (default `null` = unlimited) replaces hard-coded ANN top-50.
- `spreadActivation` now L2-averages over *active* predecessors only, dropping hops with no active neighbors so hub nodes don't get crushed by structural in-degree.
- `simBatch` / `simSkillBatch` short-circuit on empty text (turn 1 assistant channel) to dodge Gemini HTTP 400.
- Activation log surfaces a new `page_missing` status (with `log.warn`) whenever `readPage` returns null for a selected slug — the silent drop previously masked stale Qdrant / edge-index entries.
- Opt-in `skipSparse` kill-switch on `hybridQueryConceptPages` / `hybridQuerySkills` — escape hatch for a Qdrant 1.13.x sparse-index OOM we reproduced live (not wired in by default).
- New `POST /v1/memory/v2/concept-page` route + macOS inspector view: expanding a concept row lazy-loads the page's rendered markdown next to its activation breakdown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->