### PR TITLE
fix(app-control): focus, sequence tool, observe staleness

### DIFF
--- a/assistant/src/__tests__/app-control-tool-schemas.test.ts
+++ b/assistant/src/__tests__/app-control-tool-schemas.test.ts
@@ -143,8 +143,8 @@ const ctx: ToolContext = {
 // ---------------------------------------------------------------------------
 
 describe("app-control TOOLS.json (aggregate)", () => {
-  test("contains exactly 8 tools", () => {
-    expect(toolsJson.tools.length).toBe(8);
+  test("contains exactly 9 tools", () => {
+    expect(toolsJson.tools.length).toBe(9);
   });
 
   test("all tools target host execution", () => {
@@ -323,6 +323,65 @@ describe("app_control_combo", () => {
     });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("keys");
+  });
+});
+
+describe("app_control_sequence", () => {
+  const s = toolByName("app_control_sequence").input_schema;
+
+  test("well-formed input passes (minimal step)", () => {
+    expect(
+      validate(s, {
+        app: "com.apple.Safari",
+        steps: [{ key: "right" }],
+        reasoning: "advance one step",
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("well-formed input passes (full step fields)", () => {
+    expect(
+      validate(s, {
+        app: "com.apple.Safari",
+        steps: [
+          { key: "right", duration_ms: 50, gap_ms: 30 },
+          { key: "a", modifiers: ["cmd"], duration_ms: 50, gap_ms: 30 },
+        ],
+        reasoning: "navigate menu",
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("missing required app rejects", () => {
+    const result = validate(s, {
+      steps: [{ key: "right" }],
+      reasoning: "navigate",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("app");
+  });
+
+  test("missing required steps rejects", () => {
+    const result = validate(s, {
+      app: "com.apple.Safari",
+      reasoning: "navigate",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("steps");
+  });
+
+  test("non-array steps rejects", () => {
+    const result = validate(s, {
+      app: "com.apple.Safari",
+      steps: "right,right",
+      reasoning: "navigate",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("steps");
+  });
+
+  test("declares low risk", () => {
+    expect(toolByName("app_control_sequence").risk).toBe("low");
   });
 });
 

--- a/assistant/src/config/bundled-skills/app-control/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-control/SKILL.md
@@ -39,6 +39,12 @@ moved the window or changed visibility.
 
 ## Input choice
 
+- Prefer `app_control_sequence` over multiple back-to-back `app_control_press`
+  calls when sending an ordered batch of presses (e.g. menu navigation,
+  repeated movement). Sequence runs in a single round-trip — the target app is
+  activated once at the start and the keys are sent serially without any
+  window for keyboard focus to drift to another app between presses. Each step
+  may carry its own `duration_ms` (hold) and `gap_ms` (pause after).
 - Prefer `app_control_combo` over rapid sequential `app_control_press` for
   simultaneous inputs (e.g. cmd+shift+4). `combo` holds every key at once;
   sequential presses interleave key-down and key-up events.

--- a/assistant/src/config/bundled-skills/app-control/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-control/TOOLS.json
@@ -129,6 +129,59 @@
       "execution_target": "host"
     },
     {
+      "name": "app_control_sequence",
+      "description": "Send an ordered batch of single-key presses to the target application. The target app is activated once at the start, then each step is pressed serially with optional inter-step gaps. PREFER this over multiple back-to-back app_control_press calls when sending an ordered batch (e.g. menu navigation, repeated movement) — sequence runs in a single round-trip with no window for keyboard focus to drift between presses.",
+      "category": "app-control",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string",
+            "description": "Bundle ID (preferred, e.g. 'com.apple.Safari') or process name of the target application"
+          },
+          "steps": {
+            "type": "array",
+            "description": "Ordered list of single-key presses to execute serially.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "description": "Key identifier, e.g. \"return\", \"a\", \"right\""
+                },
+                "modifiers": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Modifier list for this step, e.g. [\"cmd\", \"shift\"]. Omit for no modifiers."
+                },
+                "duration_ms": {
+                  "type": "integer",
+                  "description": "Hold duration for this key in milliseconds (default 50)"
+                },
+                "gap_ms": {
+                  "type": "integer",
+                  "description": "Pause after this step before starting the next, in milliseconds (default 30)"
+                }
+              },
+              "required": ["key"]
+            }
+          },
+          "reasoning": {
+            "type": "string",
+            "description": "Explanation of what this sequence does and why"
+          },
+          "activity": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["app", "steps", "reasoning"]
+      },
+      "executor": "tools/app-control-sequence.ts",
+      "execution_target": "host"
+    },
+    {
       "name": "app_control_type",
       "description": "Type literal text into the target application at the current focus. Ensure the intended field is focused before calling.",
       "category": "app-control",

--- a/assistant/src/config/bundled-skills/app-control/tools/app-control-sequence.ts
+++ b/assistant/src/config/bundled-skills/app-control/tools/app-control-sequence.ts
@@ -1,0 +1,12 @@
+import { forwardAppControlProxyTool } from "../../../../tools/app-control/skill-proxy-bridge.js";
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return forwardAppControlProxyTool("app_control_sequence", input, context);
+}

--- a/assistant/src/daemon/message-types/host-app-control.ts
+++ b/assistant/src/daemon/message-types/host-app-control.ts
@@ -6,12 +6,13 @@
 
 // === Tool input discriminated union ===
 
-/** Inputs accepted by the eight app-control tool variants. */
+/** Inputs accepted by the nine app-control tool variants. */
 export type HostAppControlInput =
   | HostAppControlStartInput
   | HostAppControlObserveInput
   | HostAppControlPressInput
   | HostAppControlComboInput
+  | HostAppControlSequenceInput
   | HostAppControlTypeInput
   | HostAppControlClickInput
   | HostAppControlDragInput
@@ -48,6 +49,25 @@ export interface HostAppControlComboInput {
   keys: string[];
   /** Hold duration in milliseconds. */
   duration_ms?: number;
+}
+
+/** A single step inside a sequence: one key press with optional modifiers, hold duration, and post-press gap. */
+export interface HostAppControlSequenceStep {
+  /** Single key identifier, e.g. "right", "a", "return". */
+  key: string;
+  /** Modifier list, e.g. ["cmd", "shift"]. Omit for no modifiers. */
+  modifiers?: string[];
+  /** Hold duration for this key in milliseconds. */
+  duration_ms?: number;
+  /** Pause after this step before starting the next, in milliseconds. */
+  gap_ms?: number;
+}
+
+export interface HostAppControlSequenceInput {
+  tool: "sequence";
+  app: string;
+  /** Ordered list of single-key presses to execute serially. */
+  steps: HostAppControlSequenceStep[];
 }
 
 export interface HostAppControlTypeInput {

--- a/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
@@ -7,6 +7,29 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppControlExecutor")
 
+/// Hard cap on how long we'll wait for a target app to become frontmost
+/// after `NSRunningApplication.activate()`. macOS focus transitions are
+/// usually well under 50ms; capping at 100ms keeps cold-start cases from
+/// stalling the input pipeline indefinitely.
+private let ACTIVATE_WAIT_DEADLINE_MS = 100
+
+/// Poll interval used while waiting for the target app's `isActive` to flip
+/// to true after `activate()`.
+private let ACTIVATE_POLL_INTERVAL_MS = 5
+
+/// Settle delay applied at the start of `observe` so the window server has
+/// time to composite a fresh frame after recent synthetic input events.
+private let OBSERVE_SETTLE_DELAY_MS = 80
+
+/// Default per-step gap inside `app_control_sequence` when a step omits its
+/// own `gap_ms`. Keeps consecutive presses far enough apart that emulators
+/// and games register them as discrete inputs.
+private let SEQUENCE_DEFAULT_GAP_MS = 30
+
+/// Default per-step hold duration inside `app_control_sequence` when a step
+/// omits its own `duration_ms`.
+private let SEQUENCE_DEFAULT_DURATION_MS = 50
+
 /// Dispatches a `HostAppControlRequest` to the appropriate per-process input
 /// helper (`AppKeyboard`, `AppMouse`, `AppWindowCapture`) and returns a
 /// `HostAppControlResultPayload` for the daemon.
@@ -15,6 +38,31 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AppCo
 /// `requestId` so the daemon can correlate failures with the request that
 /// produced them.
 enum AppControlExecutor {
+
+    // MARK: - Focus management
+
+    /// Bring the target process to the front of macOS's keyboard-focus stack
+    /// before posting synthetic input. `CGEvent.postToPid(_:)` queues events
+    /// at the target's port, but the WindowServer still routes keystrokes by
+    /// global keyboard focus — if another app holds focus, the events get
+    /// queued and never delivered. Activating the target app first
+    /// eliminates that drop window.
+    ///
+    /// Polls briefly until `isActive` flips to true (capped at
+    /// `ACTIVATE_WAIT_DEADLINE_MS`). Best-effort: returns even if the
+    /// deadline expires without focus transferring, so callers still attempt
+    /// the input.
+    private static func ensureActive(pid: pid_t) async {
+        guard let runningApp = NSRunningApplication(processIdentifier: pid) else { return }
+        if runningApp.isActive { return }
+        runningApp.activate(options: [.activateIgnoringOtherApps])
+        let deadline = Date().addingTimeInterval(Double(ACTIVATE_WAIT_DEADLINE_MS) / 1000.0)
+        while !runningApp.isActive && Date() < deadline {
+            try? await Task.sleep(
+                nanoseconds: UInt64(ACTIVATE_POLL_INTERVAL_MS) * 1_000_000
+            )
+        }
+    }
 
     /// Execute `request` and produce a wire result. Never throws — every
     /// failure is reported as a result payload with `executionError` set.
@@ -38,6 +86,12 @@ enum AppControlExecutor {
                 app: app,
                 keys: keys,
                 durationMs: durationMs ?? 50
+            )
+        case .sequence(let app, let steps):
+            return await performSequence(
+                requestId: request.requestId,
+                app: app,
+                steps: steps
             )
         case .type(let app, let text):
             return await performType(requestId: request.requestId, app: app, text: text)
@@ -139,6 +193,12 @@ enum AppControlExecutor {
                 executionError: "App not running: \(app)"
             )
         }
+        // Brief settle delay before capture: lets the target app finish
+        // processing any pending synthetic input events and lets the window
+        // server composite a fresh frame for ScreenCaptureKit. Without this,
+        // back-to-back press → observe sequences can return a screenshot
+        // captured one input behind the latest state.
+        try? await Task.sleep(nanoseconds: UInt64(OBSERVE_SETTLE_DELAY_MS) * 1_000_000)
         let capture = await AppWindowCapture.capture(forPid: resolved.pid)
         return HostAppControlResultPayload(
             requestId: requestId,
@@ -166,6 +226,8 @@ enum AppControlExecutor {
                 executionError: "App not running: \(app)"
             )
         }
+
+        await ensureActive(pid: resolved.pid)
 
         do {
             try await AppKeyboard.press(
@@ -205,6 +267,8 @@ enum AppControlExecutor {
             )
         }
 
+        await ensureActive(pid: resolved.pid)
+
         do {
             try await AppKeyboard.combo(
                 pid: resolved.pid,
@@ -226,6 +290,71 @@ enum AppControlExecutor {
         }
     }
 
+    // MARK: - sequence
+
+    /// Run an ordered batch of single-key presses serially against the same
+    /// target app. Activates the app once at the start (rather than before
+    /// every step) so synthesis runs without any window for keyboard focus
+    /// to drift between presses. On any per-step failure, halts immediately
+    /// and surfaces the failing step's error in `executionError`; steps
+    /// already executed are not undone.
+    private static func performSequence(
+        requestId: String,
+        app: String,
+        steps: [HostAppControlSequenceStep]
+    ) async -> HostAppControlResultPayload {
+        guard let resolved = resolvePid(forApp: app) else {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .missing,
+                executionError: "App not running: \(app)"
+            )
+        }
+
+        if steps.isEmpty {
+            return HostAppControlResultPayload(
+                requestId: requestId,
+                state: .running,
+                executionError: "sequence requires at least one step"
+            )
+        }
+
+        await ensureActive(pid: resolved.pid)
+
+        for (index, step) in steps.enumerated() {
+            do {
+                try await AppKeyboard.press(
+                    pid: resolved.pid,
+                    key: step.key,
+                    modifiers: step.modifiers ?? [],
+                    durationMs: step.durationMs ?? SEQUENCE_DEFAULT_DURATION_MS
+                )
+            } catch {
+                return HostAppControlResultPayload(
+                    requestId: requestId,
+                    state: .running,
+                    executionError: "step \(index) (key=\(step.key)) failed: \(error.localizedDescription)"
+                )
+            }
+
+            // Apply per-step gap (skip after the final step — no follow-up
+            // press to space it from).
+            if index < steps.count - 1 {
+                let gap = step.gapMs ?? SEQUENCE_DEFAULT_GAP_MS
+                if gap > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(gap) * 1_000_000)
+                }
+            }
+        }
+
+        return HostAppControlResultPayload(
+            requestId: requestId,
+            state: .running,
+            executionResult: "sequence: \(steps.count) step(s) (pid=\(resolved.pid))",
+            executionError: nil
+        )
+    }
+
     // MARK: - type
 
     private static func performType(
@@ -240,6 +369,8 @@ enum AppControlExecutor {
                 executionError: "App not running: \(app)"
             )
         }
+
+        await ensureActive(pid: resolved.pid)
 
         do {
             try await AppKeyboard.type(pid: resolved.pid, text: text)
@@ -275,6 +406,8 @@ enum AppControlExecutor {
                 executionError: "App not running: \(app)"
             )
         }
+
+        await ensureActive(pid: resolved.pid)
 
         let capture = await AppWindowCapture.capture(forPid: resolved.pid)
         guard capture.state == .running, let bounds = capture.bounds else {
@@ -333,6 +466,8 @@ enum AppControlExecutor {
                 executionError: "App not running: \(app)"
             )
         }
+
+        await ensureActive(pid: resolved.pid)
 
         let capture = await AppWindowCapture.capture(forPid: resolved.pid)
         guard capture.state == .running, let bounds = capture.bounds else {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1706,6 +1706,36 @@ public struct HostAppControlRequest: Codable, Equatable, Sendable {
     }
 }
 
+/// A single step inside `.sequence`: one key press with optional modifiers,
+/// hold duration, and post-press gap. Mirrors the TypeScript
+/// `HostAppControlSequenceStep` shape — snake_case wire keys mapped to Swift
+/// camelCase via explicit raw values.
+public struct HostAppControlSequenceStep: Codable, Equatable, Sendable {
+    public let key: String
+    public let modifiers: [String]?
+    public let durationMs: Int?
+    public let gapMs: Int?
+
+    public init(
+        key: String,
+        modifiers: [String]? = nil,
+        durationMs: Int? = nil,
+        gapMs: Int? = nil
+    ) {
+        self.key = key
+        self.modifiers = modifiers
+        self.durationMs = durationMs
+        self.gapMs = gapMs
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case modifiers
+        case durationMs = "duration_ms"
+        case gapMs = "gap_ms"
+    }
+}
+
 /// Discriminated-union payload for `HostAppControlRequest.input`. The wire
 /// shape is `{ "tool": "<variant>", ...fields }` for each variant — Swift
 /// hides the discriminator inside the enum case.
@@ -1714,6 +1744,7 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
     case observe(app: String)
     case press(app: String, key: String, modifiers: [String]?, durationMs: Int?)
     case combo(app: String, keys: [String], durationMs: Int?)
+    case sequence(app: String, steps: [HostAppControlSequenceStep])
     case type(app: String, text: String)
     case click(app: String, x: Double, y: Double, button: String?, double: Bool?)
     case drag(app: String, fromX: Double, fromY: Double, toX: Double, toY: Double, button: String?)
@@ -1727,6 +1758,7 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
         case keys
         case modifiers
         case durationMs
+        case steps
         case text
         case x
         case y
@@ -1761,6 +1793,10 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
             let keys = try container.decode([String].self, forKey: .keys)
             let durationMs = try container.decodeIfPresent(Int.self, forKey: .durationMs)
             self = .combo(app: app, keys: keys, durationMs: durationMs)
+        case "sequence":
+            let app = try container.decode(String.self, forKey: .app)
+            let steps = try container.decode([HostAppControlSequenceStep].self, forKey: .steps)
+            self = .sequence(app: app, steps: steps)
         case "type":
             let app = try container.decode(String.self, forKey: .app)
             let text = try container.decode(String.self, forKey: .text)
@@ -1814,6 +1850,10 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
             try container.encode(app, forKey: .app)
             try container.encode(keys, forKey: .keys)
             try container.encodeIfPresent(durationMs, forKey: .durationMs)
+        case .sequence(let app, let steps):
+            try container.encode("sequence", forKey: .tool)
+            try container.encode(app, forKey: .app)
+            try container.encode(steps, forKey: .steps)
         case .type(let app, let text):
             try container.encode("type", forKey: .tool)
             try container.encode(app, forKey: .app)


### PR DESCRIPTION
## Summary

Three correctness fixes for the app-control skill, surfaced by real use:

- **Auto-activate target app before press/combo/type/click/drag.** `CGEvent.postToPid` queues events at the target's port, but macOS's WindowServer routes keystrokes by global keyboard focus — if another app holds focus, events get queued and never delivered. `AppControlExecutor.ensureActive(pid:)` now calls `NSRunningApplication.activate()` and polls `isActive` (capped at 100ms) before each input action, eliminating the silent-drop window. `observe`/`start`/`stop` intentionally don't activate.
- **New `app_control_sequence` tool** for ordered batches of single-key presses. Activates once at the start, then runs every step serially with optional per-step `duration_ms` and `gap_ms`. Prefer over multiple back-to-back `app_control_press` calls — one round-trip, no focus-drift window between presses. SKILL.md updated to recommend it.
- **80ms settle delay before `observe` screenshot** so the WindowServer has time to composite a fresh frame after recent synthetic input. Without this, back-to-back press → observe could return a screenshot one input behind.

## Test plan

- [x] `bunx tsc --noEmit` clean in `assistant/`
- [x] `bun test src/__tests__/app-control-tool-schemas.test.ts` — 47 passing (added 6 new tests for `app_control_sequence`, bumped tool count from 8 → 9)
- [x] `bun test` for all app-control-related tests — 38 passing across 5 files, no regressions
- [x] macOS `./build.sh build` succeeds
- [ ] Manual: send a sequence to mGBA after typing in another app — all keys land
- [ ] Manual: verify `observe` after a press shows the post-press state, not the previous frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->