### PR TITLE
feat(memory-v2): lower BM25 b default 0.75 → 0.4

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -22,7 +22,7 @@ describe("MemoryV2ConfigSchema", () => {
       dense_weight: 0.7,
       sparse_weight: 0.3,
       bm25_k1: 1.2,
-      bm25_b: 0.75,
+      bm25_b: 0.4,
       consolidation_interval_hours: 4,
       max_page_chars: 5000,
       consolidation_prompt_path: null,

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -139,9 +139,9 @@ export const MemoryV2ConfigSchema = z
       .number({ error: "memory.v2.bm25_b must be a number" })
       .min(0, "memory.v2.bm25_b must be >= 0")
       .max(1, "memory.v2.bm25_b must be <= 1")
-      .default(0.75)
+      .default(0.4)
       .describe(
-        "BM25 document-length normalization. 0 disables length normalization, 1 fully normalizes — standard Lucene default is 0.75.",
+        "BM25 document-length normalization. 0 disables length normalization, 1 fully normalizes. Lucene's default is 0.75 (tuned for narrative/web corpora); we run lower because concept-page collections include structured list pages with high information density per word — full Lucene normalization over-penalizes them.",
       ),
     consolidation_interval_hours: z
       .number({


### PR DESCRIPTION
## Summary
- Lowers the BM25 \`b\` default from Lucene's 0.75 to 0.4 in the memory v2 config schema. Lucene's default is tuned for narrative/web corpora; concept-page collections include structured list pages (canonical aggregators, glossaries) where length comes from per-row content density, not topic dilution.
- Diagnosed via the \`memory v2 explain-similarity\` tool: under b=0.75 a long structured list page gets a length factor ~3× that of a short narrative page, so its per-query-term contribution is divided by ~3× more — narrative pages with one incidental query-word match outscore the topical aggregator. Lower b preserves length normalization without over-penalizing focused list pages.
- No code changes beyond the schema default. Fully tunable via \`memory.v2.bm25_b\` in workspace config.json. **Migration**: run \`assistant memory v2 reembed\` once after deploy — b enters the document-side BM25 weights, so existing sparse vectors must be regenerated.

## Original prompt
ship #1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->