### PR TITLE
Decouple memory v2 skill candidate pool from injection cap

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -18,6 +18,7 @@ describe("MemoryV2ConfigSchema", () => {
       top_k: 20,
       ann_candidate_limit: null,
       top_k_skills: 5,
+      ann_candidate_limit_skills: null,
       epsilon: 0.01,
       dense_weight: 0.7,
       sparse_weight: 0.3,

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -104,6 +104,19 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Cap on the per-turn skill-autoinjection slate rendered in `### Skills You Can Use`. 0 disables skill autoinjection without code changes.",
       ),
+    ann_candidate_limit_skills: z
+      .number({
+        error: "memory.v2.ann_candidate_limit_skills must be a number",
+      })
+      .int("memory.v2.ann_candidate_limit_skills must be an integer")
+      .positive(
+        "memory.v2.ann_candidate_limit_skills must be a positive integer",
+      )
+      .nullable()
+      .default(null)
+      .describe(
+        "Per-channel cap on the unrestricted skill ANN query (dense and sparse each return up to this many hits before they are unioned and fed into the activation scorer). `null` = unlimited (every skill in the v2 collection is eligible). Separate from `top_k_skills`, which caps the post-scoring injected slate. Mirrors `ann_candidate_limit` for concept pages.",
+      ),
     epsilon: z
       .number({ error: "memory.v2.epsilon must be a number" })
       .min(0, "memory.v2.epsilon must be >= 0")

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -194,6 +194,7 @@ function makeConfig(
     dense_weight: number;
     sparse_weight: number;
     ann_candidate_limit: number | null;
+    ann_candidate_limit_skills: number | null;
   }> = {},
 ): AssistantConfig {
   return {
@@ -207,6 +208,7 @@ function makeConfig(
         dense_weight: 1.0,
         sparse_weight: 0.0,
         ann_candidate_limit: null,
+        ann_candidate_limit_skills: null,
         ...overrides,
       },
     },
@@ -957,7 +959,7 @@ describe("selectSkillCandidates", () => {
     expect(state.queryCalls).toHaveLength(0);
   });
 
-  test("forwards topK and queries the skills collection unrestricted", async () => {
+  test("default config queries the skills collection with the unlimited limit (decoupled from topK)", async () => {
     stageSkillHybridResponse([
       { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
     ]);
@@ -968,13 +970,34 @@ describe("selectSkillCandidates", () => {
       config: makeConfig(),
       topK: 7,
     });
-    // Both channels (dense + sparse) ran with limit=7 and no slug/id filter,
-    // against the dedicated skills collection.
+    // Both channels (dense + sparse) ran with the unlimited sentinel and no
+    // id filter, against the dedicated skills collection. The pre-scoring
+    // candidate pool is intentionally decoupled from `topK` (the post-
+    // scoring injection cap) so literal-name matches that rank outside the
+    // top-K-per-channel still get scored.
     expect(state.queryCalls).toHaveLength(2);
     for (const call of state.queryCalls) {
       expect(call.collection).toBe("memory_v2_skills");
-      expect(call.limit).toBe(7);
+      expect(call.limit).toBe(1_000_000);
       expect(call.filter).toBeUndefined();
+    }
+  });
+
+  test("honors `config.memory.v2.ann_candidate_limit_skills`", async () => {
+    stageSkillHybridResponse([
+      { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
+    ]);
+    await selectSkillCandidates({
+      userText: "hello",
+      assistantText: "",
+      nowText: "",
+      config: makeConfig({ ann_candidate_limit_skills: 25 }),
+      topK: 7,
+    });
+    expect(state.queryCalls).toHaveLength(2);
+    for (const call of state.queryCalls) {
+      expect(call.collection).toBe("memory_v2_skills");
+      expect(call.limit).toBe(25);
     }
   });
 

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -459,7 +459,16 @@ export async function selectSkillCandidates(
   const denseResult = await embedWithBackend(config, [annQueryText]);
   const dense = denseResult.vectors[0];
   const sparse = generateSparseEmbedding(annQueryText);
-  const hits = await hybridQuerySkills(dense, sparse, topK);
+  // Candidate pool size is intentionally decoupled from `topK` (the
+  // post-scoring injection cap). Driving the Qdrant limit by `topK`
+  // would cap the scored set at ~10 skills per turn, dropping literal
+  // name matches that rank outside the top-5 per channel — see the
+  // concept-page pipeline (`selectCandidates`) for the equivalent
+  // separation.
+  const limit =
+    config.memory.v2.ann_candidate_limit_skills ??
+    UNLIMITED_ANN_CANDIDATE_LIMIT;
+  const hits = await hybridQuerySkills(dense, sparse, limit);
   for (const hit of hits) candidates.add(hit.id);
 
   return candidates;


### PR DESCRIPTION
## Summary
- `selectSkillCandidates` was using `top_k_skills` (default 5) as the Qdrant query limit, conflating the pre-scoring candidate pool with the post-scoring injection cap. With 79 skills in the collection, this excluded ~87% from activation scoring on every turn.
- Add `ann_candidate_limit_skills` (default `null` = unlimited) so every skill is eligible for scoring, mirroring `ann_candidate_limit` for concept pages. `top_k_skills` keeps its role as the injection cap.
- Observed regression: the assistant literally referenced 'computer-use skill' in a turn but the skill didn't rank because it fell outside the dense and sparse top-5 hits. With this change, the literal-match skill is scored and can win on activation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->