### PR TITLE
memory-v2: enrich thin bundled SKILL.md frontmatter

### DIFF
--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -6,6 +6,12 @@ metadata:
   emoji: "🔗"
   vellum:
     display-name: "ACP"
+    activation-hints:
+      - "User wants to delegate a coding task to Claude Code, Codex, or another ACP agent"
+      - "User wants to spawn an external coding agent that runs autonomously and streams results back"
+      - "User mentions ACP, claude-agent-acp, codex-acp, or running multiple coding agents in parallel"
+    avoid-when:
+      - "Task is small enough to do inline with the assistant's own tools — no need for an external agent"
 ---
 
 ACP agent orchestration - spawn external coding agents (Claude Code, Codex, etc.) to work on tasks via the Agent Client Protocol. Each agent runs as its own subprocess speaking ACP over stdio and streams results back into the conversation.

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -6,6 +6,12 @@ metadata:
   emoji: "🖥️"
   vellum:
     display-name: "Computer Use"
+    activation-hints:
+      - "User asks the assistant to click, type, drag, or interact with the macOS GUI directly"
+      - "User wants control of a desktop app with no CLI or API alternative (games, design tools, visual workflows)"
+      - "User wants screenshots or visual inspection of what is currently on screen"
+    avoid-when:
+      - "Task can be done via a more specific skill (gmail, calendar, contacts, terminal-sessions) or a CLI / API call"
 ---
 
 This skill provides the computer_use_* action tools for controlling

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -6,6 +6,10 @@ metadata:
   emoji: "🎨"
   vellum:
     display-name: "Image Studio"
+    activation-hints:
+      - "User asks to generate, draw, or create an image from a text prompt"
+      - "User wants to edit an existing image — background removal, in-painting, style change, retouching"
+      - "User wants multiple variations of a visual (logo concepts, mood boards, illustration options)"
 ---
 
 You are an image generation assistant. When the user asks you to create or edit images, use the `media_generate_image` tool.

--- a/assistant/src/config/bundled-skills/settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/settings/SKILL.md
@@ -6,6 +6,10 @@ metadata:
   emoji: "\u2699\uFE0F"
   vellum:
     display-name: "Settings"
+    activation-hints:
+      - "User wants to change the assistant's voice, TTS provider, or speech output"
+      - "User wants to rebind the push-to-talk key or adjust microphone / conversation timeout"
+      - "User wants to open the in-app settings tab or navigate to a specific preference"
 ---
 
 Tools for managing assistant settings: voice configuration (TTS voice, PTT activation key, conversation timeout), system settings navigation, and in-app settings tab navigation.

--- a/assistant/src/config/bundled-skills/skill-management/SKILL.md
+++ b/assistant/src/config/bundled-skills/skill-management/SKILL.md
@@ -5,6 +5,12 @@ metadata:
   emoji: "\U0001F9E9"
   vellum:
     display-name: "Skill Management"
+    activation-hints:
+      - "User wants to scaffold a new managed skill in their workspace from a description"
+      - "User wants to delete or list the custom skills they have defined"
+      - "User wants to author or edit a SKILL.md and have it become invocable as a skill"
+    avoid-when:
+      - "User just wants to use an existing skill — that is normal skill activation, not management"
 ---
 
 Manage the lifecycle of custom managed skills in `{workspaceDir}/skills`.

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -7,8 +7,12 @@ metadata:
   vellum:
     display-name: "Subagent"
     activation-hints:
-      - "Run tasks in parallel, delegate work to background agents, or do multiple things at once"
-      - "Spawn a researcher, coder, or planner agent for independent work"
+      - "Spawn a background worker that runs in parallel with the main turn"
+      - "Delegate a self-contained research or implementation task off the main thread"
+      - "Multiple agents at once, or a context-inheriting fork"
+    avoid-when:
+      - "Task is small enough to do inline (single tool call, quick lookup)"
+      - "User wants Claude Code or Codex — use the acp skill instead"
 ---
 
 Subagent orchestration -- spawn background agents to work on tasks in parallel.

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -6,6 +6,10 @@ metadata:
   emoji: "🎙️"
   vellum:
     display-name: "Transcribe"
+    activation-hints:
+      - "User has an audio or video file on disk they want converted to text"
+      - "User wants speech-to-text on a recording, voice memo, podcast, or meeting capture"
+      - "User asks for a transcript of a media file (mp3, wav, m4a, mp4, mov, etc.)"
 ---
 
 Transcribe audio and video files using the configured speech-to-text provider. Supports multiple STT providers including OpenAI Whisper, Deepgram, and Google Gemini — the active provider is selected in Settings under Speech-to-Text (`services.stt`).


### PR DESCRIPTION
## Summary

- Memory-v2 ranks skills by dense + sparse similarity over each skill's `buildSkillContent` text. Skills with no `activation-hints` and no `avoid-when` get very short embeddings (`computer-use` was 85 chars), so they barely beat unrelated skills in the inspector even when the user names them explicitly.
- Adds richer `activation-hints` (and `avoid-when` where appropriate) to the seven bundled skills with under-200-char embedded content. All updated skills now land between 343 and 492 chars — comfortably under the 500-char cap in `buildSkillContent`.
- Frontmatter only; no code changes. The skills updated are: `computer-use`, `skill-management`, `image-studio`, `settings`, `transcribe`, `acp`, `subagent`.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->