### PR TITLE
fix(macos): conform ConversationKind to Codable

### DIFF
--- a/clients/shared/Network/LLMContextClient.swift
+++ b/clients/shared/Network/LLMContextClient.swift
@@ -671,7 +671,7 @@ public struct LLMLogPayloadResponse: Codable, Sendable {
 /// `assistant/src/runtime/routes/conversation-query-routes.ts`. Unknown
 /// values from a newer daemon decode to `nil` rather than failing the
 /// whole response.
-public enum ConversationKind: String, Sendable, Equatable, Hashable {
+public enum ConversationKind: String, Codable, Sendable, Equatable, Hashable {
     case user
     case background
     case backgroundMemoryConsolidation = "background_memory_consolidation"


### PR DESCRIPTION
## Summary
- `LLMContextResponse` declares `Codable` conformance, but auto-synthesis of `Encodable` failed because `ConversationKind?` did not conform to `Encodable`.
- Adding `Codable` to the `String`-backed `ConversationKind` enum auto-synthesizes both directions; the existing custom `init(from:)` on `LLMContextResponse` (lossy String-based decode) is unaffected and continues to swallow unknown daemon values.

## Original prompt
\`\`\`
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
error: emit-module command failed with exit code 1 (use -v to see invocation)
clients/shared/Network/LLMContextClient.swift:682:15: error: type 'LLMContextResponse' does not conform to protocol 'Encodable'
note: cannot automatically synthesize 'Encodable' because 'ConversationKind?' does not conform to 'Encodable'
\`\`\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->