### PR TITLE
feat(macos): add per-app window screenshot helper

### DIFF
--- a/clients/macos/vellum-assistant/AppControl/AppWindowCapture.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppWindowCapture.swift
@@ -1,0 +1,131 @@
+#if os(macOS)
+import AppKit
+import CoreGraphics
+import ImageIO
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppWindowCapture")
+
+/// Captures the frontmost normal window of a target process by PID.
+///
+/// Returns a `CaptureResult` whose `state` distinguishes:
+///   - `.running`   — the process is alive and an on-screen normal window was captured.
+///   - `.minimized` — the process is alive but no normal layer-0 window is on-screen
+///                    (e.g. minimized to Dock or app is hidden).
+///   - `.missing`   — no running NSRunningApplication has the requested PID.
+///
+/// PNG bytes (base64) and `WindowBounds` are populated when a normal window was
+/// found and ScreenCaptureKit was able to capture it (`state == .running`).
+///
+/// Window filtering uses `CGWindowListCopyWindowInfo` (which remains available in
+/// macOS 15) to identify on-screen layer-0 windows owned by the target PID. The
+/// actual pixel capture goes through `SCScreenshotManager` because
+/// `CGWindowListCreateImage` is unavailable in macOS 15.
+enum AppWindowCapture {
+
+    struct CaptureResult: Equatable {
+        let state: HostAppControlState
+        let pngBase64: String?
+        let bounds: WindowBounds?
+    }
+
+    /// Capture the frontmost normal window owned by `pid`. See type docs for state semantics.
+    static func capture(forPid pid: pid_t) async -> CaptureResult {
+        let infoList = (CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[CFString: Any]]) ?? []
+
+        let match = infoList.first { entry in
+            guard let ownerPID = entry[kCGWindowOwnerPID] as? pid_t,
+                  ownerPID == pid else { return false }
+            // Layer 0 is the normal application-window layer; menu bar / dock / overlays sit
+            // on positive layers we explicitly want to skip.
+            guard let layer = entry[kCGWindowLayer] as? Int, layer == 0 else { return false }
+            return true
+        }
+
+        guard let entry = match,
+              let windowNumber = entry[kCGWindowNumber] as? CGWindowID else {
+            // Distinguish a missing process from a running-but-minimized one.
+            let processIsAlive = NSWorkspace.shared.runningApplications
+                .contains(where: { $0.processIdentifier == pid })
+            return CaptureResult(
+                state: processIsAlive ? .minimized : .missing,
+                pngBase64: nil,
+                bounds: nil
+            )
+        }
+
+        let bounds = parseBounds(entry[kCGWindowBounds])
+        let pngBase64 = await captureWindowPNG(windowID: windowNumber)
+        return CaptureResult(state: .running, pngBase64: pngBase64, bounds: bounds)
+    }
+
+    // MARK: - Private helpers
+
+    private static func parseBounds(_ value: Any?) -> WindowBounds? {
+        // kCGWindowBounds is a CFDictionary representation of a CGRect. Cast through
+        // CFDictionary explicitly — `Any as CFDictionary` requires forced conversion.
+        guard let value, CFGetTypeID(value as CFTypeRef) == CFDictionaryGetTypeID() else {
+            return nil
+        }
+        let cfDict = value as! CFDictionary
+        guard let rect = CGRect(dictionaryRepresentation: cfDict) else { return nil }
+        return WindowBounds(
+            x: Double(rect.origin.x),
+            y: Double(rect.origin.y),
+            width: Double(rect.size.width),
+            height: Double(rect.size.height)
+        )
+    }
+
+    private static func captureWindowPNG(windowID: CGWindowID) async -> String? {
+        do {
+            let shareable = try await SCShareableContent.current
+            guard let scWindow = shareable.windows.first(where: { $0.windowID == windowID }) else {
+                log.warning("AppWindowCapture: SCShareableContent missing windowID \(windowID)")
+                return nil
+            }
+
+            let filter = SCContentFilter(desktopIndependentWindow: scWindow)
+            let config = SCStreamConfiguration()
+            config.width = max(Int(scWindow.frame.width), 1)
+            config.height = max(Int(scWindow.frame.height), 1)
+            config.pixelFormat = kCVPixelFormatType_32BGRA
+            config.showsCursor = false
+
+            let cgImage = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: config
+            )
+            return encodePNGBase64(cgImage: cgImage)
+        } catch {
+            log.warning("AppWindowCapture: ScreenCaptureKit capture failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    private static func encodePNGBase64(cgImage: CGImage) -> String? {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            log.warning("AppWindowCapture: CGImageDestinationCreateWithData returned nil")
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            log.warning("AppWindowCapture: CGImageDestinationFinalize failed")
+            return nil
+        }
+        return (data as Data).base64EncodedString()
+    }
+}
+#endif

