### PR TITLE
fix(gateway): drop bot-self message_deleted in Slack normalizer

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1231,6 +1231,30 @@ describe("normalizeSlackMessageDelete", () => {
     // DMs should not be tagged as channel chat even when inferred.
     expect(result!.event.source.chatType).toBeUndefined();
   });
+
+  it("returns null when previous_message author is the bot itself", () => {
+    // Slack echoes self-deletes back via Socket Mode. Without this filter,
+    // the bot's user ID flows through as the actor and triggers a spurious
+    // ingress access-request notification to the guardian.
+    const config = makeConfig();
+    const event = makeMessageDeletedEvent({
+      channel: "D789",
+      channel_type: "im",
+      previous_message: {
+        user: "UBOT",
+        text: "deleted bot message",
+        ts: "1700000000.000100",
+      },
+    });
+    const result = normalizeSlackMessageDelete(
+      event,
+      "evt-del-self",
+      config,
+      "UBOT",
+    );
+
+    expect(result).toBeNull();
+  });
 });
 
 // --- source.threadId propagation ---

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -942,8 +942,16 @@ export function normalizeSlackMessageDelete(
   event: SlackMessageDeletedEvent,
   eventId: string,
   config: GatewayConfig,
+  botUserId?: string,
 ): NormalizedSlackEvent | null {
   if (!event.deleted_ts) return null;
+
+  // Drop deletions of the bot's own messages. Slack echoes self-deletes back
+  // via Socket Mode; without this filter the bot's user ID flows into the
+  // assistant's ACL as the actor, fails member lookup (the bot is never its
+  // own trusted contact), and triggers a spurious access-request notification
+  // to the guardian. Mirrors the bot-self filter on the edit path above.
+  if (botUserId && event.previous_message?.user === botUserId) return null;
 
   // Use the previous author for actor identity when available; otherwise fall
   // back to a synthetic identifier so routing/trust still has something to key on.

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -811,6 +811,7 @@ export class SlackSocketModeClient {
         event as SlackMessageDeletedEvent,
         eventId,
         this.config.gatewayConfig,
+        this.config.botUserId,
       );
     } else if (isActiveThreadReply) {
       normalized = normalizeSlackChannelMessage(


### PR DESCRIPTION
## Summary

- Add `botUserId` parameter to `normalizeSlackMessageDelete` and early-return when `previous_message.user === botUserId`, mirroring the existing bot-self filter on the edit (line 859) and inbound (lines 482, 744) paths.
- Pass `this.config.botUserId` from `socket-mode.ts:810` to the delete normalizer (it was already passed to the edit normalizer at line 806).
- Add a regression test in `normalize.test.ts` covering the bot-self-delete case.

When the assistant deletes one of its own Slack messages, Slack echoes the `message_deleted` event back via Socket Mode. Without this filter the bot's user ID flowed into the assistant's ACL as the actor, failed member lookup (the bot is never its own trusted contact), and fired a spurious `ingress.access_request` notification telling the guardian "the bot is requesting access to the assistant" — delivered back into the same DM the deletion happened in. The assistant-side `message_deleted` short-circuit at `inbound-message-handler.ts:279` runs after the ACL check by design ("Gated behind ingress ACL so non-members cannot drive deletes"), so the cleaner fix is at the gateway boundary where the parallel filters already live.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->