### PR TITLE
ci(ios): re-enable iOS dispatch in dev-release

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1172,7 +1172,6 @@ jobs:
   # ── Dispatch iOS release to platform repo ────────────────────────────
 
   dispatch-ios-release:
-    if: false  # TEMP: xcodeproj broken for all Xcode versions, XcodeGen fix in progress
     needs: [compute-version, register-release, publish-sparkle, build-chrome-extension]
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Prompt / plan

Reverts the temporary `if: false` skip on `dispatch-ios-release` in `.github/workflows/dev-release.yaml`, added in #29273 while the Capacitor iOS `App.xcodeproj` was incompatible with the CI runner's Xcode 26.2 toolchain.

The underlying issue is fixed in [vellum-ai/vellum-assistant-platform#5505](https://github.com/vellum-ai/vellum-assistant-platform/pull/5505): the committed `App.xcodeproj` is deleted entirely and regenerated from `web/ios/App/project.yml` on every CI run via XcodeGen, so the workflow no longer depends on a hand-maintained `pbxproj` whose `objectVersion` drifts out of sync with the Xcode toolchain.

> [!IMPORTANT]
> **Merge order:** this PR must merge **after** [vellum-ai/vellum-assistant-platform#5505](https://github.com/vellum-ai/vellum-assistant-platform/pull/5505). Otherwise the first dev-release cron run after this merges will dispatch into the platform repo and fail at the same Archive step.

## Test plan

- After both PRs land, monitor the next hourly `dev-release.yaml` run and confirm the `dispatch-ios-release` job runs (no longer skipped) and successfully dispatches the `ios-release` event to `vellum-assistant-platform`.
- Confirm the corresponding `Release iOS` workflow run in `vellum-assistant-platform` reaches `xcodebuild archive` and uploads to TestFlight (Dev).
- If the platform-side workflow fails, the dev-release run will surface a red `dispatch-ios-release` step + a Slack notification via the existing `notify-releases` job.


Link to Devin session: https://app.devin.ai/sessions/d9d80ac831364e90be422265206d1ed6
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->