### PR TITLE
fix(tests): unblock CLI test timeouts and complete v2 qdrant mock

### DIFF
--- a/assistant/src/__tests__/test-preload.ts
+++ b/assistant/src/__tests__/test-preload.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { afterAll } from "bun:test";
 
 import { installGatewayIpcMock } from "../__tests__/mock-gateway-ipc.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import { resetDb } from "../memory/db-connection.js";
 import { _setStorePath } from "../security/encrypted-store.js";
 
@@ -35,6 +36,13 @@ _setStorePath(join(testDir, "keys.enc"));
 // Mock gateway IPC so no test accidentally connects to a real gateway socket.
 // Tests that need to control IPC responses use mockGatewayIpc() / resetMockGatewayIpc().
 installGatewayIpcMock();
+
+// Pre-populate the feature-flag override cache so `initFeatureFlagOverrides()`
+// short-circuits its retry loop — there is no real gateway in tests, and the
+// retry backoff would otherwise exceed the per-test timeout for any test that
+// builds the CLI program. Tests exercising the retry behavior call
+// `clearFeatureFlagOverridesCache()` first.
+_setOverridesForTesting({});
 
 // Force-close any DB connection inherited from the parent process (e.g. when
 // the test runner is spawned by the running assistant via a pre-push hook).

--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -103,6 +103,9 @@ mock.module("../../v2/qdrant.js", () => ({
   deleteConceptPageEmbedding: async (slug: string) => {
     deleteCalls.push(slug);
   },
+  // Other exports from the real module — stubbed so transitive imports
+  // don't crash on missing names when the mock replaces the module wholesale.
+  hybridQueryConceptPages: async () => [],
 }));
 
 // ── Workspace setup ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Two failures on main CI (CI Main Assistant Checks, run 25258377325): seven CLI test files were timing out at 5s, and `embed-concept-page.test.ts` was failing to load due to an incomplete module mock.
- Root cause for the CLI timeouts: PR #29261 added a 7.75s retry backoff to `initFeatureFlagOverrides()` for the daemon-vs-gateway startup race; in tests the gateway IPC mock returns empty by default, so any test building the CLI program through `buildCliProgram()` blocks past the 5s test timeout. Fix: pre-populate the override cache in `test-preload.ts` via `_setOverridesForTesting({})` so `initFeatureFlagOverrides()` short-circuits — tests that exercise retry behavior already clear the cache first.
- Root cause for `embed-concept-page.test.ts`: the test stubs `v2/qdrant.js` with two functions, but `db-init.ts` transitively reaches `context-search/sources/memory-v2.ts` which imports a third (`hybridQueryConceptPages`); replacing the module wholesale breaks that import. Fix: add a stubbed export to the mock.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25258377325/job/74061405748
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->