### PR TITLE
fix(migrations): align runtime-compat error messages and reuse RuntimeCompatibility type

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -134,9 +134,9 @@ export function formatRuntimeCompatibilityMessage(
   runtimeVersion: string,
 ): string {
   const range = compat.max_runtime_version
-    ? `${compat.min_runtime_version}..${compat.max_runtime_version}`
+    ? `${compat.min_runtime_version}–${compat.max_runtime_version}`
     : `${compat.min_runtime_version}+`;
-  return `Bundle requires runtime ${range} but runtime is ${runtimeVersion}`;
+  return `Cannot import: bundle requires runtime ${range}, but this runtime is ${runtimeVersion}. Update your runtime before importing.`;
 }
 
 export function evaluateRuntimeCompatibility(

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -32,6 +32,7 @@ import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import { APP_VERSION } from "../../version.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
+import type { RuntimeCompatibility } from "./vbundle-import-policy.js";
 import * as policy from "./vbundle-import-policy.js";
 import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
@@ -90,10 +91,7 @@ export type ImportCommitResult =
   | {
       ok: false;
       reason: "version_incompatible";
-      bundle_compat: {
-        min_runtime_version: string;
-        max_runtime_version: string | null;
-      };
+      bundle_compat: RuntimeCompatibility;
       runtime_version: string;
     }
   | {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -65,7 +65,10 @@ import {
   analyzeImport,
   DefaultPathResolver,
 } from "../migrations/vbundle-import-analyzer.js";
-import { formatRuntimeCompatibilityMessage } from "../migrations/vbundle-import-policy.js";
+import {
+  formatRuntimeCompatibilityMessage,
+  type RuntimeCompatibility,
+} from "../migrations/vbundle-import-policy.js";
 import {
   commitImport,
   extractCredentialsFromBundle,
@@ -1031,10 +1034,7 @@ interface GcsImportErrorInit {
   partial_report?: ImportCommitReport;
   /** Populated for `version_incompatible` — mirrors the platform's PR #5470
    *  response shape so the URL-body endpoint can return the same body. */
-  bundle_compat?: {
-    min_runtime_version: string;
-    max_runtime_version: string | null;
-  };
+  bundle_compat?: RuntimeCompatibility;
   /** Populated for `version_incompatible`. */
   runtime_version?: string;
 }
@@ -1045,7 +1045,7 @@ class GcsImportError extends Error {
   public readonly reason?: string;
   public readonly errors?: GcsImportErrorInit["errors"];
   public readonly partial_report?: ImportCommitReport;
-  public readonly bundle_compat?: GcsImportErrorInit["bundle_compat"];
+  public readonly bundle_compat?: RuntimeCompatibility;
   public readonly runtime_version?: string;
 
   constructor(init: GcsImportErrorInit) {


### PR DESCRIPTION
## Summary
- One canonical `RuntimeCompatibility` type used by `vbundle-importer.ts` and `migration-routes.ts` (was re-declared inline x3).
- `formatRuntimeCompatibilityMessage` aligned with `VersionMismatchError.formatMessage` — same en-dash range, same remediation hint.

Caught during self-review of plan vbundle-version-gate.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->