### PR TITLE
docs(macos): tighten bundledAppIcon doc comments and clarify nonisolated rule

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -244,7 +244,7 @@ Prefer migrating the parent to `@Observable` so the bridge becomes unnecessary (
 
 **Two failure modes to avoid:**
 1. **Over-isolation** — putting `@MainActor` on a type is correct, but running CPU-bound work *inside* it without offloading blocks the UI. Fix: offload the expensive method, not the whole type.
-2. **Under-isolation** — making a stateful class `nonisolated` removes all thread safety. Concurrent access to its stored properties is a data race. Only use `nonisolated` for truly stateless types (enums with static methods, structs, pure-function utilities).
+2. **Under-isolation** — making a stateful class itself `nonisolated` removes all thread safety. Concurrent access to its stored properties is a data race. `nonisolated` is appropriate for stateless types (enums with static methods, structs, pure-function utilities) and for individual `static let` constants of `Sendable` type when they need to be read from off-actor contexts (e.g. a `Task.detached` prefetch). See [SE-0434](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0434-global-actor-isolated-types-usability.md).
 
 **Offloading CPU-bound work:** Use `Task.detached(priority:)` to escape `@MainActor` for the smallest piece of work that needs it. This is the correct approach for the project's current Swift 5 language mode. If the project later enables the `NonisolatedNonsendingByDefault` feature flag (or migrates to Swift 6 language mode), `Task.detached` calls can be replaced with [`@concurrent` functions (SE-0461)](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md), which achieve the same isolation escape with structured concurrency benefits.
 

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -104,12 +104,10 @@ final class AvatarAppearanceManager {
     @ObservationIgnored private var identityLoadTask: Task<Void, Never>?
 
     func start() {
-        // Pre-load the bundle icon on a background thread so the
-        // dispatch_once doesn't block the main thread if updateDockIcon()
-        // falls through to restoreBundleIcon() during resetForDisconnect,
-        // clearCustomAvatar, or an authoritative 404 response.
-        // NSWorkspace.icon(forFile:) is documented as thread-safe.
-        // Reference: https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)
+        // Warm `bundledAppIcon` off the main thread so a later main-thread
+        // read in `restoreBundleIcon()` (resetForDisconnect, clearCustomAvatar,
+        // or 404 fall-through in updateDockIcon) doesn't pay the
+        // NSWorkspace.icon(forFile:) cost on the main thread.
         Task.detached { _ = Self.bundledAppIcon }
 
         identityLoadTask = Task {
@@ -558,12 +556,13 @@ final class AvatarAppearanceManager {
     /// `applicationIconImage` is set at runtime and already includes all
     /// system-resolved representations.
     ///
-    /// `nonisolated` so `start()` can warm the lazy initializer from a
-    /// `Task.detached`. The enclosing class is `@MainActor`, which would
-    /// otherwise main-actor-isolate this static and force the detached task
-    /// to hop to the main actor — defeating the prefetch. `NSImage` is
-    /// `Sendable` as of Swift 6.2 (Xcode 26.0), so plain `nonisolated`
-    /// suffices and `(unsafe)` is not required.
+    /// Marked `nonisolated` to opt this static out of the enclosing
+    /// `@MainActor` isolation so the background prefetch in `start()` can
+    /// trigger the lazy initializer off the main thread without crossing
+    /// an actor boundary. The initializer is safe to run on any thread:
+    /// `NSWorkspace.icon(forFile:)` is documented thread-safe, and the
+    /// resulting `NSImage` is treated as a single immutable value for the
+    /// life of the process.
     ///
     /// References:
     /// - https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)


### PR DESCRIPTION
## Prompt / plan

Follow-up to #29264 (which fixed the regression) to polish the documentation surface around the same code. This PR only changes comments and one rule in `clients/AGENTS.md`; no executable code is touched.

## What changes

1. **`AvatarAppearanceManager.swift`** — rewrite the doc comment on `bundledAppIcon` and the inline comment above the `Task.detached` warming call so they describe the load-bearing semantics of the code (why `nonisolated` is required, what would break without it) instead of narrating the iteration history of #29062 / #29088 / #29264.
2. **`clients/AGENTS.md`** — clarify the "Under-isolation" rule under `@MainActor Isolation Boundaries` so it distinguishes between marking the *type* `nonisolated` (still wrong for stateful types) and marking an individual `static let` of `Sendable` type `nonisolated` (correct, and required when a `Task.detached` reads it). Links to [SE-0434](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0434-global-actor-isolated-types-usability.md) as the authoritative source.

## Why this is needed

The fix in #29264 is correct, but the comments shipped with it explain the iteration history rather than the code. Future readers (and coding agents) skimming the file should be able to tell *from the comments alone* why `nonisolated` is load-bearing — not have to chase down three PR threads to reconstruct it.

The `clients/AGENTS.md` rule, as written before this PR, said:

> **Under-isolation** — making a stateful class `nonisolated` removes all thread safety. … **Only use `nonisolated` for truly stateless types** (enums with static methods, structs, pure-function utilities).

That sentence is technically about marking the *class itself* `nonisolated`, but it reads as a blanket "only use `nonisolated` for stateless types," which is what #29088 plausibly latched onto when it removed `nonisolated(unsafe)` from a `static let` constant on a stateful `@MainActor` class. SE-0434 explicitly carves out individual constants of `Sendable` type as a legitimate use case for `nonisolated`, and the rule should reflect that.

## Why this is safe

- Pure documentation change — `git diff` is comments + one rule edit, zero executable code.
- The `nonisolated static let bundledAppIcon` declaration itself is unchanged; this PR does not re-litigate the runtime fix.
- AGENTS.md edit is one sentence, scoped to the existing "Under-isolation" rule, and cites SE-0434 directly so reviewers can verify against the authoritative source.

## References

- [SE-0434 — Usability of global-actor-isolated types](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0434-global-actor-isolated-types-usability.md) — defines `nonisolated` semantics on stored properties of types isolated to a global actor.
- [Apple — `NSWorkspace.icon(forFile:)`](https://developer.apple.com/documentation/appkit/nsworkspace/icon(forfile:)) — documented thread-safe; underpins why the prefetch is allowed off the main actor.
- [Matt Massicotte — Problematic patterns](https://massicotte.org/problematic-patterns) — corroborates that `Task.detached` is appropriate for one-shot off-actor warming of a static-let initializer.

## Alternatives considered and rejected

- **Add a new rule about `nonisolated(unsafe)` vs plain `nonisolated` semantics in AGENTS.md.** Rejected: that distinction depends on the SDK's `Sendable` annotations on AppKit types, which are still in flux (e.g., `NSImage` only became `Sendable` in Xcode 26 / Swift 6.2). A rule encoding "use plain `nonisolated`" would go stale the moment Apple changes a `Sendable` annotation. Linking to SE-0434 and letting the developer verify against the current SDK is more durable.
- **Remove the "Under-isolation" rule entirely.** Rejected: the failure mode it warns about (slapping `nonisolated` on a stateful class to silence isolation warnings) is real and recurring. Clarifying the rule keeps the warning while removing the false implication that *all* uses of `nonisolated` are wrong.
- **Reference the original PR numbers (#29062 / #29088 / #29264) inline in the doc comments.** Rejected: doc comments should describe the code, not the merge history. PR archaeology belongs in `git blame`, not in the source.

## Root cause analysis

Repeating here so the history is durable in the merged commit, not just the parent PR.

**1. How did the code get into this state?**
Three sequential PRs touched the same property:

- **#29062** added `nonisolated(unsafe) static let bundledAppIcon` to silence a Swift 6 cross-actor warning when `Task.detached` (added by #28981 to fix the LUM-1301 quit hang) reads the property from off-main.
- **#29088** ran on a newer Xcode that recognized `NSImage` as `Sendable`, so the compiler emitted a *new* warning: `"nonisolated(unsafe)" is unnecessary for a constant with Sendable type 'NSImage'`. The author interpreted "unnecessary" as "remove this annotation entirely," and deleted both `nonisolated` and `(unsafe)` together. Plain `nonisolated` (which would have silenced both warnings) was the correct downgrade and was suggested by the review bot at the time, but not adopted.
- **#29264** restored plain `nonisolated`, which is what SE-0434 prescribes for this case. This PR follows up to clean up the documentation surface left over from those three iterations.

**2. What mistakes or decisions led to it?**
The compiler diagnostic `"nonisolated(unsafe)" is unnecessary` is ambiguous between two corrective actions:

- *Downgrade* the annotation (drop `(unsafe)`, keep `nonisolated`) — correct here.
- *Remove* the annotation (drop both) — incorrect here, because the underlying class is `@MainActor` and the property is read from a non-isolated context.

The diagnostic does not say which action it expects, and a reasonable reading is "remove the whole thing." That reading is wrong specifically for `static let` properties on global-actor-isolated classes that are read from off-actor contexts; SE-0434 covers this case explicitly.

**3. Were there warning signs we missed?**
Yes. The Devin review bot on #29088 explicitly flagged that removing `nonisolated` would re-trigger the original cross-actor warning. That comment was not addressed before merge.

**4. What can we do to prevent this pattern from recurring?**
Two changes:

- The doc comment on `bundledAppIcon` now explains *why* `nonisolated` is load-bearing (background prefetch must not cross a main-actor boundary), so a future "this annotation looks unnecessary" instinct is met with code-level context, not silence.
- `clients/AGENTS.md` `@MainActor Isolation Boundaries` § now explicitly notes that `nonisolated` *is* appropriate for `static let` constants of `Sendable` type that need to be read off-actor, with a link to SE-0434 — closing the loophole that allowed "only use `nonisolated` for stateless types" to be misread.

**5. Should we add/remove/change a guideline to AGENTS.md to prevent this in the future?**
Yes — and this PR makes that change. The edit is one sentence, durable (links to SE-0434, doesn't depend on SDK-specific `Sendable` status), and scoped to the existing rule. No new sections, no PR-number references, nothing that will go stale.

## Test plan

- `git diff origin/main..HEAD` — confirms documentation-only changes (12 insertions, 13 deletions across 2 files).
- No code paths exercised; no test impact.
- CI lint/typecheck still pass since no executable code changed.


Link to Devin session: https://app.devin.ai/sessions/39fbdd1645da4f4a82be0c2d1db14581
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->