### PR TITLE
feat(daemon): add host_app_control capability and message types

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -91,17 +91,18 @@ export function isInteractiveInterface(id: InterfaceId): boolean {
 
 /**
  * Host proxy capabilities that an interface can support. The macOS client
- * supports all four; the chrome-extension interface only supports
+ * supports all five; the chrome-extension interface only supports
  * host_browser (via the Chrome DevTools Protocol proxy).
  */
 export type HostProxyCapability =
   | "host_bash"
   | "host_file"
   | "host_cu"
-  | "host_browser";
+  | "host_browser"
+  | "host_app_control";
 
 /**
- * Interfaces that support the full desktop host-proxy set (all four
+ * Interfaces that support the full desktop host-proxy set (all five
  * `HostProxyCapability` values). This is the capability-level identity used
  * by the discriminated transport metadata union and by the
  * `supportsHostProxy(id)` type predicate.
@@ -135,10 +136,10 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
-  // macOS supports all four host proxy capabilities including host_browser.
-  // The host_browser proxy is provisioned via the assistant event hub. When no
-  // extension is connected, browser tools fall through to cdp-inspect/local
-  // via the CDP factory's candidate chain.
+  // macOS supports all five host proxy capabilities including host_browser
+  // and host_app_control. The host_browser proxy is provisioned via the
+  // assistant event hub. When no extension is connected, browser tools fall
+  // through to cdp-inspect/local via the CDP factory's candidate chain.
   if (id === "macos") return true;
   if (id === "chrome-extension" && capability === "host_browser") return true;
   return false;

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -23,6 +23,7 @@ export * from "./message-types/diagnostics.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
 export * from "./message-types/home.js";
+export * from "./message-types/host-app-control.js";
 export * from "./message-types/host-bash.js";
 export * from "./message-types/host-browser.js";
 export * from "./message-types/host-cu.js";
@@ -79,6 +80,7 @@ import type {
   _GuardianActionsServerMessages,
 } from "./message-types/guardian-actions.js";
 import type { _HomeServerMessages } from "./message-types/home.js";
+import type { _HostAppControlServerMessages } from "./message-types/host-app-control.js";
 import type { _HostBashServerMessages } from "./message-types/host-bash.js";
 import type {
   _HostBrowserClientMessages,
@@ -185,6 +187,7 @@ export type ServerMessage =
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
   | _HomeServerMessages
+  | _HostAppControlServerMessages
   | _HostBashServerMessages
   | _HostBrowserServerMessages
   | _HostCuServerMessages

--- a/assistant/src/daemon/message-types/host-app-control.ts
+++ b/assistant/src/daemon/message-types/host-app-control.ts
@@ -1,0 +1,125 @@
+// Host app-control proxy types.
+// Enables proxying app-control actions (start, observe, press, combo, type,
+// click, drag, stop) to the desktop client (host machine) when running as a
+// managed assistant. Targets a specific application by bundle ID or process
+// name — distinct from the system-wide computer-use proxy in host-cu.ts.
+
+// === Tool input discriminated union ===
+
+/** Inputs accepted by the eight app-control tool variants. */
+export type HostAppControlInput =
+  | HostAppControlStartInput
+  | HostAppControlObserveInput
+  | HostAppControlPressInput
+  | HostAppControlComboInput
+  | HostAppControlTypeInput
+  | HostAppControlClickInput
+  | HostAppControlDragInput
+  | HostAppControlStopInput;
+
+export interface HostAppControlStartInput {
+  tool: "start";
+  /** Bundle ID (preferred) or process name. */
+  app: string;
+  /** Optional command-line arguments to launch the app with. */
+  args?: string[];
+}
+
+export interface HostAppControlObserveInput {
+  tool: "observe";
+  app: string;
+}
+
+export interface HostAppControlPressInput {
+  tool: "press";
+  app: string;
+  /** Single key identifier, e.g. "return", "a", "f12". */
+  key: string;
+  /** Modifier list, e.g. ["cmd", "shift"]. */
+  modifiers?: string[];
+  /** Hold duration in milliseconds. */
+  duration_ms?: number;
+}
+
+export interface HostAppControlComboInput {
+  tool: "combo";
+  app: string;
+  /** Sequence of keys pressed simultaneously, e.g. ["cmd", "shift", "4"]. */
+  keys: string[];
+  /** Hold duration in milliseconds. */
+  duration_ms?: number;
+}
+
+export interface HostAppControlTypeInput {
+  tool: "type";
+  app: string;
+  text: string;
+}
+
+export interface HostAppControlClickInput {
+  tool: "click";
+  app: string;
+  x: number;
+  y: number;
+  button?: "left" | "right" | "middle";
+  double?: boolean;
+}
+
+export interface HostAppControlDragInput {
+  tool: "drag";
+  app: string;
+  from_x: number;
+  from_y: number;
+  to_x: number;
+  to_y: number;
+  button?: "left" | "right" | "middle";
+}
+
+export interface HostAppControlStopInput {
+  tool: "stop";
+  /** Optional — when omitted the proxy stops whichever app currently holds the session. */
+  app?: string;
+  /** Free-form reason, surfaced for logging. */
+  reason?: string;
+}
+
+// === Server → Client ===
+
+export interface HostAppControlRequest {
+  type: "host_app_control_request";
+  requestId: string;
+  conversationId: string;
+  toolName: string; // "app_control_start", "app_control_observe", etc.
+  input: HostAppControlInput;
+}
+
+export interface HostAppControlCancel {
+  type: "host_app_control_cancel";
+  requestId: string;
+}
+
+// === Result payload (HTTP /v1/host-app-control-result body) ===
+
+/** Lifecycle state of the targeted application as seen by the client. */
+export type HostAppControlState =
+  | "running"
+  | "missing"
+  | "minimized"
+  | "occluded";
+
+export interface HostAppControlResultPayload {
+  requestId: string;
+  state: HostAppControlState;
+  /** Base64-encoded PNG screenshot of the targeted app window, when available. */
+  pngBase64?: string;
+  /** Window bounds in screen-space points. */
+  windowBounds?: { x: number; y: number; width: number; height: number };
+  executionResult?: string;
+  executionError?: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _HostAppControlServerMessages =
+  | HostAppControlRequest
+  | HostAppControlCancel;

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -1,16 +1,16 @@
 /**
  * In-memory tracker that maps requestId to conversation info for pending
- * confirmation, secret, host_bash, host_file, host_cu, host_browser, and
- * host_transfer interactions.
+ * confirmation, secret, host_bash, host_file, host_cu, host_browser,
+ * host_app_control, and host_transfer interactions.
  *
  * When the agent loop emits a confirmation_request, secret_request,
  * host_bash_request, host_file_request, host_cu_request,
- * host_browser_request, or host_transfer_request, the onEvent callback
- * registers the interaction here.
+ * host_browser_request, host_app_control_request, or host_transfer_request,
+ * the onEvent callback registers the interaction here.
  * Standalone HTTP endpoints (/v1/confirm, /v1/secret, /v1/trust-rules,
  * /v1/host-bash-result, /v1/host-file-result, /v1/host-cu-result,
- * /v1/host-browser-result) look up the conversation from this tracker to
- * resolve the interaction.
+ * /v1/host-browser-result, /v1/host-app-control-result) look up the
+ * conversation from this tracker to resolve the interaction.
  */
 
 import type { UserDecision } from "../permissions/types.js";
@@ -46,6 +46,7 @@ export interface PendingInteraction {
     | "host_file"
     | "host_cu"
     | "host_browser"
+    | "host_app_control"
     | "host_transfer"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
@@ -102,11 +103,12 @@ export function getByConversation(
  * Remove pending confirmation and secret interactions for a given conversation.
  * Used when auto-denying all pending interactions (e.g. new user message).
  *
- * host_bash, host_file, host_cu, host_browser, and host_transfer interactions
- * are intentionally skipped — they represent in-flight tool executions proxied
- * to the client, not confirmations to auto-deny. Removing them would orphan
- * the request: the client would POST to /v1/host-bash-result,
- * /v1/host-file-result, /v1/host-cu-result, /v1/host-browser-result, or
+ * host_bash, host_file, host_cu, host_browser, host_app_control, and
+ * host_transfer interactions are intentionally skipped — they represent
+ * in-flight tool executions proxied to the client, not confirmations to
+ * auto-deny. Removing them would orphan the request: the client would POST to
+ * /v1/host-bash-result, /v1/host-file-result, /v1/host-cu-result,
+ * /v1/host-browser-result, /v1/host-app-control-result, or
  * /v1/host-transfer-result after completing the operation, get a 404, and the
  * proxy timer would fire with a spurious timeout error.
  */
@@ -118,6 +120,7 @@ export function removeByConversation(conversationId: string): void {
       interaction.kind !== "host_file" &&
       interaction.kind !== "host_cu" &&
       interaction.kind !== "host_browser" &&
+      interaction.kind !== "host_app_control" &&
       interaction.kind !== "host_transfer" &&
       interaction.kind !== "acp_confirmation"
     ) {


### PR DESCRIPTION
## Summary
- Add 'host_app_control' to HostProxyCapability union; macOS row in supportsHostProxy matrix.
- Declare HostAppControlRequest / HostAppControlInput / HostAppControlCancel / HostAppControlResultPayload wire types.
- Extend message-protocol envelope and pending-interactions kind union.

Part of plan: app-control-skill.md (PR 2 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->