### PR TITLE
fix(typecheck): unbreak main type-check

### DIFF
--- a/assistant/src/__tests__/inline-skill-load-permissions.test.ts
+++ b/assistant/src/__tests__/inline-skill-load-permissions.test.ts
@@ -70,6 +70,7 @@ mockIpcResponse("get_global_thresholds", {
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import { check, generateAllowlistOptions } from "../permissions/checker.js";
 import { clearRiskCache } from "../permissions/checker.js";
 import { _clearGlobalCacheForTesting } from "../permissions/gateway-threshold-reader.js";

--- a/assistant/src/permissions/gateway-threshold-reader.ts
+++ b/assistant/src/permissions/gateway-threshold-reader.ts
@@ -63,13 +63,6 @@ function mapExecutionContextToField(
   return "autonomous";
 }
 
-function resolveExecutionContextThreshold(
-  executionContext: ExecutionContext,
-  globalThresholds: GlobalThresholds,
-): string {
-  return globalThresholds[mapExecutionContextToField(executionContext)];
-}
-
 function isValidThreshold(value: string): value is Threshold {
   return (
     value === "none" ||
@@ -144,7 +137,8 @@ export async function getAutoApproveThreshold(
   // Fetch global thresholds (with 30s cache)
   try {
     const global = await fetchGlobalThresholds();
-    const value = resolveExecutionContextThreshold(ctx, global);
+    const field = mapExecutionContextToField(ctx);
+    const value = global[field];
     if (isValidThreshold(value)) {
       return value;
     }


### PR DESCRIPTION
## Summary
- Restore the `field` local in `gateway-threshold-reader.ts` by inlining the global-threshold lookup; drop the now-dead `resolveExecutionContextThreshold` helper. The previous refactor removed the local but left a `log.warn({ field, value }, …)` reference behind.
- Add the missing `_setOverridesForTesting` import in `inline-skill-load-permissions.test.ts`. The call was added without the import.

Both errors are surfacing on every push to main as Type Check failures (e.g. https://github.com/vellum-ai/vellum-assistant/actions/runs/25256440020/job/74056513707).

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25256440020/job/74056513707
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->