### PR TITLE
feat(memory-v2): default dense_weight=0.85, sparse_weight=0.15

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -19,8 +19,8 @@ describe("MemoryV2ConfigSchema", () => {
       ann_candidate_limit: null,
       top_k_skills: 5,
       epsilon: 0.01,
-      dense_weight: 0.7,
-      sparse_weight: 0.3,
+      dense_weight: 0.85,
+      sparse_weight: 0.15,
       bm25_k1: 1.2,
       bm25_b: 0.4,
       consolidation_interval_hours: 4,
@@ -158,8 +158,8 @@ describe("MemoryConfigSchema integration with v2 block", () => {
     expect(parsed.v2.enabled).toBe(false);
     expect(parsed.v2.sweep_enabled).toBe(false);
     expect(parsed.v2.d).toBe(0.3);
-    expect(parsed.v2.dense_weight).toBe(0.7);
-    expect(parsed.v2.sparse_weight).toBe(0.3);
+    expect(parsed.v2.dense_weight).toBe(0.85);
+    expect(parsed.v2.sparse_weight).toBe(0.15);
     expect(parsed.v2.top_k_skills).toBe(5);
     expect(parsed.v2.consolidation_interval_hours).toBe(4);
     expect(parsed.v2.max_page_chars).toBe(5000);

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -116,17 +116,17 @@ export const MemoryV2ConfigSchema = z
       .number({ error: "memory.v2.dense_weight must be a number" })
       .min(0, "memory.v2.dense_weight must be >= 0")
       .max(1, "memory.v2.dense_weight must be <= 1")
-      .default(0.7)
+      .default(0.85)
       .describe(
-        "Weight on dense (cosine) similarity in the hybrid retrieval score",
+        "Weight on dense (cosine) similarity in the hybrid retrieval score — dense embeddings dominate the score.",
       ),
     sparse_weight: z
       .number({ error: "memory.v2.sparse_weight must be a number" })
       .min(0, "memory.v2.sparse_weight must be >= 0")
       .max(1, "memory.v2.sparse_weight must be <= 1")
-      .default(0.3)
+      .default(0.15)
       .describe(
-        "Weight on sparse (BM25-style) similarity in the hybrid retrieval score",
+        "Weight on sparse (BM25-style) similarity in the hybrid retrieval score — sparse acts as a discriminator for keyword-rich queries.",
       ),
     bm25_k1: z
       .number({ error: "memory.v2.bm25_k1 must be a number" })


### PR DESCRIPTION
## Summary
- Change MemoryV2ConfigSchema dense_weight default 0.7 → 0.85 and sparse_weight default 0.3 → 0.15. Sum-to-1 invariant preserved.
- Update memory-v2 schema tests to assert the new documented defaults.

Part of plan: config-defaults-job-lanes.md (PR 3 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->