### PR TITLE
feat(heartbeat): detect and surface missed or failed heartbeat runs

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5321,7 +5321,53 @@ paths:
                 properties:
                   runs:
                     type: array
-                    items: {}
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        scheduledFor:
+                          type: number
+                        startedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        finishedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        durationMs:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        status:
+                          type: string
+                        skipReason:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        conversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdAt:
+                          type: number
+                      required:
+                        - id
+                        - scheduledFor
+                        - startedAt
+                        - finishedAt
+                        - durationMs
+                        - status
+                        - skipReason
+                        - error
+                        - conversationId
+                        - createdAt
+                      additionalProperties: false
                     description: Heartbeat run records
                 required:
                   - runs

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -1,8 +1,40 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  mock,
+  test,
+} from "bun:test";
 
 const testWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
+
+// ── Heartbeat run store mock ───────────────────────────────────────
+const mockInsertPendingHeartbeatRun = mock(() => "mock-run-id");
+const mockStartHeartbeatRun = mock(() => true);
+const mockCompleteHeartbeatRun = mock(() => true);
+const mockSkipHeartbeatRun = mock(() => true);
+const mockSupersedePendingRun = mock(() => true);
+const mockMarkStaleRunsAsMissed = mock(() => 0);
+const mockMarkStaleRunningAsError = mock(() => 0);
+mock.module("../heartbeat/heartbeat-run-store.js", () => ({
+  insertPendingHeartbeatRun: mockInsertPendingHeartbeatRun,
+  startHeartbeatRun: mockStartHeartbeatRun,
+  completeHeartbeatRun: mockCompleteHeartbeatRun,
+  skipHeartbeatRun: mockSkipHeartbeatRun,
+  supersedePendingRun: mockSupersedePendingRun,
+  markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
+  markStaleRunningAsError: mockMarkStaleRunningAsError,
+}));
+
+// ── Feed event mock ───────────────────────────────────────────────
+const mockEmitFeedEvent = mock(() => Promise.resolve());
+mock.module("../home/emit-feed-event.js", () => ({
+  emitFeedEvent: mockEmitFeedEvent,
+}));
 
 // Mock config loader
 let mockConfig = {
@@ -273,6 +305,15 @@ describe("HeartbeatService", () => {
       });
       return { messageId: "msg-1" };
     });
