### PR TITLE
fix(app-control): defeat SCK stale-frame buffer + post-activation focus-race drops

### DIFF
--- a/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
@@ -17,6 +17,14 @@ private let ACTIVATE_WAIT_DEADLINE_MS = 100
 /// to true after `activate()`.
 private let ACTIVATE_POLL_INTERVAL_MS = 5
 
+/// Extra settle applied AFTER `isActive` flips to true (or after the activate
+/// deadline expires). The WindowServer's keyboard-focus routing lags AppKit's
+/// `isActive` flag by 1-2 frames — without this settle, the very first
+/// synthesized key in a sequence can land mid-focus-transition and get
+/// dropped by the WindowServer (observed: a 3-key "delete name" prefix only
+/// landed twice). 30ms ≈ 2 frames at 60fps.
+private let ACTIVATE_POSTFLIP_SETTLE_MS = 30
+
 /// Default settle delay applied at the start of `observe` so the target
 /// app and the WindowServer have time to composite a fresh frame after
 /// recent synthetic input events. ~12 frames at 60fps — sized for
@@ -59,7 +67,16 @@ enum AppControlExecutor {
     /// the input.
     private static func ensureActive(pid: pid_t) async {
         guard let runningApp = NSRunningApplication(processIdentifier: pid) else { return }
-        if runningApp.isActive { return }
+        if runningApp.isActive {
+            // Already active. Skip the activate call but still apply a tiny
+            // post-flip settle: even when the AppKit-level `isActive` is true,
+            // a recent focus transition (e.g., the user clicked into another
+            // app, then we got called immediately) can leave the WindowServer
+            // routing keys to the previous owner for 1-2 frames. Cheap
+            // insurance against the first key getting dropped.
+            try? await Task.sleep(nanoseconds: UInt64(ACTIVATE_POSTFLIP_SETTLE_MS) * 1_000_000)
+            return
+        }
         runningApp.activate(options: [.activateIgnoringOtherApps])
         let deadline = Date().addingTimeInterval(Double(ACTIVATE_WAIT_DEADLINE_MS) / 1000.0)
         while !runningApp.isActive && Date() < deadline {
@@ -67,6 +84,10 @@ enum AppControlExecutor {
                 nanoseconds: UInt64(ACTIVATE_POLL_INTERVAL_MS) * 1_000_000
             )
         }
+        // Even after `isActive` flips, the WindowServer's keyboard-focus
+        // route can lag by 1-2 frames. Settle here so the very first
+        // synthesized key isn't lost to an in-flight focus transition.
+        try? await Task.sleep(nanoseconds: UInt64(ACTIVATE_POSTFLIP_SETTLE_MS) * 1_000_000)
     }
 
     /// Execute `request` and produce a wire result. Never throws — every

--- a/clients/macos/vellum-assistant/AppControl/AppWindowCapture.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppWindowCapture.swift
@@ -113,6 +113,17 @@ enum AppWindowCapture {
     /// silently return an empty `SCShareableContent.windows` list on some
     /// macOS versions — we surface a permission hint in both branches so the
     /// daemon and the LLM can suggest the right fix.
+    ///
+    /// Capture uses a warmup-then-real two-shot pattern. `SCScreenshotManager
+    /// .captureImage` empirically returns a stale buffered frame (sometimes
+    /// seconds old) on its first call against a window that hasn't been
+    /// recently captured — observed against an emulator window where the
+    /// screenshot lagged behind the live framebuffer by several seconds even
+    /// after a 200ms settle delay. The first call flushes whatever the
+    /// WindowServer / SCK had cached; we then sleep ~2 frames at 60fps for
+    /// the SCK pipeline to advance, and the second call returns the current
+    /// frame. The cost is one extra capture + ~33ms; the benefit is that
+    /// `observe` reflects reality.
     private static func captureWindowPNG(windowID: CGWindowID) async -> PNGCaptureResult {
         do {
             let shareable = try await SCShareableContent.current
@@ -129,6 +140,15 @@ enum AppWindowCapture {
             config.pixelFormat = kCVPixelFormatType_32BGRA
             config.showsCursor = false
 
+            // Warmup capture — discarded. Forces SCK to invalidate any stale
+            // buffered frame for this window. Errors here are non-fatal: if
+            // the warmup fails, the real capture below will surface the error.
+            _ = try? await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: config
+            )
+            try? await Task.sleep(nanoseconds: UInt64(CAPTURE_INTER_SHOT_GAP_MS) * 1_000_000)
+
             let cgImage = try await SCScreenshotManager.captureImage(
                 contentFilter: filter,
                 configuration: config
@@ -143,6 +163,12 @@ enum AppWindowCapture {
             return PNGCaptureResult(pngBase64: nil, error: message)
         }
     }
+
+    /// Gap between the warmup capture and the real capture. ~2 frames at
+    /// 60fps — long enough for the SCK pipeline to advance past whatever
+    /// stale frame was cached, short enough that the added observe latency
+    /// is unnoticeable.
+    private static let CAPTURE_INTER_SHOT_GAP_MS: Int = 33
 
     private static func encodePNGBase64(cgImage: CGImage) -> String? {
         let data = NSMutableData()


### PR DESCRIPTION
## Summary

Two complementary fixes after #29377 still left the symptoms reported:

- **Stale screenshots** — \`SCScreenshotManager.captureImage\` returns a buffered/cached frame on its first call against a window that hasn't been recently captured. Observed against an emulator window: \`observe\` returned a screenshot from ~2s before the call even with \`settle_ms: 200\`. Fix: take a discardable warmup capture, sleep ~33ms (2 frames at 60fps) for SCK's pipeline to advance, then take the real capture.
- **First-key drops** — \`ensureActive\` returned the moment \`NSRunningApplication.isActive\` flipped to \`true\`, but the WindowServer's keyboard-focus route lags AppKit's signal by 1-2 frames. The very first key in a sequence could land mid-transition and be dropped (observed: 3 \`b\` presses to clear a 3-char field only landed twice, leaving 1 char remaining). Fix: add a 30ms post-flip settle in both branches of \`ensureActive\`.

## Test plan

- [x] \`./build.sh build\` clean.
- [x] \`./build.sh test --filter AppControlExecutorTests\` — 7/7 pass.
- [ ] Manual: re-run the emulator multi-key sequence-then-observe flow; confirm (a) all keys land, (b) the post-sequence observe shows the actual final state, not a stale early frame.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->