### PR TITLE
chore(macos): drop unread Swift fields on app-control wire structs

### DIFF
--- a/clients/macos/vellum-assistantTests/AppControlConnectionTests.swift
+++ b/clients/macos/vellum-assistantTests/AppControlConnectionTests.swift
@@ -41,7 +41,6 @@ final class AppControlConnectionTests: XCTestCase {
         XCTAssertEqual(payload.type, "host_app_control_request")
         XCTAssertEqual(payload.requestId, "req-app-1")
         XCTAssertEqual(payload.conversationId, "conv-1")
-        XCTAssertEqual(payload.toolName, "app_control_press")
         guard case .press(let app, let key, let modifiers, let durationMs) = payload.input else {
             XCTFail("Expected .press input variant, got \(payload.input)")
             return
@@ -107,7 +106,6 @@ final class AppControlConnectionTests: XCTestCase {
         }
         XCTAssertEqual(payload.type, "host_app_control_cancel")
         XCTAssertEqual(payload.requestId, "req-app-1")
-        XCTAssertEqual(payload.conversationId, "conv-1")
     }
 
     // MARK: - Existing host_cu_* still decode

--- a/clients/macos/vellum-assistantTests/AppControlExecutorTests.swift
+++ b/clients/macos/vellum-assistantTests/AppControlExecutorTests.swift
@@ -15,7 +15,6 @@ final class AppControlExecutorTests: XCTestCase {
             type: "host_app_control_request",
             requestId: "req-start-missing",
             conversationId: "conv-test",
-            toolName: "app_control_start",
             input: .start(app: "com.example.does-not-exist", args: nil)
         )
 
@@ -37,7 +36,6 @@ final class AppControlExecutorTests: XCTestCase {
             type: "host_app_control_request",
             requestId: "req-stop-1",
             conversationId: "conv-test",
-            toolName: "app_control_stop",
             input: .stop(app: "com.example.does-not-exist", reason: "test")
         )
 
@@ -54,7 +52,6 @@ final class AppControlExecutorTests: XCTestCase {
             type: "host_app_control_request",
             requestId: "req-stop-2",
             conversationId: "conv-test",
-            toolName: "app_control_stop",
             input: .stop(app: nil, reason: nil)
         )
 
@@ -75,7 +72,6 @@ final class AppControlExecutorTests: XCTestCase {
             type: "host_app_control_request",
             requestId: "req-observe-missing",
             conversationId: "conv-test",
-            toolName: "app_control_observe",
             input: .observe(app: "com.example.does-not-exist")
         )
 

--- a/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
@@ -132,7 +132,6 @@ final class HostAppControlTypesTests: XCTestCase {
             type: "host_app_control_request",
             requestId: "req-1",
             conversationId: "conv-1",
-            toolName: "host_app_control_click",
             input: .click(app: "com.apple.Safari", x: 50, y: 75, button: "left", double: false)
         )
         XCTAssertEqual(try roundTrip(request), request)
@@ -143,8 +142,7 @@ final class HostAppControlTypesTests: XCTestCase {
     func test_cancel_roundTrips() throws {
         let cancel = HostAppControlCancel(
             type: "host_app_control_cancel",
-            requestId: "req-1",
-            conversationId: "conv-1"
+            requestId: "req-1"
         )
         XCTAssertEqual(try roundTrip(cancel), cancel)
     }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1684,20 +1684,17 @@ public struct HostAppControlRequest: Codable, Equatable, Sendable {
     public let type: String
     public let requestId: String
     public let conversationId: String
-    public let toolName: String
     public let input: HostAppControlInput
 
     public init(
         type: String,
         requestId: String,
         conversationId: String,
-        toolName: String,
         input: HostAppControlInput
     ) {
         self.type = type
         self.requestId = requestId
         self.conversationId = conversationId
-        self.toolName = toolName
         self.input = input
     }
 
@@ -1705,7 +1702,6 @@ public struct HostAppControlRequest: Codable, Equatable, Sendable {
         case type
         case requestId
         case conversationId
-        case toolName
         case input
     }
 }
@@ -1850,12 +1846,10 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
 public struct HostAppControlCancel: Codable, Equatable, Sendable {
     public let type: String
     public let requestId: String
-    public let conversationId: String
 
-    public init(type: String, requestId: String, conversationId: String) {
+    public init(type: String, requestId: String) {
         self.type = type
         self.requestId = requestId
-        self.conversationId = conversationId
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove HostAppControlRequest.toolName (Swift) — only input.tool is consumed.
- Remove HostAppControlCancel.conversationId (Swift) — cancel handler uses requestId only.
- TypeScript wire types unchanged; Swift Codable ignores unknown fields.

Addresses slop issues #4 and #5 from app-control-skill.md round-2 review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->