### PR TITLE
feat(macos): consolidate tool activity into burst-based cards in interleaved content (LUM-1287)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -112,8 +112,6 @@ struct ChatBubble: View, Equatable {
     // correct layout path instead of flashing through the fallback layout.
     @State var cachedHasInterleavedContent: Bool
     @State var cachedContentGroups: [ContentGroup]
-    /// Set of stableIds for tool-call groups that have non-empty text after them.
-    @State var cachedToolGroupsWithTrailingText: Set<String>
 
     /// Interaction state for progress cards that must outlive lazy row churn.
     /// Consolidates step expansion, card expansion overrides, and rehydration
@@ -189,7 +187,6 @@ struct ChatBubble: View, Equatable {
         if let cached = Self.cachedInterleavedResult(for: message) {
             _cachedHasInterleavedContent = State(initialValue: cached.hasInterleaved)
             _cachedContentGroups = State(initialValue: cached.groups)
-            _cachedToolGroupsWithTrailingText = State(initialValue: cached.trailingTextIds)
         } else {
             let interleaved = Self.computeHasInterleavedContent(message.contentOrder)
             _cachedHasInterleavedContent = State(initialValue: interleaved)
@@ -213,7 +210,6 @@ struct ChatBubble: View, Equatable {
                         trailingTextIds.insert(group.stableId)
                     }
                 }
-                _cachedToolGroupsWithTrailingText = State(initialValue: trailingTextIds)
 
                 // Store in static cache for future init() calls
                 Self.storeInterleavedResult(
@@ -222,7 +218,6 @@ struct ChatBubble: View, Equatable {
                 )
             } else {
                 _cachedContentGroups = State(initialValue: [])
-                _cachedToolGroupsWithTrailingText = State(initialValue: [])
 
                 // Store non-interleaved result in static cache
                 Self.storeInterleavedResult(

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -545,15 +545,59 @@ extension ChatBubble {
                 var found = false
                 if lastIdx + 1 < groups.count {
                     for followingGroup in groups[(lastIdx + 1)...] {
-                        if case .texts = followingGroup {
-                            found = true
-                            break
+                        if case .texts(let textIndices) = followingGroup {
+                            let hasNonEmpty = textIndices.contains { i in
+                                i < message.textSegments.count
+                                    && !message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            }
+                            if hasNonEmpty {
+                                found = true
+                                break
+                            }
                         }
                     }
                 }
                 result[burst.stableId] = found
             }
             return result
+        }()
+
+        // Bursts immediately followed by a text group defer their images to
+        // render after the text, so "Here's the screenshot:" appears before
+        // the screenshot it introduces.
+        let deferredImageBurstIds: Set<String> = {
+            var ids = Set<String>()
+            for burst in bursts {
+                if burstTrailingText[burst.stableId] == true {
+                    ids.insert(burst.stableId)
+                }
+            }
+            return ids
+        }()
+
+        // Map text group stableIds to the burst whose images they should render
+        let textGroupDeferredBurst: [String: WorkBurst] = {
+            var map: [String: WorkBurst] = [:]
+            for burst in bursts {
+                guard deferredImageBurstIds.contains(burst.stableId) else { continue }
+                let burstToolSet = Set(burst.toolIndices)
+                let burstThinkingSet = Set(burst.thinkingIndices)
+                var lastBurstGroupIdx: Int?
+                for (idx, group) in groups.enumerated() {
+                    switch group {
+                    case .toolCalls(let indices):
+                        if !Set(indices).isDisjoint(with: burstToolSet) { lastBurstGroupIdx = idx }
+                    case .thinking(let indices):
+                        if !Set(indices).isDisjoint(with: burstThinkingSet) { lastBurstGroupIdx = idx }
+                    default: break
+                    }
+                }
+                guard let lastIdx = lastBurstGroupIdx, lastIdx + 1 < groups.count else { continue }
+                if case .texts = groups[lastIdx + 1] {
+                    map[groups[lastIdx + 1].stableId] = burst
+                }
+            }
+            return map
         }()
 
         // Identify the last text group so attachments render right after it
@@ -577,6 +621,16 @@ extension ChatBubble {
                 if !joined.isEmpty {
                     textBubble(for: joined, textGroupIndex: indices.first ?? 0)
                 }
+                // Render deferred burst images after the text so descriptive
+                // text appears before the screenshot it introduces.
+                if shouldRenderToolProgressInline,
+                   let deferredBurst = textGroupDeferredBurst[group.stableId] {
+                    let deferredCalls: [ToolCallData] = deferredBurst.toolIndices.compactMap { tcIdx in
+                        guard tcIdx < message.toolCalls.count else { return nil }
+                        return message.toolCalls[tcIdx]
+                    }
+                    inlineToolCallImages(from: deferredCalls)
+                }
                 // Render attachments right after the last text group
                 if group.stableId == lastTextGroupId {
                     inlineAttachments
@@ -592,12 +646,14 @@ extension ChatBubble {
                             hasTrailingText: burstTrailingText[burst.stableId] ?? false,
                             expandedItems: burst.expandedItems.isEmpty ? nil : burst.expandedItems
                         )
-                        // Render tool call images after the burst card
-                        let burstToolCalls: [ToolCallData] = burst.toolIndices.compactMap { tcIdx in
-                            guard tcIdx < message.toolCalls.count else { return nil }
-                            return message.toolCalls[tcIdx]
+                        // Render tool call images unless deferred to the following text group
+                        if !deferredImageBurstIds.contains(burst.stableId) {
+                            let burstToolCalls: [ToolCallData] = burst.toolIndices.compactMap { tcIdx in
+                                guard tcIdx < message.toolCalls.count else { return nil }
+                                return message.toolCalls[tcIdx]
+                            }
+                            inlineToolCallImages(from: burstToolCalls)
                         }
-                        inlineToolCallImages(from: burstToolCalls)
                     } else if burstForGroup[group.stableId] != nil {
                         // Part of a burst but not the anchor — skip rendering
                         EmptyView()
@@ -630,11 +686,13 @@ extension ChatBubble {
                                 hasTrailingText: burstTrailingText[burst.stableId] ?? false,
                                 expandedItems: burst.expandedItems.isEmpty ? nil : burst.expandedItems
                             )
-                            let burstToolCalls: [ToolCallData] = burst.toolIndices.compactMap { tcIdx in
-                                guard tcIdx < message.toolCalls.count else { return nil }
-                                return message.toolCalls[tcIdx]
+                            if !deferredImageBurstIds.contains(burst.stableId) {
+                                let burstToolCalls: [ToolCallData] = burst.toolIndices.compactMap { tcIdx in
+                                    guard tcIdx < message.toolCalls.count else { return nil }
+                                    return message.toolCalls[tcIdx]
+                                }
+                                inlineToolCallImages(from: burstToolCalls)
                             }
-                            inlineToolCallImages(from: burstToolCalls)
                         }
                     } else {
                         EmptyView()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -39,6 +39,129 @@ extension ChatBubble {
         }
     }
 
+    /// A contiguous burst of work activity (tool calls and optionally thinking)
+    /// that renders as a single progress card. Text and surface groups act as
+    /// burst boundaries — each burst gets its own "Worked for X.Ys" card.
+    struct WorkBurst {
+        /// All tool call indices in this burst.
+        let toolIndices: [Int]
+        /// All thinking segment indices in this burst.
+        let thinkingIndices: [Int]
+        /// Identity from the first group's stableId.
+        let stableId: String
+        /// Chronological sequence of tool calls and thinking for the progress
+        /// card's expanded view.
+        var expandedItems: [ProgressExpandedItem]
+    }
+
+    /// Computes work bursts from content groups by merging consecutive tool-call
+    /// and thinking groups into a single burst. Text and surface groups flush the
+    /// current burst and create boundaries.
+    ///
+    /// A burst MUST contain at least one tool call. Thinking-only groups (thinking
+    /// with no adjacent tool calls) are NOT included in any burst — they remain
+    /// standalone groups for separate rendering.
+    static func computeWorkBursts(
+        groups: [ContentGroup],
+        contentOrder: [ContentBlockRef],
+        toolCalls: [ToolCallData],
+        thinkingSegments: [String],
+        showThinking: Bool,
+        isStreaming: Bool,
+        messageId: UUID
+    ) -> [WorkBurst] {
+        var bursts: [WorkBurst] = []
+
+        // Accumulate consecutive tool/thinking groups into a pending burst
+        var pendingToolIndices: [Int] = []
+        var pendingThinkingIndices: [Int] = []
+        var pendingStableId: String?
+        var pendingGroupStableIds: [String] = []
+
+        func flushBurst() {
+            guard !pendingToolIndices.isEmpty else {
+                // Thinking-only — not a burst, reset and skip
+                pendingToolIndices = []
+                pendingThinkingIndices = []
+                pendingStableId = nil
+                pendingGroupStableIds = []
+                return
+            }
+
+            let toolSet = Set(pendingToolIndices)
+            let thinkingSet = Set(pendingThinkingIndices)
+
+            // Build expandedItems by walking contentOrder for chronological ordering
+            var items: [ProgressExpandedItem] = []
+            for ref in contentOrder {
+                switch ref {
+                case .toolCall(let i):
+                    if toolSet.contains(i), i < toolCalls.count {
+                        items.append(.toolCall(toolCalls[i]))
+                    }
+                case .thinking(let i):
+                    guard showThinking, thinkingSet.contains(i) else { continue }
+                    guard i < thinkingSegments.count, !thinkingSegments[i].isEmpty else { continue }
+                    let expansionKey = "\(messageId.uuidString)-th\(i)"
+                    // isStreaming is set later for the last burst only
+                    items.append(.thinking(
+                        content: thinkingSegments[i],
+                        expansionKey: expansionKey,
+                        isStreaming: false
+                    ))
+                default:
+                    continue
+                }
+            }
+
+            bursts.append(WorkBurst(
+                toolIndices: pendingToolIndices,
+                thinkingIndices: pendingThinkingIndices,
+                stableId: pendingStableId ?? "burst-\(bursts.count)",
+                expandedItems: items
+            ))
+
+            pendingToolIndices = []
+            pendingThinkingIndices = []
+            pendingStableId = nil
+            pendingGroupStableIds = []
+        }
+
+        for group in groups {
+            switch group {
+            case .toolCalls(let indices):
+                if pendingStableId == nil {
+                    pendingStableId = group.stableId
+                }
+                pendingToolIndices.append(contentsOf: indices)
+                pendingGroupStableIds.append(group.stableId)
+            case .thinking(let indices):
+                if pendingStableId == nil {
+                    pendingStableId = group.stableId
+                }
+                pendingThinkingIndices.append(contentsOf: indices)
+                pendingGroupStableIds.append(group.stableId)
+            case .texts, .surface:
+                flushBurst()
+            }
+        }
+        // Flush any trailing burst
+        flushBurst()
+
+        // Set isStreaming on thinking items in the last burst only
+        if isStreaming, var lastBurst = bursts.last {
+            lastBurst.expandedItems = lastBurst.expandedItems.map { item in
+                if case .thinking(let content, let key, _) = item {
+                    return .thinking(content: content, expansionKey: key, isStreaming: true)
+                }
+                return item
+            }
+            bursts[bursts.count - 1] = lastBurst
+        }
+
+        return bursts
+    }
+
     // MARK: - Static Interleaved Content Cache
 
     /// Cache key for memoized interleaved content computation results.
@@ -113,9 +236,6 @@ extension ChatBubble {
             if !cachedContentGroups.isEmpty {
                 cachedContentGroups = []
             }
-            if !cachedToolGroupsWithTrailingText.isEmpty {
-                cachedToolGroupsWithTrailingText = []
-            }
             // Update static cache with non-interleaved result
             Self.storeInterleavedResult(
                 InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
@@ -130,8 +250,7 @@ extension ChatBubble {
         )
 
         // Pre-compute which tool-call groups have trailing text so that
-        // `interleavedContent` can look up the set instead of scanning
-        // contentOrder per group during body evaluation.
+        // the static cache can store them for future init() calls.
         var trailingTextIds = Set<String>()
         for group in groups {
             guard case .toolCalls(let indices) = group else { continue }
@@ -149,9 +268,6 @@ extension ChatBubble {
         }
         if cachedContentGroups != groups {
             cachedContentGroups = groups
-        }
-        if cachedToolGroupsWithTrailingText != trailingTextIds {
-            cachedToolGroupsWithTrailingText = trailingTextIds
         }
 
         // Update static cache so the next init() for this message uses fresh values
@@ -292,7 +408,7 @@ extension ChatBubble {
     }
 
     @ViewBuilder
-    private func inlineToolProgress(toolIndices: [Int], isLatestGroup: Bool, hasTrailingText: Bool) -> some View {
+    private func inlineToolProgress(toolIndices: [Int], isLatestGroup: Bool, hasTrailingText: Bool, expandedItems: [ProgressExpandedItem]? = nil) -> some View {
         let groupedToolCalls: [ToolCallData] = toolIndices.compactMap { idx -> ToolCallData? in
             guard idx < message.toolCalls.count else { return nil }
             return message.toolCalls[idx]
@@ -337,6 +453,7 @@ extension ChatBubble {
                     streamingCodePreview: isLatestGroup ? message.streamingCodePreview : nil,
                     streamingCodeToolName: isLatestGroup ? message.streamingCodeToolName : nil,
                     decidedConfirmations: groupConfirmations,
+                    expandedItems: expandedItems,
                     onRehydrate: onRehydrate,
                     onConfirmationAllow: onConfirmationAllow,
                     onConfirmationDeny: onConfirmationDeny,
@@ -355,51 +472,97 @@ extension ChatBubble {
     @ViewBuilder
     var interleavedContent: some View {
         let groups = cachedContentGroups
-        let latestToolGroup: [Int]? = groups.reversed().compactMap { group in
-            guard case .toolCalls(let indices) = group else { return nil }
-            return indices
-        }.first
+        let showThinking = MacOSClientFeatureFlagManager.shared.isEnabled("show-thinking-blocks")
 
-        // Pre-compute which tool groups defer images to the following text group.
-        // When a tool group is immediately followed by a text group, images render
-        // after the text so descriptive text like "Here's the screenshot:" appears
-        // before the screenshot it introduces.
-        let deferredImageGroupIds: Set<String> = {
-            var ids = Set<String>()
-            for i in 0..<groups.count {
-                guard case .toolCalls = groups[i] else { continue }
-                if i + 1 < groups.count, case .texts = groups[i + 1] {
-                    ids.insert(groups[i].stableId)
-                }
-            }
-            return ids
-        }()
+        // Compute work bursts — consecutive tool/thinking groups merged into cards
+        let bursts = Self.computeWorkBursts(
+            groups: groups,
+            contentOrder: message.contentOrder,
+            toolCalls: message.toolCalls,
+            thinkingSegments: message.thinkingSegments,
+            showThinking: showThinking,
+            isStreaming: message.isStreaming,
+            messageId: message.id
+        )
 
-        // Pre-compute which text groups should show deferred images from preceding tool group
-        let textGroupDeferredToolIndices: [String: [Int]] = {
-            var map: [String: [Int]] = [:]
-            for i in 0..<groups.count {
-                guard case .texts = groups[i] else { continue }
-                if i > 0, case .toolCalls(let tcIndices) = groups[i - 1],
-                   deferredImageGroupIds.contains(groups[i - 1].stableId) {
-                    map[groups[i].stableId] = tcIndices
+        // Map each participating group's stableId to its burst
+        let burstForGroup: [String: WorkBurst] = {
+            var map: [String: WorkBurst] = [:]
+            for burst in bursts {
+                let toolSet = Set(burst.toolIndices)
+                let thinkingSet = Set(burst.thinkingIndices)
+                for group in groups {
+                    switch group {
+                    case .toolCalls(let indices):
+                        if !Set(indices).isDisjoint(with: toolSet) {
+                            map[group.stableId] = burst
+                        }
+                    case .thinking(let indices):
+                        if !Set(indices).isDisjoint(with: thinkingSet) {
+                            map[group.stableId] = burst
+                        }
+                    default:
+                        continue
+                    }
                 }
             }
             return map
         }()
 
+        // The anchor group is the first group in each burst (renders the card)
+        let burstAnchorIds: Set<String> = Set(bursts.map(\.stableId))
+
+        // Identify the latest burst by stableId (last burst in the list)
+        let latestBurstId: String? = bursts.last?.stableId
+
+        // Compute hasTrailingText per-burst: true if any text group follows
+        // the burst's last tool call group in the groups array
+        let burstTrailingText: [String: Bool] = {
+            var result: [String: Bool] = [:]
+            for burst in bursts {
+                let burstToolSet = Set(burst.toolIndices)
+                // Find the last group index that belongs to this burst
+                var lastBurstGroupIdx: Int?
+                for (idx, group) in groups.enumerated() {
+                    switch group {
+                    case .toolCalls(let indices):
+                        if !Set(indices).isDisjoint(with: burstToolSet) {
+                            lastBurstGroupIdx = idx
+                        }
+                    case .thinking(let indices):
+                        let burstThinkingSet = Set(burst.thinkingIndices)
+                        if !Set(indices).isDisjoint(with: burstThinkingSet) {
+                            lastBurstGroupIdx = idx
+                        }
+                    default:
+                        break
+                    }
+                }
+                guard let lastIdx = lastBurstGroupIdx else {
+                    result[burst.stableId] = false
+                    continue
+                }
+                var found = false
+                if lastIdx + 1 < groups.count {
+                    for followingGroup in groups[(lastIdx + 1)...] {
+                        if case .texts = followingGroup {
+                            found = true
+                            break
+                        }
+                    }
+                }
+                result[burst.stableId] = found
+            }
+            return result
+        }()
+
         // Identify the last text group so attachments render right after it
-        // (inline with text) instead of at the very bottom after tool calls.
         let lastTextGroupId: String? = groups.last(where: {
             if case .texts = $0 { return true }
             return false
         })?.stableId
 
-
-        // Render all content groups in order: text, tool calls, and surfaces.
-        // Uses \.stableId (based on the first index in each group) so SwiftUI
-        // preserves @State (like isExpanded) when new items are appended to a
-        // group, and skips re-evaluating children whose identity hasn't changed.
+        // Render all content groups in order: text, burst cards, and surfaces.
         ForEach(groups, id: \.stableId) { group in
             switch group {
             case .texts(let indices):
@@ -414,40 +577,39 @@ extension ChatBubble {
                 if !joined.isEmpty {
                     textBubble(for: joined, textGroupIndex: indices.first ?? 0)
                 }
-                // Render deferred tool call images from the preceding tool group,
-                // so descriptive text appears before the screenshot it introduces.
-                if shouldRenderToolProgressInline,
-                   let deferredIndices = textGroupDeferredToolIndices[group.stableId] {
-                    let deferredCalls: [ToolCallData] = deferredIndices.compactMap { tcIdx in
-                        guard tcIdx < message.toolCalls.count else { return nil }
-                        return message.toolCalls[tcIdx]
-                    }
-                    inlineToolCallImages(from: deferredCalls)
-                }
-                // Render attachments right after the last text group so they
-                // appear inline with the text (like "Here's your SVG:" + image)
-                // instead of buried below tool call progress views.
+                // Render attachments right after the last text group
                 if group.stableId == lastTextGroupId {
                     inlineAttachments
                 }
             case .toolCalls(let indices):
                 if shouldRenderToolProgressInline {
-                    inlineToolProgress(
-                        toolIndices: indices,
-                        isLatestGroup: indices == latestToolGroup,
-                        hasTrailingText: cachedToolGroupsWithTrailingText.contains(group.stableId)
-                    )
-                    // Show images immediately when no text follows;
-                    // otherwise they are deferred to render after the next text group.
-                    if !deferredImageGroupIds.contains(group.stableId) {
-                        let toolCalls: [ToolCallData] = indices.compactMap { tcIdx in
+                    if burstAnchorIds.contains(group.stableId),
+                       let burst = burstForGroup[group.stableId] {
+                        // This group is the anchor for its burst — render the burst card
+                        inlineToolProgress(
+                            toolIndices: burst.toolIndices,
+                            isLatestGroup: burst.stableId == latestBurstId,
+                            hasTrailingText: burstTrailingText[burst.stableId] ?? false,
+                            expandedItems: burst.expandedItems.isEmpty ? nil : burst.expandedItems
+                        )
+                        // Render tool call images after the burst card
+                        let burstToolCalls: [ToolCallData] = burst.toolIndices.compactMap { tcIdx in
                             guard tcIdx < message.toolCalls.count else { return nil }
                             return message.toolCalls[tcIdx]
                         }
-                        inlineToolCallImages(from: toolCalls)
+                        inlineToolCallImages(from: burstToolCalls)
+                    } else if burstForGroup[group.stableId] != nil {
+                        // Part of a burst but not the anchor — skip rendering
+                        EmptyView()
+                    } else {
+                        // Not part of any burst (shouldn't happen for toolCalls, but fallback)
+                        inlineToolProgress(
+                            toolIndices: indices,
+                            isLatestGroup: false,
+                            hasTrailingText: false
+                        )
                     }
                 } else {
-                    // Tool calls are rendered by trailingStatus below the message
                     EmptyView()
                 }
             case .surface(let i):
@@ -456,21 +618,48 @@ extension ChatBubble {
                     InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction, onRefetch: onSurfaceRefetch)
                 }
             case .thinking(let indices):
-                let joined = indices
-                    .compactMap { i in
-                        i < message.thinkingSegments.count
-                            ? message.thinkingSegments[i]
-                            : nil
+                if burstForGroup[group.stableId] != nil {
+                    // Thinking folded into a burst — rendered by the burst anchor
+                    if burstAnchorIds.contains(group.stableId),
+                       let burst = burstForGroup[group.stableId] {
+                        // This thinking group is the anchor for its burst
+                        if shouldRenderToolProgressInline {
+                            inlineToolProgress(
+                                toolIndices: burst.toolIndices,
+                                isLatestGroup: burst.stableId == latestBurstId,
+                                hasTrailingText: burstTrailingText[burst.stableId] ?? false,
+                                expandedItems: burst.expandedItems.isEmpty ? nil : burst.expandedItems
+                            )
+                            let burstToolCalls: [ToolCallData] = burst.toolIndices.compactMap { tcIdx in
+                                guard tcIdx < message.toolCalls.count else { return nil }
+                                return message.toolCalls[tcIdx]
+                            }
+                            inlineToolCallImages(from: burstToolCalls)
+                        }
+                    } else {
+                        EmptyView()
                     }
-                    .filter { !$0.isEmpty }
-                    .joined(separator: "\n")
-                if !joined.isEmpty {
-                    ThinkingBlockView(
-                        content: joined,
-                        isStreaming: message.isStreaming,
-                        expansionKey: "\(message.id.uuidString)-th\(indices.first ?? 0)",
-                        typographyGeneration: typographyGeneration
-                    )
+                } else {
+                    // Standalone thinking (not adjacent to any tool calls) —
+                    // render as ThinkingBlockView (gated by feature flag)
+                    if showThinking {
+                        let joined = indices
+                            .compactMap { i in
+                                i < message.thinkingSegments.count
+                                    ? message.thinkingSegments[i]
+                                    : nil
+                            }
+                            .filter { !$0.isEmpty }
+                            .joined(separator: "\n")
+                        if !joined.isEmpty {
+                            ThinkingBlockView(
+                                content: joined,
+                                isStreaming: message.isStreaming,
+                                expansionKey: "\(message.id.uuidString)-th\(indices.first ?? 0)",
+                                typographyGeneration: typographyGeneration
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistantTests/WorkBurstComputationTests.swift
+++ b/clients/macos/vellum-assistantTests/WorkBurstComputationTests.swift
@@ -1,0 +1,480 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Tests for `ChatBubble.computeWorkBursts(...)` — verifies that consecutive
+/// tool-call and thinking groups are merged into work bursts, while text and
+/// surface groups create burst boundaries.
+@Suite("WorkBurst Computation")
+struct WorkBurstComputationTests {
+
+    // MARK: - Helpers
+
+    private static let messageId = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+
+    /// Creates a minimal ToolCallData with a deterministic UUID.
+    private static func makeToolCall(index: Int) -> ToolCallData {
+        let id = UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012d", index))")!
+        var tc = ToolCallData(
+            id: id,
+            toolName: "tool_\(index)",
+            inputSummary: "input \(index)"
+        )
+        tc.isComplete = true
+        tc.startedAt = Date(timeIntervalSince1970: 1000 + Double(index))
+        tc.completedAt = Date(timeIntervalSince1970: 1001 + Double(index))
+        return tc
+    }
+
+    private typealias ContentGroup = ChatBubble.ContentGroup
+
+    // MARK: - Single tool group -> one burst
+
+    @Test("Single tool group produces one burst")
+    func singleToolGroup() {
+        let groups: [ContentGroup] = [
+            .toolCalls([0, 1])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .toolCall(0), .toolCall(1)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0), Self.makeToolCall(index: 1)]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: [],
+            showThinking: false,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 1)
+        #expect(bursts[0].toolIndices == [0, 1])
+        #expect(bursts[0].thinkingIndices.isEmpty)
+        #expect(bursts[0].stableId == "tc0")
+        #expect(bursts[0].expandedItems.count == 2)
+    }
+
+    // MARK: - tool-text-tool -> two bursts
+
+    @Test("Tool-text-tool produces two bursts")
+    func toolTextTool() {
+        let groups: [ContentGroup] = [
+            .toolCalls([0]),
+            .texts([0]),
+            .toolCalls([1])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .toolCall(0), .text(0), .toolCall(1)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0), Self.makeToolCall(index: 1)]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: [],
+            showThinking: false,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 2)
+        #expect(bursts[0].toolIndices == [0])
+        #expect(bursts[0].stableId == "tc0")
+        #expect(bursts[1].toolIndices == [1])
+        #expect(bursts[1].stableId == "tc1")
+    }
+
+    // MARK: - thinking-tool-text-thinking-tool -> two bursts, thinking folded correctly
+
+    @Test("Thinking-tool-text-thinking-tool produces two bursts with thinking folded")
+    func thinkingToolTextThinkingTool() {
+        let groups: [ContentGroup] = [
+            .thinking([0]),
+            .toolCalls([0]),
+            .texts([0]),
+            .thinking([1]),
+            .toolCalls([1])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(0), .toolCall(0), .text(0), .thinking(1), .toolCall(1)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0), Self.makeToolCall(index: 1)]
+        let thinkingSegments = ["Thinking about first task...", "Thinking about second task..."]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: true,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 2)
+
+        // First burst: thinking[0] + tool[0]
+        #expect(bursts[0].toolIndices == [0])
+        #expect(bursts[0].thinkingIndices == [0])
+        #expect(bursts[0].stableId == "th0")
+        #expect(bursts[0].expandedItems.count == 2)
+        // Verify order: thinking first, then tool call
+        if case .thinking(let content, _, _) = bursts[0].expandedItems[0] {
+            #expect(content == "Thinking about first task...")
+        } else {
+            Issue.record("Expected thinking item at index 0")
+        }
+        if case .toolCall(let tc) = bursts[0].expandedItems[1] {
+            #expect(tc.toolName == "tool_0")
+        } else {
+            Issue.record("Expected tool call item at index 1")
+        }
+
+        // Second burst: thinking[1] + tool[1]
+        #expect(bursts[1].toolIndices == [1])
+        #expect(bursts[1].thinkingIndices == [1])
+        #expect(bursts[1].stableId == "th1")
+    }
+
+    // MARK: - Standalone thinking (no adjacent tools) -> not part of any burst
+
+    @Test("Standalone thinking without adjacent tools is not part of any burst")
+    func standaloneThinking() {
+        let groups: [ContentGroup] = [
+            .thinking([0]),
+            .texts([0]),
+            .toolCalls([0])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(0), .text(0), .toolCall(0)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0)]
+        let thinkingSegments = ["Standalone thought"]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: true,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        // Only one burst — the tool call. The thinking is standalone (separated by text).
+        #expect(bursts.count == 1)
+        #expect(bursts[0].toolIndices == [0])
+        #expect(bursts[0].thinkingIndices.isEmpty)
+        #expect(bursts[0].stableId == "tc0")
+    }
+
+    // MARK: - thinking-tool-tool-thinking-tool-text -> one burst with all items
+
+    @Test("Thinking-tool-tool-thinking-tool-text produces one burst with all items")
+    func thinkingToolToolThinkingToolText() {
+        let groups: [ContentGroup] = [
+            .thinking([0]),
+            .toolCalls([0, 1]),
+            .thinking([1]),
+            .toolCalls([2]),
+            .texts([0])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(0), .toolCall(0), .toolCall(1), .thinking(1), .toolCall(2), .text(0)
+        ]
+        let toolCalls = [
+            Self.makeToolCall(index: 0),
+            Self.makeToolCall(index: 1),
+            Self.makeToolCall(index: 2)
+        ]
+        let thinkingSegments = ["First thought", "Second thought"]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: true,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 1)
+        #expect(bursts[0].toolIndices == [0, 1, 2])
+        #expect(bursts[0].thinkingIndices == [0, 1])
+        #expect(bursts[0].stableId == "th0")
+
+        // Verify expandedItems order matches contentOrder
+        #expect(bursts[0].expandedItems.count == 5)
+        if case .thinking(let content, _, _) = bursts[0].expandedItems[0] {
+            #expect(content == "First thought")
+        } else {
+            Issue.record("Expected thinking at index 0")
+        }
+        if case .toolCall(let tc) = bursts[0].expandedItems[1] {
+            #expect(tc.toolName == "tool_0")
+        } else {
+            Issue.record("Expected tool_0 at index 1")
+        }
+        if case .toolCall(let tc) = bursts[0].expandedItems[2] {
+            #expect(tc.toolName == "tool_1")
+        } else {
+            Issue.record("Expected tool_1 at index 2")
+        }
+        if case .thinking(let content, _, _) = bursts[0].expandedItems[3] {
+            #expect(content == "Second thought")
+        } else {
+            Issue.record("Expected thinking at index 3")
+        }
+        if case .toolCall(let tc) = bursts[0].expandedItems[4] {
+            #expect(tc.toolName == "tool_2")
+        } else {
+            Issue.record("Expected tool_2 at index 4")
+        }
+    }
+
+    // MARK: - Empty content order -> no bursts
+
+    @Test("Empty content order produces no bursts")
+    func emptyContentOrder() {
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: [],
+            contentOrder: [],
+            toolCalls: [],
+            thinkingSegments: [],
+            showThinking: true,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.isEmpty)
+    }
+
+    // MARK: - expandedItems order matches contentOrder within each burst
+
+    @Test("Expanded items order matches contentOrder within each burst")
+    func expandedItemsOrderMatchesContentOrder() {
+        // Content order: think0, tool0, think1, tool1
+        // But groups merge consecutive types:
+        let groups: [ContentGroup] = [
+            .thinking([0]),
+            .toolCalls([0]),
+            .thinking([1]),
+            .toolCalls([1])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(0), .toolCall(0), .thinking(1), .toolCall(1)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0), Self.makeToolCall(index: 1)]
+        let thinkingSegments = ["Thought A", "Thought B"]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: true,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 1)
+        #expect(bursts[0].expandedItems.count == 4)
+
+        // Verify chronological order: think0, tool0, think1, tool1
+        if case .thinking(let content, _, _) = bursts[0].expandedItems[0] {
+            #expect(content == "Thought A")
+        } else {
+            Issue.record("Expected thinking 'Thought A' at index 0")
+        }
+        if case .toolCall(let tc) = bursts[0].expandedItems[1] {
+            #expect(tc.toolName == "tool_0")
+        } else {
+            Issue.record("Expected tool_0 at index 1")
+        }
+        if case .thinking(let content, _, _) = bursts[0].expandedItems[2] {
+            #expect(content == "Thought B")
+        } else {
+            Issue.record("Expected thinking 'Thought B' at index 2")
+        }
+        if case .toolCall(let tc) = bursts[0].expandedItems[3] {
+            #expect(tc.toolName == "tool_1")
+        } else {
+            Issue.record("Expected tool_1 at index 3")
+        }
+    }
+
+    // MARK: - showThinking flag gates thinking items
+
+    @Test("Thinking items are excluded when showThinking is false")
+    func showThinkingFlagGatesThinking() {
+        let groups: [ContentGroup] = [
+            .thinking([0]),
+            .toolCalls([0])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(0), .toolCall(0)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0)]
+        let thinkingSegments = ["Some thought"]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: false,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 1)
+        // Thinking is in the burst's thinkingIndices (for grouping) but not in expandedItems
+        #expect(bursts[0].thinkingIndices == [0])
+        #expect(bursts[0].expandedItems.count == 1)
+        if case .toolCall = bursts[0].expandedItems[0] {
+            // Good — only tool call present
+        } else {
+            Issue.record("Expected only tool call in expanded items when showThinking is false")
+        }
+    }
+
+    // MARK: - isStreaming only applies to last burst thinking items
+
+    @Test("isStreaming flag only applies to thinking items in the last burst")
+    func streamingOnlyLastBurst() {
+        let groups: [ContentGroup] = [
+            .thinking([0]),
+            .toolCalls([0]),
+            .texts([0]),
+            .thinking([1]),
+            .toolCalls([1])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(0), .toolCall(0), .text(0), .thinking(1), .toolCall(1)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0), Self.makeToolCall(index: 1)]
+        let thinkingSegments = ["First thought", "Second thought"]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: true,
+            isStreaming: true,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 2)
+
+        // First burst's thinking should NOT be streaming
+        if case .thinking(_, _, let isStreaming) = bursts[0].expandedItems[0] {
+            #expect(!isStreaming)
+        } else {
+            Issue.record("Expected thinking item in first burst")
+        }
+
+        // Second burst's thinking SHOULD be streaming
+        if case .thinking(_, _, let isStreaming) = bursts[1].expandedItems[0] {
+            #expect(isStreaming)
+        } else {
+            Issue.record("Expected thinking item in second burst")
+        }
+    }
+
+    // MARK: - Empty thinking segments are skipped
+
+    @Test("Empty thinking segments are not included in expanded items")
+    func emptyThinkingSegmentsSkipped() {
+        let groups: [ContentGroup] = [
+            .thinking([0]),
+            .toolCalls([0])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(0), .toolCall(0)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0)]
+        let thinkingSegments = [""]  // Empty segment
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: true,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 1)
+        // Only tool call — empty thinking is skipped
+        #expect(bursts[0].expandedItems.count == 1)
+    }
+
+    // MARK: - Expansion key format
+
+    @Test("Thinking expansion keys use correct format")
+    func thinkingExpansionKeyFormat() {
+        let groups: [ContentGroup] = [
+            .thinking([3]),
+            .toolCalls([0])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .thinking(3), .toolCall(0)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0)]
+        let thinkingSegments = ["", "", "", "Third thought"]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: thinkingSegments,
+            showThinking: true,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 1)
+        if case .thinking(_, let key, _) = bursts[0].expandedItems[0] {
+            #expect(key == "\(Self.messageId.uuidString)-th3")
+        } else {
+            Issue.record("Expected thinking item with correct expansion key")
+        }
+    }
+
+    // MARK: - Surface group flushes burst
+
+    @Test("Surface groups flush the current burst like text groups")
+    func surfaceFlushBurst() {
+        let groups: [ContentGroup] = [
+            .toolCalls([0]),
+            .surface(0),
+            .toolCalls([1])
+        ]
+        let contentOrder: [ContentBlockRef] = [
+            .toolCall(0), .surface(0), .toolCall(1)
+        ]
+        let toolCalls = [Self.makeToolCall(index: 0), Self.makeToolCall(index: 1)]
+
+        let bursts = ChatBubble.computeWorkBursts(
+            groups: groups,
+            contentOrder: contentOrder,
+            toolCalls: toolCalls,
+            thinkingSegments: [],
+            showThinking: false,
+            isStreaming: false,
+            messageId: Self.messageId
+        )
+
+        #expect(bursts.count == 2)
+        #expect(bursts[0].toolIndices == [0])
+        #expect(bursts[1].toolIndices == [1])
+    }
+}


### PR DESCRIPTION
## Summary
- Replace per-tool-group progress cards with burst-based cards: consecutive tool calls and thinking groups merge into a single card per work burst
- Text chunks between tool activity create natural burst boundaries — each burst gets its own "Worked for X.Ys" card
- Expanding a burst card shows the full chronological trace of thinking and tool calls
- Add WorkBurstComputationTests with unit tests for burst computation logic

Part of plan: burst-progress-model.md (PR 3 of 4)