### PR TITLE
chore(macos): raise minimum supported macOS version to 15.0

### DIFF
--- a/clients/macos/VellumQLPreview/Info.plist
+++ b/clients/macos/VellumQLPreview/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>15.0</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/clients/macos/VellumQLThumbnail/Info.plist
+++ b/clients/macos/VellumQLThumbnail/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>15.0</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1413,7 +1413,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     $LSE_ENVIRONMENT_PLIST
     $COMMIT_SHA_PLIST
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>15.0</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>NSScreenRecordingUsageDescription</key>
@@ -1564,7 +1564,7 @@ if [ -d "$XCASSETS" ]; then
         if ACTOOL_OUTPUT=$(xcrun actool "${ACTOOL_INPUTS[@]}" \
             --compile "$RESOURCES_DIR" \
             --platform macosx \
-            --minimum-deployment-target 14.0 \
+            --minimum-deployment-target 15.0 \
             --app-icon AppIcon \
             --output-partial-info-plist /dev/null \
             2>&1); then
@@ -1584,7 +1584,7 @@ if [ -d "$XCASSETS" ]; then
         if xcrun actool "$XCASSETS" \
             --compile "$RESOURCES_DIR" \
             --platform macosx \
-            --minimum-deployment-target 14.0 \
+            --minimum-deployment-target 15.0 \
             --app-icon AppIcon \
             --output-partial-info-plist /dev/null \
             2>&1; then
@@ -1891,7 +1891,7 @@ if [ -d "$QLTHUMB_SRC" ]; then
     xcrun swiftc \
         -module-name VellumQLThumbnail \
         -emit-executable \
-        -target "${QL_TARGET_ARCH}-apple-macosx14.0" \
+        -target "${QL_TARGET_ARCH}-apple-macosx15.0" \
         -sdk "$(xcrun --show-sdk-path)" \
         -framework QuickLookThumbnailing \
         -framework AppKit \
@@ -1920,7 +1920,7 @@ if [ -d "$QLPREV_SRC" ]; then
     xcrun swiftc \
         -module-name VellumQLPreview \
         -emit-executable \
-        -target "${QL_TARGET_ARCH}-apple-macosx14.0" \
+        -target "${QL_TARGET_ARCH}-apple-macosx15.0" \
         -sdk "$(xcrun --show-sdk-path)" \
         -framework QuickLookUI \
         -framework UniformTypeIdentifiers \

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -23,7 +23,7 @@
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>15.0</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary
- Raise the macOS client minimum OS from 14.0 to 15.0 (Sequoia) in app and Quick Look extension Info.plists.
- Update macOS build/deployment target flags in the macOS build script to 15.0 so built artifacts match the new minimum.

## Original prompt
a PR fix to increase it to 15.0 (Sequoia)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->