### PR TITLE
fix: show cron expression in heartbeat subtitle when in cron mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
@@ -620,6 +620,13 @@ struct SettingsSchedulesTab: View {
     }
 
     private func heartbeatSubtitle(_ config: HeartbeatConfigResponse) -> String {
+        if let cron = config.cronExpression {
+            var subtitle = "Cron: \(cron)"
+            if let tz = config.timezone {
+                subtitle += " (\(tz))"
+            }
+            return subtitle
+        }
         let interval = Int(config.intervalMs / 60_000)
         var subtitle = "Every \(interval) min"
         if let start = config.activeHoursStart, let end = config.activeHoursEnd {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for heartbeat-cron-scheduling.md.

**Gap:** heartbeatSubtitle always shows interval-based subtitle even in cron mode
**What was expected:** Subtitle should reflect the active scheduling mode
**What was found:** Always shows 'Every X min' regardless of cron configuration
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->