### PR TITLE
fix(macos): make notification conversation deep-links reliable

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -30,6 +30,9 @@ extension AppDelegate {
         log.info("Bootstrap state: \(self.bootstrapState.rawValue, privacy: .public) → \(newState.rawValue, privacy: .public)")
         bootstrapState = newState
         persistBootstrapState()
+        if newState == .complete {
+            drainPendingConversationOpenRequestIfNeeded()
+        }
 
         // Emit stage timing when a start timestamp is available.
         if let start = bootstrapStartTime {

--- a/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Conversations.swift
@@ -101,35 +101,41 @@ extension AppDelegate {
     }
 
     /// Opens the main window and navigates to the given conversation.
-    /// Retries if the conversation isn't populated yet (e.g., ConversationManager hasn't loaded it).
     /// Used by Quick Chat and notification deep links.
     /// - Parameters:
     ///   - conversationId: The conversation to navigate to.
     ///   - anchorMessageId: Optional message ID to scroll to after the conversation is selected.
     func openConversation(conversationId: String?, anchorMessageId: String? = nil) {
-        showMainWindow()
         guard let conversationId else { return }
+        if isBootstrapping {
+            pendingConversationOpenRequest = (conversationId: conversationId, anchorMessageId: anchorMessageId)
+            log.info("Queued conversation open for \(conversationId, privacy: .public) until bootstrap completes")
+            return
+        }
 
-        func trySelect() -> Bool {
-            guard let conversationManager = mainWindow?.conversationManager,
-                  let conversation = conversationManager.conversations.first(where: { $0.conversationId == conversationId }) else {
-                return false
+        showMainWindow()
+
+        Task { @MainActor in
+            let conversationManager = self.ensureMainWindowExists().conversationManager
+            let found = await conversationManager.selectConversationByConversationIdAsync(conversationId)
+            guard found, let conversation = conversationManager.activeConversation else {
+                log.warning("Could not find conversation \(conversationId, privacy: .public) after async fetch")
+                return
             }
-            conversationManager.activateConversation(conversation.id)
             // Switch the main content area to the chat — but if App Builder
             // is open, transition to .appEditing so the app stays visible
             // with the new conversation in the chat dock.
-            if let sel = mainWindow?.windowState.selection {
+            if let sel = self.mainWindow?.windowState.selection {
                 switch sel {
                 case .app(let appId):
-                    mainWindow?.windowState.selection = .appEditing(appId: appId, conversationId: conversation.id)
+                    self.mainWindow?.windowState.selection = .appEditing(appId: appId, conversationId: conversation.id)
                 case .appEditing(let appId, _):
-                    mainWindow?.windowState.selection = .appEditing(appId: appId, conversationId: conversation.id)
+                    self.mainWindow?.windowState.selection = .appEditing(appId: appId, conversationId: conversation.id)
                 default:
-                    mainWindow?.windowState.selection = nil
+                    self.mainWindow?.windowState.selection = nil
                 }
             } else {
-                mainWindow?.windowState.selection = nil
+                self.mainWindow?.windowState.selection = nil
             }
             // Clear unseen state and notify the assistant when deep-linking into a
             // conversation. selectConversation's unseen-clear is guarded by
@@ -142,19 +148,13 @@ extension AppDelegate {
             if let anchorMessageId, let anchorUUID = UUID(uuidString: anchorMessageId) {
                 conversationManager.setPendingAnchorMessage(conversationId: conversation.id, messageId: anchorUUID)
             }
-            return true
         }
+    }
 
-        if trySelect() { return }
-
-        // Conversation may not be loaded yet — retry up to 5 times with 500ms delay
-        Task { @MainActor in
-            for _ in 0..<5 {
-                try? await Task.sleep(nanoseconds: 500_000_000)
-                if trySelect() { return }
-            }
-            log.warning("Could not find conversation \(conversationId) after retries")
-        }
+    func drainPendingConversationOpenRequestIfNeeded() {
+        guard !isBootstrapping, let pending = pendingConversationOpenRequest else { return }
+        pendingConversationOpenRequest = nil
+        openConversation(conversationId: pending.conversationId, anchorMessageId: pending.anchorMessageId)
     }
 
     func showDaemonConnectionError() {

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -531,18 +531,19 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 response.notification.request.content.userInfo["conversation_id"] as? String
             let messageId = self.messageId(from: response.notification.request.content.userInfo)
             await MainActor.run {
-                guard !self.isBootstrapping else { return }
                 if let conversationId {
                     self.openConversation(conversationId: conversationId, anchorMessageId: messageId)
-                    self.sendConversationSeenSignal(
-                        conversationId: conversationId,
-                        signalType: "macos_notification_view",
-                        source: "notification-action",
-                        evidenceText: "User clicked View on notification"
-                    )
-                    // Clear local unseen state so sidebar dot disappears immediately
-                    if let conversationIdx = self.mainWindow?.conversationManager.conversations.firstIndex(where: { $0.conversationId == conversationId }) {
-                        self.mainWindow?.conversationManager.conversations[conversationIdx].hasUnseenLatestAssistantMessage = false
+                    if !self.isBootstrapping {
+                        self.sendConversationSeenSignal(
+                            conversationId: conversationId,
+                            signalType: "macos_notification_view",
+                            source: "notification-action",
+                            evidenceText: "User clicked View on notification"
+                        )
+                        // Clear local unseen state so sidebar dot disappears immediately
+                        if let conversationIdx = self.mainWindow?.conversationManager.conversations.firstIndex(where: { $0.conversationId == conversationId }) {
+                            self.mainWindow?.conversationManager.conversations[conversationIdx].hasUnseenLatestAssistantMessage = false
+                        }
                     }
                 } else {
                     self.showMainWindow()

--- a/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Notifications.swift
@@ -469,7 +469,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         if categoryId == "ACTIVITY_COMPLETE" {
             let conversationId = response.notification.request.content.userInfo["conversationId"] as? String
             await MainActor.run {
-                guard !self.isBootstrapping else { return }
                 if let conversationId, !conversationId.isEmpty {
                     self.openConversation(conversationId: conversationId)
                 } else {
@@ -493,7 +492,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 // confirmation's conversation and let the inline bubble handle it.
                 // Do NOT auto-deny.
                 await MainActor.run {
-                    guard !self.isBootstrapping else { return }
                     let conversationId = response.notification.request.content.userInfo["conversationId"] as? String
                     if let conversationId {
                         self.openConversation(conversationId: conversationId)

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -200,6 +200,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     var hasRequestedNotificationAuthorizationFromConversationSignal = false
     /// Last time we surfaced the denied-notification permission toast.
     var lastNotificationPermissionToastAtMs: Double = 0
+    /// Pending conversation deep link captured while first-launch bootstrap is
+    /// active. Drained once bootstrap reaches `.complete`.
+    var pendingConversationOpenRequest: (conversationId: String, anchorMessageId: String?)?
 
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local assistant hatching is skipped.


### PR DESCRIPTION
## Summary
- Route conversation notification opens through the async selector that fetches/upserts missing conversations instead of relying on short local retries.
- Queue conversation deep links clicked during bootstrap and replay them when bootstrap completes.
- Avoid sending notification seen signals while bootstrap is still in progress, preventing false seen events before navigation is possible.

## Original prompt
the fix for this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->