### PR TITLE
fix(memory-v2): unbreak Test job after BM25 rollout

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -21,6 +21,7 @@ import {
   type SparseEmbedding,
   type TextEmbeddingInput,
 } from "./embedding-types.js";
+import { SPARSE_VOCAB_SIZE, tokenHash, tokenize } from "./sparse-tokenize.js";
 
 export type { EmbeddingInput, MultimodalEmbeddingInput, TextEmbeddingInput };
 
@@ -787,8 +788,9 @@ async function isOllamaConfigured(config: AssistantConfig): Promise<boolean> {
 // Simple tokenizer + TF-IDF sparse encoder. Produces a SparseEmbedding
 // with term indices (hashed to a fixed vocabulary) and TF-IDF weights.
 // Can be upgraded to a learned sparse encoder (e.g. SPLADE) later.
-
-export const SPARSE_VOCAB_SIZE = 30_000;
+// Tokenization primitives (`tokenize`, `tokenHash`, `SPARSE_VOCAB_SIZE`) live
+// in `./sparse-tokenize.ts` so the BM25 encoder can share them without
+// transitively depending on this module.
 
 /**
  * Bump this version whenever the sparse embedding algorithm changes
@@ -796,22 +798,6 @@ export const SPARSE_VOCAB_SIZE = 30_000;
  * of existing sparse vectors via the sentinel mismatch mechanism.
  */
 export const SPARSE_EMBEDDING_VERSION = 3;
-
-/** Tokenize text into lowercase alphanumeric tokens (Unicode-aware). */
-export function tokenize(text: string): string[] {
-  return text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
-}
-
-/** Hash a token to a stable index in [0, vocabSize). */
-export function tokenHash(token: string, vocabSize: number): number {
-  // FNV-1a 32-bit hash for speed
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < token.length; i++) {
-    hash ^= token.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
-  }
-  return hash % vocabSize;
-}
 
 /**
  * Generate a TF-IDF-based sparse embedding for the given text.

--- a/assistant/src/memory/sparse-tokenize.ts
+++ b/assistant/src/memory/sparse-tokenize.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// Sparse-vector tokenization primitives
+// ---------------------------------------------------------------------------
+//
+// Shared by both the legacy TF-only encoder in `embedding-backend.ts`
+// (`generateSparseEmbedding`) and the BM25 encoder in `v2/sparse-bm25.ts`.
+//
+// Lives in its own module so consumers of the BM25 encoder don't transitively
+// depend on `embedding-backend.ts` for these primitives — that matters
+// because many tests mock `embedding-backend.js` wholesale via
+// `mock.module(...)`, and a missing export from the mock would break any
+// transitive importer of these helpers.
+
+/** Hashed-vocabulary size for sparse encoders. */
+export const SPARSE_VOCAB_SIZE = 30_000;
+
+/** Tokenize text into lowercase alphanumeric tokens (Unicode-aware). */
+export function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
+/** Hash a token to a stable index in [0, vocabSize). */
+export function tokenHash(token: string, vocabSize: number): number {
+  // FNV-1a 32-bit hash for speed
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < token.length; i++) {
+    hash ^= token.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash % vocabSize;
+}

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -60,7 +60,6 @@ const state = {
   embedCalls: [] as Array<{ inputs: unknown[] }>,
   sparseCalls: [] as string[],
   embedReturn: [[0.1, 0.2, 0.3]] as number[][],
-  sparseReturn: { indices: [1, 2, 3], values: [0.5, 0.5, 0.5] },
   // Programmable Qdrant query response — one entry per `using` channel,
   // shifted in order so each test can stage dense + sparse results.
   queryResponses: {
@@ -90,7 +89,7 @@ const state = {
 };
 
 // Re-export every real symbol from the embedding-backend module, overriding
-// only the two we control. Bun's `mock.module` replacement is process-wide,
+// only the one we control. Bun's `mock.module` replacement is process-wide,
 // so a partial mock here would break sibling test files that import other
 // exports from the same module (`selectEmbeddingBackend`, etc.).
 const realEmbeddingBackend = await import("../../embedding-backend.js");
@@ -104,9 +103,23 @@ mock.module("../../embedding-backend.js", () => ({
       vectors: state.embedReturn,
     };
   },
-  generateSparseEmbedding: (text: string) => {
+}));
+
+// `sim.ts` builds the query-side sparse vector via BM25's
+// `generateBm25QueryEmbedding`. Wrap it to record the call text, then
+// delegate to the real implementation so the resulting sparse vector is
+// well-formed. Capture the function reference *before* registering the
+// mock — ESM live bindings resolve through the namespace at call time, so
+// `realSparseBm25.fn(...)` after `mock.module` would route into the
+// mocked version and recurse.
+const realSparseBm25 = await import("../sparse-bm25.js");
+const realGenerateBm25QueryEmbedding =
+  realSparseBm25.generateBm25QueryEmbedding;
+mock.module("../sparse-bm25.js", () => ({
+  ...realSparseBm25,
+  generateBm25QueryEmbedding: (text: string) => {
     state.sparseCalls.push(text);
-    return state.sparseReturn;
+    return realGenerateBm25QueryEmbedding(text);
   },
 }));
 
@@ -159,7 +172,6 @@ function resetState(): void {
   state.embedCalls.length = 0;
   state.sparseCalls.length = 0;
   state.embedReturn = [[0.1, 0.2, 0.3]];
-  state.sparseReturn = { indices: [1, 2, 3], values: [0.5, 0.5, 0.5] };
   state.queryResponses.dense.length = 0;
   state.queryResponses.sparse.length = 0;
   state.skillQueryResponses.dense.length = 0;

--- a/assistant/src/memory/v2/__tests__/sparse-bm25.test.ts
+++ b/assistant/src/memory/v2/__tests__/sparse-bm25.test.ts
@@ -7,7 +7,7 @@ import {
   SPARSE_VOCAB_SIZE,
   tokenHash,
   tokenize,
-} from "../../embedding-backend.js";
+} from "../../sparse-tokenize.js";
 import {
   _resetCorpusStatsForTests,
   _setCorpusStatsForTests,

--- a/assistant/src/memory/v2/sparse-bm25.ts
+++ b/assistant/src/memory/v2/sparse-bm25.ts
@@ -26,12 +26,8 @@
 
 import { readFile } from "node:fs/promises";
 
-import {
-  SPARSE_VOCAB_SIZE,
-  tokenHash,
-  tokenize,
-} from "../embedding-backend.js";
 import type { SparseEmbedding } from "../embedding-types.js";
+import { SPARSE_VOCAB_SIZE, tokenHash, tokenize } from "../sparse-tokenize.js";
 import { listPages } from "./page-store.js";
 
 /**

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -425,6 +425,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/concept-page:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/reembed-skills:POST", scopes: ["settings.write"] },
   { endpoint: "memory/v2/explain-similarity:POST", scopes: ["settings.read"] },
+  {
+    endpoint: "memory/v2/rebuild-corpus-stats:POST",
+    scopes: ["settings.write"],
+  },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary

- Extract \`SPARSE_VOCAB_SIZE\` / \`tokenize\` / \`tokenHash\` into a new \`assistant/src/memory/sparse-tokenize.ts\` so the BM25 encoder no longer depends on \`embedding-backend.ts\` for these primitives — that fixes 5 tests that wholesale-mock \`embedding-backend.js\` and were failing with \`SyntaxError: Export named 'SPARSE_VOCAB_SIZE' not found\` whenever \`sparse-bm25.ts\` was transitively imported.
- Register \`memory/v2/rebuild-corpus-stats:POST\` under \`settings.write\` in \`route-policy.ts\` (added in #29344, never wired up) so the \`guard-tests\` route-policy coverage check passes.
- Update \`sim.test.ts\` to wrap \`generateBm25QueryEmbedding\` instead of the now-unused \`generateSparseEmbedding\` mock — capture the real function reference into a local before \`mock.module\` so the wrapper can delegate without recursing through the ESM live binding.

## Original prompt

--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25270799681/job/74092696777
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->