### PR TITLE
fix(memory-v2): register route policy for explain-similarity endpoint

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -424,6 +424,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/validate:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/concept-page:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/reembed-skills:POST", scopes: ["settings.write"] },
+  { endpoint: "memory/v2/explain-similarity:POST", scopes: ["settings.read"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary
- Adds missing route policy entry for memory/v2/explain-similarity:POST in route-policy.ts
- Fixes guard-tests.test.ts failure on main caused by #29334 landing without the policy registration
- Registers the endpoint with settings.read scope, matching the read-only diagnostic pattern of memory/v2/validate and memory/v2/concept-page

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25269332276/job/74089019475
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->