### PR TITLE
chore(daemon): remove test-only public API from host proxies

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -121,7 +121,6 @@ describe("HostAppControlProxy", () => {
 
       // Singleton lock acquired by this conversation.
       expect(_getActiveAppControlConversationId()).toBe("conv-1");
-      expect(proxy.currentApp).toEqual({ name: "com.example.editor" });
 
       proxy.dispose();
     });

--- a/assistant/src/__tests__/host-proxy-base.test.ts
+++ b/assistant/src/__tests__/host-proxy-base.test.ts
@@ -308,31 +308,4 @@ describe("HostProxyBase", () => {
       expect(proxy.isAvailable()).toBe(true);
     });
   });
-
-  describe("cancel", () => {
-    test("broadcasts cancel envelope and rejects the pending request", async () => {
-      setup();
-
-      const promise = proxy.send("t1", { payload: "1" }, "conv-1");
-      promise.catch(() => {});
-      const requestId = (sentMessages[0] as Record<string, unknown>)
-        .requestId as string;
-
-      proxy.cancel(requestId, "user-canceled");
-
-      await expect(promise).rejects.toMatchObject({ reason: "aborted" });
-      expect(proxy.hasPendingRequest(requestId)).toBe(false);
-
-      const cancel = sentMessages[1] as Record<string, unknown>;
-      expect(cancel.type).toBe("test_cancel");
-      expect(cancel.requestId).toBe(requestId);
-      expect(resolvedInteractionIds).toContain(requestId);
-    });
-
-    test("is a no-op for unknown request id", () => {
-      setup();
-      proxy.cancel("nope", "any");
-      expect(sentMessages).toHaveLength(0);
-    });
-  });
 });

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -8,8 +8,8 @@
  *
  * Lifecycle (pending map, timeout, abort SSE, dispose, isAvailable) lives
  * in {@link HostProxyBase}; this class layers app-control-specific state
- * (active app, PNG-hash loop guard) and the result-payload →
- * ToolExecutionResult translation on top.
+ * (PNG-hash loop guard) and the result-payload → ToolExecutionResult
+ * translation on top.
  *
  * **Singleton lock.** Only one conversation may hold an active app-control
  * session at a time. The lock is module-level (`activeAppControlConversationId`)
@@ -84,16 +84,6 @@ export function _resetActiveAppControlConversationId(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Per-instance state types
-// ---------------------------------------------------------------------------
-
-interface ActiveApp {
-  bundleId?: string;
-  pid?: number;
-  name: string;
-}
-
-// ---------------------------------------------------------------------------
 // HostAppControlProxy
 // ---------------------------------------------------------------------------
 
@@ -103,9 +93,6 @@ export class HostAppControlProxy extends HostProxyBase<
 > {
   /** Conversation that owns this proxy instance. Used by `dispose()` to release the singleton lock only when this proxy is the holder. */
   private readonly conversationId: string;
-
-  /** Application identity captured from the most recent successful `start` result. */
-  private activeApp?: ActiveApp;
 
   /** sha256 hex of the most recent observation's `pngBase64`, or undefined. */
   private lastObservationHash?: string;
@@ -132,10 +119,6 @@ export class HostAppControlProxy extends HostProxyBase<
   // ---------------------------------------------------------------------------
   // State accessors (testing / external inspection)
   // ---------------------------------------------------------------------------
-
-  get currentApp(): ActiveApp | undefined {
-    return this.activeApp;
-  }
 
   get observationRepeatCount(): number {
     return this.observationHashRepeatCount;
@@ -184,7 +167,7 @@ export class HostAppControlProxy extends HostProxyBase<
         conversationId,
         signal,
       );
-      return this.handleSuccess(toolName, input, payload);
+      return this.handleSuccess(toolName, payload);
     } catch (err) {
       if (err instanceof HostProxyRequestError) {
         if (err.reason === "timeout") {
@@ -210,7 +193,6 @@ export class HostAppControlProxy extends HostProxyBase<
 
   private handleSuccess(
     toolName: string,
-    input: HostAppControlInput,
     payload: HostAppControlResultPayload,
   ): ToolExecutionResult {
     // Update PNG-hash loop tracking only for the "running" state — other
@@ -230,18 +212,9 @@ export class HostAppControlProxy extends HostProxyBase<
       }
     }
 
-    // Acquire the singleton lock on a successful `start`. Capture the
-    // app identity from the request input — the current result-payload
-    // shape doesn't carry bundleId/pid, but the start input names the
-    // target app (bundle id or process name), which is the most
-    // authoritative identity we have at this layer.
-    if (
-      toolName === TOOL_START &&
-      input.tool === "start" &&
-      payload.state === "running"
-    ) {
+    // Acquire the singleton lock on a successful `start`.
+    if (toolName === TOOL_START && payload.state === "running") {
       activeAppControlConversationId = this.conversationId;
-      this.activeApp = { name: input.app };
     }
 
     return this.formatResult(payload, stuck);

--- a/assistant/src/daemon/host-proxy-base.ts
+++ b/assistant/src/daemon/host-proxy-base.ts
@@ -233,34 +233,6 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
   }
 
   /**
-   * Cancel a pending request out-of-band (e.g. when the conversation is
-   * being torn down). Broadcasts a cancel envelope and rejects with
-   * `"aborted"`. No-op when no entry is registered.
-   */
-  cancel(requestId: string, reason: string): void {
-    const entry = this.pending.get(requestId);
-    if (!entry) return;
-    clearTimeout(entry.timer);
-    entry.detachAbort();
-    this.pending.delete(requestId);
-    pendingInteractions.resolve(requestId);
-    log.info(
-      { requestId, reason, kind: this.resultPendingKind },
-      "Host proxy request canceled",
-    );
-    try {
-      broadcastDynamic({
-        type: this.cancelEventName,
-        requestId,
-        conversationId: entry.conversationId,
-      });
-    } catch {
-      // Best-effort cancel notification — connection may already be closed.
-    }
-    entry.reject(new HostProxyRequestError("aborted", "aborted"));
-  }
-
-  /**
    * Reject every pending request and clear the map. Called during graceful
    * shutdown or proxy teardown.
    */


### PR DESCRIPTION
## Summary
- Delete HostProxyBase.cancel() (test-only public method).
- Delete HostAppControlProxy.activeApp / ActiveApp / currentApp (test-only readback shadow of the singleton lock).
- Update tests accordingly.

Addresses slop issues #2 and #3 from app-control-skill.md round-2 review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->