### PR TITLE
fix(openapi): regenerate spec for memory/v2/explain-similarity

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6804,6 +6804,42 @@ paths:
               required:
                 - slug
               additionalProperties: false
+  /v1/memory/v2/explain-similarity:
+    post:
+      operationId: memory_v2_explainsimilarity_post
+      summary: Diagnose dense vs sparse similarity score distributions
+      description:
+        Read-only diagnostic. Embeds the supplied text(s), runs hybrid dense + sparse queries against the
+        concept-page collection, and returns per-slug raw dense, raw sparse, normalized sparse, and fused scores plus
+        per-channel summary stats. Used to investigate score-compression at the head of the activation distribution.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userText:
+                  type: string
+                  minLength: 1
+                assistantText:
+                  type: string
+                nowText:
+                  type: string
+                top:
+                  default: 25
+                  type: integer
+                  minimum: 1
+                  maximum: 9007199254740991
+              required:
+                - userText
+                - top
+              additionalProperties: false
   /v1/memory/v2/reembed-skills:
     post:
       operationId: memory_v2_reembedskills_post


### PR DESCRIPTION
## Summary
- Regenerates \`assistant/openapi.yaml\` to include the \`memory/v2/explain-similarity\` endpoint added in #29334.
- Fixes the OpenAPI Spec Check CI job which was failing with \`openapi.yaml is stale\`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25269332276/job/74089019485
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->