### PR TITLE
feat(schedule): expose maxRetries and retryBackoffMs in tools and routes

### DIFF
--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -54,6 +54,9 @@ function handleListSchedules(queryParams: Record<string, string>) {
       nextRunAt: j.nextRunAt,
       lastRunAt: j.lastRunAt,
       lastStatus: j.lastStatus,
+      retryCount: j.retryCount,
+      maxRetries: j.maxRetries,
+      retryBackoffMs: j.retryBackoffMs,
       description:
         j.syntax === "cron"
           ? describeCronExpression(j.cronExpression)
@@ -139,6 +142,8 @@ function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
     "quiet",
     "reuseConversation",
     "wakeConversationId",
+    "maxRetries",
+    "retryBackoffMs",
   ] as const) {
     if (key in body) {
       updates[key] = body[key];
@@ -294,6 +299,8 @@ export const ROUTES: RouteDefinition[] = [
         .describe("single_channel, multi_channel, or all_channels"),
       quiet: z.boolean(),
       reuseConversation: z.boolean(),
+      maxRetries: z.number().describe("Maximum retry attempts"),
+      retryBackoffMs: z.number().describe("Retry backoff in milliseconds"),
     }),
     responseBody: z.object({
       schedules: z.array(z.unknown()).describe("Updated schedule list"),

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -44,6 +44,8 @@ export async function executeScheduleCreate(
     | undefined;
   const quiet = (input.quiet as boolean) ?? false;
   const reuseConversation = (input.reuse_conversation as boolean) ?? false;
+  const maxRetries = input.max_retries as number | undefined;
+  const retryBackoffMs = input.retry_backoff_ms as number | undefined;
 
   if (!name || typeof name !== "string") {
     return {
@@ -130,6 +132,8 @@ export async function executeScheduleCreate(
         routingHints,
         quiet,
         reuseConversation,
+        maxRetries,
+        retryBackoffMs,
       });
 
       const fireDate = formatLocalDate(job.nextRunAt);
@@ -208,6 +212,8 @@ export async function executeScheduleCreate(
       routingHints,
       quiet,
       reuseConversation,
+      maxRetries,
+      retryBackoffMs,
     });
 
     const scheduleDescription =

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -77,6 +77,8 @@ export async function executeScheduleList(
       `  Last run: ${job.lastRunAt ? formatLocalDate(job.lastRunAt) : "never"}`,
       `  Last status: ${job.lastStatus ?? "n/a"}`,
       `  Retry count: ${job.retryCount}`,
+      `  Max retries: ${job.maxRetries}`,
+      `  Retry backoff: ${job.retryBackoffMs}ms`,
       `  Created: ${formatLocalDate(job.createdAt)}`,
     );
 

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -108,6 +108,14 @@ export async function executeScheduleUpdate(
     updates.reuseConversation = input.reuse_conversation;
   }
 
+  // Retry policy
+  if (input.max_retries !== undefined) {
+    updates.maxRetries = input.max_retries;
+  }
+  if (input.retry_backoff_ms !== undefined) {
+    updates.retryBackoffMs = input.retry_backoff_ms;
+  }
+
   // Auto-detect syntax when expression changes without explicit syntax
   if (input.expression !== undefined || input.syntax !== undefined) {
     const resolved = normalizeScheduleSyntax({
@@ -173,6 +181,8 @@ export async function executeScheduleUpdate(
         routingHints?: Record<string, unknown>;
         quiet?: boolean;
         reuseConversation?: boolean;
+        maxRetries?: number;
+        retryBackoffMs?: number;
       },
     );
 


### PR DESCRIPTION
## Summary
- Add `max_retries` and `retry_backoff_ms` params to schedule create and update tools
- Show Max retries and Retry backoff in schedule list detail view
- Include `retryCount`, `maxRetries`, `retryBackoffMs` in GET /schedules response
- Forward `maxRetries` and `retryBackoffMs` in PATCH /schedules/:id

Part of plan: sched-retry-handling.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->