### PR TITLE
feat(macos): change completed progress card headline from step count to "Worked for X.Ys" (LUM-1287)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -202,6 +202,14 @@ struct AssistantProgressView: View {
         )
     }
 
+    private func completedHeadline(model: ProgressCardPresentationModel) -> String {
+        guard let start = model.earliestStartedAt else { return "Worked" }
+        let effectiveEnd = thinkingAfterToolsEndDate ?? cardCompletedAt ?? model.latestCompletedAt
+        guard let end = effectiveEnd else { return "Worked" }
+        let seconds = end.timeIntervalSince(start)
+        return "Worked for \(VCollapsibleStepRowDurationFormatter.format(seconds))"
+    }
+
     private func headlineText(for model: ProgressCardPresentationModel) -> String {
         switch model.phase {
         case .thinking:
@@ -249,7 +257,7 @@ struct AssistantProgressView: View {
                 }
                 return "Completed with blocked permissions"
             }
-            return "Completed \(model.totalToolCount) step\(model.totalToolCount == 1 ? "" : "s")"
+            return completedHeadline(model: model)
         case .denied:
             let primary = model.uniqueToolNamesSorted.first ?? "Tool"
             return ChatBubble.friendlyRunningLabel(primary) + " denied"
@@ -606,11 +614,9 @@ struct AssistantProgressView: View {
 
             Spacer()
 
-            // Elapsed time: live counter when active, final duration when complete
+            // Elapsed time: live counter when active
             if model.isActive {
                 ElapsedTimeLabel(startDate: startDate)
-            } else if model.hasTools {
-                completedDurationLabel(model: model)
             }
 
             // Chevron (only if tools exist)
@@ -659,26 +665,6 @@ struct AssistantProgressView: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .animation(.easeInOut(duration: 0.3), value: text)
-            }
-        }
-    }
-
-    // MARK: - Completed Duration
-
-    @ViewBuilder
-    private func completedDurationLabel(model: ProgressCardPresentationModel) -> some View {
-        if let start = model.earliestStartedAt {
-            // Prefer thinkingAfterToolsEndDate (when real thinking was tracked) so the
-            // parent total matches the sum of sub-activity durations. Otherwise fall
-            // back to cardCompletedAt, captured at the `.complete` transition, so the
-            // live elapsed timer doesn't drop back to tool-runtime-only when the card
-            // passes through `.toolsCompleteThinking` without ever hitting `.processing`.
-            let effectiveEnd = thinkingAfterToolsEndDate ?? cardCompletedAt ?? model.latestCompletedAt
-            if let end = effectiveEnd {
-                let seconds = end.timeIntervalSince(start)
-                Text(VCollapsibleStepRowDurationFormatter.format(seconds))
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace "Completed N steps" headline with "Worked for X.Ys" using time-based duration
- Remove redundant duration label from the right side of completed cards (duration is now in the headline)
- Keep elapsed time counter for active/streaming cards unchanged

Part of plan: burst-progress-model.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->