### PR TITLE
fix(computer-use): drop activity from core definitions to match TOOLS.json

### DIFF
--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -21,12 +21,6 @@ function proxyExecute(): Promise<ToolExecutionResult> {
   );
 }
 
-const activityProperty = {
-  type: "string" as const,
-  description:
-    "Brief non-technical explanation of why this tool is being called",
-};
-
 // ---------------------------------------------------------------------------
 // click (unified - click_type selects single / double / right)
 // ---------------------------------------------------------------------------
@@ -69,7 +63,6 @@ export const computerUseClickTool: Tool = {
             description:
               "Explanation of what you see and why you are clicking here",
           },
-          activity: activityProperty,
         },
         required: ["reasoning"],
       },
@@ -106,7 +99,6 @@ export const computerUseTypeTextTool: Tool = {
             type: "string",
             description: "Explanation of what you are typing and why",
           },
-          activity: activityProperty,
         },
         required: ["text", "reasoning"],
       },
@@ -144,7 +136,6 @@ export const computerUseKeyTool: Tool = {
             type: "string",
             description: "Explanation of why you are pressing this key",
           },
-          activity: activityProperty,
         },
         required: ["key", "reasoning"],
       },
@@ -199,7 +190,6 @@ export const computerUseScrollTool: Tool = {
             type: "string",
             description: "Explanation of why you are scrolling",
           },
-          activity: activityProperty,
         },
         required: ["direction", "amount", "reasoning"],
       },
@@ -260,7 +250,6 @@ export const computerUseDragTool: Tool = {
             type: "string",
             description: "Explanation of what you are dragging and why",
           },
-          activity: activityProperty,
         },
         required: ["reasoning"],
       },
@@ -296,7 +285,6 @@ export const computerUseWaitTool: Tool = {
             type: "string",
             description: "Explanation of what you are waiting for",
           },
-          activity: activityProperty,
         },
         required: ["duration_ms", "reasoning"],
       },
@@ -335,7 +323,6 @@ export const computerUseOpenAppTool: Tool = {
             description:
               "Explanation of why you need to open or switch to this app",
           },
-          activity: activityProperty,
         },
         required: ["app_name", "reasoning"],
       },
@@ -373,7 +360,6 @@ export const computerUseRunAppleScriptTool: Tool = {
             description:
               "Explanation of what this script does and why AppleScript is better than UI interaction for this step",
           },
-          activity: activityProperty,
         },
         required: ["script", "reasoning"],
       },
@@ -406,7 +392,6 @@ export const computerUseDoneTool: Tool = {
             type: "string",
             description: "Human-readable summary of what was accomplished",
           },
-          activity: activityProperty,
         },
         required: ["summary"],
       },
@@ -443,7 +428,6 @@ export const computerUseRespondTool: Tool = {
             type: "string",
             description: "Explanation of how you determined the answer",
           },
-          activity: activityProperty,
         },
         required: ["answer", "reasoning"],
       },
@@ -471,10 +455,8 @@ const computerUseObserveTool: Tool = {
       description: this.description,
       input_schema: {
         type: "object",
-        properties: {
-          activity: activityProperty,
-        },
-        required: ["activity"],
+        properties: {},
+        required: [],
       },
     };
   },


### PR DESCRIPTION
## Summary
- PR #29374 removed the redundant per-tool \`activity\` field from bundled-skill \`TOOLS.json\` but missed the parallel definitions in \`assistant/src/tools/computer-use/definitions.ts\`.
- The orphaned \`activity\` properties caused \`computer-use-skill-manifest-regression.test.ts > manifest input_schema matches core definitions\` to fail in CI ([job](https://github.com/vellum-ai/vellum-assistant/actions/runs/25275619605/job/74105006539)).
- Drops the \`activityProperty\` constant and all 11 \`activity:\` entries from the core definitions so they match the manifest again.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25275619605/job/74105006539
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->