### PR TITLE
feat(daemon): add HostAppControlProxy over HostProxyBase

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -1,0 +1,634 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const sentMessages: unknown[] = [];
+const resolvedInteractionIds: string[] = [];
+let mockHasClient = false;
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  assistantEventHub: {
+    getMostRecentClientByCapability: (cap: string) =>
+      cap === "host_app_control" && mockHasClient
+        ? { id: "mock-client" }
+        : null,
+  },
+}));
+
+mock.module("../runtime/pending-interactions.js", () => ({
+  resolve: (requestId: string) => {
+    resolvedInteractionIds.push(requestId);
+    return undefined;
+  },
+  get: () => undefined,
+  getByKind: () => [],
+  getByConversation: () => [],
+  removeByConversation: () => {},
+}));
+
+const {
+  HostAppControlProxy,
+  _getActiveAppControlConversationId,
+  _resetActiveAppControlConversationId,
+} = await import("../daemon/host-app-control-proxy.js");
+
+import type { HostAppControlResultPayload } from "../daemon/message-types/host-app-control.js";
+
+/**
+ * Build a result payload with stable defaults plus per-test overrides.
+ * Default state is "running" so `start` succeeds and the singleton lock
+ * is acquired.
+ */
+function payload(
+  overrides: Partial<HostAppControlResultPayload> = {},
+): HostAppControlResultPayload {
+  return {
+    requestId: "ignored-by-proxy",
+    state: "running",
+    ...overrides,
+  };
+}
+
+/** Tiny base64-encoded PNG-ish blob — content is irrelevant to the hashing logic. */
+const PNG_A = "AAAA";
+const PNG_B = "BBBB";
+
+describe("HostAppControlProxy", () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+    resolvedInteractionIds.length = 0;
+    mockHasClient = false;
+    _resetActiveAppControlConversationId();
+  });
+
+  afterEach(() => {
+    _resetActiveAppControlConversationId();
+  });
+
+  // -------------------------------------------------------------------------
+  // (a) Start round-trip
+  // -------------------------------------------------------------------------
+
+  describe("start round-trip", () => {
+    test("dispatches host_app_control_request and resolves with formatted result", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const controller = new AbortController();
+
+      const resultPromise = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        controller.signal,
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_app_control_request");
+      expect(sent.conversationId).toBe("conv-1");
+      expect(sent.toolName).toBe("app_control_start");
+      expect(sent.input).toEqual({
+        tool: "start",
+        app: "com.example.editor",
+      });
+      expect(typeof sent.requestId).toBe("string");
+
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      proxy.resolve(
+        requestId,
+        payload({
+          pngBase64: PNG_A,
+          windowBounds: { x: 10, y: 20, width: 800, height: 600 },
+          executionResult: "Editor launched",
+        }),
+      );
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("State: running");
+      expect(result.content).toContain("800x600 at (10, 20)");
+      expect(result.content).toContain("Editor launched");
+      expect(result.contentBlocks).toBeDefined();
+      expect(result.contentBlocks).toHaveLength(1);
+      expect(result.contentBlocks![0]).toEqual({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: PNG_A,
+        },
+      });
+
+      // Singleton lock acquired by this conversation.
+      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+      expect(proxy.currentApp).toEqual({ name: "com.example.editor" });
+
+      proxy.dispose();
+    });
+
+    test("formats execution error with isError=true", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const controller = new AbortController();
+
+      const resultPromise = proxy.request(
+        "app_control_click",
+        { tool: "click", app: "com.example.editor", x: 100, y: 200 },
+        "conv-1",
+        controller.signal,
+      );
+
+      const sent = sentMessages[0] as Record<string, unknown>;
+      proxy.resolve(
+        sent.requestId as string,
+        payload({
+          executionError: "Element not found at (100, 200)",
+        }),
+      );
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        "Action failed: Element not found at (100, 200)",
+      );
+      expect(result.content).toContain("State: running");
+
+      proxy.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (b) Singleton lock
+  // -------------------------------------------------------------------------
+
+  describe("singleton lock", () => {
+    test("second conversation's start returns isError naming the holder", async () => {
+      const proxy1 = new HostAppControlProxy("conv-1");
+      const ctrl1 = new AbortController();
+
+      const p1 = proxy1.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl1.signal,
+      );
+      const sent1 = sentMessages[0] as Record<string, unknown>;
+      proxy1.resolve(sent1.requestId as string, payload({ pngBase64: PNG_A }));
+      await p1;
+
+      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+
+      // Second conversation tries to start — should be rejected without
+      // sending any envelope.
+      const proxy2 = new HostAppControlProxy("conv-2");
+      const ctrl2 = new AbortController();
+      sentMessages.length = 0;
+
+      const result = await proxy2.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-2",
+        ctrl2.signal,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("conv-1");
+      expect(result.content.toLowerCase()).toContain(
+        "currently holds the app-control session",
+      );
+      expect(sentMessages).toHaveLength(0); // No envelope dispatched
+
+      proxy1.dispose();
+      proxy2.dispose();
+    });
+
+    test("same conversation re-starting is allowed", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      const p1 = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await p1;
+
+      // Same conversation can re-start without being blocked.
+      const p2 = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      expect(sentMessages).toHaveLength(2);
+      proxy.resolve(
+        (sentMessages[1] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_B }),
+      );
+      const result2 = await p2;
+      expect(result2.isError).toBe(false);
+
+      proxy.dispose();
+    });
+
+    test("non-start tools are not gated by the lock", async () => {
+      const proxy = new HostAppControlProxy("conv-2");
+      const ctrl = new AbortController();
+
+      // Pretend another conversation already owns the session by manually
+      // priming the lock via a successful start in conv-1.
+      const proxyOwner = new HostAppControlProxy("conv-1");
+      const startCtrl = new AbortController();
+      const pStart = proxyOwner.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        startCtrl.signal,
+      );
+      proxyOwner.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await pStart;
+
+      sentMessages.length = 0;
+
+      // conv-2 issues a non-start tool — proxy must NOT short-circuit on
+      // the lock; the dispatch goes through.
+      const observePromise = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-2",
+        ctrl.signal,
+      );
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.toolName).toBe("app_control_observe");
+
+      proxy.resolve(sent.requestId as string, payload({ pngBase64: PNG_B }));
+      const result = await observePromise;
+      expect(result.isError).toBe(false);
+
+      proxy.dispose();
+      proxyOwner.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (c) PNG-hash loop guard
+  // -------------------------------------------------------------------------
+
+  describe("PNG-hash loop guard", () => {
+    test("attaches stuck warning after 5 identical observations", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      // First observation establishes the baseline (count = 0).
+      const p0 = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      const r0 = await p0;
+      expect(r0.content).not.toContain("WARNING");
+      expect(proxy.observationRepeatCount).toBe(0);
+
+      // 4 additional identical observations bring the repeat count to 4 —
+      // still below the threshold (5).
+      for (let i = 0; i < 4; i++) {
+        const p = proxy.request(
+          "app_control_observe",
+          { tool: "observe", app: "com.example.editor" },
+          "conv-1",
+          ctrl.signal,
+        );
+        const sent = sentMessages[i + 1] as Record<string, unknown>;
+        proxy.resolve(sent.requestId as string, payload({ pngBase64: PNG_A }));
+        const r = await p;
+        expect(r.content).not.toContain("WARNING");
+      }
+      expect(proxy.observationRepeatCount).toBe(4);
+
+      // 5th identical observation — count reaches 5, warning fires.
+      const pFinal = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const sentFinal = sentMessages[5] as Record<string, unknown>;
+      proxy.resolve(
+        sentFinal.requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      const rFinal = await pFinal;
+      expect(rFinal.content).toContain("WARNING");
+      expect(rFinal.content.toLowerCase()).toContain("stuck");
+      expect(proxy.observationRepeatCount).toBe(5);
+
+      proxy.dispose();
+    });
+
+    test("resets repeat count when the screenshot hash differs", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      // Establish baseline at PNG_A.
+      const p1 = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await p1;
+
+      // Repeat 3 times to bring count to 3.
+      for (let i = 0; i < 3; i++) {
+        const p = proxy.request(
+          "app_control_observe",
+          { tool: "observe", app: "com.example.editor" },
+          "conv-1",
+          ctrl.signal,
+        );
+        const sent = sentMessages[i + 1] as Record<string, unknown>;
+        proxy.resolve(sent.requestId as string, payload({ pngBase64: PNG_A }));
+        await p;
+      }
+      expect(proxy.observationRepeatCount).toBe(3);
+
+      // A different PNG resets the count to 0.
+      const pDiff = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      const sentDiff = sentMessages[4] as Record<string, unknown>;
+      proxy.resolve(
+        sentDiff.requestId as string,
+        payload({ pngBase64: PNG_B }),
+      );
+      const rDiff = await pDiff;
+      expect(rDiff.content).not.toContain("WARNING");
+      expect(proxy.observationRepeatCount).toBe(0);
+
+      proxy.dispose();
+    });
+
+    test("non-running states do not feed the loop guard", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      // Several observations with state != running (and identical PNGs)
+      // should not increment the repeat count.
+      for (let i = 0; i < 6; i++) {
+        const p = proxy.request(
+          "app_control_observe",
+          { tool: "observe", app: "com.example.editor" },
+          "conv-1",
+          ctrl.signal,
+        );
+        const sent = sentMessages[i] as Record<string, unknown>;
+        proxy.resolve(
+          sent.requestId as string,
+          payload({ state: "minimized", pngBase64: PNG_A }),
+        );
+        const r = await p;
+        expect(r.content).not.toContain("WARNING");
+      }
+      expect(proxy.observationRepeatCount).toBe(0);
+
+      proxy.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (d) dispose releases the lock
+  // -------------------------------------------------------------------------
+
+  describe("dispose lock release", () => {
+    test("releases singleton lock so a new conversation can start", async () => {
+      const proxy1 = new HostAppControlProxy("conv-1");
+      const ctrl1 = new AbortController();
+
+      const p1 = proxy1.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl1.signal,
+      );
+      proxy1.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await p1;
+      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+
+      proxy1.dispose();
+      expect(_getActiveAppControlConversationId()).toBeUndefined();
+
+      // Now a new conversation can acquire the lock.
+      sentMessages.length = 0;
+      const proxy2 = new HostAppControlProxy("conv-2");
+      const ctrl2 = new AbortController();
+
+      const p2 = proxy2.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-2",
+        ctrl2.signal,
+      );
+      expect(sentMessages).toHaveLength(1); // Dispatch happened — not blocked
+      proxy2.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_B }),
+      );
+      const result = await p2;
+      expect(result.isError).toBe(false);
+      expect(_getActiveAppControlConversationId()).toBe("conv-2");
+
+      proxy2.dispose();
+    });
+
+    test("dispose by a non-holder does not clear the lock", async () => {
+      const proxyOwner = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      const pStart = proxyOwner.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        ctrl.signal,
+      );
+      proxyOwner.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await pStart;
+      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+
+      // A different conversation's proxy disposes — the lock should remain
+      // with conv-1.
+      const proxyOther = new HostAppControlProxy("conv-2");
+      proxyOther.dispose();
+      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+
+      proxyOwner.dispose();
+      expect(_getActiveAppControlConversationId()).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // (e) Abort
+  // -------------------------------------------------------------------------
+
+  describe("abort", () => {
+    test("propagates abort and emits cancel envelope", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const controller = new AbortController();
+
+      const resultPromise = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-1",
+        controller.signal,
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(proxy.hasPendingRequest(requestId)).toBe(true);
+
+      controller.abort();
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Aborted");
+      expect(proxy.hasPendingRequest(requestId)).toBe(false);
+
+      // Cancel envelope was broadcast.
+      expect(sentMessages).toHaveLength(2);
+      const cancel = sentMessages[1] as Record<string, unknown>;
+      expect(cancel.type).toBe("host_app_control_cancel");
+      expect(cancel.requestId).toBe(requestId);
+
+      proxy.dispose();
+    });
+
+    test("returns immediately when signal is already aborted", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-1",
+        controller.signal,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Aborted");
+      expect(sentMessages).toHaveLength(0); // No envelope sent
+
+      proxy.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // No 50-step cap (different policy from CU)
+  // -------------------------------------------------------------------------
+
+  describe("no step cap", () => {
+    test("100 sequential requests dispatch without an artificial limit", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      for (let i = 0; i < 100; i++) {
+        const p = proxy.request(
+          "app_control_observe",
+          { tool: "observe", app: "com.example.editor" },
+          "conv-1",
+          ctrl.signal,
+        );
+        const sent = sentMessages[i] as Record<string, unknown>;
+        // Alternate PNGs so the loop guard does not fire.
+        proxy.resolve(
+          sent.requestId as string,
+          payload({ pngBase64: i % 2 === 0 ? PNG_A : PNG_B }),
+        );
+        const r = await p;
+        expect(r.isError).toBe(false);
+      }
+      expect(sentMessages).toHaveLength(100);
+
+      proxy.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Action history bounding
+  // -------------------------------------------------------------------------
+
+  describe("action history", () => {
+    test("keeps only the most recent 5 entries", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctrl = new AbortController();
+
+      for (let i = 0; i < 8; i++) {
+        const p = proxy.request(
+          "app_control_press",
+          { tool: "press", app: "com.example.editor", key: `k${i}` },
+          "conv-1",
+          ctrl.signal,
+        );
+        const sent = sentMessages[i] as Record<string, unknown>;
+        proxy.resolve(
+          sent.requestId as string,
+          payload({ pngBase64: `P${i}` }),
+        );
+        await p;
+      }
+
+      expect(proxy.actionHistory).toHaveLength(5);
+      // Oldest retained entry should fingerprint key "k3".
+      expect(proxy.actionHistory[0]).toContain('"key":"k3"');
+      expect(proxy.actionHistory[4]).toContain('"key":"k7"');
+
+      proxy.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isAvailable
+  // -------------------------------------------------------------------------
+
+  describe("isAvailable", () => {
+    test("returns false when no host_app_control client is connected", () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      mockHasClient = false;
+      expect(proxy.isAvailable()).toBe(false);
+      proxy.dispose();
+    });
+
+    test("returns true when a host_app_control client is connected", () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      mockHasClient = true;
+      expect(proxy.isAvailable()).toBe(true);
+      proxy.dispose();
+    });
+  });
+});

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -1,0 +1,340 @@
+/**
+ * Host app-control proxy.
+ *
+ * Proxies app-control actions (start, observe, press, combo, type, click,
+ * drag, stop) to the desktop client. Targets a specific application by
+ * bundle ID or process name — distinct from the system-wide computer-use
+ * proxy ({@link HostCuProxy}).
+ *
+ * Lifecycle (pending map, timeout, abort SSE, dispose, isAvailable) lives
+ * in {@link HostProxyBase}; this class layers app-control-specific state
+ * (active app, PNG-hash loop guard, action history) and the result-payload
+ * → ToolExecutionResult translation on top.
+ *
+ * **Singleton lock.** Only one conversation may hold an active app-control
+ * session at a time. The lock is module-level (`activeAppControlConversationId`)
+ * because a session targets the user's actual desktop application, which
+ * is a host-wide resource. The lock is acquired on a successful
+ * `app_control_start` and released when the owning proxy's `dispose()`
+ * fires. A second conversation that calls `start` while the lock is held
+ * receives an `isError: true` tool result naming the holding conversation.
+ *
+ * **No step cap.** Unlike {@link HostCuProxy} which enforces a per-session
+ * step ceiling via `loadConfig().maxStepsPerSession`, app-control sessions
+ * are not capped. App-control flows are typically narrower (single-app,
+ * shorter horizons) and the loop guard plus user oversight are the
+ * intended safeguards.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { ContentBlock } from "../providers/types.js";
+import type { ToolExecutionResult } from "../tools/types.js";
+import { getLogger } from "../util/logger.js";
+import { HostProxyBase, HostProxyRequestError } from "./host-proxy-base.js";
+import type {
+  HostAppControlInput,
+  HostAppControlResultPayload,
+} from "./message-types/host-app-control.js";
+
+const log = getLogger("host-app-control-proxy");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const REQUEST_TIMEOUT_MS = 60 * 1000;
+const ACTION_HISTORY_LIMIT = 5;
+const STUCK_REPEAT_THRESHOLD = 5;
+
+// ---------------------------------------------------------------------------
+// Tool name constants
+// ---------------------------------------------------------------------------
+//
+// Kept here (rather than imported from PR 5's tool registrations) so the
+// proxy is independently testable. PR 5 must use these same string values.
+
+const TOOL_START = "app_control_start";
+
+// ---------------------------------------------------------------------------
+// Module-level singleton lock
+// ---------------------------------------------------------------------------
+
+/**
+ * Conversation id that currently owns the active app-control session, or
+ * `undefined` if no session is active. Set on a successful
+ * `app_control_start`; cleared by the owning proxy's `dispose()`.
+ *
+ * Exported for test inspection only. Production code paths must not read
+ * or mutate this directly — use the proxy methods.
+ */
+let activeAppControlConversationId: string | undefined;
+
+/** Test-only helper: read current lock owner. */
+export function _getActiveAppControlConversationId(): string | undefined {
+  return activeAppControlConversationId;
+}
+
+/** Test-only helper: clear lock between test cases. */
+export function _resetActiveAppControlConversationId(): void {
+  activeAppControlConversationId = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Per-instance state types
+// ---------------------------------------------------------------------------
+
+interface ActiveApp {
+  bundleId?: string;
+  pid?: number;
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// HostAppControlProxy
+// ---------------------------------------------------------------------------
+
+export class HostAppControlProxy extends HostProxyBase<
+  HostAppControlInput,
+  HostAppControlResultPayload
+> {
+  /** Conversation that owns this proxy instance. Used by `dispose()` to release the singleton lock only when this proxy is the holder. */
+  private readonly conversationId: string;
+
+  /** Application identity captured from the most recent successful `start` result. */
+  private activeApp?: ActiveApp;
+
+  /** sha256 hex of the most recent observation's `pngBase64`, or undefined. */
+  private lastObservationHash?: string;
+
+  /**
+   * Number of consecutive observations whose PNG hash matched the previous
+   * one. Reset to 0 when a different hash is observed. When this reaches
+   * {@link STUCK_REPEAT_THRESHOLD}, results carry a `"stuck"` warning.
+   */
+  private observationHashRepeatCount = 0;
+
+  /** Ring buffer of the last {@link ACTION_HISTORY_LIMIT} tool+input fingerprints (FIFO). */
+  private _actionHistory: string[] = [];
+
+  constructor(conversationId: string) {
+    super({
+      capabilityName: "host_app_control",
+      requestEventName: "host_app_control_request",
+      cancelEventName: "host_app_control_cancel",
+      resultPendingKind: "host_app_control",
+      timeoutMs: REQUEST_TIMEOUT_MS,
+      disposedMessage: "Host app-control proxy disposed",
+    });
+    this.conversationId = conversationId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // State accessors (testing / external inspection)
+  // ---------------------------------------------------------------------------
+
+  get currentApp(): ActiveApp | undefined {
+    return this.activeApp;
+  }
+
+  get observationRepeatCount(): number {
+    return this.observationHashRepeatCount;
+  }
+
+  get actionHistory(): readonly string[] {
+    return this._actionHistory;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public request entry point
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Dispatch an app-control tool call to the desktop client. Catches the
+   * base's typed lifecycle errors (timeout/aborted/disposed) and returns
+   * a `ToolExecutionResult` instead of letting them bubble.
+   */
+  async request(
+    toolName: string,
+    input: HostAppControlInput,
+    conversationId: string,
+    signal: AbortSignal,
+  ): Promise<ToolExecutionResult> {
+    if (signal.aborted) {
+      return { content: "Aborted", isError: true };
+    }
+
+    // Singleton-lock guard for `start`. Other tools assume a session
+    // already exists and are not gated here.
+    if (toolName === TOOL_START) {
+      if (
+        activeAppControlConversationId != null &&
+        activeAppControlConversationId !== conversationId
+      ) {
+        return {
+          content:
+            `Another conversation (${activeAppControlConversationId}) currently holds the ` +
+            `app-control session. Wait for it to finish, or call app_control_stop ` +
+            `from that conversation first.`,
+          isError: true,
+        };
+      }
+    }
+
+    // Record the action fingerprint up-front so it shows up in history
+    // even if the request times out / aborts.
+    this.recordActionFingerprint(toolName, input);
+
+    try {
+      const payload = await this.dispatchRequest(
+        toolName,
+        input,
+        conversationId,
+        signal,
+      );
+      return this.handleSuccess(toolName, input, payload);
+    } catch (err) {
+      if (err instanceof HostProxyRequestError) {
+        if (err.reason === "timeout") {
+          log.warn({ toolName }, "Host app-control proxy request timed out");
+          return {
+            content:
+              "Host app-control proxy timed out waiting for client response",
+            isError: true,
+          };
+        }
+        if (err.reason === "aborted") {
+          return { content: "Aborted", isError: true };
+        }
+      }
+      // `disposed` and any other unexpected errors propagate.
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Result handling
+  // ---------------------------------------------------------------------------
+
+  private handleSuccess(
+    toolName: string,
+    input: HostAppControlInput,
+    payload: HostAppControlResultPayload,
+  ): ToolExecutionResult {
+    // Update PNG-hash loop tracking only for the "running" state — other
+    // states (missing/minimized/occluded) intentionally won't carry a
+    // representative window screenshot, so they should not feed the guard.
+    let stuck = false;
+    if (payload.state === "running" && payload.pngBase64) {
+      const hash = createHash("sha256").update(payload.pngBase64).digest("hex");
+      if (hash === this.lastObservationHash) {
+        this.observationHashRepeatCount++;
+      } else {
+        this.observationHashRepeatCount = 0;
+      }
+      this.lastObservationHash = hash;
+      if (this.observationHashRepeatCount >= STUCK_REPEAT_THRESHOLD) {
+        stuck = true;
+      }
+    }
+
+    // Acquire the singleton lock on a successful `start`. Capture the
+    // app identity from the request input — the current result-payload
+    // shape doesn't carry bundleId/pid, but the start input names the
+    // target app (bundle id or process name), which is the most
+    // authoritative identity we have at this layer.
+    if (
+      toolName === TOOL_START &&
+      input.tool === "start" &&
+      payload.state === "running"
+    ) {
+      activeAppControlConversationId = this.conversationId;
+      this.activeApp = { name: input.app };
+    }
+
+    return this.formatResult(payload, stuck);
+  }
+
+  private formatResult(
+    payload: HostAppControlResultPayload,
+    stuck: boolean,
+  ): ToolExecutionResult {
+    const parts: string[] = [];
+
+    if (stuck) {
+      parts.push(
+        `WARNING: ${this.observationHashRepeatCount} consecutive observations ` +
+          `produced an identical screenshot — the app appears stuck. Try a ` +
+          `different action or call app_control_stop and restart.`,
+      );
+      parts.push("");
+    }
+
+    parts.push(`State: ${payload.state}`);
+
+    if (payload.windowBounds) {
+      const { x, y, width, height } = payload.windowBounds;
+      parts.push(`Window bounds: ${width}x${height} at (${x}, ${y})`);
+    }
+
+    if (payload.executionResult) {
+      parts.push("");
+      parts.push(payload.executionResult);
+    }
+
+    const isError = payload.executionError != null;
+    const errorPrefix = isError
+      ? `Action failed: ${payload.executionError}`
+      : null;
+
+    const baseContent = parts.join("\n").trim() || `State: ${payload.state}`;
+    const content = errorPrefix
+      ? `${errorPrefix}\n\n${baseContent}`
+      : baseContent;
+
+    const contentBlocks: ContentBlock[] = [];
+    if (payload.pngBase64) {
+      contentBlocks.push({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: payload.pngBase64,
+        },
+      });
+    }
+
+    return {
+      content,
+      isError,
+      ...(contentBlocks.length > 0 ? { contentBlocks } : {}),
+    };
+  }
+
+  /** Append `<toolName>:<JSON(input)>` to the bounded action history. */
+  private recordActionFingerprint(
+    toolName: string,
+    input: HostAppControlInput,
+  ): void {
+    const fingerprint = `${toolName}:${JSON.stringify(input)}`;
+    this._actionHistory.push(fingerprint);
+    if (this._actionHistory.length > ACTION_HISTORY_LIMIT) {
+      this._actionHistory = this._actionHistory.slice(-ACTION_HISTORY_LIMIT);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Reject pending requests via the base, then release the singleton lock
+   * if this proxy is the holder. Idempotent: safe to call multiple times.
+   */
+  override dispose(): void {
+    super.dispose();
+    if (activeAppControlConversationId === this.conversationId) {
+      activeAppControlConversationId = undefined;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- HostAppControlProxy extends HostProxyBase<HostAppControlInput, HostAppControlResultPayload>.
- Module-level singleton lock; second conversation's start returns isError tool result.
- PNG-hash loop guard attaches 'stuck' warning after 5 identical observations.
- No 50-step cap (different policy from CU).

Part of plan: app-control-skill.md (PR 4 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->