### PR TITLE
fix(app-control): decode snake_case duration_ms / from_x / to_x on Swift side

### DIFF
--- a/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
@@ -99,13 +99,16 @@ final class HostAppControlTypesTests: XCTestCase {
     // MARK: - HostAppControlInput wire shape
 
     func test_input_decodes_from_tool_discriminator() throws {
+        // Wire format uses snake_case (matches TOOLS.json input schema and the
+        // TypeScript HostAppControlPressInput shape). Swift maps to camelCase
+        // via explicit CodingKey raw values.
         let json = #"""
         {
           "tool": "press",
           "app": "com.apple.Safari",
           "key": "Return",
           "modifiers": ["cmd"],
-          "durationMs": 100
+          "duration_ms": 100
         }
         """#
         let decoded = try JSONDecoder().decode(HostAppControlInput.self, from: Data(json.utf8))
@@ -116,6 +119,34 @@ final class HostAppControlTypesTests: XCTestCase {
         XCTAssertEqual(key, "Return")
         XCTAssertEqual(modifiers, ["cmd"])
         XCTAssertEqual(durationMs, 100)
+    }
+
+    func test_input_drag_decodes_snake_case_coordinates() throws {
+        // Regression guard for the pre-existing CodingKey bug where the
+        // snake_case `from_x`/`from_y`/`to_x`/`to_y` wire keys silently
+        // failed to decode and drag coordinates fell through to undefined
+        // behavior.
+        let json = #"""
+        {
+          "tool": "drag",
+          "app": "com.apple.Safari",
+          "from_x": 10,
+          "from_y": 20,
+          "to_x": 100,
+          "to_y": 200,
+          "button": "left"
+        }
+        """#
+        let decoded = try JSONDecoder().decode(HostAppControlInput.self, from: Data(json.utf8))
+        guard case .drag(let app, let fromX, let fromY, let toX, let toY, let button) = decoded else {
+            return XCTFail("Expected .drag variant, got \(decoded)")
+        }
+        XCTAssertEqual(app, "com.apple.Safari")
+        XCTAssertEqual(fromX, 10)
+        XCTAssertEqual(fromY, 20)
+        XCTAssertEqual(toX, 100)
+        XCTAssertEqual(toY, 200)
+        XCTAssertEqual(button, "left")
     }
 
     func test_input_unknown_tool_throws() {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1757,17 +1757,21 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
         case key
         case keys
         case modifiers
-        case durationMs
+        // Wire format uses snake_case for multi-word fields (driven by
+        // TOOLS.json schema property names). Map explicitly — without these
+        // raw values, decode silently misses `duration_ms` / `from_x` / etc.
+        // and hold-durations and drag coordinates fall through to defaults.
+        case durationMs = "duration_ms"
         case steps
         case text
         case x
         case y
         case button
         case double
-        case fromX
-        case fromY
-        case toX
-        case toY
+        case fromX = "from_x"
+        case fromY = "from_y"
+        case toX = "to_x"
+        case toY = "to_y"
         case reason
     }
 


### PR DESCRIPTION
## Summary

Addresses Devin's review comment on #29363 about a pre-existing CodingKey mismatch in `HostAppControlInput`.

The TypeScript wire format (matching `TOOLS.json` schema property names) sends snake_case keys for multi-word fields: `duration_ms`, `from_x`, `from_y`, `to_x`, `to_y`. The Swift `HostAppControlInput.CodingKeys` enum declared these as `case durationMs` / `case fromX` / etc. without explicit raw values, which made the default raw value the camelCase Swift identifier — so `JSONDecoder` silently failed to find the wire keys and `decodeIfPresent(...)` always returned `nil`.

Result: agent-supplied `duration_ms` on `app_control_press` / `app_control_combo` was silently ignored, and drag coordinates went through unset paths (the executor still posted events, but the model's intent didn't make it through).

This PR maps the affected CodingKeys to their snake_case wire names, adds a regression test for `from_x`/`from_y`/`to_x`/`to_y`, and corrects the existing press-decode test that was using camelCase JSON (and thus inadvertently exercising the bug).

The new `HostAppControlSequenceStep` struct from #29363 already uses the correct mapping — no change needed there.

## Test plan

- [x] macOS \`./build.sh build\` succeeds
- [x] macOS \`./build.sh test\` exit 0 (failing-test-tolerant mode is not engaged, so all assertions passed)
- [x] Updated \`test_input_decodes_from_tool_discriminator\` to use \`duration_ms\` (snake_case wire format)
- [x] New \`test_input_drag_decodes_snake_case_coordinates\` exercises \`from_x\`/\`from_y\`/\`to_x\`/\`to_y\`
- [ ] Manual: send a drag with non-zero \`from_x\` from the agent — verify it lands at the correct global coordinate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->