### PR TITLE
fix: prevent reconfigure() race in cron heartbeat scheduling

### DIFF
--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -111,6 +111,7 @@ export class HeartbeatService {
   private _nextRunAt: number | null = null;
   private cronMode = false;
   private stopped = false;
+  private configEpoch = 0;
 
   constructor(deps: HeartbeatDeps) {
     this.deps = deps;
@@ -179,10 +180,15 @@ export class HeartbeatService {
         this.timer = null;
       }
       const delayMs = Math.max(0, nextRunAt - Date.now());
+      const epoch = this.configEpoch;
       this.timer = setTimeout(() => {
         this.runOnce()
           .catch((err) => log.error({ err }, "Cron heartbeat failed"))
-          .finally(() => this.scheduleNextCronRun(getConfig().heartbeat));
+          .finally(() => {
+            if (this.configEpoch === epoch) {
+              this.scheduleNextCronRun(getConfig().heartbeat);
+            }
+          });
       }, delayMs);
       (this.timer as ReturnType<typeof setTimeout>).unref();
       log.info(
@@ -200,6 +206,7 @@ export class HeartbeatService {
 
   /** Restart the timer with the latest config (e.g. after settings change). */
   reconfigure(): void {
+    this.configEpoch++;
     if (this.timer) {
       clearTimeout(this.timer as ReturnType<typeof setTimeout>);
       clearInterval(this.timer as ReturnType<typeof setInterval>);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for heartbeat-cron-scheduling.md.

**Gap:** Race condition — scheduleNextCronRun finally-chain clobbers reconfigure() timer
**What was expected:** reconfigure() should cleanly replace the scheduling state
**What was found:** The .finally() chain from an in-flight cron run fires after reconfigure() resets stopped=false, clobbering the new timer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->