### PR TITLE
feat(heartbeat): schedule heartbeats at specific clock times via cron expression

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -9,6 +9,8 @@ let mockConfig = {
   heartbeat: {
     enabled: true,
     intervalMs: 60_000,
+    cronExpression: null as string | null,
+    timezone: null as string | null,
     activeHoursStart: undefined as number | undefined,
     activeHoursEnd: undefined as number | undefined,
   },
@@ -20,6 +22,32 @@ mock.module("../config/loader.js", () => ({
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
   invalidateConfigCache: () => {},
+}));
+
+// ── Recurrence engine mock ──────────────────────────────────────────
+//
+// HeartbeatService imports computeNextRunAt for cron scheduling.
+// Tests mutate `mockComputeNextRunAt` to control the next cron occurrence.
+let mockComputeNextRunAtResult: number | null = null;
+let mockComputeNextRunAtError: Error | null = null;
+let computeNextRunAtCallCount = 0;
+
+mock.module("../schedule/recurrence-engine.js", () => ({
+  computeNextRunAt: (_spec: {
+    syntax: string;
+    expression: string;
+    timezone?: string | null;
+  }) => {
+    computeNextRunAtCallCount++;
+    if (mockComputeNextRunAtError) {
+      throw mockComputeNextRunAtError;
+    }
+    if (mockComputeNextRunAtResult != null) {
+      return mockComputeNextRunAtResult;
+    }
+    // Default: 1 hour from now
+    return Date.now() + 3_600_000;
+  },
 }));
 
 // ── Guardian persona mock ─────────────────────────────────────────
@@ -263,6 +291,9 @@ describe("HeartbeatService", () => {
     mockCheckAllCredentialsFail = false;
     emittedNotificationSignals.length = 0;
     loggerWarnCalls.length = 0;
+    mockComputeNextRunAtResult = null;
+    mockComputeNextRunAtError = null;
+    computeNextRunAtCallCount = 0;
 
     // Default processMessage mock: capture calls for assertions.
     setTestProcessMessage(async (...args: unknown[]) => {
@@ -278,6 +309,8 @@ describe("HeartbeatService", () => {
       heartbeat: {
         enabled: true,
         intervalMs: 60_000,
+        cronExpression: null,
+        timezone: null,
         activeHoursStart: undefined,
         activeHoursEnd: undefined,
       },
@@ -1051,6 +1084,193 @@ describe("HeartbeatService", () => {
       );
       expect(unreachableWarns).toHaveLength(1);
       expect(unreachableWarns[0].unreachableCount).toBe(2);
+    });
+  });
+
+  describe("cron scheduling mode", () => {
+    test("start() with cronExpression sets nextRunAt to cron occurrence, not now+intervalMs", () => {
+      const cronNextRunAt = Date.now() + 7_200_000; // 2 hours from now
+      mockComputeNextRunAtResult = cronNextRunAt;
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+      mockConfig.heartbeat.timezone = "America/New_York";
+
+      const service = createService();
+      service.start();
+
+      expect(service.nextRunAt).toBe(cronNextRunAt);
+      // Should NOT be now + intervalMs
+      expect(service.nextRunAt).not.toBeCloseTo(
+        Date.now() + mockConfig.heartbeat.intervalMs,
+        -3,
+      );
+      service.stop();
+    });
+
+    test("runOnce() does not call scheduleNextRun(intervalMs) in cron mode — nextRunAt is not clobbered", async () => {
+      const cronNextRunAt = Date.now() + 7_200_000;
+      mockComputeNextRunAtResult = cronNextRunAt;
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+
+      const service = createService();
+      service.start();
+
+      // nextRunAt should be the cron time before runOnce
+      expect(service.nextRunAt).toBe(cronNextRunAt);
+
+      await service.runOnce();
+
+      // After runOnce(), nextRunAt should still reflect a cron time, not now + intervalMs.
+      // The finally chain in scheduleNextCronRun recalculates it, but the runOnce()
+      // finally block should NOT have called scheduleNextRun(intervalMs).
+      // Since our mock always returns cronNextRunAt, nextRunAt should remain that value.
+      expect(service.nextRunAt).toBe(cronNextRunAt);
+      service.stop();
+    });
+
+    test("after runOnce() rejects in cron mode, the next cron run is still scheduled via finally", async () => {
+      const cronNextRunAt = Date.now() + 7_200_000;
+      mockComputeNextRunAtResult = cronNextRunAt;
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("LLM down");
+        },
+      });
+      service.start();
+
+      await service.runOnce();
+
+      // Even though executeRun failed, the service should still have a nextRunAt
+      // set to the cron occurrence (the finally chain reschedules)
+      expect(service.nextRunAt).toBe(cronNextRunAt);
+      service.stop();
+    });
+
+    test("resetTimer() in cron mode recomputes from the current time", () => {
+      const firstCronTime = Date.now() + 3_600_000;
+      mockComputeNextRunAtResult = firstCronTime;
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+
+      const service = createService();
+      service.start();
+      expect(service.nextRunAt).toBe(firstCronTime);
+
+      // Simulate time passing and a new cron occurrence
+      const secondCronTime = Date.now() + 5_400_000;
+      mockComputeNextRunAtResult = secondCronTime;
+
+      service.resetTimer();
+      expect(service.nextRunAt).toBe(secondCronTime);
+      service.stop();
+    });
+
+    test("reconfigure() switches from interval to cron mode", () => {
+      const service = createService();
+      // Start in interval mode
+      service.start();
+      const intervalNextRunAt = service.nextRunAt;
+      expect(intervalNextRunAt).not.toBeNull();
+
+      // Reconfigure to cron mode
+      const cronNextRunAt = Date.now() + 7_200_000;
+      mockComputeNextRunAtResult = cronNextRunAt;
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+      service.reconfigure();
+
+      expect(service.nextRunAt).toBe(cronNextRunAt);
+      service.stop();
+    });
+
+    test("reconfigure() switches from cron to interval mode", () => {
+      const cronNextRunAt = Date.now() + 7_200_000;
+      mockComputeNextRunAtResult = cronNextRunAt;
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+
+      const service = createService();
+      service.start();
+      expect(service.nextRunAt).toBe(cronNextRunAt);
+
+      // Reconfigure to interval mode
+      mockConfig.heartbeat.cronExpression = null;
+      const before = Date.now();
+      service.reconfigure();
+
+      expect(service.nextRunAt).not.toBeNull();
+      expect(service.nextRunAt!).toBeGreaterThanOrEqual(
+        before + mockConfig.heartbeat.intervalMs,
+      );
+      service.stop();
+    });
+
+    test("active hours guard uses cron timezone when configured", async () => {
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+      mockConfig.heartbeat.timezone = "UTC";
+      mockConfig.heartbeat.activeHoursStart = 9;
+      mockConfig.heartbeat.activeHoursEnd = 17;
+      mockComputeNextRunAtResult = Date.now() + 3_600_000;
+
+      const service = createService();
+      service.start();
+
+      // In cron mode with timezone, the hour is computed via Intl.DateTimeFormat
+      // rather than getCurrentHour(). The test verifies the code path runs without
+      // error — the actual hour depends on the system clock and UTC conversion.
+      // We just verify it doesn't throw and returns a boolean result.
+      const result = await service.runOnce();
+      // Result depends on current UTC hour vs active window — either outcome is valid
+      expect(typeof result).toBe("boolean");
+      service.stop();
+    });
+
+    test("active hours guard falls back to getCurrentHour when cron mode has no timezone", async () => {
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+      mockConfig.heartbeat.timezone = null;
+      mockConfig.heartbeat.activeHoursStart = 9;
+      mockConfig.heartbeat.activeHoursEnd = 17;
+      mockComputeNextRunAtResult = Date.now() + 3_600_000;
+
+      // getCurrentHour returns 3 (outside 9-17 window), so runOnce should skip
+      const service = createService({ getCurrentHour: () => 3 });
+      service.start();
+      const result = await service.runOnce();
+      expect(result).toBe(false);
+      expect(processMessageCalls).toHaveLength(0);
+      service.stop();
+    });
+
+    test("runtime fallback: computeNextRunAt throws, service falls back to interval mode", () => {
+      mockComputeNextRunAtError = new Error("No upcoming runs");
+      mockConfig.heartbeat.cronExpression = "0 9,12,15,18 * * *";
+
+      const service = createService();
+      service.start();
+
+      // Should have fallen back to interval mode — nextRunAt should be ~now + intervalMs
+      expect(service.nextRunAt).not.toBeNull();
+      const expectedMin = Date.now() + mockConfig.heartbeat.intervalMs - 100;
+      expect(service.nextRunAt!).toBeGreaterThanOrEqual(expectedMin);
+
+      // Should have logged a warning about the fallback
+      const fallbackWarns = loggerWarnCalls.filter((call) => "err" in call);
+      expect(fallbackWarns.length).toBeGreaterThanOrEqual(1);
+      service.stop();
+    });
+
+    test("null cronExpression behaves identically to current fixed-interval mode", () => {
+      mockConfig.heartbeat.cronExpression = null;
+
+      const service = createService();
+      const before = Date.now();
+      service.start();
+
+      expect(service.nextRunAt).not.toBeNull();
+      expect(service.nextRunAt!).toBeGreaterThanOrEqual(
+        before + mockConfig.heartbeat.intervalMs,
+      );
+      // computeNextRunAt should not have been called
+      expect(computeNextRunAtCallCount).toBe(0);
+      service.stop();
     });
   });
 });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -110,6 +110,7 @@ export class HeartbeatService {
   private _lastRunAt: number | null = null;
   private _nextRunAt: number | null = null;
   private cronMode = false;
+  private stopped = false;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -127,6 +128,7 @@ export class HeartbeatService {
   }
 
   start(): void {
+    this.stopped = false;
     const config = getConfig().heartbeat;
     if (!config.enabled) {
       log.info("Heartbeat disabled by config");
@@ -163,6 +165,7 @@ export class HeartbeatService {
   }
 
   private scheduleNextCronRun(config: HeartbeatConfig): void {
+    if (this.stopped) return;
     try {
       const nextRunAt = computeNextRunAt({
         syntax: "cron",
@@ -232,6 +235,7 @@ export class HeartbeatService {
   }
 
   async stop(): Promise<void> {
+    this.stopped = true;
     if (this.timer) {
       clearTimeout(this.timer as ReturnType<typeof setTimeout>);
       clearInterval(this.timer as ReturnType<typeof setInterval>);

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
+import type { HeartbeatConfig } from "../config/schemas/heartbeat.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { processMessage } from "../daemon/process-message.js";
 import { emitFeedEvent } from "../home/emit-feed-event.js";
@@ -13,6 +14,7 @@ import {
   resolveGuardianPersona,
 } from "../prompts/persona-resolver.js";
 import { isTemplateContent } from "../prompts/system-prompt.js";
+import { computeNextRunAt } from "../schedule/recurrence-engine.js";
 import { readTextFileSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
@@ -100,10 +102,14 @@ export class HeartbeatService {
   }
 
   private readonly deps: HeartbeatDeps;
-  private timer: ReturnType<typeof setInterval> | null = null;
+  private timer:
+    | ReturnType<typeof setInterval>
+    | ReturnType<typeof setTimeout>
+    | null = null;
   private activeRun: Promise<void> | null = null;
   private _lastRunAt: number | null = null;
   private _nextRunAt: number | null = null;
+  private cronMode = false;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -129,7 +135,25 @@ export class HeartbeatService {
     }
     if (this.timer) return;
 
-    log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
+    if (config.cronExpression != null) {
+      this.cronMode = true;
+      this.scheduleNextCronRun(config);
+    } else {
+      this.startIntervalMode(config);
+    }
+  }
+
+  private startIntervalMode(config: HeartbeatConfig): void {
+    this.cronMode = false;
+    if (this.timer) {
+      clearTimeout(this.timer as ReturnType<typeof setTimeout>);
+      clearInterval(this.timer as ReturnType<typeof setInterval>);
+      this.timer = null;
+    }
+    log.info(
+      { intervalMs: config.intervalMs },
+      "Heartbeat service started (interval mode)",
+    );
     this.scheduleNextRun(config.intervalMs);
     this.timer = setInterval(() => {
       this.runOnce().catch((err) => {
@@ -138,13 +162,48 @@ export class HeartbeatService {
     }, config.intervalMs);
   }
 
+  private scheduleNextCronRun(config: HeartbeatConfig): void {
+    try {
+      const nextRunAt = computeNextRunAt({
+        syntax: "cron",
+        expression: config.cronExpression!,
+        timezone: config.timezone,
+      });
+      this._nextRunAt = nextRunAt;
+      if (this.timer) {
+        clearTimeout(this.timer as ReturnType<typeof setTimeout>);
+        clearInterval(this.timer as ReturnType<typeof setInterval>);
+        this.timer = null;
+      }
+      const delayMs = Math.max(0, nextRunAt - Date.now());
+      this.timer = setTimeout(() => {
+        this.runOnce()
+          .catch((err) => log.error({ err }, "Cron heartbeat failed"))
+          .finally(() => this.scheduleNextCronRun(getConfig().heartbeat));
+      }, delayMs);
+      (this.timer as ReturnType<typeof setTimeout>).unref();
+      log.info(
+        { nextRunAt: new Date(nextRunAt).toISOString(), delayMs },
+        "Heartbeat cron run scheduled",
+      );
+    } catch (err) {
+      log.warn(
+        { err },
+        "Failed to compute next cron run, falling back to interval mode",
+      );
+      this.startIntervalMode(config);
+    }
+  }
+
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer as ReturnType<typeof setTimeout>);
+      clearInterval(this.timer as ReturnType<typeof setInterval>);
       this.timer = null;
     }
     this._nextRunAt = null;
+    this.cronMode = false;
     this.start();
   }
 
@@ -155,8 +214,15 @@ export class HeartbeatService {
    */
   resetTimer(): void {
     if (!this.timer) return;
+    if (this.cronMode) {
+      clearTimeout(this.timer as ReturnType<typeof setTimeout>);
+      clearInterval(this.timer as ReturnType<typeof setInterval>);
+      this.timer = null;
+      this.scheduleNextCronRun(getConfig().heartbeat);
+      return;
+    }
     const config = getConfig().heartbeat;
-    clearInterval(this.timer);
+    clearInterval(this.timer as ReturnType<typeof setInterval>);
     this.scheduleNextRun(config.intervalMs);
     this.timer = setInterval(() => {
       this.runOnce().catch((err) => {
@@ -167,7 +233,8 @@ export class HeartbeatService {
 
   async stop(): Promise<void> {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer as ReturnType<typeof setTimeout>);
+      clearInterval(this.timer as ReturnType<typeof setInterval>);
       this.timer = null;
     }
     this._nextRunAt = null;
@@ -195,7 +262,17 @@ export class HeartbeatService {
       config.activeHoursStart != null &&
       config.activeHoursEnd != null
     ) {
-      const hour = this.deps.getCurrentHour?.() ?? new Date().getHours();
+      let hour: number;
+      if (this.cronMode && config.timezone) {
+        const parts = new Intl.DateTimeFormat("en-US", {
+          timeZone: config.timezone,
+          hourCycle: "h23",
+          hour: "numeric",
+        }).formatToParts(new Date());
+        hour = Number(parts.find((p) => p.type === "hour")!.value);
+      } else {
+        hour = this.deps.getCurrentHour?.() ?? new Date().getHours();
+      }
       if (
         !isWithinActiveHours(
           hour,
@@ -211,7 +288,9 @@ export class HeartbeatService {
           },
           "Outside active hours, skipping",
         );
-        this.scheduleNextRun(config.intervalMs);
+        if (!this.cronMode) {
+          this.scheduleNextRun(config.intervalMs);
+        }
         return false;
       }
     }
@@ -255,7 +334,9 @@ export class HeartbeatService {
     } finally {
       clearTimeout(timerId);
       this._lastRunAt = Date.now();
-      this.scheduleNextRun(getConfig().heartbeat.intervalMs);
+      if (!this.cronMode) {
+        this.scheduleNextRun(getConfig().heartbeat.intervalMs);
+      }
     }
     return true;
   }


### PR DESCRIPTION
## Summary
- Add cron-based scheduling to HeartbeatService (setTimeout chain instead of setInterval)
- Extract startIntervalMode helper for reliable fallback from cron mode
- Guard runOnce() scheduleNextRun to prevent nextRunAt clobber in cron mode
- Use formatToParts with hourCycle h23 for timezone-aware active-hours check
- Add comprehensive tests for cron mode, fallback, and timezone behavior

Part of plan: heartbeat-cron-scheduling.md (PR 2 of 3)

Closes JARVIS-478
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->