### PR TITLE
fix(feature-flags): retry gateway IPC fetch on startup race

### DIFF
--- a/assistant/src/__tests__/init-feature-flag-overrides.test.ts
+++ b/assistant/src/__tests__/init-feature-flag-overrides.test.ts
@@ -41,8 +41,11 @@ describe("initFeatureFlagOverrides", () => {
   it("falls back gracefully when gateway socket is unavailable", async () => {
     mockGatewayIpc(null, { error: true });
 
-    // Should not throw
-    await initFeatureFlagOverrides();
+    // Disable retries — production retries the IPC fetch on failure to
+    // dodge the daemon-vs-gateway startup race, but here we're explicitly
+    // testing the no-gateway fallback and don't want the test to wait
+    // through the backoff schedule.
+    await initFeatureFlagOverrides({ retryBackoffsMs: [] });
 
     // Without gateway data or file, undeclared flags default to true
     const config = {} as any;
@@ -64,12 +67,32 @@ describe("initFeatureFlagOverrides", () => {
   it("does not cache empty gateway response", async () => {
     mockGatewayIpc({});
 
-    await initFeatureFlagOverrides();
+    // Disable retries — this test explicitly simulates a sustained empty
+    // response (gateway up but reporting zero flags) and should not wait
+    // through the production backoff schedule.
+    await initFeatureFlagOverrides({ retryBackoffsMs: [] });
 
     // Undeclared flags without overrides default to true (not false from
     // a cached empty map)
     const config = {} as any;
     expect(isAssistantFeatureFlagEnabled("foo-enabled", config)).toBe(true);
+  });
+
+  it("retries empty gateway responses and picks up flags once they become available", async () => {
+    // Simulate the daemon-vs-gateway startup race: the first IPC call
+    // returns empty (gateway not yet ready), but a later attempt sees
+    // the populated flag map. The retry loop in init should bridge this
+    // gap without losing the flag.
+    mockGatewayIpc({});
+    setTimeout(() => {
+      resetMockGatewayIpc();
+      mockGatewayIpc({ "retry-test-flag": true });
+    }, 50);
+
+    await initFeatureFlagOverrides({ retryBackoffsMs: [200] });
+
+    const config = {} as any;
+    expect(isAssistantFeatureFlagEnabled("retry-test-flag", config)).toBe(true);
   });
 
   it("does not re-fetch when cache is already populated", async () => {

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -17,7 +17,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { ipcGetFeatureFlags } from "../ipc/gateway-client.js";
+import { getLogger } from "../util/logger.js";
 import type { AssistantConfig } from "./schema.js";
+
+const log = getLogger("assistant-feature-flags");
 
 // ---------------------------------------------------------------------------
 // Types
@@ -141,6 +144,20 @@ async function fetchOverridesFromGateway(): Promise<Record<string, boolean>> {
 }
 
 /**
+ * Default backoff schedule (ms) between `initFeatureFlagOverrides` retries
+ * when the gateway IPC fetch returns empty. The daemon and gateway start
+ * as sibling child processes of the macOS app, so the daemon can race
+ * ahead of the gateway binding `gateway.sock`. Each delay is the
+ * *additional* wait before the next attempt, so total worst-case latency
+ * is the sum: 250 + 500 + 1000 + 2000 + 4000 = 7.75s. All retries run in
+ * the background (lifecycle.ts fires `initFeatureFlagOverrides`
+ * non-blocking), so this never delays startup.
+ */
+const DEFAULT_INIT_RETRY_BACKOFFS_MS: readonly number[] = [
+  250, 500, 1000, 2000, 4000,
+];
+
+/**
  * Pre-populate the override cache from the gateway (async).
  *
  * Call this once during startup (daemon or CLI entry) before any sync
@@ -148,26 +165,66 @@ async function fetchOverridesFromGateway(): Promise<Record<string, boolean>> {
  * uses the gateway. In local mode, falls back to the local file when
  * the gateway is unreachable.
  *
- * On failure, the cache is left unset so subsequent sync calls return an
- * empty override map (registry defaults only).
+ * Retries the gateway IPC fetch on empty/failed results — the gateway
+ * may not have bound its IPC socket yet when the daemon races ahead at
+ * startup. After exhausting retries, the cache is left unset so
+ * subsequent sync calls return an empty override map (registry defaults
+ * only).
+ *
+ * Pass `retryBackoffsMs: []` to disable retries (used by unit tests that
+ * intentionally simulate an unreachable gateway and want immediate
+ * fallback without waiting through the production schedule).
  *
  * No-ops when the cache is already populated — callers that want to
  * refresh must call `clearFeatureFlagOverridesCache()` first. This lets
  * tests preseed flag state via `_setOverridesForTesting()` without the
  * gateway IPC call clobbering their setup.
  */
-export async function initFeatureFlagOverrides(): Promise<void> {
+export async function initFeatureFlagOverrides(options?: {
+  retryBackoffsMs?: readonly number[];
+}): Promise<void> {
   if (cachedOverridesFromGateway) return;
 
-  const gatewayOverrides = await fetchOverridesFromGateway();
-  if (Object.keys(gatewayOverrides).length > 0) {
-    cachedOverrides = gatewayOverrides;
-    cachedOverridesFromGateway = true;
-    return;
+  const backoffs = options?.retryBackoffsMs ?? DEFAULT_INIT_RETRY_BACKOFFS_MS;
+
+  // First attempt has no preceding delay; subsequent attempts wait per the
+  // backoff schedule. An empty result is treated as a transient miss
+  // (gateway not yet bound) and triggers a retry — a healthy gateway
+  // always returns at least the registry-merged flags.
+  for (let attempt = 0; attempt <= backoffs.length; attempt++) {
+    if (attempt > 0) {
+      const delay = backoffs[attempt - 1]!;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      // Re-check after the wait: a concurrent caller (e.g. a test using
+      // `_setOverridesForTesting`) may have populated the cache while we
+      // were sleeping. Bail out so we don't clobber their setup.
+      if (cachedOverridesFromGateway) return;
+    }
+
+    const gatewayOverrides = await fetchOverridesFromGateway();
+    if (Object.keys(gatewayOverrides).length > 0) {
+      cachedOverrides = gatewayOverrides;
+      cachedOverridesFromGateway = true;
+      if (attempt > 0) {
+        log.info(
+          { attempt: attempt + 1 },
+          "Feature flag overrides loaded from gateway after retry",
+        );
+      }
+      return;
+    }
   }
 
-  // Gateway returned empty or failed — leave cache unset so loadOverrides()
-  // returns an empty map on subsequent sync reads.
+  // Exhausted retries — leave cache unset so loadOverrides() returns an
+  // empty map on subsequent sync reads. Flag checks fall through to the
+  // registry default (`defaultEnabled`), which biases toward off for
+  // newer assistant-scope flags.
+  if (backoffs.length > 0) {
+    log.warn(
+      { attempts: backoffs.length + 1 },
+      "Feature flag overrides empty after all retries; falling back to registry defaults",
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Retry empty/failed gateway feature-flag IPC fetches with a 250/500/1000/2000/4000ms backoff schedule (7.75s worst-case) to bridge the daemon-vs-gateway startup race where the daemon races ahead of the gateway binding `gateway.sock`.
- Without retries, the override cache is left unset on a transient miss and assistant-scope flags fall through to registry defaults — which bias toward off and can leave features silently disabled until the next daemon restart.
- Tests can pass `retryBackoffsMs: []` to disable retries when intentionally simulating an unreachable gateway; init runs non-blocking from `lifecycle.ts` so retries never delay startup.

## Original prompt
mainline
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->