### PR TITLE
fix(macos): remove duplicate rule editor sheet from AssistantProgressView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -301,35 +301,6 @@ struct AssistantProgressView: View {
         .onAppear {
             handleOnAppear()
         }
-        .sheet(item: $suggestRuleToolCall) { tc in
-            RuleEditorModal(
-                toolName: tc.toolName,
-                commandText: ToolCallStepDetailRow.commandDisplayText(from: tc),
-                commandDescription: tc.reasonDescription ?? "",
-                riskLevel: tc.riskLevel ?? "medium",
-                scopeOptions: ToolCallStepDetailRow.scopeOptions(from: tc),
-                directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
-                suggestion: suggestRuleSuggestion,
-                onSave: { rule in
-                    Task {
-                        try? await TrustRuleClient().createRule(
-                            tool: rule.toolName,
-                            pattern: rule.pattern,
-                            risk: rule.riskLevel,
-                            description: {
-                                let desc = tc.reasonDescription ?? ""
-                                return desc.isEmpty ? "\(rule.toolName) — \(rule.pattern)" : desc
-                            }(),
-                            scope: rule.scope
-                        )
-                    }
-                },
-                onDismiss: {
-                    suggestRuleToolCall = nil
-                    suggestRuleSuggestion = nil
-                }
-            )
-        }
     }
 
     // MARK: - Change Handlers (extracted to reduce body type-check complexity)


### PR DESCRIPTION
## Prompt / plan

Investigation of LUM-1373 (focus-responder hang on v0.7.x) surfaced that `AssistantProgressView` ships a `.sheet(item: $suggestRuleToolCall)` modifier in addition to the canonical one on `ChatBubble`. This is a merge-collision regression introduced by the Trust Rules v3 GA rename (#28376) after #28382 had already moved that sheet to `ChatBubble`. This PR is **scoped to that one regression** — it deletes the duplicate sheet block. The broader hang investigation is **not** addressed here (see "What this PR is not" below and the LUM-1373 comment).

## What changed

Deletes the `.sheet(item: $suggestRuleToolCall)` block on `AssistantProgressView.swift:304–331`.

The two `@Binding` properties (`suggestRuleToolCall`, `suggestRuleSuggestion`) are kept — `AssistantProgressView` still writes to them at `AssistantProgressView.swift:513–514` and `:517–518` to trigger the canonical sheet on `ChatBubble`.

The canonical `.sheet` on `ChatBubble.swift:457–490` is unchanged. The state owner is still `ChatBubble` (`ChatBubble.swift:127–128`), per #28382's design intent.

## Why this is correct

- `ChatBubble` already owns `@State suggestRuleToolCall` (and `suggestRuleSuggestion`) and presents `RuleEditorModal` via its own `.sheet(item:)` modifier — see `ChatBubble.swift:125-128` (state) and `ChatBubble.swift:455-490` (sheet).
- `ChatBubble` passes `$suggestRuleToolCall` down through `ChatBubbleToolStatusView` and `ChatBubbleInterleavedContent` into `AssistantProgressView` as a `Binding<ToolCallData?>`. `AssistantProgressView` writes through the binding when the user picks "Allow & Create Rule" — those writes land in `ChatBubble`'s `@State`, which `ChatBubble`'s sheet observes and presents.
- The duplicate sheet on `AssistantProgressView` observed the same binding. With both modifiers attached to the same item-driven binding, SwiftUI receives two presentation requests every time the binding flips non-nil. The behavior of two `.sheet(item:)` modifiers driven by the same item on a parent and child view is not part of SwiftUI's documented contract; it is at best redundant and at worst causes the modal to dismiss when one of the views (typically `AssistantProgressView`, which gets destroyed mid-stream during the trailing→interleaved rendering-path switch) leaves the hierarchy. That mid-stream-dismiss bug is precisely what #28382 was originally fixing — the inline comment on `ChatBubble.swift:125-126` documents this:

  ```swift
  /// Rule editor modal state. Lives here (not in AssistantProgressView)
  /// so the modal survives the trailing→interleaved rendering path switch.
  @State var suggestRuleToolCall: ToolCallData?
  ```

  Removing the duplicate sheet restores that invariant.

## Why this is safe

- No state changes. No init signature changes. No call-site changes. `AssistantProgressView`'s public API is unchanged — both bindings (`suggestRuleToolCall`, `suggestRuleSuggestion`) still exist, and the two call sites in `ChatBubbleToolStatusView.swift:56-57` and `ChatBubbleInterleavedContent.swift:347-348` continue to pass them through unmodified.
- Behavior is unchanged for all callers that pass real bindings (i.e., `ChatBubble`-owned chat bubbles): the sheet was already being presented twice; one presentation now stops happening, and the other (the canonical one on `ChatBubble`) continues exactly as before.
- The default-`.constant(nil)` bindings on the init (lines 70–71) mean any caller that doesn't bind these never had a working "Allow & Create Rule" flow anyway, so removing this sheet does not regress them.
- The other rule-editor sheet on `AssistantProgressView` (driven by `ruleEditorToolCall`, line ~935 in v0.7.x) is a separate flow (inline edit existing rule) and is untouched.

## What this PR is not

- This PR is **not** a hang fix. The Sentry issue group that LUM-1373 references (`VELLUM-ASSISTANT-MACOS-G`, 4002 events since 2026-03-11) is grouped only by the catch-all culprit `VellumAssistantApp.$main` and conflates at least two distinct stack patterns:
  - The body-eval / `AG::Subgraph::update` hang seen on a v0.6.6 event (`44d5a3105b424f7f8948367f46111cca`).
  - The focus-responder / `swift_conformsToProtocol2 → _dyld_find_protocol_conformance` hang seen on the v0.7.1 event in the LUM-1373 ticket (`4652c5b637f648bebee6f4c1ad66de88`).

  Quantifying whether the focus-responder pattern is genuinely elevated in v0.7.x requires Instruments profiling on representative builds — which is not done in this PR. See the LUM-1373 comment for details.
- This PR is **not** a sheet-hoist refactor. Hoisting `suggestRuleToolCall` further up to `ChatView` was discussed in the investigation but explicitly rejected — Swift's protocol-conformance cache is keyed on `(Type, Protocol)`, so 50 `ChatBubble` sheets share one cache entry and one cold lookup, not 50. Hoisting reduces nothing meaningful and re-litigates state-ownership tradeoffs #28382 already evaluated.

## Root cause analysis

1. **How did the code get into this state?** PR #28382 (Apr 26 20:42 EDT, commit `084be78d5b`) hoisted the rule-editor sheet from `AssistantProgressView` to `ChatBubble` to fix a separate bug where the modal closed when `AssistantProgressView` was destroyed mid-stream during the trailing→interleaved rendering-path switch. PR #28376 (Apr 26 21:01 EDT, commit `46d64df40d`, the Trust Rules v3 GA rename) was based on a tree from before #28382 landed. When it merged 19 minutes after #28382, GitHub auto-merged without conflict because the renamed file's diff didn't textually overlap with #28382's deletion — the rename added a new copy of the (still-present-on-its-base) sheet block back into `AssistantProgressView`. `git blame v0.7.0` confirms `AssistantProgressView.swift` lines 304–333 are authored by `46d64df40d`.

2. **What mistakes or decisions led to it?** Two PRs touching the same file landed in rapid succession with no manual conflict review. GitHub's text-diff merge resolution does not understand SwiftUI semantic intent — when one PR deletes a `.sheet` modifier and another (based on an older tree) keeps it, the result is a re-introduction even though there's no textual conflict. Neither PR's reviewer caught the duplicate at review time because the duplicate looked like the original code and had a green CI build (CI doesn't build the macOS target).

