### PR TITLE
feat(daemon): route app_control_* tools through HostAppControlProxy

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the surfaceProxyResolver's app_control_* dispatch branch.
+ *
+ * Mirrors the structure of cu-unified-flow.test.ts but exercises the
+ * sibling branch added for app-control: unavailability when no proxy is
+ * attached, end-to-end dispatch through HostAppControlProxy.request, and
+ * the local short-circuit for app_control_stop (no client round-trip).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const sentMessages: unknown[] = [];
+let mockHasClient = true;
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: unknown) => sentMessages.push(msg),
+  assistantEventHub: {
+    getMostRecentClientByCapability: (cap: string) =>
+      cap === "host_app_control" && mockHasClient
+        ? { id: "mock-client" }
+        : null,
+  },
+}));
+
+mock.module("../runtime/pending-interactions.js", () => ({
+  resolve: () => undefined,
+  get: () => undefined,
+  getByKind: () => [],
+  getByConversation: () => [],
+  removeByConversation: () => {},
+}));
+
+const { surfaceProxyResolver } =
+  await import("../daemon/conversation-surfaces.js");
+const { HostAppControlProxy, _resetActiveAppControlConversationId } =
+  await import("../daemon/host-app-control-proxy.js");
+type SurfaceConversationContext =
+  import("../daemon/conversation-surfaces.js").SurfaceConversationContext;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal SurfaceConversationContext with an optional
+ * hostAppControlProxy. Only the fields required by the app-control routing
+ * path are populated.
+ */
+function buildMockContext(
+  hostAppControlProxy?: InstanceType<typeof HostAppControlProxy>,
+  conversationId = "test-session",
+): SurfaceConversationContext {
+  return {
+    conversationId,
+    traceEmitter: { emit: () => {} },
+    sendToClient: () => {},
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set(),
+    currentTurnSurfaces: [],
+    hostAppControlProxy,
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "r1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "",
+    withSurface: async (_id, fn) => fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("surfaceProxyResolver — app-control tool routing", () => {
+  beforeEach(() => {
+    sentMessages.length = 0;
+    mockHasClient = true;
+    _resetActiveAppControlConversationId();
+  });
+
+  afterEach(() => {
+    _resetActiveAppControlConversationId();
+  });
+
+  // -------------------------------------------------------------------------
+  // Unavailability
+  // -------------------------------------------------------------------------
+
+  describe("no app-control proxy attached", () => {
+    test("returns isError result when ctx.hostAppControlProxy is undefined", async () => {
+      const ctx = buildMockContext(/* no proxy */);
+
+      const result = await surfaceProxyResolver(ctx, "app_control_observe", {
+        tool: "observe",
+        app: "com.example.editor",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not available");
+      expect(result.content).toContain("app-control");
+      // No envelope dispatched.
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("returns isError when proxy exists but no client is connected", async () => {
+      mockHasClient = false;
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctx = buildMockContext(proxy);
+
+      const result = await surfaceProxyResolver(ctx, "app_control_observe", {
+        tool: "observe",
+        app: "com.example.editor",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not available");
+      expect(sentMessages).toHaveLength(0);
+
+      proxy.dispose();
+    });
+
+    test("returns isError for app_control_stop when no proxy is attached", async () => {
+      const ctx = buildMockContext();
+
+      const result = await surfaceProxyResolver(ctx, "app_control_stop", {
+        tool: "stop",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not available");
+      expect(sentMessages).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dispatch through proxy.request
+  // -------------------------------------------------------------------------
+
+  describe("non-stop tools dispatch through proxy.request", () => {
+    test("app_control_observe routes through proxy and returns observation", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctx = buildMockContext(proxy, "conv-1");
+
+      const resultPromise = surfaceProxyResolver(ctx, "app_control_observe", {
+        tool: "observe",
+        app: "com.example.editor",
+      });
+
+      // The proxy fired exactly one host_app_control_request envelope.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_app_control_request");
+      expect(sent.toolName).toBe("app_control_observe");
+      expect(sent.conversationId).toBe("conv-1");
+      expect(sent.input).toEqual({
+        tool: "observe",
+        app: "com.example.editor",
+      });
+
+      const requestId = sent.requestId as string;
+      proxy.resolve(requestId, {
+        requestId: "ignored-by-proxy",
+        state: "running",
+        executionResult: "Window observed",
+      });
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("State: running");
+      expect(result.content).toContain("Window observed");
+
+      proxy.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Local short-circuit on app_control_stop
+  // -------------------------------------------------------------------------
+
+  describe("app_control_stop short-circuits locally", () => {
+    test("calls proxy.dispose() and returns a stopped summary without a client round-trip", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const ctx = buildMockContext(proxy);
+
+      let disposeCalls = 0;
+      const realDispose = proxy.dispose.bind(proxy);
+      proxy.dispose = () => {
+        disposeCalls++;
+        realDispose();
+      };
+
+      let requestCalls = 0;
+      const realRequest = proxy.request.bind(proxy);
+      proxy.request = (...args) => {
+        requestCalls++;
+        return realRequest(...args);
+      };
+
+      const result = await surfaceProxyResolver(ctx, "app_control_stop", {
+        tool: "stop",
+      });
+
+      expect(result.isError).toBe(false);
+      expect(result.content.toLowerCase()).toContain("stopped");
+      expect(disposeCalls).toBe(1);
+      expect(requestCalls).toBe(0);
+      // No envelope dispatched for the local short-circuit.
+      expect(sentMessages).toHaveLength(0);
+    });
+  });
+});

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -24,6 +24,7 @@ import { getLogger } from "../util/logger.js";
 import { isPlainObject } from "../util/object.js";
 import { buildConversationErrorMessage } from "./conversation-error.js";
 import { launchConversation } from "./conversation-launch.js";
+import type { HostAppControlProxy } from "./host-app-control-proxy.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
 import type {
   CardSurfaceData,
@@ -41,6 +42,7 @@ import type {
 } from "./message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "./message-protocol.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
+import type { HostAppControlInput } from "./message-types/host-app-control.js";
 import type { UserMessageAttachment } from "./message-types/shared.js";
 import type { TrustContext } from "./trust-context.js";
 
@@ -320,6 +322,8 @@ export interface SurfaceConversationContext {
   }>;
   /** Optional proxy for delegating computer-use actions to a connected desktop client. */
   hostCuProxy?: HostCuProxy;
+  /** Optional proxy for delegating per-app app-control actions to a connected desktop client. */
+  hostAppControlProxy?: HostAppControlProxy;
   /** True when no interactive client is connected (headless / channel-only). */
   readonly hasNoClient?: boolean;
   isProcessing(): boolean;
@@ -1777,6 +1781,32 @@ export async function surfaceProxyResolver(
       ctx.hostCuProxy.stepCount,
       reasoning,
       signal,
+    );
+  }
+
+  // Route app-control proxy tools (all app_control_* tool variants)
+  if (toolName.startsWith("app_control_")) {
+    if (!ctx.hostAppControlProxy || !ctx.hostAppControlProxy.isAvailable()) {
+      return {
+        content:
+          "App control is not available — enable the `app-control` feature flag and connect a macOS client.",
+        isError: true,
+      };
+    }
+
+    // `app_control_stop` resolves immediately: tear down the proxy without
+    // a client round-trip. Mirrors CU's terminal-tool short-circuit
+    // (`computer_use_done` / `computer_use_respond`).
+    if (toolName === "app_control_stop") {
+      ctx.hostAppControlProxy.dispose();
+      return { content: "App control stopped.", isError: false };
+    }
+
+    return ctx.hostAppControlProxy.request(
+      toolName,
+      input as unknown as HostAppControlInput,
+      ctx.conversationId,
+      signal ?? new AbortController().signal,
     );
   }
 


### PR DESCRIPTION
## Summary
- New app_control_* dispatch branch in surfaceProxyResolver, parallel to computer_use_*.
- app_control_stop short-circuits locally with proxy.dispose().
- All other tools forward to proxy.request(toolName, input, conversationId, signal).
- Tests cover unavailability, dispatch, and stop short-circuit.

Part of plan: app-control-skill.md (PR 11 of 16)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->