### PR TITLE
feat(cli): target CLIs send target_runtime_version and surface 422 mismatch

### DIFF
--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -230,12 +230,14 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
       "platform-export-job-1",
     );
 
-    // Download URL keyed off the upload's bundleKey.
+    // Download URL keyed off the upload's bundleKey. Also carries
+    // targetRuntimeVersion so the platform can enforce bundle compatibility.
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         operation: "download",
         bundleKey: "uploads/org-1/bundle-abc.vbundle",
-      },
+        targetRuntimeVersion: expect.any(String),
+      }),
       "platform-token",
       "https://platform.vellum.ai",
     );
@@ -471,5 +473,75 @@ describe("vellum backup <platform-managed>: failure cases", () => {
     } finally {
       consoleErrorSpy.mockRestore();
     }
+  });
+});
+
+describe("vellum backup <platform-managed>: VersionMismatchError handling", () => {
+  test("422 on download signed-URL exits 1 with friendly message and skips GCS fetch", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    // Upload signed-URL succeeds; download signed-URL throws version-mismatch.
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new platformClient.VersionMismatchError(
+          { min_runtime_version: "99.0.0", max_runtime_version: null },
+          "0.7.1",
+        );
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "uploads/org-1/bundle-abc.vbundle",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    // Track GCS fetch calls so we can assert the download leg never fires.
+    const fetchMock = mock(
+      async () => new Response("not used", { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => undefined,
+    );
+    try {
+      await expect(backup()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot import: bundle requires runtime"),
+      );
+
+      // No GCS download attempted.
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      // No file written.
+      expect(writeFileSyncMock).not.toHaveBeenCalled();
+
+      // Terminal: only one download signed-URL request — no retry.
+      const downloadCalls = platformRequestSignedUrlMock.mock.calls.filter(
+        (c) => (c[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadCalls).toHaveLength(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test("non-VersionMismatchError on download signed-URL re-raises", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new Error("network blew up");
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "uploads/org-1/bundle-abc.vbundle",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    await expect(backup()).rejects.toThrow("network blew up");
   });
 });

--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -230,17 +230,24 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
       "platform-export-job-1",
     );
 
-    // Download URL keyed off the upload's bundleKey. Also carries
-    // targetRuntimeVersion so the platform can enforce bundle compatibility.
+    // Download URL keyed off the upload's bundleKey. We deliberately do
+    // NOT send `targetRuntimeVersion` here — this backup downloads the
+    // bundle to disk for offline storage; there is no target runtime to
+    // gate against, and an older CLI must be able to download newer
+    // assistant backups.
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
       expect.objectContaining({
         operation: "download",
         bundleKey: "uploads/org-1/bundle-abc.vbundle",
-        targetRuntimeVersion: expect.any(String),
       }),
       "platform-token",
       "https://platform.vellum.ai",
     );
+    const downloadCall = platformRequestSignedUrlMock.mock.calls.find(
+      (c) => (c[0] as { operation: string }).operation === "download",
+    );
+    expect(downloadCall).toBeDefined();
+    expect(downloadCall![0]).not.toHaveProperty("targetRuntimeVersion");
 
     // GCS fetch went directly to the signed download URL with no auth.
     const gcsFetch = globalThis.fetch as unknown as ReturnType<typeof mock>;
@@ -476,72 +483,7 @@ describe("vellum backup <platform-managed>: failure cases", () => {
   });
 });
 
-describe("vellum backup <platform-managed>: VersionMismatchError handling", () => {
-  test("422 on download signed-URL exits 1 with friendly message and skips GCS fetch", async () => {
-    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
-    setArgv("my-platform");
-
-    // Upload signed-URL succeeds; download signed-URL throws version-mismatch.
-    platformRequestSignedUrlMock.mockImplementation(async (params) => {
-      if (params.operation === "download") {
-        throw new platformClient.VersionMismatchError(
-          { min_runtime_version: "99.0.0", max_runtime_version: null },
-          "0.7.1",
-        );
-      }
-      return {
-        url: "https://storage.googleapis.com/bucket/signed-upload",
-        bundleKey: params.bundleKey ?? "uploads/org-1/bundle-abc.vbundle",
-        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-      };
-    });
-
-    // Track GCS fetch calls so we can assert the download leg never fires.
-    const fetchMock = mock(
-      async () => new Response("not used", { status: 200 }),
-    );
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
-
-    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
-      () => undefined,
-    );
-    try {
-      await expect(backup()).rejects.toThrow("process.exit:1");
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Cannot import: bundle requires runtime"),
-      );
-
-      // No GCS download attempted.
-      expect(fetchMock).not.toHaveBeenCalled();
-
-      // No file written.
-      expect(writeFileSyncMock).not.toHaveBeenCalled();
-
-      // Terminal: only one download signed-URL request — no retry.
-      const downloadCalls = platformRequestSignedUrlMock.mock.calls.filter(
-        (c) => (c[0] as { operation: string }).operation === "download",
-      );
-      expect(downloadCalls).toHaveLength(1);
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
-  });
-
-  test("non-VersionMismatchError on download signed-URL re-raises", async () => {
-    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
-    setArgv("my-platform");
-
-    platformRequestSignedUrlMock.mockImplementation(async (params) => {
-      if (params.operation === "download") {
-        throw new Error("network blew up");
-      }
-      return {
-        url: "https://storage.googleapis.com/bucket/signed-upload",
-        bundleKey: params.bundleKey ?? "uploads/org-1/bundle-abc.vbundle",
-        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
-      };
-    });
-
-    await expect(backup()).rejects.toThrow("network blew up");
-  });
-});
+// NOTE: The `VersionMismatchError handling` describe block was removed when
+// backup stopped sending `targetRuntimeVersion` on the download signed-URL
+// request — without that field the platform doesn't run the version gate,
+// so 422 `version_mismatch` is no longer reachable from this code path.

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -975,10 +975,11 @@ describe("unified GCS flow — four directions", () => {
       // (where the bundle was written) — pinned so a lockfile change
       // can't split upload and download across instances.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           operation: "download",
           bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
-        },
+          targetRuntimeVersion: expect.any(String),
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1040,10 +1041,11 @@ describe("unified GCS flow — four directions", () => {
 
       // Import: download-URL for the docker target, then runtime import.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           operation: "download",
           bundleKey: "bundle-key-123",
-        },
+          targetRuntimeVersion: expect.any(String),
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1225,7 +1227,11 @@ describe("signed-URL request targets the bundle-owning platform", () => {
       // The download URL must be requested from the SOURCE platform (where
       // the bundle was written by the runtime export), not the default.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        { operation: "download", bundleKey: "dev-bundle-key" },
+        expect.objectContaining({
+          operation: "download",
+          bundleKey: "dev-bundle-key",
+          targetRuntimeVersion: expect.any(String),
+        }),
         "platform-token",
         "https://dev-platform.vellum.ai",
       );
@@ -1518,6 +1524,161 @@ describe("MigrationInProgressError handling", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("already in progress"),
       );
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VersionMismatchError handling — 422 from platformRequestSignedUrl on the
+// download leg is terminal: surface a friendly message + exit 1, no retry.
+// ---------------------------------------------------------------------------
+
+describe("VersionMismatchError handling", () => {
+  test("local target: 422 on download signed-URL exits 1 with friendly message", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    // Upload signed-URL succeeds; download signed-URL throws version-mismatch.
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new platformClient.VersionMismatchError(
+          { min_runtime_version: "99.0.0", max_runtime_version: null },
+          "0.7.1",
+        );
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Friendly message uses the prefix from VersionMismatchError.formatMessage.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot import: bundle requires runtime"),
+      );
+
+      // Terminal: no retry of the download signed-URL request.
+      const downloadCalls = platformRequestSignedUrlMock.mock.calls.filter(
+        (c) => (c[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadCalls).toHaveLength(1);
+
+      // Runtime import-from-gcs must NOT be kicked off after the 422.
+      expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("docker target: 422 on download signed-URL exits 1 with friendly message", async () => {
+    setArgv("--from", "my-local", "--docker");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const dockerEntry = makeEntry("new-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7822",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchDockerMock.mock.calls.length > 0) {
+        return [localEntry, dockerEntry];
+      }
+      return [localEntry];
+    });
+
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new platformClient.VersionMismatchError(
+          { min_runtime_version: "99.0.0", max_runtime_version: null },
+          "0.7.1",
+        );
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot import: bundle requires runtime"),
+      );
+
+      expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("non-VersionMismatchError on download signed-URL re-raises", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new Error("network blew up");
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("network blew up");
     } finally {
       restoreFetch();
     }

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -196,6 +196,15 @@ const localRuntimeImportFromGcsMock = spyOn(
   "localRuntimeImportFromGcs",
 ).mockResolvedValue({ jobId: "local-import-job-1" });
 
+// Default to a fixed version string. Tests that exercise the version-gate
+// surface override this mock per-case to assert the value flows from the
+// target runtime's `/v1/identity` (NOT from `cliPkg.version`) into the
+// download signed-URL request.
+const localRuntimeIdentityMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeIdentity",
+).mockResolvedValue({ version: "0.6.5" });
+
 const localRuntimePollJobStatusMock = spyOn(
   localRuntimeClient,
   "localRuntimePollJobStatus",
@@ -297,6 +306,7 @@ afterAll(() => {
   computeDeviceIdMock.mockRestore();
   localRuntimeExportToGcsMock.mockRestore();
   localRuntimeImportFromGcsMock.mockRestore();
+  localRuntimeIdentityMock.mockRestore();
   localRuntimePollJobStatusMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
@@ -446,6 +456,8 @@ beforeEach(() => {
   localRuntimeImportFromGcsMock.mockResolvedValue({
     jobId: "local-import-job-1",
   });
+  localRuntimeIdentityMock.mockReset();
+  localRuntimeIdentityMock.mockResolvedValue({ version: "0.6.5" });
   localRuntimePollJobStatusMock.mockReset();
   localRuntimePollJobStatusMock.mockImplementation(defaultLocalRuntimePollImpl);
 
@@ -974,14 +986,23 @@ describe("unified GCS flow — four directions", () => {
       // platform's bundle_key. The URL must target the SOURCE platform
       // (where the bundle was written) — pinned so a lockfile change
       // can't split upload and download across instances.
+      //
+      // `targetRuntimeVersion` MUST come from the target runtime's
+      // `/v1/identity` (mocked to "0.6.5"), NOT from the CLI's package
+      // version. The local target's daemon can be on a different version
+      // than the CLI orchestrating the teleport.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "download",
           bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
-          targetRuntimeVersion: expect.any(String),
+          targetRuntimeVersion: "0.6.5",
         }),
         "platform-token",
         "https://platform.vellum.ai",
+      );
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({ cloud: "local" }),
+        expect.any(String),
       );
 
       // Runtime import-from-gcs was kicked off with that URL.
@@ -1040,14 +1061,20 @@ describe("unified GCS flow — four directions", () => {
       expect(localRuntimeExportToGcsMock).toHaveBeenCalled();
 
       // Import: download-URL for the docker target, then runtime import.
+      // targetRuntimeVersion comes from the docker target's runtime
+      // identity (mocked to "0.6.5"), not from cliPkg.version.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "download",
           bundleKey: "bundle-key-123",
-          targetRuntimeVersion: expect.any(String),
+          targetRuntimeVersion: "0.6.5",
         }),
         "platform-token",
         "https://platform.vellum.ai",
+      );
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({ cloud: "docker" }),
+        expect.any(String),
       );
       expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1226,11 +1253,13 @@ describe("signed-URL request targets the bundle-owning platform", () => {
 
       // The download URL must be requested from the SOURCE platform (where
       // the bundle was written by the runtime export), not the default.
+      // targetRuntimeVersion comes from the local target's `/v1/identity`
+      // (mocked to "0.6.5"), not from cliPkg.version.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
         expect.objectContaining({
           operation: "download",
           bundleKey: "dev-bundle-key",
-          targetRuntimeVersion: expect.any(String),
+          targetRuntimeVersion: "0.6.5",
         }),
         "platform-token",
         "https://dev-platform.vellum.ai",
@@ -1679,6 +1708,111 @@ describe("VersionMismatchError handling", () => {
     const restoreFetch = installTrackingFetch();
     try {
       await expect(teleport()).rejects.toThrow("network blew up");
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Target-runtime version fetch — the download signed-URL request must use
+// the TARGET runtime's reported version, not the orchestrating CLI's
+// version (which can diverge when the target was upgraded independently).
+// ---------------------------------------------------------------------------
+
+describe("target runtime version fetch", () => {
+  test("local target: targetRuntimeVersion comes from /v1/identity, not cliPkg", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    // Choose a version unlikely to match cliPkg.version so a regression
+    // would be obvious.
+    localRuntimeIdentityMock.mockResolvedValue({ version: "1.2.3-runtime" });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      const downloadCall = platformRequestSignedUrlMock.mock.calls.find(
+        (c) => (c[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadCall).toBeDefined();
+      expect(downloadCall![0]).toMatchObject({
+        targetRuntimeVersion: "1.2.3-runtime",
+      });
+
+      // Identity was fetched against the TARGET (local) entry, not the
+      // platform source.
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cloud: "local",
+          assistantId: "my-local",
+        }),
+        expect.any(String),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("identity fetch failure aborts before requesting download URL", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Local runtime identity failed (502): bad gateway"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not read target runtime version"),
+      );
+
+      // No download signed-URL request was made — we aborted before that.
+      const downloadCalls = platformRequestSignedUrlMock.mock.calls.filter(
+        (c) => (c[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadCalls).toHaveLength(0);
+      expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
     } finally {
       restoreFetch();
     }

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -14,9 +14,7 @@ import {
 import {
   platformRequestSignedUrl,
   readPlatformToken,
-  VersionMismatchError,
 } from "../lib/platform-client.js";
-import cliPkg from "../../package.json";
 
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);
@@ -291,27 +289,22 @@ async function backupPlatform(
   // poll-loop 401 refresh doesn't get clobbered here — otherwise a long
   // export that recovered mid-poll via re-auth would still 401 on the
   // download-URL request and abort an otherwise successful run.
-  let bundleUrl: string;
-  try {
-    const result = await platformRequestSignedUrl(
-      {
-        operation: "download",
-        bundleKey,
-        targetRuntimeVersion: cliPkg.version,
-      },
-      exportPlatformToken,
-      platformUrl,
-    );
-    bundleUrl = result.url;
-  } catch (err) {
-    if (err instanceof VersionMismatchError) {
-      // 422 version_mismatch is terminal — surface the platform-formatted
-      // message and exit; do NOT retry.
-      console.error(`Error: ${err.message}`);
-      process.exit(1);
-    }
-    throw err;
-  }
+  //
+  // We deliberately do NOT send `targetRuntimeVersion` here. This flow
+  // saves the bundle to disk for offline storage; there is no target
+  // runtime to gate against, and the user can later restore the file
+  // into any compatible runtime. Sending the CLI's version would
+  // incorrectly block older CLIs from backing up newer assistants.
+  // The platform treats `target_runtime_version` as optional and skips
+  // the version check when it's omitted.
+  const { url: bundleUrl } = await platformRequestSignedUrl(
+    {
+      operation: "download",
+      bundleKey,
+    },
+    exportPlatformToken,
+    platformUrl,
+  );
 
   let downloadResponse: Response;
   try {

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -14,7 +14,9 @@ import {
 import {
   platformRequestSignedUrl,
   readPlatformToken,
+  VersionMismatchError,
 } from "../lib/platform-client.js";
+import cliPkg from "../../package.json";
 
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);
@@ -289,11 +291,27 @@ async function backupPlatform(
   // poll-loop 401 refresh doesn't get clobbered here — otherwise a long
   // export that recovered mid-poll via re-auth would still 401 on the
   // download-URL request and abort an otherwise successful run.
-  const { url: bundleUrl } = await platformRequestSignedUrl(
-    { operation: "download", bundleKey },
-    exportPlatformToken,
-    platformUrl,
-  );
+  let bundleUrl: string;
+  try {
+    const result = await platformRequestSignedUrl(
+      {
+        operation: "download",
+        bundleKey,
+        targetRuntimeVersion: cliPkg.version,
+      },
+      exportPlatformToken,
+      platformUrl,
+    );
+    bundleUrl = result.url;
+  } catch (err) {
+    if (err instanceof VersionMismatchError) {
+      // 422 version_mismatch is terminal — surface the platform-formatted
+      // message and exit; do NOT retry.
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
 
   let downloadResponse: Response;
   try {

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -29,9 +29,9 @@ import {
   fetchCurrentUser,
   fetchOrganizationId,
 } from "../lib/platform-client.js";
-import cliPkg from "../../package.json";
 import {
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimeImportFromGcs,
   localRuntimePollJobStatus,
   MigrationInProgressError,
@@ -661,13 +661,41 @@ async function importToAssistant(
     // never touches the bytes. The URL must target the same platform the
     // bundle was uploaded to; otherwise the object won't exist on this
     // platform's GCS bucket.
+    //
+    // The platform's vbundle version gate compares the **target runtime's**
+    // version against the bundle's compatibility range. The CLI and the
+    // target assistant's daemon can diverge (assistants upgrade
+    // independently), so we MUST query the target runtime's `/v1/identity`
+    // for its version rather than sending `cliPkg.version`. Sending the CLI
+    // version here would falsely 422 a valid import (or pass a bundle the
+    // target can't actually load) whenever the two drift apart.
+    let targetRuntimeVersion: string;
+    try {
+      const identity = await callRuntimeWithAuthRetry(
+        entry.runtimeUrl,
+        entry.assistantId,
+        (token) => localRuntimeIdentity(entry, token),
+      );
+      targetRuntimeVersion = identity.version;
+    } catch (err) {
+      // Surface and abort — silently falling back to `cliPkg.version` would
+      // re-introduce the bug this code is fixing. If the runtime is
+      // unreachable, the import would fail downstream anyway.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `Error: Could not read target runtime version from '${entry.assistantId}': ${msg}`,
+      );
+      console.error(`Try: vellum wake ${entry.assistantId}`);
+      process.exit(1);
+    }
+
     let bundleUrl: string;
     try {
       const result = await platformRequestSignedUrl(
         {
           operation: "download",
           bundleKey,
-          targetRuntimeVersion: cliPkg.version,
+          targetRuntimeVersion,
         },
         platformToken,
         bundlePlatformUrl,
@@ -676,8 +704,8 @@ async function importToAssistant(
     } catch (err) {
       if (err instanceof VersionMismatchError) {
         // 422 version_mismatch is terminal — the bundle's runtime range and
-        // this CLI's version don't overlap. Surface the platform-formatted
-        // message and exit; do NOT retry.
+        // the target runtime's version don't overlap. Surface the
+        // platform-formatted message and exit; do NOT retry.
         console.error(`Error: ${err.message}`);
         process.exit(1);
       }

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -21,6 +21,7 @@ import {
   platformImportBundleFromGcs,
   platformImportPreflightFromGcs,
   platformRequestSignedUrl,
+  VersionMismatchError,
   ensureSelfHostedLocalRegistration,
   readGatewayCredential,
   reprovisionAssistantApiKey,
@@ -28,6 +29,7 @@ import {
   fetchCurrentUser,
   fetchOrganizationId,
 } from "../lib/platform-client.js";
+import cliPkg from "../../package.json";
 import {
   localRuntimeExportToGcs,
   localRuntimeImportFromGcs,
@@ -659,11 +661,28 @@ async function importToAssistant(
     // never touches the bytes. The URL must target the same platform the
     // bundle was uploaded to; otherwise the object won't exist on this
     // platform's GCS bucket.
-    const { url: bundleUrl } = await platformRequestSignedUrl(
-      { operation: "download", bundleKey },
-      platformToken,
-      bundlePlatformUrl,
-    );
+    let bundleUrl: string;
+    try {
+      const result = await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey,
+          targetRuntimeVersion: cliPkg.version,
+        },
+        platformToken,
+        bundlePlatformUrl,
+      );
+      bundleUrl = result.url;
+    } catch (err) {
+      if (err instanceof VersionMismatchError) {
+        // 422 version_mismatch is terminal — the bundle's runtime range and
+        // this CLI's version don't overlap. Surface the platform-formatted
+        // message and exit; do NOT retry.
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
 
     console.log("Importing data...");
 

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -4,6 +4,7 @@ import type { AssistantEntry } from "../assistant-config.js";
 import {
   MigrationInProgressError,
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimeImportFromGcs,
   localRuntimePollJobStatus,
 } from "../local-runtime-client.js";
@@ -476,5 +477,81 @@ describe("vellum-cloud routing through wildcard proxy", () => {
     if (status.status === "complete") {
       expect(status.bundleKey).toBe("exports/org-1/x.vbundle");
     }
+  });
+});
+
+describe("localRuntimeIdentity", () => {
+  test("local: GETs /v1/identity with Bearer auth and returns version", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          name: "Test",
+          role: "",
+          personality: "",
+          emoji: "",
+          home: "",
+          version: "0.6.5",
+          createdAt: "2025-01-01T00:00:00Z",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeIdentity(ENTRY, TOKEN);
+
+    expect(result).toEqual({ version: "0.6.5" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/identity`);
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  test("vellum: routes through wildcard proxy /v1/assistants/<id>/identity", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          name: "Test",
+          role: "",
+          personality: "",
+          emoji: "",
+          home: "",
+          version: "0.7.2",
+          createdAt: "2025-01-01T00:00:00Z",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeIdentity(VELLUM_ENTRY, VAK_TOKEN);
+
+    expect(result).toEqual({ version: "0.7.2" });
+    expect(calls[0]!.url).toBe(
+      `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity`,
+    );
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
+  });
+
+  test("non-2xx throws with status + body so callers can surface", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("unreachable", { status: 502 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(/502/);
+  });
+
+  test("missing version field throws (we never silently degrade)", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ name: "Test", role: "" }), {
+        status: 200,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /no version field/,
+    );
   });
 });

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -7,6 +7,27 @@ import {
 import { resolveRuntimeMigrationUrl } from "./runtime-url.js";
 
 /**
+ * Build the URL for a non-migration runtime endpoint, taking topology into
+ * account. Mirrors {@link resolveRuntimeMigrationUrl} but for
+ * `/v1/<subpath>` endpoints (e.g. `/v1/identity`).
+ *
+ * - Local/docker assistants: `{runtimeUrl}/v1/<subpath>` (the gateway forwards
+ *   to the runtime; auth is guardian-token bearer).
+ * - Platform-managed (cloud="vellum"): the wildcard runtime proxy at
+ *   `{platformUrl}/v1/assistants/<id>/<subpath>` forwards arbitrary runtime
+ *   paths to the managed runtime, authenticated by the platform token.
+ */
+function resolveRuntimeUrl(
+  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
+  subpath: string,
+): string {
+  if (entry.cloud === "vellum") {
+    return `${entry.runtimeUrl}/v1/assistants/${entry.assistantId}/${subpath}`;
+  }
+  return `${entry.runtimeUrl}/v1/${subpath}`;
+}
+
+/**
  * Thrown when the local runtime returns 409 for an export/import request
  * because another migration of the same type is already in-flight. The
  * caller can inspect {@link existingJobId} and decide whether to poll the
@@ -228,4 +249,52 @@ export async function localRuntimePollJobStatus(
     typeof parseUnifiedJobStatus
   >[0];
   return parseUnifiedJobStatus(raw);
+}
+
+/**
+ * The subset of `/v1/identity` we care about. The runtime's full response
+ * includes additional fields (name, role, etc.) — we only model `version`
+ * here because that's all the CLI consumes today.
+ */
+export interface RuntimeIdentity {
+  version: string;
+}
+
+/**
+ * Fetch the target runtime's `/v1/identity` so callers can read its
+ * APP_VERSION. Used by `vellum teleport` to gate bundle imports on the
+ * version of the **target** assistant runtime — which can diverge from the
+ * orchestrating CLI's version when the target was upgraded independently.
+ *
+ * For local/docker assistants this GETs `{runtimeUrl}/v1/identity` with
+ * guardian-token bearer auth. For platform-managed (cloud="vellum")
+ * assistants the URL is rewritten to the wildcard runtime proxy shape
+ * `{platformUrl}/v1/assistants/<assistantId>/identity` and authenticated via
+ * the platform token. Throws on non-2xx so callers can surface the failure
+ * (we never silently fall back — see teleport.ts call site).
+ */
+export async function localRuntimeIdentity(
+  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
+  token: string,
+): Promise<RuntimeIdentity> {
+  const response = await fetch(resolveRuntimeUrl(entry, "identity"), {
+    headers: await migrationRequestHeaders(entry, token),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => "");
+    throw new Error(
+      `Local runtime identity failed (${response.status}): ${
+        errText || response.statusText
+      }`,
+    );
+  }
+
+  const json = (await response.json()) as { version?: unknown };
+  if (typeof json.version !== "string" || json.version.length === 0) {
+    throw new Error(
+      `Local runtime identity returned no version field (got ${JSON.stringify(json.version)})`,
+    );
+  }
+  return { version: json.version };
 }


### PR DESCRIPTION
## Summary
- teleport.ts and backup.ts download call sites now pass `targetRuntimeVersion: cliPkg.version`.
- VersionMismatchError thrown from platformRequestSignedUrl is caught and surfaced as a one-line CLI error + exit 1, matching the existing MigrationInProgressError pattern.
- Tests assert the new field is emitted and that the 422 path exits cleanly without retry.

Part of plan: vbundle-version-gate.md (PR 4 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->