### PR TITLE
fix(app-control): bump observe settle to 200ms and expose settle_ms override

### DIFF
--- a/assistant/src/__tests__/app-control-tool-schemas.test.ts
+++ b/assistant/src/__tests__/app-control-tool-schemas.test.ts
@@ -241,10 +241,41 @@ describe("app_control_observe", () => {
     ).toBe(true);
   });
 
+  test("well-formed input passes (with optional settle_ms override)", () => {
+    expect(
+      validate(s, {
+        app: "com.apple.Safari",
+        settle_ms: 0,
+        activity: "static UI",
+      }).ok,
+    ).toBe(true);
+    expect(
+      validate(s, {
+        app: "com.apple.Safari",
+        settle_ms: 500,
+        activity: "slow-feedback app",
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("non-integer settle_ms rejects", () => {
+    const result = validate(s, {
+      app: "com.apple.Safari",
+      settle_ms: "200",
+      activity: "wrong type",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("settle_ms");
+  });
+
   test("missing required app rejects", () => {
     const result = validate(s, { activity: "check state" });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("app");
+  });
+
+  test("settle_ms is optional", () => {
+    expect(s.required ?? []).not.toContain("settle_ms");
   });
 
   test("declares low risk", () => {

--- a/assistant/src/config/bundled-skills/app-control/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-control/SKILL.md
@@ -37,6 +37,13 @@ state matters (e.g. you need to know what is on screen, where a UI element is,
 or whether the app is even running). Re-observe after actions that may have
 moved the window or changed visibility.
 
+`observe` waits a short settle delay (default ~200ms) before capturing so the
+target app and the WindowServer can flush pending input and composite a fresh
+frame. If the captured screenshot looks one input behind the latest state
+(common with emulators or other slow-feedback apps), pass a larger
+`settle_ms`. For static UIs where you just want a quick snapshot, pass
+`settle_ms: 0` to skip the wait.
+
 ## Input choice
 
 - Prefer `app_control_sequence` over multiple back-to-back `app_control_press`

--- a/assistant/src/config/bundled-skills/app-control/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-control/TOOLS.json
@@ -44,6 +44,10 @@
             "type": "string",
             "description": "Bundle ID (preferred, e.g. 'com.apple.Safari') or process name of the target application"
           },
+          "settle_ms": {
+            "type": "integer",
+            "description": "Milliseconds to wait before capturing so the target app and the WindowServer can flush pending input + composite a fresh frame. Default ~200ms (sized for emulator-class apps at 60fps). Pass 0 for static UIs; raise for slow-feedback apps."
+          },
           "activity": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"

--- a/assistant/src/daemon/message-types/host-app-control.ts
+++ b/assistant/src/daemon/message-types/host-app-control.ts
@@ -29,6 +29,14 @@ export interface HostAppControlStartInput {
 export interface HostAppControlObserveInput {
   tool: "observe";
   app: string;
+  /**
+   * Milliseconds to wait between receiving the request and capturing the
+   * window. Lets the target app process pending input and the WindowServer
+   * composite a fresh frame. When omitted, the client uses its default
+   * (~200ms, sized for emulator-class apps at 60fps). Pass `0` for static
+   * UIs to make `observe` snappier; raise it for slow-feedback apps.
+   */
+  settle_ms?: number;
 }
 
 export interface HostAppControlPressInput {

--- a/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
@@ -17,9 +17,14 @@ private let ACTIVATE_WAIT_DEADLINE_MS = 100
 /// to true after `activate()`.
 private let ACTIVATE_POLL_INTERVAL_MS = 5
 
-/// Settle delay applied at the start of `observe` so the window server has
-/// time to composite a fresh frame after recent synthetic input events.
-private let OBSERVE_SETTLE_DELAY_MS = 80
+/// Default settle delay applied at the start of `observe` so the target
+/// app and the WindowServer have time to composite a fresh frame after
+/// recent synthetic input events. ~12 frames at 60fps — sized for
+/// emulator-class apps where the input → game-state-update → render →
+/// composite → ScreenCaptureKit-pickup pipeline is the limiting factor.
+/// Callers can override per-request via `HostAppControlInput.observe`'s
+/// `settleMs` field.
+private let DEFAULT_OBSERVE_SETTLE_DELAY_MS = 200
 
 /// Default per-step gap inside `app_control_sequence` when a step omits its
 /// own `gap_ms`. Keeps consecutive presses far enough apart that emulators
@@ -70,8 +75,12 @@ enum AppControlExecutor {
         switch request.input {
         case .start(let app, let args):
             return await performStart(requestId: request.requestId, app: app, args: args)
-        case .observe(let app):
-            return await performObserve(requestId: request.requestId, app: app)
+        case .observe(let app, let settleMs):
+            return await performObserve(
+                requestId: request.requestId,
+                app: app,
+                settleMs: settleMs
+            )
         case .press(let app, let key, let modifiers, let durationMs):
             return await performPress(
                 requestId: request.requestId,
@@ -184,7 +193,8 @@ enum AppControlExecutor {
 
     private static func performObserve(
         requestId: String,
-        app: String
+        app: String,
+        settleMs: Int?
     ) async -> HostAppControlResultPayload {
         guard let resolved = resolvePid(forApp: app) else {
             return HostAppControlResultPayload(
@@ -193,12 +203,16 @@ enum AppControlExecutor {
                 executionError: "App not running: \(app)"
             )
         }
-        // Brief settle delay before capture: lets the target app finish
-        // processing any pending synthetic input events and lets the window
-        // server composite a fresh frame for ScreenCaptureKit. Without this,
+        // Settle delay before capture: lets the target app finish processing
+        // any pending synthetic input events and lets the window server
+        // composite a fresh frame for ScreenCaptureKit. Without this,
         // back-to-back press → observe sequences can return a screenshot
-        // captured one input behind the latest state.
-        try? await Task.sleep(nanoseconds: UInt64(OBSERVE_SETTLE_DELAY_MS) * 1_000_000)
+        // captured one input behind the latest state. Caller may override
+        // via `settleMs` (clamped at zero); omit it to use the default.
+        let effectiveSettle = max(0, settleMs ?? DEFAULT_OBSERVE_SETTLE_DELAY_MS)
+        if effectiveSettle > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(effectiveSettle) * 1_000_000)
+        }
         let capture = await AppWindowCapture.capture(forPid: resolved.pid)
         return HostAppControlResultPayload(
             requestId: requestId,

--- a/clients/macos/vellum-assistantTests/AppControlExecutorTests.swift
+++ b/clients/macos/vellum-assistantTests/AppControlExecutorTests.swift
@@ -72,7 +72,7 @@ final class AppControlExecutorTests: XCTestCase {
             type: "host_app_control_request",
             requestId: "req-observe-missing",
             conversationId: "conv-test",
-            input: .observe(app: "com.example.does-not-exist")
+            input: .observe(app: "com.example.does-not-exist", settleMs: 0)
         )
 
         let result = await AppControlExecutor.perform(request)

--- a/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
+++ b/clients/macos/vellum-assistantTests/Network/HostAppControlTypesTests.swift
@@ -24,7 +24,12 @@ final class HostAppControlTypesTests: XCTestCase {
     }
 
     func test_input_observe_roundTrips() throws {
-        let input = HostAppControlInput.observe(app: "com.apple.Safari")
+        let input = HostAppControlInput.observe(app: "com.apple.Safari", settleMs: nil)
+        XCTAssertEqual(try roundTrip(input), input)
+    }
+
+    func test_input_observe_withSettle_roundTrips() throws {
+        let input = HostAppControlInput.observe(app: "com.apple.Safari", settleMs: 350)
         XCTAssertEqual(try roundTrip(input), input)
     }
 
@@ -119,6 +124,43 @@ final class HostAppControlTypesTests: XCTestCase {
         XCTAssertEqual(key, "Return")
         XCTAssertEqual(modifiers, ["cmd"])
         XCTAssertEqual(durationMs, 100)
+    }
+
+    func test_input_observe_decodes_snake_case_settle_ms() throws {
+        // Wire format uses snake_case `settle_ms`; Swift maps to camelCase via
+        // the explicit `case settleMs = "settle_ms"` raw value. Without that
+        // mapping the override would silently fall through to nil and the
+        // executor would always use its default settle.
+        let json = #"""
+        {
+          "tool": "observe",
+          "app": "com.apple.Safari",
+          "settle_ms": 350
+        }
+        """#
+        let decoded = try JSONDecoder().decode(HostAppControlInput.self, from: Data(json.utf8))
+        guard case .observe(let app, let settleMs) = decoded else {
+            return XCTFail("Expected .observe variant, got \(decoded)")
+        }
+        XCTAssertEqual(app, "com.apple.Safari")
+        XCTAssertEqual(settleMs, 350)
+    }
+
+    func test_input_observe_decodes_without_settle_ms() throws {
+        // Caller may omit `settle_ms`; decode must still succeed with nil so
+        // the executor falls back to its default settle delay.
+        let json = #"""
+        {
+          "tool": "observe",
+          "app": "com.apple.Safari"
+        }
+        """#
+        let decoded = try JSONDecoder().decode(HostAppControlInput.self, from: Data(json.utf8))
+        guard case .observe(let app, let settleMs) = decoded else {
+            return XCTFail("Expected .observe variant, got \(decoded)")
+        }
+        XCTAssertEqual(app, "com.apple.Safari")
+        XCTAssertNil(settleMs)
     }
 
     func test_input_drag_decodes_snake_case_coordinates() throws {

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -1741,7 +1741,7 @@ public struct HostAppControlSequenceStep: Codable, Equatable, Sendable {
 /// hides the discriminator inside the enum case.
 public enum HostAppControlInput: Codable, Equatable, Sendable {
     case start(app: String, args: [String]?)
-    case observe(app: String)
+    case observe(app: String, settleMs: Int?)
     case press(app: String, key: String, modifiers: [String]?, durationMs: Int?)
     case combo(app: String, keys: [String], durationMs: Int?)
     case sequence(app: String, steps: [HostAppControlSequenceStep])
@@ -1762,6 +1762,7 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
         // raw values, decode silently misses `duration_ms` / `from_x` / etc.
         // and hold-durations and drag coordinates fall through to defaults.
         case durationMs = "duration_ms"
+        case settleMs = "settle_ms"
         case steps
         case text
         case x
@@ -1785,7 +1786,8 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
             self = .start(app: app, args: args)
         case "observe":
             let app = try container.decode(String.self, forKey: .app)
-            self = .observe(app: app)
+            let settleMs = try container.decodeIfPresent(Int.self, forKey: .settleMs)
+            self = .observe(app: app, settleMs: settleMs)
         case "press":
             let app = try container.decode(String.self, forKey: .app)
             let key = try container.decode(String.self, forKey: .key)
@@ -1840,9 +1842,10 @@ public enum HostAppControlInput: Codable, Equatable, Sendable {
             try container.encode("start", forKey: .tool)
             try container.encode(app, forKey: .app)
             try container.encodeIfPresent(args, forKey: .args)
-        case .observe(let app):
+        case .observe(let app, let settleMs):
             try container.encode("observe", forKey: .tool)
             try container.encode(app, forKey: .app)
+            try container.encodeIfPresent(settleMs, forKey: .settleMs)
         case .press(let app, let key, let modifiers, let durationMs):
             try container.encode("press", forKey: .tool)
             try container.encode(app, forKey: .app)


### PR DESCRIPTION
## Summary

- Bump default observe settle from 80ms → 200ms in `AppControlExecutor` so back-to-back press/sequence → observe sequences no longer capture a frame one input behind on emulator-class apps. ~12 frames at 60fps gives comfortable headroom for the input → game-state-update → render → composite → ScreenCaptureKit-pickup pipeline.
- Add per-call `settle_ms` override on `app_control_observe`. Callers can pass `0` for static UIs (snappier observe) or higher for slow-feedback apps. Plumbed through TS schema, Swift `HostAppControlInput.observe` (with explicit `case settleMs = "settle_ms"` snake_case raw value), and the executor.
- Update SKILL.md to document `settle_ms` and when to tune it.

## Test plan

- [x] `bun test src/__tests__/app-control-tool-schemas.test.ts` — 50/50 pass (3 new tests for `settle_ms` accept/reject).
- [x] `bun test src/__tests__/host-app-control-{proxy,routes}.test.ts src/__tests__/conversation-app-control-instantiation.test.ts` — 33/33 pass.
- [x] `bunx tsc --noEmit` clean.
- [x] `./build.sh build` — macOS app builds and signs.
- [x] `./build.sh test --filter "HostAppControlTypesTests|AppControlExecutorTests"` — 30/30 pass (3 new Swift tests covering snake_case `settle_ms` decode, omitted `settle_ms`, and the `settleMs: Int?` round-trip).
- [ ] Manual: launch an emulator-class app, run a 4-step sequence then observe — confirm the rendered state matches the last input.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->