### PR TITLE
fix(macos): improve conversation switch UX with immediate skeleton

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -81,6 +81,10 @@ struct MainWindowView: View {
     @State var showConversationSwitcher = false
     @State var showEarnCreditsModal = false
     @State var conversationSwitcherTriggerFrame: CGRect = .zero
+    /// Selected conversation currently being activated from a user navigation
+    /// action. While non-nil, the chat surface renders a switch-loading
+    /// skeleton until this conversation becomes active and history is loaded.
+    @State var pendingConversationSwitchId: UUID? = nil
 
     /// Cached assistant display name, seeded from the static identity cache on init
     /// and refreshed when the daemon emits an identity change event.
@@ -329,6 +333,12 @@ struct MainWindowView: View {
                     voiceModeManager.deactivate()
                 }
             }
+            .onChange(of: conversationManager.activeViewModel?.isHistoryLoaded) { _, isLoaded in
+                guard isLoaded == true,
+                      let pendingId = pendingConversationSwitchId,
+                      pendingId == conversationManager.activeConversationId else { return }
+                pendingConversationSwitchId = nil
+            }
             .onChange(of: windowState.selection) { oldSelection, newSelection in
                 // Validate the new selection synchronously so that if the target
                 // is stale (archived / abandoned draft) we can correct the
@@ -337,9 +347,21 @@ struct MainWindowView: View {
                 // deferred below so SwiftUI can paint the selection change
                 // before we block on VM creation.
                 var conversationIdToActivate: UUID?
+                let selectionTargetConversationId: UUID? = {
+                    switch newSelection {
+                    case .conversation(let id):
+                        return id
+                    case .appEditing(_, let id):
+                        return id
+                    default:
+                        return nil
+                    }
+                }()
                 if case .conversation(let id) = newSelection {
                     if listStore.conversations.contains(where: { $0.id == id && !$0.isArchived }) {
-                        conversationIdToActivate = id
+                        if conversationManager.activeConversationId != id {
+                            conversationIdToActivate = id
+                        }
                     } else {
                         // Conversation was archived/deleted — fall back to the first visible conversation
                         if let fallback = listStore.visibleConversations.first {
@@ -366,6 +388,16 @@ struct MainWindowView: View {
                         // Stale target — drop the dock but keep the app visible.
                         windowState.applySelectionCorrection(.app(appId))
                     }
+                }
+
+                // The skeleton gate is only for explicit user-initiated switches.
+                // If selection is stale, inactive, or already rendered, clear it.
+                if let id = conversationIdToActivate {
+                    pendingConversationSwitchId = id
+                } else if selectionTargetConversationId == nil
+                    || selectionTargetConversationId == conversationManager.activeConversationId
+                    || selectionTargetConversationId == conversationManager.draftLocalId {
+                    pendingConversationSwitchId = nil
                 }
 
                 // Yield to the run loop before the heavy `ConversationManager`

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -11,20 +11,6 @@ private let panelCoordinatorLog = Logger(
 // MARK: - Panel Coordination Extension
 
 extension MainWindowView {
-    /// Conversation local-id explicitly targeted by current navigation state.
-    /// Used to avoid rendering stale chat content while a conversation switch
-    /// is still activating on the main actor.
-    private var selectedConversationIdForChatSurface: UUID? {
-        switch windowState.selection {
-        case .conversation(let id):
-            return id
-        case .appEditing(_, let id):
-            return id
-        default:
-            return nil
-        }
-    }
-
     /// Current conversation being rendered by `chatView`.
     private var renderedConversationIdForChatSurface: UUID? {
         conversationManager.activeConversationId ?? conversationManager.draftLocalId
@@ -32,10 +18,10 @@ extension MainWindowView {
 
     /// True while the chat surface should show a loading skeleton instead of
     /// rendering a stale or partially-initialized conversation.
-    private func shouldShowConversationSwitchSkeleton(targetConversationId: UUID?) -> Bool {
-        guard let targetConversationId else { return false }
+    private func shouldShowConversationSwitchSkeleton() -> Bool {
+        guard let targetConversationId = pendingConversationSwitchId else { return false }
         guard renderedConversationIdForChatSurface == targetConversationId else {
-            // Selection changed but ConversationManager has not activated yet.
+            // Explicit switch pending but ConversationManager has not activated yet.
             return true
         }
 
@@ -674,7 +660,7 @@ extension MainWindowView {
         let config = windowState.layoutConfig
         let isDisabledACPSessionsRightSlot = Self.isDisabledACPSessionsRightSlot(config.right)
         let showConfigPanel = config.right.visible && config.right.content != .empty && !isDisabledACPSessionsRightSlot
-        let isSwitchingConversation = shouldShowConversationSwitchSkeleton(targetConversationId: selectedConversationIdForChatSurface)
+        let isSwitchingConversation = shouldShowConversationSwitchSkeleton()
         let showSubagentPanel = !isSwitchingConversation
             && windowState.selectedSubagentId != nil
             && conversationManager.activeViewModel != nil
@@ -739,8 +725,7 @@ extension MainWindowView {
 
     @ViewBuilder
     var chatView: some View {
-        let targetConversationId = selectedConversationIdForChatSurface
-        if shouldShowConversationSwitchSkeleton(targetConversationId: targetConversationId) {
+        if shouldShowConversationSwitchSkeleton() {
             ConversationSwitchLoadingView()
         } else if let viewModel = conversationManager.activeViewModel {
             let activeConversation = conversationManager.activeConversation

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1123,11 +1123,16 @@ struct ActiveChatViewWrapper: View {
 /// Immediate visual placeholder while switching conversations.
 private struct ConversationSwitchLoadingView: View {
     var body: some View {
-        ChatLoadingSkeleton()
-            .padding(VSpacing.lg)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Loading chat history")
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                ChatLoadingSkeleton()
+                    .padding(VSpacing.lg)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Loading chat history")
+                Spacer(minLength: 0)
+            }
+            Spacer(minLength: 0)
+        }
             .background(VColor.surfaceBase)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -11,6 +11,48 @@ private let panelCoordinatorLog = Logger(
 // MARK: - Panel Coordination Extension
 
 extension MainWindowView {
+    /// Conversation local-id explicitly targeted by current navigation state.
+    /// Used to avoid rendering stale chat content while a conversation switch
+    /// is still activating on the main actor.
+    private var selectedConversationIdForChatSurface: UUID? {
+        switch windowState.selection {
+        case .conversation(let id):
+            return id
+        case .appEditing(_, let id):
+            return id
+        default:
+            return nil
+        }
+    }
+
+    /// Current conversation being rendered by `chatView`.
+    private var renderedConversationIdForChatSurface: UUID? {
+        conversationManager.activeConversationId ?? conversationManager.draftLocalId
+    }
+
+    /// True while the chat surface should show a loading skeleton instead of
+    /// rendering a stale or partially-initialized conversation.
+    private func shouldShowConversationSwitchSkeleton(targetConversationId: UUID?) -> Bool {
+        guard let targetConversationId else { return false }
+        guard renderedConversationIdForChatSurface == targetConversationId else {
+            // Selection changed but ConversationManager has not activated yet.
+            return true
+        }
+
+        // Draft conversations are local-only and immediately ready.
+        if conversationManager.activeConversationId == nil,
+           conversationManager.draftLocalId == targetConversationId {
+            return false
+        }
+
+        // Require the selected VM history to load before enabling interaction.
+        // Use the active VM only (no cache/LRU mutations during body eval).
+        guard let targetViewModel = conversationManager.activeViewModel else {
+            return true
+        }
+        return !targetViewModel.isHistoryLoaded
+    }
+
     // MARK: - Config-Driven Slot Rendering
 
     @ViewBuilder
@@ -632,7 +674,10 @@ extension MainWindowView {
         let config = windowState.layoutConfig
         let isDisabledACPSessionsRightSlot = Self.isDisabledACPSessionsRightSlot(config.right)
         let showConfigPanel = config.right.visible && config.right.content != .empty && !isDisabledACPSessionsRightSlot
-        let showSubagentPanel = windowState.selectedSubagentId != nil && conversationManager.activeViewModel != nil
+        let isSwitchingConversation = shouldShowConversationSwitchSkeleton(targetConversationId: selectedConversationIdForChatSurface)
+        let showSubagentPanel = !isSwitchingConversation
+            && windowState.selectedSubagentId != nil
+            && conversationManager.activeViewModel != nil
 
         VSplitView(
             panelWidth: clampedSidePanelWidth(windowSize: windowSize),
@@ -694,7 +739,10 @@ extension MainWindowView {
 
     @ViewBuilder
     var chatView: some View {
-        if let viewModel = conversationManager.activeViewModel {
+        let targetConversationId = selectedConversationIdForChatSurface
+        if shouldShowConversationSwitchSkeleton(targetConversationId: targetConversationId) {
+            ConversationSwitchLoadingView()
+        } else if let viewModel = conversationManager.activeViewModel {
             let activeConversation = conversationManager.activeConversation
             let conversationStartersEnabled = true
             let showInspectButton = MacOSClientFeatureFlagManager.shared.isEnabled(
@@ -750,7 +798,8 @@ extension MainWindowView {
                 },
                 conversationId: conversationManager.activeConversationId ?? conversationManager.draftLocalId,
                 anchorMessageId: $conversationManager.pendingAnchorMessageId,
-                highlightedMessageId: $conversationManager.highlightedMessageId
+                highlightedMessageId: $conversationManager.highlightedMessageId,
+                isInteractionEnabled: viewModel.isHistoryLoaded
             )
         }
     }
@@ -961,6 +1010,7 @@ struct ActiveChatViewWrapper: View {
     var conversationId: UUID?
     @Binding var anchorMessageId: UUID?
     @Binding var highlightedMessageId: UUID?
+    var isInteractionEnabled: Bool = true
 
     /// Reads the persisted bootstrap state so the chat view can suppress
     /// the empty state during first-launch bootstrap.
@@ -1019,7 +1069,7 @@ struct ActiveChatViewWrapper: View {
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 conversationId: conversationId,
-                isInteractionEnabled: windowState.inspectorMessageId == nil,
+                isInteractionEnabled: isInteractionEnabled && windowState.inspectorMessageId == nil,
                 isReadonly: isReadonly,
                 isBootstrapping: isBootstrapping,
                 isBootstrapTimedOut: isBootstrapTimedOut,
@@ -1036,7 +1086,7 @@ struct ActiveChatViewWrapper: View {
                 showThresholdPicker: showThresholdPicker
             )
             .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
-            .disabled(windowState.inspectorMessageId != nil)
+            .disabled(windowState.inspectorMessageId != nil || !isInteractionEnabled)
 
             if let messageId = windowState.inspectorMessageId {
                 MessageInspectorView(
@@ -1067,6 +1117,18 @@ struct ActiveChatViewWrapper: View {
         withAnimation(VAnimation.standard) {
             windowState.inspectorMessageId = nil
         }
+    }
+}
+
+/// Immediate visual placeholder while switching conversations.
+private struct ConversationSwitchLoadingView: View {
+    var body: some View {
+        ChatLoadingSkeleton()
+            .padding(VSpacing.lg)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Loading chat history")
+            .background(VColor.surfaceBase)
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -672,7 +672,8 @@ extension MainWindowView {
             mainCornerRadius: 0,
             main: { slotView(for: config.center.content) },
             panel: {
-                if let subagentId = windowState.selectedSubagentId,
+                if !isSwitchingConversation,
+                   let subagentId = windowState.selectedSubagentId,
                    let viewModel = conversationManager.activeViewModel {
                     SubagentDetailPanel(
                         subagentId: subagentId,


### PR DESCRIPTION
## Summary
- add a conversation-switch loading gate keyed by selected versus rendered conversation ids
- render an immediate loading skeleton during activation/history load so stale thread content is not shown
- keep chat interaction and subagent side panel disabled until the selected conversation is ready

## Original prompt
this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->