+
+    mockInsertPendingHeartbeatRun.mockClear();
+    mockStartHeartbeatRun.mockClear();
+    mockCompleteHeartbeatRun.mockClear();
+    mockSkipHeartbeatRun.mockClear();
+    mockSupersedePendingRun.mockClear();
+    mockMarkStaleRunsAsMissed.mockClear();
+    mockMarkStaleRunningAsError.mockClear();
+    mockEmitFeedEvent.mockClear();
 
     mockConfig = {
       heartbeat: {
@@ -1051,6 +1092,252 @@ describe("HeartbeatService", () => {
       );
       expect(unreachableWarns).toHaveLength(1);
       expect(unreachableWarns[0].unreachableCount).toBe(2);
+    });
+  });
+
+  describe("heartbeat run store instrumentation", () => {
+    test("successful run: pending → running → ok with conversationId", async () => {
+      const service = createService();
+      await service.runOnce();
+
+      expect(mockStartHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledWith("mock-run-id", {
+        status: "ok",
+        conversationId: "conv-1",
+      });
+    });
+
+    test("failed run: pending → running → error preserving conversationId", async () => {
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("LLM timeout");
+        },
+      });
+
+      await service.runOnce();
+
+      expect(mockStartHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledTimes(1);
+      expect(mockCompleteHeartbeatRun).toHaveBeenCalledWith("mock-run-id", {
+        status: "error",
+        conversationId: "conv-1",
+        error: "LLM timeout",
+      });
+    });
+
+    test("CAS false suppresses success feed event", async () => {
+      mockCompleteHeartbeatRun.mockImplementation(() => false);
+
+      const service = createService();
+      await service.runOnce();
+
+      // completeHeartbeatRun returned false, so no feed event should be emitted for success
+      const successCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { dedupKey?: string };
+          return opts.dedupKey?.startsWith("heartbeat:ok:");
+        },
+      );
+      expect(successCalls).toHaveLength(0);
+    });
+
+    test("CAS false suppresses failure alerter and feed event", async () => {
+      mockCompleteHeartbeatRun.mockImplementation(() => false);
+
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("LLM timeout");
+        },
+      });
+
+      await service.runOnce();
+
+      // completeHeartbeatRun returned false, so alerter should NOT be called
+      expect(alerterCalls).toHaveLength(0);
+
+      // No failure feed event either
+      const failCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { dedupKey?: string };
+          return opts.dedupKey?.startsWith("heartbeat:fail:");
+        },
+      );
+      expect(failCalls).toHaveLength(0);
+    });
+
+    test("active-hours skip calls skipHeartbeatRun", async () => {
+      mockConfig.heartbeat.activeHoursStart = 9;
+      mockConfig.heartbeat.activeHoursEnd = 17;
+
+      const service = createService({ getCurrentHour: () => 3 });
+      service.start();
+      await service.runOnce();
+
+      expect(mockSkipHeartbeatRun).toHaveBeenCalledWith(
+        "mock-run-id",
+        "outside_active_hours",
+      );
+      service.stop();
+    });
+
+    test("overlap skip calls skipHeartbeatRun", async () => {
+      let resolveFirst: () => void;
+      const firstPromise = new Promise<void>((r) => {
+        resolveFirst = r;
+      });
+
+      const service = createService({
+        processMessage: async () => {
+          await firstPromise;
+          return { messageId: "msg-1" };
+        },
+      });
+
+      // Start first run (will block)
+      const run1 = service.runOnce();
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Start service so the second runOnce has a pending row
+      service.start();
+      mockSkipHeartbeatRun.mockClear();
+
+      // Second run should be skipped due to overlap
+      await service.runOnce();
+
+      expect(mockSkipHeartbeatRun).toHaveBeenCalledWith(
+        "mock-run-id",
+        "overlap",
+      );
+
+      resolveFirst!();
+      await run1;
+      service.stop();
+    });
+
+    test("start() calls markStaleRunsAsMissed and markStaleRunningAsError", () => {
+      const service = createService();
+      service.start();
+
+      expect(mockMarkStaleRunsAsMissed).toHaveBeenCalledTimes(1);
+      expect(mockMarkStaleRunningAsError).toHaveBeenCalledTimes(1);
+      service.stop();
+    });
+
+    test("scheduleNextRun supersedes old pending row before creating new one", async () => {
+      const service = createService();
+
+      // First runOnce: scheduleNextRun is called in the finally block, creating a pending row
+      await service.runOnce();
+      const callOrder: string[] = [];
+      mockSupersedePendingRun.mockImplementation(() => {
+        callOrder.push("supersede");
+        return true;
+      });
+      mockInsertPendingHeartbeatRun.mockImplementation(() => {
+        callOrder.push("insert");
+        return "mock-run-id";
+      });
+
+      // Second runOnce: scheduleNextRun should supersede the old pending row first
+      await service.runOnce();
+
+      // The finally block's scheduleNextRun should supersede then insert
+      expect(callOrder.filter((c) => c === "supersede").length).toBeGreaterThan(
+        0,
+      );
+      const firstSupersede = callOrder.indexOf("supersede");
+      const firstInsert = callOrder.indexOf("insert");
+      expect(firstSupersede).toBeLessThan(firstInsert);
+    });
+
+    test("resetTimer() supersedes pending row", () => {
+      const service = createService();
+      service.start();
+
+      mockSupersedePendingRun.mockClear();
+      service.resetTimer();
+
+      // resetTimer calls scheduleNextRun which supersedes existing pending
+      expect(mockSupersedePendingRun).toHaveBeenCalled();
+      service.stop();
+    });
+
+    test("force run creates its own pending row, does not consume scheduled one", async () => {
+      const service = createService();
+      service.start();
+
+      // Clear to track only the force run's calls
+      mockInsertPendingHeartbeatRun.mockClear();
+
+      await service.runOnce({ force: true });
+
+      // Force run should have called insertPendingHeartbeatRun for itself
+      // (at least once for its own row, plus the scheduleNextRun in finally)
+      expect(mockInsertPendingHeartbeatRun).toHaveBeenCalled();
+
+      // The scheduled pending row (from start()) should NOT have been consumed
+      // by the force run — force creates its own
+      service.stop();
+    });
+
+    test("disabled config with stale pending row skips it as disabled", async () => {
+      const service = createService();
+      service.start();
+
+      // Now disable config and call runOnce — should skip the pending row
+      mockConfig.heartbeat.enabled = false;
+      mockSkipHeartbeatRun.mockClear();
+
+      await service.runOnce();
+
+      expect(mockSkipHeartbeatRun).toHaveBeenCalledWith(
+        "mock-run-id",
+        "disabled",
+      );
+      service.stop();
+    });
+
+    test("stop() supersedes outstanding pending row", async () => {
+      const service = createService();
+      service.start();
+
+      mockSupersedePendingRun.mockClear();
+      await service.stop();
+
+      expect(mockSupersedePendingRun).toHaveBeenCalledWith("mock-run-id");
+    });
+
+    test("timeout calls completeHeartbeatRun with status timeout", async () => {
+      jest.useFakeTimers();
+      try {
+        let resolveRun: () => void;
+        const runPromise = new Promise<void>((r) => {
+          resolveRun = r;
+        });
+
+        const service = createService({
+          processMessage: async () => {
+            await runPromise;
+            return { messageId: "msg-1" };
+          },
+        });
+
+        const runOncePromise = service.runOnce();
+        // Advance past the 30-minute timeout
+        jest.advanceTimersByTime(30 * 60 * 1000 + 1000);
+        await runOncePromise;
+
+        expect(mockCompleteHeartbeatRun).toHaveBeenCalledWith("mock-run-id", {
+          status: "timeout",
+          error: "Heartbeat execution exceeded the 30-minute timeout",
+        });
+
+        // Clean up — resolve the hanging promise so it doesn't leak
+        resolveRun!();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -1339,5 +1339,168 @@ describe("HeartbeatService", () => {
         jest.useRealTimers();
       }
     });
+
+    test("failure feed event has urgency high and includes error message", async () => {
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("web_search outage");
+        },
+      });
+
+      await service.runOnce();
+
+      const failCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Failed";
+        },
+      );
+      expect(failCalls).toHaveLength(1);
+      const opts = failCalls[0][0] as {
+        urgency?: string;
+        summary?: string;
+      };
+      expect(opts.urgency).toBe("high");
+      expect(opts.summary).toContain("web_search outage");
+    });
+
+    test("CAS false on complete suppresses failure feed event", async () => {
+      mockCompleteHeartbeatRun.mockImplementation(() => false);
+
+      const service = createService({
+        processMessage: async () => {
+          throw new Error("some error");
+        },
+      });
+
+      await service.runOnce();
+
+      const failCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Failed";
+        },
+      );
+      expect(failCalls).toHaveLength(0);
+    });
+
+    test("timeout emits feed event with urgency high", async () => {
+      jest.useFakeTimers();
+      try {
+        let resolveRun: () => void;
+        const runPromise = new Promise<void>((r) => {
+          resolveRun = r;
+        });
+
+        const service = createService({
+          processMessage: async () => {
+            await runPromise;
+            return { messageId: "msg-1" };
+          },
+        });
+
+        const runOncePromise = service.runOnce();
+        jest.advanceTimersByTime(30 * 60 * 1000 + 1000);
+        await runOncePromise;
+
+        const timeoutCalls = mockEmitFeedEvent.mock.calls.filter(
+          (call: unknown[]) => {
+            const opts = call[0] as { title?: string };
+            return opts.title === "Heartbeat Timed Out";
+          },
+        );
+        expect(timeoutCalls).toHaveLength(1);
+        const opts = timeoutCalls[0][0] as {
+          urgency?: string;
+        };
+        expect(opts.urgency).toBe("high");
+
+        resolveRun!();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test("late run emits late feed event", async () => {
+      const service = createService();
+      service.start();
+
+      // Set the pending run to be 10 minutes in the past
+      (service as any)._nextRunAt = Date.now() - 10 * 60 * 1000;
+      (service as any)._pendingRunId = "late-run-id";
+
+      await service.runOnce();
+
+      const lateCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Ran Late";
+        },
+      );
+      expect(lateCalls).toHaveLength(1);
+      const opts = lateCalls[0][0] as {
+        urgency?: string;
+        summary?: string;
+      };
+      expect(opts.urgency).toBe("medium");
+      expect(opts.summary).toContain("10 minutes late");
+
+      await service.stop();
+    });
+
+    test("on-time run does not emit late feed event", async () => {
+      const service = createService();
+      await service.runOnce();
+
+      const lateCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Ran Late";
+        },
+      );
+      expect(lateCalls).toHaveLength(0);
+    });
+
+    test("start() emits missed-run feed event when stale rows exist", () => {
+      mockMarkStaleRunsAsMissed.mockImplementation(() => 2);
+      mockMarkStaleRunningAsError.mockImplementation(() => 1);
+
+      const service = createService();
+      service.start();
+
+      const missedCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Runs Missed";
+        },
+      );
+      expect(missedCalls).toHaveLength(1);
+      const opts = missedCalls[0][0] as {
+        urgency?: string;
+        summary?: string;
+      };
+      expect(opts.urgency).toBe("high");
+      expect(opts.summary).toContain("3");
+
+      service.stop();
+    });
+
+    test("start() does not emit missed-run feed event when counts are 0", () => {
+      mockMarkStaleRunsAsMissed.mockImplementation(() => 0);
+      mockMarkStaleRunningAsError.mockImplementation(() => 0);
+
+      const service = createService();
+      service.start();
+
+      const missedCalls = mockEmitFeedEvent.mock.calls.filter(
+        (call: unknown[]) => {
+          const opts = call[0] as { title?: string };
+          return opts.title === "Heartbeat Runs Missed";
+        },
+      );
+      expect(missedCalls).toHaveLength(0);
+
+      service.stop();
+    });
   });
 });

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -307,13 +307,21 @@ describe("HeartbeatService", () => {
     });
 
     mockInsertPendingHeartbeatRun.mockClear();
+    mockInsertPendingHeartbeatRun.mockImplementation(() => "mock-run-id");
     mockStartHeartbeatRun.mockClear();
+    mockStartHeartbeatRun.mockImplementation(() => true);
     mockCompleteHeartbeatRun.mockClear();
