### PR TITLE
fix: CI failures and reviewer feedback for heartbeat run tracking

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5321,7 +5321,53 @@ paths:
                 properties:
                   runs:
                     type: array
-                    items: {}
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        scheduledFor:
+                          type: number
+                        startedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        finishedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        durationMs:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        status:
+                          type: string
+                        skipReason:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        conversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdAt:
+                          type: number
+                      required:
+                        - id
+                        - scheduledFor
+                        - startedAt
+                        - finishedAt
+                        - durationMs
+                        - status
+                        - skipReason
+                        - error
+                        - conversationId
+                        - createdAt
+                      additionalProperties: false
                     description: Heartbeat run records
                 required:
                   - runs

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -307,13 +307,21 @@ describe("HeartbeatService", () => {
     });
 
     mockInsertPendingHeartbeatRun.mockClear();
+    mockInsertPendingHeartbeatRun.mockImplementation(() => "mock-run-id");
     mockStartHeartbeatRun.mockClear();
+    mockStartHeartbeatRun.mockImplementation(() => true);
     mockCompleteHeartbeatRun.mockClear();
+    mockCompleteHeartbeatRun.mockImplementation(() => true);
     mockSkipHeartbeatRun.mockClear();
+    mockSkipHeartbeatRun.mockImplementation(() => true);
     mockSupersedePendingRun.mockClear();
+    mockSupersedePendingRun.mockImplementation(() => true);
     mockMarkStaleRunsAsMissed.mockClear();
+    mockMarkStaleRunsAsMissed.mockImplementation(() => 0);
     mockMarkStaleRunningAsError.mockClear();
+    mockMarkStaleRunningAsError.mockImplementation(() => 0);
     mockEmitFeedEvent.mockClear();
