### PR TITLE
refactor(skills): remove redundant per-tool activity field

### DIFF
--- a/assistant/src/__tests__/app-control-tool-schemas.test.ts
+++ b/assistant/src/__tests__/app-control-tool-schemas.test.ts
@@ -236,13 +236,11 @@ describe("app_control_observe", () => {
   const s = tool.input_schema;
 
   test("well-formed input passes", () => {
-    expect(
-      validate(s, { app: "com.apple.Safari", activity: "check state" }).ok,
-    ).toBe(true);
+    expect(validate(s, { app: "com.apple.Safari" }).ok).toBe(true);
   });
 
   test("missing required app rejects", () => {
-    const result = validate(s, { activity: "check state" });
+    const result = validate(s, {});
     expect(result.ok).toBe(false);
     expect(result.error).toContain("app");
   });
@@ -538,7 +536,7 @@ describe("app_control_stop", () => {
   const s = toolByName("app_control_stop").input_schema;
 
   test("well-formed input passes (no app — terminal)", () => {
-    expect(validate(s, { activity: "wrap up" }).ok).toBe(true);
+    expect(validate(s, {}).ok).toBe(true);
   });
 
   test("well-formed input passes (with app + reason)", () => {
@@ -546,15 +544,8 @@ describe("app_control_stop", () => {
       validate(s, {
         app: "com.apple.Safari",
         reason: "task complete",
-        activity: "wrap up",
       }).ok,
     ).toBe(true);
-  });
-
-  test("missing activity rejects", () => {
-    const result = validate(s, { reason: "task complete" });
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("activity");
   });
 
   test("app is optional (terminal tool may omit it)", () => {

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -20,10 +20,6 @@
           "cwd": {
             "type": "string",
             "description": "Working directory for the agent. This determines where the agent runs and where its session is stored. Set this to the project/repo root the user wants the agent to work in. Defaults to current conversation's working directory."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief explanation of why this tool is being called"
           }
         },
         "required": ["task"]
@@ -42,10 +38,6 @@
           "acp_session_id": {
             "type": "string",
             "description": "Optional ACP session ID to query. If omitted, returns all ACP sessions."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief explanation of why this tool is being called"
           }
         },
         "required": []
@@ -64,10 +56,6 @@
           "acp_session_id": {
             "type": "string",
             "description": "The ID of the ACP session to abort."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief explanation of why this tool is being called"
           }
         },
         "required": ["acp_session_id"]
@@ -90,10 +78,6 @@
           "instruction": {
             "type": "string",
             "description": "The new instruction that replaces the in-flight prompt."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief explanation of why this tool is being called"
           }
         },
         "required": ["acp_session_id", "instruction"]
@@ -108,12 +92,7 @@
       "risk": "low",
       "input_schema": {
         "type": "object",
-        "properties": {
-          "activity": {
-            "type": "string",
-            "description": "Brief explanation of why this tool is being called"
-          }
-        },
+        "properties": {},
         "required": []
       },
       "executor": "tools/acp-list-agents.ts",

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -78,10 +78,6 @@
           "change_summary": {
             "type": "string",
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: add coin flip app', 'fix: correct button alignment'). Used as the version history entry."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["name"]
@@ -104,10 +100,6 @@
           "change_summary": {
             "type": "string",
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'chore: delete unused app'). Used as the version history entry."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app_id"]
@@ -130,10 +122,6 @@
           "change_summary": {
             "type": "string",
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: add dark mode toggle', 'fix: form validation'). Used as the version history entry."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app_id"]
@@ -160,10 +148,6 @@
           "change_summary": {
             "type": "string",
             "description": "Short summary of what changed, using git conventional commit format (e.g. 'feat: generate app icon'). Used as the version history entry."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app_id"]

--- a/assistant/src/config/bundled-skills/app-control/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-control/TOOLS.json
@@ -21,10 +21,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of why you are starting this app"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app", "reasoning"]
@@ -43,13 +39,9 @@
           "app": {
             "type": "string",
             "description": "Bundle ID (preferred, e.g. 'com.apple.Safari') or process name of the target application"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
-        "required": ["app", "activity"]
+        "required": ["app"]
       },
       "executor": "tools/app-control-observe.ts",
       "execution_target": "host"
@@ -82,10 +74,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of why you are pressing this key"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app", "key", "reasoning"]
@@ -117,10 +105,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of why you are pressing this combo"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app", "keys", "reasoning"]
@@ -170,10 +154,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what this sequence does and why"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app", "steps", "reasoning"]
@@ -200,10 +180,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what you are typing and why"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app", "text", "reasoning"]
@@ -243,10 +219,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what you see and why you are clicking here"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app", "x", "y", "reasoning"]
@@ -290,10 +262,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what you are dragging and why"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app", "from_x", "from_y", "to_x", "to_y", "reasoning"]
@@ -316,13 +284,9 @@
           "reason": {
             "type": "string",
             "description": "Free-form reason, surfaced for logging"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
-        "required": ["activity"]
+        "required": []
       },
       "executor": "tools/app-control-stop.ts",
       "execution_target": "host"

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -8,13 +8,8 @@
       "risk": "low",
       "input_schema": {
         "type": "object",
-        "properties": {
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
-          }
-        },
-        "required": ["activity"]
+        "properties": {},
+        "required": []
       },
       "executor": "tools/computer-use-observe.ts",
       "execution_target": "host"
