### PR TITLE
fix(types): app-control wire-type coherence (cancel.conversationId, drop occluded)

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -524,6 +524,7 @@ describe("HostAppControlProxy", () => {
       const cancel = sentMessages[1] as Record<string, unknown>;
       expect(cancel.type).toBe("host_app_control_cancel");
       expect(cancel.requestId).toBe(requestId);
+      expect(cancel.conversationId).toBe("conv-1");
 
       proxy.dispose();
     });

--- a/assistant/src/config/bundled-skills/app-control/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-control/TOOLS.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "app_control_observe",
-      "description": "Capture the current window state of the target application — returns lifecycle state (running/missing/minimized/occluded), an optional screenshot, and window bounds. Use this before issuing input actions, or to check progress without acting.",
+      "description": "Capture the current window state of the target application — returns lifecycle state (running/missing/minimized), an optional screenshot, and window bounds. Use this before issuing input actions, or to check progress without acting.",
       "category": "app-control",
       "risk": "low",
       "input_schema": {

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -214,7 +214,7 @@ export class HostAppControlProxy extends HostProxyBase<
     payload: HostAppControlResultPayload,
   ): ToolExecutionResult {
     // Update PNG-hash loop tracking only for the "running" state — other
-    // states (missing/minimized/occluded) intentionally won't carry a
+    // states (missing/minimized) intentionally won't carry a
     // representative window screenshot, so they should not feed the guard.
     let stuck = false;
     if (payload.state === "running" && payload.pngBase64) {

--- a/assistant/src/daemon/message-types/host-app-control.ts
+++ b/assistant/src/daemon/message-types/host-app-control.ts
@@ -96,16 +96,13 @@ export interface HostAppControlRequest {
 export interface HostAppControlCancel {
   type: "host_app_control_cancel";
   requestId: string;
+  conversationId: string;
 }
 
 // === Result payload (HTTP /v1/host-app-control-result body) ===
 
 /** Lifecycle state of the targeted application as seen by the client. */
-export type HostAppControlState =
-  | "running"
-  | "missing"
-  | "minimized"
-  | "occluded";
+export type HostAppControlState = "running" | "missing" | "minimized";
 
 export interface HostAppControlResultPayload {
   requestId: string;

--- a/assistant/src/runtime/routes/host-app-control-routes.ts
+++ b/assistant/src/runtime/routes/host-app-control-routes.ts
@@ -27,7 +27,6 @@ const VALID_STATES: ReadonlySet<HostAppControlState> = new Set([
   "running",
   "missing",
   "minimized",
-  "occluded",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -61,7 +60,7 @@ function handleHostAppControlResult({ body }: RouteHandlerArgs) {
 
   if (!state || !VALID_STATES.has(state as HostAppControlState)) {
     throw new BadRequestError(
-      "state must be one of: running, missing, minimized, occluded",
+      "state must be one of: running, missing, minimized",
     );
   }
 
@@ -110,7 +109,7 @@ export const ROUTES: RouteDefinition[] = [
     requestBody: z.object({
       requestId: z.string().describe("Pending app-control request ID"),
       state: z
-        .enum(["running", "missing", "minimized", "occluded"])
+        .enum(["running", "missing", "minimized"])
         .describe("Lifecycle state of the targeted application"),
       pngBase64: z
         .string()

--- a/clients/macos/vellum-assistantTests/AppControlConnectionTests.swift
+++ b/clients/macos/vellum-assistantTests/AppControlConnectionTests.swift
@@ -94,7 +94,8 @@ final class AppControlConnectionTests: XCTestCase {
         let json = #"""
         {
           "type": "host_app_control_cancel",
-          "requestId": "req-app-1"
+          "requestId": "req-app-1",
+          "conversationId": "conv-1"
         }
         """#
 
@@ -106,6 +107,7 @@ final class AppControlConnectionTests: XCTestCase {
         }
         XCTAssertEqual(payload.type, "host_app_control_cancel")
         XCTAssertEqual(payload.requestId, "req-app-1")
+        XCTAssertEqual(payload.conversationId, "conv-1")
     }
 
     // MARK: - Existing host_cu_* still decode

--- a/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
@@ -141,7 +141,11 @@ final class HostAppControlTypesTests: XCTestCase {
     // MARK: - HostAppControlCancel
 
     func test_cancel_roundTrips() throws {
-        let cancel = HostAppControlCancel(type: "host_app_control_cancel", requestId: "req-1")
+        let cancel = HostAppControlCancel(
+            type: "host_app_control_cancel",
+            requestId: "req-1",
+            conversationId: "conv-1"
+        )
         XCTAssertEqual(try roundTrip(cancel), cancel)
     }
 
@@ -152,7 +156,6 @@ final class HostAppControlTypesTests: XCTestCase {
             ("\"running\"", .running),
             ("\"missing\"", .missing),
             ("\"minimized\"", .minimized),
-            ("\"occluded\"", .occluded),
         ]
         for (json, expected) in cases {
             let decoded = try JSONDecoder().decode(HostAppControlState.self, from: Data(json.utf8))

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1850,10 +1850,12 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
 public struct HostAppControlCancel: Codable, Equatable, Sendable {
     public let type: String
     public let requestId: String
+    public let conversationId: String
 
-    public init(type: String, requestId: String) {
+    public init(type: String, requestId: String, conversationId: String) {
         self.type = type
         self.requestId = requestId
+        self.conversationId = conversationId
     }
 }
 
@@ -1862,7 +1864,6 @@ public enum HostAppControlState: String, Codable, Equatable, Sendable {
     case running
     case missing
     case minimized
-    case occluded
 }
 
 /// Window bounds in points for the focused window of the target app.


### PR DESCRIPTION
## Summary
- Add conversationId to HostAppControlCancel in both TS and Swift.
- Drop unused occluded state from HostAppControlState everywhere.
- Update route validation, TOOLS.json, definitions.ts, and tests accordingly.

Addresses self-review gaps 6 and 11.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->