### PR TITLE
feat(memory-v2): add explain-similarity diagnostic CLI

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2.test.ts
@@ -146,6 +146,7 @@ describe("subcommand registration", () => {
     const subcommandNames = v2!.commands.map((c) => c.name()).sort();
     expect(subcommandNames).toEqual([
       "activation",
+      "explain",
       "migrate",
       "reembed",
       "reembed-skills",
@@ -171,6 +172,7 @@ describe("subcommand registration", () => {
     expect(help).toContain("reembed-skills");
     expect(help).toContain("activation");
     expect(help).toContain("validate");
+    expect(help).toContain("explain");
     // rebuild-edges was retired alongside the directed-edges work.
     expect(help).not.toContain("rebuild-edges");
   });

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -36,6 +36,8 @@ import { cliIpcCall } from "../../ipc/cli-client.js";
 import type {
   MemoryV2BackfillOp,
   MemoryV2BackfillResult,
+  MemoryV2ExplainSimilarityResult,
+  MemoryV2ExplainSimilarityStats,
   MemoryV2ReembedSkillsResult,
   MemoryV2ValidateResult,
 } from "../../runtime/routes/memory-v2-routes.js";
@@ -71,6 +73,71 @@ async function runBackfillOp(
   }
 
   log.info(`Queued ${op} job: ${result.result!.jobId}`);
+}
+
+/** Format a number for table output. */
+function fmt(n: number | null, decimals: number): string {
+  if (n === null) return "—";
+  return n.toFixed(decimals);
+}
+
+/** Render the per-channel breakdown table + stats for the explain command. */
+function printExplainResult(result: MemoryV2ExplainSimilarityResult): void {
+  log.info(
+    `dense_weight=${result.config.dense_weight}  sparse_weight=${result.config.sparse_weight}`,
+  );
+
+  for (const channel of result.channels) {
+    log.info("");
+    log.info(`── channel: ${channel.channel} ──`);
+    log.info(`text: ${channel.textPreview}`);
+    log.info(
+      `maxSparse (used for normalization): ${channel.maxSparse.toFixed(4)}`,
+    );
+    log.info("");
+    log.info(
+      "slug".padEnd(48) +
+        "dense".padStart(10) +
+        "sparseRaw".padStart(12) +
+        "sparseNorm".padStart(12) +
+        "fused".padStart(10),
+    );
+    log.info("─".repeat(92));
+    for (const row of channel.rows) {
+      const slugCol =
+        row.slug.length > 47 ? `${row.slug.slice(0, 46)}…` : row.slug;
+      log.info(
+        slugCol.padEnd(48) +
+          fmt(row.denseScore, 4).padStart(10) +
+          fmt(row.sparseRaw, 4).padStart(12) +
+          fmt(row.sparseNorm, 4).padStart(12) +
+          fmt(row.fused, 4).padStart(10),
+      );
+    }
+    log.info("");
+    log.info("Stats (per channel):");
+    log.info(`  ${formatStatLine("dense       ", channel.stats.dense)}`);
+    log.info(`  ${formatStatLine("sparseRaw   ", channel.stats.sparseRaw)}`);
+    log.info(`  ${formatStatLine("sparseNorm  ", channel.stats.sparseNorm)}`);
+    log.info(`  ${formatStatLine("fused       ", channel.stats.fused)}`);
+  }
+}
+
+function formatStatLine(
+  label: string,
+  stats: MemoryV2ExplainSimilarityStats,
+): string {
+  if (stats.count === 0) {
+    return `${label} n=0`;
+  }
+  const range = stats.max - stats.min;
+  return (
+    `${label} n=${String(stats.count).padStart(3)}` +
+    ` range=[${stats.min.toFixed(4)}, ${stats.max.toFixed(4)}]` +
+    ` (Δ=${range.toFixed(4)})` +
+    ` mean=${stats.mean.toFixed(4)}` +
+    ` std=${stats.stddev.toFixed(4)}`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -240,6 +307,89 @@ Examples:
     .action(async () => {
       await runBackfillOp("activation-recompute");
     });
+
+  // ── explain ───────────────────────────────────────────────────────────
+
+  v2.command("explain")
+    .description(
+      "Diagnose dense vs sparse score distributions for a query (read-only)",
+    )
+    .requiredOption(
+      "--text <text>",
+      "Query text to embed and score against the concept-page collection (the user channel).",
+    )
+    .option(
+      "--assistant-text <text>",
+      "Optional second query text — scored independently as the assistant channel.",
+    )
+    .option(
+      "--now-text <text>",
+      "Optional third query text — scored independently as the now channel.",
+    )
+    .option(
+      "--top <n>",
+      "Number of top hits to fetch per channel (default 25)",
+      "25",
+    )
+    .addHelpText(
+      "after",
+      `
+Embeds the supplied text(s), runs the hybrid dense + sparse query against
+the v2 concept-page Qdrant collection, and prints per-slug raw dense, raw
+sparse, normalized sparse, and fused scores plus per-channel summary
+statistics (range, mean, stddev). Use this to identify whether dense
+embedding compression (anisotropy) or per-batch sparse normalization is
+the dominant cause of score compression at the head of the activation
+distribution.
+
+Read-only: does not mutate Qdrant, the workspace, or the activation log.
+
+Interpretation:
+  Dense range  < 0.1  AND sparseNorm range > 0.5 → embedding anisotropy
+  Dense range  > 0.2  AND sparseNorm range < 0.1 → sparse max-normalization
+  Both compressed                                → both contribute
+  Both wide                                      → channel mixing is the cause
+
+Examples:
+  $ assistant memory v2 explain --text "what's bothering me"
+  $ assistant memory v2 explain --text "..." --top 50
+  $ assistant memory v2 explain --text "..." --assistant-text "..." --now-text "..."`,
+    )
+    .action(
+      async (opts: {
+        text: string;
+        assistantText?: string;
+        nowText?: string;
+        top: string;
+      }) => {
+        const top = Number.parseInt(opts.top, 10);
+        if (!Number.isFinite(top) || top < 1) {
+          log.error("--top must be a positive integer");
+          process.exitCode = 1;
+          return;
+        }
+
+        const result = await cliIpcCall<MemoryV2ExplainSimilarityResult>(
+          "memory_v2_explain_similarity",
+          {
+            body: {
+              userText: opts.text,
+              assistantText: opts.assistantText,
+              nowText: opts.nowText,
+              top,
+            },
+          },
+        );
+
+        if (!result.ok) {
+          log.error(result.error ?? "Failed to run similarity diagnostic");
+          process.exitCode = 1;
+          return;
+        }
+
+        printExplainResult(result.result!);
+      },
+    );
 
   // ── validate ──────────────────────────────────────────────────────────
 

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -9,6 +9,10 @@ import { z } from "zod";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { loadConfig } from "../../config/loader.js";
 import {
+  embedWithBackend,
+  generateSparseEmbedding,
+} from "../../memory/embedding-backend.js";
+import {
   enqueueMemoryJob,
   type MemoryJobType,
 } from "../../memory/jobs-store.js";
@@ -22,6 +26,7 @@ import {
   readPage,
   renderPageContent,
 } from "../../memory/v2/page-store.js";
+import { hybridQueryConceptPages } from "../../memory/v2/qdrant.js";
 import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { RouteError } from "./errors.js";
@@ -192,6 +197,192 @@ async function handleReembedSkills({
   return { success: true };
 }
 
+// ── Explain similarity ──────────────────────────────────────────────────
+
+const MemoryV2ExplainSimilarityParams = z
+  .object({
+    userText: z.string().min(1),
+    assistantText: z.string().optional(),
+    nowText: z.string().optional(),
+    top: z.number().int().min(1).default(25),
+  })
+  .strict();
+
+export interface MemoryV2ExplainSimilarityRow {
+  slug: string;
+  /** Raw dense cosine score, or null when the slug missed the dense channel. */
+  denseScore: number | null;
+  /** Raw sparse score (Qdrant scale), or null when the slug missed sparse. */
+  sparseRaw: number | null;
+  /** Sparse score divided by the per-batch max, in [0, 1]. */
+  sparseNorm: number | null;
+  /** `clamp01(dense_weight·dense + sparse_weight·sparseNorm)` — the simBatch fused value. */
+  fused: number;
+}
+
+export interface MemoryV2ExplainSimilarityStats {
+  count: number;
+  min: number;
+  max: number;
+  mean: number;
+  stddev: number;
+}
+
+export interface MemoryV2ExplainSimilarityChannel {
+  channel: "user" | "assistant" | "now";
+  textPreview: string;
+  maxSparse: number;
+  rows: MemoryV2ExplainSimilarityRow[];
+  stats: {
+    dense: MemoryV2ExplainSimilarityStats;
+    sparseRaw: MemoryV2ExplainSimilarityStats;
+    sparseNorm: MemoryV2ExplainSimilarityStats;
+    fused: MemoryV2ExplainSimilarityStats;
+  };
+}
+
+export interface MemoryV2ExplainSimilarityResult {
+  config: {
+    dense_weight: number;
+    sparse_weight: number;
+  };
+  channels: MemoryV2ExplainSimilarityChannel[];
+}
+
+function summarizeStats(values: number[]): MemoryV2ExplainSimilarityStats {
+  if (values.length === 0) {
+    return { count: 0, min: 0, max: 0, mean: 0, stddev: 0 };
+  }
+  let min = Infinity;
+  let max = -Infinity;
+  let sum = 0;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+  }
+  const mean = sum / values.length;
+  let sqDiff = 0;
+  for (const v of values) sqDiff += (v - mean) * (v - mean);
+  const stddev = Math.sqrt(sqDiff / values.length);
+  return { count: values.length, min, max, mean, stddev };
+}
+
+async function scoreChannel(
+  channel: "user" | "assistant" | "now",
+  text: string,
+  top: number,
+  denseWeight: number,
+  sparseWeight: number,
+  config: ReturnType<typeof loadConfig>,
+): Promise<MemoryV2ExplainSimilarityChannel> {
+  const denseResult = await embedWithBackend(config, [text]);
+  const denseVec = denseResult.vectors[0];
+  const sparseVec = generateSparseEmbedding(text);
+
+  const hits = await hybridQueryConceptPages(denseVec, sparseVec, top);
+
+  let maxSparse = 0;
+  for (const hit of hits) {
+    if (hit.sparseScore !== undefined && hit.sparseScore > maxSparse) {
+      maxSparse = hit.sparseScore;
+    }
+  }
+
+  const rows: MemoryV2ExplainSimilarityRow[] = hits.map((hit) => {
+    const dense = hit.denseScore ?? 0;
+    const sparseNorm =
+      hit.sparseScore !== undefined && maxSparse > 0
+        ? hit.sparseScore / maxSparse
+        : 0;
+    const fusedRaw = denseWeight * dense + sparseWeight * sparseNorm;
+    const fused = Math.max(0, Math.min(1, fusedRaw));
+    return {
+      slug: hit.slug,
+      denseScore: hit.denseScore ?? null,
+      sparseRaw: hit.sparseScore ?? null,
+      sparseNorm: hit.sparseScore !== undefined ? sparseNorm : null,
+      fused,
+    };
+  });
+
+  rows.sort((a, b) => b.fused - a.fused);
+
+  const denseValues: number[] = [];
+  const sparseRawValues: number[] = [];
+  const sparseNormValues: number[] = [];
+  const fusedValues: number[] = [];
+  for (const row of rows) {
+    if (row.denseScore !== null) denseValues.push(row.denseScore);
+    if (row.sparseRaw !== null) sparseRawValues.push(row.sparseRaw);
+    if (row.sparseNorm !== null) sparseNormValues.push(row.sparseNorm);
+    fusedValues.push(row.fused);
+  }
+
+  return {
+    channel,
+    textPreview: text.length > 120 ? `${text.slice(0, 120)}…` : text,
+    maxSparse,
+    rows,
+    stats: {
+      dense: summarizeStats(denseValues),
+      sparseRaw: summarizeStats(sparseRawValues),
+      sparseNorm: summarizeStats(sparseNormValues),
+      fused: summarizeStats(fusedValues),
+    },
+  };
+}
+
+async function handleExplainSimilarity({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV2ExplainSimilarityResult> {
+  const params = MemoryV2ExplainSimilarityParams.parse(body);
+  const config = loadConfig();
+  const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
+    config.memory.v2;
+
+  const channels: MemoryV2ExplainSimilarityChannel[] = [];
+  channels.push(
+    await scoreChannel(
+      "user",
+      params.userText,
+      params.top,
+      denseWeight,
+      sparseWeight,
+      config,
+    ),
+  );
+  if (params.assistantText && params.assistantText.length > 0) {
+    channels.push(
+      await scoreChannel(
+        "assistant",
+        params.assistantText,
+        params.top,
+        denseWeight,
+        sparseWeight,
+        config,
+      ),
+    );
+  }
+  if (params.nowText && params.nowText.length > 0) {
+    channels.push(
+      await scoreChannel(
+        "now",
+        params.nowText,
+        params.top,
+        denseWeight,
+        sparseWeight,
+        config,
+      ),
+    );
+  }
+
+  return {
+    config: { dense_weight: denseWeight, sparse_weight: sparseWeight },
+    channels,
+  };
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -238,5 +429,16 @@ export const ROUTES: RouteDefinition[] = [
       "Synchronously re-runs seedV2SkillEntries against the current skill catalog. Gated on memory-v2-enabled flag and config.memory.v2.enabled.",
     tags: ["memory"],
     requestBody: MemoryV2ReembedSkillsParams,
+  },
+  {
+    operationId: "memory_v2_explain_similarity",
+    method: "POST",
+    endpoint: "memory/v2/explain-similarity",
+    handler: handleExplainSimilarity,
+    summary: "Diagnose dense vs sparse similarity score distributions",
+    description:
+      "Read-only diagnostic. Embeds the supplied text(s), runs hybrid dense + sparse queries against the concept-page collection, and returns per-slug raw dense, raw sparse, normalized sparse, and fused scores plus per-channel summary stats. Used to investigate score-compression at the head of the activation distribution.",
+    tags: ["memory"],
+    requestBody: MemoryV2ExplainSimilarityParams,
   },
 ];


### PR DESCRIPTION
## Summary
- Adds \`assistant memory v2 explain --text <q> [--assistant-text ...] [--now-text ...] [--top N]\` — read-only diagnostic that runs the hybrid dense + sparse query and prints per-slug dense/sparseRaw/sparseNorm/fused scores plus per-channel range/mean/stddev. \`--top\` is uncapped.
- Backing IPC route \`memory_v2_explain_similarity\` reuses \`embedWithBackend()\`, \`generateSparseEmbedding()\`, and \`hybridQueryConceptPages()\` so the diagnostic faithfully reproduces \`simBatch\`'s fusion math.
- Designed to identify which knob is broken when the activation distribution looks compressed: anisotropic dense, max-normalized sparse, common-word-poisoned sparse, or channel-mixing.

## Original prompt
remove the cap on \`top\` for the cli command and /mainline your changes
after that, plan the IDF fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->