### PR TITLE
fix(cli): localRuntimeIdentity uses /v1/health, not /v1/identity

### DIFF
--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -481,12 +481,19 @@ describe("vellum-cloud routing through wildcard proxy", () => {
 });
 
 describe("localRuntimeIdentity", () => {
-  test("local entry: GETs /v1/identity with Bearer auth and returns the version", async () => {
+  test("local entry: GETs /v1/health with Bearer auth and returns the version", async () => {
     const { calls, fetchMock } = captureFetch(() => {
-      return new Response(JSON.stringify({ version: "0.6.5" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({
+          status: "healthy",
+          timestamp: "2025-01-01T00:00:00Z",
+          version: "0.6.5",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     });
     globalThis.fetch = fetchMock;
 
@@ -494,12 +501,29 @@ describe("localRuntimeIdentity", () => {
 
     expect(result.version).toBe("0.6.5");
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/identity`);
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/health`);
     expect(calls[0]!.method).toBe("GET");
     expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
   });
 
-  test("vellum entry: GETs /v1/assistants/<id>/identity through the wildcard proxy", async () => {
+  test("GETs /v1/health, not /v1/identity (works on pre-onboarding runtimes)", async () => {
+    // Regression guard: /v1/identity reads IDENTITY.md (written during
+    // onboarding, NOT hatch) and 404s on freshly-hatched targets. /v1/health
+    // returns the version field unconditionally, so it's the right source.
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: "0.7.0" }), {
+        status: 200,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await localRuntimeIdentity(ENTRY, TOKEN);
+
+    expect(calls[0]!.url.endsWith("/v1/health")).toBe(true);
+    expect(calls[0]!.url).not.toContain("/v1/identity");
+  });
+
+  test("vellum entry: GETs /v1/assistants/<id>/health through the wildcard proxy", async () => {
     const { calls, fetchMock } = captureFetch(() => {
       return new Response(JSON.stringify({ version: "0.7.2" }), {
         status: 200,
@@ -511,7 +535,7 @@ describe("localRuntimeIdentity", () => {
 
     expect(result.version).toBe("0.7.2");
     expect(calls[0]!.url).toBe(
-      `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity`,
+      `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/health`,
     );
     expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
   });
@@ -577,14 +601,14 @@ describe("localRuntimeIdentity", () => {
     const PLATFORM_URL = "https://platform.vellum.ai";
     const ASSISTANT_ID = "11111111-2222-3333-4444-555555555555";
 
-    let identityCalls = 0;
+    let healthCalls = 0;
     const orgIdFetchedAs: string[] = [];
 
     const fetchMock = mock(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.endsWith("/v1/organizations/")) {
         // Each org-ID fetch returns a different ID to prove that the
-        // second identity request DID re-resolve the org rather than
+        // second health request DID re-resolve the org rather than
         // reuse a stale cache entry.
         orgIdFetchedAs.push(`org-${orgIdFetchedAs.length + 1}`);
         return new Response(
@@ -594,9 +618,9 @@ describe("localRuntimeIdentity", () => {
           { status: 200 },
         );
       }
-      if (urlStr.endsWith(`/v1/assistants/${ASSISTANT_ID}/identity`)) {
-        identityCalls += 1;
-        if (identityCalls === 1) {
+      if (urlStr.endsWith(`/v1/assistants/${ASSISTANT_ID}/health`)) {
+        healthCalls += 1;
+        if (healthCalls === 1) {
           return new Response("unauthorized", { status: 401 });
         }
         return new Response(JSON.stringify({ version: "0.7.4" }), {
@@ -617,7 +641,7 @@ describe("localRuntimeIdentity", () => {
     );
 
     expect(result.version).toBe("0.7.4");
-    expect(identityCalls).toBe(2);
+    expect(healthCalls).toBe(2);
     // Two org-ID fetches: the first to satisfy the initial authHeaders
     // call, the second after the 401-driven cache invalidation.
     expect(orgIdFetchedAs).toEqual(["org-1", "org-2"]);

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -235,25 +235,32 @@ export async function localRuntimePollJobStatus(
 }
 
 /**
- * The subset of `/v1/identity` we care about. The runtime's full response
- * includes additional fields (name, role, etc.) — we only model `version`
- * here because that's all the CLI consumes today.
+ * The subset of `/v1/health` we care about. The runtime's full response
+ * includes additional fields (status, disk, memory, cpu, migrations, etc.)
+ * — we only model `version` here because that's all the CLI consumes today.
  */
 export interface RuntimeIdentity {
   version: string;
 }
 
 /**
- * Fetch the target runtime's `/v1/identity` so callers can read its
- * APP_VERSION. Used by `vellum teleport` and `vellum backup` to stamp the
- * exported bundle's `min_runtime_version` with the version of the runtime
- * that actually produced it — which can diverge from the orchestrating CLI's
- * version when the target was upgraded independently.
+ * Fetch the target runtime's APP_VERSION via `/v1/health`. Used by
+ * `vellum teleport` and `vellum backup` to stamp the exported bundle's
+ * `min_runtime_version` with the version of the runtime that actually
+ * produced it — which can diverge from the orchestrating CLI's version when
+ * the target was upgraded independently.
  *
- * For local/docker assistants this GETs `{runtimeUrl}/v1/identity` with
+ * GETs `/v1/health` (not `/v1/identity`) so the call works on freshly-
+ * hatched runtimes that haven't completed onboarding. The `/v1/identity`
+ * handler reads `IDENTITY.md` from the workspace and 404s if it's missing
+ * — and `IDENTITY.md` is only written during onboarding, not hatch. The
+ * `/v1/health` handler returns the same `version` field unconditionally
+ * (no filesystem reads), so it's safe to call against any running runtime.
+ *
+ * For local/docker assistants this GETs `{runtimeUrl}/v1/health` with
  * guardian-token bearer auth. For platform-managed (cloud="vellum")
  * assistants the URL is rewritten to the wildcard runtime proxy shape
- * `{platformUrl}/v1/assistants/<assistantId>/identity` and authenticated via
+ * `{platformUrl}/v1/assistants/<assistantId>/health` and authenticated via
  * the platform token.
  *
  * For the vellum target this is the FIRST network call in the
@@ -265,6 +272,10 @@ export interface RuntimeIdentity {
  * `callRuntimeWithAuthRetry` by callers for guardian-token refresh, so the
  * retry is intentionally vellum-only.
  *
+ * The function name is intentionally retained ("identity-ish info about the
+ * runtime") even though the implementation now hits `/v1/health` — renaming
+ * would force changes in 4+ callsites for no behavioral benefit.
+ *
  * Throws on non-2xx so callers can surface the failure (we never silently
  * fall back — see teleport.ts call site).
  */
@@ -272,7 +283,7 @@ export async function localRuntimeIdentity(
   entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
   token: string,
 ): Promise<RuntimeIdentity> {
-  const url = resolveRuntimeUrl(entry, "identity");
+  const url = resolveRuntimeUrl(entry, "health");
   const doRequest = async (): Promise<Response> =>
     fetch(url, {
       method: "GET",


### PR DESCRIPTION
## Summary
Fixes a regression in the source/target version-fetch path: `localRuntimeIdentity` was calling `/v1/identity`, which 404s on freshly-hatched assistants (no `IDENTITY.md` until onboarding). Switches to `/v1/health` which returns the same `version` field unconditionally.

Caught during self-review of plan vbundle-version-gate.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->