### PR TITLE
feat(migrations): commitImport gates on runtime-version compat before mutation

### DIFF
--- a/assistant/src/__tests__/helpers/call-route-handler.ts
+++ b/assistant/src/__tests__/helpers/call-route-handler.ts
@@ -63,7 +63,13 @@ export async function callHandler(
   } catch (err) {
     if (err instanceof RouteError) {
       return Response.json(
-        { error: { code: err.code, message: err.message } },
+        {
+          error: {
+            code: err.code,
+            message: err.message,
+            ...(err.details !== undefined && { details: err.details }),
+          },
+        },
         { status: err.statusCode },
       );
     }

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -256,6 +256,8 @@ function createValidVBundle(
     bundle_id: string;
     origin_mode: "managed" | "self-hosted-remote" | "self-hosted-local";
     secrets_redacted: boolean;
+    min_runtime_version: string;
+    max_runtime_version: string | null;
   }>,
 ): Uint8Array {
   const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
@@ -296,8 +298,11 @@ function createValidVBundle(
       mode: overrides?.origin_mode ?? "self-hosted-local",
     },
     compatibility: {
-      min_runtime_version: "0.0.0-test",
-      max_runtime_version: null,
+      min_runtime_version: overrides?.min_runtime_version ?? "0.0.0-test",
+      max_runtime_version:
+        overrides?.max_runtime_version === undefined
+          ? null
+          : overrides.max_runtime_version,
     },
     contents,
     checksum: "",
@@ -644,6 +649,78 @@ describe("handleMigrationImport — validation failures", () => {
     await callHandler(handleMigrationImport, req);
 
     // Verify disk was not modified
+    const currentDb = new Uint8Array(readFileSync(testDbPath));
+    const currentConfig = readFileSync(testConfigPath, "utf8");
+
+    expect(currentDb).toEqual(originalDb);
+    expect(currentConfig).toBe(originalConfig);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP handler tests: version_incompatible (Codex P2 regression)
+//
+// Pin: a bundle whose min_runtime_version exceeds APP_VERSION must surface as
+// a 4xx user-actionable response (422 Unprocessable Entity), not a 500
+// InternalError. Body mirrors the platform's PR #5470 response shape so
+// clients can render the same UX regardless of which gate (platform or
+// runtime) rejected the bundle.
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationImport — version_incompatible", () => {
+  test("incompatible bundle returns 422 with structured body, not 500", async () => {
+    const vbundle = createValidVBundle(undefined, {
+      min_runtime_version: "99.0.0",
+    });
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as {
+      error: {
+        code: string;
+        message: string;
+        details?: {
+          reason: string;
+          bundle_compat: {
+            min_runtime_version: string;
+            max_runtime_version: string | null;
+          };
+          runtime_version: string;
+        };
+      };
+    };
+
+    expect(res.status).toBe(422);
+    expect(body.error.code).toBe("UNPROCESSABLE_ENTITY");
+    expect(body.error.message).toContain("99.0.0");
+    expect(body.error.details).toBeDefined();
+    expect(body.error.details!.reason).toBe("version_incompatible");
+    expect(body.error.details!.bundle_compat.min_runtime_version).toBe(
+      "99.0.0",
+    );
+    expect(body.error.details!.bundle_compat.max_runtime_version).toBeNull();
+    expect(typeof body.error.details!.runtime_version).toBe("string");
+  });
+
+  test("incompatible bundle does not modify disk", async () => {
+    const originalDb = new Uint8Array(readFileSync(testDbPath));
+    const originalConfig = readFileSync(testConfigPath, "utf8");
+
+    const vbundle = createValidVBundle(undefined, {
+      min_runtime_version: "99.0.0",
+    });
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    await callHandler(handleMigrationImport, req);
+
     const currentDb = new Uint8Array(readFileSync(testDbPath));
     const currentConfig = readFileSync(testConfigPath, "utf8");
 

--- a/assistant/src/ipc/__tests__/route-error-envelope.test.ts
+++ b/assistant/src/ipc/__tests__/route-error-envelope.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the IPC error envelope built from `RouteError` instances.
+ *
+ * Asserts that `AssistantIpcServer.buildErrorResponse` forwards the full
+ * `RouteError` shape — including the `details` field — into the IPC response
+ * envelope so IPC clients (e.g. gateway→daemon) receive the same structured
+ * payload as HTTP clients (e.g. `version_incompatible` migration imports).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  RouteError,
+  UnprocessableEntityError,
+} from "../../runtime/routes/errors.js";
+import { AssistantIpcServer, type IpcResponse } from "../assistant-server.js";
+
+/**
+ * `buildErrorResponse` is private; access it through an interface cast so the
+ * test exercises the actual production code path without exporting a
+ * test-only API on the server class.
+ */
+type PrivateApi = {
+  buildErrorResponse(id: string, err: unknown): IpcResponse;
+};
+
+function buildErrorResponse(err: unknown): IpcResponse {
+  const server = new AssistantIpcServer() as unknown as PrivateApi;
+  return server.buildErrorResponse("req-1", err);
+}
+
+describe("AssistantIpcServer error envelope", () => {
+  test("forwards RouteError message, statusCode, and code", () => {
+    const err = new RouteError("boom", "BOOM", 418);
+    const response = buildErrorResponse(err);
+
+    expect(response.id).toBe("req-1");
+    expect(response.error).toBe("boom");
+    expect(response.statusCode).toBe(418);
+    expect(response.errorCode).toBe("BOOM");
+    expect(response.errorDetails).toBeUndefined();
+  });
+
+  test("forwards RouteError.details into errorDetails when present", () => {
+    const details = {
+      reason: "version_incompatible" as const,
+      bundle_compat: { engineMin: "0.7.0" },
+      runtime_version: "0.6.0",
+    };
+    const err = new UnprocessableEntityError(
+      "incompatible bundle version",
+      details,
+    );
+
+    const response = buildErrorResponse(err);
+
+    expect(response.errorCode).toBe("UNPROCESSABLE_ENTITY");
+    expect(response.statusCode).toBe(422);
+    expect(response.errorDetails).toEqual(details);
+  });
+
+  test("omits errorDetails when RouteError has no details", () => {
+    const err = new UnprocessableEntityError("plain validation failure");
+
+    const response = buildErrorResponse(err);
+
+    expect(response.errorCode).toBe("UNPROCESSABLE_ENTITY");
+    // `errorDetails` must be omitted entirely (not `undefined` value) so the
+    // serialized JSON envelope stays minimal.
+    expect("errorDetails" in response).toBe(false);
+  });
+
+  test("non-RouteError errors are stringified into `error`", () => {
+    const response = buildErrorResponse(new Error("raw"));
+
+    expect(response.error).toBe("Error: raw");
+    expect(response.errorCode).toBeUndefined();
+    expect(response.errorDetails).toBeUndefined();
+  });
+});

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -70,6 +70,14 @@ export type IpcResponse = {
   statusCode?: number;
   /** Machine-readable error code (e.g. "NOT_FOUND") for RouteError instances. */
   errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating `RouteError` carries a `details` field (e.g.
+   * `version_incompatible` migration imports). Mirrors the HTTP adapter's
+   * `error.details` envelope so IPC clients can recover the same
+   * machine-readable context as HTTP clients.
+   */
+  errorDetails?: unknown;
   headers?: Record<string, string>;
 };
 
@@ -274,12 +282,16 @@ export class AssistantIpcServer {
 
   private buildErrorResponse(id: string, err: unknown): IpcResponse {
     if (err instanceof RouteError) {
-      return {
+      const response: IpcResponse = {
         id,
         error: err.message,
         statusCode: err.statusCode,
         errorCode: err.code,
       };
+      if (err.details !== undefined) {
+        response.errorDetails = err.details;
+      }
+      return response;
     }
     return { id, error: String(err) };
   }

--- a/assistant/src/ipc/cli-client.ts
+++ b/assistant/src/ipc/cli-client.ts
@@ -30,6 +30,16 @@ type IpcResponse = {
   id: string;
   result?: unknown;
   error?: string;
+  /** HTTP-style status code mirrored from `RouteError.statusCode`. */
+  statusCode?: number;
+  /** Machine-readable error code (e.g. "UNPROCESSABLE_ENTITY"). */
+  errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating error carried a `details` field. Mirrors the HTTP
+   * adapter's `error.details` envelope.
+   */
+  errorDetails?: unknown;
 };
 
 // ---------------------------------------------------------------------------
@@ -43,6 +53,15 @@ export interface CliIpcCallResult<T = unknown> {
   ok: boolean;
   result?: T;
   error?: string;
+  /** HTTP-style status code surfaced from a daemon-side `RouteError`. */
+  statusCode?: number;
+  /** Machine-readable error code (e.g. "UNPROCESSABLE_ENTITY"). */
+  errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating daemon-side error carried a `details` field.
+   */
+  errorDetails?: unknown;
 }
 
 /**
@@ -115,7 +134,19 @@ export async function cliIpcCall<T = unknown>(
             const msg = JSON.parse(line) as IpcResponse;
             if (msg.id === reqId) {
               if (msg.error) {
-                finish({ ok: false, error: msg.error });
+                finish({
+                  ok: false,
+                  error: msg.error,
+                  ...(msg.statusCode !== undefined && {
+                    statusCode: msg.statusCode,
+                  }),
+                  ...(msg.errorCode !== undefined && {
+                    errorCode: msg.errorCode,
+                  }),
+                  ...(msg.errorDetails !== undefined && {
+                    errorDetails: msg.errorDetails,
+                  }),
+                });
               } else {
                 finish({ ok: true, result: msg.result as T });
               }

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-version-compat.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-version-compat.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Buffer importer runtime-version compat gate.
+ *
+ * Wires `commitImport` to `policy.evaluateRuntimeCompatibility` BEFORE any
+ * state mutation. The platform-side gate is the primary check; this catches
+ * legacy bundles whose ExportJob row predates PR #5470 (compat columns NULL
+ * → platform gate skipped) and any caller that bypasses the platform-issued
+ * signed URL flow.
+ *
+ * Invariants pinned here:
+ *   - A compatible bundle imports normally.
+ *   - An incompatible bundle (min_runtime_version above APP_VERSION) returns
+ *     `{ ok: false, reason: "version_incompatible", bundle_compat,
+ *     runtime_version }` with NO disk mutation.
+ *   - The legacy sentinel "0.0.0-legacy" passes the gate unconditionally.
+ *   - Pre-existing workspace files are byte-identical and no `*.backup-*`
+ *     files are created when the gate rejects.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { APP_VERSION } from "../../../version.js";
+import { buildVBundle } from "../vbundle-builder.js";
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { commitImport } from "../vbundle-importer.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function freshWorkspace(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "vbundle-import-version-compat-")),
+  );
+  return join(parent, "workspace");
+}
+
+function cleanupWorkspaceParent(workspaceDir: string): void {
+  try {
+    rmSync(join(workspaceDir, ".."), { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/** Recursively yields every regular file under `root` as a relative path. */
+function* walkFiles(root: string): Generator<string> {
+  if (!existsSync(root)) return;
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(abs);
+      else if (entry.isFile()) yield relative(root, abs);
+    }
+  }
+}
+
+function buildBundleWithMinRuntimeVersion(
+  minRuntimeVersion: string,
+): Uint8Array {
+  const dbBytes = new TextEncoder().encode("db-payload");
+  const configJson = JSON.stringify({ version: 1 });
+  const { archive } = buildVBundle({
+    files: [
+      { path: "workspace/data/db/assistant.db", data: dbBytes },
+      {
+        path: "workspace/config.json",
+        data: new TextEncoder().encode(configJson),
+      },
+    ],
+    ...defaultV1Options(),
+    compatibility: {
+      min_runtime_version: minRuntimeVersion,
+      max_runtime_version: null,
+    },
+  });
+  return archive;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("commitImport runtime-version compat gate", () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = freshWorkspace();
+    mkdirSync(workspaceDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanupWorkspaceParent(workspaceDir);
+  });
+
+  test("compatible bundle imports normally", () => {
+    const archive = buildBundleWithMinRuntimeVersion("0.0.1");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(workspaceDir, "data/db/assistant.db"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(true);
+  });
+
+  test("incompatible bundle (above APP_VERSION) returns version_incompatible without writing", () => {
+    const archive = buildBundleWithMinRuntimeVersion("99.0.0");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === "version_incompatible") {
+      expect(result.bundle_compat.min_runtime_version).toBe("99.0.0");
+      expect(result.bundle_compat.max_runtime_version).toBeNull();
+      expect(result.runtime_version).toBe(APP_VERSION);
+    } else {
+      throw new Error(
+        `expected version_incompatible, got ${JSON.stringify(result)}`,
+      );
+    }
+
+    // Fresh workspace stays empty — no bundle files, no backups.
+    expect([...walkFiles(workspaceDir)]).toEqual([]);
+  });
+
+  test("legacy sentinel passes through", () => {
+    const archive = buildBundleWithMinRuntimeVersion("0.0.0-legacy");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(workspaceDir, "data/db/assistant.db"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(true);
+  });
+
+  test("pre-existing workspace files stay untouched on incompatibility", () => {
+    const sentinelPath = join(workspaceDir, "sentinel.txt");
+    const sentinelContent = "keep me";
+    writeFileSync(sentinelPath, sentinelContent);
+
+    const archive = buildBundleWithMinRuntimeVersion("99.0.0");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("version_incompatible");
+
+    expect(readFileSync(sentinelPath, "utf-8")).toBe(sentinelContent);
+    // Only the seeded sentinel remains — no bundle files, no `*.backup-*`.
+    expect([...walkFiles(workspaceDir)]).toEqual(["sentinel.txt"]);
+  });
+});

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -30,6 +30,7 @@ import { dirname, join, resolve, sep } from "node:path";
 import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
+import { APP_VERSION } from "../../version.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
 import * as policy from "./vbundle-import-policy.js";
 import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
@@ -202,6 +203,24 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
 
     manifest = validation.manifest;
     entryMap = validation.entries;
+  }
+
+  // Defense-in-depth: refuse to import a bundle whose declared compat range
+  // excludes this runtime BEFORE any state mutation. The platform-side gate
+  // is the primary check; this catches legacy bundles whose ExportJob row
+  // predates PR #5470 (compat columns NULL → platform gate skipped) and
+  // any caller that bypasses the platform-issued signed URL flow.
+  const compatResult = policy.evaluateRuntimeCompatibility(
+    manifest.compatibility,
+    APP_VERSION,
+  );
+  if (!compatResult.ok) {
+    return {
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compatResult.bundle_compat,
+      runtime_version: compatResult.runtime_version,
+    };
   }
 
   // Directories to preserve when clearing the workspace. Derived from the

--- a/assistant/src/runtime/routes/errors.ts
+++ b/assistant/src/runtime/routes/errors.ts
@@ -10,12 +10,27 @@
 export class RouteError extends Error {
   readonly code: string;
   readonly statusCode: number;
+  /**
+   * Optional structured payload surfaced to clients in the standard
+   * error envelope as `error.details`. Use sparingly — only when the
+   * client genuinely needs machine-readable context beyond `code` and
+   * `message` (e.g. mirroring a platform-side response shape).
+   */
+  readonly details?: unknown;
 
-  constructor(message: string, code: string, statusCode: number) {
+  constructor(
+    message: string,
+    code: string,
+    statusCode: number,
+    details?: unknown,
+  ) {
     super(message);
     this.name = "RouteError";
     this.code = code;
     this.statusCode = statusCode;
+    if (details !== undefined) {
+      this.details = details;
+    }
   }
 }
 
@@ -55,8 +70,8 @@ export class NotFoundError extends RouteError {
 }
 
 export class UnprocessableEntityError extends RouteError {
-  constructor(message: string) {
-    super(message, "UNPROCESSABLE_ENTITY", 422);
+  constructor(message: string, details?: unknown) {
+    super(message, "UNPROCESSABLE_ENTITY", 422, details);
     this.name = "UnprocessableEntityError";
   }
 }

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -163,6 +163,7 @@ export function routeDefinitionsToHTTPRoutes(
             err.code as HttpErrorCode,
             err.message,
             err.statusCode,
+            err.details,
           );
         }
         throw err;

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -80,6 +80,7 @@ import {
   InternalError,
   NotFoundError,
   RouteError,
+  UnprocessableEntityError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
@@ -919,6 +920,12 @@ export async function handleMigrationImport(
 
     return importCommitSuccessResult(result.report, credentialsImported);
   } catch (err) {
+    // Preserve typed RouteError instances (e.g. UnprocessableEntityError for
+    // version_incompatible, BadRequestError for validation_failed) — only
+    // wrap genuinely unexpected errors as 500 InternalError.
+    if (err instanceof RouteError) {
+      throw err;
+    }
     log.error({ err }, "Unexpected error during import commit");
     throw new InternalError(
       err instanceof Error ? err.message : "Unexpected import error",
@@ -1022,6 +1029,14 @@ interface GcsImportErrorInit {
   reason?: string;
   errors?: Array<{ code: string; message: string; path?: string }>;
   partial_report?: ImportCommitReport;
+  /** Populated for `version_incompatible` — mirrors the platform's PR #5470
+   *  response shape so the URL-body endpoint can return the same body. */
+  bundle_compat?: {
+    min_runtime_version: string;
+    max_runtime_version: string | null;
+  };
+  /** Populated for `version_incompatible`. */
+  runtime_version?: string;
 }
 
 class GcsImportError extends Error {
@@ -1030,6 +1045,8 @@ class GcsImportError extends Error {
   public readonly reason?: string;
   public readonly errors?: GcsImportErrorInit["errors"];
   public readonly partial_report?: ImportCommitReport;
+  public readonly bundle_compat?: GcsImportErrorInit["bundle_compat"];
+  public readonly runtime_version?: string;
 
   constructor(init: GcsImportErrorInit) {
     super(init.message);
@@ -1046,6 +1063,12 @@ class GcsImportError extends Error {
     }
     if (init.partial_report !== undefined) {
       this.partial_report = init.partial_report;
+    }
+    if (init.bundle_compat !== undefined) {
+      this.bundle_compat = init.bundle_compat;
+    }
+    if (init.runtime_version !== undefined) {
+      this.runtime_version = init.runtime_version;
     }
   }
 }
@@ -1357,6 +1380,8 @@ async function runGcsImport(
           result.runtime_version,
         ),
         reason: result.reason,
+        bundle_compat: result.bundle_compat,
+        runtime_version: result.runtime_version,
       });
     }
     // write_failed
@@ -1457,6 +1482,20 @@ function throwGcsImportError(err: unknown): never {
           errors: err.errors ?? [],
         }),
       );
+    }
+    if (err.code === "version_incompatible") {
+      // 422 (not 500) — the bundle is structurally valid but cannot be
+      // imported on this runtime. Body mirrors the platform's PR #5470
+      // response shape.
+      throw new UnprocessableEntityError(err.message, {
+        reason: "version_incompatible" as const,
+        ...(err.bundle_compat !== undefined && {
+          bundle_compat: err.bundle_compat,
+        }),
+        ...(err.runtime_version !== undefined && {
+          runtime_version: err.runtime_version,
+        }),
+      });
     }
     if (err.code === "extraction_failed") {
       throw new InternalError(err.message);
@@ -1695,11 +1734,21 @@ function throwImportCommitFailure(
     // outside the bundle's compat range. The platform-side gate is the
     // primary check; this catches legacy bundles whose ExportJob row
     // predates PR #5470 (compat columns NULL → platform gate skipped).
-    throw new InternalError(
+    //
+    // 422 (not 500) — the bundle is structurally valid but cannot be
+    // imported on this runtime; the caller can act on it (upgrade the
+    // runtime, choose a different bundle). Body mirrors the platform's
+    // PR #5470 response shape.
+    throw new UnprocessableEntityError(
       formatRuntimeCompatibilityMessage(
         result.bundle_compat,
         result.runtime_version,
       ),
+      {
+        reason: "version_incompatible" as const,
+        bundle_compat: result.bundle_compat,
+        runtime_version: result.runtime_version,
+      },
     );
   }
 

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -1346,8 +1346,10 @@ async function runGcsImport(
       });
     }
     if (result.reason === "version_incompatible") {
-      // Wired by PR 5 — until then the importer never returns this variant,
-      // but we narrow explicitly to keep the union exhaustive.
+      // Returned by commitImport / streamCommitImport when the runtime falls
+      // outside the bundle's compat range. The platform-side gate is the
+      // primary check; this catches legacy bundles whose ExportJob row
+      // predates PR #5470 (compat columns NULL → platform gate skipped).
       throw new GcsImportError({
         code: "version_incompatible",
         message: formatRuntimeCompatibilityMessage(
@@ -1689,8 +1691,10 @@ function throwImportCommitFailure(
   }
 
   if (result.reason === "version_incompatible") {
-    // Wired by PR 5 — until then the importer never returns this variant,
-    // but we narrow explicitly to keep the union exhaustive.
+    // Returned by commitImport / streamCommitImport when the runtime falls
+    // outside the bundle's compat range. The platform-side gate is the
+    // primary check; this catches legacy bundles whose ExportJob row
+    // predates PR #5470 (compat columns NULL → platform gate skipped).
     throw new InternalError(
       formatRuntimeCompatibilityMessage(
         result.bundle_compat,

--- a/packages/gateway-client/src/ipc-client.ts
+++ b/packages/gateway-client/src/ipc-client.ts
@@ -14,6 +14,38 @@ import type { IpcRequest, IpcResponse, Logger } from "./types.js";
 import { noopLogger } from "./types.js";
 
 // ---------------------------------------------------------------------------
+// Error surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Error class thrown by `PersistentIpcClient.call` when the daemon returns
+ * a structured error envelope (i.e. `RouteError`-derived). Mirrors the HTTP
+ * adapter's `error.details` shape so IPC callers can branch on `errorCode`
+ * or recover machine-readable `errorDetails` (e.g. `version_incompatible`).
+ */
+export class IpcCallError extends Error {
+  readonly statusCode?: number;
+  readonly errorCode?: string;
+  readonly errorDetails?: unknown;
+
+  constructor(
+    message: string,
+    fields: {
+      statusCode?: number;
+      errorCode?: string;
+      errorDetails?: unknown;
+    } = {},
+  ) {
+    super(message);
+    this.name = "IpcCallError";
+    if (fields.statusCode !== undefined) this.statusCode = fields.statusCode;
+    if (fields.errorCode !== undefined) this.errorCode = fields.errorCode;
+    if (fields.errorDetails !== undefined)
+      this.errorDetails = fields.errorDetails;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
@@ -294,7 +326,13 @@ export class PersistentIpcClient {
             this.pending.delete(msg.id);
             clearTimeout(entry.timer);
             if (msg.error) {
-              entry.reject(new Error(msg.error));
+              entry.reject(
+                new IpcCallError(msg.error, {
+                  statusCode: msg.statusCode,
+                  errorCode: msg.errorCode,
+                  errorDetails: msg.errorDetails,
+                }),
+              );
             } else {
               entry.resolve(msg.result);
             }

--- a/packages/gateway-client/src/types.ts
+++ b/packages/gateway-client/src/types.ts
@@ -105,6 +105,17 @@ export interface IpcResponse {
   id: string;
   result?: unknown;
   error?: string;
+  /** HTTP-style status code mirrored from `RouteError.statusCode`. */
+  statusCode?: number;
+  /** Machine-readable error code (e.g. "UNPROCESSABLE_ENTITY"). */
+  errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating error carried a `details` field. Mirrors the HTTP
+   * adapter's `error.details` envelope so IPC clients can recover the same
+   * machine-readable context as HTTP clients.
+   */
+  errorDetails?: unknown;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `commitImport` now calls `evaluateRuntimeCompatibility` before any state mutation; returns the `version_incompatible` variant cleanly when the runtime is outside the bundle's compat range.
- Pre-existing workspace files survive an incompatible-bundle call (regression test).
- Legacy bundles with the `0.0.0-legacy` sentinel still import cleanly.
- Refreshes the placeholder comments PR 1 left in migration-routes.ts and restore.ts.

Part of plan: vbundle-version-gate.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->