### PR TITLE
feat(macos): add AppControlExecutor dispatching tool actions

### DIFF
--- a/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
@@ -1,0 +1,474 @@
+#if os(macOS)
+import AppKit
+import CoreGraphics
+import Foundation
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppControlExecutor")
+
+/// Dispatches a `HostAppControlRequest` to the appropriate per-process input
+/// helper (`AppKeyboard`, `AppMouse`, `AppWindowCapture`) and returns a
+/// `HostAppControlResultPayload` for the daemon.
+///
+/// All catch-paths surface as a result payload tagged with the originating
+/// `requestId` so the daemon can correlate failures with the request that
+/// produced them.
+enum AppControlExecutor {
+
+    /// Execute `request` and produce a wire result. Never throws — every
+    /// failure is reported as a result payload with `executionError` set.
+    static func perform(_ request: HostAppControlRequest) async -> HostAppControlResultPayload {
+        switch request.input {
+        case .start(let app, let args):
+            return await performStart(requestId: request.requestId, app: app, args: args)
+        case .observe(let app):
+            return await performObserve(requestId: request.requestId, app: app)
+        case .press(let app, let key, let modifiers, let durationMs):
+            return await performPress(
+                requestId: request.requestId,
+                app: app,
+                key: key,
+                modifiers: modifiers ?? [],
+                durationMs: durationMs ?? 50
+            )
+        case .combo(let app, let keys, let durationMs):
+            return await performCombo(
+                requestId: request.requestId,
+                app: app,
+                keys: keys,
+                durationMs: durationMs ?? 50
+            )
+        case .type(let app, let text):
+            return await performType(requestId: request.requestId, app: app, text: text)
+        case .click(let app, let x, let y, let button, let double):
+            return await performClick(
+                requestId: request.requestId,
+                app: app,
+                x: x,
+                y: y,
+                button: button,
+                double: double ?? false
+            )
+        case .drag(let app, let fromX, let fromY, let toX, let toY, let button):
+            return await performDrag(
+                requestId: request.requestId,
+                app: app,
+                fromX: fromX,
+                fromY: fromY,
+                toX: toX,
+                toY: toY,
+                button: button
+            )
+        case .stop:
+            return performStop(requestId: request.requestId)
+        }
+    }
+
+    // MARK: - start
+
+    private static func performStart(
+        requestId: String,
+        app: String,
+        args: [String]?
+    ) async -> HostAppControlResultPayload {
+        if let resolved = resolvePid(forApp: app) {
+            // Already running — capture and return.
+            let capture = await AppWindowCapture.capture(forPid: resolved.pid)
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionResult: "started: \(resolved.name) (already running, pid=\(resolved.pid))",
+                executionError: nil
+            )
+        }
+
+        // Not running — try to launch.
+        guard let appURL = locateApplicationURL(for: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not found: \(app)"
+            )
+        }
+
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        if let args, !args.isEmpty {
+            config.arguments = args
+        }
+
+        do {
+            let runningApp = try await NSWorkspace.shared.openApplication(
+                at: appURL,
+                configuration: config
+            )
+            let pid = runningApp.processIdentifier
+            let displayName = runningApp.localizedName ?? runningApp.bundleIdentifier ?? app
+            let capture = await AppWindowCapture.capture(forPid: pid)
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionResult: "started: \(displayName) (launched, pid=\(pid))",
+                executionError: nil
+            )
+        } catch {
+            log.warning("AppControlExecutor: openApplication failed for \(app, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "Failed to launch \(app): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    // MARK: - observe
+
+    private static func performObserve(
+        requestId: String,
+        app: String
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+        let capture = await AppWindowCapture.capture(forPid: resolved.pid)
+        return HostAppControlResultPayload(
+            requestId: requestId,
+            state: capture.state,
+            pngBase64: capture.pngBase64,
+            windowBounds: capture.bounds,
+            executionResult: "observed: \(resolved.name) (pid=\(resolved.pid))",
+            executionError: nil
+        )
+    }
+
+    // MARK: - press
+
+    private static func performPress(
+        requestId: String,
+        app: String,
+        key: String,
+        modifiers: [String],
+        durationMs: Int
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        do {
+            try await AppKeyboard.press(
+                pid: resolved.pid,
+                key: key,
+                modifiers: modifiers,
+                durationMs: durationMs
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionResult: "pressed \(key) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - combo
+
+    private static func performCombo(
+        requestId: String,
+        app: String,
+        keys: [String],
+        durationMs: Int
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        do {
+            try await AppKeyboard.combo(
+                pid: resolved.pid,
+                keys: keys,
+                durationMs: durationMs
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionResult: "combo \(keys.joined(separator: "+")) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - type
+
+    private static func performType(
+        requestId: String,
+        app: String,
+        text: String
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        do {
+            try await AppKeyboard.type(pid: resolved.pid, text: text)
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionResult: "typed \(text.count) char(s) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - click
+
+    private static func performClick(
+        requestId: String,
+        app: String,
+        x: Double,
+        y: Double,
+        button: String?,
+        double: Bool
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        let capture = await AppWindowCapture.capture(forPid: resolved.pid)
+        guard capture.state == .running, let bounds = capture.bounds else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionError: "Window not visible (state=\(capture.state.rawValue))"
+            )
+        }
+
+        do {
+            try AppMouse.click(
+                pid: resolved.pid,
+                windowBounds: bounds,
+                x: x,
+                y: y,
+                button: parseButton(button),
+                double: double
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionResult: "clicked at (\(x), \(y)) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - drag
+
+    private static func performDrag(
+        requestId: String,
+        app: String,
+        fromX: Double,
+        fromY: Double,
+        toX: Double,
+        toY: Double,
+        button: String?
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        let capture = await AppWindowCapture.capture(forPid: resolved.pid)
+        guard capture.state == .running, let bounds = capture.bounds else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: capture.state,
+                pngBase64: capture.pngBase64,
+                windowBounds: capture.bounds,
+                executionError: "Window not visible (state=\(capture.state.rawValue))"
+            )
+        }
+
+        do {
+            try AppMouse.drag(
+                pid: resolved.pid,
+                windowBounds: bounds,
+                fromX: fromX,
+                fromY: fromY,
+                toX: toX,
+                toY: toY,
+                button: parseButton(button)
+            )
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionResult: "dragged (\(fromX), \(fromY)) -> (\(toX), \(toY)) (pid=\(resolved.pid))",
+                executionError: nil
+            )
+        } catch {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                pngBase64: capture.pngBase64,
+                windowBounds: bounds,
+                executionError: error.localizedDescription
+            )
+        }
+    }
+
+    // MARK: - stop
+
+    /// `stop` does NOT terminate the target app — it just acknowledges the
+    /// session-end signal so the daemon can finalize bookkeeping.
+    private static func performStop(requestId: String) -> HostAppControlResultPayload {
+        return HostAppControlResultPayload(
+            requestId: requestId,
+            state: .running,
+            executionResult: "session stopped",
+            executionError: nil
+        )
+    }
+
+    // MARK: - PID resolution
+
+    /// Resolves a user-supplied app identifier to a running PID and a display
+    /// name. Tries bundle-ID match first (preferred), then falls back to a
+    /// case-insensitive localized-name match across all running apps.
+    ///
+    /// When multiple processes match the bundle ID or localized name, the
+    /// first match is returned and the count is encoded into the display name
+    /// so callers can surface it in `executionResult`.
+    private static func resolvePid(forApp app: String) -> (pid: pid_t, name: String)? {
+        // Bundle ID (preferred).
+        let bundleMatches = NSRunningApplication.runningApplications(withBundleIdentifier: app)
+        if let first = bundleMatches.first {
+            let pid = first.processIdentifier
+            let name = displayName(for: first, fallback: app)
+            if bundleMatches.count > 1 {
+                return (pid, "\(name) [\(bundleMatches.count) matches]")
+            }
+            return (pid, name)
+        }
+
+        // Localized name (case-insensitive).
+        let lowered = app.lowercased()
+        let nameMatches = NSWorkspace.shared.runningApplications.filter { running in
+            (running.localizedName?.lowercased() == lowered)
+        }
+        if let first = nameMatches.first {
+            let pid = first.processIdentifier
+            let name = displayName(for: first, fallback: app)
+            if nameMatches.count > 1 {
+                return (pid, "\(name) [\(nameMatches.count) matches]")
+            }
+            return (pid, name)
+        }
+
+        return nil
+    }
+
+    private static func displayName(for app: NSRunningApplication, fallback: String) -> String {
+        return app.localizedName ?? app.bundleIdentifier ?? fallback
+    }
+
+    /// Try to find an installed `.app` URL for `app`, treating `app` first as a
+    /// bundle identifier and falling back to a localized name lookup that
+    /// scans common install directories.
+    private static func locateApplicationURL(for app: String) -> URL? {
+        if let bundleURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app) {
+            return bundleURL
+        }
+
+        // Fall back to scanning common application directories by name.
+        let searchDirs = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            NSString("~/Applications").expandingTildeInPath,
+        ]
+        let nameWithSuffix = app.hasSuffix(".app") ? app : "\(app).app"
+        let lowerName = nameWithSuffix.lowercased()
+
+        for dir in searchDirs {
+            let direct = "\(dir)/\(nameWithSuffix)"
+            if FileManager.default.fileExists(atPath: direct) {
+                return URL(fileURLWithPath: direct)
+            }
+            // Case-insensitive match within the directory.
+            if let entries = try? FileManager.default.contentsOfDirectory(atPath: dir),
+               let match = entries.first(where: { $0.lowercased() == lowerName }) {
+                return URL(fileURLWithPath: "\(dir)/\(match)")
+            }
+        }
+        return nil
+    }
+
+    /// Convert a daemon-supplied button string to an `AppMouse.MouseButton`.
+    /// Defaults to `.left` for `nil` or unrecognized input so callers always
+    /// get a valid button without surfacing parse errors.
+    private static func parseButton(_ s: String?) -> AppMouse.MouseButton {
+        guard let s, let parsed = AppMouse.MouseButton(rawValue: s.lowercased()) else {
+            return .left
+        }
+        return parsed
+    }
+}
+#endif

--- a/clients/macos/vellum-assistantTests/AppControlExecutorTests.swift
+++ b/clients/macos/vellum-assistantTests/AppControlExecutorTests.swift
@@ -1,0 +1,90 @@
+#if os(macOS)
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class AppControlExecutorTests: XCTestCase {
+
+    // MARK: - .start with unknown bundle ID
+
+    /// A bundle ID that no installed app advertises should resolve to neither
+    /// a running PID nor a launchable URL — `perform` must surface that as a
+    /// `.missing` result with a non-empty `executionError` rather than throwing.
+    func test_start_unknownBundleId_returnsMissingWithError() async {
+        let request = HostAppControlRequest(
+            type: "host_app_control_request",
+            requestId: "req-start-missing",
+            conversationId: "conv-test",
+            toolName: "app_control_start",
+            input: .start(app: "com.example.does-not-exist", args: nil)
+        )
+
+        let result = await AppControlExecutor.perform(request)
+
+        XCTAssertEqual(result.requestId, "req-start-missing")
+        XCTAssertEqual(result.state, .missing)
+        let error = result.executionError ?? ""
+        XCTAssertFalse(error.isEmpty, "Expected non-empty executionError; got: \(error)")
+    }
+
+    // MARK: - .stop is always a no-op success
+
+    /// `.stop` is a session-acknowledgement signal and does not terminate the
+    /// target app. It must succeed for any input — including a bogus name —
+    /// and never throw.
+    func test_stop_alwaysReturnsStoppedRegardlessOfApp() async {
+        let request = HostAppControlRequest(
+            type: "host_app_control_request",
+            requestId: "req-stop-1",
+            conversationId: "conv-test",
+            toolName: "app_control_stop",
+            input: .stop(app: "com.example.does-not-exist", reason: "test")
+        )
+
+        let result = await AppControlExecutor.perform(request)
+
+        XCTAssertEqual(result.requestId, "req-stop-1")
+        XCTAssertEqual(result.state, .running)
+        XCTAssertEqual(result.executionResult, "session stopped")
+        XCTAssertNil(result.executionError)
+    }
+
+    func test_stop_withNilApp_alsoReturnsStopped() async {
+        let request = HostAppControlRequest(
+            type: "host_app_control_request",
+            requestId: "req-stop-2",
+            conversationId: "conv-test",
+            toolName: "app_control_stop",
+            input: .stop(app: nil, reason: nil)
+        )
+
+        let result = await AppControlExecutor.perform(request)
+
+        XCTAssertEqual(result.requestId, "req-stop-2")
+        XCTAssertEqual(result.state, .running)
+        XCTAssertEqual(result.executionResult, "session stopped")
+        XCTAssertNil(result.executionError)
+    }
+
+    // MARK: - .observe with unresolvable name
+
+    /// Observe with a name that resolves to no running process should report
+    /// `.missing` rather than crashing or hanging.
+    func test_observe_unknownApp_returnsMissing() async {
+        let request = HostAppControlRequest(
+            type: "host_app_control_request",
+            requestId: "req-observe-missing",
+            conversationId: "conv-test",
+            toolName: "app_control_observe",
+            input: .observe(app: "com.example.does-not-exist")
+        )
+
+        let result = await AppControlExecutor.perform(request)
+
+        XCTAssertEqual(result.requestId, "req-observe-missing")
+        XCTAssertEqual(result.state, .missing)
+        XCTAssertNil(result.windowBounds)
+        XCTAssertNil(result.pngBase64)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- AppControlExecutor.perform(_:) async -> HostAppControlResultPayload.
- Resolves PID via bundle ID first, then localized name; reports ambiguity in executionResult.
- start launches via NSWorkspace if not running; observe/click/drag fetch window bounds.
- stop returns 'stopped' without terminating the app.
- Tests cover missing-app and stop-always-succeeds.

Part of plan: app-control-skill.md (PR 13 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->