### PR TITLE
fix(gateway/slack): catch up on @mentions missed during socket reconnect

### DIFF
--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -730,7 +730,7 @@ The Slack channel enables inbound and outbound messaging via Slack's Socket Mode
 
 1. Every Socket Mode envelope is ACKed immediately by echoing `{ envelope_id }` back on the WebSocket — this is required by Slack regardless of whether the event is processed.
 2. Only `events_api` envelopes with `app_mention` events are processed in MVP. Other envelope types (slash commands, interactive payloads) are ACKed but ignored.
-3. Events are deduplicated by `event_id` using an in-memory `Map<string, number>` with a 24-hour TTL. A periodic cleanup sweep runs every hour to evict expired entries.
+3. Events are deduplicated by a compound key in the SQLite-backed `slack_seen_events` table: every event records its Slack `event_id`, and message-shaped events additionally record `msg:${channel}:${ts}` so the live and reconnect-replay paths dedup symmetrically. Entries TTL out after 24h; a periodic cleanup sweep evicts expired rows.
 4. The `normalizeSlackAppMention()` function strips leading bot-mention tokens (`<@U...>`) from the message text and produces a `GatewayInboundEvent` with `sourceChannel: "slack"`, using the Slack channel ID as `conversationExternalId` and the sender's user ID as `actorExternalId`.
 5. Routing uses the standard `resolveAssistant()` chain (conversation_id -> actor_id -> default/reject). Events that cannot be routed are dropped.
 6. The normalized event is forwarded to the runtime via `POST /v1/channels/inbound` with a `replyCallbackUrl` pointing to `/deliver/slack`.
@@ -757,13 +757,24 @@ Both tokens are stored in secure storage (`credential/slack_channel/app_token`, 
 
 The Socket Mode client auto-reconnects on any WebSocket close or error. The backoff schedule is: `min(1000 * 2^attempt, 30000)` + random jitter. After a successful connection, the attempt counter resets. Slack-initiated disconnects (envelope `type: "disconnect"`) trigger an immediate reconnect with no backoff.
 
+**Reconnect catch-up:**
+
+Slack [does not buffer Socket Mode events](https://api.slack.com/apis/socket-mode#events) for disconnected clients, so any @mention or DM that arrives during a reconnect window is lost on the wire. The client recovers these by maintaining a persistent high-watermark (`slack_last_seen_ts`) of the latest accepted event timestamp and, on every WebSocket `open`, fetching a bounded slice of [`conversations.history`](https://api.slack.com/methods/conversations.history) and [`conversations.replies`](https://api.slack.com/methods/conversations.replies) since that watermark. Recovered messages are wrapped in synthetic Socket Mode envelopes and dispatched through the same `processEventPayload` path as live events, so filter, dedup, normalize, and routing logic stay in one place.
+
+Catch-up is scoped to channels the gateway can reasonably reach: routing entries with a Slack-shaped conversation ID (`C…` / `D…` / `G…`), tracked active threads (`slack_active_threads`), and previously-seen DM channels (`contact_channels` rows of type `slack`). It is bounded by max-lookback (1h), per-channel limit (50), and concurrency (4); on a 429 the cycle aborts immediately and resumes on the next reconnect. Brand-new mentions in unrouted, never-engaged channels remain unrecoverable here — the daemon's existing inbound-triggered Slack backfill (`triggerSlackThreadBackfillIfNeeded` and `tryBackfillSlackDmIfCold`) hydrates context once the next live event arrives.
+
+**General principle — stateful-stream transports require catch-up-on-reconnect:**
+
+Any persistent-stream transport that does not buffer events for disconnected clients (Slack Socket Mode, similar WebSocket gateways) must combine the WebSocket with a HTTP catch-up path on reconnect. A persisted high-watermark + bounded replay through the shared event pipeline is the standard pattern; without it, every transient disconnect silently drops events.
+
 **Key modules:**
 
-| Module                                     | Purpose                                                                      |
-| ------------------------------------------ | ---------------------------------------------------------------------------- |
-| `gateway/src/slack/socket-mode.ts`         | `SlackSocketModeClient` — WebSocket lifecycle, ACK, dedup, auto-reconnect    |
-| `gateway/src/slack/normalize.ts`           | `normalizeSlackAppMention()` — event normalization and bot-mention stripping |
-| `gateway/src/http/routes/slack-deliver.ts` | `/deliver/slack` — outbound message delivery via `chat.postMessage`          |
+| Module                                     | Purpose                                                                                       |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `gateway/src/slack/socket-mode.ts`         | `SlackSocketModeClient` — WebSocket lifecycle, ACK, dedup, auto-reconnect, reconnect catch-up |
+| `gateway/src/slack/slack-web.ts`           | `conversations.history` / `conversations.replies` helpers for reconnect catch-up              |
+| `gateway/src/slack/normalize.ts`           | `normalizeSlackAppMention()` — event normalization and bot-mention stripping                  |
+| `gateway/src/http/routes/slack-deliver.ts` | `/deliver/slack` — outbound message delivery via `chat.postMessage`                           |
 
 **Limitations (MVP):** Text-only — attachments are rejected. Only `app_mention` events are processed (direct messages to the bot are not handled). Rich approval UI (inline buttons) is not supported.
 

--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -53,7 +53,7 @@ function makeConfig(): GatewayConfig {
     routingEntries: [
       {
         type: "conversation_id",
-        key: "C-routed",
+        key: "CROUTED01",
         assistantId: "ast-slack",
       },
     ],
@@ -171,7 +171,7 @@ describe("compound dedup across live and replay paths", () => {
               user: "U-author",
               text: "<@UBOT> hi",
               ts: "1700000000.000100",
-              channel: "C-routed",
+              channel: "CROUTED01",
             },
           },
         }),
@@ -188,13 +188,13 @@ describe("compound dedup across live and replay paths", () => {
           envelope_id: "env-replay",
           type: "events_api",
           payload: {
-            event_id: "replay:C-routed:1700000000.000100",
+            event_id: "replay:CROUTED01:1700000000.000100",
             event: {
               type: "app_mention",
               user: "U-author",
               text: "<@UBOT> hi",
               ts: "1700000000.000100",
-              channel: "C-routed",
+              channel: "CROUTED01",
             },
           },
         }),
@@ -220,13 +220,13 @@ describe("compound dedup across live and replay paths", () => {
           envelope_id: "env-replay",
           type: "events_api",
           payload: {
-            event_id: "replay:C-routed:1700000000.000200",
+            event_id: "replay:CROUTED01:1700000000.000200",
             event: {
               type: "app_mention",
               user: "U-author",
               text: "<@UBOT> hi",
               ts: "1700000000.000200",
-              channel: "C-routed",
+              channel: "CROUTED01",
             },
           },
         }),
@@ -247,7 +247,7 @@ describe("compound dedup across live and replay paths", () => {
               user: "U-author",
               text: "<@UBOT> hi",
               ts: "1700000000.000200",
-              channel: "C-routed",
+              channel: "CROUTED01",
             },
           },
         }),
@@ -280,7 +280,7 @@ describe("catch-up watermark", () => {
               user: "U-author",
               text: "<@UBOT> first",
               ts: "1700000010.000000",
-              channel: "C-routed",
+              channel: "CROUTED01",
             },
           },
         }),
@@ -299,7 +299,7 @@ describe("catch-up watermark", () => {
               user: "U-author",
               text: "<@UBOT> second",
               ts: "1700000020.000000",
-              channel: "C-routed",
+              channel: "CROUTED01",
             },
           },
         }),
@@ -321,7 +321,7 @@ describe("catch-up watermark", () => {
               user: "U-author",
               text: "<@UBOT> earlier",
               ts: "1700000005.000000",
-              channel: "C-routed",
+              channel: "CROUTED01",
             },
           },
         }),