+    mockCompleteHeartbeatRun.mockImplementation(() => true);
     mockSkipHeartbeatRun.mockClear();
+    mockSkipHeartbeatRun.mockImplementation(() => true);
     mockSupersedePendingRun.mockClear();
+    mockSupersedePendingRun.mockImplementation(() => true);
     mockMarkStaleRunsAsMissed.mockClear();
+    mockMarkStaleRunsAsMissed.mockImplementation(() => 0);
     mockMarkStaleRunningAsError.mockClear();
+    mockMarkStaleRunningAsError.mockImplementation(() => 0);
     mockEmitFeedEvent.mockClear();
+    mockEmitFeedEvent.mockImplementation(() => Promise.resolve());
 
     mockConfig = {
       heartbeat: {
@@ -1224,11 +1232,14 @@ describe("HeartbeatService", () => {
       service.stop();
     });
 
-    test("scheduleNextRun supersedes old pending row before creating new one", async () => {
+    test("scheduleNextRun supersedes old pending row before creating new one", () => {
       const service = createService();
+      service.start();
 
-      // First runOnce: scheduleNextRun is called in the finally block, creating a pending row
-      await service.runOnce();
+      // start() called scheduleNextRun which set _pendingRunId.
+      // Calling resetTimer triggers another scheduleNextRun which
+      // should supersede the existing pending row before inserting
+      // a new one.
       const callOrder: string[] = [];
       mockSupersedePendingRun.mockImplementation(() => {
         callOrder.push("supersede");
@@ -1239,16 +1250,17 @@ describe("HeartbeatService", () => {
         return "mock-run-id";
       });
 
-      // Second runOnce: scheduleNextRun should supersede the old pending row first
-      await service.runOnce();
+      service.resetTimer();
 
-      // The finally block's scheduleNextRun should supersede then insert
+      // resetTimer's scheduleNextRun should supersede then insert
       expect(callOrder.filter((c) => c === "supersede").length).toBeGreaterThan(
         0,
       );
       const firstSupersede = callOrder.indexOf("supersede");
       const firstInsert = callOrder.indexOf("insert");
       expect(firstSupersede).toBeLessThan(firstInsert);
+
+      service.stop();
     });
 
     test("resetTimer() supersedes pending row", () => {
@@ -1356,7 +1368,7 @@ describe("HeartbeatService", () => {
         },
       );
       expect(failCalls).toHaveLength(1);
-      const opts = failCalls[0][0] as {
+      const opts = (failCalls as any[][])[0][0] as {
         urgency?: string;
         summary?: string;
       };
@@ -1410,7 +1422,7 @@ describe("HeartbeatService", () => {
           },
         );
         expect(timeoutCalls).toHaveLength(1);
-        const opts = timeoutCalls[0][0] as {
+        const opts = (timeoutCalls as any[][])[0][0] as {
           urgency?: string;
         };
         expect(opts.urgency).toBe("high");
@@ -1474,7 +1486,7 @@ describe("HeartbeatService", () => {
         },
       );
       expect(lateCalls).toHaveLength(1);
-      const opts = lateCalls[0][0] as {
+      const opts = (lateCalls as any[][])[0][0] as {
         urgency?: string;
         summary?: string;
       };
@@ -1511,7 +1523,7 @@ describe("HeartbeatService", () => {
         },
       );
       expect(missedCalls).toHaveLength(1);
-      const opts = missedCalls[0][0] as {
+      const opts = (missedCalls as any[][])[0][0] as {
         urgency?: string;
         summary?: string;
       };

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -1421,6 +1421,42 @@ describe("HeartbeatService", () => {
       }
     });
 
+    test("CAS false on timeout suppresses timeout feed event", async () => {
+      jest.useFakeTimers();
+      try {
+        mockCompleteHeartbeatRun.mockImplementation(() => false);
+
+        let resolveRun: () => void;
+        const runPromise = new Promise<void>((r) => {
+          resolveRun = r;
+        });
+
+        const service = createService({
+          processMessage: async () => {
+            await runPromise;
+            return { messageId: "msg-1" };
+          },
+        });
+
+        const runOncePromise = service.runOnce();
+        jest.advanceTimersByTime(30 * 60 * 1000 + 1000);
+        await runOncePromise;
+
+        // completeHeartbeatRun returned false, so no timeout feed event
+        const timeoutCalls = mockEmitFeedEvent.mock.calls.filter(
+          (call: unknown[]) => {
+            const opts = call[0] as { title?: string };
+            return opts.title === "Heartbeat Timed Out";
+          },
+        );
+        expect(timeoutCalls).toHaveLength(0);
+
+        resolveRun!();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     test("late run emits late feed event", async () => {
       const service = createService();
       service.start();

--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -118,10 +118,15 @@ export interface HeartbeatRunsListResponse {
   type: "heartbeat_runs_list_response";
   runs: Array<{
     id: string;
-    title: string;
+    scheduledFor: number;
+    startedAt: number | null;
+    finishedAt: number | null;
+    durationMs: number | null;
+    status: string;
+    skipReason: string | null;
+    error: string | null;
+    conversationId: string | null;
     createdAt: number;
-    result: string;
-    summary?: string;
   }>;
 }
 

--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -5,6 +5,18 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let workspaceDir: string;
 
+// Stub the heartbeat run store so HeartbeatService doesn't hit the real DB.
+mock.module("../heartbeat-run-store.js", () => ({
+  insertPendingHeartbeatRun: () => "mock-run-id",
+  startHeartbeatRun: () => true,
+  completeHeartbeatRun: () => true,
+  skipHeartbeatRun: () => true,
+  supersedePendingRun: () => true,
+  markStaleRunsAsMissed: () => 0,
+  markStaleRunningAsError: () => 0,
+  listHeartbeatRuns: () => [],
+}));
+
 // Stub the in-process SSE hub so the writer's publish path is a
 // no-op in these tests.
 const publishSpy = mock<(event: unknown) => Promise<void>>(async () => {});
@@ -200,13 +212,11 @@ describe("heartbeat feed events", () => {
     await new Promise((r) => setTimeout(r, 100));
 
     const items = readFeedItems();
-    const heartbeatItem = items.find((i) => i.title === "Heartbeat");
+    const heartbeatItem = items.find((i) => i.title === "Heartbeat Failed");
     expect(heartbeatItem).toBeDefined();
-    expect(heartbeatItem!.summary).toBe(
-      "Heartbeat check failed. Check logs for details.",
-    );
+    expect(heartbeatItem!.summary).toContain("LLM call failed");
     expect(heartbeatItem!.priority).toBe(55);
-    expect(heartbeatItem!.urgency).toBe("medium");
+    expect(heartbeatItem!.urgency).toBe("high");
     expect(heartbeatItem!.source).toBe("assistant");
   });
 

--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mock } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (value: string) => value,
+}));
+
+import { sql } from "drizzle-orm";
+
+import { getDb } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import {
+  completeHeartbeatRun,
+  insertPendingHeartbeatRun,
+  listHeartbeatRuns,
+  markStaleRunningAsError,
+  markStaleRunsAsMissed,
+  skipHeartbeatRun,
+  startHeartbeatRun,
+  supersedePendingRun,
+} from "../heartbeat-run-store.js";
+
+initializeDb();
+
+describe("heartbeat-run-store", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM heartbeat_runs");
+  });
+
+  test("insertPendingHeartbeatRun creates row with status pending and null timing", () => {
+    const scheduledFor = Date.now();
+    const id = insertPendingHeartbeatRun(scheduledFor);
+    expect(id).toBeTruthy();
+
+    const rows = listHeartbeatRuns();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(id);
+    expect(rows[0].status).toBe("pending");
+    expect(rows[0].scheduledFor).toBe(scheduledFor);
+    expect(rows[0].startedAt).toBeNull();
+    expect(rows[0].finishedAt).toBeNull();
+    expect(rows[0].durationMs).toBeNull();
+    expect(rows[0].error).toBeNull();
+    expect(rows[0].conversationId).toBeNull();
+    expect(rows[0].skipReason).toBeNull();
+  });
+
+  test("startHeartbeatRun transitions pending -> running and sets startedAt", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    const ok = startHeartbeatRun(id);
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("running");
+    expect(rows[0].startedAt).toBeGreaterThan(0);
+  });
+
+  test("startHeartbeatRun returns false for non-pending row", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+
+    // Start once — succeeds
+    expect(startHeartbeatRun(id)).toBe(true);
+    // Start again — fails (already running)
+    expect(startHeartbeatRun(id)).toBe(false);
+
+    // Also: superseded row cannot be started
+    const id2 = insertPendingHeartbeatRun(Date.now());
+    supersedePendingRun(id2);
+    expect(startHeartbeatRun(id2)).toBe(false);
+  });
+
+  test("completeHeartbeatRun transitions running -> ok with conversationId", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    const ok = completeHeartbeatRun(id, {
+      status: "ok",
+      conversationId: "conv-123",
+    });
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("ok");
+    expect(rows[0].conversationId).toBe("conv-123");
+    expect(rows[0].finishedAt).toBeGreaterThan(0);
+    expect(rows[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("completeHeartbeatRun transitions running -> error with truncated error", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+
+    // 3KB string — should be truncated to 2000 chars
+    const longError = "x".repeat(3000);
+    const ok = completeHeartbeatRun(id, {
+      status: "error",
+      error: longError,
+    });
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("error");
+    expect(rows[0].error).toHaveLength(2000);
+  });
+
+  test("completeHeartbeatRun returns false when status is not running (CAS)", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    // Complete with timeout
+    completeHeartbeatRun(id, { status: "timeout" });
+    // Try to complete again with ok — should fail (already timeout)
+    const ok = completeHeartbeatRun(id, { status: "ok" });
+    expect(ok).toBe(false);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("timeout");
+  });
+
+  test("skipHeartbeatRun transitions pending -> skipped with reason", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    const ok = skipHeartbeatRun(id, "outside_active_hours");
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("skipped");
+    expect(rows[0].skipReason).toBe("outside_active_hours");
+  });
+
+  test("skipHeartbeatRun returns false for non-pending row", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    const ok = skipHeartbeatRun(id, "disabled");
+    expect(ok).toBe(false);
+  });
+
+  test("supersedePendingRun transitions pending -> superseded", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    const ok = supersedePendingRun(id);
+    expect(ok).toBe(true);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("superseded");
+  });
+
+  test("supersedePendingRun returns false for non-pending row", () => {
+    const id = insertPendingHeartbeatRun(Date.now());
+    startHeartbeatRun(id);
+    const ok = supersedePendingRun(id);
+    expect(ok).toBe(false);
+  });
+
+  test("markStaleRunsAsMissed transitions old pending rows to missed", () => {
+    const now = Date.now();
+    // Two old pending rows
+    const id1 = insertPendingHeartbeatRun(now - 10 * 60 * 1000);
+    const id2 = insertPendingHeartbeatRun(now - 8 * 60 * 1000);
+    // One recent pending row
+    const id3 = insertPendingHeartbeatRun(now);
+
+    const count = markStaleRunsAsMissed(5 * 60 * 1000);
+    expect(count).toBe(2);
+
+    const rows = listHeartbeatRuns();
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+    expect(byId[id1].status).toBe("missed");
+    expect(byId[id2].status).toBe("missed");
+    expect(byId[id3].status).toBe("pending");
+  });
+
+  test("markStaleRunningAsError transitions old running rows to error", () => {
+    const now = Date.now();
+    const id = insertPendingHeartbeatRun(now - 60 * 60 * 1000);
+    startHeartbeatRun(id);
+
+    // Backdate started_at to simulate a long-running process
+    const db = getDb();
+    const backdatedStartedAt = now - 60 * 60 * 1000;
+    db.run(
+      sql`UPDATE heartbeat_runs SET started_at = ${backdatedStartedAt} WHERE id = ${id}`,
+    );
+
+    const count = markStaleRunningAsError(45 * 60 * 1000);
+    expect(count).toBe(1);
+
+    const rows = listHeartbeatRuns();
+    expect(rows[0].status).toBe("error");
+    expect(rows[0].error).toBe("Process crashed or restarted during execution");
+  });
+
+  test("listHeartbeatRuns returns rows ordered by scheduledFor desc", () => {
+    const now = Date.now();
+    insertPendingHeartbeatRun(now - 2000);
+    insertPendingHeartbeatRun(now);
+    insertPendingHeartbeatRun(now - 1000);
+
+    const rows = listHeartbeatRuns();
+    expect(rows).toHaveLength(3);
+    expect(rows[0].scheduledFor).toBe(now);
+    expect(rows[1].scheduledFor).toBe(now - 1000);
+    expect(rows[2].scheduledFor).toBe(now - 2000);
+  });
+
+  test("listHeartbeatRuns respects limit", () => {
+    const now = Date.now();
+    for (let i = 0; i < 5; i++) {
+      insertPendingHeartbeatRun(now + i);
+    }
+
+    const rows = listHeartbeatRuns(3);
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -1,0 +1,236 @@
+import { desc, eq, sql } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "../memory/db-connection.js";
+import { rawChanges } from "../memory/raw-query.js";
+import { heartbeatRuns } from "../memory/schema.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type HeartbeatRunStatus =
+  | "pending"
+  | "running"
+  | "ok"
+  | "error"
+  | "timeout"
+  | "skipped"
+  | "missed"
+  | "superseded";
+
+export type HeartbeatSkipReason =
+  | "disabled"
+  | "outside_active_hours"
+  | "overlap";
+
+export interface HeartbeatRunRecord {
+  id: string;
+  scheduledFor: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+  durationMs: number | null;
+  status: HeartbeatRunStatus;
+  skipReason: string | null;
+  error: string | null;
+  conversationId: string | null;
+  createdAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Threshold for marking stale running rows as error (45 minutes). */
+const STALE_RUNNING_THRESHOLD_MS = 45 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Store functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a new heartbeat run in `pending` status.
+ * Returns the generated run id.
+ */
+export function insertPendingHeartbeatRun(scheduledFor: number): string {
+  const db = getDb();
+  const id = uuid();
+  const now = Date.now();
+  db.insert(heartbeatRuns)
+    .values({
+      id,
+      scheduledFor,
+      startedAt: null,
+      finishedAt: null,
+      durationMs: null,
+      status: "pending",
+      skipReason: null,
+      error: null,
+      conversationId: null,
+      createdAt: now,
+    })
+    .run();
+  return id;
+}
+
+/**
+ * CAS transition from `pending` to `running`. Sets `startedAt` to now.
+ * Returns `true` if the transition succeeded.
+ */
+export function startHeartbeatRun(runId: string): boolean {
+  const db = getDb();
+  const now = Date.now();
+  db.update(heartbeatRuns)
+    .set({ status: "running", startedAt: now })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'pending'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * CAS transition from `running` to a terminal status (`ok`, `error`, or `timeout`).
+ * Computes `durationMs` from the row's `startedAt`. Error text is capped at 2 KB.
+ * Returns `true` if the transition succeeded.
+ */
+export function completeHeartbeatRun(
+  runId: string,
+  result: {
+    status: "ok" | "error" | "timeout";
+    conversationId?: string;
+    error?: string;
+  },
+): boolean {
+  const db = getDb();
+  const now = Date.now();
+
+  // Read the row to get startedAt for durationMs computation.
+  const row = db
+    .select({ startedAt: heartbeatRuns.startedAt })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .get();
+  if (!row) return false;
+
+  const durationMs = row.startedAt != null ? now - row.startedAt : null;
+
+  db.update(heartbeatRuns)
+    .set({
+      status: result.status,
+      finishedAt: now,
+      durationMs,
+      error: result.error?.slice(0, 2000) ?? null,
+      conversationId: result.conversationId ?? null,
+    })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'running'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * CAS transition from `pending` to `skipped` with the given reason.
+ * Returns `true` if the transition succeeded.
+ */
+export function skipHeartbeatRun(
+  runId: string,
+  skipReason: HeartbeatSkipReason,
+): boolean {
+  const db = getDb();
+  db.update(heartbeatRuns)
+    .set({ status: "skipped", skipReason })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'pending'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * CAS transition from `pending` to `superseded`.
+ * Returns `true` if the transition succeeded.
+ */
+export function supersedePendingRun(runId: string): boolean {
+  const db = getDb();
+  db.update(heartbeatRuns)
+    .set({ status: "superseded" })
+    .where(
+      sql`${heartbeatRuns.id} = ${runId} AND ${heartbeatRuns.status} = 'pending'`,
+    )
+    .run();
+  return rawChanges() > 0;
+}
+
+/**
+ * Mark all `pending` rows older than the threshold as `missed`.
+ * Handles the crash-before-run scenario. Returns the number of rows affected.
+ */
+export function markStaleRunsAsMissed(
+  thresholdMs: number = 5 * 60 * 1000,
+): number {
+  const db = getDb();
+  const cutoff = Date.now() - thresholdMs;
+  db.update(heartbeatRuns)
+    .set({ status: "missed" })
+    .where(
+      sql`${heartbeatRuns.status} = 'pending' AND ${heartbeatRuns.scheduledFor} < ${cutoff}`,
+    )
+    .run();
+  return rawChanges();
+}
+
+/**
+ * Mark all `running` rows older than the threshold as `error`.
+ * Handles the crash-during-run scenario. Returns the number of rows affected.
+ */
+export function markStaleRunningAsError(
+  thresholdMs: number = STALE_RUNNING_THRESHOLD_MS,
+): number {
+  const db = getDb();
+  const cutoff = Date.now() - thresholdMs;
+  db.update(heartbeatRuns)
+    .set({
+      status: "error",
+      error: "Process crashed or restarted during execution",
+    })
+    .where(
+      sql`${heartbeatRuns.status} = 'running' AND ${heartbeatRuns.startedAt} < ${cutoff}`,
+    )
+    .run();
+  return rawChanges();
+}
+
+/**
+ * List heartbeat runs ordered by `scheduledFor` descending.
+ */
+export function listHeartbeatRuns(limit = 20): HeartbeatRunRecord[] {
+  const db = getDb();
+  const rows = db
+    .select()
+    .from(heartbeatRuns)
+    .orderBy(desc(heartbeatRuns.scheduledFor))
+    .limit(limit)
+    .all();
+  return rows.map(parseRow);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function parseRow(row: typeof heartbeatRuns.$inferSelect): HeartbeatRunRecord {
+  return {
+    id: row.id,
+    scheduledFor: row.scheduledFor,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
+    durationMs: row.durationMs,
+    status: row.status as HeartbeatRunStatus,
+    skipReason: row.skipReason,
+    error: row.error,
+    conversationId: row.conversationId,
+    createdAt: row.createdAt,
+  };
+}

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -116,6 +116,7 @@ export class HeartbeatService {
   private _pendingRunId: string | null = null;
   private _startupMissedCount = 0;
   private _startupCrashedCount = 0;
+  private _hasRunStartupRecovery = false;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -141,29 +142,36 @@ export class HeartbeatService {
     }
     if (this.timer) return;
 
-    this._startupMissedCount = markStaleRunsAsMissed();
-    this._startupCrashedCount = markStaleRunningAsError();
-    if (this._startupMissedCount > 0 || this._startupCrashedCount > 0) {
-      log.info(
-        {
-          missedCount: this._startupMissedCount,
-          crashedCount: this._startupCrashedCount,
-        },
-        "Recovered stale heartbeat runs on startup",
-      );
+    if (!this._hasRunStartupRecovery) {
+      this._hasRunStartupRecovery = true;
+      try {
+        this._startupMissedCount = markStaleRunsAsMissed();
+        this._startupCrashedCount = markStaleRunningAsError();
+      } catch (err) {
+        log.error({ err }, "Failed to recover stale heartbeat runs on startup");
+      }
+      if (this._startupMissedCount > 0 || this._startupCrashedCount > 0) {
+        log.info(
+          {
+            missedCount: this._startupMissedCount,
+            crashedCount: this._startupCrashedCount,
+          },
+          "Recovered stale heartbeat runs on startup",
+        );
 
-      const total = this._startupMissedCount + this._startupCrashedCount;
-      const today = new Date().toISOString().split("T")[0];
-      void emitFeedEvent({
-        source: "assistant",
-        title: "Heartbeat Runs Missed",
-        summary: `${total} heartbeat run${total > 1 ? "s were" : " was"} missed while the assistant was offline.`,
-        dedupKey: `heartbeat:missed:${today}`,
-        priority: 55,
-        urgency: "high",
-      }).catch((err) => {
-        log.warn({ err }, "Failed to emit missed heartbeat feed event");
-      });
+        const total = this._startupMissedCount + this._startupCrashedCount;
+        const today = new Date().toISOString().split("T")[0];
+        void emitFeedEvent({
+          source: "assistant",
+          title: "Heartbeat Runs Missed",
+          summary: `${total} heartbeat run${total > 1 ? "s were" : " was"} missed while the assistant was offline.`,
+          dedupKey: `heartbeat:missed:${today}`,
+          priority: 55,
+          urgency: "high",
+        }).catch((err) => {
+          log.warn({ err }, "Failed to emit missed heartbeat feed event");
+        });
+      }
     }
 
     log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
@@ -177,6 +185,10 @@ export class HeartbeatService {
 
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
+    if (this._pendingRunId) {
+      supersedePendingRun(this._pendingRunId);
+      this._pendingRunId = null;
+    }
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -313,21 +313,23 @@ export class HeartbeatService {
       // Release activeRun so the overlap guard doesn't permanently block
       // future heartbeat runs when executeRun hangs past the timeout.
       this.activeRun = null;
-      if (runId) {
-        completeHeartbeatRun(runId, {
-          status: "timeout",
-          error: "Heartbeat execution exceeded the 30-minute timeout",
-        });
+      const transitioned = runId
+        ? completeHeartbeatRun(runId, {
+            status: "timeout",
+            error: "Heartbeat execution exceeded the 30-minute timeout",
+          })
+        : false;
+      if (transitioned) {
+        const today = new Date().toISOString().split("T")[0];
+        void emitFeedEvent({
+          source: "assistant",
+          title: "Heartbeat Timed Out",
+          summary: "Heartbeat execution exceeded the 30-minute timeout.",
+          dedupKey: `heartbeat:timeout:${today}`,
+          priority: 55,
+          urgency: "high",
+        }).catch(() => {});
       }
-      const today = new Date().toISOString().split("T")[0];
-      void emitFeedEvent({
-        source: "assistant",
-        title: "Heartbeat Timed Out",
-        summary: "Heartbeat execution exceeded the 30-minute timeout.",
-        dedupKey: `heartbeat:timeout:${today}`,
-        priority: 55,
-        urgency: "high",
-      }).catch(() => {});
     } finally {
       clearTimeout(timerId);
       this._lastRunAt = Date.now();

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -151,6 +151,19 @@ export class HeartbeatService {
         },
         "Recovered stale heartbeat runs on startup",
       );
+
+      const total = this._startupMissedCount + this._startupCrashedCount;
+      const today = new Date().toISOString().split("T")[0];
+      void emitFeedEvent({
+        source: "assistant",
+        title: "Heartbeat Runs Missed",
+        summary: `${total} heartbeat run${total > 1 ? "s were" : " was"} missed while the assistant was offline.`,
+        dedupKey: `heartbeat:missed:${today}`,
+        priority: 55,
+        urgency: "high",
+      }).catch((err) => {
+        log.warn({ err }, "Failed to emit missed heartbeat feed event");
+      });
     }
 
     log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
@@ -306,6 +319,15 @@ export class HeartbeatService {
           error: "Heartbeat execution exceeded the 30-minute timeout",
         });
       }
+      const today = new Date().toISOString().split("T")[0];
+      void emitFeedEvent({
+        source: "assistant",
+        title: "Heartbeat Timed Out",
+        summary: "Heartbeat execution exceeded the 30-minute timeout.",
+        dedupKey: `heartbeat:timeout:${today}`,
+        priority: 55,
+        urgency: "high",
+      }).catch(() => {});
     } finally {
       clearTimeout(timerId);
       this._lastRunAt = Date.now();
@@ -441,13 +463,13 @@ export class HeartbeatService {
     }
   }
 
-  private async executeRun(
-    runId: string,
-    _scheduledFor: number,
-  ): Promise<void> {
+  private async executeRun(runId: string, scheduledFor: number): Promise<void> {
     log.info("Running heartbeat");
 
     startHeartbeatRun(runId);
+
+    const latenessMs = Date.now() - scheduledFor;
+    const LATE_THRESHOLD_MS = 5 * 60 * 1000;
 
     // Credential health check — surface broken credentials proactively
     // before the LLM heartbeat prompt runs. Returns unhealthy provider
@@ -519,6 +541,18 @@ export class HeartbeatService {
             "Failed to emit heartbeat feed event",
           );
         });
+
+        if (latenessMs > LATE_THRESHOLD_MS) {
+          const lateMinutes = Math.round(latenessMs / 60_000);
+          void emitFeedEvent({
+            source: "assistant",
+            title: "Heartbeat Ran Late",
+            summary: `Heartbeat ran ${lateMinutes} minutes late (scheduled for ${new Date(scheduledFor).toLocaleTimeString()}).`,
+            dedupKey: `heartbeat:late:${today}`,
+            priority: 45,
+            urgency: "medium",
+          }).catch(() => {});
+        }
       }
     } catch (err) {
       log.error({ err }, "Heartbeat failed");
@@ -543,11 +577,11 @@ export class HeartbeatService {
         const today = new Date().toISOString().split("T")[0];
         void emitFeedEvent({
           source: "assistant",
-          title: "Heartbeat",
-          summary: "Heartbeat check failed. Check logs for details.",
+          title: "Heartbeat Failed",
+          summary: `Heartbeat check failed: ${(err instanceof Error ? err.message : String(err)).slice(0, 200)}`,
           dedupKey: `heartbeat:fail:${today}`,
           priority: 55,
-          urgency: "medium",
+          urgency: "high",
         }).catch(() => {});
       }
     }

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -17,6 +17,15 @@ import { readTextFileSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
+import {
+  completeHeartbeatRun,
+  insertPendingHeartbeatRun,
+  markStaleRunningAsError,
+  markStaleRunsAsMissed,
+  skipHeartbeatRun,
+  startHeartbeatRun,
+  supersedePendingRun,
+} from "./heartbeat-run-store.js";
 
 const log = getLogger("heartbeat-check");
 
@@ -104,6 +113,9 @@ export class HeartbeatService {
   private activeRun: Promise<void> | null = null;
   private _lastRunAt: number | null = null;
   private _nextRunAt: number | null = null;
+  private _pendingRunId: string | null = null;
+  private _startupMissedCount = 0;
+  private _startupCrashedCount = 0;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -128,6 +140,18 @@ export class HeartbeatService {
       return;
     }
     if (this.timer) return;
+
+    this._startupMissedCount = markStaleRunsAsMissed();
+    this._startupCrashedCount = markStaleRunningAsError();
+    if (this._startupMissedCount > 0 || this._startupCrashedCount > 0) {
+      log.info(
+        {
+          missedCount: this._startupMissedCount,
+          crashedCount: this._startupCrashedCount,
+        },
+        "Recovered stale heartbeat runs on startup",
+      );
+    }
 
     log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
     this.scheduleNextRun(config.intervalMs);
@@ -170,6 +194,10 @@ export class HeartbeatService {
       clearInterval(this.timer);
       this.timer = null;
     }
+    if (this._pendingRunId) {
+      supersedePendingRun(this._pendingRunId);
+      this._pendingRunId = null;
+    }
     this._nextRunAt = null;
     if (this.activeRun) {
       let timerId: ReturnType<typeof setTimeout>;
@@ -186,7 +214,22 @@ export class HeartbeatService {
    *  When `force` is true (e.g. manual "Run Now"), skip enabled & active-hours guards. */
   async runOnce({ force = false }: { force?: boolean } = {}): Promise<boolean> {
     const config = getConfig().heartbeat;
-    if (!force && !config.enabled) return false;
+
+    let runId: string | null;
+    let scheduledFor: number;
+    if (force) {
+      scheduledFor = Date.now();
+      runId = insertPendingHeartbeatRun(scheduledFor);
+    } else {
+      runId = this._pendingRunId;
+      scheduledFor = this._nextRunAt ?? Date.now();
+      this._pendingRunId = null;
+    }
+
+    if (!force && !config.enabled) {
+      if (runId) skipHeartbeatRun(runId, "disabled");
+      return false;
+    }
 
     // Active hours guard — only applied when both bounds are set.
     // The schema rejects configs where only one bound is provided.
@@ -211,6 +254,7 @@ export class HeartbeatService {
           },
           "Outside active hours, skipping",
         );
+        if (runId) skipHeartbeatRun(runId, "outside_active_hours");
         this.scheduleNextRun(config.intervalMs);
         return false;
       }
@@ -219,10 +263,14 @@ export class HeartbeatService {
     // Overlap prevention
     if (this.activeRun) {
       log.debug("Previous heartbeat run still active, skipping");
+      if (runId) skipHeartbeatRun(runId, "overlap");
       return false;
     }
 
-    const run = this.executeRun();
+    if (!runId) {
+      runId = insertPendingHeartbeatRun(scheduledFor);
+    }
+    const run = this.executeRun(runId, scheduledFor);
     this.activeRun = run;
     // Clear activeRun once executeRun finishes. On timeout, runOnce releases
     // activeRun separately (see catch block below) so future runs aren't
@@ -252,6 +300,12 @@ export class HeartbeatService {
       // Release activeRun so the overlap guard doesn't permanently block
       // future heartbeat runs when executeRun hangs past the timeout.
       this.activeRun = null;
+      if (runId) {
+        completeHeartbeatRun(runId, {
+          status: "timeout",
+          error: "Heartbeat execution exceeded the 30-minute timeout",
+        });
+      }
     } finally {
       clearTimeout(timerId);
       this._lastRunAt = Date.now();
@@ -261,7 +315,11 @@ export class HeartbeatService {
   }
 
   private scheduleNextRun(intervalMs: number): void {
+    if (this._pendingRunId) {
+      supersedePendingRun(this._pendingRunId);
+    }
     this._nextRunAt = Date.now() + intervalMs;
+    this._pendingRunId = insertPendingHeartbeatRun(this._nextRunAt);
   }
 
   /**
@@ -383,14 +441,20 @@ export class HeartbeatService {
     }
   }
 
-  private async executeRun(): Promise<void> {
+  private async executeRun(
+    runId: string,
+    _scheduledFor: number,
+  ): Promise<void> {
     log.info("Running heartbeat");
+
+    startHeartbeatRun(runId);
 
     // Credential health check — surface broken credentials proactively
     // before the LLM heartbeat prompt runs. Returns unhealthy provider
     // names so the prompt can instruct the LLM to skip those providers.
     const unhealthyProviders = await this.runCredentialHealthCheck();
 
+    let conversationId: string | undefined;
     try {
       const checklist = this.readChecklist();
       const { prompt, includedReengagement } = this.buildPrompt(
@@ -405,6 +469,7 @@ export class HeartbeatService {
         origin: "heartbeat",
         systemHint: "Heartbeat",
       });
+      conversationId = conversation.id;
 
       this.deps.onConversationCreated?.({
         conversationId: conversation.id,
@@ -425,50 +490,66 @@ export class HeartbeatService {
 
       log.info({ conversationId: conversation.id }, "Heartbeat completed");
 
-      let title = "Heartbeat";
-      try {
-        const row = getConversation(conversation.id);
-        if (row?.title && row.title !== GENERATING_TITLE) {
-          title = row.title;
-        }
-      } catch {
-        // Best-effort; fall back to generic title.
-      }
-
-      const today = new Date().toISOString().split("T")[0];
-      void emitFeedEvent({
-        source: "assistant",
-        title,
-        summary: "Periodic check completed. Tap to see details.",
-        dedupKey: `heartbeat:ok:${today}`,
-        priority: 30,
-      }).catch((err) => {
-        log.warn(
-          { err, conversationId: conversation.id },
-          "Failed to emit heartbeat feed event",
-        );
+      const transitioned = completeHeartbeatRun(runId, {
+        status: "ok",
+        conversationId,
       });
+
+      if (transitioned) {
+        let title = "Heartbeat";
+        try {
+          const row = getConversation(conversation.id);
+          if (row?.title && row.title !== GENERATING_TITLE) {
+            title = row.title;
+          }
+        } catch {
+          // Best-effort; fall back to generic title.
+        }
+
+        const today = new Date().toISOString().split("T")[0];
+        void emitFeedEvent({
+          source: "assistant",
+          title,
+          summary: "Periodic check completed. Tap to see details.",
+          dedupKey: `heartbeat:ok:${today}`,
+          priority: 30,
+        }).catch((err) => {
+          log.warn(
+            { err, conversationId: conversation.id },
+            "Failed to emit heartbeat feed event",
+          );
+        });
+      }
     } catch (err) {
       log.error({ err }, "Heartbeat failed");
-      try {
-        this.deps.alerter({
-          type: "heartbeat_alert",
-          title: "Heartbeat Failed",
-          body: err instanceof Error ? err.message : String(err),
-        });
-      } catch (alertErr) {
-        log.error({ alertErr }, "Failed to broadcast heartbeat alert");
-      }
 
-      const today = new Date().toISOString().split("T")[0];
-      void emitFeedEvent({
-        source: "assistant",
-        title: "Heartbeat",
-        summary: "Heartbeat check failed. Check logs for details.",
-        dedupKey: `heartbeat:fail:${today}`,
-        priority: 55,
-        urgency: "medium",
-      }).catch(() => {});
+      const transitioned = completeHeartbeatRun(runId, {
+        status: "error",
+        conversationId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+
+      if (transitioned) {
+        try {
+          this.deps.alerter({
+            type: "heartbeat_alert",
+            title: "Heartbeat Failed",
+            body: err instanceof Error ? err.message : String(err),
+          });
+        } catch (alertErr) {
+          log.error({ alertErr }, "Failed to broadcast heartbeat alert");
+        }
+
+        const today = new Date().toISOString().split("T")[0];
+        void emitFeedEvent({
+          source: "assistant",
+          title: "Heartbeat",
+          summary: "Heartbeat check failed. Check logs for details.",
+          dedupKey: `heartbeat:fail:${today}`,
+          priority: 55,
+          urgency: "medium",
+        }).catch(() => {});
+      }
     }
   }
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -102,6 +102,7 @@ import {
   migrateGuardianTimestampsEpochMs,
   migrateGuardianVerificationPurpose,
   migrateGuardianVerificationSessions,
+  migrateHeartbeatRuns,
   migrateInviteCodeHashColumn,
   migrateInviteContactId,
   migrateLlmRequestLogMessageId,
@@ -401,6 +402,7 @@ export function initializeDb(): void {
     migrateLlmUsageAttribution,
     migrateSlackCompactionWatermark,
     migrateToolInvocationsMatchedRuleId,
+    migrateHeartbeatRuns,
     function migrateBackfillAppConversationIds() {
       backfillAppConversationIds();
     },

--- a/assistant/src/memory/migrations/237-heartbeat-runs.ts
+++ b/assistant/src/memory/migrations/237-heartbeat-runs.ts
@@ -1,0 +1,45 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_heartbeat_runs_v1";
+
+/**
+ * Create the heartbeat_runs table for tracking heartbeat execution lifecycle.
+ *
+ * Each row represents one scheduled heartbeat tick, tracking its progression
+ * through the status lifecycle: pending -> running -> ok/error/timeout, or
+ * pending -> skipped/missed/superseded.
+ */
+export function migrateHeartbeatRuns(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    if (tableHasColumn(database, "heartbeat_runs", "id")) {
+      return;
+    }
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS heartbeat_runs (
+        id TEXT PRIMARY KEY,
+        scheduled_for INTEGER NOT NULL,
+        started_at INTEGER,
+        finished_at INTEGER,
+        duration_ms INTEGER,
+        status TEXT NOT NULL,
+        skip_reason TEXT,
+        error TEXT,
+        conversation_id TEXT,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_heartbeat_runs_scheduled_for
+        ON heartbeat_runs (scheduled_for)
+    `);
+  });
+}
+
+export function downHeartbeatRuns(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS heartbeat_runs`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -196,6 +196,10 @@ export {
   migrateToolInvocationsMatchedRuleId,
 } from "./236-tool-invocations-matched-rule-id.js";
 export {
+  downHeartbeatRuns,
+  migrateHeartbeatRuns,
+} from "./237-heartbeat-runs.js";
+export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -47,6 +47,7 @@ import { downActivationState } from "./232-activation-state.js";
 import { downMemoryV2ActivationLogs } from "./234-memory-v2-activation-logs.js";
 import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.js";
 import { downToolInvocationsMatchedRuleId } from "./236-tool-invocations-matched-rule-id.js";
+import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -403,6 +404,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Add matched_trust_rule_id column to tool_invocations for trust rule audit and rule editor UI",
     down: downToolInvocationsMatchedRuleId,
+  },
+  {
+    key: "migration_heartbeat_runs_v1",
+    version: 47,
+    description:
+      "Create heartbeat_runs table for tracking heartbeat execution lifecycle with CAS state transitions",
+    down: downHeartbeatRuns,
   },
 ];
 

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -54,6 +54,19 @@ export const cronRuns = sqliteTable("cron_runs", {
 export const scheduleJobs = cronJobs;
 export const scheduleRuns = cronRuns;
 
+export const heartbeatRuns = sqliteTable("heartbeat_runs", {
+  id: text("id").primaryKey(),
+  scheduledFor: integer("scheduled_for").notNull(),
+  startedAt: integer("started_at"),
+  finishedAt: integer("finished_at"),
+  durationMs: integer("duration_ms"),
+  status: text("status").notNull(), // 'pending' | 'running' | 'ok' | 'error' | 'timeout' | 'skipped' | 'missed' | 'superseded'
+  skipReason: text("skip_reason"), // 'disabled' | 'outside_active_hours' | 'overlap'
+  error: text("error"),
+  conversationId: text("conversation_id"),
+  createdAt: integer("created_at").notNull(),
+});
+
 export const sharedAppLinks = sqliteTable("shared_app_links", {
   id: text("id").primaryKey(),
   shareToken: text("share_token").notNull().unique(),

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -8,13 +8,11 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
-import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getConfig, saveConfig } from "../../config/loader.js";
+import { listHeartbeatRuns } from "../../heartbeat/heartbeat-run-store.js";
 import { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
-import { getDb } from "../../memory/db-connection.js";
-import { conversations } from "../../memory/schema/conversations.js";
 import { readTextFileSync } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
@@ -32,25 +30,20 @@ function handleListRuns(queryParams: Record<string, string>) {
   const limit = Number.isFinite(rawLimit)
     ? Math.min(Math.max(Math.floor(rawLimit), 1), 100)
     : 20;
-  const db = getDb();
-  const rows = db
-    .select({
-      id: conversations.id,
-      title: conversations.title,
-      createdAt: conversations.createdAt,
-    })
-    .from(conversations)
-    .where(eq(conversations.source, "heartbeat"))
-    .orderBy(desc(conversations.createdAt))
-    .limit(limit)
-    .all();
 
+  const runs = listHeartbeatRuns(limit);
   return {
-    runs: rows.map((r) => ({
+    runs: runs.map((r) => ({
       id: r.id,
-      title: r.title ?? "Heartbeat",
+      scheduledFor: r.scheduledFor,
+      startedAt: r.startedAt,
+      finishedAt: r.finishedAt,
+      durationMs: r.durationMs,
+      status: r.status,
+      skipReason: r.skipReason,
+      error: r.error,
+      conversationId: r.conversationId,
       createdAt: r.createdAt,
-      result: "ok",
     })),
   };
 }
@@ -102,7 +95,22 @@ export const ROUTES: RouteDefinition[] = [
       },
     ],
     responseBody: z.object({
-      runs: z.array(z.unknown()).describe("Heartbeat run records"),
+      runs: z
+        .array(
+          z.object({
+            id: z.string(),
+            scheduledFor: z.number(),
+            startedAt: z.number().nullable(),
+            finishedAt: z.number().nullable(),
+            durationMs: z.number().nullable(),
+            status: z.string(),
+            skipReason: z.string().nullable(),
+            error: z.string().nullable(),
+            conversationId: z.string().nullable(),
+            createdAt: z.number(),
+          }),
+        )
+        .describe("Heartbeat run records"),
     }),
     handler: ({ queryParams }: RouteHandlerArgs) =>
       handleListRuns(queryParams ?? {}),
@@ -135,8 +143,7 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       success: z.boolean(),
     }),
-    handler: ({ body }: RouteHandlerArgs) =>
-      handleWriteChecklist(body ?? {}),
+    handler: ({ body }: RouteHandlerArgs) => handleWriteChecklist(body ?? {}),
   },
   {
     operationId: "getHeartbeatConfig",

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1994,17 +1994,31 @@ public struct HeartbeatRunsListResponse: Codable, Sendable {
 
 public struct HeartbeatRunsListResponseRun: Codable, Sendable {
     public let id: String
-    public let title: String
+    public let scheduledFor: Int
+    public let startedAt: Int?
+    public let finishedAt: Int?
+    public let durationMs: Int?
+    public let status: String
+    public let skipReason: String?
+    public let error: String?
+    public let conversationId: String?
     public let createdAt: Int
-    public let result: String
-    public let summary: String?
 
-    public init(id: String, title: String, createdAt: Int, result: String, summary: String? = nil) {
+    public init(
+        id: String, scheduledFor: Int, startedAt: Int?, finishedAt: Int?,
+        durationMs: Int?, status: String, skipReason: String?,
+        error: String?, conversationId: String?, createdAt: Int
+    ) {
         self.id = id
-        self.title = title
+        self.scheduledFor = scheduledFor
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.durationMs = durationMs
+        self.status = status
+        self.skipReason = skipReason
+        self.error = error
+        self.conversationId = conversationId
         self.createdAt = createdAt
-        self.result = result
-        self.summary = summary
     }
 }
 


### PR DESCRIPTION
## Summary
Add durable heartbeat run tracking with a full lifecycle (`pending` → `running` → `ok`/`error`/`timeout`/`skipped`/`missed`/`superseded`), replacing the broken `/heartbeat/runs` API that hardcoded `result: "ok"` for every row. Failures, timeouts, late runs, and missed runs are now detected and surfaced via Home feed events.

## Self-review result
GAPS FOUND — 1 gap fixed (timeout feed event not CAS-gated) across 1 fix PR

## PRs merged into feature branch
- #29286: feat(heartbeat): add heartbeat_runs table and CRUD store with CAS lifecycle
- #29287: feat(heartbeat): record every run outcome in heartbeat_runs
- #29288: fix(heartbeat): return real run status from /heartbeat/runs and update client types
- #29290: feat(heartbeat): surface failures, timeouts, late runs, and missed runs in Home feed

### Fix PRs
- #29291: fix: gate timeout feed event behind CAS result

Part of plan: detect-surface-failed-heartbeats.md

Closes JARVIS-480
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->