### PR TITLE
feat(heartbeat): add heartbeat_runs table and CRUD store with CAS lifecycle

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+import { getDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import {
+  completeHeartbeatRun,
+  insertPendingHeartbeatRun,
+  listHeartbeatRuns,
+  markStaleRunningAsError,
+  markStaleRunsAsMissed,
+  skipHeartbeatRun,
+  startHeartbeatRun,
+  supersedePendingRun,
+} from "../heartbeat-run-store.js";
+
+initializeDb();
+
+describe("heartbeat-run-store", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM heartbeat_runs");
+  });
+
+  test("insertPendingHeartbeatRun creates row with status pending and null timing", () => {
+    const scheduledFor = Date.now();
+    const id = insertPendingHeartbeatRun(scheduledFor);
+    expect(id).toBeTruthy();
+
+    const rows = listHeartbeatRuns();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(id);
+    expect(rows[0].status).toBe("pending");
+    expect(rows[0].scheduledFor).toBe(scheduledFor);
+    expect(rows[0].startedAt).toBeNull();
+    expect(rows[0].finishedAt).toBeNull();
+    expect(rows[0].durationMs).toBeNull();
+    expect(rows[0].error).toBeNull();
+    expect(rows[0].conversationId).toBeNull();
+    expect(rows[0].skipReason).toBeNull();
+  });
+
+  test("startHeartbeatRun transitions pending -> running and sets startedAt", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    const ok = startHeartbeatRun(id);
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("running");
+    expect(rows[0].startedAt).toBeGreaterThan(0);
+  });
+
+  test("startHeartbeatRun returns false for non-pending row", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+
+    // Start once — succeeds
+    expect(startHeartbeatRun(id)).toBe(true);
+    // Start again — fails (already running)
+    expect(startHeartbeatRun(id)).toBe(false);
+
+    // Also: superseded row cannot be started
+    const id2 = insertPendingHeartbeatRun(Date.now());
+    supersedePendingRun(id2);
+    expect(startHeartbeatRun(id2)).toBe(false);
+  });
+
+  test("completeHeartbeatRun transitions running -> ok with conversationId", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    const ok = completeHeartbeatRun(id, {
+      status: "ok",
+      conversationId: "conv-123",
+    });
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("ok");
+    expect(rows[0].conversationId).toBe("conv-123");
+    expect(rows[0].finishedAt).toBeGreaterThan(0);
+    expect(rows[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("completeHeartbeatRun transitions running -> error with truncated error", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+
+    // 3KB string — should be truncated to 2000 chars
+    const longError = "x".repeat(3000);
+    const ok = completeHeartbeatRun(id, {
+      status: "error",
+      error: longError,
+    });
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("error");
+    expect(rows[0].error).toHaveLength(2000);
+  });
+
+  test("completeHeartbeatRun returns false when status is not running (CAS)", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    // Complete with timeout
+    completeHeartbeatRun(id, { status: "timeout" });
+    // Try to complete again with ok — should fail (already timeout)
+    const ok = completeHeartbeatRun(id, { status: "ok" });
+    expect(ok).toBe(false);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("timeout");
+  });
+
+  test("skipHeartbeatRun transitions pending -> skipped with reason", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    const ok = skipHeartbeatRun(id, "outside_active_hours");
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("skipped");
+    expect(rows[0].skipReason).toBe("outside_active_hours");
+  });
+
+  test("skipHeartbeatRun returns false for non-pending row", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    const ok = skipHeartbeatRun(id, "disabled");
+    expect(ok).toBe(false);
+  });
+
+  test("supersedePendingRun transitions pending -> superseded", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    const ok = supersedePendingRun(id);
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("superseded");
+  });
+
+  test("supersedePendingRun returns false for non-pending row", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    const ok = supersedePendingRun(id);
+    expect(ok).toBe(false);
+  });
+
+  test("markStaleRunsAsMissed transitions old pending rows to missed", () => {
+    const now = Date.now();
+    // Two old pending rows
+    const id1 = insertPendingHeartbeatRun(now - 10 * 60 * 1000);
+    const id2 = insertPendingHeartbeatRun(now - 8 * 60 * 1000);
+    // One recent pending row
+    const id3 = insertPendingHeartbeatRun(now);
+
+    const count = markStaleRunsAsMissed(5 * 60 * 1000);
+    expect(count).toBe(2);
+
+    const rows = listHeartbeatRuns();
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+    expect(byId[id1].status).toBe("missed");
+    expect(byId[id2].status).toBe("missed");
+    expect(byId[id3].status).toBe("pending");
+  });
+
+  test("markStaleRunningAsError transitions old running rows to error", () => {
+    const now = Date.now();
+    const id = insertPendingHeartbeatRun(now - 60 * 60 * 1000);
+    startHeartbeatRun(id);
+
+    // Backdate started_at to simulate a long-running process
+    const db = getDb();
+    db.run(
+      `UPDATE heartbeat_runs SET started_at = ? WHERE id = ?`,
+      now - 60 * 60 * 1000,
+      id,
+    );
+
+    const count = markStaleRunningAsError(45 * 60 * 1000);
+    expect(count).toBe(1);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("error");
+    expect(rows[0].error).toBe("Process crashed or restarted during execution");
+  });
+
+  test("listHeartbeatRuns returns rows ordered by scheduledFor desc", () => {
+    const now = Date.now();
+    insertPendingHeartbeatRun(now - 2000);
+    insertPendingHeartbeatRun(now);
+    insertPendingHeartbeatRun(now - 1000);
+
+    const rows = listHeartbeatRuns();
+    expect(rows).toHaveLength(3);
+    expect(rows[0].scheduledFor).toBe(now);
+    expect(rows[1].scheduledFor).toBe(now - 1000);
+    expect(rows[2].scheduledFor).toBe(now - 2000);
+  });
+
+  test("listHeartbeatRuns respects limit", () => {
+    const now = Date.now();
+    for (let i = 0; i < 5; i++) {
+      insertPendingHeartbeatRun(now + i);
+    }
+
+    const rows = listHeartbeatRuns(3);
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -9,6 +9,8 @@ mock.module("../../util/logger.js", () => ({
   truncateForLog: (value: string) => value,
 }));
 
+import { sql } from "drizzle-orm";
+
 import { getDb } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import {
@@ -176,10 +178,9 @@ describe("heartbeat-run-store", () => {
 
     // Backdate started_at to simulate a long-running process
     const db = getDb();
+    const backdatedStartedAt = now - 60 * 60 * 1000;
     db.run(
-      `UPDATE heartbeat_runs SET started_at = ? WHERE id = ?`,
-      now - 60 * 60 * 1000,
-      id,
+      sql`UPDATE heartbeat_runs SET started_at = ${backdatedStartedAt} WHERE id = ${id}`,
     );
 
     const count = markStaleRunningAsError(45 * 60 * 1000);

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -1,0 +1,236 @@
+import { desc, eq, sql } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "../memory/db-connection.js";
+import { rawChanges } from "../memory/raw-query.js";
+import { heartbeatRuns } from "../memory/schema.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type HeartbeatRunStatus =
+  | "pending"
+  | "running"
+  | "ok"
+  | "error"
+  | "timeout"
+  | "skipped"
+  | "missed"
+  | "superseded";
+
+export type HeartbeatSkipReason =
+  | "disabled"
+  | "outside_active_hours"
+  | "overlap";
+
+export interface HeartbeatRunRecord {
+  id: string;
+  scheduledFor: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+  durationMs: number | null;
+  status: HeartbeatRunStatus;
+  skipReason: string | null;
+  error: string | null;
+  conversationId: string | null;
+  createdAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Threshold for marking stale running rows as error (45 minutes). */
+const STALE_RUNNING_THRESHOLD_MS = 45 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Store functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a new heartbeat run in `pending` status.
+ * Returns the generated run id.
+ */
+export function insertPendingHeartbeatRun(scheduledFor: number): string {
+  const db = getDb();
+  const id = uuid();
+  const now = Date.now();
+  db.insert(heartbeatRuns)
+    .values({
+      id,
+      scheduledFor,
+      startedAt: null,
+      finishedAt: null,
+      durationMs: null,
+      status: "pending",
+      skipReason: null,
+      error: null,
+      conversationId: null,
+      createdAt: now,
+    })
+    .run();
+  return id;
+}
+
+/**
+ * CAS transition from `pending` to `running`. Sets `startedAt` to now.
+ * Returns `true` if the transition succeeded.
+ */
+export function startHeartbeatRun(runId: string): boolean {
+  const db = getDb();
+  const now = Date.now();
+  db.update(heartbeatRuns)
+    .set({ status: "running", startedAt: now })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'pending'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * CAS transition from `running` to a terminal status (`ok`, `error`, or `timeout`).
+ * Computes `durationMs` from the row's `startedAt`. Error text is capped at 2 KB.
+ * Returns `true` if the transition succeeded.
+ */
+export function completeHeartbeatRun(
+  runId: string,
+  result: {
+    status: "ok" | "error" | "timeout";
+    conversationId?: string;
+    error?: string;
+  },
+): boolean {
+  const db = getDb();
+  const now = Date.now();
+
+  // Read the row to get startedAt for durationMs computation.
+  const row = db
+    .select({ startedAt: heartbeatRuns.startedAt })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .get();
+  if (!row) return false;
+
+  const durationMs = row.startedAt != null ? now - row.startedAt : null;
+
+  db.update(heartbeatRuns)
+    .set({
+      status: result.status,
+      finishedAt: now,
+      durationMs,
+      error: result.error?.slice(0, 2000) ?? null,
+      conversationId: result.conversationId ?? null,
+    })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'running'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * CAS transition from `pending` to `skipped` with the given reason.
+ * Returns `true` if the transition succeeded.
+ */
+export function skipHeartbeatRun(
+  runId: string,
+  skipReason: HeartbeatSkipReason,
+): boolean {
+  const db = getDb();
+  db.update(heartbeatRuns)
+    .set({ status: "skipped", skipReason })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'pending'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * CAS transition from `pending` to `superseded`.
+ * Returns `true` if the transition succeeded.
+ */
+export function supersedePendingRun(runId: string): boolean {
+  const db = getDb();
+  db.update(heartbeatRuns)
+    .set({ status: "superseded" })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'pending'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * Mark all `pending` rows older than the threshold as `missed`.
+ * Handles the crash-before-run scenario. Returns the number of rows affected.
+ */
+export function markStaleRunsAsMissed(
+  thresholdMs: number = 5 * 60 * 1000,
+): number {
+  const db = getDb();
+  const cutoff = Date.now() - thresholdMs;
+  db.update(heartbeatRuns)
+    .set({ status: "missed" })
+    .where(
+      sql`${heartbeatRuns.status} = 'pending' AND ${heartbeatRuns.scheduledFor} < ${cutoff}`,
+    )
+    .run();
+  return rawChanges();
+}
+
+/**
+ * Mark all `running` rows older than the threshold as `error`.
+ * Handles the crash-during-run scenario. Returns the number of rows affected.
+ */
+export function markStaleRunningAsError(
+  thresholdMs: number = STALE_RUNNING_THRESHOLD_MS,
+): number {
+  const db = getDb();
+  const cutoff = Date.now() - thresholdMs;
+  db.update(heartbeatRuns)
+    .set({
+      status: "error",
+      error: "Process crashed or restarted during execution",
+    })
+    .where(
+      sql`${heartbeatRuns.status} = 'running' AND ${heartbeatRuns.startedAt} < ${cutoff}`,
+    )
+    .run();
+  return rawChanges();
+}
+
+/**
+ * List heartbeat runs ordered by `scheduledFor` descending.
+ */
+export function listHeartbeatRuns(limit = 20): HeartbeatRunRecord[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(heartbeatRuns)
+    .orderBy(desc(heartbeatRuns.scheduledFor))
+    .limit(limit)
+    .all();
+  return rows.map(parseRow);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function parseRow(row: typeof heartbeatRuns.$inferSelect): HeartbeatRunRecord {
+  return {
+    id: row.id,
+    scheduledFor: row.scheduledFor,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
+    durationMs: row.durationMs,
+    status: row.status as HeartbeatRunStatus,
+    skipReason: row.skipReason,
+    error: row.error,
+    conversationId: row.conversationId,
+    createdAt: row.createdAt,
+  };
+}

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -102,6 +102,7 @@ import {
   migrateGuardianTimestampsEpochMs,
   migrateGuardianVerificationPurpose,
   migrateGuardianVerificationSessions,
+  migrateHeartbeatRuns,
   migrateInviteCodeHashColumn,
   migrateInviteContactId,
   migrateLlmRequestLogMessageId,
@@ -401,6 +402,7 @@ export function initializeDb(): void {
     migrateLlmUsageAttribution,
     migrateSlackCompactionWatermark,
     migrateToolInvocationsMatchedRuleId,
+    migrateHeartbeatRuns,
     function migrateBackfillAppConversationIds() {
       backfillAppConversationIds();
     },

--- a/assistant/src/memory/migrations/237-heartbeat-runs.ts
+++ b/assistant/src/memory/migrations/237-heartbeat-runs.ts
@@ -1,0 +1,45 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_heartbeat_runs_v1";
+
+/**
+ * Create the heartbeat_runs table for tracking heartbeat execution lifecycle.
+ *
+ * Each row represents one scheduled heartbeat tick, tracking its progression
+ * through the status lifecycle: pending -> running -> ok/error/timeout, or
+ * pending -> skipped/missed/superseded.
+ */
+export function migrateHeartbeatRuns(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    if (tableHasColumn(database, "heartbeat_runs", "id")) {
+      return;
+    }
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS heartbeat_runs (
+        id TEXT PRIMARY KEY,
+        scheduled_for INTEGER NOT NULL,
+        started_at INTEGER,
+        finished_at INTEGER,
+        duration_ms INTEGER,
+        status TEXT NOT NULL,
+        skip_reason TEXT,
+        error TEXT,
+        conversation_id TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_heartbeat_runs_scheduled_for
+        ON heartbeat_runs (scheduled_for)
+    `);
+  });
+}
+
+export function downHeartbeatRuns(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS heartbeat_runs`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -196,6 +196,10 @@ export {
   migrateToolInvocationsMatchedRuleId,
 } from "./236-tool-invocations-matched-rule-id.js";
 export {
+  downHeartbeatRuns,
+  migrateHeartbeatRuns,
+} from "./237-heartbeat-runs.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -47,6 +47,7 @@ import { downActivationState } from "./232-activation-state.js";
 import { downMemoryV2ActivationLogs } from "./234-memory-v2-activation-logs.js";
 import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.js";
 import { downToolInvocationsMatchedRuleId } from "./236-tool-invocations-matched-rule-id.js";
+import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -403,6 +404,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Add matched_trust_rule_id column to tool_invocations for trust rule audit and rule editor UI",
     down: downToolInvocationsMatchedRuleId,
+  },
+  {
+    key: "migration_heartbeat_runs_v1",
+    version: 47,
+    description:
+      "Create heartbeat_runs table for tracking heartbeat execution lifecycle with CAS state transitions",
+    down: downHeartbeatRuns,
   },
 ];
 

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -54,6 +54,19 @@ export const cronRuns = sqliteTable("cron_runs", {
 export const scheduleJobs = cronJobs;
 export const scheduleRuns = cronRuns;
 
+export const heartbeatRuns = sqliteTable("heartbeat_runs", {
+  id: text("id").primaryKey(),
+  scheduledFor: integer("scheduled_for").notNull(),
+  startedAt: integer("started_at"),
+  finishedAt: integer("finished_at"),
+  durationMs: integer("duration_ms"),
+  status: text("status").notNull(), // 'pending' | 'running' | 'ok' | 'error' | 'timeout' | 'skipped' | 'missed' | 'superseded'
+  skipReason: text("skip_reason"), // 'disabled' | 'outside_active_hours' | 'overlap'
+  error: text("error"),
+  conversationId: text("conversation_id"),
+  createdAt: integer("created_at").notNull(),
+});
+
 export const sharedAppLinks = sqliteTable("shared_app_links", {
   id: text("id").primaryKey(),
   shareToken: text("share_token").notNull().unique(),


### PR DESCRIPTION
## Summary
- Add heartbeat_runs table (migration 237/v47) with full lifecycle status tracking
- Create heartbeat-run-store.ts with CAS-protected state transitions
- Add comprehensive store tests with real DB

Part of plan: detect-surface-failed-heartbeats.md (PR 1 of 4)

Closes JARVIS-480
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->