### PR TITLE
fix(migrations): defer streaming importer temp mkdir until after version gate

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -654,6 +654,12 @@ describe("streamCommitImport — runtime-version compat gate", () => {
       },
     });
 
+    // Pre-condition: workspace dir does NOT exist on a fresh filesystem.
+    // The plan invariant requires that the streaming importer gate on
+    // runtime-version compat BEFORE any state mutation, so an
+    // incompatible bundle must leave the filesystem untouched.
+    expect(existsSync(workspaceDir)).toBe(false);
+
     const result = await streamCommitImport({
       source: readableFrom(archive),
       pathResolver: new DefaultPathResolver(workspaceDir),
@@ -669,12 +675,10 @@ describe("streamCommitImport — runtime-version compat gate", () => {
     expect(result.bundle_compat.max_runtime_version).toBeNull();
     expect(result.runtime_version).toBe(APP_VERSION);
 
-    // The streaming importer mkdir's `${workspaceDir}/.import-<uuid>` before
-    // reading the manifest, which materializes an empty workspace dir as a
-    // side effect. Verify nothing FROM THE BUNDLE landed there.
-    if (existsSync(workspaceDir)) {
-      expect(readdirSync(workspaceDir)).toEqual([]);
-    }
+    // Post-condition: workspace dir STILL does not exist. The version
+    // gate now runs before the temp-staging mkdir, so rejecting an
+    // incompatible bundle leaves zero filesystem trace.
+    expect(existsSync(workspaceDir)).toBe(false);
     assertNoLeftoverTempDirs();
   });
 

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -278,18 +278,16 @@ export async function streamCommitImport(
   // Compared against `bundleEntryCap`.
   let entryCount = 0;
 
-  // Create the temp workspace dir up front so any failure between here and
-  // the atomic swap can be cleaned up by the catch block below.
-  try {
-    await mkdir(tempWorkspaceDir, { recursive: true });
-  } catch (err) {
-    return {
-      ok: false,
-      reason: "write_failed",
-      message: `Failed to create temp workspace dir "${tempWorkspaceDir}": ${errMessage(err)}`,
-    };
-  }
-
+  // The temp workspace dir is created lazily inside the parse loop AFTER
+  // the manifest's version gate passes (see the `entryIndex === 0` block
+  // below). Creating it up front would materialize `${workspaceDir}` (and
+  // the `.import-<uuid>` subdir) on a fresh filesystem before we knew the
+  // bundle was compatible — violating the plan invariant that importers
+  // gate on runtime-version compat BEFORE any state mutation.
+  //
+  // `cleanupTempDir` is safe whether or not the dir was ever created:
+  // `rm(..., { recursive: true, force: true })` is a no-op on a missing
+  // path.
   const cleanupTempDir = async (): Promise<void> => {
     try {
       await rm(tempWorkspaceDir, { recursive: true, force: true });
@@ -320,11 +318,15 @@ export async function streamCommitImport(
         expected = manifestResult.expected;
 
         // Defense-in-depth: refuse to populate the temp tree when the
-        // bundle's compat range excludes APP_VERSION. Throwing inside the
-        // generator's try block triggers cleanupTempDir() in the catch,
-        // so the empty `${workspaceDir}/.import-<uuid>` is removed and the
-        // real workspace is untouched. Catches legacy bundles whose
-        // ExportJob row predates the platform compat-column rollout
+        // bundle's compat range excludes APP_VERSION. The version gate
+        // runs BEFORE we materialize `${workspaceDir}/.import-<uuid>`
+        // (the mkdir below is sequenced after this check), so on a fresh
+        // filesystem an incompatible bundle leaves zero filesystem trace.
+        // Throwing inside the generator's try block still triggers
+        // cleanupTempDir() in the catch — a safe no-op on a missing path
+        // — and mapThrownToResult translates VersionIncompatibleError into
+        // the version_incompatible result shape. Catches legacy bundles
+        // whose ExportJob row predates the platform compat-column rollout
         // (compat columns NULL → platform gate skipped) and any future
         // drift between the platform gate and the manifest.
         const compatResult = policy.evaluateRuntimeCompatibility(
@@ -347,6 +349,24 @@ export async function streamCommitImport(
             `bundle contains more than ${bundleEntryCap} entries (declared: ${manifest.contents.length})`,
           );
         }
+
+        // Only NOW — after the manifest is parsed, the version gate passes,
+        // and the entry-count ceiling is enforced — do we materialize the
+        // temp staging dir on disk. Doing this lazily preserves the plan
+        // invariant that importers gate on runtime-version compat BEFORE
+        // any state mutation. If this throws, the outer catch runs
+        // cleanupTempDir (a safe no-op on a missing path) and
+        // mapThrownToResult translates the WriteFailedError into the
+        // write_failed shape of ImportCommitResult.
+        try {
+          await mkdir(tempWorkspaceDir, { recursive: true });
+        } catch (err) {
+          throw wrapWriteError(
+            `Failed to create temp workspace dir "${tempWorkspaceDir}"`,
+            err,
+          );
+        }
+
         entryIndex += 1;
         continue;
       }


### PR DESCRIPTION
## Summary
- Streaming `streamCommitImport` no longer creates the temp staging dir before the manifest is parsed and the runtime-version gate evaluated. An incompatible bundle now leaves zero filesystem trace.
- Test assertion tightened from "empty workspaceDir present" to "no workspaceDir created".

Caught during self-review of plan vbundle-version-gate.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->