### PR TITLE
feat(schedule): add exponential backoff utility and shared retry policy helper

### DIFF
--- a/assistant/src/__tests__/retry-backoff.test.ts
+++ b/assistant/src/__tests__/retry-backoff.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeRetryDelay,
+  DEFAULT_MAX_BACKOFF_MS,
+} from "../schedule/retry-backoff.js";
+import { decideRetry } from "../schedule/retry-policy.js";
+
+describe("computeRetryDelay", () => {
+  const noJitter = () => 0.5;
+  const maxJitter = () => 1.0;
+  const minJitter = () => 0.0;
+
+  test("returns exact baseMs with no jitter for attempt 0", () => {
+    expect(computeRetryDelay(0, 60_000, undefined, noJitter)).toBe(60_000);
+  });
+
+  test("doubles for each subsequent attempt", () => {
+    expect(computeRetryDelay(0, 1000, undefined, noJitter)).toBe(1000);
+    expect(computeRetryDelay(1, 1000, undefined, noJitter)).toBe(2000);
+    expect(computeRetryDelay(2, 1000, undefined, noJitter)).toBe(4000);
+    expect(computeRetryDelay(3, 1000, undefined, noJitter)).toBe(8000);
+  });
+
+  test("applies +20% jitter at max", () => {
+    expect(computeRetryDelay(0, 10_000, undefined, maxJitter)).toBe(12_000);
+  });
+
+  test("applies -20% jitter at min", () => {
+    expect(computeRetryDelay(0, 10_000, undefined, minJitter)).toBe(8_000);
+  });
+
+  test("caps at maxMs AFTER jitter (never exceeds cap)", () => {
+    expect(computeRetryDelay(20, 60_000, 300_000, maxJitter)).toBe(300_000);
+    expect(computeRetryDelay(20, 60_000, 300_000, noJitter)).toBe(300_000);
+  });
+
+  test("caps at DEFAULT_MAX_BACKOFF_MS when maxMs not specified", () => {
+    const d = computeRetryDelay(100, 60_000, undefined, maxJitter);
+    expect(d).toBeLessThanOrEqual(DEFAULT_MAX_BACKOFF_MS);
+  });
+
+  test("never returns negative", () => {
+    expect(
+      computeRetryDelay(0, 1, undefined, minJitter),
+    ).toBeGreaterThanOrEqual(0);
+    expect(computeRetryDelay(0, 0, undefined, minJitter)).toBe(0);
+  });
+});
+
+describe("decideRetry", () => {
+  const baseJob = {
+    id: "job-1",
+    name: "Test",
+    maxRetries: 3,
+    retryBackoffMs: 60_000,
+  };
+  const now = 1_000_000;
+
+  test("retries when retryCount < maxRetries", () => {
+    const d = decideRetry({ ...baseJob, retryCount: 0 }, now);
+    expect(d.action).toBe("retry");
+    if (d.action === "retry") {
+      expect(d.nextRetryAt).toBeGreaterThan(now);
+    }
+  });
+
+  test("retries on last allowed attempt (retryCount = maxRetries - 1)", () => {
+    const d = decideRetry({ ...baseJob, retryCount: 2 }, now);
+    expect(d.action).toBe("retry");
+  });
+
+  test("exhausts when retryCount >= maxRetries", () => {
+    expect(decideRetry({ ...baseJob, retryCount: 3 }, now).action).toBe(
+      "exhaust",
+    );
+    expect(decideRetry({ ...baseJob, retryCount: 5 }, now).action).toBe(
+      "exhaust",
+    );
+  });
+
+  test("maxRetries=0 means no retries", () => {
+    expect(
+      decideRetry({ ...baseJob, maxRetries: 0, retryCount: 0 }, now).action,
+    ).toBe("exhaust");
+  });
+});

