### PR TITLE
fix(macos/design-system): replace FlexFrame ancestor in VSidePanel with containerRelativeFrame (LUM-1049)

### DIFF
--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -42,10 +42,25 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
 
             // Scrollable content — lower priority so pinnedContent's
             // own ScrollView (e.g. TraceTimelineView) isn't starved.
+            //
+            // `.containerRelativeFrame(.horizontal)` (rather than
+            // `.frame(maxWidth: .infinity, alignment: .top)`) sizes the
+            // padded content to the ScrollView's visible width without
+            // emitting `_FlexFrameLayout`. A FlexFrame here would query
+            // `explicitAlignment` recursively on every descendant — when
+            // `content()` is a `LazyVStack` of streaming events the
+            // cascade walks every realized cell on every layout pass,
+            // O(n × depth), which has caused multi-second hangs in
+            // sibling surfaces (see clients/macos/AGENTS.md
+            // "No `_FlexFrameLayout` ... in LazyVStack" and the
+            // matching `.containerRelativeFrame` adoption in
+            // `HomeDetailPanel`).
+            //
+            // Reference: https://developer.apple.com/documentation/swiftui/view/containerrelativeframe(_:alignment:)
             ScrollView {
                 content()
                     .padding(contentPadding)
-                    .frame(maxWidth: .infinity, alignment: .top)
+                    .containerRelativeFrame(.horizontal, alignment: .top)
             }
             .layoutPriority(-1)
         }


### PR DESCRIPTION
## Prompt / plan

