### PR TITLE
fix: add max_retries and retry_backoff_ms to schedule tool schemas

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -8452,6 +8452,12 @@ paths:
                   type: boolean
                 reuseConversation:
                   type: boolean
+                maxRetries:
+                  type: number
+                  description: Maximum retry attempts
+                retryBackoffMs:
+                  type: number
+                  description: Retry backoff in milliseconds
               required:
                 - name
                 - expression
@@ -8462,6 +8468,8 @@ paths:
                 - routingIntent
                 - quiet
                 - reuseConversation
+                - maxRetries
+                - retryBackoffMs
               additionalProperties: false
   /v1/schedules/{id}/cancel:
     post:

--- a/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
+++ b/assistant/src/__tests__/db-schedule-syntax-migration.test.ts
@@ -36,6 +36,8 @@ describe("schedule_syntax column migration", () => {
         last_run_at INTEGER,
         last_status TEXT,
         retry_count INTEGER NOT NULL DEFAULT 0,
+        max_retries INTEGER NOT NULL DEFAULT 3,
+        retry_backoff_ms INTEGER NOT NULL DEFAULT 60000,
         created_by TEXT NOT NULL,
         mode TEXT NOT NULL DEFAULT 'execute',
         routing_intent TEXT NOT NULL DEFAULT 'all_channels',

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -64,6 +64,14 @@
             "type": "boolean",
             "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Useful for polling-style schedules that accumulate context over time. Ignored for one-shot schedules. Defaults to false."
           },
+          "max_retries": {
+            "type": "integer",
+            "description": "Maximum number of retries after the initial execution fails. Defaults to 3."
+          },
+          "retry_backoff_ms": {
+            "type": "integer",
+            "description": "Base backoff delay in milliseconds between retries. Exponential backoff is applied. Defaults to 60000."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"
@@ -162,6 +170,14 @@
           "reuse_conversation": {
             "type": "boolean",
             "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Useful for polling-style schedules that accumulate context over time. Ignored for one-shot schedules."
+          },
+          "max_retries": {
+            "type": "integer",
+            "description": "Maximum number of retries after the initial execution fails. Defaults to 3."
+          },
+          "retry_backoff_ms": {
+            "type": "integer",
+            "description": "Base backoff delay in milliseconds between retries. Exponential backoff is applied. Defaults to 60000."
           },
           "activity": {
             "type": "string",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for sched-retry-handling.md.

**Gap:** Tool JSON schema not updated for retry parameters
**What was expected:** LLM-facing tool schemas include retry policy parameters
**What was found:** Executors read the params but the tool schema didn't expose them
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->