### PR TITLE
feat(migrations): streamCommitImport gates on runtime-version compat before tree population

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -36,8 +36,10 @@ import { Readable } from "node:stream";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { APP_VERSION } from "../../../version.js";
 import { buildVBundle } from "../vbundle-builder.js";
 import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { LEGACY_RUNTIME_VERSION_SENTINEL } from "../vbundle-import-policy.js";
 import { commitImport } from "../vbundle-importer.js";
 import { streamCommitImport } from "../vbundle-streaming-importer.js";
 import { canonicalizeJson } from "../vbundle-validator.js";
@@ -589,6 +591,141 @@ describe("streamCommitImport — failure modes", () => {
 
     expect(readFileSync(join(workspaceDir, "existing.txt"), "utf8")).toBe(
       "keep me\n",
+    );
+    assertNoLeftoverTempDirs();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime-version compat gate — the streaming importer must refuse to
+// populate the temp tree when the bundle's compat range excludes APP_VERSION.
+// ---------------------------------------------------------------------------
+
+describe("streamCommitImport — runtime-version compat gate", () => {
+  let workspaceDir: string;
+  beforeEach(() => {
+    workspaceDir = freshWorkspace();
+  });
+  afterEach(() => {
+    const parent = join(workspaceDir, "..");
+    try {
+      rmSync(parent, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  function assertNoLeftoverTempDirs(): void {
+    const parent = join(workspaceDir, "..");
+    const base = workspaceDir.split("/").pop()!;
+    const siblings = readdirSync(parent);
+    const leftover = siblings.filter(
+      (name) =>
+        name.startsWith(`${base}.import-`) ||
+        name.startsWith(`${base}.pre-import-`),
+    );
+    expect(leftover).toEqual([]);
+  }
+
+  test("incompatible bundle returns version_incompatible without writing the temp tree", async () => {
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "workspace/a.txt",
+          data: new TextEncoder().encode("never-written"),
+        },
+      ],
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: "99.0.0",
+        max_runtime_version: null,
+      },
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    if (result.ok || result.reason !== "version_incompatible") {
+      throw new Error(
+        `expected version_incompatible, got ${JSON.stringify(result)}`,
+      );
+    }
+    expect(result.bundle_compat.min_runtime_version).toBe("99.0.0");
+    expect(result.bundle_compat.max_runtime_version).toBeNull();
+    expect(result.runtime_version).toBe(APP_VERSION);
+
+    // The streaming importer mkdir's `${workspaceDir}/.import-<uuid>` before
+    // reading the manifest, which materializes an empty workspace dir as a
+    // side effect. Verify nothing FROM THE BUNDLE landed there.
+    if (existsSync(workspaceDir)) {
+      expect(readdirSync(workspaceDir)).toEqual([]);
+    }
+    assertNoLeftoverTempDirs();
+  });
+
+  test("legacy sentinel passes through the streaming path", async () => {
+    const fileA = new TextEncoder().encode("legacy-import\n");
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        { path: "workspace/a.txt", data: fileA },
+      ],
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: LEGACY_RUNTIME_VERSION_SENTINEL,
+        max_runtime_version: null,
+      },
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(join(workspaceDir, "a.txt"))).toEqual(
+      Buffer.from(fileA),
+    );
+    assertNoLeftoverTempDirs();
+  });
+
+  test("pre-existing workspace files stay untouched on incompatibility", async () => {
+    mkdirSync(workspaceDir, { recursive: true });
+    const seedBytes = new TextEncoder().encode("preserve-me\n");
+    writeFileSync(join(workspaceDir, "seed.txt"), seedBytes);
+
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "workspace/a.txt",
+          data: new TextEncoder().encode("never-written"),
+        },
+      ],
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: "99.0.0",
+        max_runtime_version: null,
+      },
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("version_incompatible");
+
+    expect(readFileSync(join(workspaceDir, "seed.txt"))).toEqual(
+      Buffer.from(seedBytes),
     );
     assertNoLeftoverTempDirs();
   });

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -41,7 +41,11 @@ import { buildVBundle } from "../vbundle-builder.js";
 import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
 import { LEGACY_RUNTIME_VERSION_SENTINEL } from "../vbundle-import-policy.js";
 import { commitImport } from "../vbundle-importer.js";
-import { streamCommitImport } from "../vbundle-streaming-importer.js";
+import {
+  IMPORT_BACKUP_PREFIX,
+  IMPORT_TEMP_PREFIX,
+  streamCommitImport,
+} from "../vbundle-streaming-importer.js";
 import { canonicalizeJson } from "../vbundle-validator.js";
 import { defaultV1Options } from "./v1-test-helpers.js";
 
@@ -615,14 +619,21 @@ describe("streamCommitImport — runtime-version compat gate", () => {
     }
   });
 
