### PR TITLE
feat(cli): platformRequestSignedUrl emits/handles version-compat fields

### DIFF
--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   platformPollJobStatus,
   platformRequestSignedUrl,
+  VersionMismatchError,
   type UnifiedJobStatus,
 } from "../platform-client.js";
 
@@ -289,6 +290,240 @@ describe("platformRequestSignedUrl", () => {
     // Session tokens use X-Session-Token, not Bearer.
     expect(signedUrlCalls[0]!.headers["X-Session-Token"]).toBe(SESSION_TOKEN);
     expect(signedUrlCalls[0]!.headers.Authorization).toBeUndefined();
+  });
+
+  test("upload operation with min/max runtime versions → posts them in body", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/v",
+          bundle_key: "bundles/v.tar.gz",
+          expires_at: "2026-04-22T05:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    await platformRequestSignedUrl(
+      {
+        operation: "upload",
+        minRuntimeVersion: "1.2.3",
+        maxRuntimeVersion: null,
+      },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(calls[0]!.body).toEqual({
+      operation: "upload",
+      min_runtime_version: "1.2.3",
+      max_runtime_version: null,
+    });
+  });
+
+  test("download operation with target_runtime_version → posts it in body", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/dl-v",
+          bundle_key: "bundles/dl-v.tar.gz",
+          expires_at: "2026-04-22T06:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    await platformRequestSignedUrl(
+      {
+        operation: "download",
+        bundleKey: "bundles/dl-v.tar.gz",
+        targetRuntimeVersion: "2.0.0",
+      },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(calls[0]!.body).toEqual({
+      operation: "download",
+      bundle_key: "bundles/dl-v.tar.gz",
+      target_runtime_version: "2.0.0",
+    });
+  });
+
+  test("download 422 with version_mismatch body → throws VersionMismatchError", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          reason: "version_mismatch",
+          bundle_compat: {
+            min_runtime_version: "2.0.0",
+            max_runtime_version: "2.5.0",
+          },
+          target_runtime_version: "1.9.0",
+        }),
+        { status: 422 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey: "bundles/foo.tar.gz",
+          targetRuntimeVersion: "1.9.0",
+        },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(VersionMismatchError);
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as VersionMismatchError;
+    expect(err.bundleCompat).toEqual({
+      min_runtime_version: "2.0.0",
+      max_runtime_version: "2.5.0",
+    });
+    expect(err.targetRuntimeVersion).toBe("1.9.0");
+    expect(err.message).toBe(
+      "Cannot import: bundle requires runtime 2.0.0–2.5.0, but this runtime is 1.9.0. Update your runtime before importing.",
+    );
+  });
+
+  test("download 422 with version_mismatch and null max_runtime_version → '+' suffix in message", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          reason: "version_mismatch",
+          bundle_compat: {
+            min_runtime_version: "3.0.0",
+            max_runtime_version: null,
+          },
+          target_runtime_version: "2.9.0",
+        }),
+        { status: 422 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey: "bundles/foo.tar.gz",
+          targetRuntimeVersion: "2.9.0",
+        },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(VersionMismatchError);
+    const err = caught as VersionMismatchError;
+    expect(err.message).toBe(
+      "Cannot import: bundle requires runtime 3.0.0+, but this runtime is 2.9.0. Update your runtime before importing.",
+    );
+  });
+
+  test("download 422 with arbitrary body (no reason field) → falls through to generic Error", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ detail: "validation failed" }), {
+        status: 422,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        { operation: "download", bundleKey: "bundles/foo.tar.gz" },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(VersionMismatchError);
+    expect((caught as Error).message).toBe("validation failed");
+  });
+
+  test("422 is NOT retried after a 401", async () => {
+    let callCount = 0;
+    const { calls, fetchMock } = captureFetch(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ detail: "unauthorized" }), {
+          status: 401,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          reason: "version_mismatch",
+          bundle_compat: {
+            min_runtime_version: "2.0.0",
+            max_runtime_version: "2.5.0",
+          },
+          target_runtime_version: "1.9.0",
+        }),
+        { status: 422 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey: "bundles/foo.tar.gz",
+          targetRuntimeVersion: "1.9.0",
+        },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(calls).toHaveLength(2);
+    expect(caught).toBeInstanceOf(VersionMismatchError);
+  });
+
+  test("non-422 download path remains unchanged (regression pin on body shape)", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/dl-xyz",
+          bundle_key: "bundles/xyz.tar.gz",
+          expires_at: "2026-04-22T02:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "download", bundleKey: "bundles/xyz.tar.gz" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.url).toBe("https://storage.example/signed/dl-xyz");
+    expect(calls[0]!.body).toEqual({
+      operation: "download",
+      bundle_key: "bundles/xyz.tar.gz",
+    });
   });
 
   test("5xx error response → surfaces platform detail message", async () => {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -806,6 +806,45 @@ export function parseUnifiedJobStatus(
   };
 }
 
+export interface BundleCompatibility {
+  min_runtime_version: string;
+  max_runtime_version: string | null;
+}
+
+/**
+ * Thrown by platformRequestSignedUrl when the platform rejects a download
+ * signed-URL request because the target runtime version is outside the
+ * ExportJob's [min_runtime_version, max_runtime_version] band. Terminal
+ * — callers must NOT retry; surface to the user and abort the
+ * teleport/restore wizard.
+ */
+export class VersionMismatchError extends Error {
+  readonly bundleCompat: BundleCompatibility;
+  readonly targetRuntimeVersion: string;
+
+  constructor(bundleCompat: BundleCompatibility, targetRuntimeVersion: string) {
+    super(
+      VersionMismatchError.formatMessage(bundleCompat, targetRuntimeVersion),
+    );
+    this.name = "VersionMismatchError";
+    this.bundleCompat = bundleCompat;
+    this.targetRuntimeVersion = targetRuntimeVersion;
+  }
+
+  static formatMessage(
+    compat: BundleCompatibility,
+    targetRuntimeVersion: string,
+  ): string {
+    const range = compat.max_runtime_version
+      ? `${compat.min_runtime_version}–${compat.max_runtime_version}`
+      : `${compat.min_runtime_version}+`;
+    return (
+      `Cannot import: bundle requires runtime ${range}, but this runtime is ${targetRuntimeVersion}. ` +
+      `Update your runtime before importing.`
+    );
+  }
+}
+
 /**
  * Request a signed URL from the platform for either uploading a new bundle
  * or downloading an existing one. Calls `POST /v1/migrations/signed-url/`.
@@ -817,6 +856,9 @@ export function parseUnifiedJobStatus(
  *
  * Retries once with a fresh org-ID cache on 401 to match the retry pattern
  * used by other authenticated platform helpers.
+ *
+ * Throws {@link VersionMismatchError} on a 422 `version_mismatch` response,
+ * which is terminal — callers must NOT retry.
  */
 export async function platformRequestSignedUrl(
   params: {
@@ -824,6 +866,11 @@ export async function platformRequestSignedUrl(
     bundleKey?: string;
     contentType?: string;
     contentLength?: number;
+    // Source-side, upload only: runtime version that produced the bundle.
+    minRuntimeVersion?: string;
+    maxRuntimeVersion?: string | null;
+    // Target-side, download only: runtime version that will import.
+    targetRuntimeVersion?: string;
   },
   token: string,
   platformUrl?: string,
@@ -839,6 +886,17 @@ export async function platformRequestSignedUrl(
   if (params.contentType !== undefined) body.content_type = params.contentType;
   if (params.contentLength !== undefined) {
     body.content_length = params.contentLength;
+  }
+  if (params.minRuntimeVersion !== undefined) {
+    body.min_runtime_version = params.minRuntimeVersion;
+  }
+  if (params.maxRuntimeVersion !== undefined) {
+    // Explicit null is the documented "no upper bound" sentinel; keep it
+    // in the payload rather than stripping to undefined.
+    body.max_runtime_version = params.maxRuntimeVersion;
+  }
+  if (params.targetRuntimeVersion !== undefined) {
+    body.target_runtime_version = params.targetRuntimeVersion;
   }
 
   const doRequest = async (): Promise<Response> =>
@@ -874,9 +932,28 @@ export async function platformRequestSignedUrl(
     };
   }
 
+  // Non-success body. Read once and reuse for both the 422 version-mismatch
+  // branch and the generic-error fallthrough — `response.json()` consumes
+  // the body, so a second read would always return undefined.
   const errorBody = (await response.json().catch(() => ({}))) as {
     detail?: string;
+    reason?: string;
+    bundle_compat?: BundleCompatibility;
+    target_runtime_version?: string;
   };
+
+  if (
+    response.status === 422 &&
+    errorBody.reason === "version_mismatch" &&
+    errorBody.bundle_compat &&
+    typeof errorBody.target_runtime_version === "string"
+  ) {
+    throw new VersionMismatchError(
+      errorBody.bundle_compat,
+      errorBody.target_runtime_version,
+    );
+  }
+
   throw new Error(
     errorBody.detail ??
       `Failed to request signed URL: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
## Summary
- Adds optional version fields (`minRuntimeVersion`, `maxRuntimeVersion`, `targetRuntimeVersion`) to `platformRequestSignedUrl` — additive, existing callers unaffected.
- Adds `VersionMismatchError` class with the exact `Cannot import: …` template message PR 4 will surface to users.
- Detects platform PR #5470's 422 `version_mismatch` response and throws `VersionMismatchError`; treats 422 as terminal (no retry).

Part of plan: vbundle-version-gate.md (PR 2 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->