### PR TITLE
feat(schedule): add max_retries and retry_backoff_ms columns to cron_jobs

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -154,6 +154,7 @@ import {
   migrateRenameVoiceToPhone,
   migrateScheduleOneShotRouting,
   migrateScheduleQuietFlag,
+  migrateScheduleRetryPolicy,
   migrateScheduleReuseConversation,
   migrateScheduleScriptColumn,
   migrateScheduleWakeConversationId,
@@ -406,6 +407,7 @@ export function initializeDb(): void {
     function migrateBackfillAppConversationIds() {
       backfillAppConversationIds();
     },
+    migrateScheduleRetryPolicy,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/238-schedule-retry-policy.ts
+++ b/assistant/src/memory/migrations/238-schedule-retry-policy.ts
@@ -1,0 +1,20 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+export function migrateScheduleRetryPolicy(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(
+      `ALTER TABLE cron_jobs ADD COLUMN max_retries INTEGER NOT NULL DEFAULT 3`,
+    );
+  } catch {
+    /* Column already exists */
+  }
+  try {
+    raw.exec(
+      `ALTER TABLE cron_jobs ADD COLUMN retry_backoff_ms INTEGER NOT NULL DEFAULT 60000`,
+    );
+  } catch {
+    /* Column already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -199,6 +199,7 @@ export {
   downHeartbeatRuns,
   migrateHeartbeatRuns,
 } from "./237-heartbeat-runs.js";
+export { migrateScheduleRetryPolicy } from "./238-schedule-retry-policy.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -19,6 +19,8 @@ export const cronJobs = sqliteTable("cron_jobs", {
   lastRunAt: integer("last_run_at"),
   lastStatus: text("last_status"), // 'ok' | 'error'
   retryCount: integer("retry_count").notNull().default(0),
+  maxRetries: integer("max_retries").notNull().default(3),
+  retryBackoffMs: integer("retry_backoff_ms").notNull().default(60000),
   createdBy: text("created_by").notNull(), // 'agent' | 'user'
   mode: text("mode").notNull().default("execute"), // 'notify' | 'execute'
   routingIntent: text("routing_intent").notNull().default("all_channels"), // 'single_channel' | 'multi_channel' | 'all_channels'

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -33,6 +33,8 @@ export interface ScheduleJob {
   lastRunAt: number | null;
   lastStatus: string | null;
   retryCount: number;
+  maxRetries: number;
+  retryBackoffMs: number;
   createdBy: string;
   mode: ScheduleMode;
   routingIntent: RoutingIntent;
@@ -83,6 +85,8 @@ export function createSchedule(params: {
   routingHints?: Record<string, unknown>;
   quiet?: boolean;
   reuseConversation?: boolean;
+  maxRetries?: number;
+  retryBackoffMs?: number;
 }): ScheduleJob {
   const expression = params.expression ?? params.cronExpression ?? null;
   const isOneShot = expression == null;
@@ -116,6 +120,8 @@ export function createSchedule(params: {
   const routingHints = params.routingHints ?? {};
   const quiet = params.quiet ?? false;
   const reuseConversation = params.reuseConversation ?? false;
+  const maxRetries = params.maxRetries ?? 3;
+  const retryBackoffMs = params.retryBackoffMs ?? 60000;
 
   let nextRunAt: number;
   if (isOneShot) {
@@ -140,6 +146,8 @@ export function createSchedule(params: {
     lastRunAt: null as number | null,
     lastStatus: null as string | null,
     retryCount: 0,
+    maxRetries,
+    retryBackoffMs,
     createdBy: params.createdBy ?? "agent",
     mode,
     routingIntent,
@@ -235,6 +243,8 @@ export function updateSchedule(
     quiet?: boolean;
     reuseConversation?: boolean;
     wakeConversationId?: string | null;
+    maxRetries?: number;
+    retryBackoffMs?: number;
   },
 ): ScheduleJob | null {
   const db = getDb();
@@ -295,6 +305,9 @@ export function updateSchedule(
     set.reuseConversation = updates.reuseConversation;
   if (updates.wakeConversationId !== undefined)
     set.wakeConversationId = updates.wakeConversationId;
+  if (updates.maxRetries !== undefined) set.maxRetries = updates.maxRetries;
+  if (updates.retryBackoffMs !== undefined)
+    set.retryBackoffMs = updates.retryBackoffMs;
 
   // Recompute nextRunAt if schedule timing may have changed (only for recurring)
   if (
@@ -817,6 +830,37 @@ export function describeCronExpression(expr: string | null): string {
   }
 }
 
+/**
+ * Set the next retry time for a schedule and revert one-shot status from
+ * "firing" to "active" so the scheduler will claim it again when nextRetryAt
+ * arrives. No-op for recurring schedules (they stay in their current status).
+ */
+export function scheduleRetry(id: string, nextRetryAt: number): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(scheduleJobs)
+    .set({ nextRunAt: nextRetryAt, updatedAt: now })
+    .where(eq(scheduleJobs.id, id))
+    .run();
+  // Revert one-shot status from "firing" to "active" so the scheduler
+  // will claim it again when nextRetryAt arrives. No-op for recurring.
+  db.update(scheduleJobs)
+    .set({ status: "active", updatedAt: now })
+    .where(and(eq(scheduleJobs.id, id), eq(scheduleJobs.status, "firing")))
+    .run();
+}
+
+/**
+ * Reset the retry count for a schedule back to zero (e.g. after a successful run).
+ */
+export function resetRetryCount(id: string): void {
+  const db = getDb();
+  db.update(scheduleJobs)
+    .set({ retryCount: 0, updatedAt: Date.now() })
+    .where(eq(scheduleJobs.id, id))
+    .run();
+}
+
 function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
   return {
     id: row.id,
@@ -833,6 +877,8 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     lastRunAt: row.lastRunAt,
     lastStatus: row.lastStatus,
     retryCount: row.retryCount,
+    maxRetries: row.maxRetries ?? 3,
+    retryBackoffMs: row.retryBackoffMs ?? 60000,
     createdBy: row.createdBy,
     mode: (row.mode ?? "execute") as ScheduleMode,
     routingIntent: (row.routingIntent ?? "all_channels") as RoutingIntent,


### PR DESCRIPTION
## Summary
- Add `max_retries` and `retry_backoff_ms` columns to `cron_jobs` table with defaults (3 retries, 60s backoff)
- Add `scheduleRetry` and `resetRetryCount` store functions
- Update `createSchedule`/`updateSchedule` to accept new fields

Part of plan: sched-retry-handling.md (PR 1 of 6)

Part of JARVIS-481
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->