3. **Were there warning signs we missed?** The inline comment on `ChatBubble.swift:125–126` ("Lives here (not in AssistantProgressView) so the modal survives the trailing→interleaved rendering path switch") was the documented invariant. After #28376 landed, that comment became inconsistent with the actual code (sheet existed in both places). A grep for `.sheet(item: $suggestRuleToolCall)` would have found two hits — but no one ran that grep.

4. **What can we do to prevent this pattern from recurring?** When two PRs touch the same file in close succession and a recent PR has just *removed* code, the reviewer of the second PR should rebase locally and check whether the second PR's diff inadvertently re-adds removed code. Inline comments documenting invariants ("Lives here, not there") are useful but not enforceable.

5. **Should we add a guideline to AGENTS.md?** Probably not as a hard rule — this is the kind of thing that's hard to write a durable rule about without it going stale. The existing guidance in `clients/AGENTS.md` already covers state ownership patterns ("Scope observation narrowly", lines 196-201). The most durable safeguard is reviewer awareness when a PR is based on a stale tree against a recently-merged PR in the same file. Not adding a guideline.

## References

- [#28382](https://github.com/vellum-ai/vellum-assistant/pull/28382) — the original sheet-hoist fix that this PR restores
- [#28376](https://github.com/vellum-ai/vellum-assistant/pull/28376) — the Trust Rules v3 GA rename that re-introduced the duplicate
- [LUM-1373](https://linear.app/vellum/issue/LUM-1373/app-hang-2s-v070v071-hang-volume-unknown-root-cause-macos-g-catch-all) — investigation ticket
- [Apple — `View.sheet(item:onDismiss:content:)`](https://developer.apple.com/documentation/swiftui/view/sheet(item:ondismiss:content:)) — for context on item-driven sheet presentation semantics

## Test plan

CI does not build the macOS target — manual local verification is required. To verify:

1. Build locally: `cd clients/macos && ./build.sh run`.
2. In a chat with a tool-call card showing the "Allow & Create Rule" option, click that action.
3. Confirm `RuleEditorModal` opens once (not flickers), shows the expected suggestion, and stays open while subsequent assistant messages stream.
4. Click "Save" or "Cancel"; confirm the modal dismisses cleanly and `suggestRuleToolCall` returns to nil.
5. Repeat the flow on a chat that transitions trailing → interleaved rendering paths during the modal being open; confirm the modal does not close prematurely (this is the original #28382 invariant being restored).

Link to Devin session: https://app.devin.ai/sessions/b664e1451908470cb6ec8adc5635ec60
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->