### PR TITLE
fix(heartbeat): return real run status from /heartbeat/runs and update client types

### DIFF
--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -118,10 +118,15 @@ export interface HeartbeatRunsListResponse {
   type: "heartbeat_runs_list_response";
   runs: Array<{
     id: string;
-    title: string;
+    scheduledFor: number;
+    startedAt: number | null;
+    finishedAt: number | null;
+    durationMs: number | null;
+    status: string;
+    skipReason: string | null;
+    error: string | null;
+    conversationId: string | null;
     createdAt: number;
-    result: string;
-    summary?: string;
   }>;
 }
 

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -8,13 +8,11 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
-import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getConfig, saveConfig } from "../../config/loader.js";
+import { listHeartbeatRuns } from "../../heartbeat/heartbeat-run-store.js";
 import { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
-import { getDb } from "../../memory/db-connection.js";
-import { conversations } from "../../memory/schema/conversations.js";
 import { readTextFileSync } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
@@ -32,25 +30,20 @@ function handleListRuns(queryParams: Record<string, string>) {
   const limit = Number.isFinite(rawLimit)
     ? Math.min(Math.max(Math.floor(rawLimit), 1), 100)
     : 20;
-  const db = getDb();
-  const rows = db
-    .select({
-      id: conversations.id,
-      title: conversations.title,
-      createdAt: conversations.createdAt,
-    })
-    .from(conversations)
-    .where(eq(conversations.source, "heartbeat"))
-    .orderBy(desc(conversations.createdAt))
-    .limit(limit)
-    .all();
 
+  const runs = listHeartbeatRuns(limit);
   return {
-    runs: rows.map((r) => ({
+    runs: runs.map((r) => ({
       id: r.id,
-      title: r.title ?? "Heartbeat",
+      scheduledFor: r.scheduledFor,
+      startedAt: r.startedAt,
+      finishedAt: r.finishedAt,
+      durationMs: r.durationMs,
+      status: r.status,
+      skipReason: r.skipReason,
+      error: r.error,
+      conversationId: r.conversationId,
       createdAt: r.createdAt,
-      result: "ok",
     })),
   };
 }
@@ -102,7 +95,22 @@ export const ROUTES: RouteDefinition[] = [
       },
     ],
     responseBody: z.object({
-      runs: z.array(z.unknown()).describe("Heartbeat run records"),
+      runs: z
+        .array(
+          z.object({
+            id: z.string(),
+            scheduledFor: z.number(),
+            startedAt: z.number().nullable(),
+            finishedAt: z.number().nullable(),
+            durationMs: z.number().nullable(),
+            status: z.string(),
+            skipReason: z.string().nullable(),
+            error: z.string().nullable(),
+            conversationId: z.string().nullable(),
+            createdAt: z.number(),
+          }),
+        )
+        .describe("Heartbeat run records"),
     }),
     handler: ({ queryParams }: RouteHandlerArgs) =>
       handleListRuns(queryParams ?? {}),
@@ -135,8 +143,7 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       success: z.boolean(),
     }),
-    handler: ({ body }: RouteHandlerArgs) =>
-      handleWriteChecklist(body ?? {}),
+    handler: ({ body }: RouteHandlerArgs) => handleWriteChecklist(body ?? {}),
   },
   {
     operationId: "getHeartbeatConfig",

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1994,17 +1994,31 @@ public struct HeartbeatRunsListResponse: Codable, Sendable {
 
 public struct HeartbeatRunsListResponseRun: Codable, Sendable {
     public let id: String
-    public let title: String
+    public let scheduledFor: Int
+    public let startedAt: Int?
+    public let finishedAt: Int?
+    public let durationMs: Int?
+    public let status: String
+    public let skipReason: String?
+    public let error: String?
+    public let conversationId: String?
     public let createdAt: Int
-    public let result: String
-    public let summary: String?
 
-    public init(id: String, title: String, createdAt: Int, result: String, summary: String? = nil) {
+    public init(
+        id: String, scheduledFor: Int, startedAt: Int?, finishedAt: Int?,
+        durationMs: Int?, status: String, skipReason: String?,
+        error: String?, conversationId: String?, createdAt: Int
+    ) {
         self.id = id
-        self.title = title
+        self.scheduledFor = scheduledFor
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.durationMs = durationMs
+        self.status = status
+        self.skipReason = skipReason
+        self.error = error
+        self.conversationId = conversationId
         self.createdAt = createdAt
-        self.result = result
-        self.summary = summary
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded result: ok with real data from heartbeat_runs table
- Update HeartbeatRunsListResponse IPC type with new fields
- Update HeartbeatRunsListResponseRun Swift struct (maintained manually)

Part of plan: detect-surface-failed-heartbeats.md (PR 3 of 4)

Closes JARVIS-480
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->