### PR TITLE
fix(memory-jobs): remove dead batchSize config field

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -346,6 +346,24 @@ describe("loadConfig startup behavior", () => {
     expect(raw.provider).toBe("anthropic");
   });
 
+  test("strips memory.jobs.batchSize from existing user configs", () => {
+    // Pre-PR-#29364, the memory job worker read `memory.jobs.batchSize` to
+    // size its single claim batch. The per-lane scheduler no longer reads
+    // it, so the field is deprecated. Existing configs that have it
+    // written to disk should load cleanly with the field silently stripped.
+    writeConfig({
+      provider: "anthropic",
+      memory: { jobs: { batchSize: 25, workerConcurrency: 4 } },
+    });
+
+    loadConfig();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.memory?.jobs?.batchSize).toBeUndefined();
+    // Sibling fields under memory.jobs are preserved
+    expect(raw.memory?.jobs?.workerConcurrency).toBe(4);
+  });
+
   test("still writes a default config on first launch when file is absent", () => {
     // Discoverability: when no config.json exists, write one populated with
     // all schema defaults so users can see and edit available options.

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -265,6 +265,11 @@ const DEPRECATED_FIELDS: Record<string, string> = {
   "permissions.autoApproveUpTo":
     "permissions.autoApproveUpTo has been removed. The gateway now controls all " +
     "auto-approve thresholds. The field will be removed from your config file.",
+  "memory.jobs.batchSize":
+    "memory.jobs.batchSize has been removed. The memory job worker now uses " +
+    "per-lane concurrency caps (slowLlmConcurrency, fastConcurrency, " +
+    "embedConcurrency) instead of a single batch size. " +
+    "The field will be removed from your config file.",
 };
 
 /**

--- a/assistant/src/config/schemas/__tests__/memory-lifecycle.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-lifecycle.test.ts
@@ -7,7 +7,6 @@ describe("MemoryJobsConfigSchema", () => {
     const parsed = MemoryJobsConfigSchema.parse({});
     expect(parsed).toEqual({
       workerConcurrency: 2,
-      batchSize: 10,
       stalledJobTimeoutMs: 30 * 60 * 1000,
       slowLlmConcurrency: 1,
       fastConcurrency: 2,

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -19,9 +19,6 @@ const MemoryJobsConfigInputSchema = z.object({
   workerConcurrency: positiveInt("workerConcurrency")
     .optional()
     .describe("Number of concurrent workers processing memory jobs"),
-  batchSize: positiveInt("batchSize")
-    .default(10)
-    .describe("Number of memory items processed per batch"),
   stalledJobTimeoutMs: positiveInt("stalledJobTimeoutMs")
     .default(30 * 60 * 1000)
     .describe(
@@ -73,7 +70,6 @@ export const MemoryJobsConfigSchema = MemoryJobsConfigInputSchema.transform(
 
     return {
       workerConcurrency,
-      batchSize: input.batchSize,
       stalledJobTimeoutMs: input.stalledJobTimeoutMs,
       slowLlmConcurrency,
       fastConcurrency,


### PR DESCRIPTION
## Summary
Cleanup gap identified during self-review of plan config-defaults-job-lanes.md.

- Drop batchSize from MemoryJobsConfigSchema — no consumer reads it after PR #29364's per-lane scheduler.
- Route batchSize through warnAndStripDeprecatedFields so existing user configs aren't rejected.

**Gap:** Dead batchSize field in MemoryJobsConfigSchema
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->