### PR TITLE
feat(macos): add ProgressExpandedItem and ThinkingStepDetailRow for mixed expanded content (LUM-1287)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -2,6 +2,28 @@ import SwiftUI
 import VellumAssistantShared
 import Dispatch
 
+// MARK: - ProgressExpandedItem
+
+/// Represents a single item in a chronological expanded-content trace.
+/// When `AssistantProgressView.expandedItems` is provided, the expanded
+/// body renders these items in order instead of the default `toolCalls`
+/// array, allowing thinking blocks to appear interleaved with tool calls.
+enum ProgressExpandedItem: Identifiable {
+    /// A tool call to render via `ToolCallStepDetailRow`.
+    case toolCall(ToolCallData)
+    /// A thinking block to render via `ThinkingStepDetailRow`.
+    case thinking(content: String, expansionKey: String, isStreaming: Bool)
+
+    var id: String {
+        switch self {
+        case .toolCall(let tc):
+            return tc.id.uuidString
+        case .thinking(_, let key, _):
+            return key
+        }
+    }
+}
+
 // MARK: - AssistantProgressView
 
 /// Unified container that handles all tool progress states through a single component
@@ -15,6 +37,7 @@ struct AssistantProgressView: View {
     let streamingCodePreview: String?
     let streamingCodeToolName: String?
     let decidedConfirmations: [ToolConfirmationData]
+    let expandedItems: [ProgressExpandedItem]?
     var onRehydrate: (() -> Void)?
 
     // Confirmation action callbacks (threaded from MessageListView)
@@ -60,6 +83,7 @@ struct AssistantProgressView: View {
         streamingCodePreview: String? = nil,
         streamingCodeToolName: String? = nil,
         decidedConfirmations: [ToolConfirmationData],
+        expandedItems: [ProgressExpandedItem]? = nil,
         onRehydrate: (() -> Void)? = nil,
         onConfirmationAllow: ((String) -> Void)? = nil,
         onConfirmationDeny: ((String) -> Void)? = nil,
@@ -78,6 +102,7 @@ struct AssistantProgressView: View {
         self.streamingCodePreview = streamingCodePreview
         self.streamingCodeToolName = streamingCodeToolName
         self.decidedConfirmations = decidedConfirmations
+        self.expandedItems = expandedItems
         self.onRehydrate = onRehydrate
         self.onConfirmationAllow = onConfirmationAllow
         self.onConfirmationDeny = onConfirmationDeny
@@ -698,52 +723,91 @@ struct AssistantProgressView: View {
         )
     }
 
+    /// Renders a single tool call row with its inline confirmation bubble.
+    /// Extracted from `expandedContent` so the same rendering logic is shared
+    /// between the default `toolCalls` path and the `expandedItems` path.
+    @ViewBuilder
+    private func toolCallRow(toolCall: ToolCallData, model: ProgressCardPresentationModel, phase: ProgressCardPhase) -> some View {
+        ToolCallStepDetailRow(
+            toolCall: toolCall,
+            phase: phase,
+            isDetailExpanded: isStepExpanded(toolCall.id),
+            skillLabel: toolCall.toolName == "skill_execute" ? model.skillExecuteLabel : nil,
+            onRehydrate: onRehydrate
+        )
+
+        // Inline confirmation bubble for tool calls awaiting approval
+        if let confirmation = toolCall.pendingConfirmation {
+            ToolConfirmationBubble(
+                confirmation: confirmation,
+                isKeyboardActive: confirmation.requestId == activeConfirmationRequestId,
+                onAllow: { onConfirmationAllow?(confirmation.requestId) },
+                onDeny: { onConfirmationDeny?(confirmation.requestId) },
+                onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
+                onTemporaryAllow: onTemporaryAllow,
+                onAllowAndSuggestRule: {
+                    // Allow the tool first
+                    if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
+                        let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
+                        onAlwaysAllow?(confirmation.requestId, option.pattern, scope, "allow")
+                    } else {
+                        onConfirmationAllow?(confirmation.requestId)
+                    }
+                    // Fire the suggest API and open the rule editor with the result
+                    Task {
+                        await fetchSuggestionAndOpenEditor(for: toolCall)
+                    }
+                }
+            )
+            .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+        }
+    }
+
+    /// Derives a `Binding<Bool>` for a thinking block's expansion state from the
+    /// shared `ProgressCardUIState`. Scoped to one string key so
+    /// `ThinkingStepDetailRow` can use it as a drop-in `@Binding`.
+    private func isThinkingExpanded(_ key: String) -> Binding<Bool> {
+        Binding(
+            get: { progressUIState.isThinkingExpanded(key) },
+            set: { newValue in
+                progressUIState.setThinkingExpanded(key, expanded: newValue)
+            }
+        )
+    }
+
     @ViewBuilder
     private func expandedContent(model: ProgressCardPresentationModel, phase: ProgressCardPhase) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(toolCalls) { toolCall in
-                ToolCallStepDetailRow(
-                    toolCall: toolCall,
-                    phase: phase,
-                    isDetailExpanded: isStepExpanded(toolCall.id),
-                    skillLabel: toolCall.toolName == "skill_execute" ? model.skillExecuteLabel : nil,
-                    onRehydrate: onRehydrate
-                )
-
-                // Inline confirmation bubble for tool calls awaiting approval
-                if let confirmation = toolCall.pendingConfirmation {
-                    ToolConfirmationBubble(
-                        confirmation: confirmation,
-                        isKeyboardActive: confirmation.requestId == activeConfirmationRequestId,
-                        onAllow: { onConfirmationAllow?(confirmation.requestId) },
-                        onDeny: { onConfirmationDeny?(confirmation.requestId) },
-                        onAlwaysAllow: onAlwaysAllow ?? { _, _, _, _ in },
-                        onTemporaryAllow: onTemporaryAllow,
-                        onAllowAndSuggestRule: {
-                            // Allow the tool first
-                            if let option = confirmation.allowlistOptions.first, !option.pattern.isEmpty {
-                                let scope = confirmation.scopeOptions.first?.scope ?? "everywhere"
-                                onAlwaysAllow?(confirmation.requestId, option.pattern, scope, "allow")
-                            } else {
-                                onConfirmationAllow?(confirmation.requestId)
-                            }
-                            // Fire the suggest API and open the rule editor with the result
-                            Task {
-                                await fetchSuggestionAndOpenEditor(for: toolCall)
-                            }
-                        }
-                    )
-                    .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.sm))
+            if let items = expandedItems {
+                // Chronological trace with interleaved tool calls and thinking blocks.
+                ForEach(items) { item in
+                    switch item {
+                    case .toolCall(let tc):
+                        toolCallRow(toolCall: tc, model: model, phase: phase)
+                    case .thinking(let content, let key, let streaming):
+                        ThinkingStepDetailRow(
+                            content: content,
+                            isStreaming: streaming,
+                            isExpanded: isThinkingExpanded(key)
+                        )
+                    }
                 }
-            }
+                // No synthetic ThinkingStepRow — thinking content is already
+                // represented in the chronological trace above.
+            } else {
+                // Default path: render tool calls from the flat array.
+                ForEach(toolCalls) { toolCall in
+                    toolCallRow(toolCall: toolCall, model: model, phase: phase)
+                }
 
-            // Synthetic "Thinking" row for the post-tool-completion thinking phase.
-            if let thinkingStart = thinkingAfterToolsStartDate, model.allComplete, model.hasTools {
-                ThinkingStepRow(
-                    startDate: thinkingStart,
-                    completedAt: thinkingAfterToolsEndDate,
-                    isActive: model.isActive
-                )
+                // Synthetic "Thinking" row for the post-tool-completion thinking phase.
+                if let thinkingStart = thinkingAfterToolsStartDate, model.allComplete, model.hasTools {
+                    ThinkingStepRow(
+                        startDate: thinkingStart,
+                        completedAt: thinkingAfterToolsEndDate,
+                        isActive: model.isActive
+                    )
+                }
             }
         }
     }
