### PR TITLE
feat(heartbeat): add cronExpression and timezone fields to HeartbeatConfigSchema

### DIFF
--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -1,3 +1,4 @@
+import { Cron } from "croner";
 import { z } from "zod";
 
 export const HeartbeatConfigSchema = z
@@ -12,6 +13,20 @@ export const HeartbeatConfigSchema = z
       .positive("heartbeat.intervalMs must be a positive integer")
       .default(6 * 3_600_000)
       .describe("Time between heartbeat checks in milliseconds"),
+    cronExpression: z
+      .string()
+      .nullable()
+      .default(null)
+      .describe(
+        "Cron expression for heartbeat timing. When set, heartbeats fire at the specified clock times instead of using intervalMs.",
+      ),
+    timezone: z
+      .string()
+      .nullable()
+      .default(null)
+      .describe(
+        "Timezone for cron expression evaluation, e.g. 'America/New_York'. Ignored when cronExpression is null.",
+      ),
     activeHoursStart: z
       .number({ error: "heartbeat.activeHoursStart must be a number" })
       .int("heartbeat.activeHoursStart must be an integer")
@@ -79,6 +94,33 @@ export const HeartbeatConfigSchema = z
         path: ["activeHoursEnd"],
         message,
       });
+    }
+
+    // Validate cronExpression (and timezone together) when cronExpression is set
+    if (config.cronExpression != null) {
+      try {
+        new Cron(config.cronExpression, {
+          maxRuns: 0,
+          timezone: config.timezone ?? undefined,
+        });
+      } catch (err) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["cronExpression"],
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } else if (config.timezone != null) {
+      // cronExpression is null but timezone is set — validate timezone independently
+      try {
+        Intl.DateTimeFormat(undefined, { timeZone: config.timezone });
+      } catch (err) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["timezone"],
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   });
 

--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -96,19 +96,40 @@ export const HeartbeatConfigSchema = z
       });
     }
 
-    // Validate cronExpression (and timezone together) when cronExpression is set
+    // Validate cronExpression and timezone when cronExpression is set.
+    // Separate the validations so timezone errors are attributed to the
+    // timezone path — if both paths point at cronExpression, the config
+    // loader's delete-and-retry would strip cronExpression but leave the
+    // invalid timezone, cascading to a full defaults reset.
     if (config.cronExpression != null) {
       try {
-        new Cron(config.cronExpression, {
-          maxRuns: 0,
-          timezone: config.timezone ?? undefined,
-        });
+        new Cron(config.cronExpression, { maxRuns: 0 });
       } catch (err) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["cronExpression"],
           message: err instanceof Error ? err.message : String(err),
         });
+      }
+      if (config.timezone != null) {
+        try {
+          new Cron(config.cronExpression, {
+            maxRuns: 0,
+            timezone: config.timezone,
+          });
+        } catch {
+          // The cron expression itself is valid (or already flagged above),
+          // so a failure here is from the timezone.
+          try {
+            Intl.DateTimeFormat(undefined, { timeZone: config.timezone });
+          } catch (tzErr) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["timezone"],
+              message: tzErr instanceof Error ? tzErr.message : String(tzErr),
+            });
+          }
+        }
       }
     } else if (config.timezone != null) {
       // cronExpression is null but timezone is set — validate timezone independently

--- a/assistant/src/schedule/recurrence-engine.ts
+++ b/assistant/src/schedule/recurrence-engine.ts
@@ -107,7 +107,10 @@ export function validateRruleSetLines(expression: string): string | null {
 export function isValidScheduleExpression(spec: ScheduleSpec): boolean {
   try {
     if (spec.syntax === "cron") {
-      new Cron(spec.expression, { maxRuns: 0 });
+      new Cron(spec.expression, {
+        maxRuns: 0,
+        timezone: spec.timezone ?? undefined,
+      });
       return true;
     }
 

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -257,12 +257,13 @@ export function updateSchedule(
 
   const isOneShot = newExpr == null;
 
-  // Validate if expression or syntax changed (only for recurring schedules)
+  // Validate if expression, syntax, or timezone changed (only for recurring schedules)
   if (
     !isOneShot &&
     (updates.expression !== undefined ||
       updates.cronExpression !== undefined ||
-      updates.syntax !== undefined)
+      updates.syntax !== undefined ||
+      updates.timezone !== undefined)
   ) {
     const spec = {
       syntax: newSyntax,


### PR DESCRIPTION
## Summary
- Add cronExpression and timezone fields to HeartbeatConfigSchema with full validation
- Validate cron expressions and timezones in the schema superRefine
- Fix isValidScheduleExpression to pass timezone for cron validation

Part of plan: heartbeat-cron-scheduling.md (PR 1 of 3)

Closes JARVIS-478
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->