### PR TITLE
feat(memory-jobs): classify slow LLM-bound job types

### DIFF
--- a/assistant/src/memory/__tests__/jobs-store-job-classes.test.ts
+++ b/assistant/src/memory/__tests__/jobs-store-job-classes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { EMBED_JOB_TYPES, SLOW_LLM_JOB_TYPES } from "../jobs-store.js";
+
+describe("memory job classes", () => {
+  test("EMBED_JOB_TYPES and SLOW_LLM_JOB_TYPES are disjoint", () => {
+    const embedSet = new Set<string>(EMBED_JOB_TYPES);
+    const overlap = SLOW_LLM_JOB_TYPES.filter((t) => embedSet.has(t));
+    expect(overlap).toEqual([]);
+  });
+
+  test("SLOW_LLM_JOB_TYPES entries are non-empty strings", () => {
+    expect(SLOW_LLM_JOB_TYPES.length).toBeGreaterThan(0);
+    for (const t of SLOW_LLM_JOB_TYPES) {
+      expect(typeof t).toBe("string");
+      expect(t.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("SLOW_LLM_JOB_TYPES has no duplicate entries", () => {
+    const set = new Set(SLOW_LLM_JOB_TYPES);
+    expect(set.size).toBe(SLOW_LLM_JOB_TYPES.length);
+  });
+});

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -43,7 +43,7 @@ export type MemoryJobType =
   | "memory_v2_reembed"
   | "memory_v2_activation_recompute";
 
-const EMBED_JOB_TYPES: MemoryJobType[] = [
+export const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_segment",
   "embed_summary",
   "embed_media",
@@ -51,6 +51,21 @@ const EMBED_JOB_TYPES: MemoryJobType[] = [
   "embed_graph_node",
   "embed_pkb_file",
   "graph_trigger_embed",
+];
+
+export const SLOW_LLM_JOB_TYPES: MemoryJobType[] = [
+  "graph_consolidate",
+  "graph_pattern_scan",
+  "graph_narrative_refine",
+  "graph_extract",
+  "conversation_analyze",
+  "build_conversation_summary",
+  "generate_conversation_starters",
+  "memory_v2_sweep",
+  "memory_v2_consolidate",
+  "memory_v2_migrate",
+  "backfill",
+  "graph_bootstrap",
 ];
 
 export interface MemoryJob<T = Record<string, unknown>> {


### PR DESCRIPTION
## Summary
- Export SLOW_LLM_JOB_TYPES from jobs-store.ts: a typed array of MemoryJobType members for slow LLM-bound jobs (graph consolidation, narrative refine, conversation analysis, etc.).
- Test asserts mutual exclusion with EMBED_JOB_TYPES.
- Constants-only — PR 6 in this plan adds the lane-aware claimMemoryJobs variant that uses this set.

Part of plan: config-defaults-job-lanes.md (PR 5 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->