### PR TITLE
feat(memory-jobs): per-lane scheduler eliminates head-of-line blocking

### DIFF
--- a/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Head-of-line repro for the per-lane scheduler in `runMemoryJobsOnce`.
+ *
+ * Before this fix, all non-embed jobs ran through a single bounded worker
+ * pool, so a long-running `graph_consolidate` LLM call would pin every slot
+ * and starve fast-lane jobs (e.g. `embed_concept_page` consolidation pages)
+ * for the duration of that call.
+ *
+ * The new scheduler runs slow / fast / embed lanes in parallel pools, each
+ * with its own concurrency budget. This test enqueues a wave of slow LLM
+ * jobs alongside fast jobs and asserts that every fast job completes before
+ * any slow job's promise resolves — proving the lanes are truly independent.
+ */
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+import type { AssistantConfig } from "../config/types.js";
+
+// ── Mocks (must precede imports of tested module) ──────────────────
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Per-lane caps: 1 slow slot (so only 1 of the 5 enqueued slow jobs runs in
+// this tick) and a generous fast cap so every fast job both gets claimed
+// and gets a slot in the lane pool. The OLD shared-pool scheduler — which
+// claimed jobs without lane awareness and ran them through a single
+// workerConcurrency-sized pool — would pin its slots on the first claimed
+// slow jobs and force the fast jobs to queue behind a 200ms LLM call.
+const TEST_CONFIG: AssistantConfig = {
+  ...DEFAULT_CONFIG,
+  memory: {
+    ...DEFAULT_CONFIG.memory,
+    enabled: true,
+    jobs: {
+      ...DEFAULT_CONFIG.memory.jobs,
+      slowLlmConcurrency: 1,
+      fastConcurrency: 5,
+      embedConcurrency: 1,
+      workerConcurrency: 2,
+    },
+  },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => TEST_CONFIG,
+  loadConfig: () => TEST_CONFIG,
+  invalidateConfigCache: () => {},
+}));
+
+// ── Track timestamps so we can assert ordering ─────────────────────
+
+type CompletionRecord = {
+  type: string;
+  conversationId: string;
+  completedAt: number;
+};
+const completions: CompletionRecord[] = [];
+
+// Slow-lane handler: blocks for SLOW_DELAY_MS. The test asserts every fast
+// job completes before any slow job — a single 200ms window is plenty.
+const SLOW_DELAY_MS = 200;
+
+mock.module("../memory/graph/consolidation.js", () => ({
+  runConsolidation: async (
+    scopeId: string,
+  ): Promise<{
+    totalUpdated: number;
+    totalDeleted: number;
+    totalMergeEdges: number;
+  }> => {
+    await new Promise((resolve) => setTimeout(resolve, SLOW_DELAY_MS));
+    completions.push({
+      type: "graph_consolidate",
+      conversationId: scopeId,
+      completedAt: Date.now(),
+    });
+    return { totalUpdated: 0, totalDeleted: 0, totalMergeEdges: 0 };
+  },
+}));
+
+// Fast-lane handler: resolves on the next microtask. The test fires this
+// many times in parallel; nothing should block.
+mock.module("../memory/jobs/embed-concept-page.js", () => ({
+  embedConceptPageJob: async (job: {
+    payload: { slug?: string };
+  }): Promise<void> => {
+    completions.push({
+      type: "embed_concept_page",
+      conversationId: job.payload.slug ?? "",
+      completedAt: Date.now(),
+    });
+  },
+}));
+
+// Stub remaining heavy boundaries that we never exercise but that get pulled
+// in transitively through jobs-worker's eager imports. These aren't strictly
+// required if the host machine can resolve them, but mocking them keeps the
+// test hermetic and fast under `bun test`.
+mock.module("../memory/db-maintenance.js", () => ({
+  maybeRunDbMaintenance: () => {},
+}));
+
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { enqueueMemoryJob } from "../memory/jobs-store.js";
+import { runMemoryJobsOnce } from "../memory/jobs-worker.js";
+import { _resetQdrantBreaker } from "../memory/qdrant-circuit-breaker.js";
+import { memoryJobs } from "../memory/schema.js";
+
+describe("memory jobs worker lane scheduling", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM memory_jobs");
+    completions.length = 0;
+    _resetQdrantBreaker();
+  });
+
+  test("fast lane completes before slow lane releases its slot", async () => {
+    // 5 slow `graph_consolidate` jobs across distinct scopes (so they would
+    // serialize behind a single shared pool) plus 5 fast `embed_concept_page`
+    // jobs across distinct slugs.
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("graph_consolidate", { scopeId: `slow-${i}` });
+    }
+    for (let i = 0; i < 5; i++) {
+      enqueueMemoryJob("embed_concept_page", { slug: `fast-${i}` });
+    }
+
+    await runMemoryJobsOnce();
+
+    const fastDone = completions.filter((c) => c.type === "embed_concept_page");
+    const slowDone = completions.filter((c) => c.type === "graph_consolidate");
+
+    // Slow lane is capped at 1 in this test, so only 1 slow job ran in this
+    // tick. Fast lane has cap 2, but with 5 fast jobs it runs all 5 because
+    // each handler resolves on the next microtask.
+    expect(fastDone).toHaveLength(5);
+    expect(slowDone).toHaveLength(1);
+
+    // Head-of-line guarantee: every fast completion timestamp must precede
+    // the (single) slow completion timestamp. Under the old shared pool with
+    // workerConcurrency=2 and 1 slow slot occupied, this still held only if
+    // a fast slot freed up first — but with 2 slow jobs in flight (the old
+    // claim path would have claimed multiple slow jobs into the shared pool)
+    // both slots would be pinned for SLOW_DELAY_MS and fast work would queue
+    // behind. With the lane scheduler, fast work has its own pool.
+    const earliestSlow = Math.min(...slowDone.map((c) => c.completedAt));
+    for (const fast of fastDone) {
+      expect(fast.completedAt).toBeLessThan(earliestSlow);
+    }
+
+    // Sanity: exactly 1 of the 5 enqueued slow jobs reached `completed` (the
+    // slow lane's per-tick budget). The other 4 are still pending and will be
+    // picked up on subsequent ticks. (FIFO ordering inside the slow lane is
+    // covered separately in jobs-store-qdrant-breaker.test.ts.)
+    //
+    // Note: a sixth `graph_consolidate` row may also appear here — the
+    // `maybeEnqueueGraphMaintenanceJobs` tail of `runMemoryJobsOnce` enqueues
+    // its own maintenance job whose checkpoint is missing in this fresh DB.
+    // That row is irrelevant; we only care about the completed-vs-pending
+    // counts of jobs we explicitly seeded.
+    const completedSlow = countSlowByStatus("completed");
+    expect(completedSlow).toBe(1);
+  });
+});
+
+function countSlowByStatus(
+  status: "pending" | "running" | "completed",
+): number {
+  const db = getDb();
+  return db
+    .select()
+    .from(memoryJobs)
+    .where(eq(memoryJobs.type, "graph_consolidate"))
+    .all()
+    .filter((row) => row.status === status).length;
+}

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -50,6 +50,7 @@ import {
   claimMemoryJobs,
   completeMemoryJob,
   deferMemoryJob,
+  EMBED_JOB_TYPES,
   enqueueMemoryJob,
   enqueuePruneOldConversationsJob,
   enqueuePruneOldLlmRequestLogsJob,
@@ -58,6 +59,7 @@ import {
   type MemoryJob,
   type MemoryJobType,
   resetRunningJobsToPending,
+  SLOW_LLM_JOB_TYPES,
 } from "./jobs-store.js";
 import { QdrantCircuitOpenError } from "./qdrant-circuit-breaker.js";
 import {
@@ -156,7 +158,9 @@ export function startMemoryJobsWorker(): MemoryJobsWorker {
   };
 }
 
-async function runMemoryJobsOnce(
+type ProcessGroup = (group: MemoryJob[]) => Promise<number>;
+
+export async function runMemoryJobsOnce(
   options: { enableScheduledCleanup?: boolean } = {},
 ): Promise<number> {
   const config = getConfig();
@@ -169,10 +173,20 @@ async function runMemoryJobsOnce(
     log.warn({ timedOut }, "Timed out stalled memory jobs");
   }
 
-  const batchSize = Math.max(1, config.memory.jobs.batchSize);
-  const concurrency = Math.max(1, config.memory.jobs.workerConcurrency);
-  const jobs = claimMemoryJobs(batchSize);
-  if (jobs.length === 0) {
+  const cfgSlow = Math.max(1, config.memory.jobs.slowLlmConcurrency);
+  const cfgFast = Math.max(1, config.memory.jobs.fastConcurrency);
+  const cfgEmbed = Math.max(1, config.memory.jobs.embedConcurrency);
+
+  // Claim per-lane budgets so a backlog of slow LLM jobs cannot starve fast
+  // jobs (and vice versa). The Qdrant circuit breaker still gates only the
+  // embed lane inside `claimMemoryJobs`.
+  const claimed = claimMemoryJobs({
+    slowLlm: cfgSlow,
+    fast: cfgFast,
+    embed: cfgEmbed,
+  });
+
+  if (claimed.length === 0) {
     if (enableScheduledCleanup) {
       maybeEnqueueScheduledCleanupJobs(config);
     }
@@ -181,34 +195,22 @@ async function runMemoryJobsOnce(
     return 0;
   }
 
-  // Group jobs so they can run concurrently across independent work units.
-  // Jobs targeting different conversations (via payload.conversationId) are
-  // placed in separate groups and can run in parallel. Jobs targeting the
-  // same conversation, or global jobs without a conversationId (backfill,
-  // cleanup, rebuild_index), are grouped together and run sequentially to
-  // prevent checkpoint races.
-  const jobGroups = new Map<string, MemoryJob[]>();
-  for (const job of jobs) {
-    const convId =
-      typeof job.payload.conversationId === "string"
-        ? job.payload.conversationId
-        : null;
-    const groupKey = convId ? `${job.type}:${convId}` : job.type;
-    let group = jobGroups.get(groupKey);
-    if (!group) {
-      group = [];
-      jobGroups.set(groupKey, group);
+  const slowSet = new Set<MemoryJobType>(SLOW_LLM_JOB_TYPES);
+  const embedSet = new Set<MemoryJobType>(EMBED_JOB_TYPES);
+  const slowJobs: MemoryJob[] = [];
+  const fastJobs: MemoryJob[] = [];
+  const embedJobs: MemoryJob[] = [];
+  for (const job of claimed) {
+    if (slowSet.has(job.type)) {
+      slowJobs.push(job);
+    } else if (embedSet.has(job.type)) {
+      embedJobs.push(job);
+    } else {
+      fastJobs.push(job);
     }
-    group.push(job);
   }
 
-  let processed = 0;
-  const typeGroups = [...jobGroups.values()];
-
-  // Run type groups concurrently using a task pool (up to workerConcurrency
-  // active at a time). Unlike the old wave approach, a new group starts as
-  // soon as any slot frees up — no waiting for an entire wave to finish.
-  const processGroup = async (group: MemoryJob[]): Promise<number> => {
+  const processGroup: ProcessGroup = async (group) => {
     let groupProcessed = 0;
     for (const job of group) {
       try {
@@ -229,8 +231,59 @@ async function runMemoryJobsOnce(
     return groupProcessed;
   };
 
+  // Run all three lanes in parallel. Each lane runs its own bounded task pool
+  // so a slow `graph_consolidate` cannot block embed or fast jobs from making
+  // progress, and per-`(type, conversationId)` grouping inside each lane keeps
+  // same-conversation jobs serialized.
+  const [slowProcessed, fastProcessed, embedProcessed] = await Promise.all([
+    runLanePool(slowJobs, cfgSlow, processGroup),
+    runLanePool(fastJobs, cfgFast, processGroup),
+    runLanePool(embedJobs, cfgEmbed, processGroup),
+  ]);
+
+  if (enableScheduledCleanup) {
+    maybeEnqueueScheduledCleanupJobs(config);
+  }
+  maybeEnqueueGraphMaintenanceJobs(config);
+  maybeRunDbMaintenance();
+  return slowProcessed + fastProcessed + embedProcessed;
+}
+
+/**
+ * Run a single lane's jobs through a bounded task pool of size `concurrency`.
+ *
+ * Jobs targeting different conversations (via payload.conversationId) are
+ * placed in separate groups and run in parallel up to the lane's concurrency
+ * cap. Jobs targeting the same conversation — or global jobs without a
+ * conversationId — share a group and run sequentially to avoid checkpoint
+ * races.
+ */
+async function runLanePool(
+  jobs: MemoryJob[],
+  concurrency: number,
+  processGroup: ProcessGroup,
+): Promise<number> {
+  if (jobs.length === 0) return 0;
+
+  const groups = new Map<string, MemoryJob[]>();
+  for (const job of jobs) {
+    const convId =
+      typeof job.payload.conversationId === "string"
+        ? job.payload.conversationId
+        : null;
+    const groupKey = convId ? `${job.type}:${convId}` : job.type;
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = [];
+      groups.set(groupKey, group);
+    }
+    group.push(job);
+  }
+
+  let processed = 0;
+  const typeGroups = [...groups.values()];
+
   if (typeGroups.length <= concurrency) {
-    // Fast path: all groups fit within the concurrency limit
     const results = await Promise.allSettled(typeGroups.map(processGroup));
     for (const result of results) {
       if (result.status === "fulfilled") {
@@ -242,39 +295,35 @@ async function runMemoryJobsOnce(
         );
       }
     }
-  } else {
-    // Task pool: maintain `concurrency` in-flight groups at all times
-    let nextIdx = 0;
-
-    const startNext = (): Promise<void> | undefined => {
-      if (nextIdx >= typeGroups.length) return undefined;
-      const group = typeGroups[nextIdx++]!;
-      return processGroup(group)
-        .then(
-          (count) => {
-            processed += count;
-          },
-          (err) => {
-            log.error(
-              { err },
-              "Memory job group rejected unexpectedly — jobs in this batch may have been dropped",
-            );
-          },
-        )
-        .then(() => startNext());
-    };
-
-    const workers = Array.from(
-      { length: Math.min(concurrency, typeGroups.length) },
-      () => startNext()!,
-    );
-    await Promise.all(workers);
+    return processed;
   }
-  if (enableScheduledCleanup) {
-    maybeEnqueueScheduledCleanupJobs(config);
-  }
-  maybeEnqueueGraphMaintenanceJobs(config);
-  maybeRunDbMaintenance();
+
+  // Task pool: keep `concurrency` groups in flight at all times so a new group
+  // starts the instant any slot frees up.
+  let nextIdx = 0;
+  const startNext = (): Promise<void> | undefined => {
+    if (nextIdx >= typeGroups.length) return undefined;
+    const group = typeGroups[nextIdx++]!;
+    return processGroup(group)
+      .then(
+        (count) => {
+          processed += count;
+        },
+        (err) => {
+          log.error(
+            { err },
+            "Memory job group rejected unexpectedly — jobs in this batch may have been dropped",
+          );
+        },
+      )
+      .then(() => startNext());
+  };
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, typeGroups.length) },
+    () => startNext()!,
+  );
+  await Promise.all(workers);
   return processed;
 }
 


### PR DESCRIPTION
## Summary
- Replace runMemoryJobsOnce's single-pool worker loop with three concurrent lane pools (slow / fast / embed), each bounded by its own concurrency cap (PR 4 schema fields).
- Uses claimMemoryJobs({slowLlm, fast, embed}) from PR 6 to claim jobs per lane; partitions claimed jobs by SLOW_LLM_JOB_TYPES / EMBED_JOB_TYPES membership; runs the three lanes in Promise.all.
- Adds a head-of-line repro test asserting fast jobs complete before slow LLM jobs release their lane.
- Per-conversation grouping inside each lane preserved. Qdrant breaker still gates only embed lane.

Part of plan: config-defaults-job-lanes.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->