+  /**
+   * The streaming importer creates scratch dirs `${workspaceDir}/.import-<uuid>`
+   * and `${workspaceDir}/.pre-import-<ts>-<uuid>` INSIDE workspaceDir (so every
+   * rename during the content-level swap stays on the same filesystem). Scan
+   * for orphan entries with those prefixes inside workspaceDir using the
+   * importer's own constants so this assertion stays in sync with the
+   * importer's actual layout.
+   */
   function assertNoLeftoverTempDirs(): void {
-    const parent = join(workspaceDir, "..");
-    const base = workspaceDir.split("/").pop()!;
-    const siblings = readdirSync(parent);
-    const leftover = siblings.filter(
+    if (!existsSync(workspaceDir)) return;
+    const entries = readdirSync(workspaceDir);
+    const leftover = entries.filter(
       (name) =>
-        name.startsWith(`${base}.import-`) ||
-        name.startsWith(`${base}.pre-import-`),
+        name.startsWith(IMPORT_TEMP_PREFIX) ||
+        name.startsWith(IMPORT_BACKUP_PREFIX),
     );
     expect(leftover).toEqual([]);
   }

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -104,9 +104,13 @@ const DEFAULT_MAX_BUNDLE_ENTRIES = 100_000;
  * this run (via a `Set<string>` built from the backupDir/tempWorkspaceDir
  * basenames), so a user entry that happens to start with one of these
  * prefixes is still swept into the swap.
+ *
+ * Exported so tests asserting "no orphan temp/backup dirs" stay in sync with
+ * the actual layout. Both dirs are created at `${workspaceDir}/<prefix><uuid>`
+ * (i.e. INSIDE workspaceDir, not as a sibling).
  */
-const IMPORT_TEMP_PREFIX = ".import-";
-const IMPORT_BACKUP_PREFIX = ".pre-import-";
+export const IMPORT_TEMP_PREFIX = ".import-";
+export const IMPORT_BACKUP_PREFIX = ".pre-import-";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -318,7 +322,7 @@ export async function streamCommitImport(
         // Defense-in-depth: refuse to populate the temp tree when the
         // bundle's compat range excludes APP_VERSION. Throwing inside the
         // generator's try block triggers cleanupTempDir() in the catch,
-        // so the empty `${workspaceDir}.import-<uuid>` is removed and the
+        // so the empty `${workspaceDir}/.import-<uuid>` is removed and the
         // real workspace is untouched. Catches legacy bundles whose
         // ExportJob row predates the platform compat-column rollout
         // (compat columns NULL → platform gate skipped) and any future

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -52,6 +52,7 @@ import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js
 import { resetDb } from "../../memory/db-connection.js";
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
+import { APP_VERSION } from "../../version.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
 import * as policy from "./vbundle-import-policy.js";
 import type {
@@ -313,6 +314,26 @@ export async function streamCommitImport(
         const manifestResult = await readAndValidateManifest(entry);
         manifest = manifestResult.manifest;
         expected = manifestResult.expected;
+
+        // Defense-in-depth: refuse to populate the temp tree when the
+        // bundle's compat range excludes APP_VERSION. Throwing inside the
+        // generator's try block triggers cleanupTempDir() in the catch,
+        // so the empty `${workspaceDir}.import-<uuid>` is removed and the
+        // real workspace is untouched. Catches legacy bundles whose
+        // ExportJob row predates the platform compat-column rollout
+        // (compat columns NULL → platform gate skipped) and any future
+        // drift between the platform gate and the manifest.
+        const compatResult = policy.evaluateRuntimeCompatibility(
+          manifest.compatibility,
+          APP_VERSION,
+        );
+        if (!compatResult.ok) {
+          throw new VersionIncompatibleError(
+            compatResult.bundle_compat,
+            compatResult.runtime_version,
+          );
+        }
+
         // Entry-count ceiling check. The manifest declares every file the
         // bundle claims to contain, so one check here bounds the work the
         // importer is willing to do for this bundle.
@@ -2400,6 +2421,15 @@ function mapThrownToResult(err: unknown): ImportCommitResult {
     };
   }
 
+  if (err instanceof VersionIncompatibleError) {
+    return {
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: err.bundleCompat,
+      runtime_version: err.runtimeVersion,
+    };
+  }
+
   // Errors we raised ourselves for disk-side failures.
   if (err instanceof WriteFailedError) {
     return {
@@ -2429,6 +2459,25 @@ class WriteFailedError extends Error {
 
 function wrapWriteError(prefix: string, cause: unknown): WriteFailedError {
   return new WriteFailedError(`${prefix}: ${errMessage(cause)}`);
+}
+
+/**
+ * Sentinel error thrown when the bundle's manifest declares a runtime-version
+ * compat range that excludes the current `APP_VERSION`. Caught by the same
+ * try/catch that wraps the streaming parse loop so `cleanupTempDir()` runs
+ * before `mapThrownToResult` translates it into the `version_incompatible`
+ * shape of `ImportCommitResult`.
+ */
+class VersionIncompatibleError extends Error {
+  constructor(
+    readonly bundleCompat: policy.RuntimeCompatibility,
+    readonly runtimeVersion: string,
+  ) {
+    super(
+      policy.formatRuntimeCompatibilityMessage(bundleCompat, runtimeVersion),
+    );
+    this.name = "VersionIncompatibleError";
+  }
 }
 
 function errMessage(err: unknown): string {


### PR DESCRIPTION
## Summary
- `streamCommitImport` now refuses to populate the temp tree when the bundle's compat range excludes APP_VERSION.
- Module-internal `VersionIncompatibleError` thrown immediately after manifest parse; existing catch/cleanup logic translates it into the `version_incompatible` result variant.
- Legacy bundles (`0.0.0-legacy` sentinel) still import cleanly.
- New tests verify no orphan temp dirs and pre-seeded files survive incompatible-bundle calls.

Part of plan: vbundle-version-gate.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->