### PR TITLE
feat(memory-jobs): claim jobs with per-lane budgets

### DIFF
--- a/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
+++ b/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
@@ -13,6 +13,8 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
+import { eq } from "drizzle-orm";
+
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
@@ -24,6 +26,7 @@ import {
   _resetQdrantBreaker,
   withQdrantBreaker,
 } from "../memory/qdrant-circuit-breaker.js";
+import { memoryJobs } from "../memory/schema.js";
 
 describe("claimMemoryJobs with Qdrant circuit breaker", () => {
   beforeAll(() => {
@@ -111,6 +114,85 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     const types = claimedAfterClose.map((j) => j.type);
 
     expect(types).toContain("embed_graph_node");
+  });
+
+  test("lane budgets are honored when called with explicit budgets", () => {
+    // 5 slow-lane jobs
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("graph_extract", { conversationId: `slow-${i}` });
+    }
+    // 5 fast-lane jobs (rebuild_index is neither slow-LLM nor embed)
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("rebuild_index", { id: `fast-${i}` });
+    }
+    // 5 embed-lane jobs
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("embed_segment", { segmentId: `embed-${i}` });
+    }
+
+    const claimed = claimMemoryJobs({ slowLlm: 1, fast: 2, embed: 2 });
+    const slowClaimed = claimed.filter((j) => j.type === "graph_extract");
+    const fastClaimed = claimed.filter((j) => j.type === "rebuild_index");
+    const embedClaimed = claimed.filter((j) => j.type === "embed_segment");
+
+    expect(claimed).toHaveLength(5);
+    expect(slowClaimed).toHaveLength(1);
+    expect(fastClaimed).toHaveLength(2);
+    expect(embedClaimed).toHaveLength(2);
+
+    // Remaining 10 jobs should still be pending.
+    const db = getDb();
+    const pendingRows = db
+      .select()
+      .from(memoryJobs)
+      .where(eq(memoryJobs.status, "pending"))
+      .all();
+    expect(pendingRows).toHaveLength(10);
+  });
+
+  test("Qdrant breaker gates only the embed lane in lane-aware mode", async () => {
+    // 5 slow + 5 fast + 5 embed pending jobs
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("graph_extract", { conversationId: `slow-${i}` });
+    }
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("rebuild_index", { id: `fast-${i}` });
+    }
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("embed_segment", { segmentId: `embed-${i}` });
+    }
+
+    // Trip the breaker
+    for (let i = 0; i < 5; i++) {
+      try {
+        await withQdrantBreaker(async () => {
+          throw new Error("simulated qdrant failure");
+        });
+      } catch {
+        // expected
+      }
+    }
+
+    const claimed = claimMemoryJobs({ slowLlm: 1, fast: 2, embed: 2 });
+    const slowClaimed = claimed.filter((j) => j.type === "graph_extract");
+    const fastClaimed = claimed.filter((j) => j.type === "rebuild_index");
+    const embedClaimed = claimed.filter((j) => j.type === "embed_segment");
+
+    expect(slowClaimed).toHaveLength(1);
+    expect(fastClaimed).toHaveLength(2);
+    // Breaker is open and probe window has not elapsed → no embed jobs claimed.
+    expect(embedClaimed).toHaveLength(0);
+  });
+
+  test("FIFO order within a lane is preserved by runAfter ascending", () => {
+    const t0 = Date.now() - 30_000;
+    enqueueMemoryJob("graph_extract", { conversationId: "third" }, t0 + 200);
+    enqueueMemoryJob("graph_extract", { conversationId: "first" }, t0);
+    enqueueMemoryJob("graph_extract", { conversationId: "second" }, t0 + 100);
+
+    const claimed = claimMemoryJobs({ slowLlm: 3, fast: 0, embed: 0 });
+    const order = claimed.map((j) => j.payload.conversationId);
+    expect(order).toEqual(["first", "second", "third"]);
   });
 
   test("all embed job types are skipped when breaker is open", async () => {

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -366,8 +366,23 @@ export function enqueuePruneOldConversationsJob(
   return enqueueMemoryJob("prune_old_conversations", payload);
 }
 
-export function claimMemoryJobs(limit: number): MemoryJob[] {
-  if (limit <= 0) return [];
+export interface LaneBudgets {
+  slowLlm: number;
+  fast: number;
+  embed: number;
+}
+
+export function claimMemoryJobs(limit: number): MemoryJob[];
+export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[];
+export function claimMemoryJobs(arg: number | LaneBudgets): MemoryJob[] {
+  // Back-compat: a single numeric limit is applied as the per-lane budget on
+  // every lane. The one current caller (jobs-worker.ts) is migrated to the
+  // explicit signature in a follow-up PR.
+  const limits: LaneBudgets =
+    typeof arg === "number" ? { slowLlm: arg, fast: arg, embed: arg } : arg;
+
+  if (limits.slowLlm <= 0 && limits.fast <= 0 && limits.embed <= 0) return [];
+
   const db = getDb();
   const now = Date.now();
   const pendingFilter = and(
@@ -375,38 +390,60 @@ export function claimMemoryJobs(limit: number): MemoryJob[] {
     lte(memoryJobs.runAfter, now),
   );
 
-  // Claim non-embed jobs first, then fill remaining slots with embed jobs.
-  // This prevents embed retries from starving other job types during a backend outage.
-  const nonEmbedCandidates = db
-    .select()
-    .from(memoryJobs)
-    .where(and(pendingFilter, notInArray(memoryJobs.type, EMBED_JOB_TYPES)))
-    .orderBy(asc(memoryJobs.runAfter), asc(memoryJobs.createdAt))
-    .limit(limit)
-    .all();
+  // Slow lane: long-running LLM jobs (graph extract/consolidate, analysis, etc.).
+  const slowCandidates =
+    limits.slowLlm > 0
+      ? db
+          .select()
+          .from(memoryJobs)
+          .where(
+            and(pendingFilter, inArray(memoryJobs.type, SLOW_LLM_JOB_TYPES)),
+          )
+          .orderBy(asc(memoryJobs.runAfter), asc(memoryJobs.createdAt))
+          .limit(limits.slowLlm)
+          .all()
+      : [];
 
-  const remainingSlots = limit - nonEmbedCandidates.length;
+  // Fast lane: everything that is neither slow-LLM nor embed.
+  const fastCandidates =
+    limits.fast > 0
+      ? db
+          .select()
+          .from(memoryJobs)
+          .where(
+            and(
+              pendingFilter,
+              notInArray(memoryJobs.type, SLOW_LLM_JOB_TYPES),
+              notInArray(memoryJobs.type, EMBED_JOB_TYPES),
+            ),
+          )
+          .orderBy(asc(memoryJobs.runAfter), asc(memoryJobs.createdAt))
+          .limit(limits.fast)
+          .all()
+      : [];
 
-  // When the Qdrant circuit breaker is open, skip embed jobs entirely —
-  // they would just be claimed → fail → deferred, wasting CPU cycles.
-  // Exception: if the cooldown has elapsed (breaker ready for half-open probe),
-  // allow exactly 1 embed job through so the breaker can self-heal.
+  // Embed lane: gated by the Qdrant circuit breaker. When the breaker is open,
+  // skip embed jobs entirely — they would just be claimed → fail → deferred,
+  // wasting CPU cycles. Exception: if the cooldown has elapsed (breaker ready
+  // for half-open probe), allow exactly 1 embed job through so the breaker
+  // can self-heal. Note: this gate applies ONLY to the embed lane; slow and
+  // fast lanes run unimpeded.
   const breakerOpen = isQdrantBreakerOpen();
   const probeAllowed = breakerOpen && shouldAllowQdrantProbe();
   const skipEmbedJobs = breakerOpen && !probeAllowed;
-  const embedLimit = probeAllowed ? 1 : remainingSlots;
+  const embedLimit = probeAllowed ? Math.min(1, limits.embed) : limits.embed;
 
-  if (skipEmbedJobs && remainingSlots > 0) {
+  if (skipEmbedJobs && limits.embed > 0) {
     log.debug("Skipping embed job claims — Qdrant circuit breaker is open");
   }
-  if (probeAllowed && remainingSlots > 0) {
+  if (probeAllowed && limits.embed > 0) {
     log.debug(
       "Allowing 1 embed probe job — Qdrant circuit breaker cooldown elapsed",
     );
   }
 
   const embedCandidates =
-    remainingSlots > 0 && !skipEmbedJobs
+    embedLimit > 0 && !skipEmbedJobs
       ? db
           .select()
           .from(memoryJobs)
@@ -416,7 +453,7 @@ export function claimMemoryJobs(limit: number): MemoryJob[] {
           .all()
       : [];
 
-  const candidates = [...nonEmbedCandidates, ...embedCandidates];
+  const candidates = [...slowCandidates, ...fastCandidates, ...embedCandidates];
 
   const claimed: MemoryJob[] = [];
   for (const row of candidates) {


### PR DESCRIPTION
## Summary
- Add lane-aware claimMemoryJobs({slowLlm, fast, embed}) overload that issues per-lane SELECTs and concatenates results before the existing row-level claim loop.
- Qdrant circuit breaker still gates only the embed lane; slow and fast lanes are independent.
- Single-arg form preserved as back-compat overload — no consumer changes in this PR.

Part of plan: config-defaults-job-lanes.md (PR 6 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->