### PR TITLE
fix(memory): decouple v1 Qdrant sentinel from sparse encoder version

### DIFF
--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -15,10 +15,7 @@ import {
 } from "../../memory/conversation-crud.js";
 import { listConversations } from "../../memory/conversation-queries.js";
 import { getDb } from "../../memory/db-connection.js";
-import {
-  selectEmbeddingBackend,
-  SPARSE_EMBEDDING_VERSION,
-} from "../../memory/embedding-backend.js";
+import { selectEmbeddingBackend } from "../../memory/embedding-backend.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import {
   initQdrantClient,
@@ -307,7 +304,7 @@ Examples:
       const qdrantUrl = resolveQdrantUrl(config);
       const embeddingSelection = await selectEmbeddingBackend(config);
       const embeddingModel = embeddingSelection.backend
-        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
+        ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
         : undefined;
       const qdrant = initQdrantClient({
         url: qdrantUrl,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -50,10 +50,7 @@ import {
 import { expireAllPendingCanonicalRequests } from "../memory/canonical-guardian-store.js";
 import { deleteMessageById, getMessages } from "../memory/conversation-crud.js";
 import { initializeDb } from "../memory/db-init.js";
-import {
-  selectEmbeddingBackend,
-  SPARSE_EMBEDDING_VERSION,
-} from "../memory/embedding-backend.js";
+import { selectEmbeddingBackend } from "../memory/embedding-backend.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient, resolveQdrantUrl } from "../memory/qdrant-client.js";
@@ -691,8 +688,11 @@ export async function runDaemon(): Promise<void> {
       if (qdrantStarted) {
         try {
           const embeddingSelection = await selectEmbeddingBackend(config);
+          // Sentinel only encodes the dense provider+model identity; sparse
+          // encoder changes never require collection recreation, so they
+          // intentionally do not contribute to the v1 collection identity.
           const embeddingModel = embeddingSelection.backend
-            ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}:sparse-v${SPARSE_EMBEDDING_VERSION}`
+            ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
             : undefined;
           const qdrantClient = initQdrantClient({
             url: qdrantUrl,

--- a/assistant/src/memory/__tests__/qdrant-client-sentinel.test.ts
+++ b/assistant/src/memory/__tests__/qdrant-client-sentinel.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { stripLegacySparseSuffix } from "../qdrant-client.js";
+
+describe("stripLegacySparseSuffix", () => {
+  test("strips a trailing :sparse-v<digit> suffix", () => {
+    expect(
+      stripLegacySparseSuffix("gemini:gemini-embedding-2-preview:sparse-v3"),
+    ).toBe("gemini:gemini-embedding-2-preview");
+  });
+
+  test("strips multi-digit version suffixes", () => {
+    expect(stripLegacySparseSuffix("openai:text-embed-3:sparse-v42")).toBe(
+      "openai:text-embed-3",
+    );
+  });
+
+  test("returns the input unchanged when no suffix is present", () => {
+    expect(stripLegacySparseSuffix("gemini:gemini-embedding-2-preview")).toBe(
+      "gemini:gemini-embedding-2-preview",
+    );
+  });
+
+  test("does not strip a non-trailing :sparse-v segment", () => {
+    expect(stripLegacySparseSuffix("foo:sparse-v3:bar")).toBe(
+      "foo:sparse-v3:bar",
+    );
+  });
+
+  test("does not strip when the version part is missing", () => {
+    expect(stripLegacySparseSuffix("provider:model:sparse-v")).toBe(
+      "provider:model:sparse-v",
+    );
+  });
+
+  test("normalizes legacy and current sentinels to the same value", () => {
+    const legacy = "gemini:gemini-embedding-2-preview:sparse-v2";
+    const current = "gemini:gemini-embedding-2-preview";
+    expect(stripLegacySparseSuffix(legacy)).toBe(
+      stripLegacySparseSuffix(current),
+    );
+  });
+
+  test("differentiates sentinels that diverge on the dense identity", () => {
+    const a = "gemini:gemini-embedding-2-preview:sparse-v2";
+    const b = "openai:text-embedding-3-small:sparse-v2";
+    expect(stripLegacySparseSuffix(a)).not.toBe(stripLegacySparseSuffix(b));
+  });
+});

--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -73,19 +73,31 @@ export interface QdrantSearchResult {
   payload: QdrantPointPayload;
 }
 
+/**
+ * Strip a trailing `:sparse-v<digits>` segment from a sentinel string.
+ *
+ * Legacy v1 sentinels (pre-decouple) included the sparse encoder version in
+ * the embedding-model identity. The suffix is no longer written, but stored
+ * sentinels written by older daemons may still carry it — strip it before
+ * comparing identities so existing collections aren't unnecessarily rebuilt.
+ */
+export function stripLegacySparseSuffix(sentinel: string): string {
+  return sentinel.replace(/:sparse-v\d+$/, "");
+}
+
 let _instance: VellumQdrantClient | null = null;
 
 export function getQdrantClient(): VellumQdrantClient {
   if (!_instance) {
     throw new Error(
-      "Qdrant client not initialized. Call initQdrantClient() first."
+      "Qdrant client not initialized. Call initQdrantClient() first.",
     );
   }
   return _instance;
 }
 
 export function initQdrantClient(
-  config: QdrantClientConfig
+  config: QdrantClientConfig,
 ): VellumQdrantClient {
   _instance = new VellumQdrantClient(config);
   return _instance;
@@ -140,12 +152,28 @@ export class VellumQdrantClient {
           const dimMismatch =
             currentSize != null && currentSize !== this.vectorSize;
 
-          // Check model identity via a sentinel point that stores the embedding model
+          // Check model identity via a sentinel point that stores the embedding model.
+          //
+          // Legacy sentinels included a ":sparse-v<N>" suffix that conflated the
+          // sparse encoder version with the dense model identity. Sparse vectors
+          // are upserted in place and never require collection recreation, so a
+          // stored value matching the current dense identity after stripping any
+          // legacy sparse suffix is treated as compatible. Compatible-but-legacy
+          // sentinels are rewritten to the new format below to clean up gradually.
           let modelMismatch = false;
+          let needsSentinelRewrite = false;
           if (this.embeddingModel) {
             const sentinel = await this.readSentinel();
-            if (sentinel && sentinel !== this.embeddingModel) {
-              modelMismatch = true;
+            if (sentinel) {
+              const normalizedStored = stripLegacySparseSuffix(sentinel);
+              const normalizedCurrent = stripLegacySparseSuffix(
+                this.embeddingModel,
+              );
+              if (normalizedStored !== normalizedCurrent) {
+                modelMismatch = true;
+              } else if (sentinel !== this.embeddingModel) {
+                needsSentinelRewrite = true;
+              }
             }
           }
 
@@ -156,7 +184,7 @@ export class VellumQdrantClient {
                 currentSize,
                 expectedSize: this.vectorSize,
               },
-              "Qdrant collection uses unnamed vectors (legacy) — deleting and recreating with named vectors. Embeddings will be re-indexed."
+              "Qdrant collection uses unnamed vectors (legacy) — deleting and recreating with named vectors. Embeddings will be re-indexed.",
             );
             await this.client.deleteCollection(this.collection);
             migrated = true;
@@ -169,7 +197,7 @@ export class VellumQdrantClient {
                 expectedSize: this.vectorSize,
                 modelMismatch,
               },
-              "Qdrant collection incompatible (dimension or model change) — deleting and recreating. Embeddings will be regenerated on demand."
+              "Qdrant collection incompatible (dimension or model change) — deleting and recreating. Embeddings will be regenerated on demand.",
             );
             await this.client.deleteCollection(this.collection);
             migrated = true;
@@ -178,12 +206,15 @@ export class VellumQdrantClient {
             if (await this.ensurePayloadIndexesSafe()) {
               this.collectionReady = true;
             }
+            if (needsSentinelRewrite && this.embeddingModel) {
+              await this.writeSentinel(this.embeddingModel);
+            }
             return { migrated: false };
           }
         } catch (err) {
           log.warn(
             { err },
-            "Failed to verify collection compatibility, assuming compatible"
+            "Failed to verify collection compatibility, assuming compatible",
           );
           if (await this.ensurePayloadIndexesSafe()) {
             this.collectionReady = true;
@@ -197,7 +228,7 @@ export class VellumQdrantClient {
 
     log.info(
       { collection: this.collection, vectorSize: this.vectorSize },
-      "Creating Qdrant collection with named vectors (dense + sparse)"
+      "Creating Qdrant collection with named vectors (dense + sparse)",
     );
 
     try {
@@ -253,7 +284,7 @@ export class VellumQdrantClient {
       this.collectionReady = true;
       log.info(
         { collection: this.collection },
-        "Qdrant collection created with payload indexes"
+        "Qdrant collection created with payload indexes",
       );
     }
 
@@ -265,7 +296,7 @@ export class VellumQdrantClient {
     targetId: string,
     vector: number[],
     payload: Omit<QdrantPointPayload, "target_type" | "target_id">,
-    sparseVector?: QdrantSparseVector
+    sparseVector?: QdrantSparseVector,
   ): Promise<string> {
     await this.ensureCollection();
 
@@ -320,7 +351,7 @@ export class VellumQdrantClient {
   async search(
     vector: number[],
     limit: number,
-    filter?: Record<string, unknown>
+    filter?: Record<string, unknown>,
   ): Promise<QdrantSearchResult[]> {
     await this.ensureCollection();
 
@@ -348,7 +379,7 @@ export class VellumQdrantClient {
     return results.map((result) => ({
       id: typeof result.id === "string" ? result.id : String(result.id),
       score: result.score,
-      payload: (result.payload as unknown) as QdrantPointPayload,
+      payload: result.payload as unknown as QdrantPointPayload,
     }));
   }
 
@@ -357,7 +388,7 @@ export class VellumQdrantClient {
     limit: number,
     targetTypes: Array<"segment" | "item" | "summary" | "media">,
     excludeMessageIds?: string[],
-    scopeIds?: string[]
+    scopeIds?: string[],
   ): Promise<QdrantSearchResult[]> {
     const mustConditions: Array<Record<string, unknown>> = [
       {
@@ -434,7 +465,7 @@ export class VellumQdrantClient {
     const queryParams = {
       prefetch: [
         {
-          query: (denseVector as unknown) as number[],
+          query: denseVector as unknown as number[],
           using: "dense",
           limit: effectivePrefetchLimit,
         },
@@ -469,7 +500,7 @@ export class VellumQdrantClient {
     return (results.points ?? []).map((point) => ({
       id: typeof point.id === "string" ? point.id : String(point.id),
       score: point.score ?? 0,
-      payload: (point.payload as unknown) as QdrantPointPayload,
+      payload: point.payload as unknown as QdrantPointPayload,
     }));
   }
 
@@ -594,7 +625,7 @@ export class VellumQdrantClient {
     } catch (err) {
       log.warn(
         { err, collection: this.collection },
-        "Failed to delete Qdrant collection"
+        "Failed to delete Qdrant collection",
       );
       return false;
     }
@@ -762,8 +793,7 @@ export class VellumQdrantClient {
           ...(offset !== undefined ? { offset } : {}),
         });
         for (const point of result.points) {
-          const id =
-            typeof point.id === "string" ? point.id : String(point.id);
+          const id = typeof point.id === "string" ? point.id : String(point.id);
           const payload = (point.payload ?? {}) as Record<string, unknown>;
           out.push({ id, payload });
         }
@@ -788,7 +818,7 @@ export class VellumQdrantClient {
 
   private async findByTarget(
     targetType: string,
-    targetId: string
+    targetId: string,
   ): Promise<string | null> {
     try {
       const results = await this.client.scroll(this.collection, {


### PR DESCRIPTION
## Summary
- The v1 Qdrant collection sentinel mixed dense model identity with the sparse encoder version (\`provider:model:sparse-v<N>\`). Bumping the sparse version for unrelated v2 work caused \`ensureCollection()\` to treat the stored value as incompatible, drop the v1 \`memory\` collection, and trigger a full rebuild_index → fanned-out embed_segment jobs.
- Sparse vectors are upserted in place and never require collection recreation. The sentinel now encodes only \`provider:model\`. \`ensureCollection()\` strips a trailing \`:sparse-v<N>\` from stored values before comparison so existing collections aren't unnecessarily rebuilt, and silently rewrites the sentinel in the new format when the stripped values match.
- New unit test covers the \`stripLegacySparseSuffix\` helper.

## Original prompt
plan the v1 sentinel decoupling and ship it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->