### PR TITLE
fix(clients): fix Swift argument order in sendContactPromptResponse

### DIFF
--- a/clients/shared/Network/InteractionClient.swift
+++ b/clients/shared/Network/InteractionClient.swift
@@ -107,9 +107,9 @@ public struct InteractionClient: InteractionClientProtocol {
             // Route is /v1/contacts/prompt/submit — not scoped under assistants/{id}.
             let response = try await GatewayHTTPClient.post(
                 path: "contacts/prompt/submit",
-                unprefixed: true,
                 json: body,
-                timeout: 10
+                timeout: 10,
+                unprefixed: true
             )
             if !response.isSuccess {
                 log.error("sendContactPromptResponse failed (HTTP \(response.statusCode))")


### PR DESCRIPTION
## Summary

- Fixed argument order in `InteractionClient.sendContactPromptResponse` — `json` must precede `unprefixed` per the `GatewayHTTPClient.post` function signature
- This was causing Swift compilation failures on CI for both the macOS build and test jobs

## Original prompt

the fix anyway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->