### PR TITLE
fix(macos): replace FlexFrame with HStack+Spacer in ConceptPageContentView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
@@ -569,14 +569,16 @@ private struct ConceptPageContentView: View {
                 .font(VFont.labelSmall)
                 .foregroundStyle(VColor.contentTertiary)
         case .loaded(let text):
-            Text(text)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(VColor.contentDefault)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(VSpacing.sm)
-                .background(VColor.surfaceBase)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            HStack(spacing: 0) {
+                Text(text)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(VColor.contentDefault)
+                    .textSelection(.enabled)
+                Spacer(minLength: 0)
+            }
+            .padding(VSpacing.sm)
+            .background(VColor.surfaceBase)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `.frame(maxWidth: .infinity, alignment: .leading)` on the loaded concept-page `Text` with the documented `HStack { content; Spacer(minLength: 0) }` alternative so it stops triggering `_FlexFrameLayout` inside the LazyVStack-backed inspector.
- Restores green CI on the FlexFrame Lint job.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25248434367/job/74036544724
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->