### PR TITLE
feat(macos): fold thinking content into progress card for non-interleaved messages (LUM-1287)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -811,6 +811,11 @@ struct ChatBubble: View, Equatable {
     /// rendered alongside a bubble that contains the remaining content.
     /// This keeps the transformation at the presentation layer — the
     /// streaming pipeline and `ChatMessage` data model are unchanged.
+    ///
+    /// When tool calls are present, thinking content is folded into the
+    /// progress card (via `expandedItemsForProgressCard`) instead of
+    /// rendering as standalone `ThinkingBlockView`s. Only the stripped
+    /// text is rendered in the bubble.
     @ViewBuilder
     private var bubbleContentWithInlineThinking: some View {
         let chunks = parseInlineThinkingTags(message.text)
@@ -828,17 +833,28 @@ struct ChatBubble: View, Equatable {
         let hasRenderedText = !joinedText.isEmpty
         let hasAttachments = !message.attachments.isEmpty
 
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { offset, content in
-                ThinkingBlockView(
-                    content: content,
-                    isStreaming: message.isStreaming,
-                    expansionKey: "\(message.id.uuidString)-inline-\(offset)",
-                    typographyGeneration: typographyGeneration
-                )
-            }
+        if !message.toolCalls.isEmpty {
+            // Tool calls present — thinking is folded into the progress
+            // card via expandedItemsForProgressCard. Render only the
+            // stripped text content in the bubble.
             if hasRenderedText || hasAttachments {
                 bubbleContent(renderingText: joinedText)
+            }
+        } else {
+            // No tool calls — render ThinkingBlockViews above the text
+            // bubble as before (no progress card to fold into).
+            VStack(alignment: .leading, spacing: VSpacing.sm) {
+                ForEach(Array(thinkingChunks.enumerated()), id: \.offset) { offset, content in
+                    ThinkingBlockView(
+                        content: content,
+                        isStreaming: message.isStreaming,
+                        expansionKey: "\(message.id.uuidString)-inline-\(offset)",
+                        typographyGeneration: typographyGeneration
+                    )
+                }
+                if hasRenderedText || hasAttachments {
+                    bubbleContent(renderingText: joinedText)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -15,6 +15,93 @@ extension ChatBubble {
             || message.toolCalls.contains { $0.confirmationDecision == .denied || $0.confirmationDecision == .timedOut }
     }
 
+    /// Builds an ordered list of `ProgressExpandedItem`s that folds thinking
+    /// content into the progress card alongside tool calls.
+    ///
+    /// Returns `nil` when no thinking content should be folded — preserving
+    /// the default tool-calls-only rendering path in `AssistantProgressView`.
+    ///
+    /// Two thinking sources are considered:
+    /// 1. **Structured `thinkingSegments`** referenced by `contentOrder`
+    ///    `.thinking(i)` entries.
+    /// 2. **Inline `<thinking>` XML tags** embedded in `message.text`.
+    var expandedItemsForProgressCard: [ProgressExpandedItem]? {
+        let showThinking = MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks")
+        guard showThinking else { return nil }
+
+        // --- Source 1: Structured thinking segments from contentOrder ---
+        let hasStructuredThinking = message.contentOrder.contains { ref in
+            if case .thinking = ref { return true }
+            return false
+        }
+
+        if hasStructuredThinking {
+            var items: [ProgressExpandedItem] = []
+            let lastThinkingIndex = message.contentOrder.lastIndex { ref in
+                if case .thinking = ref { return true }
+                return false
+            }
+            for (orderIdx, ref) in message.contentOrder.enumerated() {
+                switch ref {
+                case .thinking(let i):
+                    guard i < message.thinkingSegments.count else { continue }
+                    let content = message.thinkingSegments[i]
+                    guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+                    let key = "\(message.id.uuidString)-th\(i)"
+                    let isLast = orderIdx == lastThinkingIndex
+                    let streaming = message.isStreaming && isLast
+                    items.append(.thinking(content: content, expansionKey: key, isStreaming: streaming))
+                case .toolCall(let i):
+                    guard i < message.toolCalls.count else { continue }
+                    items.append(.toolCall(message.toolCalls[i]))
+                default:
+                    break
+                }
+            }
+            // Only return if we actually produced thinking items
+            let hasThinkingItems = items.contains { item in
+                if case .thinking = item { return true }
+                return false
+            }
+            return hasThinkingItems ? items : nil
+        }
+
+        // --- Source 2: Inline <thinking> tags in message.text ---
+        guard containsInlineThinkingTag(message.text),
+              !message.toolCalls.isEmpty else {
+            return nil
+        }
+
+        let chunks = parseInlineThinkingTags(message.text)
+        let thinkingChunks: [(offset: Int, content: String)] = chunks.enumerated().compactMap { (idx, chunk) in
+            if case .thinking(let body) = chunk { return (idx, body) }
+            return nil
+        }
+
+        guard !thinkingChunks.isEmpty else { return nil }
+
+        var items: [ProgressExpandedItem] = []
+
+        // Determine if the last chunk overall is a thinking chunk (for isStreaming)
+        let lastChunkIsThinking: Bool = {
+            guard let last = chunks.last else { return false }
+            if case .thinking = last { return true }
+            return false
+        }()
+
+        for (i, tc) in thinkingChunks.enumerated() {
+            let key = "\(message.id.uuidString)-th\(i)"
+            let isLast = (i == thinkingChunks.count - 1) && lastChunkIsThinking
+            items.append(.thinking(content: tc.content, expansionKey: key, isStreaming: message.isStreaming && isLast))
+        }
+
+        for toolCall in message.toolCalls {
+            items.append(.toolCall(toolCall))
+        }
+
+        return items
+    }
+
     @ViewBuilder
     var trailingStatus: some View {
         let inlineToolProgressRenderedInContent = shouldRenderToolProgressInline
@@ -46,6 +133,7 @@ extension ChatBubble {
                     streamingCodePreview: message.streamingCodePreview,
                     streamingCodeToolName: message.streamingCodeToolName,
                     decidedConfirmations: effectiveConfirmations,
+                    expandedItems: expandedItemsForProgressCard,
                     onRehydrate: onRehydrate,
                     onConfirmationAllow: onConfirmationAllow,
                     onConfirmationDeny: onConfirmationDeny,


### PR DESCRIPTION
## Summary
- Fold thinking content (both inline XML tags and structured thinkingSegments) into the progress card for non-interleaved messages
- Suppress standalone ThinkingBlockView rendering when tool calls are present (thinking is now in the progress card receipt)
- Gate thinking folding behind the show-thinking-blocks feature flag

Part of plan: burst-progress-model.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->