### PR TITLE
fix(ci): remove ci-playwright gate from dispatch-ios-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2331,7 +2331,7 @@ jobs:
   # ── Dispatch iOS release to platform repo ────────────────────────────
 
   dispatch-ios-release:
-    needs: [extract-version, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, ci-playwright, build-chrome-extension]
+    needs: [extract-version, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension]
     if: >-
       ${{
         always() && !cancelled()
@@ -2341,7 +2341,6 @@ jobs:
         && needs.push-assistant-manifest.result == 'success'
         && needs.push-gateway-manifest.result == 'success'
         && needs.push-credential-executor-manifest.result == 'success'
-        && needs.ci-playwright.result == 'success'
         && needs.build-chrome-extension.result == 'success'
         && (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped')
         && (needs.publish-meta.result == 'success' || needs.publish-meta.result == 'skipped')


### PR DESCRIPTION
## Prompt / plan

Investigated why the iOS staging release did not dispatch during Release #233 — the `dispatch-ios-release` job was gated on `ci-playwright.result == 'success'`, and a Playwright test failure silently prevented the iOS staging dispatch. Meanwhile, the hourly dev-release cron dispatched an iOS dev build, which was mistaken for the staging build.

## What changed

Removed `ci-playwright` from the `dispatch-ios-release` job's `needs` list and `if` condition. The iOS Capacitor build packages web assets via `bunx cap sync ios` and has no dependency on Playwright end-to-end test results.

This aligns `dispatch-ios-release` with `build-macos-arm64` / `build-macos-x64`, which also do not depend on `ci-playwright`. The macOS desktop builds have always proceeded regardless of Playwright results — iOS should behave the same way.

## Root cause analysis

1. **How did the code get into this state?** When `dispatch-ios-release` was added to `release.yml`, it was modeled after the `release` job which gates on `ci-playwright`. But `release` is a production-only job that creates a GitHub Release, while `dispatch-ios-release` runs for both staging and production and is a build/packaging step.
2. **What mistakes or decisions led to it?** The dependencies were copied from `release` without evaluating which gates are actually relevant to the iOS dispatch. The `release` and `publish-npm` jobs have a `playwright_blocks_release` fallback (`inputs.playwright_blocks_release != true`), but `dispatch-ios-release` never got that fallback — it unconditionally required Playwright success.
3. **Were there warning signs we missed?** The inconsistency between macOS builds (no Playwright gate) and iOS dispatch (Playwright gate) was present since the job was added but only surfaced when Playwright actually failed during a staging release.
4. **What can we do to prevent this pattern from recurring?** When adding new release pipeline jobs, explicitly document which gates are intentional vs. copied, and cross-check against similar jobs (e.g., macOS builds) for consistency.
5. **Should we add a guideline to AGENTS.md?** The existing `### iOS release dispatch` section in AGENTS.md already documents the dispatch flow. No new AGENTS.md guidance needed — this was a one-time oversight in the `if` condition.

## Test plan

- Verified the YAML is syntactically valid.
- Confirmed `build-macos-arm64` does not depend on `ci-playwright` (line 1384), establishing the precedent that build/packaging jobs should not be gated on Playwright.
- The `notify-release` job (line 2740) still lists `dispatch-ios-release` in its `needs`, so the final Slack notification will correctly report the iOS dispatch result regardless of this change.

Link to Devin session: https://app.devin.ai/sessions/b4a87117e9c2404f93a3732797feb2b0
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->