### PR TITLE
fix(openapi): regenerate spec for memory/v2/rebuild-corpus-stats endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6840,6 +6840,28 @@ paths:
                 - userText
                 - top
               additionalProperties: false
+  /v1/memory/v2/rebuild-corpus-stats:
+    post:
+      operationId: memory_v2_rebuildcorpusstats_post
+      summary: Rebuild the BM25 corpus statistics for memory v2
+      description:
+        Walks every concept page on disk, recomputes the document-frequency table and average document length used
+        by the BM25 sparse channel, and atomically swaps the in-memory stats. Run after bulk content imports or to
+        recover from a rebuild that errored at startup. Does not reembed individual page sparse vectors — pair with
+        `assistant memory v2 reembed` when document-side weights need refreshing.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+              additionalProperties: false
   /v1/memory/v2/reembed-skills:
     post:
       operationId: memory_v2_reembedskills_post


### PR DESCRIPTION
## Summary
- Regenerate `assistant/openapi.yaml` to include the `/v1/memory/v2/rebuild-corpus-stats` endpoint that was added but missed the spec regeneration.
- Fixes the failing OpenAPI Spec Check on main.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25270799681/job/74092696779
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->