### PR TITLE
feat(memory-v2): show all skills in the inspector

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -18,7 +18,6 @@ describe("MemoryV2ConfigSchema", () => {
       top_k: 20,
       ann_candidate_limit: null,
       top_k_skills: 5,
-      ann_candidate_limit_skills: null,
       epsilon: 0.01,
       dense_weight: 0.7,
       sparse_weight: 0.3,

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -104,19 +104,6 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Cap on the per-turn skill-autoinjection slate rendered in `### Skills You Can Use`. 0 disables skill autoinjection without code changes.",
       ),
-    ann_candidate_limit_skills: z
-      .number({
-        error: "memory.v2.ann_candidate_limit_skills must be a number",
-      })
-      .int("memory.v2.ann_candidate_limit_skills must be an integer")
-      .positive(
-        "memory.v2.ann_candidate_limit_skills must be a positive integer",
-      )
-      .nullable()
-      .default(null)
-      .describe(
-        "Per-channel cap on the unrestricted skill ANN query (dense and sparse each return up to this many hits before they are unioned and fed into the activation scorer). `null` = unlimited (every skill in the v2 collection is eligible). Separate from `top_k_skills`, which caps the post-scoring injected slate. Mirrors `ann_candidate_limit` for concept pages.",
-      ),
     epsilon: z
       .number({ error: "memory.v2.epsilon must be a number" })
       .min(0, "memory.v2.epsilon must be >= 0")

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -148,7 +148,6 @@ const {
   computeSkillActivation,
   selectCandidates,
   selectInjections,
-  selectSkillCandidates,
   selectSkillInjections,
   spreadActivation,
 } = await import("../activation.js");
@@ -194,7 +193,6 @@ function makeConfig(
     dense_weight: number;
     sparse_weight: number;
     ann_candidate_limit: number | null;
-    ann_candidate_limit_skills: number | null;
   }> = {},
 ): AssistantConfig {
   return {
@@ -208,7 +206,6 @@ function makeConfig(
         dense_weight: 1.0,
         sparse_weight: 0.0,
         ann_candidate_limit: null,
-        ann_candidate_limit_skills: null,
         ...overrides,
       },
     },
@@ -898,7 +895,7 @@ describe("selectInjections", () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectSkillCandidates
+// computeSkillActivation
 // ---------------------------------------------------------------------------
 
 /** Stage a single hybrid response on the skills queues (payload key = `id`). */
@@ -916,111 +913,6 @@ function stageSkillHybridResponse(
       .map((h) => ({ score: h.sparseScore, payload: { id: h.id } })),
   });
 }
