### PR TITLE
feat(heartbeat): record every run outcome in heartbeat_runs

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -1,8 +1,40 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  mock,
+  test,
+} from "bun:test";
 
 const testWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
+
+// ── Heartbeat run store mock ───────────────────────────────────────
+const mockInsertPendingHeartbeatRun = mock(() => "mock-run-id");
+const mockStartHeartbeatRun = mock(() => true);
+const mockCompleteHeartbeatRun = mock(() => true);
+const mockSkipHeartbeatRun = mock(() => true);
+const mockSupersedePendingRun = mock(() => true);
+const mockMarkStaleRunsAsMissed = mock(() => 0);
+const mockMarkStaleRunningAsError = mock(() => 0);
+mock.module("../heartbeat/heartbeat-run-store.js", () => ({
+  insertPendingHeartbeatRun: mockInsertPendingHeartbeatRun,
+  startHeartbeatRun: mockStartHeartbeatRun,
+  completeHeartbeatRun: mockCompleteHeartbeatRun,
+  skipHeartbeatRun: mockSkipHeartbeatRun,
+  supersedePendingRun: mockSupersedePendingRun,
+  markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
+  markStaleRunningAsError: mockMarkStaleRunningAsError,
+}));
+
+// ── Feed event mock ───────────────────────────────────────────────
+const mockEmitFeedEvent = mock(() => Promise.resolve());
+mock.module("../home/emit-feed-event.js", () => ({
+  emitFeedEvent: mockEmitFeedEvent,
+}));
 
 // Mock config loader
 let mockConfig = {
@@ -273,6 +305,15 @@ describe("HeartbeatService", () => {
       });
       return { messageId: "msg-1" };
     });