@@ -413,7 +413,7 @@ describe("replayMissedEvents", () => {
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe(
-        "replay:C-routed:1700000050.000000",
+        "replay:CROUTED01:1700000050.000000",
       );
       expect(emitted[0].event.message.content).toContain("recovered");
       expect(store.getLastSeenTs()).toBe("1700000050.000000");
@@ -446,6 +446,83 @@ describe("replayMissedEvents", () => {
     }
   });
 
+  test("aborts remaining catch-up workers after a single 429", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+    // Many active threads so the worker pool would otherwise issue many
+    // requests in parallel; once one 429s we expect the others to bail.
+    for (let i = 0; i < 20; i++) {
+      store.trackThread(
+        `170000000${i}.000000`,
+        `CTHREAD${i}`,
+        24 * 60 * 60 * 1_000,
+      );
+    }
+
+    let calls = 0;
+    fetchMock = mock(async () => {
+      calls++;
+      return new Response("", {
+        status: 429,
+        headers: { "retry-after": "1" },
+      });
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      // The first 429 trips the abort flag; later workers see `aborted`
+      // and skip without firing additional requests. The exact number of
+      // pre-flight calls is bounded by the concurrency limit.
+      expect(calls).toBeLessThanOrEqual(4);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("ignores routing entries whose key is not a Slack conversation ID", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    // Replace the default Slack-shaped routing key with a non-Slack one
+    // (Telegram chat IDs are numeric strings, e.g. "123456789").
+    client.config = {
+      ...client.config,
+      gatewayConfig: {
+        ...client.config.gatewayConfig,
+        routingEntries: [
+          {
+            type: "conversation_id",
+            key: "123456789",
+            assistantId: "ast-telegram",
+          },
+        ],
+      },
+    };
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    const calls: string[] = [];
+    fetchMock = mock(async (input) => {
+      calls.push(String(input));
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      expect(calls.some((u) => u.includes("channel=123456789"))).toBe(false);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("recovers a missed reply from an active thread via conversations.replies", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];
@@ -454,7 +531,7 @@ describe("replayMissedEvents", () => {
     client.ws = ws;
 
     store.setLastSeenTsIfGreater("1700000000.000000");
-    store.trackThread("1700000000.000000", "C-routed", 24 * 60 * 60 * 1_000);
+    store.trackThread("1700000000.000000", "CROUTED01", 24 * 60 * 60 * 1_000);
 
     const calls: string[] = [];
     fetchMock = mock(async (input) => {
@@ -480,7 +557,7 @@ describe("replayMissedEvents", () => {
       expect(calls.some((u) => u.includes("conversations.replies"))).toBe(true);
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe(
-        "replay:C-routed:1700000060.000000",
+        "replay:CROUTED01:1700000060.000000",
       );
     } finally {
       rawDb.close();

--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -659,6 +659,59 @@ describe("replayMissedEvents", () => {
     }
   });
 
+  test("emits replayed channel messages in chronological order regardless of API order", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    fetchMock = mock(async (input) => {
+      const url = String(input);
+      if (url.includes("conversations.history")) {
+        // Slack's conversations.history returns messages newest-first per
+        // https://api.slack.com/methods/conversations.history. The replay
+        // path must reorder them so the runtime sees the conversational
+        // sequence in the order the user sent it.
+        return makeHistoryResponse([
+          {
+            type: "message",
+            user: "U-author",
+            text: "<@UBOT> please respond",
+            ts: "1700000300.000000",
+          },
+          {
+            type: "message",
+            user: "U-author",
+            text: "<@UBOT> can you help?",
+            ts: "1700000200.000000",
+          },
+          {
+            type: "message",
+            user: "U-author",
+            text: "<@UBOT> hello",
+            ts: "1700000100.000000",
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+      expect(emitted.map((e) => e.event.source.messageId)).toEqual([
+        "1700000100.000000",
+        "1700000200.000000",
+        "1700000300.000000",
+      ]);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("preserves subtype, files, attachments, and blocks on replayed file_share messages", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -564,6 +564,101 @@ describe("replayMissedEvents", () => {
     }
   });
 
+  test("replays a DM @-mention as type='message' so default-assistant fallback applies", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    // Seed a known DM channel (D...) that is *not* in routingEntries —
+    // mirrors the live shape where DMs hit the default-assistant fallback.
+    const now = Date.now();
+    rawDb
+      .prepare(
+        `INSERT INTO contact_channels (id, contact_id, type, address, is_primary, external_chat_id, status, created_at, updated_at) VALUES (?, ?, 'slack', ?, 0, ?, 'verified', ?, ?)`,
+      )
+      .run("cc-dm", "contact-1", "DABCDEFGHI", "DABCDEFGHI", now, now);
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    fetchMock = mock(async (input) => {
+      const url = String(input);
+      if (url.includes("conversations.history") && url.includes("DABCDEFGHI")) {
+        return makeHistoryResponse([
+          {
+            type: "message",
+            user: "U-friend",
+            text: "<@UBOT> hello in dm",
+            ts: "1700000060.000000",
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].routing.assistantId).toBe("ast-default");
+      expect(emitted[0].routing.routeSource).toBe("default");
+      // Synthetic event must use type:"message" so it routes through the
+      // DM normalize path (which has the default-assistant fallback) rather
+      // than the app_mention path (which doesn't).
+      const raw = emitted[0].event.raw as { type?: string };
+      expect(raw.type).toBe("message");
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("skips the thread parent returned by conversations.replies", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+    store.trackThread("1700000000.000000", "CROUTED01", 24 * 60 * 60 * 1_000);
+
+    fetchMock = mock(async (input) => {
+      const url = String(input);
+      if (url.includes("conversations.replies")) {
+        // conversations.replies always returns the parent first regardless
+        // of `oldest` — see https://api.slack.com/methods/conversations.replies.
+        return makeHistoryResponse([
+          {
+            type: "message",
+            user: "U-author",
+            text: "<@UBOT> original parent",
+            ts: "1700000000.000000",
+            thread_ts: "1700000000.000000",
+          },
+          {
+            type: "message",
+            user: "U-reply",
+            text: "<@UBOT> a real missed reply",
+            ts: "1700000090.000000",
+            thread_ts: "1700000000.000000",
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe(
+        "replay:CROUTED01:1700000090.000000",
+      );
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("skips messages with no ts and the bot's own messages", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -1,0 +1,528 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import type { GatewayConfig } from "../config.js";
+import { SlackStore } from "../db/slack-store.js";
+import * as schema from "../db/schema.js";
+import type { NormalizedSlackEvent } from "../slack/normalize.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(async () => {
+  return new Response(JSON.stringify({ ok: true, messages: [] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+});
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { SlackSocketModeClient } = await import("../slack/socket-mode.js");
+const { clearUserInfoCache } = await import("../slack/normalize.js");
+import type { SlackSocketModeConfig } from "../slack/socket-mode.js";
+
+type CatchupHarness = {
+  config: SlackSocketModeConfig;
+  onEvent: (event: NormalizedSlackEvent) => void;
+  store: SlackStore;
+  ws: WebSocket | null;
+  handleMessage(raw: string, originWs: WebSocket): void;
+  replayMissedEvents(ownerWs: WebSocket): Promise<void>;
+};
+
+function makeConfig(): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: "ast-default",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    routingEntries: [
+      {
+        type: "conversation_id",
+        key: "C-routed",
+        assistantId: "ast-slack",
+      },
+    ],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    unmappedPolicy: "reject",
+    trustProxy: false,
+  };
+}
+
+function createSlackStore(): { rawDb: Database; store: SlackStore } {
+  const rawDb = new Database(":memory:");
+  rawDb.exec(`
+    CREATE TABLE slack_active_threads (
+      thread_ts TEXT PRIMARY KEY,
+      channel_id TEXT,
+      tracked_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    );
+    CREATE TABLE slack_seen_events (
+      event_id TEXT PRIMARY KEY,
+      seen_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    );
+    CREATE TABLE slack_last_seen_ts (
+      key TEXT PRIMARY KEY,
+      ts TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      external_user_id TEXT,
+      external_chat_id TEXT,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      revoked_reason TEXT,
+      blocked_reason TEXT,
+      last_seen_at INTEGER,
+      last_interaction INTEGER,
+      interaction_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  return { rawDb, store: new SlackStore(drizzle(rawDb, { schema })) };
+}
+
+function createHarness(
+  store: SlackStore,
+  onEvent: (event: NormalizedSlackEvent) => void,
+): CatchupHarness {
+  const harness = Object.create(
+    SlackSocketModeClient.prototype,
+  ) as CatchupHarness;
+  harness.config = {
+    appToken: "xapp-test",
+    botToken: "xoxb-test",
+    botUserId: "UBOT",
+    botUsername: "assistant",
+    teamName: "Example Team",
+    gatewayConfig: makeConfig(),
+  };
+  harness.onEvent = onEvent;
+  harness.store = store;
+  harness.ws = null;
+  return harness;
+}
+
+function makeOpenSocket(): WebSocket {
+  return {
+    readyState: WebSocket.OPEN,
+    send: mock(() => {}),
+  } as unknown as WebSocket;
+}
+
+function flushAsyncEventEmission(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeHistoryResponse(messages: unknown[]): Response {
+  return new Response(JSON.stringify({ ok: true, messages }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  clearUserInfoCache();
+  fetchMock = mock(async () => makeHistoryResponse([]));
+});
+
+describe("compound dedup across live and replay paths", () => {
+  test("replay of an event whose live event_id was already seen is deduped", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-live",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-live",
+            event: {
+              type: "app_mention",
+              user: "U-author",
+              text: "<@UBOT> hi",
+              ts: "1700000000.000100",
+              channel: "C-routed",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+
+      // Same message arrives again via the replay path with a synthetic
+      // event_id but the same (channel, ts) — the compound key prevents
+      // a second emission.
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-replay",
+          type: "events_api",
+          payload: {
+            event_id: "replay:C-routed:1700000000.000100",
+            event: {
+              type: "app_mention",
+              user: "U-author",
+              text: "<@UBOT> hi",
+              ts: "1700000000.000100",
+              channel: "C-routed",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("live event after replay of the same (channel, ts) is deduped", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      // Replay arrives first.
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-replay",
+          type: "events_api",
+          payload: {
+            event_id: "replay:C-routed:1700000000.000200",
+            event: {
+              type: "app_mention",
+              user: "U-author",
+              text: "<@UBOT> hi",
+              ts: "1700000000.000200",
+              channel: "C-routed",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+
+      // Now Slack delivers it live — should be deduped via the message key.
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-live",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-live-late",
+            event: {
+              type: "app_mention",
+              user: "U-author",
+              text: "<@UBOT> hi",
+              ts: "1700000000.000200",
+              channel: "C-routed",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+    } finally {
+      rawDb.close();
+    }
+  });
+});
+
+describe("catch-up watermark", () => {
+  test("watermark advances monotonically across accepted events", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-1",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-1",
+            event: {
+              type: "app_mention",
+              user: "U-author",
+              text: "<@UBOT> first",
+              ts: "1700000010.000000",
+              channel: "C-routed",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-2",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-2",
+            event: {
+              type: "app_mention",
+              user: "U-author",
+              text: "<@UBOT> second",
+              ts: "1700000020.000000",
+              channel: "C-routed",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(store.getLastSeenTs()).toBe("1700000020.000000");
+
+      // Out-of-order older event must not pull the watermark backwards.
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-3",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-3",
+            event: {
+              type: "app_mention",
+              user: "U-author",
+              text: "<@UBOT> earlier",
+              ts: "1700000005.000000",
+              channel: "C-routed",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(store.getLastSeenTs()).toBe("1700000020.000000");
+    } finally {
+      rawDb.close();
+    }
+  });
+});
+
+describe("replayMissedEvents", () => {
+  test("bootstraps watermark to now and skips replay on first connect", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    expect(store.getLastSeenTs()).toBeUndefined();
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch on bootstrap");
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      expect(store.getLastSeenTs()).toBeDefined();
+      expect(emitted).toHaveLength(0);
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("bails out when this.ws !== ownerWs (stale generation)", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const oldWs = makeOpenSocket();
+    const newWs = makeOpenSocket();
+
+    // Seed a watermark so we wouldn't bootstrap-skip.
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    client.ws = newWs;
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch from a stale generation");
+    });
+
+    try {
+      await client.replayMissedEvents(oldWs);
+      expect(emitted).toHaveLength(0);
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("recovers a missed app_mention from a routed channel", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    fetchMock = mock(async (input) => {
+      const url = String(input);
+      if (url.includes("conversations.history")) {
+        return makeHistoryResponse([
+          {
+            type: "message",
+            user: "U-author",
+            text: "<@UBOT> recovered",
+            ts: "1700000050.000000",
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe(
+        "replay:C-routed:1700000050.000000",
+      );
+      expect(emitted[0].event.message.content).toContain("recovered");
+      expect(store.getLastSeenTs()).toBe("1700000050.000000");
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("tolerates conversations.history HTTP 429 without throwing", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    fetchMock = mock(async () => {
+      return new Response("", {
+        status: 429,
+        headers: { "retry-after": "1" },
+      });
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("recovers a missed reply from an active thread via conversations.replies", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+    store.trackThread("1700000000.000000", "C-routed", 24 * 60 * 60 * 1_000);
+
+    const calls: string[] = [];
+    fetchMock = mock(async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes("conversations.replies")) {
+        return makeHistoryResponse([
+          {
+            type: "message",
+            user: "U-reply",
+            text: "<@UBOT> reply caught up",
+            ts: "1700000060.000000",
+            thread_ts: "1700000000.000000",
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+      expect(calls.some((u) => u.includes("conversations.replies"))).toBe(true);
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe(
+        "replay:C-routed:1700000060.000000",
+      );
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("skips messages with no ts and the bot's own messages", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    fetchMock = mock(async (input) => {
+      if (String(input).includes("conversations.history")) {
+        return makeHistoryResponse([
+          {
+            type: "message",
+            user: "UBOT",
+            text: "from bot",
+            ts: "1700000070.000000",
+          },
+          { type: "message", user: "U-author", text: "no ts here" },
+          {
+            type: "message",
+            subtype: "channel_join",
+            user: "U-x",
+            ts: "1700000080.000000",
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+});

--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -659,6 +659,58 @@ describe("replayMissedEvents", () => {
     }
   });
 
+  test("preserves subtype, files, attachments, and blocks on replayed file_share messages", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+
+    const files = [
+      { id: "F123", name: "report.pdf", mimetype: "application/pdf" },
+    ];
+    const attachments = [{ id: 1, fallback: "legacy attachment" }];
+    const blocks = [{ type: "rich_text", block_id: "b1" }];
+
+    fetchMock = mock(async (input) => {
+      if (String(input).includes("conversations.history")) {
+        return makeHistoryResponse([
+          {
+            type: "message",
+            subtype: "file_share",
+            user: "U-uploader",
+            text: "<@UBOT> here's the doc",
+            ts: "1700000050.000000",
+            files,
+            attachments,
+            blocks,
+          },
+        ]);
+      }
+      return makeHistoryResponse([]);
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      await flushAsyncEventEmission();
+      expect(emitted).toHaveLength(1);
+      const raw = emitted[0].event.raw as {
+        subtype?: string;
+        files?: unknown;
+        attachments?: unknown;
+        blocks?: unknown;
+      };
+      expect(raw.subtype).toBe("file_share");
+      expect(raw.files).toEqual(files);
+      expect(raw.attachments).toEqual(attachments);
+      expect(raw.blocks).toEqual(blocks);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("skips messages with no ts and the bot's own messages", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-catchup.test.ts
@@ -359,6 +359,58 @@ describe("replayMissedEvents", () => {
     }
   });
 
+  test("bootstraps watermark even if botUserId is not yet resolved", async () => {
+    // If `auth.test` errored transiently in `start()`, `botUserId` is
+    // undefined for the rest of that gateway lifetime (reconnects do not
+    // retry `auth.test`). Bootstrap must not be gated on identity, or the
+    // watermark stays unwritten across the entire degraded session and the
+    // next gateway restart bootstraps fresh against "now then" — silently
+    // widening the unrecoverable window past the original ws.open.
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    client.config.botUserId = undefined;
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    expect(store.getLastSeenTs()).toBeUndefined();
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch when botUserId is unresolved");
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      expect(store.getLastSeenTs()).toBeDefined();
+      expect(emitted).toHaveLength(0);
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("returns without fetching when watermark is set but botUserId is unresolved", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    client.config.botUserId = undefined;
+    const ws = makeOpenSocket();
+    client.ws = ws;
+
+    store.setLastSeenTsIfGreater("1700000000.000000");
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch when botUserId is unresolved");
+    });
+
+    try {
+      await client.replayMissedEvents(ws);
+      expect(store.getLastSeenTs()).toBe("1700000000.000000");
+      expect(emitted).toHaveLength(0);
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+    } finally {
+      rawDb.close();
+    }
+  });
+
   test("bails out when this.ws !== ownerWs (stale generation)", async () => {
     const { rawDb, store } = createSlackStore();
     const emitted: NormalizedSlackEvent[] = [];

--- a/gateway/src/__tests__/slack-socket-mode-scopes.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-scopes.test.ts
@@ -1,89 +1,52 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
-type WarnCall = [unknown, string?] | [string];
+import { inspectSlackScopes } from "../slack/socket-mode.js";
 
-const warnCalls: WarnCall[] = [];
-
-mock.module("../logger.js", () => {
-  const fakeLogger = {
-    warn: (...args: WarnCall) => {
-      warnCalls.push(args);
-    },
-    info: () => undefined,
-    debug: () => undefined,
-    error: () => undefined,
-    trace: () => undefined,
-    fatal: () => undefined,
-    child: () => fakeLogger,
-  };
-  return {
-    getLogger: () => fakeLogger,
-    initLogger: () => undefined,
-  };
-});
-
-const { warnOnMissingSlackScopes } = await import("../slack/socket-mode.js");
-
-function warnedMessages(): string[] {
-  return warnCalls.map((call) =>
-    typeof call[0] === "string"
-      ? (call[0] as string)
-      : ((call[1] ?? "") as string),
-  );
-}
-
-function warnedMissingHistoryScopes(): string[] {
-  for (const call of warnCalls) {
-    if (typeof call[0] === "object" && call[0] !== null) {
-      const ctx = call[0] as { missingHistoryScopes?: string[] };
-      if (ctx.missingHistoryScopes) return ctx.missingHistoryScopes;
-    }
-  }
-  return [];
-}
-
-describe("warnOnMissingSlackScopes", () => {
-  beforeEach(() => {
-    warnCalls.length = 0;
-  });
-
-  test("warns when files:read is missing", () => {
-    warnOnMissingSlackScopes(
+describe("inspectSlackScopes", () => {
+  test("flags files:read when missing", () => {
+    const result = inspectSlackScopes(
       "app_mentions:read,channels:history,im:history,groups:history,mpim:history",
     );
-    expect(warnedMessages().some((msg) => msg.includes("'files:read'"))).toBe(
-      true,
-    );
+    expect(result.filesReadMissing).toBe(true);
+    expect(result.missingHistoryScopes).toEqual([]);
   });
 
-  test("warns when any *:history scope is missing and lists exactly the missing ones", () => {
-    warnOnMissingSlackScopes("app_mentions:read,files:read,channels:history");
-    expect(warnedMessages().some((msg) => msg.includes("*:history"))).toBe(
-      true,
+  test("returns exactly the missing *:history scopes", () => {
+    const result = inspectSlackScopes(
+      "app_mentions:read,files:read,channels:history",
     );
-    expect(warnedMissingHistoryScopes().sort()).toEqual([
+    expect(result.filesReadMissing).toBe(false);
+    expect(result.missingHistoryScopes.sort()).toEqual([
       "groups:history",
       "im:history",
       "mpim:history",
     ]);
   });
 
-  test("emits no warnings when all required scopes are present", () => {
-    warnOnMissingSlackScopes(
+  test("returns no missing scopes when all required are present", () => {
+    const result = inspectSlackScopes(
       "app_mentions:read,files:read,channels:history,im:history,groups:history,mpim:history",
     );
-    expect(warnCalls).toHaveLength(0);
+    expect(result.filesReadMissing).toBe(false);
+    expect(result.missingHistoryScopes).toEqual([]);
   });
 
   test("treats an empty scope header as everything missing", () => {
-    warnOnMissingSlackScopes("");
-    const messages = warnedMessages();
-    expect(messages.some((msg) => msg.includes("'files:read'"))).toBe(true);
-    expect(warnedMissingHistoryScopes().sort()).toEqual([
+    const result = inspectSlackScopes("");
+    expect(result.filesReadMissing).toBe(true);
+    expect(result.missingHistoryScopes.sort()).toEqual([
       "channels:history",
       "groups:history",
       "im:history",
       "mpim:history",
     ]);
+  });
+
+  test("ignores whitespace and empty entries in the header", () => {
+    const result = inspectSlackScopes(
+      " files:read , channels:history,, im:history ,groups:history,mpim:history",
+    );
+    expect(result.filesReadMissing).toBe(false);
+    expect(result.missingHistoryScopes).toEqual([]);
   });
 });

--- a/gateway/src/__tests__/slack-socket-mode-scopes.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-scopes.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type WarnCall = [unknown, string?] | [string];
+
+const warnCalls: WarnCall[] = [];
+
+mock.module("../logger.js", () => {
+  const fakeLogger = {
+    warn: (...args: WarnCall) => {
+      warnCalls.push(args);
+    },
+    info: () => undefined,
+    debug: () => undefined,
+    error: () => undefined,
+    trace: () => undefined,
+    fatal: () => undefined,
+    child: () => fakeLogger,
+  };
+  return {
+    getLogger: () => fakeLogger,
+    initLogger: () => undefined,
+  };
+});
+
+const { warnOnMissingSlackScopes } = await import("../slack/socket-mode.js");
+
+function warnedMessages(): string[] {
+  return warnCalls.map((call) =>
+    typeof call[0] === "string"
+      ? (call[0] as string)
+      : ((call[1] ?? "") as string),
+  );
+}
+
+function warnedMissingHistoryScopes(): string[] {
+  for (const call of warnCalls) {
+    if (typeof call[0] === "object" && call[0] !== null) {
+      const ctx = call[0] as { missingHistoryScopes?: string[] };
+      if (ctx.missingHistoryScopes) return ctx.missingHistoryScopes;
+    }
+  }
+  return [];
+}
+
+describe("warnOnMissingSlackScopes", () => {
+  beforeEach(() => {
+    warnCalls.length = 0;
+  });
+
+  test("warns when files:read is missing", () => {
+    warnOnMissingSlackScopes(
+      "app_mentions:read,channels:history,im:history,groups:history,mpim:history",
+    );
+    expect(warnedMessages().some((msg) => msg.includes("'files:read'"))).toBe(
+      true,
+    );
+  });
+
+  test("warns when any *:history scope is missing and lists exactly the missing ones", () => {
+    warnOnMissingSlackScopes("app_mentions:read,files:read,channels:history");
+    expect(warnedMessages().some((msg) => msg.includes("*:history"))).toBe(
+      true,
+    );
+    expect(warnedMissingHistoryScopes().sort()).toEqual([
+      "groups:history",
+      "im:history",
+      "mpim:history",
+    ]);
+  });
+
+  test("emits no warnings when all required scopes are present", () => {
+    warnOnMissingSlackScopes(
+      "app_mentions:read,files:read,channels:history,im:history,groups:history,mpim:history",
+    );
+    expect(warnCalls).toHaveLength(0);
+  });
+
+  test("treats an empty scope header as everything missing", () => {
+    warnOnMissingSlackScopes("");
+    const messages = warnedMessages();
+    expect(messages.some((msg) => msg.includes("'files:read'"))).toBe(true);
+    expect(warnedMissingHistoryScopes().sort()).toEqual([
+      "channels:history",
+      "groups:history",
+      "im:history",
+      "mpim:history",
+    ]);
+  });
+});

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -81,6 +81,7 @@ function createSlackStore(): { rawDb: Database; store: SlackStore } {
   rawDb.exec(`
     CREATE TABLE slack_active_threads (
       thread_ts TEXT PRIMARY KEY,
+      channel_id TEXT,
       tracked_at INTEGER NOT NULL,
       expires_at INTEGER NOT NULL
     );
@@ -88,6 +89,29 @@ function createSlackStore(): { rawDb: Database; store: SlackStore } {
       event_id TEXT PRIMARY KEY,
       seen_at INTEGER NOT NULL,
       expires_at INTEGER NOT NULL
+    );
+    CREATE TABLE slack_last_seen_ts (
+      key TEXT PRIMARY KEY,
+      ts TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE contact_channels (
+      id TEXT PRIMARY KEY,
+      contact_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      address TEXT NOT NULL,
+      is_primary INTEGER NOT NULL DEFAULT 0,
+      external_user_id TEXT,
+      external_chat_id TEXT,
+      status TEXT NOT NULL DEFAULT 'unverified',
+      policy TEXT NOT NULL DEFAULT 'allow',
+      revoked_reason TEXT,
+      blocked_reason TEXT,
+      last_seen_at INTEGER,
+      last_interaction INTEGER,
+      interaction_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
     );
   `);
   return { rawDb, store: new SlackStore(drizzle(rawDb, { schema })) };

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -21,19 +21,21 @@ import {
 
 export const slackActiveThreads = sqliteTable("slack_active_threads", {
   threadTs: text("thread_ts").primaryKey(),
-  // Channel hosting the active thread. Nullable so SQLite can ALTER TABLE ADD
-  // COLUMN onto existing installs; pre-existing rows expire within
-  // ACTIVE_THREAD_TTL_MS and replay enumeration filters out null entries.
+  // Channel hosting the active thread. Nullable because SQLite's
+  // ALTER TABLE ADD COLUMN cannot add a NOT NULL column without a default
+  // (https://sqlite.org/lang_altertable.html#alter_table_add_column);
+  // legacy rows pre-dating this column carry NULL until they age out of
+  // the thread TTL window, and reconnect catch-up enumeration filters them.
   channelId: text("channel_id"),
   trackedAt: integer("tracked_at").notNull(),
   expiresAt: integer("expires_at").notNull(),
 });
 
 export const slackSeenEvents = sqliteTable("slack_seen_events", {
-  // Generic dedup key — either a Slack `event_id` (live path) or a synthetic
-  // `msg:${channel}:${ts}` key (reconnect-replay path) so both paths dedup
-  // symmetrically against the same row. Column name is retained for
-  // backwards compatibility with existing installs; semantically it's a
+  // Generic dedup key. Holds either a Slack `event_id` (live path) or a
+  // synthetic `msg:${channel}:${ts}` key (reconnect catch-up path) so both
+  // paths dedup symmetrically against the same row. The physical column
+  // name `event_id` is a historical artefact; semantically this is a
   // dedup key, not strictly an event ID.
   eventId: text("event_id").primaryKey(),
   seenAt: integer("seen_at").notNull(),
@@ -43,11 +45,14 @@ export const slackSeenEvents = sqliteTable("slack_seen_events", {
 /**
  * Persistent high-watermark for Slack Socket Mode catch-up.
  *
- * Slack does not buffer events for Socket Mode clients during disconnects,
- * so missed @mentions and DMs during a reconnect window must be recovered
- * via `conversations.history` / `conversations.replies` on reconnect. This
- * row stores the latest accepted event timestamp so catch-up knows where
- * to resume from. Single row keyed by `'global'` for v1.
+ * Slack does not buffer events for disconnected Socket Mode clients
+ * (https://api.slack.com/apis/socket-mode), so missed @mentions and DMs
+ * during a reconnect window are recovered via `conversations.history` /
+ * `conversations.replies`. This row stores the latest accepted event
+ * timestamp so catch-up knows where to resume from. A single row keyed
+ * by `'global'` is used; per-channel watermarks would add precision but
+ * are not necessary because the compound `msg:${channel}:${ts}` dedup
+ * absorbs the resulting overlap.
  */
 export const slackLastSeenTs = sqliteTable("slack_last_seen_ts", {
   key: text("key").primaryKey(),

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -21,14 +21,38 @@ import {
 
 export const slackActiveThreads = sqliteTable("slack_active_threads", {
   threadTs: text("thread_ts").primaryKey(),
+  // Channel hosting the active thread. Nullable so SQLite can ALTER TABLE ADD
+  // COLUMN onto existing installs; pre-existing rows expire within
+  // ACTIVE_THREAD_TTL_MS and replay enumeration filters out null entries.
+  channelId: text("channel_id"),
   trackedAt: integer("tracked_at").notNull(),
   expiresAt: integer("expires_at").notNull(),
 });
 
 export const slackSeenEvents = sqliteTable("slack_seen_events", {
+  // Generic dedup key — either a Slack `event_id` (live path) or a synthetic
+  // `msg:${channel}:${ts}` key (reconnect-replay path) so both paths dedup
+  // symmetrically against the same row. Column name is retained for
+  // backwards compatibility with existing installs; semantically it's a
+  // dedup key, not strictly an event ID.
   eventId: text("event_id").primaryKey(),
   seenAt: integer("seen_at").notNull(),
   expiresAt: integer("expires_at").notNull(),
+});
+
+/**
+ * Persistent high-watermark for Slack Socket Mode catch-up.
+ *
+ * Slack does not buffer events for Socket Mode clients during disconnects,
+ * so missed @mentions and DMs during a reconnect window must be recovered
+ * via `conversations.history` / `conversations.replies` on reconnect. This
+ * row stores the latest accepted event timestamp so catch-up knows where
+ * to resume from. Single row keyed by `'global'` for v1.
+ */
+export const slackLastSeenTs = sqliteTable("slack_last_seen_ts", {
+  key: text("key").primaryKey(),
+  ts: text("ts").notNull(),
+  updatedAt: integer("updated_at").notNull(),
 });
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/db/slack-store.ts
+++ b/gateway/src/db/slack-store.ts
@@ -1,11 +1,25 @@
 import type { Database } from "bun:sqlite";
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq, gt, isNotNull, like } from "drizzle-orm";
 import { type GatewayDb, getGatewayDb } from "./connection.js";
-import { slackActiveThreads, slackSeenEvents } from "./schema.js";
+import {
+  contactChannels,
+  slackActiveThreads,
+  slackLastSeenTs,
+  slackSeenEvents,
+} from "./schema.js";
+
+const LAST_SEEN_KEY = "global";
+
+/** Active thread row exposed for catch-up enumeration on reconnect. */
+export type ActiveThreadRow = {
+  threadTs: string;
+  channelId: string;
+};
 
 /**
- * Persistent store for Slack thread tracking and event deduplication.
- * Backed by SQLite so state survives gateway restarts.
+ * Persistent store for Slack thread tracking, event deduplication, and
+ * Socket Mode reconnect-catch-up watermarks. Backed by SQLite so state
+ * survives gateway restarts.
  */
 export class SlackStore {
   private db: GatewayDb;
@@ -16,14 +30,25 @@ export class SlackStore {
 
   // -- Active threads --
 
-  trackThread(threadTs: string, ttlMs: number): void {
+  /**
+   * Track a thread the bot is participating in so unmentioned replies are
+   * forwarded. `channelId` is required for new rows; pre-existing rows that
+   * predate the column carry a null channel and are skipped during reconnect
+   * catch-up enumeration.
+   */
+  trackThread(threadTs: string, channelId: string, ttlMs: number): void {
     const now = Date.now();
     this.db
       .insert(slackActiveThreads)
-      .values({ threadTs, trackedAt: now, expiresAt: now + ttlMs })
+      .values({
+        threadTs,
+        channelId,
+        trackedAt: now,
+        expiresAt: now + ttlMs,
+      })
       .onConflictDoUpdate({
         target: slackActiveThreads.threadTs,
-        set: { trackedAt: now, expiresAt: now + ttlMs },
+        set: { channelId, trackedAt: now, expiresAt: now + ttlMs },
       })
       .run();
   }
@@ -43,6 +68,58 @@ export class SlackStore {
     return row !== undefined;
   }
 
+  /**
+   * Returns all unexpired active threads with a known channel for reconnect
+   * catch-up. Rows that predate the `channel_id` column are filtered out.
+   */
+  listActiveThreadsWithChannel(): ActiveThreadRow[] {
+    const now = Date.now();
+    const rows = this.db
+      .select({
+        threadTs: slackActiveThreads.threadTs,
+        channelId: slackActiveThreads.channelId,
+      })
+      .from(slackActiveThreads)
+      .where(
+        and(
+          gt(slackActiveThreads.expiresAt, now),
+          isNotNull(slackActiveThreads.channelId),
+        ),
+      )
+      .all();
+    return rows
+      .filter(
+        (row): row is { threadTs: string; channelId: string } =>
+          typeof row.channelId === "string" && row.channelId.length > 0,
+      )
+      .map((row) => ({ threadTs: row.threadTs, channelId: row.channelId }));
+  }
+
+  /**
+   * Returns distinct Slack DM channel IDs known to the gateway. Used by
+   * reconnect catch-up to recover missed direct messages — DMs always route
+   * to the default assistant, so any DM channel the gateway has previously
+   * received from is a valid catch-up target.
+   */
+  listKnownSlackDmChannels(): string[] {
+    const rows = this.db
+      .select({ externalChatId: contactChannels.externalChatId })
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.type, "slack"),
+          isNotNull(contactChannels.externalChatId),
+          like(contactChannels.externalChatId, "D%"),
+        ),
+      )
+      .all();
+    const seen = new Set<string>();
+    for (const row of rows) {
+      if (row.externalChatId) seen.add(row.externalChatId);
+    }
+    return Array.from(seen);
+  }
+
   cleanupExpiredThreads(): number {
     const now = Date.now();
     const raw = (this.db as unknown as { $client: Database }).$client;
@@ -53,23 +130,28 @@ export class SlackStore {
 
   // -- Event dedup --
 
-  markEventSeen(eventId: string, ttlMs: number): void {
+  /**
+   * Mark a generic dedup key as seen. Callers pass either a Slack `event_id`
+   * (live path) or a synthetic `msg:${channel}:${ts}` key (replay path);
+   * both flow into the same dedup table so the two paths dedup symmetrically.
+   */
+  markEventSeen(key: string, ttlMs: number): void {
     const now = Date.now();
     this.db
       .insert(slackSeenEvents)
-      .values({ eventId, seenAt: now, expiresAt: now + ttlMs })
+      .values({ eventId: key, seenAt: now, expiresAt: now + ttlMs })
       .onConflictDoNothing()
       .run();
   }
 
-  hasEvent(eventId: string): boolean {
+  hasEvent(key: string): boolean {
     const now = Date.now();
     const row = this.db
       .select({ eventId: slackSeenEvents.eventId })
       .from(slackSeenEvents)
       .where(
         and(
-          eq(slackSeenEvents.eventId, eventId),
+          eq(slackSeenEvents.eventId, key),
           gt(slackSeenEvents.expiresAt, now),
         ),
       )
@@ -84,4 +166,55 @@ export class SlackStore {
       .prepare("DELETE FROM slack_seen_events WHERE expires_at < ?")
       .run(now).changes;
   }
+
+  // -- Catch-up watermark --
+
+  /**
+   * Latest accepted Slack event timestamp (`<seconds>.<microseconds>`),
+   * persisted across reconnects so catch-up knows where to resume from.
+   * Returns undefined on first ever start — callers should bootstrap to
+   * "now" and skip catch-up.
+   */
+  getLastSeenTs(): string | undefined {
+    const row = this.db
+      .select({ ts: slackLastSeenTs.ts })
+      .from(slackLastSeenTs)
+      .where(eq(slackLastSeenTs.key, LAST_SEEN_KEY))
+      .get();
+    return row?.ts;
+  }
+
+  /**
+   * Advances the watermark to `ts` only if it is greater than the persisted
+   * value, so out-of-order live + replay events cannot push it backwards.
+   * Comparison is numeric (Slack ts is a `<secs>.<micros>` string but lex
+   * order matches numeric order until the seconds component grows in width
+   * — well past 2286 — so string comparison is safe in practice).
+   */
+  setLastSeenTsIfGreater(ts: string): void {
+    if (!ts) return;
+    const now = Date.now();
+    const current = this.getLastSeenTs();
+    if (current && compareSlackTs(ts, current) <= 0) return;
+    this.db
+      .insert(slackLastSeenTs)
+      .values({ key: LAST_SEEN_KEY, ts, updatedAt: now })
+      .onConflictDoUpdate({
+        target: slackLastSeenTs.key,
+        set: { ts, updatedAt: now },
+      })
+      .run();
+  }
+}
+
+/**
+ * Numeric comparator for Slack timestamps. Returns negative/zero/positive
+ * mirroring `Number(a) - Number(b)`. Falls back to string comparison if
+ * either value fails to parse.
+ */
+export function compareSlackTs(a: string, b: string): number {
+  const na = Number(a);
+  const nb = Number(b);
+  if (Number.isFinite(na) && Number.isFinite(nb)) return na - nb;
+  return a < b ? -1 : a > b ? 1 : 0;
 }

--- a/gateway/src/db/slack-store.ts
+++ b/gateway/src/db/slack-store.ts
@@ -32,9 +32,8 @@ export class SlackStore {
 
   /**
    * Track a thread the bot is participating in so unmentioned replies are
-   * forwarded. `channelId` is required for new rows; pre-existing rows that
-   * predate the column carry a null channel and are skipped during reconnect
-   * catch-up enumeration.
+   * forwarded. `channelId` is required so reconnect catch-up can scope
+   * `conversations.replies` calls to the thread's channel.
    */
   trackThread(threadTs: string, channelId: string, ttlMs: number): void {
     const now = Date.now();
@@ -70,7 +69,8 @@ export class SlackStore {
 
   /**
    * Returns all unexpired active threads with a known channel for reconnect
-   * catch-up. Rows that predate the `channel_id` column are filtered out.
+   * catch-up. Rows with a NULL `channel_id` (legacy rows from before the
+   * column was introduced) are filtered out.
    */
   listActiveThreadsWithChannel(): ActiveThreadRow[] {
     const now = Date.now();

--- a/gateway/src/slack/slack-web.ts
+++ b/gateway/src/slack/slack-web.ts
@@ -48,10 +48,29 @@ export type FetchSlackHistoryResult = {
 /** Slack rate-limit handling — wait this long after a 429 before retrying. */
 const RATE_LIMIT_FALLBACK_MS = 5_000;
 
+/**
+ * Coordinates per-cycle catch-up cancellation. When any worker hits a 429,
+ * it calls `abort()`; remaining workers check `aborted` before each call
+ * and bail out without issuing further requests, so the catch-up cycle
+ * stops cleanly instead of cascading into more rate-limit responses.
+ */
+export class CatchupAbortSignal {
+  private flag = false;
+  abort(): void {
+    this.flag = true;
+  }
+  get aborted(): boolean {
+    return this.flag;
+  }
+}
+
 async function callSlackApi(
   url: string,
   botToken: string,
+  abort: CatchupAbortSignal | undefined,
 ): Promise<SlackHistoryResponse | undefined> {
+  if (abort?.aborted) return undefined;
+
   let resp: Response;
   try {
     resp = await fetchImpl(url, {
@@ -68,9 +87,10 @@ async function callSlackApi(
     const waitMs = retryHeader
       ? Number.parseInt(retryHeader, 10) * 1_000
       : RATE_LIMIT_FALLBACK_MS;
+    abort?.abort();
     log.warn(
       { url: redact(url), waitMs },
-      "Slack catch-up rate limited; abandoning this cycle",
+      "Slack catch-up rate limited; aborting cycle",
     );
     return undefined;
   }
@@ -119,15 +139,16 @@ export async function fetchChannelHistorySince(params: {
   channel: string;
   oldest: string;
   limit: number;
+  abort?: CatchupAbortSignal;
 }): Promise<FetchSlackHistoryResult> {
-  const { botToken, channel, oldest, limit } = params;
+  const { botToken, channel, oldest, limit, abort } = params;
   const url =
     "https://slack.com/api/conversations.history" +
     `?channel=${encodeURIComponent(channel)}` +
     `&oldest=${encodeURIComponent(oldest)}` +
     `&limit=${limit}` +
     `&inclusive=false`;
-  const data = await callSlackApi(url, botToken);
+  const data = await callSlackApi(url, botToken, abort);
   if (!data) return { messages: [], hasMore: false, ok: false };
   return {
     messages: data.messages ?? [],
@@ -148,8 +169,9 @@ export async function fetchThreadRepliesSince(params: {
   threadTs: string;
   oldest: string;
   limit: number;
+  abort?: CatchupAbortSignal;
 }): Promise<FetchSlackHistoryResult> {
-  const { botToken, channel, threadTs, oldest, limit } = params;
+  const { botToken, channel, threadTs, oldest, limit, abort } = params;
   const url =
     "https://slack.com/api/conversations.replies" +
     `?channel=${encodeURIComponent(channel)}` +
@@ -157,7 +179,7 @@ export async function fetchThreadRepliesSince(params: {
     `&oldest=${encodeURIComponent(oldest)}` +
     `&limit=${limit}` +
     `&inclusive=false`;
-  const data = await callSlackApi(url, botToken);
+  const data = await callSlackApi(url, botToken, abort);
   if (!data) return { messages: [], hasMore: false, ok: false };
   return {
     messages: data.messages ?? [],

--- a/gateway/src/slack/slack-web.ts
+++ b/gateway/src/slack/slack-web.ts
@@ -1,0 +1,191 @@
+import { fetchImpl } from "../fetch.js";
+import { getLogger } from "../logger.js";
+
+const log = getLogger("slack-web");
+
+/**
+ * Subset of the Slack `conversations.history` / `conversations.replies`
+ * message payload that the gateway needs for catch-up. Synthesized
+ * Socket Mode envelopes are built by mapping these fields onto the
+ * `app_mention` / `message` event shapes that the live path already
+ * understands.
+ */
+export type SlackHistoryMessage = {
+  type?: string;
+  subtype?: string;
+  user?: string;
+  bot_id?: string;
+  text?: string;
+  ts: string;
+  thread_ts?: string;
+  team?: string;
+  blocks?: unknown[];
+  files?: unknown[];
+  attachments?: unknown[];
+  edited?: { user?: string; ts?: string };
+};
+
+type SlackHistoryResponse = {
+  ok: boolean;
+  error?: string;
+  messages?: SlackHistoryMessage[];
+  has_more?: boolean;
+};
+
+export type FetchSlackHistoryResult = {
+  /** Messages returned by Slack. Empty on transient failure. */
+  messages: SlackHistoryMessage[];
+  /** True when Slack indicates additional pages are available. */
+  hasMore: boolean;
+  /**
+   * `true` when the call succeeded (HTTP 200 + `ok: true`). False results
+   * are logged and silently treated as zero messages so a transient outage
+   * during catch-up doesn't block reconnect.
+   */
+  ok: boolean;
+};
+
+/** Slack rate-limit handling — wait this long after a 429 before retrying. */
+const RATE_LIMIT_FALLBACK_MS = 5_000;
+
+async function callSlackApi(
+  url: string,
+  botToken: string,
+): Promise<SlackHistoryResponse | undefined> {
+  let resp: Response;
+  try {
+    resp = await fetchImpl(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${botToken}` },
+    });
+  } catch (err) {
+    log.warn({ err, url: redact(url) }, "Slack catch-up fetch threw");
+    return undefined;
+  }
+
+  if (resp.status === 429) {
+    const retryHeader = resp.headers.get("retry-after");
+    const waitMs = retryHeader
+      ? Number.parseInt(retryHeader, 10) * 1_000
+      : RATE_LIMIT_FALLBACK_MS;
+    log.warn(
+      { url: redact(url), waitMs },
+      "Slack catch-up rate limited; abandoning this cycle",
+    );
+    return undefined;
+  }
+
+  if (!resp.ok) {
+    log.warn(
+      { url: redact(url), status: resp.status },
+      "Slack catch-up returned non-OK HTTP status",
+    );
+    return undefined;
+  }
+
+  let data: SlackHistoryResponse;
+  try {
+    data = (await resp.json()) as SlackHistoryResponse;
+  } catch (err) {
+    log.warn({ err, url: redact(url) }, "Slack catch-up response not JSON");
+    return undefined;
+  }
+
+  if (!data.ok) {
+    log.warn(
+      { url: redact(url), error: data.error },
+      "Slack catch-up API returned ok=false",
+    );
+    return undefined;
+  }
+
+  return data;
+}
+
+/** Strip the channel/oldest query for log readability. */
+function redact(url: string): string {
+  const idx = url.indexOf("?");
+  return idx >= 0 ? url.slice(0, idx) : url;
+}
+
+/**
+ * Fetch messages in `channel` strictly newer than `oldest` (Slack ts).
+ * `inclusive=false` is the default; we set it explicitly to make the
+ * behavior obvious on read. No pagination — we cap at `limit` messages
+ * per channel per reconnect to bound API budget.
+ */
+export async function fetchChannelHistorySince(params: {
+  botToken: string;
+  channel: string;
+  oldest: string;
+  limit: number;
+}): Promise<FetchSlackHistoryResult> {
+  const { botToken, channel, oldest, limit } = params;
+  const url =
+    "https://slack.com/api/conversations.history" +
+    `?channel=${encodeURIComponent(channel)}` +
+    `&oldest=${encodeURIComponent(oldest)}` +
+    `&limit=${limit}` +
+    `&inclusive=false`;
+  const data = await callSlackApi(url, botToken);
+  if (!data) return { messages: [], hasMore: false, ok: false };
+  return {
+    messages: data.messages ?? [],
+    hasMore: data.has_more === true,
+    ok: true,
+  };
+}
+
+/**
+ * Fetch replies in a thread strictly newer than `oldest`. Uses
+ * `conversations.replies` because it returns a smaller, thread-scoped
+ * window than `conversations.history` and avoids re-paging the channel
+ * for every active thread on reconnect.
+ */
+export async function fetchThreadRepliesSince(params: {
+  botToken: string;
+  channel: string;
+  threadTs: string;
+  oldest: string;
+  limit: number;
+}): Promise<FetchSlackHistoryResult> {
+  const { botToken, channel, threadTs, oldest, limit } = params;
+  const url =
+    "https://slack.com/api/conversations.replies" +
+    `?channel=${encodeURIComponent(channel)}` +
+    `&ts=${encodeURIComponent(threadTs)}` +
+    `&oldest=${encodeURIComponent(oldest)}` +
+    `&limit=${limit}` +
+    `&inclusive=false`;
+  const data = await callSlackApi(url, botToken);
+  if (!data) return { messages: [], hasMore: false, ok: false };
+  return {
+    messages: data.messages ?? [],
+    hasMore: data.has_more === true,
+    ok: true,
+  };
+}
+
+/**
+ * Drives a list of async tasks with bounded concurrency. Used to fan out
+ * catch-up fetches across channels without flooding Slack's rate limits.
+ */
+export async function runWithConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number,
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let cursor = 0;
+  const workers = Array.from(
+    { length: Math.min(concurrency, tasks.length) },
+    async () => {
+      while (true) {
+        const idx = cursor++;
+        if (idx >= tasks.length) return;
+        results[idx] = await tasks[idx]();
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1028,20 +1028,28 @@ export class SlackSocketModeClient {
 
     const botToken = this.config.botToken;
     if (!botToken) return;
-    const botUserId = this.config.botUserId;
-    if (!botUserId) {
-      log.debug("Skipping reconnect catch-up: bot user id not yet resolved");
-      return;
-    }
 
+    // Bootstrap before the bot-identity check. The bot-identity check below
+    // can keep returning early across reconnects if `auth.test` failed
+    // transiently in `start()` and never retried — gating bootstrap on it
+    // would leave the watermark unwritten for the entire degraded session,
+    // and the eventual restart with a working `auth.test` would bootstrap
+    // fresh against "now then" rather than "now at first ws.open", silently
+    // widening the unrecoverable window. Bootstrap is identity-agnostic, so
+    // run it first; the actual replay still requires `botUserId` and is
+    // gated below.
     const persisted = this.store.getLastSeenTs();
     if (!persisted) {
-      // Bootstrap on first ever connect: seed the watermark to "now" so
-      // we never replay arbitrary historical messages on a fresh install.
       this.store.setLastSeenTsIfGreater(toSlackTs(Date.now()));
       log.info(
         "Slack catch-up: bootstrapped watermark, skipping initial replay",
       );
+      return;
+    }
+
+    const botUserId = this.config.botUserId;
+    if (!botUserId) {
+      log.debug("Skipping reconnect catch-up: bot user id not yet resolved");
       return;
     }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -5,6 +5,7 @@ import type { GatewayConfig } from "../config.js";
 import { SlackStore } from "../db/slack-store.js";
 import { isRejection, resolveAssistant } from "../routing/resolve-assistant.js";
 import {
+  CatchupAbortSignal,
   fetchChannelHistorySince,
   fetchThreadRepliesSince,
   runWithConcurrency,
@@ -992,17 +993,16 @@ export class SlackSocketModeClient {
    * dedup (`msg:${channel}:${ts}`) prevents double-emit if the same
    * message also arrives via the live socket.
    *
-   * Scope (v1):
+   * Scope:
    *   - Routed channels (gateway routing entries)
    *   - Active threads (`slack_active_threads`)
    *   - Known DM channels (`contact_channels` rows of type `slack` with
    *     a `D…` external chat id)
    *
-   * Brand-new mentions in unrouted, never-engaged channels remain
-   * unrecoverable for v1 — the daemon's existing inbound-triggered
-   * backfill (`triggerSlackThreadBackfillIfNeeded`,
-   * `tryBackfillSlackDmIfCold`) will hydrate context once the next
-   * live event arrives.
+   * Brand-new mentions in unrouted, never-engaged channels are not
+   * recoverable here — the daemon's existing inbound-triggered backfill
+   * (`triggerSlackThreadBackfillIfNeeded`, `tryBackfillSlackDmIfCold`)
+   * will hydrate context once the next live event arrives.
    */
   private async replayMissedEvents(ownerWs: WebSocket): Promise<void> {
     // Bail if a fresh forceReconnect has replaced the active socket
@@ -1037,7 +1037,17 @@ export class SlackSocketModeClient {
 
     const routedChannels = new Set<string>();
     for (const entry of this.config.gatewayConfig.routingEntries) {
-      if (entry.type === "conversation_id") routedChannels.add(entry.key);
+      // routingEntries is shared across channels (Slack, Telegram, WhatsApp,
+      // …), so filter to keys that look like Slack conversation IDs. Slack
+      // IDs always begin with C (public channel), D (DM/IM), or G (private
+      // channel / multi-person IM) — see
+      // https://api.slack.com/types/conversation.
+      if (
+        entry.type === "conversation_id" &&
+        isSlackConversationId(entry.key)
+      ) {
+        routedChannels.add(entry.key);
+      }
     }
     const dmChannels = this.store.listKnownSlackDmChannels();
     for (const channel of dmChannels) routedChannels.add(channel);
@@ -1054,6 +1064,7 @@ export class SlackSocketModeClient {
     );
 
     let recovered = 0;
+    const abort = new CatchupAbortSignal();
 
     // Channel/DM history fan-out. We use conversations.history rather than
     // conversations.replies for top-level channels because we want
@@ -1061,12 +1072,13 @@ export class SlackSocketModeClient {
     // covered separately below.
     const channelTasks = Array.from(routedChannels).map((channel) => {
       return async () => {
-        if (this.ws !== ownerWs) return;
+        if (this.ws !== ownerWs || abort.aborted) return;
         const result = await fetchChannelHistorySince({
           botToken,
           channel,
           oldest,
           limit: CATCHUP_HISTORY_LIMIT,
+          abort,
         });
         if (this.ws !== ownerWs) return;
         for (const msg of result.messages) {
@@ -1077,13 +1089,14 @@ export class SlackSocketModeClient {
 
     const threadTasks = activeThreads.map(({ channelId, threadTs }) => {
       return async () => {
-        if (this.ws !== ownerWs) return;
+        if (this.ws !== ownerWs || abort.aborted) return;
         const result = await fetchThreadRepliesSince({
           botToken,
           channel: channelId,
           threadTs,
           oldest,
           limit: CATCHUP_HISTORY_LIMIT,
+          abort,
         });
         if (this.ws !== ownerWs) return;
         for (const msg of result.messages) {
@@ -1285,6 +1298,16 @@ function toSlackTs(ms: number): string {
   const secs = Math.floor(ms / 1_000);
   const micros = Math.floor((ms % 1_000) * 1_000);
   return `${secs}.${String(micros).padStart(6, "0")}`;
+}
+
+/**
+ * True if `id` looks like a Slack conversation ID. Slack IDs are 9–11
+ * uppercase-alphanumeric characters prefixed with `C` (public channel),
+ * `D` (direct message / IM), or `G` (private channel / multi-person IM).
+ * See https://api.slack.com/types/conversation.
+ */
+function isSlackConversationId(id: string): boolean {
+  return /^[CDG][A-Z0-9]+$/.test(id);
 }
 
 /**

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1081,7 +1081,7 @@ export class SlackSocketModeClient {
           abort,
         });
         if (this.ws !== ownerWs) return;
-        for (const msg of result.messages) {
+        for (const msg of sortMessagesAscendingByTs(result.messages)) {
           if (this.injectReplayMessage(channel, msg, botUserId)) recovered++;
         }
       };
@@ -1099,7 +1099,7 @@ export class SlackSocketModeClient {
           abort,
         });
         if (this.ws !== ownerWs) return;
-        for (const msg of result.messages) {
+        for (const msg of sortMessagesAscendingByTs(result.messages)) {
           // conversations.replies always returns the thread parent as the
           // first element regardless of `oldest` / `inclusive` — see
           // https://api.slack.com/methods/conversations.replies. The parent
@@ -1334,6 +1334,29 @@ function toSlackTs(ms: number): string {
  */
 function isSlackConversationId(id: string): boolean {
   return /^[CDG][A-Z0-9]+$/.test(id);
+}
+
+/**
+ * Sort Slack messages by `ts` ascending so they replay through the
+ * per-channel emit queue in chronological order. `conversations.history`
+ * returns messages newest-first
+ * (https://api.slack.com/methods/conversations.history) and
+ * `conversations.replies` makes no strict ordering guarantee beyond
+ * "parent first", so we sort defensively rather than rely on either API's
+ * order. Without this, a flurry of missed messages emits in reverse
+ * order — the runtime sees the latest user message before the earlier
+ * ones it depends on. Messages without a `ts` are dropped by
+ * `injectReplayMessage` anyway; sort them last so they don't perturb
+ * the order of the rest.
+ */
+function sortMessagesAscendingByTs<T extends { ts?: string }>(
+  messages: readonly T[],
+): T[] {
+  return [...messages].sort((a, b) => {
+    const aTs = a.ts ? Number(a.ts) : Number.POSITIVE_INFINITY;
+    const bTs = b.ts ? Number(b.ts) : Number.POSITIVE_INFINITY;
+    return aTs - bTs;
+  });
 }
 
 /**

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -5,6 +5,12 @@ import type { GatewayConfig } from "../config.js";
 import { SlackStore } from "../db/slack-store.js";
 import { isRejection, resolveAssistant } from "../routing/resolve-assistant.js";
 import {
+  fetchChannelHistorySince,
+  fetchThreadRepliesSince,
+  runWithConcurrency,
+  type SlackHistoryMessage,
+} from "./slack-web.js";
+import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
   normalizeSlackChannelMessage,
@@ -33,6 +39,25 @@ const DEDUP_TTL_MS = 24 * 60 * 60 * 1_000;
 const DEDUP_CLEANUP_INTERVAL_MS = 60 * 60 * 1_000;
 const ACTIVE_THREAD_TTL_MS = 24 * 60 * 60 * 1_000;
 const USER_RESOLVE_TIMEOUT_MS = 3_000;
+
+/**
+ * Reconnect catch-up bounds.
+ *
+ * `MAX_LOOKBACK_MS` caps how far back we'll ask Slack for missed messages.
+ * Sleeps longer than this fall back to the daemon's existing inbound-
+ * triggered backfill (JARVIS-643) once new live events resume.
+ *
+ * `SAFETY_OVERLAP_MS` widens the `oldest` window slightly past the
+ * persisted watermark so a non-mention event that advanced the watermark
+ * cannot silently mask an earlier missed mention. Resulting overlap is
+ * absorbed by the compound `msg:${channel}:${ts}` dedup key.
+ *
+ * `HISTORY_LIMIT` and `CONCURRENCY` bound API budget per reconnect.
+ */
+const CATCHUP_MAX_LOOKBACK_MS = 60 * 60 * 1_000;
+const CATCHUP_SAFETY_OVERLAP_MS = 60 * 1_000;
+const CATCHUP_HISTORY_LIMIT = 50;
+const CATCHUP_CONCURRENCY = 4;
 
 export type SlackSocketModeConfig = {
   appToken: string;
@@ -251,10 +276,12 @@ export class SlackSocketModeClient {
   }
 
   /**
-   * Register a thread as active so future replies (without @mention) are forwarded.
+   * Register a thread as active so future replies (without @mention) are
+   * forwarded. `channelId` is required so reconnect catch-up can scope a
+   * `conversations.replies` fetch to the right channel.
    */
-  trackThread(threadTs: string): void {
-    this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
+  trackThread(threadTs: string, channelId: string): void {
+    this.store.trackThread(threadTs, channelId, ACTIVE_THREAD_TTL_MS);
   }
 
   /**
@@ -298,6 +325,13 @@ export class SlackSocketModeClient {
       ws.addEventListener("open", () => {
         log.info("Slack Socket Mode connected");
         this.reconnectAttempt = 0;
+        // Recover messages that arrived during the reconnect gap (Slack
+        // does not buffer Socket Mode events during disconnects). Runs
+        // off the open handler so initial-start, normal reconnect, and
+        // sleep/wake force-reconnect all share the same recovery path.
+        // Errors are swallowed inside replayMissedEvents — a failed
+        // catch-up should never destabilize the live socket.
+        void this.replayMissedEvents(ws);
       });
 
       ws.addEventListener("message", (messageEvent) => {
@@ -368,6 +402,7 @@ export class SlackSocketModeClient {
       type?: string;
       payload?: {
         event_id?: string;
+        event_time?: number;
         event?:
           | SlackAppMentionEvent
           | SlackDirectMessageEvent
@@ -433,11 +468,40 @@ export class SlackSocketModeClient {
 
     const eventPayload = envelope.payload;
     if (!eventPayload?.event) return;
-
-    const event = eventPayload.event;
-
     if (!eventPayload.event_id) return;
 
+    this.processEventPayload({
+      event_id: eventPayload.event_id,
+      event_time: eventPayload.event_time,
+      event: eventPayload.event,
+    });
+  }
+
+  /**
+   * Filter, deduplicate, advance the watermark, and dispatch a single
+   * Slack event payload. Shared by the live Socket Mode path
+   * (`handleMessage`) and the reconnect catch-up path
+   * (`replayMissedEvents`) so both flows enforce identical filters,
+   * dedup, and ordering semantics.
+   *
+   * The `event_id` may be either a real Slack ID (live path) or a
+   * synthetic `replay:${channel}:${ts}` ID (replay path). Both flow
+   * through the same compound dedup table so the two paths never
+   * double-emit a message that arrived on both.
+   */
+  private processEventPayload(eventPayload: {
+    event_id: string;
+    event_time?: number;
+    event:
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent
+      | SlackMessageChangedEvent
+      | SlackMessageDeletedEvent
+      | SlackReactionAddedEvent
+      | SlackReactionRemovedEvent;
+  }): void {
+    const event = eventPayload.event;
     const dmEvent = event as SlackDirectMessageEvent;
     const channelEvent = event as SlackChannelMessageEvent;
     const messageChangedEvent = event as SlackMessageChangedEvent;
@@ -582,13 +646,35 @@ export class SlackSocketModeClient {
       "Slack event accepted by filter",
     );
 
-    // Deduplicate on event_id
+    // Compound dedup. Live events are keyed by Slack `event_id`; replay
+    // events are keyed by `replay:${channel}:${ts}`. Both also write a
+    // `msg:${channel}:${ts}` key when the event has a stable
+    // (channel, ts) identity, so a message that arrives via both paths
+    // is deduped on the second arrival regardless of which came first.
     const eventId = eventPayload.event_id;
+    const messageKey = computeMessageDedupKey(event);
     if (this.store.hasEvent(eventId)) {
       log.debug({ eventId }, "Duplicate Slack event, skipping");
       return;
     }
+    if (messageKey && this.store.hasEvent(messageKey)) {
+      log.debug(
+        { eventId, messageKey },
+        "Slack event already seen via paired path, skipping",
+      );
+      return;
+    }
     this.store.markEventSeen(eventId, DEDUP_TTL_MS);
+    if (messageKey) {
+      this.store.markEventSeen(messageKey, DEDUP_TTL_MS);
+    }
+
+    // Advance the catch-up watermark before dispatch so a normalize/emit
+    // failure does not stall progress past this event on the next reconnect.
+    const watermarkTs = extractEventWatermarkTs(event, eventPayload.event_time);
+    if (watermarkTs) {
+      this.store.setLastSeenTsIfGreater(watermarkTs);
+    }
 
     if (isAppMention) {
       const appMentionEvent = event as SlackAppMentionEvent;
@@ -598,8 +684,12 @@ export class SlackSocketModeClient {
         appMentionEvent.channel,
         appMentionEvent.user,
       );
-      if (threadTs && !isRejection(routing)) {
-        this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
+      if (threadTs && !isRejection(routing) && appMentionEvent.channel) {
+        this.store.trackThread(
+          threadTs,
+          appMentionEvent.channel,
+          ACTIVE_THREAD_TTL_MS,
+        );
       }
     }
 
@@ -859,9 +949,10 @@ export class SlackSocketModeClient {
     // continue after app mentions and admitted messages, without reactions,
     // edits, or deletes arming unrelated threads.
     const threadTs = normalized.threadTs;
+    const channelId = normalized.event.message.conversationExternalId;
     const shouldTrackActiveThread = isAppMention || isActiveThreadReply;
-    if (shouldTrackActiveThread && threadTs) {
-      this.store.trackThread(threadTs, ACTIVE_THREAD_TTL_MS);
+    if (shouldTrackActiveThread && threadTs && channelId) {
+      this.store.trackThread(threadTs, channelId, ACTIVE_THREAD_TTL_MS);
     }
 
     // Enrich actor display name if the sync cache missed.
@@ -888,6 +979,184 @@ export class SlackSocketModeClient {
     }
 
     this.onEvent(normalized);
+  }
+
+  /**
+   * Catch up on messages that arrived during the reconnect window.
+   *
+   * Slack does not buffer Socket Mode events for disconnected clients
+   * (see https://api.slack.com/apis/socket-mode), so on reconnect we
+   * fetch a bounded slice of `conversations.history` /
+   * `conversations.replies` since the persisted watermark and feed any
+   * recovered messages back through `processEventPayload`. Compound
+   * dedup (`msg:${channel}:${ts}`) prevents double-emit if the same
+   * message also arrives via the live socket.
+   *
+   * Scope (v1):
+   *   - Routed channels (gateway routing entries)
+   *   - Active threads (`slack_active_threads`)
+   *   - Known DM channels (`contact_channels` rows of type `slack` with
+   *     a `D…` external chat id)
+   *
+   * Brand-new mentions in unrouted, never-engaged channels remain
+   * unrecoverable for v1 — the daemon's existing inbound-triggered
+   * backfill (`triggerSlackThreadBackfillIfNeeded`,
+   * `tryBackfillSlackDmIfCold`) will hydrate context once the next
+   * live event arrives.
+   */
+  private async replayMissedEvents(ownerWs: WebSocket): Promise<void> {
+    // Bail if a fresh forceReconnect has replaced the active socket
+    // before the async work began. Without this gate, a stale generation
+    // could fan out catch-up traffic that races with the new connection.
+    if (this.ws !== ownerWs) return;
+
+    const botToken = this.config.botToken;
+    if (!botToken) return;
+    const botUserId = this.config.botUserId;
+    if (!botUserId) {
+      log.debug("Skipping reconnect catch-up: bot user id not yet resolved");
+      return;
+    }
+
+    const persisted = this.store.getLastSeenTs();
+    if (!persisted) {
+      // Bootstrap on first ever connect: seed the watermark to "now" so
+      // we never replay arbitrary historical messages on a fresh install.
+      this.store.setLastSeenTsIfGreater(toSlackTs(Date.now()));
+      log.info(
+        "Slack catch-up: bootstrapped watermark, skipping initial replay",
+      );
+      return;
+    }
+
+    const minOldestMs = Date.now() - CATCHUP_MAX_LOOKBACK_MS;
+    const persistedMs = Math.floor(Number(persisted) * 1_000);
+    const overlapMs = Math.max(persistedMs - CATCHUP_SAFETY_OVERLAP_MS, 0);
+    const oldestMs = Math.max(overlapMs, minOldestMs);
+    const oldest = toSlackTs(oldestMs);
+
+    const routedChannels = new Set<string>();
+    for (const entry of this.config.gatewayConfig.routingEntries) {
+      if (entry.type === "conversation_id") routedChannels.add(entry.key);
+    }
+    const dmChannels = this.store.listKnownSlackDmChannels();
+    for (const channel of dmChannels) routedChannels.add(channel);
+
+    const activeThreads = this.store.listActiveThreadsWithChannel();
+
+    log.info(
+      {
+        oldest,
+        channels: routedChannels.size,
+        threads: activeThreads.length,
+      },
+      "Slack reconnect catch-up starting",
+    );
+
+    let recovered = 0;
+
+    // Channel/DM history fan-out. We use conversations.history rather than
+    // conversations.replies for top-level channels because we want
+    // any unseen top-level message — replies in tracked threads are
+    // covered separately below.
+    const channelTasks = Array.from(routedChannels).map((channel) => {
+      return async () => {
+        if (this.ws !== ownerWs) return;
+        const result = await fetchChannelHistorySince({
+          botToken,
+          channel,
+          oldest,
+          limit: CATCHUP_HISTORY_LIMIT,
+        });
+        if (this.ws !== ownerWs) return;
+        for (const msg of result.messages) {
+          if (this.injectReplayMessage(channel, msg, botUserId)) recovered++;
+        }
+      };
+    });
+
+    const threadTasks = activeThreads.map(({ channelId, threadTs }) => {
+      return async () => {
+        if (this.ws !== ownerWs) return;
+        const result = await fetchThreadRepliesSince({
+          botToken,
+          channel: channelId,
+          threadTs,
+          oldest,
+          limit: CATCHUP_HISTORY_LIMIT,
+        });
+        if (this.ws !== ownerWs) return;
+        for (const msg of result.messages) {
+          if (this.injectReplayMessage(channelId, msg, botUserId)) recovered++;
+        }
+      };
+    });
+
+    try {
+      await runWithConcurrency(
+        [...channelTasks, ...threadTasks],
+        CATCHUP_CONCURRENCY,
+      );
+    } catch (err) {
+      log.warn({ err }, "Slack reconnect catch-up encountered an error");
+    }
+
+    log.info({ recovered, oldest }, "Slack reconnect catch-up complete");
+  }
+
+  /**
+   * Build a synthetic events_api envelope for a recovered message and
+   * dispatch it through the shared `processEventPayload` path. Returns
+   * true if the message was passed through to processing (subject to
+   * filter/dedup), false if it was skipped at this stage (no `ts`,
+   * bot's own message, or other shape that the live filter would also
+   * drop).
+   */
+  private injectReplayMessage(
+    channel: string,
+    msg: SlackHistoryMessage,
+    botUserId: string,
+  ): boolean {
+    if (!msg.ts) return false;
+
+    // Skip the bot's own outbound messages and edits/deletes — the live
+    // filter would already drop these and replaying them risks loops.
+    if (msg.user === botUserId) return false;
+    if (msg.bot_id) return false;
+    if (
+      msg.subtype &&
+      msg.subtype !== "thread_broadcast" &&
+      msg.subtype !== "file_share"
+    ) {
+      return false;
+    }
+
+    const mentionsBot = msg.text?.includes(`<@${botUserId}>`) ?? false;
+    const isDm = channel.startsWith("D");
+    const eventType: "app_mention" | "message" = mentionsBot
+      ? "app_mention"
+      : "message";
+
+    const syntheticEvent = {
+      type: eventType,
+      user: msg.user ?? "",
+      text: msg.text ?? "",
+      ts: msg.ts,
+      thread_ts: msg.thread_ts,
+      channel,
+      channel_type: isDm ? "im" : "channel",
+      team: msg.team,
+    } as unknown as
+      | SlackAppMentionEvent
+      | SlackDirectMessageEvent
+      | SlackChannelMessageEvent;
+
+    this.processEventPayload({
+      event_id: `replay:${channel}:${msg.ts}`,
+      event_time: Math.floor(Number(msg.ts)) || undefined,
+      event: syntheticEvent,
+    });
+    return true;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -954,6 +1223,68 @@ export class SlackSocketModeClient {
       this.dedupCleanupTimer = null;
     }
   }
+}
+
+/**
+ * Compute a stable `msg:${channel}:${ts}` dedup key for events that carry
+ * a (channel, ts) identity. Used so the live and reconnect-replay paths
+ * dedup symmetrically — a message that arrives via both paths is rejected
+ * on the second arrival regardless of which came first.
+ *
+ * Returns undefined for events without a stable message identity (e.g.
+ * `message_changed`, `message_deleted`, reactions). Those rely on their
+ * Slack `event_id` for dedup; replay never synthesizes them.
+ */
+function computeMessageDedupKey(event: {
+  type?: string;
+  subtype?: string;
+  channel?: string;
+  ts?: string;
+}): string | undefined {
+  // Restrict to top-level message-shaped events. Edits/deletes carry a
+  // separate `previous_message`/`message` payload and don't need this key
+  // because the replay path doesn't synthesize them.
+  if (event.type !== "message" && event.type !== "app_mention") {
+    return undefined;
+  }
+  if (
+    event.subtype === "message_changed" ||
+    event.subtype === "message_deleted"
+  ) {
+    return undefined;
+  }
+  if (!event.channel || !event.ts) return undefined;
+  return `msg:${event.channel}:${event.ts}`;
+}
+
+/**
+ * Extract the watermark timestamp for an event. Prefers the message ts,
+ * falling back to envelope `event_time` for events that don't carry their
+ * own ts (reactions). Returns a Slack-format `<seconds>.<micros>` string
+ * or undefined when no usable timestamp is present.
+ */
+function extractEventWatermarkTs(
+  event: {
+    ts?: string;
+    item?: { ts?: string };
+    deleted_ts?: string;
+    message?: { ts?: string };
+  },
+  envelopeEventTime: number | undefined,
+): string | undefined {
+  if (event.ts) return event.ts;
+  if (event.message?.ts) return event.message.ts;
+  if (event.deleted_ts) return event.deleted_ts;
+  if (event.item?.ts) return event.item.ts;
+  if (envelopeEventTime) return `${envelopeEventTime}.000000`;
+  return undefined;
+}
+
+/** Convert millisecond epoch to a Slack `<seconds>.<micros>` timestamp string. */
+function toSlackTs(ms: number): string {
+  const secs = Math.floor(ms / 1_000);
+  const micros = Math.floor((ms % 1_000) * 1_000);
+  return `${secs}.${String(micros).padStart(6, "0")}`;
 }
 
 /**

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1165,6 +1165,13 @@ export class SlackSocketModeClient {
     const eventType: "app_mention" | "message" =
       mentionsBot && !isDm ? "app_mention" : "message";
 
+    // Pass through `subtype`, `files`, `attachments`, and `blocks` so the
+    // synthetic event has the same shape as a live Slack event for the
+    // same message. Without this, recovered `file_share` messages would be
+    // emitted as text-only and downstream attachment handling would diverge
+    // between the live and replay paths. See
+    // https://api.slack.com/events/message and
+    // https://api.slack.com/events/app_mention for the live event shape.
     const syntheticEvent = {
       type: eventType,
       user: msg.user ?? "",
@@ -1174,6 +1181,10 @@ export class SlackSocketModeClient {
       channel,
       channel_type: isDm ? "im" : "channel",
       team: msg.team,
+      ...(msg.subtype ? { subtype: msg.subtype } : {}),
+      ...(msg.files ? { files: msg.files } : {}),
+      ...(msg.attachments ? { attachments: msg.attachments } : {}),
+      ...(msg.blocks ? { blocks: msg.blocks } : {}),
     } as unknown as
       | SlackAppMentionEvent
       | SlackDirectMessageEvent

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1100,6 +1100,15 @@ export class SlackSocketModeClient {
         });
         if (this.ws !== ownerWs) return;
         for (const msg of result.messages) {
+          // conversations.replies always returns the thread parent as the
+          // first element regardless of `oldest` / `inclusive` — see
+          // https://api.slack.com/methods/conversations.replies. The parent
+          // was already processed when the thread was first tracked; replay
+          // is for catching up on missed *replies*. Compound dedup would
+          // catch a same-day re-emission, but for long-lived active threads
+          // (TTL refreshed past the dedup window) the dedup row could have
+          // expired, so filter explicitly.
+          if (msg.ts === threadTs) continue;
           if (this.injectReplayMessage(channelId, msg, botUserId)) recovered++;
         }
       };
@@ -1146,9 +1155,15 @@ export class SlackSocketModeClient {
 
     const mentionsBot = msg.text?.includes(`<@${botUserId}>`) ?? false;
     const isDm = channel.startsWith("D");
-    const eventType: "app_mention" | "message" = mentionsBot
-      ? "app_mention"
-      : "message";
+    // DMs are always delivered as `type: "message"` with `channel_type: "im"`
+    // by live Slack, even when the bot is `<@U…>`-mentioned in the body —
+    // Slack only emits `app_mention` for non-DM channels. Synthesizing a DM
+    // as `app_mention` would route through `normalizeSlackAppMention`, which
+    // (intentionally) lacks the DM default-assistant fallback that
+    // `normalizeSlackDirectMessage` provides, so an unrouted DM @-mention
+    // would silently drop in `unmappedPolicy: "reject"` deployments.
+    const eventType: "app_mention" | "message" =
+      mentionsBot && !isDm ? "app_mention" : "message";
 
     const syntheticEvent = {
       type: eventType,

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -137,15 +137,7 @@ export class SlackSocketModeClient {
         if (data.team) {
           this.config.teamName = data.team;
         }
-        // Warn if the bot token is missing scopes needed for file downloads.
-        const scopes = resp.headers.get("x-oauth-scopes") ?? "";
-        if (!scopes.split(",").some((s) => s.trim() === "files:read")) {
-          log.warn(
-            "Slack bot token is missing the 'files:read' scope — file/image " +
-              "attachments will not be downloaded. Add 'files:read' to your " +
-              "Slack app's Bot Token Scopes and reinstall the app.",
-          );
-        }
+        warnOnMissingSlackScopes(resp.headers.get("x-oauth-scopes") ?? "");
 
         log.info(
           {
@@ -1334,6 +1326,54 @@ function toSlackTs(ms: number): string {
  */
 function isSlackConversationId(id: string): boolean {
   return /^[CDG][A-Z0-9]+$/.test(id);
+}
+
+/**
+ * Warn on bot-token scopes whose absence makes the gateway silently degrade
+ * rather than fail loudly. Without this startup check the user sees a
+ * successful boot followed by quiet "recovered: 0" log lines on every
+ * reconnect, with no signal that catch-up is no-op'ing on `missing_scope`.
+ *
+ *   - `files:read` — required for downloading file/image attachments.
+ *   - `*:history` (channels/im/groups/mpim) — required for
+ *     `conversations.history` and `conversations.replies`. Slack returns
+ *     `ok: false, error: "missing_scope"` per channel type that is missing
+ *     the corresponding scope (see
+ *     https://api.slack.com/methods/conversations.history), and the
+ *     catch-up error handler treats that as zero messages.
+ *
+ * Exported for direct unit testing without driving the full WebSocket
+ * bootstrap.
+ */
+export function warnOnMissingSlackScopes(scopesHeader: string): void {
+  const scopes = new Set(
+    scopesHeader
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  if (!scopes.has("files:read")) {
+    log.warn(
+      "Slack bot token is missing the 'files:read' scope — file/image " +
+        "attachments will not be downloaded. Add 'files:read' to your " +
+        "Slack app's Bot Token Scopes and reinstall the app.",
+    );
+  }
+  const missingHistoryScopes = [
+    "channels:history",
+    "im:history",
+    "groups:history",
+    "mpim:history",
+  ].filter((scope) => !scopes.has(scope));
+  if (missingHistoryScopes.length > 0) {
+    log.warn(
+      { missingHistoryScopes },
+      "Slack bot token is missing one or more *:history scopes — " +
+        "reconnect catch-up will not recover messages from the affected " +
+        "channel types. Add the missing scopes to your Slack app's Bot " +
+        "Token Scopes and reinstall the app.",
+    );
+  }
 }
 
 /**

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -662,8 +662,32 @@ export class SlackSocketModeClient {
       this.store.markEventSeen(messageKey, DEDUP_TTL_MS);
     }
 
-    // Advance the catch-up watermark before dispatch so a normalize/emit
-    // failure does not stall progress past this event on the next reconnect.
+    // Advance the catch-up watermark before dispatch.
+    //
+    // Trade-off: emit happens off the per-channel `emitQueues` chain, which
+    // is in-memory and not persisted. The cases worth thinking about are:
+    //
+    //   - daemon wedged, gateway alive: the queue stalls but does not drop;
+    //     it drains when the daemon recovers. No loss.
+    //   - gateway crash with daemon healthy: messages on the wire that have
+    //     not yet been dedup-written are lost in memory, but the next
+    //     reconnect refetches them via the watermark + 60s overlap. No loss.
+    //   - gateway crash AND daemon outage simultaneously: the in-memory
+    //     queue evaporates AND this watermark write has already advanced
+    //     past the unsent messages, so the next reconnect will not refetch
+    //     them. Genuinely lost.
+    //
+    // We accept the third case because the alternatives all regress
+    // something else: advancing after successful emit makes a slow emit
+    // stall the watermark and trigger wasteful refetch loops on every
+    // reconnect during transient slowness, and a later message in the same
+    // queue can still leapfrog the failed earlier one, so it does not
+    // actually fix the silent-skip. A persistent emit outbox would cover
+    // it, but that is a larger feature. The compensating daemon-side
+    // reactive backfill (`triggerSlackThreadBackfillIfNeeded`) hydrates
+    // thread context as soon as any follow-up message arrives, narrowing
+    // the user-visible blast radius to "fully missed mention with no
+    // follow-up, during a simultaneous gateway crash + daemon outage".
     const watermarkTs = extractEventWatermarkTs(event, eventPayload.event_time);
     if (watermarkTs) {
       this.store.setLastSeenTsIfGreater(watermarkTs);
@@ -1329,10 +1353,20 @@ function isSlackConversationId(id: string): boolean {
 }
 
 /**
- * Warn on bot-token scopes whose absence makes the gateway silently degrade
- * rather than fail loudly. Without this startup check the user sees a
- * successful boot followed by quiet "recovered: 0" log lines on every
- * reconnect, with no signal that catch-up is no-op'ing on `missing_scope`.
+ * Result of inspecting a bot-token scope header. Exposed so callers can
+ * decide how to surface missing scopes (logging, telemetry, both) without
+ * coupling the inspection logic to a specific logger.
+ */
+export interface SlackScopeCheckResult {
+  filesReadMissing: boolean;
+  missingHistoryScopes: string[];
+}
+
+/**
+ * Inspect a bot-token scope header and return which optional scopes are
+ * absent. Pure / no side effects — exists alongside
+ * `warnOnMissingSlackScopes` so it can be unit-tested without observing
+ * logger output.
  *
  *   - `files:read` — required for downloading file/image attachments.
  *   - `*:history` (channels/im/groups/mpim) — required for
@@ -1341,30 +1375,44 @@ function isSlackConversationId(id: string): boolean {
  *     the corresponding scope (see
  *     https://api.slack.com/methods/conversations.history), and the
  *     catch-up error handler treats that as zero messages.
- *
- * Exported for direct unit testing without driving the full WebSocket
- * bootstrap.
  */
-export function warnOnMissingSlackScopes(scopesHeader: string): void {
+export function inspectSlackScopes(
+  scopesHeader: string,
+): SlackScopeCheckResult {
   const scopes = new Set(
     scopesHeader
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean),
   );
-  if (!scopes.has("files:read")) {
+  return {
+    filesReadMissing: !scopes.has("files:read"),
+    missingHistoryScopes: [
+      "channels:history",
+      "im:history",
+      "groups:history",
+      "mpim:history",
+    ].filter((scope) => !scopes.has(scope)),
+  };
+}
+
+/**
+ * Emit warnings for any bot-token scopes whose absence makes the gateway
+ * silently degrade rather than fail loudly. Without this startup check the
+ * user sees a successful boot followed by quiet "recovered: 0" log lines on
+ * every reconnect, with no signal that catch-up is no-op'ing on
+ * `missing_scope`.
+ */
+export function warnOnMissingSlackScopes(scopesHeader: string): void {
+  const { filesReadMissing, missingHistoryScopes } =
+    inspectSlackScopes(scopesHeader);
+  if (filesReadMissing) {
     log.warn(
       "Slack bot token is missing the 'files:read' scope — file/image " +
         "attachments will not be downloaded. Add 'files:read' to your " +
         "Slack app's Bot Token Scopes and reinstall the app.",
     );
   }
-  const missingHistoryScopes = [
-    "channels:history",
-    "im:history",
-    "groups:history",
-    "mpim:history",
-  ].filter((scope) => !scopes.has(scope));
   if (missingHistoryScopes.length > 0) {
     log.warn(
       { missingHistoryScopes },


### PR DESCRIPTION
Closes LUM-1377.

## Summary

When the Slack Socket Mode WebSocket reconnects (Mac sleep/wake, transient network drop, Slack-initiated rotation), any `app_mention` or DM that arrived during the disconnect window is silently dropped on the wire. Slack [documents](https://api.slack.com/apis/socket-mode#events) that Socket Mode does not buffer events for disconnected clients, so recovery has to happen on our side.

This PR adds a persistent high-watermark and a bounded HTTP catch-up cycle that fires on every successful WebSocket `open`. Recovered messages flow through the same dispatch pipeline as live events — same filter, same dedup, same normalize/emit — so behavior stays consistent regardless of which path a message arrived on.

## Why this is needed

- The user-visible failure mode is "I @mentioned the bot during a sleep/wake and it never replied." That is the exact behavior of Socket Mode without a catch-up layer.
- The runtime already has reactive Slack backfill ([`assistant/src/runtime/routes/inbound-message-handler.ts`](https://github.com/vellum-ai/vellum-assistant/blob/main/assistant/src/runtime/routes/inbound-message-handler.ts) → `triggerSlackThreadBackfillIfNeeded` / `tryBackfillSlackDmIfCold`) but it only hydrates context once a triggering live event arrives. It cannot recover a message when no live event ever fires. The gateway is the right layer to synthesize that triggering event.

## Why this is safe

- **No live-path behavior change.** Live events still go through `processEventPayload` exactly as before.
- **Symmetric dedup.** Every event records both a Slack `event_id` and (for message-shaped events) a `msg:${channel}:${ts}` key in the same `slack_seen_events` table. A message that arrives via both paths is rejected on the second arrival regardless of which came first.
- **Monotonic watermark.** `setLastSeenTsIfGreater` only advances forward, so out-of-order live + replay events cannot regress progress.
- **Stale-generation guard.** `replayMissedEvents` re-checks `this.ws === ownerWs` before and after each async hop; if `forceReconnect` swapped the socket while catch-up was running, the cycle exits cleanly.
- **Bounded blast radius.** `MAX_LOOKBACK = 1h`, `HISTORY_LIMIT = 50` messages per channel, `CONCURRENCY = 4`, and a 60s safety overlap. On HTTP 429 the cycle aborts via `CatchupAbortSignal` so concurrent workers stop instead of cascading more rate-limit hits.
- **Schema migration is a single nullable column add** (`slack_active_threads.channel_id`) plus a new table (`slack_last_seen_ts`). Both are picked up by the existing Drizzle declarative push (`pushSchemaNoPrompt`) at startup, and SQLite's [`ALTER TABLE ADD COLUMN`](https://sqlite.org/lang_altertable.html#alter_table_add_column) handles the column on existing installs without rewriting rows.

## What changed

| Area                                            | Change                                                                                                                                |
| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
| `gateway/src/db/schema.ts`                      | New `slack_last_seen_ts` table; added nullable `channel_id` column on `slack_active_threads`.                                         |
| `gateway/src/db/slack-store.ts`                 | `getLastSeenTs` / `setLastSeenTsIfGreater`, `listActiveThreadsWithChannel`, `listKnownSlackDmChannels`, `compareSlackTs` (numeric).   |
| `gateway/src/slack/slack-web.ts` *(new)*        | `fetchChannelHistorySince`, `fetchThreadRepliesSince`, `runWithConcurrency`, `CatchupAbortSignal`. All transient errors degrade to zero-message responses. |
| `gateway/src/slack/socket-mode.ts`              | Extracted `processEventPayload` (shared by live + replay), added compound dedup, watermark advance, `replayMissedEvents` hooked from `ws.open`. |
| `gateway/ARCHITECTURE.md`                       | Documented reconnect catch-up + a general checklist for stateful-stream transports.                                                   |
| `gateway/src/__tests__/slack-socket-mode-catchup.test.ts` *(new)* | 15 tests covering compound dedup, watermark monotonicity, bootstrap, stale-ws bailout, 429 handling + global abort, channel-id filter, message recovery via both `conversations.history` and `conversations.replies`, DM-mention shape parity, thread-parent skip, attachment/blocks pass-through, and chronological emit order. |

## References

- Slack Socket Mode — [does not buffer events for disconnected clients](https://api.slack.com/apis/socket-mode#events)
- [`conversations.history`](https://api.slack.com/methods/conversations.history) and [`conversations.replies`](https://api.slack.com/methods/conversations.replies) — the recovery primitives
- Slack [conversation ID format](https://api.slack.com/types/conversation) (`C…` / `D…` / `G…` prefix)
- Slack [rate limits](https://api.slack.com/docs/rate-limits) — `Retry-After` header semantics
- SQLite [`ALTER TABLE ADD COLUMN`](https://sqlite.org/lang_altertable.html#alter_table_add_column) — why the new column has to be nullable
- Drizzle ORM [migrations vs declarative push](https://orm.drizzle.team/docs/drizzle-kit-push) — why startup `pushSchemaNoPrompt` is sufficient here

## Alternatives considered (and rejected)

| Alternative                                                         | Why rejected                                                                                                                                                                                                                                                                              |
| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Switch to HTTP Events API** (Slack does buffer + retry there)     | `gateway/ARCHITECTURE.md` explicitly chose Socket Mode so users don't need a public ingress URL. Switching transports would regress the local-first UX for every Slack user.                                                                                                              |
| **Per-channel watermarks instead of a single global watermark**     | Per-channel keys add a row-per-channel and a non-trivial dedup matrix; the compound `msg:${channel}:${ts}` key already absorbs the resulting overlap and a global watermark + 60s safety overlap is provably no worse for the targeted failure modes. Past Slack work (the JARVIS-643 follow-up chain) showed that per-channel bookkeeping is fertile ground for off-by-one bugs.                                                                              |
| **Enumerate `users.conversations` to discover all member channels** | Wider scope, larger Slack API budget, and the gateway already has a high-confidence channel set (routing entries + active threads + known DMs). Brand-new mentions in unrouted, never-engaged channels remain unrecoverable here, but the daemon's reactive backfill hydrates them once any live event arrives. |
| **Persistent retry queue / outbox**                                 | Overkill — the failure mode is bounded reconnects, not arbitrary delivery failures, and the runtime backfill already covers post-trigger context hydration.                                                                                                                                |
| **`search.messages` query for unseen mentions**                     | Requires a user token (not available; Slack restricts it) and is rate-limited far more aggressively than `conversations.history`.                                                                                                                                                          |
| **Periodic poller** instead of reconnect-driven catch-up            | Adds load even when the socket is healthy and doesn't address the actual failure mode (lost events specifically during disconnect windows).                                                                                                                                                |
| **Treat `routingEntries` as Slack-only**                            | `RoutingEntry.key` is shared across Slack, Telegram, WhatsApp. Filtering on a Slack-shaped ID prefix (`C` / `D` / `G`, per [Slack's conversation type docs](https://api.slack.com/types/conversation)) is the only correct scoping at this layer.                                          |

## Root cause analysis

1. **How did the code get into this state?** The original Slack Socket Mode integration treated the WebSocket as a fire-and-forget event source. The reconnect path (exponential backoff, sleep/wake `forceReconnect`) was hardened over time, but the assumption that Slack would redeliver events across the gap was never explicitly validated against the [Socket Mode docs](https://api.slack.com/apis/socket-mode#events), which state the opposite.
2. **What mistakes or decisions led to it?** Missing primitive: there was no persisted watermark and no shared dispatch path that could be reused for replayed events. `handleMessage` did filter, dedup, normalize, and emit inline, so adding a second source of events would have meant duplicating that logic — which inevitably leads to live/replay drift. Without a shared `processEventPayload`, the cheapest "fix" looked too expensive and got deferred.
3. **Were there warning signs we missed?** Yes. The runtime added reactive Slack backfill (`triggerSlackThreadBackfillIfNeeded`, `tryBackfillSlackDmIfCold`) precisely because *some* messages were arriving with no usable context. That is a downstream symptom of upstream gaps. A targeted look at the gateway side at that point would have surfaced the wider problem (events that never arrive at all, not just events that arrive without context).
4. **What can we do to prevent this pattern from recurring?** Treat catch-up-on-reconnect as a transport-class checklist item, not a per-integration afterthought. Any persistent-stream transport that does not buffer events for disconnected clients (Slack Socket Mode today; potential future WebSocket gateways) needs (a) a persisted high-watermark, (b) a bounded HTTP replay path on reconnect, and (c) a single dispatch pipeline shared by live and replay so dedup/normalize/routing cannot drift.
5. **Should we add or change a guideline?** Adding a one-paragraph "stateful-stream transports require catch-up-on-reconnect" rule to `gateway/ARCHITECTURE.md`'s Slack section — included in this PR — is the right home. It lives next to the only transport class that meets the criterion, links to the authoritative Slack docs, and stays out of the global `AGENTS.md` (per the user's preference for documentation that is concrete, link-heavy, and unlikely to go stale). A global rule would be too abstract to be actionable; the architecture doc keeps the guidance next to the code that has to obey it.
Link to Devin session: https://app.devin.ai/sessions/c8d1f5ac1d744f9a93c01f6fc4c424ed
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
