### PR TITLE
Regenerate openapi.yaml for memory/v2/concept-page route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6733,6 +6733,31 @@ paths:
               required:
                 - op
               additionalProperties: false
+  /v1/memory/v2/concept-page:
+    post:
+      operationId: memory_v2_conceptpage_post
+      summary: Read a single memory v2 concept page
+      description:
+        Returns the rendered (frontmatter + body) markdown for a slug. 404 when the slug has no on-disk page — the
+        activation log inspector uses this to show what got injected.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                slug:
+                  type: string
+                  minLength: 1
+              required:
+                - slug
+              additionalProperties: false
   /v1/memory/v2/reembed-skills:
     post:
       operationId: memory_v2_reembedskills_post


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` so it includes the `POST /v1/memory/v2/concept-page` route added in #29237. The OpenAPI Spec Check job was failing on `main` because the YAML was stale relative to the route registry.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25248434422/job/74036537275
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->