### PR TITLE
fix(memory-jobs): drop dead claimMemoryJobs(limit) back-compat overload

### DIFF
--- a/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
+++ b/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
@@ -44,7 +44,7 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     enqueueMemoryJob("embed_graph_node", { nodeId: "node-1" });
     enqueueMemoryJob("graph_extract", { conversationId: "conv-1" });
 
-    const claimed = claimMemoryJobs(10);
+    const claimed = claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 });
     const types = claimed.map((j) => j.type);
 
     expect(types).toContain("embed_segment");
@@ -73,7 +73,7 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
       conversationId: "conv-1",
     });
 
-    const claimed = claimMemoryJobs(10);
+    const claimed = claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 });
     const types = claimed.map((j) => j.type);
 
     // Only non-embed jobs should be claimed
@@ -101,7 +101,11 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     enqueueMemoryJob("embed_segment", { segmentId: "seg-1" });
     enqueueMemoryJob("graph_extract", { conversationId: "conv-1" });
 
-    const claimedWhileOpen = claimMemoryJobs(10);
+    const claimedWhileOpen = claimMemoryJobs({
+      slowLlm: 10,
+      fast: 10,
+      embed: 10,
+    });
     expect(claimedWhileOpen.map((j) => j.type)).not.toContain("embed_segment");
 
     // Reset breaker (simulates successful probe closing the circuit)
@@ -110,7 +114,11 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     // Re-enqueue an embed job (the previous one is now "running")
     enqueueMemoryJob("embed_graph_node", { nodeId: "node-2" });
 
-    const claimedAfterClose = claimMemoryJobs(10);
+    const claimedAfterClose = claimMemoryJobs({
+      slowLlm: 10,
+      fast: 10,
+      embed: 10,
+    });
     const types = claimedAfterClose.map((j) => j.type);
 
     expect(types).toContain("embed_graph_node");
@@ -223,7 +231,7 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     // Also enqueue a non-embed job
     enqueueMemoryJob("graph_consolidate", { conversationId: "conv-1" });
 
-    const claimed = claimMemoryJobs(20);
+    const claimed = claimMemoryJobs({ slowLlm: 20, fast: 20, embed: 20 });
     const types = claimed.map((j) => j.type);
 
     // Only the non-embed job should be claimed

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -372,15 +372,7 @@ export interface LaneBudgets {
   embed: number;
 }
 
-export function claimMemoryJobs(limit: number): MemoryJob[];
-export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[];
-export function claimMemoryJobs(arg: number | LaneBudgets): MemoryJob[] {
-  // Back-compat: a single numeric limit is applied as the per-lane budget on
-  // every lane. The one current caller (jobs-worker.ts) is migrated to the
-  // explicit signature in a follow-up PR.
-  const limits: LaneBudgets =
-    typeof arg === "number" ? { slowLlm: arg, fast: arg, embed: arg } : arg;
-
+export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[] {
   if (limits.slowLlm <= 0 && limits.fast <= 0 && limits.embed <= 0) return [];
 
   const db = getDb();

--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -324,7 +324,7 @@ describe("enqueueEmbedConceptPageJob", () => {
     const id = enqueueEmbedConceptPageJob({ slug: "alice-prefers-vs-code" });
     expect(id).toBeTruthy();
 
-    const claimed = claimMemoryJobs(10);
+    const claimed = claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 });
     expect(claimed).toHaveLength(1);
     const [job] = claimed;
     expect(job.type).toBe("embed_concept_page");
@@ -340,7 +340,7 @@ describe("enqueueEmbedConceptPageJob", () => {
 
     enqueueEmbedConceptPageJob({ slug: "round-trip-slug" });
 
-    const claimed = claimMemoryJobs(10);
+    const claimed = claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 });
     expect(claimed).toHaveLength(1);
     const [job] = claimed;
     expect(job.type).toBe("embed_concept_page");

--- a/assistant/src/memory/jobs/embed-pkb-file.test.ts
+++ b/assistant/src/memory/jobs/embed-pkb-file.test.ts
@@ -134,7 +134,7 @@ describe("enqueuePkbIndexJob", () => {
     });
     expect(id).toBeTruthy();
 
-    const claimed = claimMemoryJobs(10);
+    const claimed = claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 });
     expect(claimed).toHaveLength(1);
     const [job] = claimed;
     const expectedType: MemoryJobType = "embed_pkb_file";
@@ -153,7 +153,7 @@ describe("enqueuePkbIndexJob", () => {
       memoryScopeId: "scope-rt",
     });
 
-    const claimed = claimMemoryJobs(10);
+    const claimed = claimMemoryJobs({ slowLlm: 10, fast: 10, embed: 10 });
     expect(claimed).toHaveLength(1);
     const [job] = claimed;
     expect(job.type).toBe("embed_pkb_file");


### PR DESCRIPTION
## Summary
Cleanup gap identified during self-review of plan config-defaults-job-lanes.md.

- Delete the claimMemoryJobs(limit: number) overload introduced by PR #29362 — production migration completed in PR #29364, only test files were still using it.
- Migrate three test callers (jobs-store-qdrant-breaker, embed-concept-page, embed-pkb-file) to pass explicit LaneBudgets objects.

**Gap:** Dead claimMemoryJobs(limit: number) back-compat overload
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->