### PR TITLE
fix: only mark last thinking item as streaming + remove dead trailingTextIds

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -198,22 +198,9 @@ struct ChatBubble: View, Equatable {
                 )
                 _cachedContentGroups = State(initialValue: groups)
 
-                var trailingTextIds = Set<String>()
-                for group in groups {
-                    guard case .toolCalls(let indices) = group else { continue }
-                    if Self.computeHasTextAfterToolGroupStatic(
-                        toolIndices: indices,
-                        contentOrder: message.contentOrder,
-                        textSegments: message.textSegments,
-                        hasText: !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ) {
-                        trailingTextIds.insert(group.stableId)
-                    }
-                }
-
                 // Store in static cache for future init() calls
                 Self.storeInterleavedResult(
-                    InterleavedCacheValue(hasInterleaved: interleaved, groups: groups, trailingTextIds: trailingTextIds),
+                    InterleavedCacheValue(hasInterleaved: interleaved, groups: groups),
                     for: message
                 )
             } else {
@@ -221,7 +208,7 @@ struct ChatBubble: View, Equatable {
 
                 // Store non-interleaved result in static cache
                 Self.storeInterleavedResult(
-                    InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
+                    InterleavedCacheValue(hasInterleaved: false, groups: []),
                     for: message
                 )
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -148,15 +148,21 @@ extension ChatBubble {
         // Flush any trailing burst
         flushBurst()
 
-        // Set isStreaming on thinking items in the last burst only
+        // Set isStreaming on the LAST thinking item in the last burst only.
+        // Earlier thinking blocks in the same burst are already complete
+        // (there's a tool call after them).
         if isStreaming, var lastBurst = bursts.last {
-            lastBurst.expandedItems = lastBurst.expandedItems.map { item in
-                if case .thinking(let content, let key, _) = item {
-                    return .thinking(content: content, expansionKey: key, isStreaming: true)
+            if let lastThinkingIdx = lastBurst.expandedItems.lastIndex(where: {
+                if case .thinking = $0 { return true }
+                return false
+            }) {
+                if case .thinking(let content, let key, _) = lastBurst.expandedItems[lastThinkingIdx] {
+                    lastBurst.expandedItems[lastThinkingIdx] = .thinking(
+                        content: content, expansionKey: key, isStreaming: true
+                    )
                 }
-                return item
+                bursts[bursts.count - 1] = lastBurst
             }
-            bursts[bursts.count - 1] = lastBurst
         }
 
         return bursts
@@ -175,7 +181,6 @@ extension ChatBubble {
     struct InterleavedCacheValue {
         let hasInterleaved: Bool
         let groups: [ContentGroup]
-        let trailingTextIds: Set<String>
     }
 
     /// Static cache of interleaved content computation results. For completed
@@ -238,7 +243,7 @@ extension ChatBubble {
             }
             // Update static cache with non-interleaved result
             Self.storeInterleavedResult(
-                InterleavedCacheValue(hasInterleaved: false, groups: [], trailingTextIds: []),
+                InterleavedCacheValue(hasInterleaved: false, groups: []),
                 for: message
             )
             return
@@ -249,20 +254,6 @@ extension ChatBubble {
             hasInterleavedContent: interleaved
         )
 
-        // Pre-compute which tool-call groups have trailing text so that
-        // the static cache can store them for future init() calls.
-        var trailingTextIds = Set<String>()
-        for group in groups {
-            guard case .toolCalls(let indices) = group else { continue }
-            if Self.computeHasTextAfterToolGroupStatic(
-                toolIndices: indices,
-                contentOrder: message.contentOrder,
-                textSegments: message.textSegments,
-                hasText: hasText
-            ) {
-                trailingTextIds.insert(group.stableId)
-            }
-        }
         if !cachedHasInterleavedContent {
             cachedHasInterleavedContent = true
         }
@@ -272,7 +263,7 @@ extension ChatBubble {
 
         // Update static cache so the next init() for this message uses fresh values
         Self.storeInterleavedResult(
-            InterleavedCacheValue(hasInterleaved: interleaved, groups: groups, trailingTextIds: trailingTextIds),
+            InterleavedCacheValue(hasInterleaved: interleaved, groups: groups),
             for: message
         )
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for burst-progress-model.md.

**Gap 1:** isStreaming was marking ALL thinking items in the last burst as streaming. Now only the last thinking item gets isStreaming: true.
**Gap 2:** Removed dead trailingTextIds field and computation from InterleavedCacheValue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->