[LUM-1049](https://linear.app/vellum/issue/LUM-1049) — App hangs/crashes while scrolling the subagent side-panel.

This PR ships **Layer 1 only** of a layered fix. After the user's deep-investigation request, the root cause was traced from `parseMarkdownSegments` in `textCell` (the obvious cell-level suspect from PR #27616) up through the panel's ancestor chain to a pre-existing `_FlexFrameLayout` wrapping the `LazyVStack` inside `VSidePanel`'s `ScrollView`. Layer 1 fixes the architectural ancestor; Layers 2 + 3a (stable group identity, async markdown parsing) will follow as a separate PR after this one is verified locally with Time Profiler.

## Summary

Single-line semantic change in `clients/shared/DesignSystem/Components/Layout/VSidePanel.swift`:

```diff
 ScrollView {
     content()
         .padding(contentPadding)
-        .frame(maxWidth: .infinity, alignment: .top)
+        .containerRelativeFrame(.horizontal, alignment: .top)
 }
 .layoutPriority(-1)
```

Plus an inline comment block at the call site explaining the rationale and linking to Apple's `containerRelativeFrame(_:alignment:)` documentation, so the next person reading this doesn't undo it.

## Root cause analysis

### How did the code get into this state?

The `.frame(maxWidth: .infinity, alignment: .top)` line predates the streaming subagent panel. `VSidePanel` was originally written as a generic side-panel chrome — pinned content on top, scrollable content below — and the fill-width behavior was expressed with the most common SwiftUI idiom for "fill horizontal, top-align". At the time, `VSidePanel`'s scrollable slot mostly hosted small/eager content (Gallery demos, a capped session list); the FlexFrame's recursive alignment cascade had nothing meaningful to walk into. When `SubagentDetailPanel` later started passing a `LazyVStack` of streaming events into that same slot, the cascade silently became O(n × depth) on every layout pass — but no one re-audited the chrome.

### What mistakes or decisions led to it?

1. **Ancestor frames look benign and slip past code review.** The audited anti-pattern in this repo (LUM-758, LUM-770, LUM-835, LUM-944, LUM-1341) has historically been about `.frame(maxWidth/maxHeight:)` *inside* a LazyVStack cell. Reviewers have an eye for cell-level FlexFrames; an *ancestor* FlexFrame wrapping the entire scroll container reads as ordinary chrome and gets nodded through. The lint script (`clients/scripts/check-flexframe.sh`) only scans `Features/Chat/`, `Features/Home/`, and `Features/MainWindow/`, so design-system files like this one aren't covered.
2. **PR [#27616](https://github.com/vellum-ai/vellum-assistant/pull/27616) added cell-level work that interacts badly with the cascade.** It introduced grouping with `id: \.offset` and an inline `parseMarkdownSegments(event.content)` call (no NSCache, no async fallback — the chat path explicitly avoids both via `ChatBubbleTextContent` + `MarkdownParseActor`). Devin Review flagged the `id: \.offset` instability with the exact recommended fix; the warning was merged unaddressed. None of these alone reach watchdog-hang territory, but combined with the ancestor FlexFrame they push past it.
3. **No local profiling step in the merge process.** macOS isn't built in CI, so layout-cost regressions can't be caught automatically. Today they're only caught when a user reports a hang or when someone runs Instruments by hand.

### Were there warning signs we missed?

Yes — the precedent for exactly this fix was already in the codebase. The sibling surface [`HomeDetailPanel.swift:55-58`](https://github.com/vellum-ai/vellum-assistant/blob/main/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift#L55-L58) writes the safe form:

```swift
ScrollView {
    content()
        .containerRelativeFrame(.horizontal, alignment: .top)
}
```

`clients/macos/AGENTS.md:313` documents `.containerRelativeFrame(.horizontal)` as the recommended replacement for `.frame(maxWidth: .infinity)` in scroll-container content. `ChatBubble.swift:289-293` already uses it for its full-width error background with an inline comment citing AGENTS.md. The pattern was known, documented, and adopted in three other places — VSidePanel was just an oversight.

### What can we do to prevent this pattern from recurring?

1. **Expand the flexframe lint scope to `clients/shared/DesignSystem/Components/Layout/`** (and ideally to all of `DesignSystem/`). Layout-shaped components in the design system are exactly the surfaces where an ancestor FlexFrame leaks into many features. The current scope (`Features/Chat/`, `Features/Home/`, `Features/MainWindow/`) catches cell-level FlexFrames but misses the chrome that wraps them.
2. **Add a brief AGENTS.md note about ancestor FlexFrames specifically.** The existing rule reads as cell-focused; a one-paragraph addition clarifying that `_FlexFrameLayout` *anywhere on the path between a `ScrollView` and a lazy container* causes the same O(n × depth) cascade would close the conceptual gap. Suggested text:

   > **`_FlexFrameLayout` anywhere between a `ScrollView` and a `LazyVStack`/`LazyHStack`/`LazyVGrid` is the same anti-pattern as inside a cell.** A `.frame(max/min/idealWidth/Height:)` wrapping the lazy container's content (e.g. `ScrollView { content().frame(maxWidth: .infinity) }` where `content` is a lazy stack) still cascades `explicitAlignment` through every realized cell on every layout pass. Use `.containerRelativeFrame(.horizontal, alignment: .top)` for the common "fill the scroll viewport horizontally, top-align" case (precedent: `HomeDetailPanel`, `VSidePanel`, `ChatBubble` error path).

3. **Re-audit other design-system surfaces that wrap a slot with a frame** for the same mistake, in a follow-up. (`VAdaptiveStack`, `VSplitView`, `VCard`, etc.)
4. **Don't merge with unresolved Devin Review warnings on perf-sensitive code.** PR #27616's `id: \.offset` warning was actionable and got merged anyway; that contributed to the eventual hang. The `id: \.offset` issue itself is fixed in the planned follow-up PR (Layer 2).

### Should we add a guideline to AGENTS.md?

Yes — the suggested addition above. I'll include it in the follow-up PR (Layer 2 + 3a) so this PR stays scoped to a single architectural fix that can be cleanly reverted if the user's local Time Profiler verification surprises us. (Splitting the AGENTS.md doc edit into the layered PR keeps each PR's commits coherent.)

## Why this change is needed

`SubagentDetailPanel` hosts a `LazyVStack` of streaming subagent events inside `VSidePanel`'s scrollable slot. SwiftUI's `_FlexFrameLayout` (which `.frame(maxWidth: .infinity, alignment: .top)` compiles to) implements `explicitAlignment(of:)` by recursively querying every descendant subview's alignment guides. When the descendant tree is a `LazyVStack` that has realized N cells (each with its own padding, dividers, conditional rows, and — in the subagent case — markdown segments), the per-layout-pass cost becomes O(N × depth). On every streaming flush (~10 Hz under load) and every scroll tick, the whole realized cell hierarchy is walked. With ~30+ events and modest text content, this passes the macOS watchdog hang threshold.

This is the same architectural anti-pattern that caused [LUM-944](https://linear.app/vellum/issue/LUM-944)'s 104.96-second hang in `MessageListView`. The LUM-944 fix was to replace the ancestor FlexFrame with a `Layout` protocol primitive (`BottomAlignedMinHeightLayout`) that returns `nil` from `explicitAlignment(of:)` and positions children manually via `placeSubviews`. The `containerRelativeFrame` modifier is the equivalent for the simpler "fill width, no minimum height" case — it produces a structural frame node rather than a `_FlexFrameLayout` cascade source.

## Why this change is safe

- **Behaviorally identical for production consumers.** `VSidePanel`'s scrollable slot is consumed by `SubagentDetailPanel` (LazyVStack, fills width naturally) and `ACPSessionsPanel` (eager VStack, also fills width). For both, the previous FlexFrame and the new `containerRelativeFrame` produce the same final width = ScrollView's visible width, with the same `.top` alignment semantics. No visual change expected.
- **Behaviorally identical for Gallery demos.** The three Gallery `VSidePanel` examples (`LayoutGallerySection.swift:155, 177, 237`) wrap text/VTabs/inline content. `containerRelativeFrame(.horizontal, alignment: .center)` is the default; we're explicitly passing `.top` to preserve the prior vertical alignment. Horizontal centering of small content (the only place `.frame(maxWidth: .infinity, alignment: .top)` ever differed from "fill") is preserved by `containerRelativeFrame`'s default `.center` horizontal alignment.
- **Padding placement is identical.** Padding stays *inside* the frame modifier so it still consumes a slice of the proposed width and is bounded by the container's visible width.
- **Established precedent in the same repo.** [`HomeDetailPanel.swift:55-58`](https://github.com/vellum-ai/vellum-assistant/blob/main/clients/macos/vellum-assistant/Features/Home/DetailPanel/HomeDetailPanel.swift#L55-L58) writes literally the same change and has been in production for some time. [`ChatBubble.swift:289-293`](https://github.com/vellum-ai/vellum-assistant/blob/main/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift#L287-L295) uses `.containerRelativeFrame(.horizontal)` for full-width error backgrounds. [`MessageListContentView.swift:515-519`](https://github.com/vellum-ai/vellum-assistant/blob/main/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift#L515-L519) uses `.containerRelativeFrame(.vertical, alignment: .top)` as a viewport probe. The pattern is the documented house style.
- **Documented in the project's own house rules.** `clients/macos/AGENTS.md:313` lists `.containerRelativeFrame(.horizontal)` as one of the canonical safe replacements for `.frame(maxWidth:)`.
- **Deployment target supports it.** `containerRelativeFrame` is available on macOS 14+; this app targets macOS 15+ (`clients/Package.swift:9`).
- **`flexframe` lint passes** (`bash clients/scripts/check-flexframe.sh` → `OK (202 allowlisted, 0 new)`). The change removes a FlexFrame; it does not need an allowlist entry.
- **Layered rollout.** This PR is intentionally limited to the architectural ancestor fix so that it can be ship-and-revert independently. Layers 2 (stable group IDs from underlying UUIDs) and 3a (NSCache + `MarkdownParseActor` async parsing in `textCell`, mirroring `ChatBubbleTextContent`) will follow in a separate PR after this one is verified with Time Profiler. Layers 3b (groups cache via `@State`+`onChange`) and 3c (per-cell `View` + `Equatable` extraction) are deferred behind profiling — they may not be needed once Layers 1 + 2 + 3a land.

## Alternatives considered

- **Introduce a new `Layout` protocol primitive `FillWidthTopAlignedLayout`** (mirroring `BottomAlignedMinHeightLayout` from the LUM-944 fix). Rejected: `containerRelativeFrame(.horizontal, alignment: .top)` already exists in SwiftUI, is documented by Apple, is already adopted in three other places in this codebase, and is explicitly listed in `clients/macos/AGENTS.md` as the recommended safe replacement. Adding a new Layout primitive would be redundant and would expand the design-system surface area for no functional gain. The Layout-protocol approach makes sense when SwiftUI's built-in modifiers can't express the desired semantics (LUM-944 needed bottom-anchored min-height behavior that no built-in modifier provides); this case is the simpler "fill viewport width" semantic that SwiftUI provides directly.
- **Address only the cell-level work (PR #27616's additions) and leave the ancestor FlexFrame.** Rejected: even with perfectly cached markdown parsing and stable group IDs, every layout pass would still walk the full cell hierarchy via `explicitAlignment`. The ancestor FlexFrame is the architectural root cause; cell-level fixes alone leave the O(n × depth) measurement in place.
- **Bundle Layers 1 + 2 + 3a in a single PR.** Rejected per the user's explicit request to ship the lowest-risk independent fix first and verify locally with Time Profiler before adding the panel-specific changes. Knowledge note guidance on bundling related fixes was overridden by the explicit per-PR request.
- **Defer the inline comment block.** Rejected: the prior FlexFrame line was load-bearing for Gallery rendering and read as ordinary chrome — exactly the pattern that caused this regression in the first place. The next person reading this file needs to know why `.containerRelativeFrame` was chosen, otherwise it's likely to regress.

## Test plan

**CI does not build the macOS target** (no Xcode runner). Verification must be local in Xcode + Instruments.

- [x] `bash clients/scripts/check-flexframe.sh` — passes (`OK (202 allowlisted, 0 new)`)
- [x] All known `VSidePanel` consumers reviewed for visual-regression risk:
  - `clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift:31` (production — the hang case)
  - `clients/macos/vellum-assistant/Features/MainWindow/Panels/ACPSessionsPanel.swift:49` (production — eager VStack)
  - `clients/macos/vellum-assistant/DesignSystem/Gallery/Sections/LayoutGallerySection.swift:155, 177, 237` (Gallery demos)
- [ ] **User to verify locally**:
  1. Build in Xcode and launch a session that triggers the subagent panel.
  2. Open Instruments → Time Profiler.
  3. Stream a long-running subagent and scroll the panel during streaming.
  4. Confirm: no main-thread hangs >250ms, scroll FPS is steady.
  5. Visual sanity-check: SubagentDetailPanel, ACPSessionsPanel, and the three Gallery `VSidePanel` demos render identically to before.
  6. Approve to proceed to PR2 (Layers 2 + 3a — stable group IDs + async markdown parsing).

## References

- Apple — [`containerRelativeFrame(_:alignment:)`](https://developer.apple.com/documentation/swiftui/view/containerrelativeframe(_:alignment:))
- Apple — [`Layout` protocol](https://developer.apple.com/documentation/swiftui/layout) (used by the LUM-944 fix; not used here because `containerRelativeFrame` is sufficient for the fill-width semantic)
- AGENTS.md — `clients/macos/AGENTS.md:295-321` (FlexFrame anti-pattern guidance + safe replacements)
- Codebase precedent — `HomeDetailPanel.swift:55-58`, `ChatBubble.swift:287-295`, `MessageListContentView.swift:515-519`
- LUM-944 fix — [commit `fd07c04ee0`](https://github.com/vellum-ai/vellum-assistant/commit/fd07c04ee0) (the structurally identical ancestor-FlexFrame fix in `MessageListView`)
- Devin Review on PR [#27616](https://github.com/vellum-ai/vellum-assistant/pull/27616) — flagged `id: \.offset` instability; will be addressed in PR2

Link to Devin session: https://app.devin.ai/sessions/e0ad9087ab994fc2be414b6743c60b20
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->