### PR TITLE
feat(heartbeat): surface failures, timeouts, late runs, and missed runs in Home feed

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -1339,5 +1339,168 @@ describe("HeartbeatService", () => {
         jest.useRealTimers();
       }
     });
+
+    test("failure feed event has urgency high and includes error message", async () => {
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("web_search outage");
+        },
+      });
+
+      await service.runOnce();
+
+      const failCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Failed";
+        },
+      );
+      expect(failCalls).toHaveLength(1);
+      const opts = failCalls[0][0] as {
+        urgency?: string;
+        summary?: string;
+      };
+      expect(opts.urgency).toBe("high");
+      expect(opts.summary).toContain("web_search outage");
+    });
+
+    test("CAS false on complete suppresses failure feed event", async () => {
+      mockCompleteHeartbeatRun.mockImplementation(() => false);
+
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("some error");
+        },
+      });
+
+      await service.runOnce();
+
+      const failCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Failed";
+        },
+      );
+      expect(failCalls).toHaveLength(0);
+    });
+
+    test("timeout emits feed event with urgency high", async () => {
+      jest.useFakeTimers();
+      try {
+        let resolveRun: () => void;
+        const runPromise = new Promise<void>((r) => {
+          resolveRun = r;
+        });
+
+        const service = createService({
+          processMessage: async () => {
+            await runPromise;
+            return { messageId: "msg-1" };
+          },
+        });
+
+        const runOncePromise = service.runOnce();
+        jest.advanceTimersByTime(30 * 60 * 1000 + 1000);
+        await runOncePromise;
+
+        const timeoutCalls = mockEmitFeedEvent.mock.calls.filter(
+          (call: unknown[]) => {
+            const opts = call[0] as { title?: string };
+            return opts.title === "Heartbeat Timed Out";
+          },
+        );
+        expect(timeoutCalls).toHaveLength(1);
+        const opts = timeoutCalls[0][0] as {
+          urgency?: string;
+        };
+        expect(opts.urgency).toBe("high");
+
+        resolveRun!();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test("late run emits late feed event", async () => {
+      const service = createService();
+      service.start();
+
+      // Set the pending run to be 10 minutes in the past
+      (service as any)._nextRunAt = Date.now() - 10 * 60 * 1000;
+      (service as any)._pendingRunId = "late-run-id";
+
+      await service.runOnce();
+
+      const lateCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Ran Late";
+        },
+      );
+      expect(lateCalls).toHaveLength(1);
+      const opts = lateCalls[0][0] as {
+        urgency?: string;
+        summary?: string;
+      };
+      expect(opts.urgency).toBe("medium");
+      expect(opts.summary).toContain("10 minutes late");
+
+      await service.stop();
+    });
+
+    test("on-time run does not emit late feed event", async () => {
+      const service = createService();
+      await service.runOnce();
+
+      const lateCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Ran Late";
+        },
+      );
+      expect(lateCalls).toHaveLength(0);
+    });
+
+    test("start() emits missed-run feed event when stale rows exist", () => {
+      mockMarkStaleRunsAsMissed.mockImplementation(() => 2);
+      mockMarkStaleRunningAsError.mockImplementation(() => 1);
+
+      const service = createService();
+      service.start();
+
+      const missedCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Runs Missed";
+        },
+      );
+      expect(missedCalls).toHaveLength(1);
+      const opts = missedCalls[0][0] as {
+        urgency?: string;
+        summary?: string;
+      };
+      expect(opts.urgency).toBe("high");
+      expect(opts.summary).toContain("3");
+
+      service.stop();
+    });
+
+    test("start() does not emit missed-run feed event when counts are 0", () => {
+      mockMarkStaleRunsAsMissed.mockImplementation(() => 0);
+      mockMarkStaleRunningAsError.mockImplementation(() => 0);
+
+      const service = createService();
+      service.start();
+
+      const missedCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Runs Missed";
+        },
+      );
+      expect(missedCalls).toHaveLength(0);
+
+      service.stop();
+    });
   });
 });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -151,6 +151,19 @@ export class HeartbeatService {
         },
         "Recovered stale heartbeat runs on startup",
       );
+
+      const total = this._startupMissedCount + this._startupCrashedCount;
+      const today = new Date().toISOString().split("T")[0];
+      void emitFeedEvent({
+        source: "assistant",
+        title: "Heartbeat Runs Missed",
+        summary: `${total} heartbeat run${total > 1 ? "s were" : " was"} missed while the assistant was offline.`,
+        dedupKey: `heartbeat:missed:${today}`,
+        priority: 55,
+        urgency: "high",
+      }).catch((err) => {
+        log.warn({ err }, "Failed to emit missed heartbeat feed event");
+      });
     }
 
     log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
@@ -306,6 +319,15 @@ export class HeartbeatService {
           error: "Heartbeat execution exceeded the 30-minute timeout",
         });
       }
+      const today = new Date().toISOString().split("T")[0];
+      void emitFeedEvent({
+        source: "assistant",
+        title: "Heartbeat Timed Out",
+        summary: "Heartbeat execution exceeded the 30-minute timeout.",
+        dedupKey: `heartbeat:timeout:${today}`,
+        priority: 55,
+        urgency: "high",
+      }).catch(() => {});
     } finally {
       clearTimeout(timerId);
       this._lastRunAt = Date.now();
@@ -441,13 +463,13 @@ export class HeartbeatService {
     }
   }
 
-  private async executeRun(
-    runId: string,
-    _scheduledFor: number,
-  ): Promise<void> {
+  private async executeRun(runId: string, scheduledFor: number): Promise<void> {
     log.info("Running heartbeat");
 
     startHeartbeatRun(runId);
+
+    const latenessMs = Date.now() - scheduledFor;
+    const LATE_THRESHOLD_MS = 5 * 60 * 1000;
 
     // Credential health check — surface broken credentials proactively
     // before the LLM heartbeat prompt runs. Returns unhealthy provider
@@ -519,6 +541,18 @@ export class HeartbeatService {
             "Failed to emit heartbeat feed event",
           );
         });
+
+        if (latenessMs > LATE_THRESHOLD_MS) {
+          const lateMinutes = Math.round(latenessMs / 60_000);
+          void emitFeedEvent({
+            source: "assistant",
+            title: "Heartbeat Ran Late",
+            summary: `Heartbeat ran ${lateMinutes} minutes late (scheduled for ${new Date(scheduledFor).toLocaleTimeString()}).`,
+            dedupKey: `heartbeat:late:${today}`,
+            priority: 45,
+            urgency: "medium",
+          }).catch(() => {});
+        }
       }
     } catch (err) {
       log.error({ err }, "Heartbeat failed");
@@ -543,11 +577,11 @@ export class HeartbeatService {
         const today = new Date().toISOString().split("T")[0];
         void emitFeedEvent({
           source: "assistant",
-          title: "Heartbeat",
-          summary: "Heartbeat check failed. Check logs for details.",
+          title: "Heartbeat Failed",
+          summary: `Heartbeat check failed: ${(err instanceof Error ? err.message : String(err)).slice(0, 200)}`,
           dedupKey: `heartbeat:fail:${today}`,
           priority: 55,
-          urgency: "medium",
+          urgency: "high",
         }).catch(() => {});
       }
     }


### PR DESCRIPTION
## Summary
- Upgrade failure feed events to urgency high with error details
- Add timeout and late-run feed events
- Emit missed-run feed events on startup when stale rows are recovered

Part of plan: detect-surface-failed-heartbeats.md (PR 4 of 4)

Closes JARVIS-480
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->