-
-describe("selectSkillCandidates", () => {
-  test("returns hit ids from the skills collection", async () => {
-    stageSkillHybridResponse([
-      { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
-      { id: "example-skill-b", denseScore: 0.3, sparseScore: 1 },
-    ]);
-    const out = await selectSkillCandidates({
-      userText: "user said hello",
-      assistantText: "",
-      nowText: "",
-      config: makeConfig(),
-      topK: 10,
-    });
-    expect(out).toEqual(new Set(["example-skill-a", "example-skill-b"]));
-  });
-
-  test("empty turn text short-circuits without backend calls", async () => {
-    const out = await selectSkillCandidates({
-      userText: "",
-      assistantText: "",
-      nowText: "",
-      config: makeConfig(),
-      topK: 10,
-    });
-    expect(out.size).toBe(0);
-    expect(state.embedCalls).toHaveLength(0);
-    expect(state.queryCalls).toHaveLength(0);
-  });
-
-  test("topK=0 short-circuits without backend calls", async () => {
-    const out = await selectSkillCandidates({
-      userText: "anything",
-      assistantText: "anything",
-      nowText: "anything",
-      config: makeConfig(),
-      topK: 0,
-    });
-    expect(out.size).toBe(0);
-    expect(state.embedCalls).toHaveLength(0);
-    expect(state.queryCalls).toHaveLength(0);
-  });
-
-  test("default config queries the skills collection with the unlimited limit (decoupled from topK)", async () => {
-    stageSkillHybridResponse([
-      { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
-    ]);
-    await selectSkillCandidates({
-      userText: "hello",
-      assistantText: "",
-      nowText: "",
-      config: makeConfig(),
-      topK: 7,
-    });
-    // Both channels (dense + sparse) ran with the unlimited sentinel and no
-    // id filter, against the dedicated skills collection. The pre-scoring
-    // candidate pool is intentionally decoupled from `topK` (the post-
-    // scoring injection cap) so literal-name matches that rank outside the
-    // top-K-per-channel still get scored.
-    expect(state.queryCalls).toHaveLength(2);
-    for (const call of state.queryCalls) {
-      expect(call.collection).toBe("memory_v2_skills");
-      expect(call.limit).toBe(1_000_000);
-      expect(call.filter).toBeUndefined();
-    }
-  });
-
-  test("honors `config.memory.v2.ann_candidate_limit_skills`", async () => {
-    stageSkillHybridResponse([
-      { id: "example-skill-a", denseScore: 0.5, sparseScore: 1 },
-    ]);
-    await selectSkillCandidates({
-      userText: "hello",
-      assistantText: "",
-      nowText: "",
-      config: makeConfig({ ann_candidate_limit_skills: 25 }),
-      topK: 7,
-    });
-    expect(state.queryCalls).toHaveLength(2);
-    for (const call of state.queryCalls) {
-      expect(call.collection).toBe("memory_v2_skills");
-      expect(call.limit).toBe(25);
-    }
-  });
-
-  test("embeds concatenated turn text exactly once", async () => {
-    stageSkillHybridResponse([]);
-    await selectSkillCandidates({
-      userText: "user line",
-      assistantText: "assistant line",
-      nowText: "now line",
-      config: makeConfig(),
-      topK: 5,
-    });
-    expect(state.embedCalls).toHaveLength(1);
-    expect(state.embedCalls[0].inputs).toEqual([
-      "user line\nassistant line\nnow line",
-    ]);
-    expect(state.sparseCalls).toEqual(["user line\nassistant line\nnow line"]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// computeSkillActivation
-// ---------------------------------------------------------------------------
 
 describe("computeSkillActivation", () => {
   test("empty candidates short-circuits without backend calls", async () => {

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -14,12 +14,12 @@
  *
  * Hermetic by design: the embedding backend, qdrant client, and `getConfig`
  * are mocked at the module level so the suite never reaches a real backend.
- * The skill activation pipeline (`selectSkillCandidates`,
- * `computeSkillActivation`, `selectSkillInjections`) and the skill-store
- * lookup (`getSkillCapability`) are also mocked at the module level so each
- * test can stage its skill slate without touching the dedicated skills
- * Qdrant collection. The activation-store uses an in-memory SQLite database
- * so writes are real but contained.
+ * The skill activation pipeline (`computeSkillActivation`,
+ * `selectSkillInjections`) and the skill-store helpers (`getAllSkillIds`,
+ * `getSkillCapability`) are also mocked at the module level so each test can
+ * stage its skill slate without touching the dedicated skills Qdrant
+ * collection. The activation-store uses an in-memory SQLite database so
+ * writes are real but contained.
  *
  * Tests use a temp workspace (mkdtemp) and never touch `~/.vellum/`. Sample
  * page content uses generic placeholders (Alice, Bob, etc.) per the cross-
@@ -127,18 +127,19 @@ mock.module("@qdrant/js-client-rest", () => ({
 // Skill pipeline mocks
 // ---------------------------------------------------------------------------
 //
-// The skill side of the per-turn pipeline (`selectSkillCandidates`,
-// `computeSkillActivation`, `selectSkillInjections`) has its own dedicated
-// Qdrant collection and embedding round-trips. Rather than threading staged
-// hits through that whole pipeline for every test, we mock the three skill
-// helpers and the synchronous `getSkillCapability` lookup at the module level
-// and let each test stage a `topNow` ordering and the matching `SkillEntry`
-// content directly.
+// The skill side of the per-turn pipeline (`computeSkillActivation`,
+// `selectSkillInjections`) has its own dedicated Qdrant collection and
+// embedding round-trips. Rather than threading staged hits through that whole
+// pipeline for every test, we mock the two activation helpers and the two
+// skill-store helpers (`getAllSkillIds` for the candidate pool,
+// `getSkillCapability` for content lookup) at the module level and let each
+// test stage a `topNow` ordering and the matching `SkillEntry` content
+// directly.
 
 const skillState = {
   /** Ordered ids `selectSkillInjections.topNow` returns this turn. */
   topSkillIds: [] as string[],
-  /** id → SkillEntry used by `getSkillCapability`. */
+  /** id → SkillEntry used by `getSkillCapability` and `getAllSkillIds`. */
   entries: new Map<string, SkillEntry>(),
 };
 
@@ -149,7 +150,6 @@ mock.module("../activation.js", () => ({
   // activation map are inputs to `selectSkillInjections`, not anything the
   // injection logic introspects. Stub them to empty so the test stays focused
   // on the wiring, not the pipeline internals (covered in activation.test.ts).
-  selectSkillCandidates: async () => new Set<string>(),
   computeSkillActivation: async () => ({
     activation: new Map<string, number>(),
     breakdown: new Map(),
@@ -160,6 +160,7 @@ mock.module("../activation.js", () => ({
 }));
 
 mock.module("../skill-store.js", () => ({
+  getAllSkillIds: () => [...skillState.entries.keys()],
   getSkillCapability: (id: string) => skillState.entries.get(id) ?? null,
 }));
 

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -40,7 +40,6 @@ import { clampUnitInterval } from "../validation.js";
 import type { EdgeIndex } from "./edge-index.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
 import { simBatch, simSkillBatch } from "./sim.js";
-import { hybridQuerySkills } from "./skill-qdrant.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
 /**
@@ -424,55 +423,6 @@ export function selectInjections(
 // The activation coefficients are reused from `config.memory.v2.{c_user,
 // c_assistant, c_now}` — the design doc (§9) deliberately shares them with
 // concept-page activation rather than introducing parallel knobs.
-
-interface SelectSkillCandidatesParams {
-  userText: string;
-  assistantText: string;
-  nowText: string;
-  config: AssistantConfig;
-  /** Top-K size for the ANN query against `memory_v2_skills`. */
-  topK: number;
-}
-
-/**
- * ANN top-K against the skills collection using the concatenated turn text.
- * Runs a single embedding pass over `concat(user, assistant, now)` and a
- * single hybrid Qdrant query — there is no prior-state carry-forward (skills
- * are stateless).
- *
- * Returns a `Set<string>` of skill ids that hit either channel. Empty when
- * the joined text is empty or `topK <= 0`.
- */
-export async function selectSkillCandidates(
-  params: SelectSkillCandidatesParams,
-): Promise<Set<string>> {
-  const { userText, assistantText, nowText, config, topK } = params;
-
-  const candidates = new Set<string>();
-  if (topK <= 0) return candidates;
-
-  const annQueryText = [userText, assistantText, nowText]
-    .filter((s) => s.length > 0)
-    .join("\n");
-  if (annQueryText.length === 0) return candidates;
-
-  const denseResult = await embedWithBackend(config, [annQueryText]);
-  const dense = denseResult.vectors[0];
-  const sparse = generateSparseEmbedding(annQueryText);
-  // Candidate pool size is intentionally decoupled from `topK` (the
-  // post-scoring injection cap). Driving the Qdrant limit by `topK`
-  // would cap the scored set at ~10 skills per turn, dropping literal
-  // name matches that rank outside the top-5 per channel — see the
-  // concept-page pipeline (`selectCandidates`) for the equivalent
-  // separation.
-  const limit =
-    config.memory.v2.ann_candidate_limit_skills ??
-    UNLIMITED_ANN_CANDIDATE_LIMIT;
-  const hits = await hybridQuerySkills(dense, sparse, limit);
-  for (const hit of hits) candidates.add(hit.id);
-
-  return candidates;
-}
 
 interface ComputeSkillActivationParams {
   candidates: ReadonlySet<string>;

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -37,14 +37,13 @@ import {
   computeSkillActivation,
   selectCandidates,
   selectInjections,
-  selectSkillCandidates,
   selectSkillInjections,
   spreadActivation,
 } from "./activation.js";
 import { hydrate, save } from "./activation-store.js";
 import { getEdgeIndex } from "./edge-index.js";
 import { readPage, renderPageContent } from "./page-store.js";
-import { getSkillCapability } from "./skill-store.js";
+import { getAllSkillIds, getSkillCapability } from "./skill-store.js";
 import type { ActivationState, EverInjectedEntry } from "./types.js";
 
 const log = getLogger("memory-v2-injection");
@@ -183,16 +182,11 @@ export async function injectMemoryV2Block(
   const slugsToRender = mode === "context-load" ? topNow : toInject;
 
   // (6b) Skill pipeline — a sibling pipeline to the concept-page one above.
-  // Skills are stateless: no decay carry-over, no spread, no `everInjected`
-  // dedup. The top-K relevant skills are re-presented every turn so the
-  // agent can drop and pick them up freely.
-  const skillCandidates = await selectSkillCandidates({
-    userText: userMessage,
-    assistantText: assistantMessage,
-    nowText,
-    config,
-    topK: config.memory.v2.top_k_skills,
-  });
+  // Skills are stateless (no decay, no spread, no `everInjected` dedup) and
+  // the catalog is small, so every known skill is scored every turn. The
+  // top-K injection slate is re-presented every turn so the agent can drop
+  // and pick skills up freely; the inspector renders the full ranked list.
+  const skillCandidates = new Set(getAllSkillIds());
   const { activation: skillActivation, breakdown: skillBreakdown } =
     await computeSkillActivation({
       candidates: skillCandidates,

--- a/assistant/src/memory/v2/skill-qdrant.ts
+++ b/assistant/src/memory/v2/skill-qdrant.ts
@@ -278,8 +278,7 @@ export async function pruneSkillsExcept(
  * candidate set is already known so the activation scorer gets scores for
  * exactly those ids rather than Qdrant's global top-`limit`. An empty list
  * short-circuits to no results — the caller is asking for "nothing", not
- * "everything". Undefined queries the full collection (used by
- * `selectSkillCandidates` to discover candidates from the global top-K).
+ * "everything". Undefined queries the full collection.
  */
 export async function hybridQuerySkills(
   dense: number[],

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -170,6 +170,15 @@ export function getSkillCapability(id: string): SkillEntry | null {
   return entries?.get(id) ?? null;
 }
 
+/**
+ * Every skill id in the cache — both installed-and-enabled skills and
+ * uninstalled-catalog skills. Empty before the first `seedV2SkillEntries`
+ * run completes.
+ */
+export function getAllSkillIds(): string[] {
+  return entries ? [...entries.keys()] : [];
+}
+
 /** @internal Test-only: clear the module-level cache. */
 export function _resetSkillStoreForTests(): void {
   entries = null;

--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorMemoryV2Tab.swift
@@ -182,7 +182,7 @@ struct MessageInspectorMemoryV2Tab: View {
                 countsRow(model: model)
                 configCard(config: model.config)
                 conceptsCard(rows: model.conceptRows)
-                skillsCard(rows: model.skillRows, topKSkills: model.config.topKSkills)
+                skillsCard(rows: model.skillRows)
             }
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -293,14 +293,13 @@ struct MessageInspectorMemoryV2Tab: View {
     // MARK: - Skills
 
     private func skillsCard(
-        rows: [MessageInspectorMemoryV2TabModel.SkillRowVM],
-        topKSkills: String
+        rows: [MessageInspectorMemoryV2TabModel.SkillRowVM]
     ) -> some View {
         VCard {
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 cardHeader(
-                    title: "Skills (top \(topKSkills))",
-                    subtitle: "Skills ranked by activation. Injected entries become available this turn."
+                    title: "Skills (\(rows.count))",
+                    subtitle: "Sorted by activation. Green-dotted rows are injected this turn; the rest are scored but not picked."
                 )
 
                 if rows.isEmpty {


### PR DESCRIPTION
## Summary
- Score every known skill each turn instead of just the ANN top-K, so the LLM Context Inspector can render the full ranked skill list (the post-scoring `top_k_skills` injection cap is unchanged).
- Replace `selectSkillCandidates` (ANN gate) with a direct enumeration of the in-process skill cache via a new `getAllSkillIds()`; delete the now-dead `ann_candidate_limit_skills` config field.
- Update the macOS inspector's Skills card to show the actual count (mirroring the Concept activations card) and rephrase the subtitle to explain the green-vs-gray dot status.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->