### PR TITLE
mem(v2): guard against v1 Qdrant OOM crashes during retirement

### DIFF
--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -66,8 +66,16 @@ const log = getLogger("context-search-memory-v2-source");
  * `null` (unlimited). Qdrant's query API requires an explicit numeric
  * `limit`, so unlimited is represented as a number large enough that any
  * realistic concept-page collection is returned in full.
+ *
+ * Why not `Number.MAX_SAFE_INTEGER`: Qdrant's sparse-vector `SearchContext`
+ * pre-allocates `limit * 16` bytes per query, so passing `MAX_SAFE_INTEGER`
+ * triggers a ~144 PB allocation and SIGABRTs the Qdrant process. 1_000_000
+ * is ~16 MB of pre-allocation in Qdrant — generous headroom over realistic
+ * concept-page counts (low thousands today) while staying well clear of
+ * the OOM cliff. Bump explicitly via `ann_candidate_limit` if you ever
+ * outgrow it.
  */
-const UNLIMITED_ANN_CANDIDATE_LIMIT = Number.MAX_SAFE_INTEGER;
+const UNLIMITED_ANN_CANDIDATE_LIMIT = 1_000_000;
 
 /** Cap individual concept-page files we are willing to read for lexical scan. */
 const MEMORY_V2_LEXICAL_MAX_FILE_SIZE_BYTES = 256 * 1024;

--- a/assistant/src/memory/graph/graph-search.ts
+++ b/assistant/src/memory/graph/graph-search.ts
@@ -2,8 +2,10 @@
 // Memory Graph — Qdrant vector search for graph nodes
 // ---------------------------------------------------------------------------
 
+import { getConfig } from "../../config/loader.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
+import { isMemoryV2ReadActive } from "../context-search/sources/memory-v2.js";
 import { selectedBackendSupportsMultimodal } from "../embedding-backend.js";
 import type { EmbeddingInput } from "../embedding-types.js";
 import { embedAndUpsert } from "../job-utils.js";