@@ -1565,6 +1629,74 @@ private struct ThinkingStepRow: View {
             }
             .padding(EdgeInsets(top: VSpacing.xs, leading: VSpacing.sm + VSpacing.sm, bottom: VSpacing.xs, trailing: VSpacing.xs + VSpacing.xs))
         }
+    }
+}
+
+// MARK: - Thinking Step Detail Row
+
+/// Collapsible row for a thinking block inside a `ProgressExpandedItem` trace.
+/// Uses `VCollapsibleStepRow` with a brain icon and secondary text styling.
+/// Markdown segments are parsed lazily — only when the row is expanded — to
+/// avoid blocking the main thread for collapsed thinking blocks.
+private struct ThinkingStepDetailRow: View {
+    let content: String
+    let isStreaming: Bool
+    @Binding var isExpanded: Bool
+
+    @Environment(\.bubbleMaxWidth) private var bubbleMaxWidth
+
+    /// Lazily parsed markdown segments. Populated on first expansion and
+    /// refreshed when the content changes while expanded.
+    @State private var cachedSegments: [MarkdownSegment] = []
+    @State private var cachedContent: String = ""
+
+    private var title: String {
+        isStreaming ? "Thinking..." : "Thought process"
+    }
+
+    private var rowState: VCollapsibleStepRowState {
+        isStreaming ? .running : .succeeded
+    }
+
+    /// Syncs the markdown segment cache when the row is expanded and the
+    /// underlying content has changed. Mirrors the lazy-parse pattern used
+    /// by `ThinkingBlockView`.
+    private func syncCacheIfExpanded() {
+        guard isExpanded, cachedContent != content else { return }
+        cachedContent = content
+        cachedSegments = parseMarkdownSegments(content)
+    }
+
+    var body: some View {
+        VCollapsibleStepRow(
+            title: title,
+            state: rowState,
+            hasDetails: !content.isEmpty,
+            isExpanded: $isExpanded,
+            leadingAccessory: {
+                VIconView(.brain, size: 11)
+                    .foregroundStyle(VColor.contentSecondary)
+            },
+            detailContent: {
+                if !cachedSegments.isEmpty {
+                    MarkdownSegmentView(
+                        segments: cachedSegments,
+                        isStreaming: isStreaming,
+                        maxContentWidth: max(bubbleMaxWidth - 2 * VSpacing.sm, 0),
+                        textColor: VColor.contentSecondary,
+                        secondaryTextColor: VColor.contentTertiary,
+                        mutedTextColor: VColor.contentTertiary,
+                        tintColor: VColor.primaryBase,
+                        codeTextColor: VColor.contentDefault,
+                        codeBackgroundColor: VColor.surfaceBase
+                    )
+                    .padding(VSpacing.sm)
+                }
+            }
+        )
+        .onAppear { syncCacheIfExpanded() }
+        .onChange(of: content) { _, _ in syncCacheIfExpanded() }
+        .onChange(of: isExpanded) { _, _ in syncCacheIfExpanded() }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -17,9 +17,9 @@ enum ProgressExpandedItem: Identifiable {
     var id: String {
         switch self {
         case .toolCall(let tc):
-            return tc.id.uuidString
+            return "tool:\(tc.id.uuidString)"
         case .thinking(_, let key, _):
-            return key
+            return "thinking:\(key)"
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ProgressCardUIState.swift
@@ -43,6 +43,14 @@ struct ProgressCardUIState: Equatable, Sendable {
     /// exact regression the anchor is meant to prevent.
     var cardCompletedDates: [UUID: Date] = [:]
 
+    // MARK: - Thinking Expansion (String-Keyed)
+
+    /// Set of thinking expansion keys currently expanded. Used by
+    /// `ThinkingStepDetailRow` inside `ProgressExpandedItem` traces where
+    /// thinking blocks are identified by a caller-provided string key rather
+    /// than a `UUID`.
+    var expandedThinkingKeys: Set<String> = []
+
     // MARK: - Rehydration Tracking
 
     /// Set of group IDs (first tool call UUID) for which rehydration has already
@@ -83,6 +91,11 @@ struct ProgressCardUIState: Equatable, Sendable {
     /// Returns the persisted completion timestamp for the given card, or nil if none.
     func cardCompletedAt(for cardKey: UUID) -> Date? {
         cardCompletedDates[cardKey]
+    }
+
+    /// Returns whether the thinking block with the given string key is expanded.
+    func isThinkingExpanded(_ key: String) -> Bool {
+        expandedThinkingKeys.contains(key)
     }
 
     /// Whether rehydration has already been performed for the given group.
@@ -140,6 +153,15 @@ struct ProgressCardUIState: Equatable, Sendable {
         thinkingDurations.removeValue(forKey: cardKey)
     }
 
+    /// Sets the expansion state for a thinking block by string key.
+    mutating func setThinkingExpanded(_ key: String, expanded: Bool) {
+        if expanded {
+            expandedThinkingKeys.insert(key)
+        } else {
+            expandedThinkingKeys.remove(key)
+        }
+    }
+
     /// Marks a group as having been rehydrated.
     mutating func markRehydrated(groupId: UUID) {
         rehydratedGroupIds.insert(groupId)
@@ -151,6 +173,7 @@ struct ProgressCardUIState: Equatable, Sendable {
         cardExpansionOverrides.removeAll()
         thinkingDurations.removeAll()
         cardCompletedDates.removeAll()
+        expandedThinkingKeys.removeAll()
         rehydratedGroupIds.removeAll()
     }
 }


### PR DESCRIPTION
## Summary
- Add ProgressExpandedItem enum and expandedItems parameter to AssistantProgressView for rendering mixed tool call + thinking content in chronological order
- Add ThinkingStepDetailRow component for collapsible thinking blocks inside expanded progress cards
- Update ProgressCardUIState to use string-keyed thinking expansion tracking

Part of plan: burst-progress-model.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->