### PR TITLE
fix: call handleExecutionFailure for recurring wake errors too

### DIFF
--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -338,9 +338,7 @@ async function runScheduleOnce(
           status: "error",
           error: errorMsg,
         });
-        if (isOneShot) {
-          handleExecutionFailure({ job, errorMsg, isOneShot: true });
-        }
+        handleExecutionFailure({ job, errorMsg, isOneShot });
       }
       processed += 1;
       continue;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sched-retry-handling.md.

**Gap:** Wake mode catch block skips handleExecutionFailure for recurring schedules
**What was expected:** All failure paths call handleExecutionFailure unconditionally
**What was found:** Wake mode catch only called it for one-shot, leaving recurring errors without retry/alert
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->