@@ -48,6 +50,12 @@ export async function searchGraphNodes(
   dateRange?: { afterMs?: number; beforeMs?: number },
   excludeScopeIds?: string[],
 ): Promise<GraphSearchResult[]> {
+  // v2 owns the read path when both gates are on. The v1 `memory` collection
+  // is in active retirement and a corrupted sparse segment can OOM-crash the
+  // shared Qdrant process — short-circuiting here keeps v1 background work
+  // and stale callers from taking v2 down with them.
+  if (isMemoryV2ReadActive(getConfig())) return [];
+
   if (isQdrantBreakerOpen()) {
     log.warn("Qdrant circuit breaker open, skipping graph search");
     return [];

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -14,6 +14,7 @@ import {
 } from "../../providers/provider-send-message.js";
 import type { ContentBlock, ImageContent } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
+import { isMemoryV2ReadActive } from "../context-search/sources/memory-v2.js";
 import { embedWithRetry } from "../embed.js";
 import {
   generateSparseEmbedding,
@@ -425,6 +426,33 @@ export interface ContextLoadResult {
 export async function loadContextMemory(
   opts: ContextLoadOpts,
 ): Promise<ContextLoadResult> {
+  // v2 owns the read path when both gates are on. The v1 collection is in
+  // active retirement and querying it can OOM-crash Qdrant via a corrupted
+  // sparse segment, so we skip the embedding work and downstream searches
+  // entirely. Caller (`runContextLoad`) sees zero nodes and routes to the
+  // v2 activation pipeline.
+  if (isMemoryV2ReadActive(opts.config)) {
+    return {
+      nodes: [],
+      serendipityNodes: [],
+      triggeredNodes: [],
+      latencyMs: 0,
+      metrics: {
+        semanticHits: 0,
+        mergedCount: 0,
+        selectedCount: 0,
+        tier1Count: 0,
+        tier2Count: 0,
+        hybridSearchLatencyMs: 0,
+        sparseVectorUsed: false,
+        embeddingProvider: null,
+        embeddingModel: null,
+        queryContext: null,
+        topCandidates: [],
+      },
+    };
+  }
+
   const start = Date.now();
   const ctxLoadCfg = opts.config.memory.retrieval.injection.contextLoad;
   const maxNodes = opts.maxNodes ?? ctxLoadCfg.maxNodes;

--- a/assistant/src/memory/pkb/pkb-search.ts
+++ b/assistant/src/memory/pkb/pkb-search.ts
@@ -2,7 +2,9 @@
 // PKB — Qdrant hybrid search for indexed PKB markdown files
 // ---------------------------------------------------------------------------
 
+import { getConfig } from "../../config/loader.js";
 import { getLogger } from "../../util/logger.js";
+import { isMemoryV2ReadActive } from "../context-search/sources/memory-v2.js";
 import {
   isQdrantBreakerOpen,
   withQdrantBreaker,
@@ -40,6 +42,11 @@ export async function searchPkbFiles(
   limit: number,
   scopeIds?: string[],
 ): Promise<PkbSearchResult[]> {
+  // v2 owns the read path when both gates are on; v2 absorbs PKB as a read
+  // source, so PKB hint search short-circuits to keep traffic off the v1
+  // collection (avoiding OOM-crash risk from a corrupted sparse segment).
+  if (isMemoryV2ReadActive(getConfig())) return [];
+
   if (isQdrantBreakerOpen()) {
     log.warn("Qdrant circuit breaker open, skipping PKB search");
     return [];

--- a/assistant/src/memory/search/semantic.ts
+++ b/assistant/src/memory/search/semantic.ts
@@ -1,5 +1,7 @@
 import { inArray } from "drizzle-orm";
 
+import { getConfig } from "../../config/loader.js";
+import { isMemoryV2ReadActive } from "../context-search/sources/memory-v2.js";
 import { getDb } from "../db-connection.js";
 import { withQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import type {
@@ -54,6 +56,11 @@ export async function semanticSearch(
   sparseVector?: QdrantSparseVector,
 ): Promise<Candidate[]> {
   if (limit <= 0) return [];
+
+  // v2 owns the read path when both gates are on; the v1 `memory` collection
+  // is in active retirement, and routing semantic recall there would re-enter
+  // the same corrupted sparse segments that can OOM-crash Qdrant.
+  if (isMemoryV2ReadActive(getConfig())) return [];
 
   const qdrant = getQdrantClient();
 

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -345,8 +345,12 @@ describe("selectCandidates", () => {
   });
 
   test("ANN candidate query honors `config.memory.v2.ann_candidate_limit` and runs without slug restriction", async () => {
-    // Default `ann_candidate_limit: null` → unlimited, so a sentinel large
-    // enough to return every page is passed to Qdrant.
+    // Default `ann_candidate_limit: null` → unlimited, so the unlimited
+    // sentinel (1_000_000 — a Qdrant-safe stand-in for "every page") is
+    // passed to both channels. We don't pin to `MAX_SAFE_INTEGER` here:
+    // Qdrant's sparse `SearchContext` pre-allocates `limit * 16` bytes,
+    // and `MAX_SAFE_INTEGER` triggers a ~144 PB alloc that SIGABRTs the
+    // Qdrant process — so the constant deliberately undercuts it.
     stageHybridResponse([{ slug: "alpha", denseScore: 0.5, sparseScore: 1 }]);
     await selectCandidates({
       priorState: null,
@@ -357,7 +361,7 @@ describe("selectCandidates", () => {
     });
     expect(state.queryCalls).toHaveLength(2);
     for (const call of state.queryCalls) {
-      expect(call.limit).toBe(Number.MAX_SAFE_INTEGER);
+      expect(call.limit).toBe(1_000_000);
       expect(call.filter).toBeUndefined();
     }
 

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -48,8 +48,16 @@ import type { ActivationState, EverInjectedEntry } from "./types.js";
  * `null` (unlimited). Qdrant's query API requires an explicit numeric
  * `limit`, so unlimited is represented as a number large enough that any
  * realistic concept-page collection is returned in full.
+ *
+ * Why not `Number.MAX_SAFE_INTEGER`: Qdrant's sparse-vector `SearchContext`
+ * pre-allocates `limit * 16` bytes per query, so passing `MAX_SAFE_INTEGER`
+ * triggers a ~144 PB allocation and SIGABRTs the Qdrant process. 1_000_000
+ * is ~16 MB of pre-allocation in Qdrant — generous headroom over realistic
+ * concept-page counts (low thousands today) while staying well clear of
+ * the OOM cliff. Bump explicitly via `ann_candidate_limit` if you ever
+ * outgrow it.
  */
-const UNLIMITED_ANN_CANDIDATE_LIMIT = Number.MAX_SAFE_INTEGER;
+const UNLIMITED_ANN_CANDIDATE_LIMIT = 1_000_000;
 
 // ---------------------------------------------------------------------------
 // Candidate selection

--- a/assistant/src/runtime/routes/memory-item-routes.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.ts
@@ -25,6 +25,7 @@ import {
 import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
+import { isMemoryV2ReadActive } from "../../memory/context-search/sources/memory-v2.js";
 import { getDb } from "../../memory/db-connection.js";
 import {
   embedWithBackend,
@@ -49,11 +50,7 @@ import { withQdrantBreaker } from "../../memory/qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../../memory/qdrant-client.js";
 import { memoryGraphNodes } from "../../memory/schema.js";
 import { getLogger } from "../../util/logger.js";
-import {
-  BadRequestError,
-  ConflictError,
-  NotFoundError,
-} from "./errors.js";
+import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 
 const log = getLogger("memory-item-routes");
@@ -179,6 +176,11 @@ async function searchNodesSemantic(
 ): Promise<{ ids: string[]; total: number } | null> {
   try {
     const config = getConfig();
+    // v2 owns the read path when both gates are on. Fall back to SQL search
+    // (the caller's `null` branch) instead of querying the v1 collection,
+    // which is in active retirement and a corrupted sparse segment can
+    // OOM-crash the shared Qdrant process.
+    if (isMemoryV2ReadActive(config)) return null;
     const backendStatus = await getMemoryBackendStatus(config);
     if (!backendStatus.provider) return null;
 
@@ -249,9 +251,7 @@ function rowToNode(row: typeof memoryGraphNodes.$inferSelect): MemoryNode {
       | "told-by-other",
     narrativeRole: row.narrativeRole as MemoryNode["narrativeRole"],
     partOfStory: row.partOfStory,
-    imageRefs: row.imageRefs
-      ? (JSON.parse(row.imageRefs) as ImageRef[])
-      : null,
+    imageRefs: row.imageRefs ? (JSON.parse(row.imageRefs) as ImageRef[]) : null,
     scopeId: row.scopeId ?? "default",
   };
 }
@@ -555,8 +555,7 @@ async function handleUpdateMemoryItem(
   // Rebuild content if subject or statement changed
   const { subject: existingSubject, statement: existingStatement } =
     splitContent(existing.content);
-  const newSubject =
-    subject !== undefined ? subject.trim() : existingSubject;
+  const newSubject = subject !== undefined ? subject.trim() : existingSubject;
   const newStatement =
     statement !== undefined ? statement.trim() : existingStatement;
 
@@ -702,8 +701,7 @@ export const ROUTES: RouteDefinition[] = [
       items: z.array(z.unknown()).describe("Memory item objects"),
       total: z.number(),
     }),
-    handler: ({ queryParams }) =>
-      handleListMemoryItems(queryParams ?? {}),
+    handler: ({ queryParams }) => handleListMemoryItems(queryParams ?? {}),
   },
 
   {


### PR DESCRIPTION
## Summary
- Cap unlimited ANN candidate limit at 1_000_000 (was `Number.MAX_SAFE_INTEGER`) to avoid Qdrant's sparse-vector pre-allocation triggering a ~144 PB alloc → SIGABRT.
- Short-circuit v1 memory read paths (graph search, context-memory retriever, PKB hint search, semantic search, memory-item-routes semantic) when memory v2 read is active, so v1 background work cannot OOM-crash the shared Qdrant process.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->