### PR TITLE
Defer memory v2 skill seed until feature flag overrides resolve

### DIFF
--- a/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
+++ b/assistant/src/__tests__/lifecycle-memory-v2-seed.test.ts
@@ -139,6 +139,23 @@ describe("maybeSeedMemoryV2Skills (daemon startup gate)", () => {
     expect(state.warnCalls).toHaveLength(0);
   });
 
+  test("re-invocation seeds after flag flips on (deferred-init race recovery)", async () => {
+    // Models the lifecycle-startup race: the synchronous seed call evaluates
+    // the flag while the gateway IPC override fetch is still in flight, falls
+    // through to the registry default (`false`), and skips. Once
+    // `initFeatureFlagOverrides()` resolves, the chained `.then` re-invokes
+    // the seed with the now-populated cache and the flag flips to `true`.
+    state.flagOverrides = { "memory-v2-enabled": false };
+    maybeSeedMemoryV2Skills(makeConfig(true));
+    await flushMicrotasks();
+    expect(state.seedCallCount).toBe(0);
+
+    state.flagOverrides = { "memory-v2-enabled": true };
+    maybeSeedMemoryV2Skills(makeConfig(true));
+    await flushMicrotasks();
+    expect(state.seedCallCount).toBe(1);
+  });
+
   test("swallows seedV2SkillEntries rejections and logs a warning", async () => {
     state.flagOverrides = { "memory-v2-enabled": true };
     state.seedShouldReject = new Error("seed failed");

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -276,9 +276,16 @@ export async function runDaemon(): Promise<void> {
     // Fired non-blocking so a slow or unreachable gateway doesn't delay
     // daemon startup (the IPC call has a 3s connect + 5s call timeout
     // that would otherwise stall the critical path).
-    void initFeatureFlagOverrides().catch((err) =>
-      log.warn({ err }, "Background feature flag init failed"),
-    );
+    //
+    // On resolve, retry the v2 skill seed: the synchronous gate at the
+    // skill-seed call site below evaluates the memory-v2-enabled flag
+    // before the gateway has populated overrides, so a cold-boot race
+    // can leave the v2 skill collection unseeded for the lifetime of
+    // the daemon. seedV2SkillEntries is idempotent, so re-running after
+    // overrides land is safe.
+    void initFeatureFlagOverrides()
+      .then(() => maybeSeedMemoryV2Skills(loadConfig()))
+      .catch((err) => log.warn({ err }, "Background feature flag init failed"));
 
     seedInterfaceFiles();
 


### PR DESCRIPTION
## Summary
- Boot race: `maybeSeedMemoryV2Skills` evaluates the `memory-v2-enabled` flag synchronously before `initFeatureFlagOverrides()` finishes, falls through to the registry default `false`, and silently skips seeding the v2 skill Qdrant collection. Result: every per-turn `hybridQuerySkills` returns zero hits and the inspector shows "No skills ranked."
- Chain a retry onto the init promise so the seed runs again with the populated override cache. `seedV2SkillEntries` is idempotent so calling it twice is safe.
- Regression test simulates the empty-then-populated flag override sequence and asserts the deferred re-trigger seeds even when the synchronous call's gate evaluates false.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->