### PR TITLE
fix(macos): mark bundledAppIcon nonisolated to silence cross-actor warning

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -558,8 +558,17 @@ final class AvatarAppearanceManager {
     /// `applicationIconImage` is set at runtime and already includes all
     /// system-resolved representations.
     ///
-    /// Reference: https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
-    private static let bundledAppIcon: NSImage = {
+    /// `nonisolated` so `start()` can warm the lazy initializer from a
+    /// `Task.detached`. The enclosing class is `@MainActor`, which would
+    /// otherwise main-actor-isolate this static and force the detached task
+    /// to hop to the main actor — defeating the prefetch. `NSImage` is
+    /// `Sendable` as of Swift 6.2 (Xcode 26.0), so plain `nonisolated`
+    /// suffices and `(unsafe)` is not required.
+    ///
+    /// References:
+    /// - https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
+    /// - https://github.com/swiftlang/swift-evolution/blob/main/proposals/0434-global-actor-isolated-types-usability.md
+    private nonisolated static let bundledAppIcon: NSImage = {
         NSWorkspace.shared.icon(forFile: Bundle.main.bundlePath)
     }()
 


### PR DESCRIPTION
## Prompt / plan

`AvatarAppearanceManager.start()` warms `bundledAppIcon` from a `Task.detached` so the `NSWorkspace.icon(forFile:)` lookup does not block the main thread during app quit (the original motivation in #28981 / LUM-1301). The static `let` lives on a `@MainActor` class, so without an explicit isolation modifier it inherits main-actor isolation — and the detached task reading it crosses an actor boundary.

Swift 6 emits the warning the user reported during local Xcode builds:

```
warning: main actor-isolated static property 'bundledAppIcon' cannot be
accessed from outside of the actor; this is an error in the Swift 6
language mode
```

This PR restores `nonisolated` on the property. Plain `nonisolated` (no `(unsafe)`) is now sufficient because **`NSImage` became `Sendable` in Swift 6.2 (Xcode 26.0)** — the runtime safety we previously asserted via `(unsafe)` is now compiler-verified.

### Root cause analysis

1. **How did the code get into this state?**
   - #28981 added the `Task.detached` prefetch to fix a 2 s+ main-thread hang during app quit.
   - #29062 noticed the resulting cross-actor warning and added `nonisolated(unsafe)` to silence it (correct fix at the time, since `NSImage` was not yet `Sendable`).
   - #29088 saw a *different* warning — `'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'NSImage'`, fired because Swift 6.2 / Xcode 26 added `Sendable` conformance to `NSImage` — and resolved it by deleting the entire modifier instead of downgrading `(unsafe)` → plain `nonisolated`. That re-introduced the original cross-actor warning #29062 had fixed.

2. **What mistakes or decisions led to it?**
   - The Swift compiler diagnostic suggests "consider removing it," meaning remove the `(unsafe)` qualifier — not the entire `nonisolated` annotation. Without `nonisolated`, the property reverts to inheriting `@MainActor` from the enclosing class, which re-triggers the cross-actor warning.
   - The PR review on #29088 ([devin-ai-integration[bot] inline comment](https://github.com/vellum-ai/vellum-assistant/pull/29088#discussion_r2172272867)) flagged exactly this regression at review time, but the suggestion was not adopted.

3. **Were there warning signs we missed?**
   - The Devin Review bot's 🟡 finding on #29088 explicitly predicted: *"Removing nonisolated(unsafe) makes bundledAppIcon main-actor-isolated, breaking the Task.detached pre-warming pattern."*
   - The doc paragraph deleted in #29088 already explained why the modifier was load-bearing.

4. **What can we do to prevent this pattern from recurring?**
   - Treat 🟡 findings on isolation/concurrency changes from the review bot as blocking until explicitly justified — they catch real regressions that CI cannot, since CI does not run Xcode builds.
   - When the compiler emits "X is unnecessary," confirm the *minimum* change that satisfies the diagnostic before deleting an annotation outright. `nonisolated(unsafe)` → `nonisolated` is a one-token change that resolves the new diagnostic without losing the old guarantee.
   - Keep the explanatory doc paragraph: it documents why the modifier is load-bearing, which makes future "is this still needed?" reviews answerable from the source.

5. **Should we add a guideline to AGENTS.md?**
   - Optional and modest. Suggested addition under `clients/macos/AGENTS.md` (or wherever the macOS Swift concurrency guidance lives): *"For static stored properties on `@MainActor` classes that are read from non-isolated contexts (e.g. `Task.detached`), use `nonisolated` (or `nonisolated(unsafe)` for non-`Sendable` types) and document the cross-actor read site in a doc comment."* — but only if the team wants AGENTS.md to track this specific pattern. The PR description + restored doc comment are also sufficient.

### Why it's safe

- One-line change (plus a doc paragraph). No runtime behavior change versus what #29062 already shipped successfully.
- `NSImage`'s `Sendable` conformance is provided by AppKit in Swift 6.2 / Xcode 26 — see [firebase-ios-sdk PR #15199](https://github.com/firebase/firebase-ios-sdk/pull/15199): *"`NSImage` / `CIImage` became `Sendable` in Swift 6.2 (Xcode 26.0)."* Plain `nonisolated` is the compiler-verified form of the safety we were asserting manually.
- `NSWorkspace.icon(forFile:)` remains documented as thread-safe ([Apple docs](https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:))), so the actual operation inside the detached task continues to be safe.
- The property is `let`, so post-init reads from any context are safe by construction.

### Alternatives considered

- **Re-add `nonisolated(unsafe)` (revert #29088 verbatim).** Rejected: would re-introduce #29088's original diagnostic *"'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type 'NSImage'"* on Xcode 26+. Plain `nonisolated` resolves both warnings.
- **Remove the `Task.detached` prefetch and just take the hit synchronously.** Rejected: defeats the fix shipped in #28981 (LUM-1301) that eliminated the 2 s+ main-thread hang during app quit.
- **Move `bundledAppIcon` out of the `@MainActor` class entirely (e.g. into a private namespace enum).** Rejected: more invasive than warranted, doesn't solve anything `nonisolated` doesn't already solve, and obscures the property's relationship to the `AvatarAppearanceManager` it serves.
- **Use `await MainActor.run { Self.bundledAppIcon }` from the detached task.** Rejected: hops back to the main actor, which is exactly the hang the prefetch exists to avoid.

## Test plan

- CI does not run Xcode builds on this repo, so the relevant verification is local.
- Reviewer should run `clients/macos/build.sh debug` (or build in Xcode) and confirm the previously-printed *"main actor-isolated static property 'bundledAppIcon' cannot be accessed from outside of the actor"* warning is gone, and that no new *"unnecessary 'nonisolated(unsafe)'"* warning appears in its place.
- No behavior change at runtime: the prefetch still runs on a detached task, the dock icon path during quit still uses the cached image, and the property is still `private` to `AvatarAppearanceManager`.


Link to Devin session: https://app.devin.ai/sessions/39fbdd1645da4f4a82be0c2d1db14581
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->