### PR TITLE
fix(skills): drop dead activity propagation in skill_execute dispatcher

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -215,16 +215,6 @@ export function createToolExecutor(
       // Clone to avoid mutating shared input objects
       const toolInput = { ...rawToolInput };
 
-      // Propagate outer activity when inner input lacks a valid one
-      if (
-        typeof input.activity === "string" &&
-        input.activity &&
-        (typeof toolInput.activity !== "string" ||
-          toolInput.activity.length === 0)
-      ) {
-        toolInput.activity = input.activity;
-      }
-
       if (!toolName) {
         return {
           content:


### PR DESCRIPTION
## Summary

- The \`skill_execute\` dispatcher copied wrapper-level \`activity\` into the inner \`toolInput\` as a fallback when the inner schema declared its own \`activity\` field. PR #29374 removed that field from every bundled-skill TOOLS.json — now \`skill-tool-factory\`'s \`validateNoUnknownParams\` rejects the propagated key with \"Unknown parameter 'activity' for tool …\" on every skill_execute call (see screenshot in conversation).
- The propagation is dead code: the only reader of \`input.activity\` is \`conversation-agent-loop-handlers.ts:373-375\`, which reads the OUTER \`skill_execute\` event's wrapper-level activity for status display, not the inner toolInput. Deleting the block restores skill_execute calls without affecting status display.

## Original prompt

In assistant/src/daemon/conversation-tool-setup.ts, delete lines 218-226 (the activity-propagation block). Context: PR #29374 removed the per-tool activity field from all bundled-skill TOOLS.json schemas, but the dispatcher still propagates outer activity into the inner toolInput, which the strict validator now rejects in production. Dead code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->