### PR TITLE
feat(migrations): add evaluateRuntimeCompatibility predicate to vbundle-import-policy

### DIFF
--- a/assistant/src/backup/restore.ts
+++ b/assistant/src/backup/restore.ts
@@ -44,6 +44,7 @@ import { join } from "node:path";
 
 import { resetDb } from "../memory/db-connection.js";
 import type { PathResolver } from "../runtime/migrations/vbundle-import-analyzer.js";
+import { formatRuntimeCompatibilityMessage } from "../runtime/migrations/vbundle-import-policy.js";
 import { commitImport } from "../runtime/migrations/vbundle-importer.js";
 import type { ManifestType } from "../runtime/migrations/vbundle-validator.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
@@ -239,6 +240,12 @@ export async function restoreFromSnapshot(
         case "extraction_failed":
         case "write_failed":
           message = commitResult.message;
+          break;
+        case "version_incompatible":
+          message = formatRuntimeCompatibilityMessage(
+            commitResult.bundle_compat,
+            commitResult.runtime_version,
+          );
           break;
       }
       throw new Error(`Snapshot restore failed: ${message}`);

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
@@ -8,8 +8,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  compareSemver,
   CONFIG_ARCHIVE_PATHS,
   CREDENTIAL_METADATA_ARCHIVE_PATH,
+  evaluateRuntimeCompatibility,
   isConfigArchivePath,
   isCredentialMetadataArchivePath,
   isLegacyPersonaArchivePath,
