### PR TITLE
feat(memory-jobs): add slowLlm/fast/embed concurrency caps to schema

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-lifecycle.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-lifecycle.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import { MemoryJobsConfigSchema } from "../memory-lifecycle.js";
+
+describe("MemoryJobsConfigSchema", () => {
+  test("parses an empty object to documented defaults", () => {
+    const parsed = MemoryJobsConfigSchema.parse({});
+    expect(parsed).toEqual({
+      workerConcurrency: 2,
+      batchSize: 10,
+      stalledJobTimeoutMs: 30 * 60 * 1000,
+      slowLlmConcurrency: 1,
+      fastConcurrency: 2,
+      embedConcurrency: 2,
+    });
+  });
+
+  test("derives lane caps from workerConcurrency when only it is set", () => {
+    const parsed = MemoryJobsConfigSchema.parse({ workerConcurrency: 4 });
+    expect(parsed.workerConcurrency).toBe(4);
+    expect(parsed.slowLlmConcurrency).toBe(2);
+    expect(parsed.fastConcurrency).toBe(4);
+    expect(parsed.embedConcurrency).toBe(4);
+  });
+
+  test("floors and clamps slowLlmConcurrency to at least 1 when deriving", () => {
+    const parsed = MemoryJobsConfigSchema.parse({ workerConcurrency: 1 });
+    expect(parsed.slowLlmConcurrency).toBe(1);
+    expect(parsed.fastConcurrency).toBe(1);
+    expect(parsed.embedConcurrency).toBe(1);
+  });
+
+  test("explicit lane cap overrides the derivation", () => {
+    const parsed = MemoryJobsConfigSchema.parse({
+      workerConcurrency: 4,
+      slowLlmConcurrency: 1,
+    });
+    expect(parsed.slowLlmConcurrency).toBe(1);
+    expect(parsed.fastConcurrency).toBe(4);
+    expect(parsed.embedConcurrency).toBe(4);
+  });
+
+  test("explicit lane caps without workerConcurrency keep workerConcurrency default", () => {
+    const parsed = MemoryJobsConfigSchema.parse({
+      slowLlmConcurrency: 3,
+      fastConcurrency: 5,
+      embedConcurrency: 7,
+    });
+    expect(parsed.workerConcurrency).toBe(2);
+    expect(parsed.slowLlmConcurrency).toBe(3);
+    expect(parsed.fastConcurrency).toBe(5);
+    expect(parsed.embedConcurrency).toBe(7);
+  });
+
+  test.each([
+    "slowLlmConcurrency",
+    "fastConcurrency",
+    "embedConcurrency",
+    "workerConcurrency",
+  ] as const)("rejects %s = 0", (field) => {
+    expect(() => MemoryJobsConfigSchema.parse({ [field]: 0 })).toThrow();
+  });
+
+  test.each([
+    "slowLlmConcurrency",
+    "fastConcurrency",
+    "embedConcurrency",
+    "workerConcurrency",
+  ] as const)("rejects negative %s", (field) => {
+    expect(() => MemoryJobsConfigSchema.parse({ [field]: -1 })).toThrow();
+  });
+
+  test.each([
+    "slowLlmConcurrency",
+    "fastConcurrency",
+    "embedConcurrency",
+    "workerConcurrency",
+  ] as const)("rejects non-integer %s", (field) => {
+    expect(() => MemoryJobsConfigSchema.parse({ [field]: 1.5 })).toThrow();
+  });
+});

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -1,29 +1,86 @@
 import { z } from "zod";
 
