### PR TITLE
feat(usage): restore Conversation in Logs & Usage group-by dropdown

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/LogsAndUsagePanel.swift
@@ -431,7 +431,7 @@ struct UsageTabContent: View {
         let isHourly = store.isHourlyGranularity
         SettingsCard(title: "Inference Usage") {
             HStack(alignment: .center, spacing: VSpacing.md) {
-                Text(isHourly ? "Hourly Trend by \(store.selectedGroupBy.displayName)" : "Daily Trend by \(store.selectedGroupBy.displayName)")
+                Text(trendTitle(isHourly: isHourly))
                     .font(VFont.bodySmallEmphasised)
                     .foregroundStyle(VColor.contentDefault)
                 Spacer()
@@ -464,6 +464,16 @@ struct UsageTabContent: View {
                 errorRow(message) { refreshTask?.cancel(); refreshTask = Task { await store.refresh() } }
             }
         }
+    }
+
+    /// Conversation grouping is breakdown-only; the chart falls back to
+    /// ungrouped totals, so the title omits the `by Conversation` suffix.
+    private func trendTitle(isHourly: Bool) -> String {
+        let prefix = isHourly ? "Hourly Trend" : "Daily Trend"
+        if store.selectedGroupBy == .conversation {
+            return prefix
+        }
+        return "\(prefix) by \(store.selectedGroupBy.displayName)"
     }
 
     private let barChartHeight: CGFloat = 140

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -504,13 +504,42 @@ struct UsageDashboardStoreGroupTests {
     }
 
     @Test
-    func dashboardPickerOptionsMatchGroupedSeriesSupport() {
+    func dashboardPickerOptionsIncludeConversation() {
         #expect(UsageGroupByDimension.dashboardOptions == [
             .callSite,
             .inferenceProfile,
             .model,
             .provider,
+            .conversation,
         ])
+    }
+
+    @Test @MainActor
+    func conversationGroupByPreservesSelectionAndFallsBackToDailySeries() async {
+        let client = MockUsageClient()
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.simulateMissingSeriesEndpoint = true
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore()
+        store.updateClient(client)
+        await store.refresh()
+        await store.selectGroupBy(.conversation)
+
+        #expect(store.selectedGroupBy == .conversation)
+        #expect(client.lastBreakdownGroupBy == "conversation")
+        #expect(client.lastSeriesGroupBy == "conversation")
+        if case .loaded = store.seriesState {
+            // OK: chart fell back to daily totals after the series endpoint
+            // rejected the conversation dimension.
+        } else {
+            Issue.record("Expected loaded series via daily fallback for conversation grouping")
+        }
+        if case .loaded = store.breakdownState {
+            // OK: breakdown still loaded with conversation grouping.
+        } else {
+            Issue.record("Expected loaded breakdown for conversation grouping")
+        }
     }
 
     @Test @MainActor

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -149,6 +149,7 @@ public enum UsageGroupByDimension: String, CaseIterable, Sendable {
         .inferenceProfile,
         .model,
         .provider,
+        .conversation,
     ]
 
     public var displayName: String {


### PR DESCRIPTION
## Summary

- Add \`.conversation\` back to \`UsageGroupByDimension.dashboardOptions\` so the Logs & Usage panel exposes the per-conversation cost breakdown again (removed in #28909 alongside the Task/Profile additions).
- Adjust the chart title to drop \`by Conversation\` when conversation is selected — the series endpoint can't stack conversations, so the chart falls back to ungrouped daily/hourly totals via the existing \`UsageSeriesResponse(daily:)\` path.
- Update the picker-options test and add coverage for the conversation fallback (series ends \`.loaded\` via daily fallback; breakdown ends \`.loaded\` with \`groupBy=conversation\`).

The backend breakdown query, conversation-aware row layout, and \`onSelectConversation\` click-through navigation were all left in place when the option was removed, so this is purely a dropdown re-exposure plus a title fix.

## Original prompt

> [Image #1] We used to show the cost breakdown per conversation on this page. Can we bring that back?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->