### PR TITLE
fix(feature-flags): remove duplicate coding-agents-panel registry entry

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -242,14 +242,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "coding-agents-panel",
-      "scope": "client",
-      "key": "coding-agents-panel",
-      "label": "Coding Agents Panel",
-      "description": "Gate native macOS/iOS Coding Agents panel entry points and inline ACP session deep links.",
-      "defaultEnabled": false
-    },
-    {
       "id": "compaction-playground",
       "scope": "assistant",
       "key": "compaction-playground",


### PR DESCRIPTION
## Summary
- Remove duplicate `coding-agents-panel` entry from `meta/feature-flags/feature-flag-registry.json`. Two PRs added the same flag, tripping the unique-id/key guard test on main.
- Restores green status on `feature-flag-registry-guard.test.ts`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25257906786/job/74060241987
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->