-export const MemoryJobsConfigSchema = z
-  .object({
-    workerConcurrency: z
-      .number({ error: "memory.jobs.workerConcurrency must be a number" })
-      .int("memory.jobs.workerConcurrency must be an integer")
-      .positive("memory.jobs.workerConcurrency must be a positive integer")
-      .default(2)
-      .describe("Number of concurrent workers processing memory jobs"),
-    batchSize: z
-      .number({ error: "memory.jobs.batchSize must be a number" })
-      .int("memory.jobs.batchSize must be an integer")
-      .positive("memory.jobs.batchSize must be a positive integer")
-      .default(10)
-      .describe("Number of memory items processed per batch"),
-    stalledJobTimeoutMs: z
-      .number({ error: "memory.jobs.stalledJobTimeoutMs must be a number" })
-      .int("memory.jobs.stalledJobTimeoutMs must be an integer")
-      .positive("memory.jobs.stalledJobTimeoutMs must be a positive integer")
-      .default(30 * 60 * 1000)
-      .describe(
-        "Timeout in milliseconds after which a stalled memory job is considered failed",
-      ),
-  })
-  .describe("Memory background job processing configuration");
+const DEFAULT_WORKER_CONCURRENCY = 2;
+const DEFAULT_SLOW_LLM_CONCURRENCY = 1;
+const DEFAULT_FAST_CONCURRENCY = 2;
+const DEFAULT_EMBED_CONCURRENCY = 2;
+
+const positiveInt = (field: string) =>
+  z
+    .number({ error: `memory.jobs.${field} must be a number` })
+    .int(`memory.jobs.${field} must be an integer`)
+    .positive(`memory.jobs.${field} must be a positive integer`);
+
+// Input shape allows all fields to be omitted so we can distinguish
+// "user explicitly set workerConcurrency" from "user accepted the default"
+// when deriving lane caps. The output shape (after transform) always has
+// all four fields populated.
+const MemoryJobsConfigInputSchema = z.object({
+  workerConcurrency: positiveInt("workerConcurrency")
+    .optional()
+    .describe("Number of concurrent workers processing memory jobs"),
+  batchSize: positiveInt("batchSize")
+    .default(10)
+    .describe("Number of memory items processed per batch"),
+  stalledJobTimeoutMs: positiveInt("stalledJobTimeoutMs")
+    .default(30 * 60 * 1000)
+    .describe(
+      "Timeout in milliseconds after which a stalled memory job is considered failed",
+    ),
+  slowLlmConcurrency: positiveInt("slowLlmConcurrency")
+    .optional()
+    .describe(
+      "Concurrent slow LLM-bound jobs (graph consolidation, narrative refine, etc.)",
+    ),
+  fastConcurrency: positiveInt("fastConcurrency")
+    .optional()
+    .describe(
+      "Concurrent fast jobs (concept-page embed, prunes, media processing, etc.)",
+    ),
+  embedConcurrency: positiveInt("embedConcurrency")
+    .optional()
+    .describe(
+      "Concurrent segment-embed jobs (gated by Qdrant circuit breaker)",
+    ),
+});
+
+export const MemoryJobsConfigSchema = MemoryJobsConfigInputSchema.transform(
+  (input) => {
+    // When `workerConcurrency` is explicitly set but lane caps are not,
+    // derive lane caps so existing user configs gain the per-lane fix
+    // without edits. Explicit lane caps always win.
+    const workerConcurrencyExplicit = input.workerConcurrency !== undefined;
+    const workerConcurrency =
+      input.workerConcurrency ?? DEFAULT_WORKER_CONCURRENCY;
+
+    const slowLlmConcurrency =
+      input.slowLlmConcurrency ??
+      (workerConcurrencyExplicit
+        ? Math.max(1, Math.floor(workerConcurrency / 2))
+        : DEFAULT_SLOW_LLM_CONCURRENCY);
+
+    const fastConcurrency =
+      input.fastConcurrency ??
+      (workerConcurrencyExplicit
+        ? workerConcurrency
+        : DEFAULT_FAST_CONCURRENCY);
+
+    const embedConcurrency =
+      input.embedConcurrency ??
+      (workerConcurrencyExplicit
+        ? workerConcurrency
+        : DEFAULT_EMBED_CONCURRENCY);
+
+    return {
+      workerConcurrency,
+      batchSize: input.batchSize,
+      stalledJobTimeoutMs: input.stalledJobTimeoutMs,
+      slowLlmConcurrency,
+      fastConcurrency,
+      embedConcurrency,
+    };
+  },
+).describe("Memory background job processing configuration");
 
 export const MemoryRetentionConfigSchema = z
   .object({


### PR DESCRIPTION
## Summary
- Extend MemoryJobsConfigSchema with slowLlmConcurrency (default 1), fastConcurrency (default 2), embedConcurrency (default 2).
- Back-compat derivation from workerConcurrency keeps existing user configs working without edits.
- Schema-only — no consumers touched. PR 7 in this plan will activate per-lane scheduling using these fields.

Part of plan: config-defaults-job-lanes.md (PR 4 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->