### PR TITLE
feat(heartbeat): expose cronExpression and timezone in heartbeat config API and client types

### DIFF
--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -135,8 +135,7 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       success: z.boolean(),
     }),
-    handler: ({ body }: RouteHandlerArgs) =>
-      handleWriteChecklist(body ?? {}),
+    handler: ({ body }: RouteHandlerArgs) => handleWriteChecklist(body ?? {}),
   },
   {
     operationId: "getHeartbeatConfig",
@@ -152,6 +151,8 @@ export const ROUTES: RouteDefinition[] = [
       intervalMs: z.number(),
       activeHoursStart: z.number().nullable(),
       activeHoursEnd: z.number().nullable(),
+      cronExpression: z.string().nullable(),
+      timezone: z.string().nullable(),
       nextRunAt: z.number().nullable(),
       lastRunAt: z.number().nullable(),
       success: z.boolean(),
@@ -164,6 +165,8 @@ export const ROUTES: RouteDefinition[] = [
         intervalMs: config.intervalMs,
         activeHoursStart: config.activeHoursStart ?? null,
         activeHoursEnd: config.activeHoursEnd ?? null,
+        cronExpression: config.cronExpression ?? null,
+        timezone: config.timezone ?? null,
         nextRunAt: svc?.nextRunAt ?? null,
         lastRunAt: svc?.lastRunAt ?? null,
         success: true,
@@ -180,16 +183,38 @@ export const ROUTES: RouteDefinition[] = [
     description: "Update the heartbeat schedule configuration.",
     tags: ["heartbeat"],
     requestBody: z.object({
-      enabled: z.boolean().describe("Enable or disable heartbeat"),
-      intervalMs: z.number().describe("Heartbeat interval in ms"),
-      activeHoursStart: z.number().describe("Active hours start (0–23)"),
-      activeHoursEnd: z.number().describe("Active hours end (0–23)"),
+      enabled: z.boolean().optional().describe("Enable or disable heartbeat"),
+      intervalMs: z.number().optional().describe("Heartbeat interval in ms"),
+      activeHoursStart: z
+        .number()
+        .nullable()
+        .optional()
+        .describe("Active hours start (0–23)"),
+      activeHoursEnd: z
+        .number()
+        .nullable()
+        .optional()
+        .describe("Active hours end (0–23)"),
+      cronExpression: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Cron expression for heartbeat timing, or null for fixed interval",
+        ),
+      timezone: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Timezone for cron evaluation"),
     }),
     responseBody: z.object({
       enabled: z.boolean(),
       intervalMs: z.number(),
       activeHoursStart: z.number().nullable(),
       activeHoursEnd: z.number().nullable(),
+      cronExpression: z.string().nullable(),
+      timezone: z.string().nullable(),
       nextRunAt: z.number().nullable(),
       lastRunAt: z.number().nullable(),
       success: z.boolean(),
@@ -198,13 +223,24 @@ export const ROUTES: RouteDefinition[] = [
       const config = getConfig();
       const heartbeat = { ...config.heartbeat };
 
-      if (typeof body.enabled === "boolean") heartbeat.enabled = body.enabled;
-      if (typeof body.intervalMs === "number")
+      if ("enabled" in body && typeof body.enabled === "boolean")
+        heartbeat.enabled = body.enabled;
+      if ("intervalMs" in body && typeof body.intervalMs === "number")
         heartbeat.intervalMs = body.intervalMs;
-      if (typeof body.activeHoursStart === "number")
-        heartbeat.activeHoursStart = body.activeHoursStart;
-      if (typeof body.activeHoursEnd === "number")
-        heartbeat.activeHoursEnd = body.activeHoursEnd;
+      if ("activeHoursStart" in body)
+        heartbeat.activeHoursStart =
+          typeof body.activeHoursStart === "number"
+            ? body.activeHoursStart
+            : null;
+      if ("activeHoursEnd" in body)
+        heartbeat.activeHoursEnd =
+          typeof body.activeHoursEnd === "number" ? body.activeHoursEnd : null;
+      if ("cronExpression" in body)
+        heartbeat.cronExpression =
+          typeof body.cronExpression === "string" ? body.cronExpression : null;
+      if ("timezone" in body)
+        heartbeat.timezone =
+          typeof body.timezone === "string" ? body.timezone : null;
 
       try {
         saveConfig({ ...config, heartbeat });
@@ -215,11 +251,15 @@ export const ROUTES: RouteDefinition[] = [
       }
 
       const svc = HeartbeatService.getInstance();
+      svc?.reconfigure();
+
       return {
         enabled: heartbeat.enabled,
         intervalMs: heartbeat.intervalMs,
         activeHoursStart: heartbeat.activeHoursStart ?? null,
         activeHoursEnd: heartbeat.activeHoursEnd ?? null,
+        cronExpression: heartbeat.cronExpression ?? null,
+        timezone: heartbeat.timezone ?? null,
         nextRunAt: svc?.nextRunAt ?? null,
         lastRunAt: svc?.lastRunAt ?? null,
         success: true,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1839,14 +1839,18 @@ public struct HeartbeatConfig: Codable, Sendable {
     public let intervalMs: Double?
     public let activeHoursStart: Double?
     public let activeHoursEnd: Double?
+    public let cronExpression: String?
+    public let timezone: String?
 
-    public init(type: String, action: String, enabled: Bool? = nil, intervalMs: Double? = nil, activeHoursStart: Double? = nil, activeHoursEnd: Double? = nil) {
+    public init(type: String, action: String, enabled: Bool? = nil, intervalMs: Double? = nil, activeHoursStart: Double? = nil, activeHoursEnd: Double? = nil, cronExpression: String? = nil, timezone: String? = nil) {
         self.type = type
         self.action = action
         self.enabled = enabled
         self.intervalMs = intervalMs
         self.activeHoursStart = activeHoursStart
         self.activeHoursEnd = activeHoursEnd
+        self.cronExpression = cronExpression
+        self.timezone = timezone
     }
 }
 
@@ -1856,17 +1860,21 @@ public struct HeartbeatConfigResponse: Codable, Sendable {
     public let intervalMs: Double
     public let activeHoursStart: Double?
     public let activeHoursEnd: Double?
+    public let cronExpression: String?
+    public let timezone: String?
     public let nextRunAt: Int?
     public let lastRunAt: Int?
     public let success: Bool
     public let error: String?
 
-    public init(type: String, enabled: Bool, intervalMs: Double, activeHoursStart: Double?, activeHoursEnd: Double?, nextRunAt: Int?, lastRunAt: Int? = nil, success: Bool, error: String? = nil) {
+    public init(type: String, enabled: Bool, intervalMs: Double, activeHoursStart: Double?, activeHoursEnd: Double?, cronExpression: String? = nil, timezone: String? = nil, nextRunAt: Int?, lastRunAt: Int? = nil, success: Bool, error: String? = nil) {
         self.type = type
         self.enabled = enabled
         self.intervalMs = intervalMs
         self.activeHoursStart = activeHoursStart
         self.activeHoursEnd = activeHoursEnd
+        self.cronExpression = cronExpression
+        self.timezone = timezone
         self.nextRunAt = nextRunAt
         self.lastRunAt = lastRunAt
         self.success = success

--- a/clients/shared/Network/HeartbeatClient.swift
+++ b/clients/shared/Network/HeartbeatClient.swift
@@ -9,7 +9,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Heart
 /// management.
 public protocol HeartbeatClientProtocol {
     func fetchConfig() async -> HeartbeatConfigResponse?
-    func updateConfig(enabled: Bool?, intervalMs: Double?, activeHoursStart: Double?, activeHoursEnd: Double?) async -> HeartbeatConfigResponse?
+    func updateConfig(enabled: Bool?, intervalMs: Double?, activeHoursStart: Double?, activeHoursEnd: Double?, cronExpression: String?, timezone: String?) async -> HeartbeatConfigResponse?
     func fetchRunsList(limit: Int?) async -> HeartbeatRunsListResponse?
     func runNow() async -> HeartbeatRunNowResponse?
     func fetchChecklist() async -> HeartbeatChecklistResponse?
@@ -37,13 +37,15 @@ public struct HeartbeatClient: HeartbeatClientProtocol {
         }
     }
 
-    public func updateConfig(enabled: Bool? = nil, intervalMs: Double? = nil, activeHoursStart: Double? = nil, activeHoursEnd: Double? = nil) async -> HeartbeatConfigResponse? {
+    public func updateConfig(enabled: Bool? = nil, intervalMs: Double? = nil, activeHoursStart: Double? = nil, activeHoursEnd: Double? = nil, cronExpression: String? = nil, timezone: String? = nil) async -> HeartbeatConfigResponse? {
         do {
             var body: [String: Any] = [:]
             if let enabled { body["enabled"] = enabled }
             if let intervalMs { body["intervalMs"] = intervalMs }
             if let activeHoursStart { body["activeHoursStart"] = activeHoursStart }
             if let activeHoursEnd { body["activeHoursEnd"] = activeHoursEnd }
+            if let cronExpression { body["cronExpression"] = cronExpression }
+            if let timezone { body["timezone"] = timezone }
 
             let response = try await GatewayHTTPClient.put(
                 path: "heartbeat/config", json: body, timeout: 10


### PR DESCRIPTION
## Summary
- Add cronExpression and timezone to heartbeat config GET/PUT routes
- Add svc.reconfigure() call after saving config (was missing)
- Make all request body fields optional with explicit null support
- Update Swift HeartbeatConfigResponse and HeartbeatClient types

Part of plan: heartbeat-cron-scheduling.md (PR 3 of 3)

Closes JARVIS-478
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->