### PR TITLE
feat(inspector): contextual empty state for background memory consolidation

### DIFF
--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -66,12 +66,10 @@ import {
   type MemoryJob,
   type MemoryJobType,
 } from "../jobs-store.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./constants.js";
 import { resolveConsolidationPrompt } from "./prompts/consolidation.js";
 
 const log = getLogger("memory-v2-consolidate");
-
-/** Source string identifying this wake in `agent-wake` logs and surfaces. */
-const WAKE_SOURCE = "memory_v2_consolidation";
 
 /**
  * Follow-up jobs to fan out after a successful consolidation.
@@ -144,7 +142,7 @@ export async function memoryV2ConsolidateJob(
     // writes in the assistant's voice.
     const conversation = bootstrapConversation({
       conversationType: "background",
-      source: WAKE_SOURCE,
+      source: MEMORY_V2_CONSOLIDATION_SOURCE,
       origin: "memory_consolidation",
       systemHint: "Running memory consolidation",
       groupId: "system:background",
@@ -159,7 +157,7 @@ export async function memoryV2ConsolidateJob(
           config.memory.v2.consolidation_prompt_path,
           cutoff,
         ),
-        source: WAKE_SOURCE,
+        source: MEMORY_V2_CONSOLIDATION_SOURCE,
         trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       });
       wakeInvoked = result.invoked;

--- a/assistant/src/memory/v2/constants.ts
+++ b/assistant/src/memory/v2/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Canonical `conversations.source` string for background memory v2
+ * consolidation runs. Lives in a tiny constants module so the route layer can
+ * recognize consolidation conversations without importing the consolidation
+ * job (which pulls in agent-wake + bootstrap dependencies).
+ */
+export const MEMORY_V2_CONSOLIDATION_SOURCE = "memory_v2_consolidation";

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -29,6 +29,7 @@ mock.module("../../../config/loader.js", () => ({
   },
 }));
 
+import type { ConversationCreateType } from "../../../memory/conversation-crud.js";
 import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import {
@@ -39,8 +40,10 @@ import {
   recordMemoryV2ActivationLog,
 } from "../../../memory/memory-v2-activation-log-store.js";
 import {
+  conversations,
   llmRequestLogs,
   memoryV2ActivationLogs,
+  messages,
 } from "../../../memory/schema.js";
 import { ROUTES } from "../conversation-query-routes.js";
 
@@ -68,6 +71,40 @@ function clearTables(): void {
   const db = getDb();
   db.delete(llmRequestLogs).run();
   db.delete(memoryV2ActivationLogs).run();
+  db.delete(messages).run();
+  db.delete(conversations).run();
+}
+
+function seedConversationAndMessage(args: {
+  conversationId: string;
+  messageId: string;
+  source: string;
+  conversationType: ConversationCreateType;
+}): void {
+  const now = Date.now();
+  getDb()
+    .insert(conversations)
+    .values({
+      id: args.conversationId,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      source: args.source,
+      conversationType: args.conversationType,
+      memoryScopeId: "default",
+    })
+    .run();
+  getDb()
+    .insert(messages)
+    .values({
+      id: args.messageId,
+      conversationId: args.conversationId,
+      role: "assistant",
+      content: "",
+      createdAt: now,
+      metadata: null,
+    })
+    .run();
 }
 
 function seedRequestLog(messageId: string, id: string): void {
@@ -140,6 +177,67 @@ describe("GET /v1/messages/:id/llm-context — memoryV2Activation", () => {
     expect(body.memoryV2Activation!.config).toEqual(sampleConfig);
     // Backwards-compat: memoryRecall field still present.
     expect(body).toHaveProperty("memoryRecall");
+  });
+});
+
+describe("GET /v1/messages/:id/llm-context — conversationKind", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("returns 'background_memory_consolidation' for memory_v2_consolidation source", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-mem-consol",
+      messageId: "msg-mem-consol",
+      source: "memory_v2_consolidation",
+      conversationType: "background",
+    });
+
+    const body = (await dispatchLlmContext("msg-mem-consol")) as {
+      conversationKind: string;
+      logs: unknown[];
+    };
+
+    expect(body.conversationKind).toBe("background_memory_consolidation");
+    expect(body.logs).toEqual([]);
+  });
+
+  test("returns 'background' for non-consolidation background conversations", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-bg",
+      messageId: "msg-bg",
+      source: "memory_consolidation",
+      conversationType: "background",
+    });
+
+    const body = (await dispatchLlmContext("msg-bg")) as {
+      conversationKind: string;
+    };
+
+    expect(body.conversationKind).toBe("background");
+  });
+
+  test("returns 'user' for standard conversations", async () => {
+    seedConversationAndMessage({
+      conversationId: "conv-user",
+      messageId: "msg-user",
+      source: "user",
+      conversationType: "standard",
+    });
+
+    const body = (await dispatchLlmContext("msg-user")) as {
+      conversationKind: string;
+    };
+
+    expect(body.conversationKind).toBe("user");
+  });
+
+  test("falls back to 'user' when the message can't be resolved", async () => {
+    const body = (await dispatchLlmContext("msg-missing")) as {
+      conversationKind: string;
+    };
+
+    expect(body.conversationKind).toBe("user");
   });
 });
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -50,7 +50,11 @@ import {
   CONFIG_RELOAD_DEBOUNCE_MS,
   log,
 } from "../../daemon/handlers/shared.js";
