### PR TITLE
fix(macos): await async history reconstruction in ConversationRestorer tests

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationRestorer.swift
@@ -49,6 +49,18 @@ final class ConversationRestorer {
     /// Exposed as internal for `@testable` test access.
     var pendingHistoryByConversationId: [String: UUID] = [:]
 
+    /// In-flight history reconstruction tasks spawned by `handleHistoryResponse`.
+    /// Each task offloads message reconstruction to a background thread, then
+    /// applies the result on the main actor. Exposed as internal so tests can
+    /// `await` pending work before asserting on view-model state. Each task
+    /// removes itself from this list after completing, keyed by `id`, so the
+    /// list does not grow unboundedly in production.
+    struct InFlightHistoryReconstructionTask {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+    var inFlightHistoryReconstructionTasks: [InFlightHistoryReconstructionTask] = []
+
     private let connectionManager: GatewayConnectionManager
     private let eventStreamClient: EventStreamClient
     private let conversationListClient: any ConversationListClientProtocol = ConversationListClient()
@@ -505,20 +517,37 @@ final class ConversationRestorer {
         let messages = response.messages
         let hasMore = response.hasMore
         let oldestTimestamp = response.oldestTimestamp
-        Task { @MainActor [weak viewModel] in
+        let taskId = UUID()
+        let task = Task { @MainActor [weak viewModel, weak self] in
             let result = await Task.detached(priority: .userInitiated) {
                 HistoryReconstructionService.reconstructMessages(from: messages, conversationId: convId)
             }.value
-            guard let viewModel else { return }
-            viewModel.applyReconstructedHistory(
+            viewModel?.applyReconstructedHistory(
                 result,
                 hasMore: hasMore,
                 oldestTimestamp: oldestTimestamp,
                 isPaginationLoad: isPaginationLoad
             )
+            self?.inFlightHistoryReconstructionTasks.removeAll(where: { $0.id == taskId })
         }
+        inFlightHistoryReconstructionTasks.append(InFlightHistoryReconstructionTask(id: taskId, task: task))
 
         log.info("Loaded \(response.messages.count) history messages for conversation \(localId) (hasMore: \(hasMore), isPagination: \(isPaginationLoad))")
+    }
+
+    /// Waits for every history-reconstruction task currently in flight to
+    /// finish. Internal helper used by tests that need to assert on
+    /// view-model state mutated by the reconstruction task.
+    func awaitPendingHistoryReconstructions() async {
+        // Snapshot the in-flight list so concurrently-appended tasks (e.g. from
+        // chained handleHistoryResponse calls in the test) are picked up on the
+        // next iteration rather than leaving the loop racing against itself.
+        while !inFlightHistoryReconstructionTasks.isEmpty {
+            let snapshot = inFlightHistoryReconstructionTasks
+            for entry in snapshot {
+                _ = await entry.task.value
+            }
+        }
     }
 
     func handleConversationTitleUpdated(_ response: ConversationTitleUpdatedMessage) {

--- a/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ConversationRestorerTests.swift
@@ -165,7 +165,7 @@ struct ConversationRestorerTests {
     // MARK: - History Response Routing
 
     @Test @MainActor
-    func historyResponseRoutesToCorrectConversation() {
+    func historyResponseRoutesToCorrectConversation() async {
         let dc = GatewayConnectionManager()
         let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
@@ -192,6 +192,7 @@ struct ConversationRestorerTests {
             (role: "assistant", text: "Hi there"),
         ])
         restorer.handleHistoryResponse(response)
+        await restorer.awaitPendingHistoryReconstructions()
 
         // session-B's view model should have history loaded
         #expect(vmB.isHistoryLoaded)
@@ -230,7 +231,7 @@ struct ConversationRestorerTests {
     }
 
     @Test @MainActor
-    func rapidTabSwitchDoesNotCrossContaminate() {
+    func rapidTabSwitchDoesNotCrossContaminate() async {
         let dc = GatewayConnectionManager()
         let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
@@ -258,6 +259,7 @@ struct ConversationRestorerTests {
             (role: "user", text: "Request A"),
             (role: "assistant", text: "Response A"),
         ]))
+        await restorer.awaitPendingHistoryReconstructions()
 
         // Each VM should have its own history only
         #expect(vmA.messages.count == 2)
@@ -682,7 +684,7 @@ struct ConversationRestorerTests {
     /// Verifies that a conversation list refresh (triggered by invalidation refetch)
     /// preserves the selected conversation's local ID, loaded history, and view model.
     @Test @MainActor
-    func refreshPreservesSelectedConversationThroughInvalidationRefetch() {
+    func refreshPreservesSelectedConversationThroughInvalidationRefetch() async {
         let dc = GatewayConnectionManager()
         let restorer = ConversationRestorer(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
         let delegate = MockConversationRestorerDelegate(connectionManager: dc, eventStreamClient: dc.eventStreamClient)
@@ -704,6 +706,7 @@ struct ConversationRestorerTests {
             conversationId: "sa",
             messages: [(role: "user", text: "Hello")]
         ))
+        await restorer.awaitPendingHistoryReconstructions()
 
         let vmB = delegate.makeViewModel()
         vmB.conversationId = "sb"


### PR DESCRIPTION
## Summary
- Track history reconstruction tasks spawned by \`ConversationRestorer.handleHistoryResponse\` in an internal list keyed by UUID; each task self-removes when it finishes so the list stays bounded in production.
- Add internal \`awaitPendingHistoryReconstructions()\` helper so tests can deterministically wait for the async reconstruction work to complete before asserting on view-model state.
- Mark the three affected tests (\`historyResponseRoutesToCorrectConversation\`, \`rapidTabSwitchDoesNotCrossContaminate\`, \`refreshPreservesSelectedConversationThroughInvalidationRefetch\`) as \`async\` and await the helper after each \`handleHistoryResponse\`.

These tests were passing on \`ced7c26bd9\` and earlier by timing luck and started failing in [run 25275401979](https://github.com/vellum-ai/vellum-assistant/actions/runs/25275401979/job/74104431059) (commit \`92ef6dd732\`) — the underlying async behavior was introduced in #28631 (\`8389b1f4d2\`), which moved \`HistoryReconstructionService.reconstructMessages\` into a \`Task.detached\` so the heavy reconstruction does not starve the main actor.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25275401979/job/74104431059
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->