### PR TITLE
fix(tests): use snake_case wire format key in AppControlConnectionTests

### DIFF
--- a/clients/macos/vellum-assistantTests/AppControlConnectionTests.swift
+++ b/clients/macos/vellum-assistantTests/AppControlConnectionTests.swift
@@ -27,7 +27,7 @@ final class AppControlConnectionTests: XCTestCase {
             "app": "com.apple.Safari",
             "key": "Return",
             "modifiers": ["cmd"],
-            "durationMs": 50
+            "duration_ms": 50
           }
         }
         """#


### PR DESCRIPTION
## Summary
- Fixed test JSON fixture in `AppControlConnectionTests.test_decodes_hostAppControlRequest_pressVariant` that used camelCase `"durationMs"` instead of the wire-format snake_case `"duration_ms"`
- The `HostAppControlInput.CodingKeys` explicitly maps `durationMs` to `"duration_ms"`, so the decoder silently produced `nil` instead of `Optional(50)`, causing the XCTAssertEqual assertion to fail

## Original prompt
help me fix CI in https://github.com/vellum-ai/vellum-assistant/actions/runs/25281001883
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->