@@ -122,5 +124,95 @@ describe("partitionWorkspacePreserveSkipDirs", () => {
     expect(dataSubdirSkipDirs.size).toBe(2);
     expect(dataSubdirSkipDirs.has("db")).toBe(true);
     expect(dataSubdirSkipDirs.has("qdrant")).toBe(true);
+  });
+});
+
+describe("compareSemver", () => {
+  test("0.10.0 > 0.9.0 (numeric, not lexical)", () => {
+    expect(compareSemver("0.10.0", "0.9.0")).toBe(1);
+  });
+
+  test("equal triples return 0", () => {
+    expect(compareSemver("0.7.1", "0.7.1")).toBe(0);
+  });
+
+  test("smaller patch returns -1", () => {
+    expect(compareSemver("0.7.0", "0.7.1")).toBe(-1);
+  });
+
+  test("prerelease tag is stripped (treated as base release)", () => {
+    expect(compareSemver("0.7.1-staging.1", "0.7.1")).toBe(0);
+  });
+
+  test("non-version string returns null", () => {
+    expect(compareSemver("not-a-version", "0.7.1")).toBe(null);
+  });
+
+  test("two-part version returns null", () => {
+    expect(compareSemver("1.2", "0.7.1")).toBe(null);
+  });
+});
+
+describe("evaluateRuntimeCompatibility", () => {
+  test("legacy sentinel passes regardless of runtime version", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.0.0-legacy", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  test("runtime above min with no max passes", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.7.0", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  test("runtime below min fails with full echo", () => {
+    const compat = {
+      min_runtime_version: "0.8.0",
+      max_runtime_version: null,
+    };
+    expect(evaluateRuntimeCompatibility(compat, "0.7.1")).toEqual({
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compat,
+      runtime_version: "0.7.1",
+    });
+  });
+
+  test("runtime above max fails", () => {
+    const compat = {
+      min_runtime_version: "0.7.0",
+      max_runtime_version: "0.7.5",
+    };
+    expect(evaluateRuntimeCompatibility(compat, "0.8.0")).toEqual({
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compat,
+      runtime_version: "0.8.0",
+    });
+  });
+
+  test("max is inclusive", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.7.0", max_runtime_version: "0.7.5" },
+        "0.7.5",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  test("unparsable min skips the gate (fail-open)", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "garbage", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
   });
 });

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
@@ -151,6 +151,34 @@ describe("compareSemver", () => {
   test("two-part version returns null", () => {
     expect(compareSemver("1.2", "0.7.1")).toBe(null);
   });
+
+  // Regression: Number.parseInt accepts numeric prefixes and ignores
+  // trailing junk ("0foo" → 0), which previously coerced malformed
+  // triples through the gate. parseSemverTriple now requires each
+  // component to match /^\d+$/ exactly.
+  test("trailing junk on a component returns null (left arg)", () => {
+    expect(compareSemver("0.8.0foo", "0.8.0")).toBe(null);
+  });
+
+  test("trailing junk on a component returns null (right arg)", () => {
+    expect(compareSemver("0.8.0", "0.7.1xyz")).toBe(null);
+  });
+
+  // Leading zeros are accepted: "01.02.03" parses to the same numeric
+  // triple as "1.2.3" since Number("01") === 1. We pin this behavior
+  // so a future tightening doesn't accidentally regress callers that
+  // pass zero-padded versions from upstream tooling.
+  test("leading zeros parse equal to un-padded triple", () => {
+    expect(compareSemver("01.02.03", "1.2.3")).toBe(0);
+  });
+
+  test("leading whitespace returns null", () => {
+    expect(compareSemver(" 0.8.0", "0.8.0")).toBe(null);
+  });
+
+  test("negative component returns null", () => {
+    expect(compareSemver("0.8.-1", "0.8.0")).toBe(null);
+  });
 });
 
 describe("evaluateRuntimeCompatibility", () => {
@@ -211,6 +239,20 @@ describe("evaluateRuntimeCompatibility", () => {
     expect(
       evaluateRuntimeCompatibility(
         { min_runtime_version: "garbage", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  // Regression for Codex feedback: a malformed min like "0.8.0foo"
+  // previously coerced to [0, 8, 0] via Number.parseInt and incorrectly
+  // produced a version_incompatible decision against runtime "0.7.1".
+  // With strict per-component digit matching, the parse fails and the
+  // gate fails open.
+  test("malformed min with trailing junk fails open, does not block", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.8.0foo", max_runtime_version: null },
         "0.7.1",
       ),
     ).toEqual({ ok: true });

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -89,7 +89,14 @@ function parseSemverTriple(version: string): SemverTriple | null {
   const base = version.split(/[-+]/)[0] ?? version;
   const parts = base.split(".");
   if (parts.length !== 3) return null;
-  const [maj, min, pat] = parts.map((p) => Number.parseInt(p, 10));
+  // Reject components with anything other than ASCII digits to avoid
+  // Number.parseInt's lenient prefix-parse — e.g. "0.8.0foo" would
+  // otherwise coerce to [0, 8, 0] and silently pass the gate, defeating
+  // the parse-failure-fail-open contract in evaluateRuntimeCompatibility.
+  // Leading zeros (e.g. "01.02.03") are intentionally accepted since
+  // they round-trip to the same numeric triple as the un-padded form.
+  if (!parts.every((p) => /^\d+$/.test(p))) return null;
+  const [maj, min, pat] = parts.map((p) => Number(p));
   if (![maj, min, pat].every((n) => Number.isFinite(n) && n >= 0)) {
     return null;
   }

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -73,3 +73,93 @@ export function partitionWorkspacePreserveSkipDirs(): {
   }
   return { topLevelSkipDirs, dataSubdirSkipDirs };
 }
+
+export const LEGACY_RUNTIME_VERSION_SENTINEL = "0.0.0-legacy";
+
+type SemverTriple = readonly [number, number, number];
+
+function parseSemverTriple(version: string): SemverTriple | null {
+  // Strip optional prerelease/build suffix ("-foo", "+sha"). We treat
+  // "0.7.1-staging.1" as equal-to-release "0.7.1" for gating purposes.
+  // The platform-side check uses packaging.version.Version, which sorts
+  // prereleases BEFORE the corresponding release; matching that exactly
+  // would require a fuller parser — for runtime-side defense-in-depth
+  // this conservative read is sufficient (matches release of the same
+  // base triple).
+  const base = version.split(/[-+]/)[0] ?? version;
+  const parts = base.split(".");
+  if (parts.length !== 3) return null;
+  const [maj, min, pat] = parts.map((p) => Number.parseInt(p, 10));
+  if (![maj, min, pat].every((n) => Number.isFinite(n) && n >= 0)) {
+    return null;
+  }
+  return [maj!, min!, pat!] as const;
+}
+
+// -1 if a < b, 0 if equal, +1 if a > b. Returns null on parse failure.
+export function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
+  const ta = parseSemverTriple(a);
+  const tb = parseSemverTriple(b);
+  if (!ta || !tb) return null;
+  for (let i = 0; i < 3; i++) {
+    if (ta[i]! < tb[i]!) return -1;
+    if (ta[i]! > tb[i]!) return +1;
+  }
+  return 0;
+}
+
+export interface RuntimeCompatibility {
+  min_runtime_version: string;
+  max_runtime_version: string | null;
+}
+
+export type RuntimeCompatibilityResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "version_incompatible";
+      bundle_compat: RuntimeCompatibility;
+      runtime_version: string;
+    };
+
+export function formatRuntimeCompatibilityMessage(
+  compat: RuntimeCompatibility,
+  runtimeVersion: string,
+): string {
+  const range = compat.max_runtime_version
+    ? `${compat.min_runtime_version}..${compat.max_runtime_version}`
+    : `${compat.min_runtime_version}+`;
+  return `Bundle requires runtime ${range} but runtime is ${runtimeVersion}`;
+}
+
+export function evaluateRuntimeCompatibility(
+  compat: RuntimeCompatibility,
+  runtimeVersion: string,
+): RuntimeCompatibilityResult {
+  if (compat.min_runtime_version === LEGACY_RUNTIME_VERSION_SENTINEL) {
+    return { ok: true };
+  }
+  const minCmp = compareSemver(runtimeVersion, compat.min_runtime_version);
+  if (minCmp === null) return { ok: true };
+  if (minCmp < 0) {
+    return {
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compat,
+      runtime_version: runtimeVersion,
+    };
+  }
+  if (compat.max_runtime_version !== null) {
+    const maxCmp = compareSemver(runtimeVersion, compat.max_runtime_version);
+    if (maxCmp === null) return { ok: true };
+    if (maxCmp > 0) {
+      return {
+        ok: false,
+        reason: "version_incompatible",
+        bundle_compat: compat,
+        runtime_version: runtimeVersion,
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -88,6 +88,15 @@ export type ImportCommitResult =
   | { ok: false; reason: "extraction_failed"; message: string }
   | {
       ok: false;
+      reason: "version_incompatible";
+      bundle_compat: {
+        min_runtime_version: string;
+        max_runtime_version: string | null;
+      };
+      runtime_version: string;
+    }
+  | {
+      ok: false;
       reason: "write_failed";
       message: string;
       partial_report?: ImportCommitReport;

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -65,6 +65,7 @@ import {
   analyzeImport,
   DefaultPathResolver,
 } from "../migrations/vbundle-import-analyzer.js";
+import { formatRuntimeCompatibilityMessage } from "../migrations/vbundle-import-policy.js";
 import {
   commitImport,
   extractCredentialsFromBundle,
@@ -1014,6 +1015,7 @@ interface GcsImportErrorInit {
     | "fetch_failed"
     | "validation_failed"
     | "extraction_failed"
+    | "version_incompatible"
     | "write_failed";
   message: string;
   upstreamStatus?: number;
@@ -1340,6 +1342,18 @@ async function runGcsImport(
       throw new GcsImportError({
         code: "extraction_failed",
         message: result.message,
+        reason: result.reason,
+      });
+    }
+    if (result.reason === "version_incompatible") {
+      // Wired by PR 5 — until then the importer never returns this variant,
+      // but we narrow explicitly to keep the union exhaustive.
+      throw new GcsImportError({
+        code: "version_incompatible",
+        message: formatRuntimeCompatibilityMessage(
+          result.bundle_compat,
+          result.runtime_version,
+        ),
         reason: result.reason,
       });
     }
@@ -1672,6 +1686,17 @@ function throwImportCommitFailure(
 
   if (result.reason === "extraction_failed") {
     throw new InternalError(result.message);
+  }
+
+  if (result.reason === "version_incompatible") {
+    // Wired by PR 5 — until then the importer never returns this variant,
+    // but we narrow explicitly to keep the union exhaustive.
+    throw new InternalError(
+      formatRuntimeCompatibilityMessage(
+        result.bundle_compat,
+        result.runtime_version,
+      ),
+    );
   }
 
   // write_failed


### PR DESCRIPTION
## Summary
- Adds `evaluateRuntimeCompatibility` and `compareSemver` to `vbundle-import-policy` — pure, no node:fs, no async, no new deps.
- Widens `ImportCommitResult` with the `version_incompatible` variant so PRs 5 and 6 can wire the runtime-side check in parallel.
- New unit tests pin the `0.10.0 > 0.9.0` regression and the legacy-sentinel passthrough.

Part of plan: vbundle-version-gate.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->