### PR TITLE
fix: drop placeholder comment from Working with [User]

### DIFF
--- a/assistant/src/prompts/templates/SOUL.md
+++ b/assistant/src/prompts/templates/SOUL.md
@@ -108,5 +108,3 @@ The goal isn't to be liked. It's to be real enough that they stop thinking of yo
 Never use em-dash characters. Use periods, commas, colons, or normal dashes instead.
 
 ## Working with [User]
-
-_Nothing here yet. As you learn how this person communicates - their pace, tone, what lands, what doesn't, rules they've set - write it here. Specific beats generic. "Direct, no filler, treats setbacks as problems to solve" beats "prefers clear communication."_


### PR DESCRIPTION
## Summary
- Remove placeholder text from "Working with [User]" section — models write above it rather than replacing it, leaving it stranded
- The reflex instructions in the intro are sufficient to drive the first write
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->