-import { getAssistantMessageIdsInTurn } from "../../memory/conversation-crud.js";
+import {
+  getAssistantMessageIdsInTurn,
+  getConversation,
+  getMessageById,
+} from "../../memory/conversation-crud.js";
 import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
 import {
   getRequestLogById,
@@ -58,6 +62,7 @@ import {
 } from "../../memory/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../memory/memory-v2-activation-log-store.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../memory/v2/constants.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { resolvePricingForUsage } from "../../util/pricing.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -459,6 +464,26 @@ function handleGetMessageContent({
   return result;
 }
 
+const CONVERSATION_KINDS = [
+  "user",
+  "background",
+  "background_memory_consolidation",
+  "scheduled",
+] as const;
+type ConversationKind = (typeof CONVERSATION_KINDS)[number];
+
+function resolveConversationKind(
+  source: string,
+  conversationType: string,
+): ConversationKind {
+  if (source === MEMORY_V2_CONSOLIDATION_SOURCE) {
+    return "background_memory_consolidation";
+  }
+  if (conversationType === "background") return "background";
+  if (conversationType === "scheduled") return "scheduled";
+  return "user";
+}
+
 function handleGetLlmContext({ pathParams = {} }: RouteHandlerArgs) {
   const messageId = pathParams.id;
   if (!messageId) {
@@ -469,8 +494,17 @@ function handleGetLlmContext({ pathParams = {} }: RouteHandlerArgs) {
   const memoryRecallLog = getMemoryRecallLogByMessageIds(turnMessageIds);
   const memoryV2Activation =
     getMemoryV2ActivationLogByMessageIds(turnMessageIds);
+  const message = getMessageById(messageId);
+  const conversation = message ? getConversation(message.conversationId) : null;
+  const conversationKind: ConversationKind = conversation
+    ? resolveConversationKind(
+        conversation.source,
+        conversation.conversationType,
+      )
+    : "user";
   return {
     messageId,
+    conversationKind,
     logs: logs.map((log) => {
       let requestPayload: unknown;
       try {
@@ -709,6 +743,7 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["messages"],
     responseBody: z.object({
       messageId: z.string(),
+      conversationKind: z.enum(CONVERSATION_KINDS),
       logs: z.array(z.unknown()),
       memoryRecall: z.object({}).passthrough().nullable(),
       memoryV2Activation: z.object({}).passthrough().nullable(),

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -143,10 +143,34 @@ struct MessageInspectorView: View {
 
     private var emptyState: some View {
         VEmptyState(
-            title: "No LLM calls yet",
-            subtitle: "This message does not have any recorded LLM context to inspect.",
+            title: emptyStateTitle,
+            subtitle: emptyStateSubtitle,
             icon: VIcon.messagesSquare.rawValue
         )
+    }
+
+    private var emptyStateTitle: String {
+        switch viewState.conversationKind {
+        case .backgroundMemoryConsolidation:
+            return "Background memory run"
+        case .background:
+            return "Background conversation"
+        case .scheduled:
+            return "Scheduled conversation"
+        case .user, nil:
+            return "No LLM calls yet"
+        }
+    }
+
+    private var emptyStateSubtitle: String {
+        switch viewState.conversationKind {
+        case .backgroundMemoryConsolidation:
+            return "Per-call LLM context isn't currently captured for memory consolidation runs."
+        case .background, .scheduled:
+            return "Per-call LLM context isn't currently captured for this conversation type."
+        case .user, nil:
+            return "This message does not have any recorded LLM context to inspect."
+        }
     }
 
     private var failedState: some View {
@@ -643,6 +667,7 @@ struct MessageInspectorViewState {
     private(set) var logs: [LLMRequestLogEntry] = []
     private(set) var memoryRecall: MemoryRecallData?
     private(set) var memoryV2Activation: MemoryV2ActivationData?
+    private(set) var conversationKind: ConversationKind?
     private(set) var selectedLogID: String?
     private(set) var selectedDetailTab: MessageInspectorDetailTab = .overview
     private(set) var selectedRawPane: RawPayloadPane = .response
@@ -681,6 +706,7 @@ struct MessageInspectorViewState {
             logs = orderedLogs
             memoryRecall = response.memoryRecall
             memoryV2Activation = response.memoryV2Activation
+            conversationKind = response.conversationKind
 
             guard !orderedLogs.isEmpty else {
                 loadState = .empty
@@ -699,12 +725,14 @@ struct MessageInspectorViewState {
             logs = []
             memoryRecall = nil
             memoryV2Activation = nil
+            conversationKind = nil
             loadState = .empty
             selectedLogID = nil
         case .failed:
             logs = []
             memoryRecall = nil
             memoryV2Activation = nil
+            conversationKind = nil
             loadState = .failed
             selectedLogID = nil
         }

--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -666,12 +666,61 @@ public struct LLMLogPayloadResponse: Codable, Sendable {
     public let responsePayload: AnyCodable
 }
 
+/// Conversation kinds the daemon may report for an LLM-context lookup.
+/// Wire raw values mirror the daemon's `CONVERSATION_KINDS` constant in
+/// `assistant/src/runtime/routes/conversation-query-routes.ts`. Unknown
+/// values from a newer daemon decode to `nil` rather than failing the
+/// whole response.
+public enum ConversationKind: String, Sendable, Equatable, Hashable {
+    case user
+    case background
+    case backgroundMemoryConsolidation = "background_memory_consolidation"
+    case scheduled
+}
+
 /// Response wrapper for the LLM context endpoint.
 public struct LLMContextResponse: Codable, Sendable {
     public let messageId: String
+    /// `nil` when the daemon predates the field or sends a value the client
+    /// doesn't recognize — render the generic empty state in that case.
+    public let conversationKind: ConversationKind?
     public let logs: [LLMRequestLogEntry]
     public let memoryRecall: MemoryRecallData?
     public let memoryV2Activation: MemoryV2ActivationData?
+
+    public init(
+        messageId: String,
+        conversationKind: ConversationKind? = nil,
+        logs: [LLMRequestLogEntry],
+        memoryRecall: MemoryRecallData? = nil,
+        memoryV2Activation: MemoryV2ActivationData? = nil
+    ) {
+        self.messageId = messageId
+        self.conversationKind = conversationKind
+        self.logs = logs
+        self.memoryRecall = memoryRecall
+        self.memoryV2Activation = memoryV2Activation
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case messageId
+        case conversationKind
+        case logs
+        case memoryRecall
+        case memoryV2Activation
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.messageId = try container.decode(String.self, forKey: .messageId)
+        // Lossy decode: unknown daemon kinds collapse to nil so the response
+        // still parses and the inspector falls back to the generic empty state.
+        let rawKind = try container.decodeIfPresent(String.self, forKey: .conversationKind)
+        self.conversationKind = rawKind.flatMap(ConversationKind.init(rawValue:))
+        self.logs = try container.decode([LLMRequestLogEntry].self, forKey: .logs)
+        self.memoryRecall = try container.decodeIfPresent(MemoryRecallData.self, forKey: .memoryRecall)
+        self.memoryV2Activation = try container.decodeIfPresent(MemoryV2ActivationData.self, forKey: .memoryV2Activation)
+    }
 }
 
 /// Explicit outcome for an LLM context fetch.
@@ -740,7 +789,10 @@ public struct LLMContextClient: LLMContextClientProtocol {
         do {
             let decoded = try JSONDecoder().decode(LLMContextResponse.self, from: response.data)
             try Task.checkCancellation()
-            return decoded.logs.isEmpty ? .empty : .loaded(decoded)
+            // Always return `.loaded` so the view state receives `conversationKind`
+            // even when the log list is empty — the empty-state branch is derived
+            // from `logs.isEmpty` inside `MessageInspectorViewState.finishLoading`.
+            return .loaded(decoded)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -831,7 +883,7 @@ public extension LLMContextClientProtocol {
             return .failed
         }
 
-        return response.logs.isEmpty ? .empty : .loaded(response)
+        return .loaded(response)
     }
 
     func fetchLogPayload(logId: String) async -> LLMLogPayloadResponse? {


### PR DESCRIPTION
## Summary
- The LLM Context Inspector previously showed the same generic "No LLM calls yet" message for background `memory_v2_consolidation` conversations, which never have recorded request logs (6 of 7 such conversations on the user's local DB had zero logs). The endpoint now returns a `conversationKind` field, and the macOS inspector renders a context-aware empty state ("Background memory run — Per-call LLM context isn't currently captured for memory consolidation runs.") instead of implying the inspector is broken.
- Extracts `MEMORY_V2_CONSOLIDATION_SOURCE` into a small constants module so the route handler and the consolidation job no longer duplicate the source string. The Swift wire struct uses a typed `ConversationKind` enum with a lossy decoder so unknown kinds from a newer daemon collapse to `nil` rather than failing the whole response.
- Adds backend route tests covering `memory_v2_consolidation`, generic `background`, `standard`, and missing-message cases.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->