### PR TITLE
chore(openapi): regenerate spec for conversationKind field

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6915,6 +6915,13 @@ paths:
                 properties:
                   messageId:
                     type: string
+                  conversationKind:
+                    type: string
+                    enum:
+                      - user
+                      - background
+                      - background_memory_consolidation
+                      - scheduled
                   logs:
                     type: array
                     items: {}
@@ -6932,6 +6939,7 @@ paths:
                       - type: "null"
                 required:
                   - messageId
+                  - conversationKind
                   - logs
                   - memoryRecall
                   - memoryV2Activation


### PR DESCRIPTION
## Summary
- Regenerate \`assistant/openapi.yaml\` to include the \`conversationKind\` field that was added to the inspector route in #29279 but not committed to the OpenAPI spec.
- Fixes the failing \"OpenAPI Spec Check\" CI job on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25264679693/job/74077236952
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->