### PR TITLE
fix(macos): drop deprecated activateIgnoringOtherApps option

### DIFF
--- a/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
+++ b/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift
@@ -77,7 +77,7 @@ enum AppControlExecutor {
             try? await Task.sleep(nanoseconds: UInt64(ACTIVATE_POSTFLIP_SETTLE_MS) * 1_000_000)
             return
         }
-        runningApp.activate(options: [.activateIgnoringOtherApps])
+        runningApp.activate()
         let deadline = Date().addingTimeInterval(Double(ACTIVATE_WAIT_DEADLINE_MS) / 1000.0)
         while !runningApp.isActive && Date() < deadline {
             try? await Task.sleep(


### PR DESCRIPTION
## Summary
- Replace `runningApp.activate(options: [.activateIgnoringOtherApps])` with `runningApp.activate()` in `AppControlExecutor.ensureActive`. The option was deprecated in macOS 14 and is documented as having no effect there, so this only silences the build warning without changing runtime behavior.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/AppControl/AppControlExecutor.swift:80:40: warning: 'activateIgnoringOtherApps' was deprecated in macOS 14.0: ignoringOtherApps is deprecated in macOS 14 and will have no effect. [#DeprecatedDeclaration]
 78 |             return
 79 |         }
 80 |         runningApp.activate(options: [.activateIgnoringOtherApps])
    |                                        \`- warning: 'activateIgnoringOtherApps' was deprecated in macOS 14.0: ignoringOtherApps is deprecated in macOS 14 and will have no effect. [#DeprecatedDeclaration]
 81 |         let deadline = Date().addingTimeInterval(Double(ACTIVATE_WAIT_DEADLINE_MS) / 1000.0)
 82 |         while !runningApp.isActive && Date() < deadline {
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->