+    mockEmitFeedEvent.mockImplementation(() => Promise.resolve());
 
     mockConfig = {
       heartbeat: {
@@ -1224,11 +1232,14 @@ describe("HeartbeatService", () => {
       service.stop();
     });
 
-    test("scheduleNextRun supersedes old pending row before creating new one", async () => {
+    test("scheduleNextRun supersedes old pending row before creating new one", () => {
       const service = createService();
+      service.start();
 
-      // First runOnce: scheduleNextRun is called in the finally block, creating a pending row
-      await service.runOnce();
+      // start() called scheduleNextRun which set _pendingRunId.
+      // Calling resetTimer triggers another scheduleNextRun which
+      // should supersede the existing pending row before inserting
+      // a new one.
       const callOrder: string[] = [];
       mockSupersedePendingRun.mockImplementation(() => {
         callOrder.push("supersede");
@@ -1239,16 +1250,17 @@ describe("HeartbeatService", () => {
         return "mock-run-id";
       });
 
-      // Second runOnce: scheduleNextRun should supersede the old pending row first
-      await service.runOnce();
+      service.resetTimer();
 
-      // The finally block's scheduleNextRun should supersede then insert
+      // resetTimer's scheduleNextRun should supersede then insert
       expect(callOrder.filter((c) => c === "supersede").length).toBeGreaterThan(
         0,
       );
       const firstSupersede = callOrder.indexOf("supersede");
       const firstInsert = callOrder.indexOf("insert");
       expect(firstSupersede).toBeLessThan(firstInsert);
+
+      service.stop();
     });
 
     test("resetTimer() supersedes pending row", () => {
@@ -1356,7 +1368,7 @@ describe("HeartbeatService", () => {
         },
       );
       expect(failCalls).toHaveLength(1);
-      const opts = failCalls[0][0] as {
+      const opts = (failCalls as any[][])[0][0] as {
         urgency?: string;
         summary?: string;
       };
@@ -1410,7 +1422,7 @@ describe("HeartbeatService", () => {
           },
         );
         expect(timeoutCalls).toHaveLength(1);
-        const opts = timeoutCalls[0][0] as {
+        const opts = (timeoutCalls as any[][])[0][0] as {
           urgency?: string;
         };
         expect(opts.urgency).toBe("high");
@@ -1474,7 +1486,7 @@ describe("HeartbeatService", () => {
         },
       );
       expect(lateCalls).toHaveLength(1);
-      const opts = lateCalls[0][0] as {
+      const opts = (lateCalls as any[][])[0][0] as {
         urgency?: string;
         summary?: string;
       };
@@ -1511,7 +1523,7 @@ describe("HeartbeatService", () => {
         },
       );
       expect(missedCalls).toHaveLength(1);
-      const opts = missedCalls[0][0] as {
+      const opts = (missedCalls as any[][])[0][0] as {
         urgency?: string;
         summary?: string;
       };

--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -5,6 +5,18 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let workspaceDir: string;
 
+// Stub the heartbeat run store so HeartbeatService doesn't hit the real DB.
+mock.module("../heartbeat-run-store.js", () => ({
+  insertPendingHeartbeatRun: () => "mock-run-id",
+  startHeartbeatRun: () => true,
+  completeHeartbeatRun: () => true,
+  skipHeartbeatRun: () => true,
+  supersedePendingRun: () => true,
+  markStaleRunsAsMissed: () => 0,
+  markStaleRunningAsError: () => 0,
+  listHeartbeatRuns: () => [],
+}));
+
 // Stub the in-process SSE hub so the writer's publish path is a
 // no-op in these tests.
 const publishSpy = mock<(event: unknown) => Promise<void>>(async () => {});
@@ -200,13 +212,11 @@ describe("heartbeat feed events", () => {
     await new Promise((r) => setTimeout(r, 100));
 
     const items = readFeedItems();
-    const heartbeatItem = items.find((i) => i.title === "Heartbeat");
+    const heartbeatItem = items.find((i) => i.title === "Heartbeat Failed");
     expect(heartbeatItem).toBeDefined();
-    expect(heartbeatItem!.summary).toBe(
-      "Heartbeat check failed. Check logs for details.",
-    );
+    expect(heartbeatItem!.summary).toContain("LLM call failed");
     expect(heartbeatItem!.priority).toBe(55);
-    expect(heartbeatItem!.urgency).toBe("medium");
+    expect(heartbeatItem!.urgency).toBe("high");
     expect(heartbeatItem!.source).toBe("assistant");
   });
 

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -116,6 +116,7 @@ export class HeartbeatService {
   private _pendingRunId: string | null = null;
   private _startupMissedCount = 0;
   private _startupCrashedCount = 0;
+  private _hasRunStartupRecovery = false;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -141,29 +142,36 @@ export class HeartbeatService {
     }
     if (this.timer) return;
 
-    this._startupMissedCount = markStaleRunsAsMissed();
-    this._startupCrashedCount = markStaleRunningAsError();
-    if (this._startupMissedCount > 0 || this._startupCrashedCount > 0) {
-      log.info(
-        {
-          missedCount: this._startupMissedCount,
-          crashedCount: this._startupCrashedCount,
-        },
-        "Recovered stale heartbeat runs on startup",
-      );
+    if (!this._hasRunStartupRecovery) {
+      this._hasRunStartupRecovery = true;
+      try {
+        this._startupMissedCount = markStaleRunsAsMissed();
+        this._startupCrashedCount = markStaleRunningAsError();
+      } catch (err) {
+        log.error({ err }, "Failed to recover stale heartbeat runs on startup");
+      }
+      if (this._startupMissedCount > 0 || this._startupCrashedCount > 0) {
+        log.info(
+          {
+            missedCount: this._startupMissedCount,
+            crashedCount: this._startupCrashedCount,
+          },
+          "Recovered stale heartbeat runs on startup",
+        );
 
-      const total = this._startupMissedCount + this._startupCrashedCount;
-      const today = new Date().toISOString().split("T")[0];
-      void emitFeedEvent({
-        source: "assistant",
-        title: "Heartbeat Runs Missed",
-        summary: `${total} heartbeat run${total > 1 ? "s were" : " was"} missed while the assistant was offline.`,
-        dedupKey: `heartbeat:missed:${today}`,
-        priority: 55,
-        urgency: "high",
-      }).catch((err) => {
-        log.warn({ err }, "Failed to emit missed heartbeat feed event");
-      });
+        const total = this._startupMissedCount + this._startupCrashedCount;
+        const today = new Date().toISOString().split("T")[0];
+        void emitFeedEvent({
+          source: "assistant",
+          title: "Heartbeat Runs Missed",
+          summary: `${total} heartbeat run${total > 1 ? "s were" : " was"} missed while the assistant was offline.`,
+          dedupKey: `heartbeat:missed:${today}`,
+          priority: 55,
+          urgency: "high",
+        }).catch((err) => {
+          log.warn({ err }, "Failed to emit missed heartbeat feed event");
+        });
+      }
     }
 
     log.info({ intervalMs: config.intervalMs }, "Heartbeat service started");
@@ -177,6 +185,10 @@ export class HeartbeatService {
 
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
+    if (this._pendingRunId) {
+      supersedePendingRun(this._pendingRunId);
+      this._pendingRunId = null;
+    }
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;


### PR DESCRIPTION
## Summary
- Fix heartbeat-feed-event.test.ts: mock heartbeat-run-store.js to prevent SQLite table-not-found
- Regenerate OpenAPI spec for updated /heartbeat/runs response shape
- Fix TypeScript type errors in heartbeat-service.test.ts mock call assertions
- Wrap stale-run recovery in try/catch (daemon must never block startup)
- Fix reconfigure() to supersede _pendingRunId and guard recovery to run only once
- Fix test mock reset (mockImplementation) to prevent cross-test contamination
- Fix heartbeat-feed-event.test.ts assertions to match actual feed event shape
- Fix scheduleNextRun supersede test to correctly exercise the supersede path

Part of plan: detect-surface-failed-heartbeats.md

Closes JARVIS-480
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->