### PR TITLE
Fix CI Test job: register concept-page route policy + harden ws-transport flake

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -422,6 +422,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory-items:DELETE", scopes: ["settings.write"] },
   { endpoint: "memory/v2/backfill:POST", scopes: ["settings.write"] },
   { endpoint: "memory/v2/validate:POST", scopes: ["settings.read"] },
+  { endpoint: "memory/v2/concept-page:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/reembed-skills:POST", scopes: ["settings.write"] },
 
   // Trust rule listing

--- a/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/ws-transport.test.ts
+++ b/assistant/src/tools/browser/cdp-client/cdp-inspect/__tests__/ws-transport.test.ts
@@ -511,14 +511,19 @@ describe("connectCdpWsTransport", () => {
   });
 
   test("addEventListener returns an unsubscribe function", async () => {
+    // Use a sentinel request to gate event emission on the server: the
+    // listener is registered before send() runs, so by the time the server
+    // receives the sentinel and starts emitting events the client listener
+    // is guaranteed to be attached. A bare setTimeout-after-open race is
+    // tight enough to flake on busy CI runners.
     const server = startFakeWsServer({
-      onOpen(ws) {
+      onMessage(ws, frame) {
+        if (frame.method !== "Test.startEvents") return;
+        ws.send(JSON.stringify({ id: frame.id, result: {} }));
+        ws.send(JSON.stringify({ method: "Ev.first", params: {} }));
         setTimeout(() => {
-          ws.send(JSON.stringify({ method: "Ev.first", params: {} }));
-          setTimeout(() => {
-            ws.send(JSON.stringify({ method: "Ev.second", params: {} }));
-          }, 10);
-        }, 5);
+          ws.send(JSON.stringify({ method: "Ev.second", params: {} }));
+        }, 10);
       },
     });
     try {
@@ -528,6 +533,7 @@ describe("connectCdpWsTransport", () => {
           received.push(ev.method);
           if (ev.method === "Ev.first") unsub();
         });
+        await transport.send("Test.startEvents");
         await new Promise((r) => setTimeout(r, 60));
         expect(received).toEqual(["Ev.first"]);
       });


### PR DESCRIPTION
## Summary
- Register `memory/v2/concept-page:POST` in `route-policy.ts` (read-only, `settings.read`). PR #29237 added the route without a matching policy entry, breaking the route-policy guard test.
- Harden the `addEventListener returns an unsubscribe function` ws-transport test: gate server event emission on a sentinel request instead of an open-side `setTimeout(5ms)` race, eliminating the flake that produced `received = []` under CI load.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25248434422/job/74036537273
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->