### PR TITLE
fix(memory-v2): stop double-wrap of <memory> on reinject and rehydrate

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -308,6 +308,42 @@ describe("loadFromDb metadata injection rehydration", () => {
     expect(messages[2].content).toEqual([{ type: "text", text: "Second" }]);
   });
 
+  test("historical wrapped memoryInjectedBlock rehydrates singly-wrapped", async () => {
+    // Historical v2 rows persisted `injectedBlockText` already wrapped in
+    // `<memory>...</memory>`. After unifying v2's storage with v1's
+    // unwrapped contract, the rehydrate path must defensively strip any
+    // pre-existing wrapper so old rows don't render double-wrapped.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Hi" }]),
+        metadata: JSON.stringify({
+          memoryInjectedBlock: "<memory>\nremember: alice\n</memory>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Hello" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(2);
+    const firstBlock = messages[0].content[0];
+    expect(firstBlock).toEqual({
+      type: "text",
+      text: "<memory>\nremember: alice\n</memory>",
+    });
+    if (firstBlock.type !== "text") throw new Error("unexpected block type");
+    expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
+  });
+
   test("malformed metadata is tolerated: load does not throw, content unchanged", async () => {
     mockConversation = defaultConv();
     mockDbMessages = [

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -240,11 +240,18 @@ export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
           }
 
           // Memory remains rehydrated on all rows (existing behavior).
+          // Strip any pre-existing wrapper before re-wrapping so historical
+          // rows persisted with the wrapper (v2 path before the
+          // injectedBlockText contract was unified with v1's unwrapped form)
+          // don't render double-wrapped after rehydrate.
           if (typeof meta.memoryInjectedBlock === "string") {
+            const inner = meta.memoryInjectedBlock
+              .replace(/^<memory>\n/, "")
+              .replace(/\n<\/memory>$/, "");
             content = [
               {
                 type: "text" as const,
-                text: `<memory>\n${meta.memoryInjectedBlock}\n</memory>`,
+                text: `<memory>\n${inner}\n</memory>`,
               },
               ...content,
             ];

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1618,7 +1618,7 @@ const RUNTIME_INJECTION_PREFIXES = [
   "<memory_context __injected>",
   "<memory_context>", // backward-compat: strip legacy blocks from pre-__injected history
   // NOTE: `<memory>` blocks (both the dynamic activation block from
-  // `prependMemoryV2Block` and the static `memory-v2-static` injector) are
+  // `injectTextBlock` and the static `memory-v2-static` injector) are
   // intentionally NOT stripped — memory injections persist in history so
   // the assistant retains intra-turn memory state. The activation pipeline
   // dedupes via `everInjected`, and compaction handles aggregate growth, so

--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -333,16 +333,54 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (per-turn path)",
 
     expect(result.mode).toBe("per-turn");
     expect(result.injectedBlockText).not.toBeNull();
-    expect(result.injectedBlockText).toContain("<memory>");
+    expect(result.injectedBlockText).not.toContain("<memory>");
     expect(result.injectedBlockText).toContain("### alice-vscode");
 
-    // The leading content block on the user message is the v2 block.
+    // The leading content block on the user message is the v2 block,
+    // wrapped exactly once.
     const lastMsg = result.runMessages[result.runMessages.length - 1];
     expect(lastMsg?.role).toBe("user");
     const firstBlock = lastMsg?.content[0];
     expect(firstBlock?.type).toBe("text");
     if (firstBlock?.type !== "text") throw new Error("unexpected block type");
-    expect(firstBlock.text).toContain("<memory>");
+    expect(firstBlock.text.startsWith("<memory>\n")).toBe(true);
+    expect(firstBlock.text.endsWith("\n</memory>")).toBe(true);
+    // No nested wrapper.
+    expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
+  });
+
+  test("reinjectCachedMemory after v2 injection wraps exactly once (no double-wrap)", async () => {
+    // Regression for the double-wrap bug: v2 cached `lastInjectedBlock`
+    // already wrapped, then `reinjectCachedMemory` re-wrapped via
+    // `injectTextBlock`, producing `<memory>\n<memory>\n...\n</memory>\n</memory>`.
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+
+    const memory = makeMemory();
+    const config = makeConfig(true);
+    const messages = makeMessages("Tell me about Alice's editor preferences");
+
+    const initial = await memory.prepareMemory(
+      messages,
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+    expect(initial.injectedBlockText).not.toBeNull();
+
+    // Simulate post-compaction: caller re-runs `applyRuntimeInjections`
+    // (which strips memory injections) and then asks for the cached
+    // memory to be re-prepended.
+    const reinjected = memory.reinjectCachedMemory(messages);
+    const lastMsg = reinjected.runMessages[reinjected.runMessages.length - 1];
+    const firstBlock = lastMsg?.content[0];
+    expect(firstBlock?.type).toBe("text");
+    if (firstBlock?.type !== "text") throw new Error("unexpected block type");
+    expect(firstBlock.text.startsWith("<memory>\n")).toBe(true);
+    expect(firstBlock.text.endsWith("\n</memory>")).toBe(true);
+    expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
+    expect(firstBlock.text.match(/<\/memory>/g)?.length).toBe(1);
+    expect(firstBlock.text).toContain("### alice-vscode");
   });
 
   test("flag on + config on with empty Qdrant hits → no v2 block, v1 fallback skipped", async () => {
@@ -384,7 +422,14 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (context-load pat
 
     expect(result.mode).toBe("context-load");
     expect(result.injectedBlockText).not.toBeNull();
-    expect(result.injectedBlockText).toContain("<memory>");
+    expect(result.injectedBlockText).toContain("### alice-vscode");
+    // injectedBlockText is the unwrapped inner content; the wrapper is
+    // applied at injection time on the run message.
+    expect(result.injectedBlockText).not.toContain("<memory>");
+    const lastMsg = result.runMessages[result.runMessages.length - 1];
+    const firstBlock = lastMsg?.content[0];
+    if (firstBlock?.type !== "text") throw new Error("unexpected block type");
+    expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
   });
 
   test("flag off → v2 not run on first turn either", async () => {

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -691,7 +691,7 @@ export class ConversationGraphMemory {
 
     return {
       routed: true,
-      runMessages: prependMemoryV2Block(messages, result.block),
+      runMessages: injectTextBlock(messages, result.block),
       injectedBlockText: result.block,
     };
   }
@@ -880,27 +880,4 @@ function readRawUserText(message: Message | undefined): string | null {
     .filter((t) => t.length > 0);
   if (texts.length === 0) return null;
   return texts.join(" ");
-}
-
-/**
- * Prepend a pre-rendered `<memory>` block (produced by
- * `injectMemoryV2Block`) to the last user message. Unlike v1's
- * {@link injectMemoryBlock}, the input here is already wrapped — we
- * just need to attach it as a leading text block. We still strip any
- * pre-existing memory injections first so the layer is idempotent
- * across compaction-driven re-injection.
- */
-function prependMemoryV2Block(messages: Message[], block: string): Message[] {
-  if (block.trim().length === 0) return messages;
-  if (messages.length === 0) return messages;
-  const cleaned = stripExistingMemoryInjections(messages);
-  const userTail = cleaned[cleaned.length - 1];
-  if (!userTail || userTail.role !== "user") return messages;
-  return [
-    ...cleaned.slice(0, -1),
-    {
-      ...userTail,
-      content: [{ type: "text" as const, text: block }, ...userTail.content],
-    },
-  ];
 }

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -407,11 +407,13 @@ describe("injectMemoryV2Block", () => {
 
     expect(result.toInject).toEqual(["alice-vscode"]);
     expect(result.block).not.toBeNull();
-    expect(result.block).toContain("<memory>");
+    // `block` is the unwrapped inner content; the caller adds the
+    // `<memory>...</memory>` wrapper exactly once at injection time.
+    expect(result.block).not.toContain("<memory>");
+    expect(result.block).not.toContain("</memory>");
     expect(result.block).not.toContain("## What I Remember Right Now");
     expect(result.block).toContain("### alice-vscode");
     expect(result.block).toContain("VS Code");
-    expect(result.block).toContain("</memory>");
 
     // State persisted: alice's activation is above epsilon and recorded;
     // everInjected captured the new slug + currentTurn.
@@ -677,7 +679,7 @@ describe("injectMemoryV2Block", () => {
   // Skill subsection rendering
   // ---------------------------------------------------------------------------
 
-  test("renders a skill-only block in the same `<memory>` wrapper as concept-page-only blocks", async () => {
+  test("renders a skill-only block alongside concept-page-only blocks", async () => {
     // No concept-page candidates this turn — the candidate query and the three
     // simBatch queries all return empty. The skill pipeline is mocked to
     // surface a single skill.
@@ -706,10 +708,11 @@ describe("injectMemoryV2Block", () => {
 
     expect(result.toInject).toEqual([]);
     expect(result.block).not.toBeNull();
-    // Same outer wrapping as concept-page-only blocks.
-    expect(result.block).toContain("<memory>");
+    // `block` is the unwrapped inner content; the caller adds the
+    // `<memory>...</memory>` wrapper exactly once at injection time.
+    expect(result.block).not.toContain("<memory>");
+    expect(result.block).not.toContain("</memory>");
     expect(result.block).not.toContain("## What I Remember Right Now");
-    expect(result.block).toContain("</memory>");
     // No concept-page sections; skills subsection present with the right
     // bullet shape and the unconditional `→ use skill_load to activate` suffix.
     expect(result.block).not.toContain("### alice-vscode");

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -88,10 +88,11 @@ export interface InjectMemoryV2BlockParams {
 
 export interface InjectMemoryV2BlockResult {
   /**
-   * Rendered `<memory>` block, ready to prepend to the current
-   * user message — or `null` when nothing new is eligible for injection.
-   * `null` is the cache-stable default: the caller adds nothing to the new
-   * user message and prior attachments stay byte-identical.
+   * Inner content for the `<memory>` block, ready for the caller to wrap
+   * exactly once at injection time — or `null` when nothing new is eligible
+   * for injection. `null` is the cache-stable default: the caller adds
+   * nothing to the new user message and prior attachments stay
+   * byte-identical.
    */
   block: string | null;
   /**
@@ -358,10 +359,15 @@ export async function injectMemoryV2Block(
 
 interface RenderInjectionBlockResult {
   /**
-   * Rendered `<memory>` block, or `null` when both the concept-page list
-   * and the skill list collapse to empty after cache misses (no on-disk
-   * pages, no resolvable skill ids). The caller falls through to its
-   * empty-block path instead of attaching an empty `<memory>` wrapper.
+   * Inner content for the `<memory>` block (concept-page sections + optional
+   * skills suffix), or `null` when both the concept-page list and the skill
+   * list collapse to empty after cache misses (no on-disk pages, no
+   * resolvable skill ids). Returned unwrapped so the caller can wrap it
+   * exactly once at injection time, matching v1's contract: callers that
+   * cache the value (`lastInjectedBlock`) or persist it (`memoryInjectedBlock`
+   * in message metadata) re-wrap on use, and storing the wrapped form here
+   * caused a double wrap on reinject after compaction and on rehydrate from
+   * DB.
    */
   block: string | null;
   /**
@@ -374,8 +380,9 @@ interface RenderInjectionBlockResult {
 }
 
 /**
- * Render the `<memory>` block for a list of slugs and a list of
- * ranked skill ids.
+ * Render the inner content of the `<memory>` block for a list of slugs and
+ * a list of ranked skill ids. The caller wraps the result in
+ * `<memory>...</memory>` exactly once at injection time.
  *
  * Concept pages are read in parallel via `readPage`. Pages whose file has
  * gone missing between selection and render (e.g. consolidation deleted
@@ -393,7 +400,6 @@ interface RenderInjectionBlockResult {
  * the agent sees the page's edges and any referenced media paths alongside
  * the prose:
  *
- *   <memory>
  *   ### <slug-1>
  *   ---
  *   edges:
@@ -413,7 +419,6 @@ interface RenderInjectionBlockResult {
  *   ### Skills You Can Use
  *   - <skill-1 content>
  *   - <skill-2 content>
- *   </memory>
  */
 async function renderInjectionBlock(
   workspaceDir: string,
@@ -453,7 +458,7 @@ async function renderInjectionBlock(
   if (sections.length === 0) return { block: null, missingSlugs };
 
   return {
-    block: `<memory>\n${sections.join("\n\n")}\n</memory>`,
+    block: sections.join("\n\n"),
     missingSlugs,
   };
 }

--- a/assistant/src/memory/v2/static-context.ts
+++ b/assistant/src/memory/v2/static-context.ts
@@ -6,11 +6,12 @@
 // and returns a concatenated, header-wrapped block ready to splice into the
 // current user message via the injector chain.
 //
-// Pairs with the v2 per-turn activation block (`prependMemoryV2Block` in
-// `conversation-graph-memory.ts`) — that block carries activated concept
-// pages selected by the activation pipeline; this static block carries the
-// always-relevant aggregate views written by consolidation and the user.
-// Both land on the user message so the system prompt stays cache-stable.
+// Pairs with the v2 per-turn activation block (`maybeRouteV2Injection` in
+// `conversation-graph-memory.ts`, which threads through `injectTextBlock`)
+// — that block carries activated concept pages selected by the activation
+// pipeline; this static block carries the always-relevant aggregate views
+// written by consolidation and the user. Both land on the user message so
+// the system prompt stays cache-stable.
 //
 // Refresh cadence is owned by the caller: the agent loop only passes the
 // content through when `mode === "full"` (first turn / post-compaction),

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -134,7 +134,7 @@ const MemoryV2GetConceptPageParams = z
 
 export type MemoryV2GetConceptPageResult = {
   slug: string;
-  /** Frontmatter + body, exactly as `renderInjectionBlock` would format it. */
+  /** Frontmatter + body, as produced by `renderPageContent`. */
   rendered: string;
 };
 


### PR DESCRIPTION
## Summary
- v2 stored its already-wrapped `<memory>...</memory>` block as `injectedBlockText`, while v1 stores unwrapped inner content. Two consumers (the post-compaction reinject path via `injectTextBlock`, and the DB rehydrate path in `conversation-lifecycle.ts:247`) wrap on use, producing `<memory>\n<memory>\n...\n</memory>\n</memory>` for v2 only.
- Aligns v2 with v1: `renderInjectionBlock` now returns unwrapped sections, `maybeRouteV2Injection` injects via `injectTextBlock` (which wraps once), and the redundant `prependMemoryV2Block` is deleted.
- Adds a defensive strip in the rehydrate path so historical v2 rows persisted with the wrapper don't render double-wrapped after the upstream fix lands. Regression tests cover both reinject-after-compaction and rehydrate-with-historical-wrapped-row.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->