### PR TITLE
feat(schedule): recover stale firing/running state on daemon startup

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -77,6 +77,7 @@ import {
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
+import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import {
   onCesClientChanged,
@@ -801,6 +802,12 @@ export async function runDaemon(): Promise<void> {
     // Register the broadcast function for the notification signal pipeline's
     // macOS adapter so it can deliver notification_intent messages to clients.
     registerBroadcastFn((msg) => broadcastMessage(msg));
+
+    try {
+      recoverStaleSchedules();
+    } catch (err) {
+      log.error({ err }, "Schedule recovery failed — continuing startup");
+    }
 
     const scheduler = startScheduler(
       async (conversationId, message, options) => {

--- a/assistant/src/schedule/schedule-recovery.ts
+++ b/assistant/src/schedule/schedule-recovery.ts
@@ -1,0 +1,64 @@
+import { getLogger } from "../util/logger.js";
+import { applyRetryDecision, decideRetry } from "./retry-policy.js";
+import {
+  completeScheduleRun,
+  createScheduleRun,
+  failOneShotPermanently,
+  findStaleInFlightJobs,
+  getSchedule,
+  resetRetryCount,
+  scheduleRetry,
+} from "./schedule-store.js";
+
+const log = getLogger("schedule-recovery");
+
+/**
+ * Recover schedules left in an inconsistent state by a prior process crash.
+ * Called once at daemon startup, before the scheduler tick loop starts,
+ * so all "firing" / "running" rows are definitively stale.
+ */
+export function recoverStaleSchedules(): number {
+  const stale = findStaleInFlightJobs(0);
+  if (stale.length === 0) return 0;
+
+  log.info({ count: stale.length }, "Recovering stale in-flight schedules");
+
+  let recovered = 0;
+  for (const { jobId, staleRunId } of stale) {
+    try {
+      const job = getSchedule(jobId);
+      if (!job) continue;
+
+      const errorMsg =
+        "Process terminated during execution (recovered on restart)";
+
+      if (staleRunId) {
+        completeScheduleRun(staleRunId, { status: "error", error: errorMsg });
+      } else {
+        const runId = createScheduleRun(jobId, `recovery:${jobId}`);
+        completeScheduleRun(runId, { status: "error", error: errorMsg });
+      }
+
+      // Use the same retry-or-exhaust path as the scheduler
+      const isOneShot = job.expression == null;
+      const decision = decideRetry(job);
+      applyRetryDecision({
+        job,
+        isOneShot,
+        errorMsg,
+        decision,
+        scheduleRetry,
+        failOneShotPermanently,
+        resetRetryCount,
+        emitAlert: () => {}, // no feed event on startup recovery
+        log,
+      });
+      recovered++;
+    } catch (err) {
+      log.error({ err, jobId }, "Failed to recover stale schedule");
+    }
+  }
+
+  log.info({ recovered }, "Stale schedule recovery complete");
+  return recovered;
+}

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -861,6 +861,63 @@ export function resetRetryCount(id: string): void {
     .run();
 }
 
+/**
+ * Find schedules stuck in an in-flight state (one-shots in "firing",
+ * cron runs in "running"). Used at daemon startup to recover from
+ * a prior process crash.
+ *
+ * @param staleThresholdMs If >0, only consider rows whose lastRunAt
+ *   (for one-shots) or startedAt (for runs) is older than `now - staleThresholdMs`.
+ *   Pass 0 at startup (the previous process is definitely dead).
+ */
+export function findStaleInFlightJobs(staleThresholdMs: number = 0): Array<{
+  jobId: string;
+  staleRunId: string | null;
+}> {
+  const db = getDb();
+  const cutoff = Date.now() - staleThresholdMs;
+
+  // One-shots stuck in "firing" where lastRunAt is older than cutoff
+  const staleOneShots = db
+    .select({ id: scheduleJobs.id })
+    .from(scheduleJobs)
+    .where(
+      and(
+        isNull(scheduleJobs.cronExpression),
+        eq(scheduleJobs.status, "firing"),
+        eq(scheduleJobs.enabled, true),
+        staleThresholdMs > 0 ? lte(scheduleJobs.lastRunAt, cutoff) : undefined,
+      ),
+    )
+    .all();
+
+  // Cron runs stuck in "running" where startedAt is older than cutoff
+  const staleRuns = db
+    .select({ id: scheduleRuns.id, jobId: scheduleRuns.jobId })
+    .from(scheduleRuns)
+    .where(
+      and(
+        eq(scheduleRuns.status, "running"),
+        staleThresholdMs > 0 ? lte(scheduleRuns.startedAt, cutoff) : undefined,
+      ),
+    )
+    .all();
+
+  const result: Array<{ jobId: string; staleRunId: string | null }> = [];
+  const seenJobIds = new Set<string>();
+
+  for (const run of staleRuns) {
+    result.push({ jobId: run.jobId, staleRunId: run.id });
+    seenJobIds.add(run.jobId);
+  }
+  for (const job of staleOneShots) {
+    if (!seenJobIds.has(job.id)) {
+      result.push({ jobId: job.id, staleRunId: null });
+    }
+  }
+  return result;
+}
+
 function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
   return {
     id: row.id,


### PR DESCRIPTION
## Summary
- Add `findStaleInFlightJobs(staleThresholdMs)` to schedule-store for detecting stuck schedules
- Add `recoverStaleSchedules()` using shared `decideRetry`/`applyRetryDecision` from retry-policy
- Call recovery at daemon startup before scheduler tick loop, wrapped in try/catch per startup convention

Part of plan: sched-retry-handling.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->