@@ -47,10 +42,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what you see and why you are clicking here"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["reasoning"]
@@ -73,10 +64,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what you are typing and why"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["text", "reasoning"]
@@ -99,10 +86,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of why you are pressing this key"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["key", "reasoning"]
@@ -142,10 +125,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of why you are scrolling"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["direction", "amount", "reasoning"]
@@ -188,10 +167,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what you are dragging and why"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["reasoning"]
@@ -214,10 +189,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what you are waiting for"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["duration_ms", "reasoning"]
@@ -240,10 +211,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of why you need to open or switch to this app"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["app_name", "reasoning"]
@@ -266,10 +233,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of what this script does and why AppleScript is better than UI interaction for this step"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["script", "reasoning"]
@@ -288,10 +251,6 @@
           "summary": {
             "type": "string",
             "description": "Human-readable summary of what was accomplished"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["summary"]
@@ -314,10 +273,6 @@
           "reasoning": {
             "type": "string",
             "description": "Explanation of how you determined the answer"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["answer", "reasoning"]

--- a/assistant/src/config/bundled-skills/contacts/TOOLS.json
+++ b/assistant/src/config/bundled-skills/contacts/TOOLS.json
@@ -51,10 +51,6 @@
               },
               "required": ["type", "address"]
             }
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["display_name"]
@@ -85,10 +81,6 @@
           "limit": {
             "type": "number",
             "description": "Maximum results to return (default 20, max 100)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []
@@ -111,10 +103,6 @@
           "merge_id": {
             "type": "string",
             "description": "ID of the contact to merge into the kept contact (will be deleted)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["keep_id", "merge_id"]
@@ -146,10 +134,6 @@
           "page_token": {
             "type": "string",
             "description": "Pagination token (for list)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           },
           "account": {
             "type": "string",

--- a/assistant/src/config/bundled-skills/document/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document/TOOLS.json
@@ -16,10 +16,6 @@
           "initial_content": {
             "type": "string",
             "description": "Initial Markdown content to populate the editor (optional)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         }
       },
@@ -46,10 +42,6 @@
             "type": "string",
             "enum": ["replace", "append"],
             "description": "Whether to replace all content or append to the end. Defaults to append."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["surface_id", "content"]

--- a/assistant/src/config/bundled-skills/followups/TOOLS.json
+++ b/assistant/src/config/bundled-skills/followups/TOOLS.json
@@ -28,10 +28,6 @@
           "reminder_schedule_id": {
             "type": "string",
             "description": "Optional recurrence schedule ID to fire a reminder when overdue"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["channel", "conversation_id"]
@@ -63,10 +59,6 @@
           "overdue_only": {
             "type": "boolean",
             "description": "When true, return only pending follow-ups past their expected response deadline"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []
@@ -93,10 +85,6 @@
           "conversation_id": {
             "type": "string",
             "description": "Conversation ID to match (used with channel for auto-resolution)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -37,10 +37,6 @@
           "variants": {
             "type": "number",
             "description": "Number of image variants to generate (1-4, default: 1)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["prompt"]

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -20,10 +20,6 @@
           "metadata": {
             "type": "object",
             "description": "Optional JSON metadata to attach to the asset (e.g., pipeline config, source info)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["file_path"]
@@ -51,10 +47,6 @@
             "type": "string",
             "enum": ["registered", "processing", "indexed", "failed"],
             "description": "Filter assets by processing status"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         }
       },
@@ -100,10 +92,6 @@
           "include_audio": {
             "type": "boolean",
             "description": "Whether to extract and transcribe audio for each segment using the configured STT service. Default: false."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["asset_id"]
@@ -153,10 +141,6 @@
             "type": "number",
             "minimum": 0,
             "description": "Maximum retry attempts per segment on failure. Default: 3"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["asset_id", "system_prompt", "output_schema"]
@@ -187,10 +171,6 @@
           "model": {
             "type": "string",
             "description": "LLM model to use for analysis. Default: 'claude-sonnet-4-6'"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["asset_id", "query"]
@@ -234,10 +214,6 @@
           "title": {
             "type": "string",
             "description": "Short descriptive title for the clip (e.g. 'snow-dive-closeup', 'goal-celebration'). Used as the filename. If omitted, falls back to timestamp-based naming."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["asset_id", "start_time", "end_time"]

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -16,10 +16,6 @@
           "account": {
             "type": "string",
             "description": "Email address of the account to use. Required when multiple accounts are connected for the same platform. If omitted, uses the most recently connected account."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false
@@ -54,10 +50,6 @@
           "limit": {
             "type": "number",
             "description": "Maximum number of conversations to return (default 200)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false
@@ -92,10 +84,6 @@
           "limit": {
             "type": "number",
             "description": "Maximum number of messages to return (default 50)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false,
@@ -127,10 +115,6 @@
           "max_results": {
             "type": "number",
             "description": "Maximum number of results to return (default 20)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false,
@@ -185,10 +169,6 @@
           "confidence": {
             "type": "number",
             "description": "Confidence score (0-1) for this action"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false,
@@ -220,10 +200,6 @@
           "message_id": {
             "type": "string",
             "description": "Specific message ID to mark as read (optional)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false,
@@ -255,10 +231,6 @@
           "query_filter": {
             "type": "string",
             "description": "Optional search filter (e.g. 'to:alice@example.com' for Gmail)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false
@@ -302,10 +274,6 @@
           "draft_id": {
             "type": "string",
             "description": "Draft ID (for delete)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false,
@@ -345,10 +313,6 @@
           "page_token": {
             "type": "string",
             "description": "Resume token from a previous scan (rarely needed - scans now cover up to 5,000 messages in a single call)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "additionalProperties": false
@@ -379,10 +343,6 @@
           "confidence": {
             "type": "number",
             "description": "Confidence score (0-1) for this action"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           },
           "user_approved": {
             "type": "boolean",

--- a/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
+++ b/assistant/src/config/bundled-skills/phone-calls/TOOLS.json
@@ -29,10 +29,6 @@
           "skip_disclosure": {
             "type": "boolean",
             "description": "Skip the disclosure announcement at the start of the call. Set to true when calling someone who already knows who you are (e.g. your guardian, a family member, or a close contact)."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["phone_number", "task"]
@@ -51,10 +47,6 @@
           "call_session_id": {
             "type": "string",
             "description": "Specific call session ID to check. If omitted, checks for an active call in the current conversation."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []
@@ -77,10 +69,6 @@
           "end_reason": {
             "type": "string",
             "description": "Reason for ending the call"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["call_session_id"]

--- a/assistant/src/config/bundled-skills/playbooks/TOOLS.json
+++ b/assistant/src/config/bundled-skills/playbooks/TOOLS.json
@@ -33,10 +33,6 @@
           "priority": {
             "type": "number",
             "description": "Relative priority \u2014 higher numbers take precedence. Defaults to 0."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["trigger", "action"]
@@ -59,10 +55,6 @@
           "category": {
             "type": "string",
             "description": "Filter by category (e.g. \"scheduling\", \"triage\"). Omit to show all."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         }
       },
@@ -105,10 +97,6 @@
           "priority": {
             "type": "number",
             "description": "Updated priority"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["playbook_id"]
@@ -127,10 +115,6 @@
           "playbook_id": {
             "type": "string",
             "description": "ID of the playbook to delete (from playbook_list results)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["playbook_id"]

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -63,10 +63,6 @@
           "reuse_conversation": {
             "type": "boolean",
             "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Useful for polling-style schedules that accumulate context over time. Ignored for one-shot schedules. Defaults to false."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["name"]
@@ -89,10 +85,6 @@
           "job_id": {
             "type": "string",
             "description": "If provided, show detailed info and recent runs for this specific job."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []
@@ -162,10 +154,6 @@
           "reuse_conversation": {
             "type": "boolean",
             "description": "When true, reuse the same conversation across recurring schedule runs instead of creating a new one each time. Useful for polling-style schedules that accumulate context over time. Ignored for one-shot schedules."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["job_id"]
@@ -184,10 +172,6 @@
           "job_id": {
             "type": "string",
             "description": "The ID of the schedule to delete"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["job_id"]

--- a/assistant/src/config/bundled-skills/sequences/TOOLS.json
+++ b/assistant/src/config/bundled-skills/sequences/TOOLS.json
@@ -54,10 +54,6 @@
           "exit_on_reply": {
             "type": "boolean",
             "description": "Whether to stop the sequence when the contact replies (default true)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["name", "channel", "steps"]
@@ -77,10 +73,6 @@
             "type": "string",
             "enum": ["active", "paused", "archived"],
             "description": "Filter by sequence status"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         }
       },
@@ -98,10 +90,6 @@
           "id": {
             "type": "string",
             "description": "Sequence ID"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["id"]
@@ -176,10 +164,6 @@
               "required": ["body_prompt"]
             },
             "description": "Replacement steps (replaces all existing steps)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "oneOf": [
@@ -201,10 +185,6 @@
           "id": {
             "type": "string",
             "description": "Sequence ID to delete"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["id"]
@@ -241,10 +221,6 @@
           "context": {
             "type": "object",
             "description": "Optional context object with personalization variables for the enrolled contacts"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["sequence_id", "emails"]
@@ -275,10 +251,6 @@
               "failed"
             ],
             "description": "Filter by enrollment status"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         }
       },
@@ -304,10 +276,6 @@
           "auto_enroll": {
             "type": "boolean",
             "description": "Set to true to enroll contacts (default false = preview mode)"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["file_path", "sequence_id"]
@@ -326,10 +294,6 @@
           "sequence_id": {
             "type": "string",
             "description": "Optional sequence ID for detailed step funnel view"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         }
       },

--- a/assistant/src/config/bundled-skills/settings/TOOLS.json
+++ b/assistant/src/config/bundled-skills/settings/TOOLS.json
@@ -22,10 +22,6 @@
           },
           "value": {
             "description": "The new value for the setting. For tts_provider: one of elevenlabs, fish-audio, deepgram, xai. For tts_voice_id: an alphanumeric ElevenLabs voice ID. For fish_audio_reference_id: a Fish Audio voice reference ID. For conversation_timeout: seconds (5, 10, 15, 30, or 60). For activation_key: key identifier string."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of what you are changing and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
         }
       },
@@ -44,10 +40,6 @@
             "type": "string",
             "enum": ["microphone", "speech_recognition"],
             "description": "The System Settings pane to open"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of what you are opening and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
         },
         "required": ["pane"]
@@ -77,10 +69,6 @@
               "Developer"
             ],
             "description": "The settings tab to navigate to"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of what you are navigating to and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
         },
         "required": ["tab"]

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -41,10 +41,6 @@
             "type": "array",
             "items": { "type": "string" },
             "description": "Optional list of child skill IDs that this skill includes (metadata only, no auto-activation)."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of what you are creating and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
         },
         "required": ["skill_id", "name", "description", "body_markdown"]
@@ -67,10 +63,6 @@
           "remove_from_index": {
             "type": "boolean",
             "description": "Whether to remove the skill from SKILLS.md index (default: true)."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of what you are deleting and why, shown to the user as a status update. Use simple language a non-technical person would understand."
           }
         },
         "required": ["skill_id"]

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -33,10 +33,6 @@
             "type": "string",
             "enum": ["general", "researcher", "coder", "planner"],
             "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'general': full access (default). Ignored when fork: true (forks always use general)."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["label", "objective"]
@@ -59,10 +55,6 @@
           "label": {
             "type": "string",
             "description": "The label of the subagent (alternative to subagent_id). Case-insensitive."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []
@@ -85,10 +77,6 @@
           "label": {
             "type": "string",
             "description": "The label of the subagent (alternative to subagent_id). Case-insensitive."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []
@@ -115,10 +103,6 @@
           "content": {
             "type": "string",
             "description": "The message content to send to the subagent."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["content"]
@@ -145,10 +129,6 @@
           "last_n": {
             "type": "integer",
             "description": "Number of recent assistant messages to return. Omit to return all messages (current behavior)."
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": []

--- a/assistant/src/config/bundled-skills/transcribe/TOOLS.json
+++ b/assistant/src/config/bundled-skills/transcribe/TOOLS.json
@@ -12,10 +12,6 @@
           "file_path": {
             "type": "string",
             "description": "Absolute path to a local audio or video file to transcribe"
-          },
-          "activity": {
-            "type": "string",
-            "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
         "required": ["file_path"]


### PR DESCRIPTION
## Summary

- The `skill_execute` wrapper requires a top-level `activity` (`assistant/src/tools/skills/execute.ts:30-36`), and the dispatcher (`assistant/src/daemon/conversation-tool-setup.ts:218-226`) propagates it into the inner input. Yet 18 bundled skills also declared `activity` inside each tool's `input_schema`, forcing the LLM to emit the same field twice per call (visible in tool-history UI and wasting tokens).
- Strips the redundant per-tool `activity` from 86 schemas across all bundled skills (acp, app-builder, app-control, computer-use, contacts, document, followups, image-studio, media-processing, messaging, phone-calls, playbooks, schedule, sequences, settings, skill-management, subagent, transcribe). Three `required` arrays (`computer_use_observe`, `app_control_observe`, `app_control_stop`) had `activity` listed and have been updated.
- Updates `assistant/src/__tests__/app-control-tool-schemas.test.ts` to drop activity-related fixtures and the now-obsolete "missing activity rejects" assertion for `app_control_stop`.

## Original prompt

Execute the plan at /Users/sidd/.claude/plans/image-1-does-the-refactored-fern.md — remove the redundant per-tool `activity` field from all bundled-skill TOOLS.json files (keeping `skill_execute`'s wrapper-level activity as the single source of truth), and update the affected test file `assistant/src/__tests__/app-control-tool-schemas.test.ts` to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->