### PR TITLE
fix(gateway-client): re-export IpcCallError from package index

### DIFF
--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -17,6 +17,7 @@ export {
 
 export {
   ipcCall,
+  IpcCallError,
   PersistentIpcClient,
 } from "./ipc-client.js";
 


### PR DESCRIPTION
## Summary
`IpcCallError` is now available from the package's public entrypoint, so consumers can `instanceof`-check the structured IPC error type the migration plan added.

Caught during self-review of plan vbundle-version-gate.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->