--- a/assistant/src/schedule/retry-backoff.ts
+++ b/assistant/src/schedule/retry-backoff.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_MAX_BACKOFF_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Compute retry delay with exponential backoff and jitter.
+ * Cap is applied AFTER jitter so the result never exceeds maxMs.
+ */
+export function computeRetryDelay(
+  attempt: number,
+  baseMs: number,
+  maxMs: number = DEFAULT_MAX_BACKOFF_MS,
+  random: () => number = Math.random,
+): number {
+  const exponential = baseMs * Math.pow(2, attempt);
+  const jitter = exponential * 0.2 * (2 * random() - 1);
+  const raw = exponential + jitter;
+  return Math.max(0, Math.min(Math.round(raw), maxMs));
+}

--- a/assistant/src/schedule/retry-policy.ts
+++ b/assistant/src/schedule/retry-policy.ts
@@ -1,0 +1,82 @@
+import type { Logger } from "pino";
+
+import { computeRetryDelay } from "./retry-backoff.js";
+
+export interface RetryPolicyJob {
+  id: string;
+  name: string;
+  retryCount: number;
+  maxRetries: number;
+  retryBackoffMs: number;
+}
+
+export type RetryDecision =
+  | { action: "retry"; delayMs: number; nextRetryAt: number }
+  | { action: "exhaust" };
+
+/**
+ * Pure decision function: given a job's retry state, decide whether
+ * to retry with backoff or give up.
+ *
+ * `retryCount` is the PRE-increment value (before completeScheduleRun
+ * bumped it). So `retryCount < maxRetries` allows exactly maxRetries
+ * retries: retryCount 0, 1, …, maxRetries−1 all pass the check.
+ */
+export function decideRetry(
+  job: RetryPolicyJob,
+  now: number = Date.now(),
+): RetryDecision {
+  if (job.retryCount < job.maxRetries) {
+    const delayMs = computeRetryDelay(job.retryCount, job.retryBackoffMs);
+    return { action: "retry", delayMs, nextRetryAt: now + delayMs };
+  }
+  return { action: "exhaust" };
+}
+
+/**
+ * Apply the retry decision to a schedule: schedule a retry or exhaust.
+ * Calls the provided store operations so this module stays decoupled
+ * from direct DB imports.
+ */
+export function applyRetryDecision(params: {
+  job: RetryPolicyJob;
+  isOneShot: boolean;
+  errorMsg: string;
+  decision: RetryDecision;
+  scheduleRetry: (id: string, nextRetryAt: number) => void;
+  failOneShotPermanently: (id: string) => void;
+  resetRetryCount: (id: string) => void;
+  emitAlert: (title: string, summary: string, dedupKey: string) => void;
+  log: Logger;
+}): void {
+  const { job, isOneShot, errorMsg, decision } = params;
+
+  if (decision.action === "retry") {
+    params.scheduleRetry(job.id, decision.nextRetryAt);
+    params.log.info(
+      {
+        jobId: job.id,
+        name: job.name,
+        attempt: job.retryCount + 1,
+        maxRetries: job.maxRetries,
+        delayMs: decision.delayMs,
+      },
+      "Scheduling retry with backoff",
+    );
+  } else {
+    if (isOneShot) {
+      params.failOneShotPermanently(job.id);
+    } else {
+      params.resetRetryCount(job.id);
+    }
+    params.emitAlert(
+      `${job.name}: Retries exhausted`,
+      `Failed after ${job.retryCount + 1} attempt(s): ${errorMsg}`,
+      `schedule-retries-exhausted:${job.id}:${Date.now()}`,
+    );
+    params.log.warn(
+      { jobId: job.id, name: job.name, attempts: job.retryCount + 1 },
+      "Schedule retries exhausted",
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `computeRetryDelay` with exponential backoff, ±20% jitter, injectable RNG, strict post-jitter cap
- Add `decideRetry` (pure decision) and `applyRetryDecision` (wires to store ops via callbacks)
- Add deterministic tests for both backoff math and retry decision logic

Part of plan: sched-retry-handling.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->