+
+    mockInsertPendingHeartbeatRun.mockClear();
+    mockStartHeartbeatRun.mockClear();
+    mockCompleteHeartbeatRun.mockClear();
+    mockSkipHeartbeatRun.mockClear();
+    mockSupersedePendingRun.mockClear();
+    mockMarkStaleRunsAsMissed.mockClear();
+    mockMarkStaleRunningAsError.mockClear();
+    mockEmitFeedEvent.mockClear();
 
     mockConfig = {
       heartbeat: {
@@ -1051,6 +1092,252 @@ describe("HeartbeatService", () => {
       );
       expect(unreachableWarns).toHaveLength(1);
       expect(unreachableWarns[0].unreachableCount).toBe(2);
+    });
+  });
+
+  describe("heartbeat run store instrumentation", () => {
+    test("successful run: pending → running → ok with conversationId", async () => {
+      const service = createService();
+      await service.runOnce();
+
+      expect(mockStartHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledWith("mock-run-id", {
+        status: "ok",
+        conversationId: "conv-1",
+      });
+    });
+
+    test("failed run: pending → running → error preserving conversationId", async () => {
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("LLM timeout");
+        },
+      });
+
+      await service.runOnce();
+
+      expect(mockStartHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledWith("mock-run-id", {
+        status: "error",
+        conversationId: "conv-1",
+        error: "LLM timeout",
+      });
+    });
+
+    test("CAS false suppresses success feed event", async () => {
+      mockCompleteHeartbeatRun.mockImplementation(() => false);
+
+      const service = createService();
+      await service.runOnce();
+
+      // completeHeartbeatRun returned false, so no feed event should be emitted for success
+      const successCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { dedupKey?: string };
+          return opts.dedupKey?.startsWith("heartbeat:ok:");
+        },
+      );
+      expect(successCalls).toHaveLength(0);
+    });
+
+    test("CAS false suppresses failure alerter and feed event", async () => {
+      mockCompleteHeartbeatRun.mockImplementation(() => false);
+
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("LLM timeout");
+        },
+      });
+
+      await service.runOnce();
+
+      // completeHeartbeatRun returned false, so alerter should NOT be called
+      expect(alerterCalls).toHaveLength(0);
+
+      // No failure feed event either
+      const failCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { dedupKey?: string };
+          return opts.dedupKey?.startsWith("heartbeat:fail:");
+        },
+      );
+      expect(failCalls).toHaveLength(0);
+    });
+
+    test("active-hours skip calls skipHeartbeatRun", async () => {
+      mockConfig.heartbeat.activeHoursStart = 9;
+      mockConfig.heartbeat.activeHoursEnd = 17;
+
+      const service = createService({ getCurrentHour: () => 3 });
+      service.start();
+      await service.runOnce();
+
+      expect(mockSkipHeartbeatRun).toHaveBeenCalledWith(
+        "mock-run-id",
+        "outside_active_hours",
+      );
+      service.stop();
+    });
+
+    test("overlap skip calls skipHeartbeatRun", async () => {
+      let resolveFirst: () => void;
+      const firstPromise = new Promise<void>((r) => {
+        resolveFirst = r;
+      });
+
+      const service = createService({
+        processMessage: async () => {
+          await firstPromise;
+          return { messageId: "msg-1" };
+        },
+      });
+
+      // Start first run (will block)
+      const run1 = service.runOnce();
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Start service so the second runOnce has a pending row
+      service.start();
+      mockSkipHeartbeatRun.mockClear();
+
+      // Second run should be skipped due to overlap
+      await service.runOnce();
+
+      expect(mockSkipHeartbeatRun).toHaveBeenCalledWith(
+        "mock-run-id",
+        "overlap",
+      );
+
+      resolveFirst!();
+      await run1;
+      service.stop();
+    });
+
+    test("start() calls markStaleRunsAsMissed and markStaleRunningAsError", () => {
+      const service = createService();
+      service.start();
+
+      expect(mockMarkStaleRunsAsMissed).toHaveBeenCalledTimes(1);
+      expect(mockMarkStaleRunningAsError).toHaveBeenCalledTimes(1);
+      service.stop();
+    });
+
+    test("scheduleNextRun supersedes old pending row before creating new one", async () => {
+      const service = createService();
+
+      // First runOnce: scheduleNextRun is called in the finally block, creating a pending row
+      await service.runOnce();
+      const callOrder: string[] = [];
+      mockSupersedePendingRun.mockImplementation(() => {
+        callOrder.push("supersede");
+        return true;
+      });
+      mockInsertPendingHeartbeatRun.mockImplementation(() => {
+        callOrder.push("insert");
+        return "mock-run-id";
+      });
+
+      // Second runOnce: scheduleNextRun should supersede the old pending row first
+      await service.runOnce();
+
+      // The finally block's scheduleNextRun should supersede then insert
+      expect(callOrder.filter((c) => c === "supersede").length).toBeGreaterThan(
+        0,
+      );
+      const firstSupersede = callOrder.indexOf("supersede");
+      const firstInsert = callOrder.indexOf("insert");
+      expect(firstSupersede).toBeLessThan(firstInsert);
+    });
+
+    test("resetTimer() supersedes pending row", () => {
+      const service = createService();
+      service.start();
+
+      mockSupersedePendingRun.mockClear();
+      service.resetTimer();
+
+      // resetTimer calls scheduleNextRun which supersedes existing pending
+      expect(mockSupersedePendingRun).toHaveBeenCalled();
+      service.stop();
+    });
+
+    test("force run creates its own pending row, does not consume scheduled one", async () => {
+      const service = createService();
+      service.start();
+
+      // Clear to track only the force run's calls
+      mockInsertPendingHeartbeatRun.mockClear();
+
+      await service.runOnce({ force: true });
+
+      // Force run should have called insertPendingHeartbeatRun for itself
+      // (at least once for its own row, plus the scheduleNextRun in finally)
+      expect(mockInsertPendingHeartbeatRun).toHaveBeenCalled();
+
+      // The scheduled pending row (from start()) should NOT have been consumed
+      // by the force run — force creates its own
+      service.stop();
+    });
+
+    test("disabled config with stale pending row skips it as disabled", async () => {
+      const service = createService();
+      service.start();
+
+      // Now disable config and call runOnce — should skip the pending row
+      mockConfig.heartbeat.enabled = false;
+      mockSkipHeartbeatRun.mockClear();
+
+      await service.runOnce();
+
+      expect(mockSkipHeartbeatRun).toHaveBeenCalledWith(
+        "mock-run-id",
+        "disabled",
+      );
+      service.stop();
+    });
+
+    test("stop() supersedes outstanding pending row", async () => {
+      const service = createService();
+      service.start();
+
+      mockSupersedePendingRun.mockClear();
+      await service.stop();
+
+      expect(mockSupersedePendingRun).toHaveBeenCalledWith("mock-run-id");
+    });
+
+    test("timeout calls completeHeartbeatRun with status timeout", async () => {
+      jest.useFakeTimers();
+      try {
+        let resolveRun: () => void;
+        const runPromise = new Promise<void>((r) => {
+          resolveRun = r;
+        });
+
+        const service = createService({
+          processMessage: async () => {
+            await runPromise;
+            return { messageId: "msg-1" };
+          },
+        });
+
+        const runOncePromise = service.runOnce();
+        // Advance past the 30-minute timeout
+        jest.advanceTimersByTime(30 * 60 * 1000 + 1000);
+        await runOncePromise;
+
+        expect(mockCompleteHeartbeatRun).toHaveBeenCalledWith("mock-run-id", {
+          status: "timeout",
+          error: "Heartbeat execution exceeded the 30-minute timeout",
+        });
+
+        // Clean up — resolve the hanging promise so it doesn't leak
+        resolveRun!();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -17,6 +17,15 @@ import { readTextFileSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
+import {
+  completeHeartbeatRun,
+  insertPendingHeartbeatRun,
+  markStaleRunningAsError,
+  markStaleRunsAsMissed,
+  skipHeartbeatRun,
+  startHeartbeatRun,
+  supersedePendingRun,
+} from "./heartbeat-run-store.js";
 
 const log = getLogger("heartbeat-check");
 
@@ -104,6 +113,9 @@ export class HeartbeatService {
   private activeRun: Promise<void> | null = null;
   private _lastRunAt: number | null = null;
   private _nextRunAt: number | null = null;
+  private _pendingRunId: string | null = null;
+  private _startupMissedCount = 0;
+  private _startupCrashedCount = 0;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -128,6 +140,18 @@ export class HeartbeatService {
       return;
     }
     if (this.timer) return;
+
+    this._startupMissedCount = markStaleRunsAsMissed();
+    this._startupCrashedCount = markStaleRunningAsError();
+    if (this._startupMissedCount > 0 || this._startupCrashedCount > 0) {
+      log.info(
+        {
+          missedCount: this._startupMissedCount,
+          crashedCount: this._startupCrashedCount,
+        },
+        "Recovered stale heartbeat runs on startup",
+      );
+    }
 
     log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
     this.scheduleNextRun(config.intervalMs);
@@ -170,6 +194,10 @@ export class HeartbeatService {
       clearInterval(this.timer);
       this.timer = null;
     }
+    if (this._pendingRunId) {
+      supersedePendingRun(this._pendingRunId);
+      this._pendingRunId = null;
+    }
     this._nextRunAt = null;
     if (this.activeRun) {
       let timerId: ReturnType<typeof setTimeout>;
@@ -186,7 +214,22 @@ export class HeartbeatService {
    *  When `force` is true (e.g. manual "Run Now"), skip enabled & active-hours guards. */
   async runOnce({ force = false }: { force?: boolean } = {}): Promise<boolean> {
     const config = getConfig().heartbeat;
-    if (!force && !config.enabled) return false;
+
+    let runId: string | null;
+    let scheduledFor: number;
+    if (force) {
+      scheduledFor = Date.now();
+      runId = insertPendingHeartbeatRun(scheduledFor);
+    } else {
+      runId = this._pendingRunId;
+      scheduledFor = this._nextRunAt ?? Date.now();
+      this._pendingRunId = null;
+    }
+
+    if (!force && !config.enabled) {
+      if (runId) skipHeartbeatRun(runId, "disabled");
+      return false;
+    }
 
     // Active hours guard — only applied when both bounds are set.
     // The schema rejects configs where only one bound is provided.
@@ -211,6 +254,7 @@ export class HeartbeatService {
           },
           "Outside active hours, skipping",
         );
+        if (runId) skipHeartbeatRun(runId, "outside_active_hours");
         this.scheduleNextRun(config.intervalMs);
         return false;
       }
@@ -219,10 +263,14 @@ export class HeartbeatService {
     // Overlap prevention
     if (this.activeRun) {
       log.debug("Previous heartbeat run still active, skipping");
+      if (runId) skipHeartbeatRun(runId, "overlap");
       return false;
     }
 
-    const run = this.executeRun();
+    if (!runId) {
+      runId = insertPendingHeartbeatRun(scheduledFor);
+    }
+    const run = this.executeRun(runId, scheduledFor);
     this.activeRun = run;
     // Clear activeRun once executeRun finishes. On timeout, runOnce releases
     // activeRun separately (see catch block below) so future runs aren't
@@ -252,6 +300,12 @@ export class HeartbeatService {
       // Release activeRun so the overlap guard doesn't permanently block
       // future heartbeat runs when executeRun hangs past the timeout.
       this.activeRun = null;
+      if (runId) {
+        completeHeartbeatRun(runId, {
+          status: "timeout",
+          error: "Heartbeat execution exceeded the 30-minute timeout",
+        });
+      }
     } finally {
       clearTimeout(timerId);
       this._lastRunAt = Date.now();
@@ -261,7 +315,11 @@ export class HeartbeatService {
   }
 
   private scheduleNextRun(intervalMs: number): void {
+    if (this._pendingRunId) {
+      supersedePendingRun(this._pendingRunId);
+    }
     this._nextRunAt = Date.now() + intervalMs;
+    this._pendingRunId = insertPendingHeartbeatRun(this._nextRunAt);
   }
 
   /**
@@ -383,14 +441,20 @@ export class HeartbeatService {
     }
   }
 
-  private async executeRun(): Promise<void> {
+  private async executeRun(
+    runId: string,
+    _scheduledFor: number,
+  ): Promise<void> {
     log.info("Running heartbeat");
+
+    startHeartbeatRun(runId);
 
     // Credential health check — surface broken credentials proactively
     // before the LLM heartbeat prompt runs. Returns unhealthy provider
     // names so the prompt can instruct the LLM to skip those providers.
     const unhealthyProviders = await this.runCredentialHealthCheck();
 
+    let conversationId: string | undefined;
     try {
       const checklist = this.readChecklist();
       const { prompt, includedReengagement } = this.buildPrompt(
@@ -405,6 +469,7 @@ export class HeartbeatService {
         origin: "heartbeat",
         systemHint: "Heartbeat",
       });
+      conversationId = conversation.id;
 
       this.deps.onConversationCreated?.({
         conversationId: conversation.id,
@@ -425,50 +490,66 @@ export class HeartbeatService {
 
       log.info({ conversationId: conversation.id }, "Heartbeat completed");
 
-      let title = "Heartbeat";
-      try {
-        const row = getConversation(conversation.id);
-        if (row?.title && row.title !== GENERATING_TITLE) {
-          title = row.title;
-        }
-      } catch {
-        // Best-effort; fall back to generic title.
-      }
-
-      const today = new Date().toISOString().split("T")[0];
-      void emitFeedEvent({
-        source: "assistant",
-        title,
-        summary: "Periodic check completed. Tap to see details.",
-        dedupKey: `heartbeat:ok:${today}`,
-        priority: 30,
-      }).catch((err) => {
-        log.warn(
-          { err, conversationId: conversation.id },
-          "Failed to emit heartbeat feed event",
-        );
+      const transitioned = completeHeartbeatRun(runId, {
+        status: "ok",
+        conversationId,
       });
+
+      if (transitioned) {
+        let title = "Heartbeat";
+        try {
+          const row = getConversation(conversation.id);
+          if (row?.title && row.title !== GENERATING_TITLE) {
+            title = row.title;
+          }
+        } catch {
+          // Best-effort; fall back to generic title.
+        }
+
+        const today = new Date().toISOString().split("T")[0];
+        void emitFeedEvent({
+          source: "assistant",
+          title,
+          summary: "Periodic check completed. Tap to see details.",
+          dedupKey: `heartbeat:ok:${today}`,
+          priority: 30,
+        }).catch((err) => {
+          log.warn(
+            { err, conversationId: conversation.id },
+            "Failed to emit heartbeat feed event",
+          );
+        });
+      }
     } catch (err) {
       log.error({ err }, "Heartbeat failed");
-      try {
-        this.deps.alerter({
-          type: "heartbeat_alert",
-          title: "Heartbeat Failed",
-          body: err instanceof Error ? err.message : String(err),
-        });
-      } catch (alertErr) {
-        log.error({ alertErr }, "Failed to broadcast heartbeat alert");
-      }
 
-      const today = new Date().toISOString().split("T")[0];
-      void emitFeedEvent({
-        source: "assistant",
-        title: "Heartbeat",
-        summary: "Heartbeat check failed. Check logs for details.",
-        dedupKey: `heartbeat:fail:${today}`,
-        priority: 55,
-        urgency: "medium",
-      }).catch(() => {});
+      const transitioned = completeHeartbeatRun(runId, {
+        status: "error",
+        conversationId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+
+      if (transitioned) {
+        try {
+          this.deps.alerter({
+            type: "heartbeat_alert",
+            title: "Heartbeat Failed",
+            body: err instanceof Error ? err.message : String(err),
+          });
+        } catch (alertErr) {
+          log.error({ alertErr }, "Failed to broadcast heartbeat alert");
+        }
+
+        const today = new Date().toISOString().split("T")[0];
+        void emitFeedEvent({
+          source: "assistant",
+          title: "Heartbeat",
+          summary: "Heartbeat check failed. Check logs for details.",
+          dedupKey: `heartbeat:fail:${today}`,
+          priority: 55,
+          urgency: "medium",
+        }).catch(() => {});
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Instrument HeartbeatService.runOnce() to write durable heartbeat_runs records
- Full lifecycle: pending → running → ok/error/timeout/skipped/superseded
- CAS return value gates feed events and alerts to prevent timeout overwrites
- Supersede-before-replace in scheduleNextRun prevents false missed runs

Part of plan: detect-surface-failed-heartbeats.md (PR 2 of 4)

Closes JARVIS-480
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->