### PR TITLE
docs: drop stale references to removed backfillConfigDefaults / deepMergeMissing

### DIFF
--- a/assistant/src/__tests__/workspace-migration-006-services-config.test.ts
+++ b/assistant/src/__tests__/workspace-migration-006-services-config.test.ts
@@ -183,8 +183,9 @@ describe("006-services-config migration", () => {
   });
 
   test("merges with existing backfilled services object", async () => {
-    // Simulates the scenario where backfillConfigDefaults wrote a default
-    // services object before migrations run, and legacy fields coexist.
+    // Simulates a legacy-daemon scenario where an older loader wrote a
+    // schema-default services object to disk before migrations run, and
+    // legacy top-level fields coexist with it.
     writeConfig({
       provider: "openai",
       model: "gpt-4o",

--- a/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
+++ b/assistant/src/__tests__/workspace-migration-unify-llm-callsite-configs.test.ts
@@ -119,15 +119,17 @@ describe("038-unify-llm-callsite-configs migration", () => {
   // ─── Schema-default-injection regression (the original bug) ────────────
 
   test("legacy services.inference.{provider,model} win over schema-default-injected llm.default", () => {
-    // Reproduces the production bug: between PR #26095 (added
-    // `LLMSchema.default(LLMSchema.parse({}))` to AssistantConfigSchema)
-    // and PR #26101 (this migration), any daemon boot caused the loader's
-    // `backfillConfigDefaults()` to write a schema-default `llm.default`
+    // Reproduces a production bug from a legacy-daemon era: between PR
+    // #26095 (added `LLMSchema.default(LLMSchema.parse({}))` to
+    // AssistantConfigSchema) and PR #26101 (this migration), any daemon
+    // boot caused the loader to write a schema-default `llm.default`
     // block to disk. Migration 038's old idempotency check (`return early
     // if llm.default exists`) then silently skipped, and migration 039
     // stripped `services.inference.{provider,model}` — losing the user's
     // actual configuration. The fix prefers legacy source keys over the
-    // injected schema defaults whenever both are present.
+    // injected schema defaults whenever both are present. (The loader
+    // no longer writes defaults to disk, but workspaces still on disk
+    // from that era can carry the bad state forward.)
     writeConfig({
       services: {
         inference: {
@@ -806,7 +808,9 @@ describe("038-unify-llm-callsite-configs migration", () => {
     // documented no-op — it leaves the config exactly as it found it,
     // whether the `llm` block is present or absent.
     const original = {
-      services: { inference: { mode: "your-own", provider: "openai", model: "gpt-5.4" } },
+      services: {
+        inference: { mode: "your-own", provider: "openai", model: "gpt-5.4" },
+      },
       maxTokens: 32000,
       llm: {
         default: {

--- a/assistant/src/workspace/migrations/006-services-config.ts
+++ b/assistant/src/workspace/migrations/006-services-config.ts
@@ -37,8 +37,9 @@ export const servicesConfigMigration: WorkspaceMigration = {
 
     // Skip if no legacy fields remain — either already migrated or a fresh install
     // where schema defaults are correct. We check for legacy fields instead of
-    // services existence because backfillConfigDefaults may have written a default
-    // services object before migrations run.
+    // services existence because legacy daemons (before defaults were applied
+    // only in-memory) may have written a default services object to disk
+    // before migrations run.
     const hasLegacyFields =
       "provider" in config ||
       "model" in config ||
@@ -46,7 +47,8 @@ export const servicesConfigMigration: WorkspaceMigration = {
       "webSearchProvider" in config;
     if (!hasLegacyFields) return;
 
-    // Start from existing services (may have been backfilled by loadConfig defaults)
+    // Start from existing services (legacy daemons may have written a
+    // schema-default services object to disk before this migration runs)
     // so we don't discard any non-default values already written there.
     const existingServices =
       config.services != null &&
@@ -96,8 +98,9 @@ export const servicesConfigMigration: WorkspaceMigration = {
     // Legacy top-level fields (provider, model) are the user's actual
     // configuration from before the services structure existed. If they're
     // present as strings they take precedence over any `existingServices`
-    // values, which are just defaults written by backfillConfigDefaults().
-    // The spread preserves any extra keys that future backfills may add.
+    // values, which on legacy daemons may just be schema defaults that an
+    // older loader wrote to disk. The spread preserves any extra keys that
+    // legacy daemons may have written alongside.
     services.inference = {
       ...(existingServices.inference ?? {}),
       mode: inferenceMode,

--- a/assistant/src/workspace/migrations/040-seed-latency-callsite-defaults.ts
+++ b/assistant/src/workspace/migrations/040-seed-latency-callsite-defaults.ts
@@ -22,8 +22,9 @@ import type { WorkspaceMigration } from "./types.js";
  *   2. **Fresh install** (config.json absent): write a minimal starter
  *      config with just the callSite seeds, using the default provider
  *      (anthropic — same as the schema default). `loadConfig()` runs
- *      after migrations and backfills the remaining schema defaults via
- *      `deepMergeMissing`, which preserves our seeded callSites.
+ *      after migrations and applies schema defaults only to the
+ *      in-memory config (disk is left untouched), so our seeded
+ *      callSites are preserved verbatim.
  *
  * Without the fresh-install branch, new users permanently fall through
  * to `llm.default` (opus + max effort) because `LLMSchema.callSites`

--- a/assistant/src/workspace/migrations/050-seed-main-agent-opus-callsite.ts
+++ b/assistant/src/workspace/migrations/050-seed-main-agent-opus-callsite.ts
@@ -12,7 +12,8 @@ import type { WorkspaceMigration } from "./types.js";
  *      `llm.callSites` without overwriting a user-defined override.
  *   2. **Fresh install** (config.json absent): write a minimal starter
  *      config with just this seed. `loadConfig()` runs after migrations
- *      and backfills the remaining schema defaults via `deepMergeMissing`.
+ *      and applies schema defaults to the in-memory config without
+ *      rewriting disk, so the seeded callSite is preserved as-is.
  *
  * Applied only when:
  *   - the resolved provider is Anthropic (other providers own their


### PR DESCRIPTION
## Summary
Cleanup gap identified during self-review of plan config-defaults-job-lanes.md.

Comment-only changes across five files. Each replaces a reference to the now-deleted backfillConfigDefaults / deepMergeMissing helpers with an accurate description of current loader behavior. No code logic is touched.

**Gap:** Stale comments referencing removed backfillConfigDefaults / deepMergeMissing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->