### PR TITLE
feat(cli): source CLIs emit min/max runtime version on signed-URL upload

### DIFF
--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -201,7 +201,11 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
 
     // Upload-URL request to the platform.
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-      expect.objectContaining({ operation: "upload" }),
+      expect.objectContaining({
+        operation: "upload",
+        minRuntimeVersion: expect.any(String),
+        maxRuntimeVersion: null,
+      }),
       "platform-token",
       "https://platform.vellum.ai",
     );
@@ -306,7 +310,11 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
     // runtimeUrl. The signed URLs returned by the platform target the
     // GCS bucket the runtime can reach, not the default platform's.
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-      expect.objectContaining({ operation: "upload" }),
+      expect.objectContaining({
+        operation: "upload",
+        minRuntimeVersion: expect.any(String),
+        maxRuntimeVersion: null,
+      }),
       "platform-token",
       "https://staging-platform.vellum.ai",
     );

--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -64,6 +64,11 @@ const localRuntimeExportToGcsMock = spyOn(
   "localRuntimeExportToGcs",
 ).mockResolvedValue({ jobId: "platform-export-job-1" });
 
+const localRuntimeIdentityMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeIdentity",
+).mockResolvedValue({ version: "0.6.5" });
+
 const localRuntimePollJobStatusMock = spyOn(
   localRuntimeClient,
   "localRuntimePollJobStatus",
@@ -138,6 +143,8 @@ beforeEach(() => {
   localRuntimeExportToGcsMock.mockResolvedValue({
     jobId: "platform-export-job-1",
   });
+  localRuntimeIdentityMock.mockReset();
+  localRuntimeIdentityMock.mockResolvedValue({ version: "0.6.5" });
   localRuntimePollJobStatusMock.mockReset();
   localRuntimePollJobStatusMock.mockResolvedValue({
     jobId: "platform-export-job-1",
@@ -165,6 +172,7 @@ afterAll(() => {
   getPlatformUrlMock.mockRestore();
   platformRequestSignedUrlMock.mockRestore();
   localRuntimeExportToGcsMock.mockRestore();
+  localRuntimeIdentityMock.mockRestore();
   localRuntimePollJobStatusMock.mockRestore();
   getBackupsDirMock.mockRestore();
   mkdirSyncMock.mockRestore();
@@ -203,7 +211,7 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
       expect.objectContaining({
         operation: "upload",
-        minRuntimeVersion: expect.any(String),
+        minRuntimeVersion: "0.6.5",
         maxRuntimeVersion: null,
       }),
       "platform-token",
@@ -312,7 +320,7 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
       expect.objectContaining({
         operation: "upload",
-        minRuntimeVersion: expect.any(String),
+        minRuntimeVersion: "0.6.5",
         maxRuntimeVersion: null,
       }),
       "platform-token",
@@ -476,6 +484,92 @@ describe("vellum backup <platform-managed>: failure cases", () => {
             m.includes("403"),
         ),
       ).toBe(true);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source-runtime version is sourced from the daemon, not the CLI
+// (Codex P1 regression guard for PR #29436)
+// ---------------------------------------------------------------------------
+describe("upload signed-URL records source runtime version (not CLI version)", () => {
+  test("identity is fetched BEFORE the upload signed-URL request", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    const callOrder: string[] = [];
+    localRuntimeIdentityMock.mockImplementationOnce(async () => {
+      callOrder.push("identity");
+      return { version: "0.5.9" };
+    });
+    platformRequestSignedUrlMock.mockImplementationOnce(async (params) => {
+      callOrder.push("signed-url");
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "uploads/org-1/bundle-abc.vbundle",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    mockGcsDownload(new Uint8Array([1]));
+
+    await backup();
+
+    expect(callOrder[0]).toBe("identity");
+    expect(callOrder[1]).toBe("signed-url");
+
+    expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "upload",
+        minRuntimeVersion: "0.5.9",
+        maxRuntimeVersion: null,
+      }),
+      "platform-token",
+      "https://platform.vellum.ai",
+    );
+  });
+
+  test("identity is fetched against the platform-managed runtime entry with the platform token", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    mockGcsDownload(new Uint8Array([1]));
+
+    await backup();
+
+    expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloud: "vellum",
+        runtimeUrl: "https://platform.vellum.ai",
+        assistantId: "11111111-2222-3333-4444-555555555555",
+      }),
+      "platform-token",
+    );
+  });
+
+  test("identity fetch failure aborts before signed-URL request", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Failed to fetch runtime identity: 503 Service Unavailable"),
+    );
+
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => undefined,
+    );
+    try {
+      await expect(backup()).rejects.toThrow("process.exit:1");
+
+      // Signed-URL must NOT have been requested.
+      expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not fetch runtime identity"),
+      );
     } finally {
       consoleErrorSpy.mockRestore();
     }

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -191,6 +191,11 @@ const localRuntimeExportToGcsMock = spyOn(
   "localRuntimeExportToGcs",
 ).mockResolvedValue({ jobId: "local-export-job-1" });
 
+const localRuntimeIdentityMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeIdentity",
+).mockResolvedValue({ version: "0.6.5" });
+
 const localRuntimeImportFromGcsMock = spyOn(
   localRuntimeClient,
   "localRuntimeImportFromGcs",
@@ -296,6 +301,7 @@ afterAll(() => {
   fetchOrganizationIdMock.mockRestore();
   computeDeviceIdMock.mockRestore();
   localRuntimeExportToGcsMock.mockRestore();
+  localRuntimeIdentityMock.mockRestore();
   localRuntimeImportFromGcsMock.mockRestore();
   localRuntimePollJobStatusMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
@@ -442,6 +448,8 @@ beforeEach(() => {
   localRuntimeExportToGcsMock.mockResolvedValue({
     jobId: "local-export-job-1",
   });
+  localRuntimeIdentityMock.mockReset();
+  localRuntimeIdentityMock.mockResolvedValue({ version: "0.6.5" });
   localRuntimeImportFromGcsMock.mockReset();
   localRuntimeImportFromGcsMock.mockResolvedValue({
     jobId: "local-import-job-1",
@@ -852,7 +860,7 @@ describe("unified GCS flow — four directions", () => {
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "upload",
-          minRuntimeVersion: expect.any(String),
+          minRuntimeVersion: "0.6.5",
           maxRuntimeVersion: null,
         }),
         "platform-token",
@@ -943,7 +951,7 @@ describe("unified GCS flow — four directions", () => {
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "upload",
-          minRuntimeVersion: expect.any(String),
+          minRuntimeVersion: "0.6.5",
           maxRuntimeVersion: null,
         }),
         "platform-token",
@@ -1042,7 +1050,7 @@ describe("unified GCS flow — four directions", () => {
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "upload",
-          minRuntimeVersion: expect.any(String),
+          minRuntimeVersion: "0.6.5",
           maxRuntimeVersion: null,
         }),
         "platform-token",
@@ -1113,7 +1121,7 @@ describe("unified GCS flow — four directions", () => {
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "upload",
-          minRuntimeVersion: expect.any(String),
+          minRuntimeVersion: "0.6.5",
           maxRuntimeVersion: null,
         }),
         "platform-token",
@@ -1181,7 +1189,7 @@ describe("signed-URL request targets the bundle-owning platform", () => {
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "upload",
-          minRuntimeVersion: expect.any(String),
+          minRuntimeVersion: "0.6.5",
           maxRuntimeVersion: null,
         }),
         "platform-token",
@@ -2164,6 +2172,185 @@ describe("auth + transient-error resilience", () => {
     } finally {
       restoreFetch();
       warnSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source-runtime version is sourced from the daemon, not the CLI
+// (Codex P1 regression guard for PR #29436)
+// ---------------------------------------------------------------------------
+
+describe("upload signed-URL records source runtime version (not CLI version)", () => {
+  test("local source: identity is fetched BEFORE the upload signed-URL request", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // Distinguish the daemon's version from anything else hardcoded.
+    localRuntimeIdentityMock.mockResolvedValue({ version: "0.5.9" });
+
+    // Order tracker: capture which mock was called first.
+    const callOrder: string[] = [];
+    localRuntimeIdentityMock.mockImplementationOnce(async () => {
+      callOrder.push("identity");
+      return { version: "0.5.9" };
+    });
+    platformRequestSignedUrlMock.mockImplementationOnce(async (params) => {
+      callOrder.push("signed-url");
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      expect(callOrder[0]).toBe("identity");
+      expect(callOrder[1]).toBe("signed-url");
+
+      // Upload request stamps minRuntimeVersion with the daemon's version,
+      // NOT cliPkg.version.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.5.9",
+          maxRuntimeVersion: null,
+        }),
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local source: identity fetch failure aborts before signed-URL request", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Failed to fetch runtime identity: 503 Service Unavailable"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Must NOT have proceeded to signed URL or export.
+      expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not fetch runtime identity"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform source: managed runtime's identity is fetched and recorded", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle",
+    });
+
+    localRuntimeIdentityMock.mockResolvedValue({ version: "0.7.2" });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // Identity was fetched against the platform-managed runtime entry
+      // (cloud=vellum) with the platform token — not via guardian token.
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cloud: "vellum",
+          runtimeUrl: "https://platform.vellum.ai",
+          assistantId: "my-platform",
+        }),
+        "platform-token",
+      );
+
+      // The recorded version came from the platform runtime, not the CLI.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.7.2",
+          maxRuntimeVersion: null,
+        }),
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform source: identity fetch failure aborts before signed-URL request", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Failed to fetch runtime identity: 502 Bad Gateway"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Signed-URL upload request must not have happened.
+      const uploadCalls = platformRequestSignedUrlMock.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { operation: string }).operation === "upload",
+      );
+      expect(uploadCalls.length).toBe(0);
+
+      // Runtime export was never kicked off.
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not fetch runtime identity"),
+      );
+    } finally {
+      restoreFetch();
     }
   });
 });

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -850,7 +850,11 @@ describe("unified GCS flow — four directions", () => {
       // Signed-URL request for upload — pinned to the platform target's URL
       // so upload and download land on the same platform.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: expect.any(String),
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -937,7 +941,11 @@ describe("unified GCS flow — four directions", () => {
       // Platform side: requested an upload URL, kicked off a runtime export to
       // GCS, and polled the unified job status.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: expect.any(String),
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1032,7 +1040,11 @@ describe("unified GCS flow — four directions", () => {
       // lives in one place end-to-end. For local→docker neither side is
       // platform, so we default to getPlatformUrl() (resolved once).
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: expect.any(String),
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1099,7 +1111,11 @@ describe("unified GCS flow — four directions", () => {
       // Export leg: upload-URL (pinned to the same platform as import),
       // then runtime export.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: expect.any(String),
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1163,7 +1179,11 @@ describe("signed-URL request targets the bundle-owning platform", () => {
       // The signed-URL request for upload MUST target the existing
       // platform assistant's runtimeUrl, not the default platform URL.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: expect.any(String),
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://staging-platform.vellum.ai",
       );

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -15,6 +15,7 @@ import {
   platformRequestSignedUrl,
   readPlatformToken,
 } from "../lib/platform-client.js";
+import cliPkg from "../../package.json";
 
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);
@@ -234,7 +235,11 @@ async function backupPlatform(
 
   // Step 1 — Request a signed upload URL.
   const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-    { operation: "upload" },
+    {
+      operation: "upload",
+      minRuntimeVersion: cliPkg.version,
+      maxRuntimeVersion: null,
+    },
     exportPlatformToken,
     platformUrl,
   );

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -9,13 +9,13 @@ import { pollJobUntilDone } from "../lib/job-polling.js";
 import {
   MigrationInProgressError,
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimePollJobStatus,
 } from "../lib/local-runtime-client.js";
 import {
   platformRequestSignedUrl,
   readPlatformToken,
 } from "../lib/platform-client.js";
-import cliPkg from "../../package.json";
 
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);
@@ -233,11 +233,28 @@ async function backupPlatform(
   // signed-download request.
   let exportPlatformToken = platformToken;
 
+  // Step 0 — Ask the source runtime which version it's running. The bundle
+  // is produced by the daemon (not the CLI), and the CLI version can drift
+  // from the daemon version, so the daemon's version is the authoritative
+  // value to record as the bundle's `min_runtime_version`. Stamping with
+  // `cliPkg.version` here would record an inaccurate compatibility band on
+  // the signed-URL request.
+  let runtimeIdentity: { version: string };
+  try {
+    runtimeIdentity = await localRuntimeIdentity(entry, exportPlatformToken);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `Error: Could not fetch runtime identity from '${name}': ${msg}`,
+    );
+    process.exit(1);
+  }
+
   // Step 1 — Request a signed upload URL.
   const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
     {
       operation: "upload",
-      minRuntimeVersion: cliPkg.version,
+      minRuntimeVersion: runtimeIdentity.version,
       maxRuntimeVersion: null,
     },
     exportPlatformToken,

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -16,6 +16,7 @@ import {
   platformPollJobStatus,
 } from "../lib/platform-client.js";
 import { performDockerRollback } from "../lib/upgrade-lifecycle.js";
+import cliPkg from "../../package.json";
 
 function printUsage(): void {
   console.log(
@@ -181,7 +182,11 @@ async function restorePlatform(
 
   // Step 1.5 — Upload to GCS via signed URL
   const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-    { operation: "upload" },
+    {
+      operation: "upload",
+      minRuntimeVersion: cliPkg.version,
+      maxRuntimeVersion: null,
+    },
     token,
     entry.runtimeUrl,
   );

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -16,7 +16,6 @@ import {
   platformPollJobStatus,
 } from "../lib/platform-client.js";
 import { performDockerRollback } from "../lib/upgrade-lifecycle.js";
-import cliPkg from "../../package.json";
 
 function printUsage(): void {
   console.log(
@@ -180,13 +179,15 @@ async function restorePlatform(
     process.exit(1);
   }
 
-  // Step 1.5 — Upload to GCS via signed URL
+  // Step 1.5 — Upload to GCS via signed URL.
+  // We deliberately omit min/max runtime version here: restore uploads an
+  // arbitrary .vbundle from disk (often produced by a different runtime
+  // than the one we'd query right now), and the bundle's own manifest is
+  // the authority on its compatibility band. The platform skips the
+  // version gate when these fields are absent and re-derives compat from
+  // the manifest when it processes the import.
   const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-    {
-      operation: "upload",
-      minRuntimeVersion: cliPkg.version,
-      maxRuntimeVersion: null,
-    },
+    { operation: "upload" },
     token,
     entry.runtimeUrl,
   );

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -48,6 +48,7 @@ import { stopProcessByPidFile } from "../lib/process.js";
 import { fetchCurrentVersion } from "../lib/upgrade-lifecycle.js";
 import { compareVersions } from "../lib/version-compat.js";
 import { join } from "node:path";
+import cliPkg from "../../package.json";
 
 function printHelp(): void {
   console.log(
@@ -373,7 +374,11 @@ async function exportFromAssistant(
     // the same platform — otherwise a non-default/stale platform URL would
     // cause the import to look at an empty object.
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-      { operation: "upload" },
+      {
+        operation: "upload",
+        minRuntimeVersion: cliPkg.version,
+        maxRuntimeVersion: null,
+      },
       platformToken,
       bundlePlatformUrl,
     );
@@ -449,7 +454,11 @@ async function exportFromAssistant(
     // pick that shape for `cloud === "vellum"` and `migrationRequestHeaders`
     // to send platform-token auth (no guardian-token bootstrap).
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-      { operation: "upload" },
+      {
+        operation: "upload",
+        minRuntimeVersion: cliPkg.version,
+        maxRuntimeVersion: null,
+      },
       platformToken,
       bundlePlatformUrl,
     );

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -30,6 +30,7 @@ import {
 } from "../lib/platform-client.js";
 import {
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimeImportFromGcs,
   localRuntimePollJobStatus,
   MigrationInProgressError,
@@ -48,7 +49,6 @@ import { stopProcessByPidFile } from "../lib/process.js";
 import { fetchCurrentVersion } from "../lib/upgrade-lifecycle.js";
 import { compareVersions } from "../lib/version-compat.js";
 import { join } from "node:path";
-import cliPkg from "../../package.json";
 
 function printHelp(): void {
   console.log(
@@ -255,13 +255,17 @@ async function getAccessToken(
 
 /**
  * Detect a 401 Unauthorized raised by `localRuntimeExportToGcs` /
- * `localRuntimeImportFromGcs`. Both throw Error with a message of the form
- * `"Local runtime <op> failed (401): ..."` when the gateway rejects the
- * cached guardian token.
+ * `localRuntimeImportFromGcs` / `localRuntimeIdentity`. They throw Error
+ * with a message of the form `"Local runtime <op> failed (401): ..."` or
+ * `"Failed to fetch runtime identity: 401 ..."` when the gateway rejects
+ * the cached guardian token.
  */
 function isRuntime401(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return /Local runtime [^(]*failed \(401\)/.test(msg);
+  return (
+    /Local runtime [^(]*failed \(401\)/.test(msg) ||
+    /Failed to fetch runtime identity: 401\b/.test(msg)
+  );
 }
 
 /**
@@ -368,6 +372,29 @@ async function exportFromAssistant(
   }
 
   if (cloud === "local" || cloud === "docker") {
+    // Ask the source runtime which version it's running before requesting
+    // the signed upload URL. The bundle is produced by the daemon (not the
+    // CLI), so the daemon's version is what defines the bundle's
+    // `min_runtime_version`. Stamping with `cliPkg.version` instead would
+    // record an inaccurate compatibility band whenever the CLI/daemon have
+    // drifted (a normal case in real usage — `vellum upgrade` swaps the
+    // daemon, the CLI is updated separately).
+    let sourceRuntimeVersion: string;
+    try {
+      const identity = await callRuntimeWithAuthRetry(
+        entry.runtimeUrl,
+        entry.assistantId,
+        async (token) => localRuntimeIdentity(entry, token),
+      );
+      sourceRuntimeVersion = identity.version;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `Error: Could not fetch runtime identity from '${entry.assistantId}': ${msg}`,
+      );
+      process.exit(1);
+    }
+
     // Request a signed upload URL from the platform instance that will
     // eventually own the bundle (i.e. the one the importer will read from).
     // Passing the target's runtime URL here keeps upload and download on
@@ -376,7 +403,7 @@ async function exportFromAssistant(
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
       {
         operation: "upload",
-        minRuntimeVersion: cliPkg.version,
+        minRuntimeVersion: sourceRuntimeVersion,
         maxRuntimeVersion: null,
       },
       platformToken,
@@ -445,6 +472,24 @@ async function exportFromAssistant(
   }
 
   if (cloud === "vellum") {
+    // Ask the managed runtime which version it's running so the signed-URL
+    // request records the bundle's actual `min_runtime_version`. The
+    // platform-managed runtime is the exporter; the CLI version is
+    // unrelated. Routed via the wildcard proxy with platform-token auth
+    // (resolveRuntimeUrl + migrationRequestHeaders inside
+    // localRuntimeIdentity).
+    let sourceRuntimeVersion: string;
+    try {
+      const identity = await localRuntimeIdentity(entry, platformToken);
+      sourceRuntimeVersion = identity.version;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `Error: Could not fetch runtime identity from '${entry.assistantId}': ${msg}`,
+      );
+      process.exit(1);
+    }
+
     // Platform source — request a signed upload URL on the same platform
     // instance the bundle will eventually be imported from, then ask the
     // managed runtime to export directly to GCS. The runtime endpoint is
@@ -456,7 +501,7 @@ async function exportFromAssistant(
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
       {
         operation: "upload",
-        minRuntimeVersion: cliPkg.version,
+        minRuntimeVersion: sourceRuntimeVersion,
         maxRuntimeVersion: null,
       },
       platformToken,

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -4,6 +4,7 @@ import type { AssistantEntry } from "../assistant-config.js";
 import {
   MigrationInProgressError,
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimeImportFromGcs,
   localRuntimePollJobStatus,
 } from "../local-runtime-client.js";
@@ -476,5 +477,89 @@ describe("vellum-cloud routing through wildcard proxy", () => {
     if (status.status === "complete") {
       expect(status.bundleKey).toBe("exports/org-1/x.vbundle");
     }
+  });
+});
+
+describe("localRuntimeIdentity", () => {
+  test("local entry: GETs /v1/identity with Bearer auth and returns the version", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: "0.6.5" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeIdentity(ENTRY, TOKEN);
+
+    expect(result.version).toBe("0.6.5");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/identity`);
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  test("vellum entry: GETs /v1/assistants/<id>/identity through the wildcard proxy", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: "0.7.2" }), {
+        status: 200,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeIdentity(VELLUM_ENTRY, VAK_TOKEN);
+
+    expect(result.version).toBe("0.7.2");
+    expect(calls[0]!.url).toBe(
+      `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity`,
+    );
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
+  });
+
+  test("non-2xx status throws with status + statusText", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("nope", {
+        status: 503,
+        statusText: "Service Unavailable",
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Failed to fetch runtime identity: 503/,
+    );
+  });
+
+  test("missing version in body throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Runtime identity response missing version/,
+    );
+  });
+
+  test("non-string version in body throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: 123 }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Runtime identity response missing version/,
+    );
+  });
+
+  test("empty-string version in body throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: "" }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Runtime identity response missing version/,
+    );
   });
 });

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -562,4 +562,81 @@ describe("localRuntimeIdentity", () => {
       /Runtime identity response missing version/,
     );
   });
+
+  // ---------------------------------------------------------------------
+  // 401-retry parity with platformRequestSignedUrl (Codex P2 regression
+  // guard). localRuntimeIdentity is the first network call in the
+  // backup/teleport export flow for vellum-cloud assistants, so a stale
+  // Vellum-Organization-Id cache entry would surface as a hard abort
+  // before any other helper got a chance to clear the cache and retry.
+  // ---------------------------------------------------------------------
+
+  test("vellum entry: retries once after 401 with a fresh org-ID lookup", async () => {
+    // Use a non-vak session token so authHeaders fetches + caches an org ID.
+    const SESSION_TOKEN = "session-abcdef";
+    const PLATFORM_URL = "https://platform.vellum.ai";
+    const ASSISTANT_ID = "11111111-2222-3333-4444-555555555555";
+
+    let identityCalls = 0;
+    const orgIdFetchedAs: string[] = [];
+
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/v1/organizations/")) {
+        // Each org-ID fetch returns a different ID to prove that the
+        // second identity request DID re-resolve the org rather than
+        // reuse a stale cache entry.
+        orgIdFetchedAs.push(`org-${orgIdFetchedAs.length + 1}`);
+        return new Response(
+          JSON.stringify({
+            results: [{ id: orgIdFetchedAs[orgIdFetchedAs.length - 1]! }],
+          }),
+          { status: 200 },
+        );
+      }
+      if (urlStr.endsWith(`/v1/assistants/${ASSISTANT_ID}/identity`)) {
+        identityCalls += 1;
+        if (identityCalls === 1) {
+          return new Response("unauthorized", { status: 401 });
+        }
+        return new Response(JSON.stringify({ version: "0.7.4" }), {
+          status: 200,
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const result = await localRuntimeIdentity(
+      {
+        cloud: "vellum",
+        runtimeUrl: PLATFORM_URL,
+        assistantId: ASSISTANT_ID,
+      },
+      SESSION_TOKEN,
+    );
+
+    expect(result.version).toBe("0.7.4");
+    expect(identityCalls).toBe(2);
+    // Two org-ID fetches: the first to satisfy the initial authHeaders
+    // call, the second after the 401-driven cache invalidation.
+    expect(orgIdFetchedAs).toEqual(["org-1", "org-2"]);
+  });
+
+  test("local entry: does NOT retry after 401 (guardian-token refresh is the caller's job via callRuntimeWithAuthRetry)", async () => {
+    let identityCalls = 0;
+    const fetchMock = mock(async () => {
+      identityCalls += 1;
+      return new Response("unauthorized", {
+        status: 401,
+        statusText: "Unauthorized",
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Failed to fetch runtime identity: 401/,
+    );
+    expect(identityCalls).toBe(1);
+  });
 });

--- a/cli/src/lib/__tests__/runtime-url.test.ts
+++ b/cli/src/lib/__tests__/runtime-url.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { AssistantEntry } from "../assistant-config.js";
-import { resolveRuntimeMigrationUrl } from "../runtime-url.js";
+import {
+  resolveRuntimeMigrationUrl,
+  resolveRuntimeUrl,
+} from "../runtime-url.js";
 
 function makeEntry(
   overrides: Partial<AssistantEntry> & {
@@ -82,6 +85,41 @@ describe("resolveRuntimeMigrationUrl", () => {
     });
     expect(resolveRuntimeMigrationUrl(entry, "export-to-gcs")).toBe(
       "http://10.0.0.5:7821/v1/migrations/export-to-gcs",
+    );
+  });
+});
+
+describe("resolveRuntimeUrl", () => {
+  test("local cloud uses gateway-loopback /v1/<subpath>", () => {
+    const entry = makeEntry({
+      cloud: "local",
+      runtimeUrl: "http://localhost:7821",
+      assistantId: "ast-local-1",
+    });
+    expect(resolveRuntimeUrl(entry, "identity")).toBe(
+      "http://localhost:7821/v1/identity",
+    );
+  });
+
+  test("docker cloud uses gateway-loopback /v1/<subpath>", () => {
+    const entry = makeEntry({
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7831",
+      assistantId: "ast-docker-1",
+    });
+    expect(resolveRuntimeUrl(entry, "identity")).toBe(
+      "http://localhost:7831/v1/identity",
+    );
+  });
+
+  test("vellum cloud uses wildcard-proxy /v1/assistants/<id>/<subpath>", () => {
+    const entry = makeEntry({
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+      assistantId: "11111111-2222-3333-4444-555555555555",
+    });
+    expect(resolveRuntimeUrl(entry, "identity")).toBe(
+      "https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity",
     );
   });
 });

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -1,6 +1,7 @@
 import type { AssistantEntry } from "./assistant-config.js";
 import {
   authHeaders,
+  invalidateOrgIdCache,
   parseUnifiedJobStatus,
   type UnifiedJobStatus,
 } from "./platform-client.js";
@@ -246,6 +247,15 @@ export interface RuntimeIdentity {
  * `{platformUrl}/v1/assistants/<assistantId>/identity` and authenticated
  * via the platform token.
  *
+ * For the vellum target this is the FIRST network call in the
+ * teleport/backup export flow, so a stale `Vellum-Organization-Id` cache
+ * entry would surface as a hard abort before any retry-friendly call (like
+ * `platformRequestSignedUrl`) gets a chance to recover. Mirror that helper's
+ * one-shot 401-retry: invalidate the org-ID cache and retry once. Local /
+ * docker entries do not use the org-ID cache and are wrapped in
+ * `callRuntimeWithAuthRetry` by callers for guardian-token refresh, so the
+ * retry is intentionally vellum-only.
+ *
  * Used by export flows (teleport, backup) to stamp the bundle's
  * `min_runtime_version` with the version of the runtime that actually
  * produced it — not the CLI version, which can drift independently.
@@ -255,10 +265,21 @@ export async function localRuntimeIdentity(
   token: string,
 ): Promise<RuntimeIdentity> {
   const url = resolveRuntimeUrl(entry, "identity");
-  const response = await fetch(url, {
-    method: "GET",
-    headers: await migrationRequestHeaders(entry, token),
-  });
+  const doRequest = async (): Promise<Response> =>
+    fetch(url, {
+      method: "GET",
+      headers: await migrationRequestHeaders(entry, token),
+    });
+
+  let response = await doRequest();
+  if (response.status === 401 && entry.cloud === "vellum") {
+    // `entry.runtimeUrl` is the platform host for vellum-cloud entries
+    // (the wildcard runtime proxy lives there). Pass it as the cache key
+    // platformUrl so we invalidate the same entry that authHeaders cached.
+    invalidateOrgIdCache(token, entry.runtimeUrl);
+    response = await doRequest();
+  }
+
   if (!response.ok) {
     throw new Error(
       `Failed to fetch runtime identity: ${response.status} ${response.statusText}`,

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -4,7 +4,10 @@ import {
   parseUnifiedJobStatus,
   type UnifiedJobStatus,
 } from "./platform-client.js";
-import { resolveRuntimeMigrationUrl } from "./runtime-url.js";
+import {
+  resolveRuntimeMigrationUrl,
+  resolveRuntimeUrl,
+} from "./runtime-url.js";
 
 /**
  * Thrown when the local runtime returns 409 for an export/import request
@@ -228,4 +231,42 @@ export async function localRuntimePollJobStatus(
     typeof parseUnifiedJobStatus
   >[0];
   return parseUnifiedJobStatus(raw);
+}
+
+export interface RuntimeIdentity {
+  version: string;
+}
+
+/**
+ * Fetch the assistant runtime's identity (currently just its version).
+ *
+ * For local/docker assistants this GETs `{runtimeUrl}/v1/identity` with
+ * guardian-token bearer auth. For platform-managed (cloud="vellum")
+ * assistants the URL is rewritten to the wildcard runtime proxy at
+ * `{platformUrl}/v1/assistants/<assistantId>/identity` and authenticated
+ * via the platform token.
+ *
+ * Used by export flows (teleport, backup) to stamp the bundle's
+ * `min_runtime_version` with the version of the runtime that actually
+ * produced it — not the CLI version, which can drift independently.
+ */
+export async function localRuntimeIdentity(
+  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
+  token: string,
+): Promise<RuntimeIdentity> {
+  const url = resolveRuntimeUrl(entry, "identity");
+  const response = await fetch(url, {
+    method: "GET",
+    headers: await migrationRequestHeaders(entry, token),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch runtime identity: ${response.status} ${response.statusText}`,
+    );
+  }
+  const body = (await response.json()) as { version?: unknown };
+  if (typeof body.version !== "string" || !body.version) {
+    throw new Error("Runtime identity response missing version");
+  }
+  return { version: body.version };
 }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -100,6 +100,23 @@ const orgIdCache = new Map<string, { orgId: string; expiresAt: number }>();
 const ORG_ID_CACHE_TTL_MS = 60_000; // 60 seconds
 
 /**
+ * Drop the cached org ID for a given (token, platformUrl) pair. Used by the
+ * one-shot 401-retry path: a 401 on a session-token request frequently means
+ * the cached `Vellum-Organization-Id` header is stale (e.g. user switched
+ * orgs in another tab). Clearing the entry forces the next `authHeaders`
+ * call to refetch the org ID from the platform.
+ *
+ * Exported so other modules (e.g. local-runtime-client) can implement the
+ * same retry pattern without needing direct access to the cache map.
+ */
+export function invalidateOrgIdCache(
+  token: string,
+  platformUrl?: string,
+): void {
+  orgIdCache.delete(`${token}::${platformUrl ?? ""}`);
+}
+
+/**
  * Returns the full set of headers needed for an authenticated platform
  * API request:
  *
@@ -913,7 +930,7 @@ export async function platformRequestSignedUrl(
     // lookup. For session-token callers, a 401 frequently means the
     // cached org ID is stale — calling doRequest() again without clearing
     // the cache would just send the same stale header and fail again.
-    orgIdCache.delete(`${token}::${platformUrl ?? ""}`);
+    invalidateOrgIdCache(token, platformUrl);
     response = await doRequest();
   }
 

--- a/cli/src/lib/runtime-url.ts
+++ b/cli/src/lib/runtime-url.ts
@@ -28,3 +28,25 @@ export function resolveRuntimeMigrationUrl(
   }
   return `${entry.runtimeUrl}/v1/migrations/${subpath}`;
 }
+
+/**
+ * Resolve the URL for a generic runtime endpoint under `/v1/<subpath>`,
+ * taking the assistant's topology into account.
+ *
+ * - For local/docker assistants, `runtimeUrl` is the loopback gateway and
+ *   the runtime serves `/v1/<subpath>` directly.
+ * - For platform-managed (cloud="vellum") assistants the path is rewritten
+ *   to the wildcard runtime proxy:
+ *   `{platformUrl}/v1/assistants/<assistantId>/<subpath>`.
+ *
+ * The `subpath` is appended verbatim (e.g. `"identity"`).
+ */
+export function resolveRuntimeUrl(
+  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
+  subpath: string,
+): string {
+  if (entry.cloud === "vellum") {
+    return `${entry.runtimeUrl}/v1/assistants/${entry.assistantId}/${subpath}`;
+  }
+  return `${entry.runtimeUrl}/v1/${subpath}`;
+}


### PR DESCRIPTION
## Summary
- Updates upload call sites in teleport.ts (×2), backup.ts, and restore.ts to pass `minRuntimeVersion: cliPkg.version, maxRuntimeVersion: null`.
- Extends teleport+backup tests to assert the new fields are emitted in every upload payload.

Part of plan: vbundle-version-gate.md (PR 3 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->