--- a/clients/macos/vellum-assistantTests/AppWindowCaptureTests.swift
+++ b/clients/macos/vellum-assistantTests/AppWindowCaptureTests.swift
@@ -1,0 +1,57 @@
+#if os(macOS)
+import XCTest
+import AppKit
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class AppWindowCaptureTests: XCTestCase {
+
+    /// Capture Finder's frontmost normal window. Finder is kept alive by macOS, so on
+    /// any normal desktop session there should always be a layer-0 Finder window
+    /// (the desktop window itself qualifies). If a hardened CI/headless environment
+    /// somehow hides Finder entirely, the test skips with `XCTSkip` rather than failing.
+    ///
+    /// This test also exercises the ScreenCaptureKit path, which requires Screen
+    /// Recording permission. In CI without that permission, the capture fails
+    /// internally and `pngBase64` will be `nil`; we tolerate that and skip rather
+    /// than fail.
+    func test_capture_finder_returnsRunningWithBounds() async throws {
+        let finders = NSRunningApplication.runningApplications(
+            withBundleIdentifier: "com.apple.finder"
+        )
+        guard let pid = finders.first?.processIdentifier else {
+            throw XCTSkip("Finder is not running in this environment; cannot exercise capture path.")
+        }
+
+        let result = await AppWindowCapture.capture(forPid: pid)
+
+        // Finder may be in a state with no on-screen layer-0 window in some headless CI
+        // contexts; tolerate that by skipping rather than failing.
+        guard result.state == .running else {
+            throw XCTSkip("Finder produced state \(result.state) — no on-screen normal window available.")
+        }
+
+        XCTAssertNotNil(result.bounds, "Expected non-nil bounds for a running Finder window")
+
+        // pngBase64 may be nil if Screen Recording permission is not granted in this
+        // test environment. When it is present, validate the PNG magic header.
+        if let pngBase64 = result.pngBase64 {
+            let pngData = try XCTUnwrap(Data(base64Encoded: pngBase64))
+            XCTAssertGreaterThanOrEqual(pngData.count, 8, "PNG payload too small to contain magic bytes")
+
+            // PNG magic header: 0x89 0x50 0x4E 0x47.
+            let magic: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+            let prefix = Array(pngData.prefix(4))
+            XCTAssertEqual(prefix, magic, "PNG bytes do not begin with the PNG magic header")
+        }
+    }
+
+    func test_capture_unknownPid_returnsMissing() async {
+        let unknownPid: pid_t = 999_999
+        let result = await AppWindowCapture.capture(forPid: unknownPid)
+        XCTAssertEqual(result.state, .missing)
+        XCTAssertNil(result.pngBase64)
+        XCTAssertNil(result.bounds)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- AppWindowCapture.capture(forPid:) returns running/missing/minimized + PNG + bounds.
- Filters CGWindowList by owner PID and layer 0 (normal window).
- Tests cover Finder capture and unknown PID -> .missing.

Part of plan: app-control-skill.md (PR 6 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->