### PR TITLE
fix: remove dead saveConfig export from config/loader.ts

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -614,15 +614,6 @@ function isManagedGeminiFFEnabled(config: AssistantConfig): boolean {
   }
 }
 
-export function saveConfig(config: AssistantConfig): void {
-  ensureMigratedDataDir();
-  const configPath = getConfigPath();
-
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-
-  cached = config;
-}
-
 export function getConfig(): AssistantConfig {
   return loadConfig();
 }


### PR DESCRIPTION
## Summary
Cleanup gap identified during self-review of plan config-defaults-job-lanes.md.

PR #29360 migrated the only production caller (heartbeat-routes.ts) off saveConfig to the loadRawConfig/saveRawConfig pattern. The export had no other production consumers, so it's dead code per CLAUDE.md's Dead Code Removal rule. Test mocks are unaffected.

**Gap:** Dead saveConfig export in loader.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->