### PR TITLE
test(runtime): fix flaky EADDRINUSE in runtime-events-sse test

### DIFF
--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -58,9 +58,9 @@ describe("SSE assistant-events endpoint", () => {
   });
 
   async function startServer(): Promise<void> {
-    port = 19500 + Math.floor(Math.random() * 500);
-    server = new RuntimeHttpServer({ port });
+    server = new RuntimeHttpServer({ port: 0 });
     await server.start();
+    port = server.actualPort;
   }
 
   async function stopServer(): Promise<void> {


### PR DESCRIPTION
## Summary
- `runtime-events-sse.test.ts` was choosing a random port from `19500..19999` and occasionally collided with parallel workers, producing `EADDRINUSE` failures (e.g. CI [run 25264679693](https://github.com/vellum-ai/vellum-assistant/actions/runs/25264679693/job/74077236959)).
- Switch `startServer()` to bind `port: 0` and read the OS-assigned port via the existing `server.actualPort` getter — the same pattern used by `conversation-fork-route.test.ts`, `gateway-only-enforcement.test.ts`, etc.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25264679693/job/74077236959
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->