### PR TITLE
Runtime side: vbundle teleport upload-time version-compat gating

### DIFF
--- a/assistant/src/__tests__/helpers/call-route-handler.ts
+++ b/assistant/src/__tests__/helpers/call-route-handler.ts
@@ -63,7 +63,13 @@ export async function callHandler(
   } catch (err) {
     if (err instanceof RouteError) {
       return Response.json(
-        { error: { code: err.code, message: err.message } },
+        {
+          error: {
+            code: err.code,
+            message: err.message,
+            ...(err.details !== undefined && { details: err.details }),
+          },
+        },
         { status: err.statusCode },
       );
     }

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -256,6 +256,8 @@ function createValidVBundle(
     bundle_id: string;
     origin_mode: "managed" | "self-hosted-remote" | "self-hosted-local";
     secrets_redacted: boolean;
+    min_runtime_version: string;
+    max_runtime_version: string | null;
   }>,
 ): Uint8Array {
   const dbData = new Uint8Array([0x53, 0x51, 0x4c, 0x69, 0x74, 0x65]);
@@ -296,8 +298,11 @@ function createValidVBundle(
       mode: overrides?.origin_mode ?? "self-hosted-local",
     },
     compatibility: {
-      min_runtime_version: "0.0.0-test",
-      max_runtime_version: null,
+      min_runtime_version: overrides?.min_runtime_version ?? "0.0.0-test",
+      max_runtime_version:
+        overrides?.max_runtime_version === undefined
+          ? null
+          : overrides.max_runtime_version,
     },
     contents,
     checksum: "",
@@ -644,6 +649,78 @@ describe("handleMigrationImport — validation failures", () => {
     await callHandler(handleMigrationImport, req);
 
     // Verify disk was not modified
+    const currentDb = new Uint8Array(readFileSync(testDbPath));
+    const currentConfig = readFileSync(testConfigPath, "utf8");
+
+    expect(currentDb).toEqual(originalDb);
+    expect(currentConfig).toBe(originalConfig);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP handler tests: version_incompatible (Codex P2 regression)
+//
+// Pin: a bundle whose min_runtime_version exceeds APP_VERSION must surface as
+// a 4xx user-actionable response (422 Unprocessable Entity), not a 500
+// InternalError. Body mirrors the platform's PR #5470 response shape so
+// clients can render the same UX regardless of which gate (platform or
+// runtime) rejected the bundle.
+// ---------------------------------------------------------------------------
+
+describe("handleMigrationImport — version_incompatible", () => {
+  test("incompatible bundle returns 422 with structured body, not 500", async () => {
+    const vbundle = createValidVBundle(undefined, {
+      min_runtime_version: "99.0.0",
+    });
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as {
+      error: {
+        code: string;
+        message: string;
+        details?: {
+          reason: string;
+          bundle_compat: {
+            min_runtime_version: string;
+            max_runtime_version: string | null;
+          };
+          runtime_version: string;
+        };
+      };
+    };
+
+    expect(res.status).toBe(422);
+    expect(body.error.code).toBe("UNPROCESSABLE_ENTITY");
+    expect(body.error.message).toContain("99.0.0");
+    expect(body.error.details).toBeDefined();
+    expect(body.error.details!.reason).toBe("version_incompatible");
+    expect(body.error.details!.bundle_compat.min_runtime_version).toBe(
+      "99.0.0",
+    );
+    expect(body.error.details!.bundle_compat.max_runtime_version).toBeNull();
+    expect(typeof body.error.details!.runtime_version).toBe("string");
+  });
+
+  test("incompatible bundle does not modify disk", async () => {
+    const originalDb = new Uint8Array(readFileSync(testDbPath));
+    const originalConfig = readFileSync(testConfigPath, "utf8");
+
+    const vbundle = createValidVBundle(undefined, {
+      min_runtime_version: "99.0.0",
+    });
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    await callHandler(handleMigrationImport, req);
+
     const currentDb = new Uint8Array(readFileSync(testDbPath));
     const currentConfig = readFileSync(testConfigPath, "utf8");
 

--- a/assistant/src/__tests__/migration-import-commit-http.test.ts
+++ b/assistant/src/__tests__/migration-import-commit-http.test.ts
@@ -727,6 +727,35 @@ describe("handleMigrationImport — version_incompatible", () => {
     expect(currentDb).toEqual(originalDb);
     expect(currentConfig).toBe(originalConfig);
   });
+
+  // Regression: the route handler pre-checks runtime-version compat using
+  // `validation.manifest.compatibility` before calling `resetDb()` and
+  // `commitImport()`. If a future refactor reorders the close to come
+  // before the gate, an incompatible bundle would still 422 (commitImport
+  // has its own defense-in-depth gate) but it would unnecessarily close
+  // and reopen the live SQLite singleton on every rejected import.
+  //
+  // We can't easily spy on `resetDb` here without mocking `db-connection.js`
+  // module-wide (which other tests in this file rely on for real). The
+  // semantic regression — disk unchanged + 422 — is covered by the two
+  // tests above. This test is a marker so future readers know the pre-
+  // check intent; if it ever starts failing, recheck `handleMigrationImport`
+  // ordering against the comment at line 861-862 ("Validate the bundle
+  // before closing the DB to avoid an unnecessary close/reopen cycle when
+  // the bundle is invalid").
+  test("incompatible bundle short-circuits before resetDb (intent marker)", async () => {
+    const vbundle = createValidVBundle(undefined, {
+      min_runtime_version: "99.0.0",
+    });
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: toArrayBuffer(vbundle),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    expect(res.status).toBe(422);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/backup/__tests__/restore.test.ts
+++ b/assistant/src/backup/__tests__/restore.test.ts
@@ -362,6 +362,44 @@ describe("restoreFromSnapshot", () => {
       }),
     ).rejects.toThrow(/disk full/);
   });
+
+  test("version-incompatible bundle short-circuits before resetDbImpl and commitImpl", async () => {
+    // Bundle declares it requires runtime 99.0.0+, but the test process is
+    // far below that. The restore wrapper must pre-check compat before the
+    // DB close/reopen cycle and skip both resetDbImpl and commitImpl.
+    const incompatPath = join(TEST_DIR, "incompat.vbundle");
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "workspace/notes/hello.txt",
+          data: new TextEncoder().encode("hello"),
+        },
+      ],
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: "99.0.0",
+        max_runtime_version: null,
+      },
+    });
+    writeFileSync(incompatPath, archive);
+
+    const { commitImpl, calls } = makeStubCommitImpl();
+    let resetCalls = 0;
+
+    await expect(
+      restoreFromSnapshot(incompatPath, {
+        pathResolver: NULL_RESOLVER,
+        commitImpl,
+        resetDbImpl: () => {
+          resetCalls += 1;
+        },
+      }),
+    ).rejects.toThrow(/Snapshot restore failed.*99\.0\.0/);
+
+    expect(resetCalls).toBe(0);
+    expect(calls.length).toBe(0);
+  });
 });
 
 describe("snapshot path detection", () => {

--- a/assistant/src/backup/restore.ts
+++ b/assistant/src/backup/restore.ts
@@ -21,10 +21,14 @@ import { readFile } from "node:fs/promises";
 
 import { resetDb } from "../memory/db-connection.js";
 import type { PathResolver } from "../runtime/migrations/vbundle-import-analyzer.js";
-import { formatRuntimeCompatibilityMessage } from "../runtime/migrations/vbundle-import-policy.js";
+import {
+  evaluateRuntimeCompatibility,
+  formatRuntimeCompatibilityMessage,
+} from "../runtime/migrations/vbundle-import-policy.js";
 import { commitImport } from "../runtime/migrations/vbundle-importer.js";
 import type { ManifestType } from "../runtime/migrations/vbundle-validator.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
+import { APP_VERSION } from "../version.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -94,6 +98,23 @@ export async function restoreFromSnapshot(
       .map((e) => `${e.code}: ${e.message}`)
       .join("; ");
     throw new Error(`Snapshot failed validation: ${summary}`);
+  }
+
+  // Pre-check runtime-version compat before the DB close/reopen cycle.
+  // commitImport runs the same gate as defense-in-depth for callers that
+  // don't pre-check; we run it here too so an incompatible bundle short-
+  // circuits before resetDbImpl().
+  const compatResult = evaluateRuntimeCompatibility(
+    validation.manifest.compatibility,
+    APP_VERSION,
+  );
+  if (!compatResult.ok) {
+    throw new Error(
+      `Snapshot restore failed: ${formatRuntimeCompatibilityMessage(
+        compatResult.bundle_compat,
+        compatResult.runtime_version,
+      )}`,
+    );
   }
 
   resetDbImpl();

--- a/assistant/src/backup/restore.ts
+++ b/assistant/src/backup/restore.ts
@@ -21,6 +21,7 @@ import { readFile } from "node:fs/promises";
 
 import { resetDb } from "../memory/db-connection.js";
 import type { PathResolver } from "../runtime/migrations/vbundle-import-analyzer.js";
+import { formatRuntimeCompatibilityMessage } from "../runtime/migrations/vbundle-import-policy.js";
 import { commitImport } from "../runtime/migrations/vbundle-importer.js";
 import type { ManifestType } from "../runtime/migrations/vbundle-validator.js";
 import { validateVBundle } from "../runtime/migrations/vbundle-validator.js";
@@ -116,6 +117,12 @@ export async function restoreFromSnapshot(
       case "extraction_failed":
       case "write_failed":
         message = commitResult.message;
+        break;
+      case "version_incompatible":
+        message = formatRuntimeCompatibilityMessage(
+          commitResult.bundle_compat,
+          commitResult.runtime_version,
+        );
         break;
     }
     throw new Error(`Snapshot restore failed: ${message}`);

--- a/assistant/src/ipc/__tests__/route-error-envelope.test.ts
+++ b/assistant/src/ipc/__tests__/route-error-envelope.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the IPC error envelope built from `RouteError` instances.
+ *
+ * Asserts that `AssistantIpcServer.buildErrorResponse` forwards the full
+ * `RouteError` shape — including the `details` field — into the IPC response
+ * envelope so IPC clients (e.g. gateway→daemon) receive the same structured
+ * payload as HTTP clients (e.g. `version_incompatible` migration imports).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  RouteError,
+  UnprocessableEntityError,
+} from "../../runtime/routes/errors.js";
+import { AssistantIpcServer, type IpcResponse } from "../assistant-server.js";
+
+/**
+ * `buildErrorResponse` is private; access it through an interface cast so the
+ * test exercises the actual production code path without exporting a
+ * test-only API on the server class.
+ */
+type PrivateApi = {
+  buildErrorResponse(id: string, err: unknown): IpcResponse;
+};
+
+function buildErrorResponse(err: unknown): IpcResponse {
+  const server = new AssistantIpcServer() as unknown as PrivateApi;
+  return server.buildErrorResponse("req-1", err);
+}
+
+describe("AssistantIpcServer error envelope", () => {
+  test("forwards RouteError message, statusCode, and code", () => {
+    const err = new RouteError("boom", "BOOM", 418);
+    const response = buildErrorResponse(err);
+
+    expect(response.id).toBe("req-1");
+    expect(response.error).toBe("boom");
+    expect(response.statusCode).toBe(418);
+    expect(response.errorCode).toBe("BOOM");
+    expect(response.errorDetails).toBeUndefined();
+  });
+
+  test("forwards RouteError.details into errorDetails when present", () => {
+    const details = {
+      reason: "version_incompatible" as const,
+      bundle_compat: { engineMin: "0.7.0" },
+      runtime_version: "0.6.0",
+    };
+    const err = new UnprocessableEntityError(
+      "incompatible bundle version",
+      details,
+    );
+
+    const response = buildErrorResponse(err);
+
+    expect(response.errorCode).toBe("UNPROCESSABLE_ENTITY");
+    expect(response.statusCode).toBe(422);
+    expect(response.errorDetails).toEqual(details);
+  });
+
+  test("omits errorDetails when RouteError has no details", () => {
+    const err = new UnprocessableEntityError("plain validation failure");
+
+    const response = buildErrorResponse(err);
+
+    expect(response.errorCode).toBe("UNPROCESSABLE_ENTITY");
+    // `errorDetails` must be omitted entirely (not `undefined` value) so the
+    // serialized JSON envelope stays minimal.
+    expect("errorDetails" in response).toBe(false);
+  });
+
+  test("non-RouteError errors are stringified into `error`", () => {
+    const response = buildErrorResponse(new Error("raw"));
+
+    expect(response.error).toBe("Error: raw");
+    expect(response.errorCode).toBeUndefined();
+    expect(response.errorDetails).toBeUndefined();
+  });
+});

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -70,6 +70,14 @@ export type IpcResponse = {
   statusCode?: number;
   /** Machine-readable error code (e.g. "NOT_FOUND") for RouteError instances. */
   errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating `RouteError` carries a `details` field (e.g.
+   * `version_incompatible` migration imports). Mirrors the HTTP adapter's
+   * `error.details` envelope so IPC clients can recover the same
+   * machine-readable context as HTTP clients.
+   */
+  errorDetails?: unknown;
   headers?: Record<string, string>;
 };
 
@@ -274,12 +282,16 @@ export class AssistantIpcServer {
 
   private buildErrorResponse(id: string, err: unknown): IpcResponse {
     if (err instanceof RouteError) {
-      return {
+      const response: IpcResponse = {
         id,
         error: err.message,
         statusCode: err.statusCode,
         errorCode: err.code,
       };
+      if (err.details !== undefined) {
+        response.errorDetails = err.details;
+      }
+      return response;
     }
     return { id, error: String(err) };
   }

--- a/assistant/src/ipc/cli-client.ts
+++ b/assistant/src/ipc/cli-client.ts
@@ -30,6 +30,16 @@ type IpcResponse = {
   id: string;
   result?: unknown;
   error?: string;
+  /** HTTP-style status code mirrored from `RouteError.statusCode`. */
+  statusCode?: number;
+  /** Machine-readable error code (e.g. "UNPROCESSABLE_ENTITY"). */
+  errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating error carried a `details` field. Mirrors the HTTP
+   * adapter's `error.details` envelope.
+   */
+  errorDetails?: unknown;
 };
 
 // ---------------------------------------------------------------------------
@@ -43,6 +53,15 @@ export interface CliIpcCallResult<T = unknown> {
   ok: boolean;
   result?: T;
   error?: string;
+  /** HTTP-style status code surfaced from a daemon-side `RouteError`. */
+  statusCode?: number;
+  /** Machine-readable error code (e.g. "UNPROCESSABLE_ENTITY"). */
+  errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating daemon-side error carried a `details` field.
+   */
+  errorDetails?: unknown;
 }
 
 /**
@@ -115,7 +134,19 @@ export async function cliIpcCall<T = unknown>(
             const msg = JSON.parse(line) as IpcResponse;
             if (msg.id === reqId) {
               if (msg.error) {
-                finish({ ok: false, error: msg.error });
+                finish({
+                  ok: false,
+                  error: msg.error,
+                  ...(msg.statusCode !== undefined && {
+                    statusCode: msg.statusCode,
+                  }),
+                  ...(msg.errorCode !== undefined && {
+                    errorCode: msg.errorCode,
+                  }),
+                  ...(msg.errorDetails !== undefined && {
+                    errorDetails: msg.errorDetails,
+                  }),
+                });
               } else {
                 finish({ ok: true, result: msg.result as T });
               }

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-policy.test.ts
@@ -8,8 +8,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  compareSemver,
   CONFIG_ARCHIVE_PATHS,
   CREDENTIAL_METADATA_ARCHIVE_PATH,
+  evaluateRuntimeCompatibility,
   isConfigArchivePath,
   isCredentialMetadataArchivePath,
   isLegacyPersonaArchivePath,
@@ -122,5 +124,137 @@ describe("partitionWorkspacePreserveSkipDirs", () => {
     expect(dataSubdirSkipDirs.size).toBe(2);
     expect(dataSubdirSkipDirs.has("db")).toBe(true);
     expect(dataSubdirSkipDirs.has("qdrant")).toBe(true);
+  });
+});
+
+describe("compareSemver", () => {
+  test("0.10.0 > 0.9.0 (numeric, not lexical)", () => {
+    expect(compareSemver("0.10.0", "0.9.0")).toBe(1);
+  });
+
+  test("equal triples return 0", () => {
+    expect(compareSemver("0.7.1", "0.7.1")).toBe(0);
+  });
+
+  test("smaller patch returns -1", () => {
+    expect(compareSemver("0.7.0", "0.7.1")).toBe(-1);
+  });
+
+  test("prerelease tag is stripped (treated as base release)", () => {
+    expect(compareSemver("0.7.1-staging.1", "0.7.1")).toBe(0);
+  });
+
+  test("non-version string returns null", () => {
+    expect(compareSemver("not-a-version", "0.7.1")).toBe(null);
+  });
+
+  test("two-part version returns null", () => {
+    expect(compareSemver("1.2", "0.7.1")).toBe(null);
+  });
+
+  // Regression: Number.parseInt accepts numeric prefixes and ignores
+  // trailing junk ("0foo" → 0), which previously coerced malformed
+  // triples through the gate. parseSemverTriple now requires each
+  // component to match /^\d+$/ exactly.
+  test("trailing junk on a component returns null (left arg)", () => {
+    expect(compareSemver("0.8.0foo", "0.8.0")).toBe(null);
+  });
+
+  test("trailing junk on a component returns null (right arg)", () => {
+    expect(compareSemver("0.8.0", "0.7.1xyz")).toBe(null);
+  });
+
+  // Leading zeros are accepted: "01.02.03" parses to the same numeric
+  // triple as "1.2.3" since Number("01") === 1. We pin this behavior
+  // so a future tightening doesn't accidentally regress callers that
+  // pass zero-padded versions from upstream tooling.
+  test("leading zeros parse equal to un-padded triple", () => {
+    expect(compareSemver("01.02.03", "1.2.3")).toBe(0);
+  });
+
+  test("leading whitespace returns null", () => {
+    expect(compareSemver(" 0.8.0", "0.8.0")).toBe(null);
+  });
+
+  test("negative component returns null", () => {
+    expect(compareSemver("0.8.-1", "0.8.0")).toBe(null);
+  });
+});
+
+describe("evaluateRuntimeCompatibility", () => {
+  test("legacy sentinel passes regardless of runtime version", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.0.0-legacy", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  test("runtime above min with no max passes", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.7.0", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  test("runtime below min fails with full echo", () => {
+    const compat = {
+      min_runtime_version: "0.8.0",
+      max_runtime_version: null,
+    };
+    expect(evaluateRuntimeCompatibility(compat, "0.7.1")).toEqual({
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compat,
+      runtime_version: "0.7.1",
+    });
+  });
+
+  test("runtime above max fails", () => {
+    const compat = {
+      min_runtime_version: "0.7.0",
+      max_runtime_version: "0.7.5",
+    };
+    expect(evaluateRuntimeCompatibility(compat, "0.8.0")).toEqual({
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compat,
+      runtime_version: "0.8.0",
+    });
+  });
+
+  test("max is inclusive", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.7.0", max_runtime_version: "0.7.5" },
+        "0.7.5",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  test("unparsable min skips the gate (fail-open)", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "garbage", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  // Regression for Codex feedback: a malformed min like "0.8.0foo"
+  // previously coerced to [0, 8, 0] via Number.parseInt and incorrectly
+  // produced a version_incompatible decision against runtime "0.7.1".
+  // With strict per-component digit matching, the parse fails and the
+  // gate fails open.
+  test("malformed min with trailing junk fails open, does not block", () => {
+    expect(
+      evaluateRuntimeCompatibility(
+        { min_runtime_version: "0.8.0foo", max_runtime_version: null },
+        "0.7.1",
+      ),
+    ).toEqual({ ok: true });
   });
 });

--- a/assistant/src/runtime/migrations/__tests__/vbundle-import-version-compat.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-import-version-compat.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Buffer importer runtime-version compat gate.
+ *
+ * Wires `commitImport` to `policy.evaluateRuntimeCompatibility` BEFORE any
+ * state mutation. The platform-side gate is the primary check; this catches
+ * legacy bundles whose ExportJob row predates PR #5470 (compat columns NULL
+ * → platform gate skipped) and any caller that bypasses the platform-issued
+ * signed URL flow.
+ *
+ * Invariants pinned here:
+ *   - A compatible bundle imports normally.
+ *   - An incompatible bundle (min_runtime_version above APP_VERSION) returns
+ *     `{ ok: false, reason: "version_incompatible", bundle_compat,
+ *     runtime_version }` with NO disk mutation.
+ *   - The legacy sentinel "0.0.0-legacy" passes the gate unconditionally.
+ *   - Pre-existing workspace files are byte-identical and no `*.backup-*`
+ *     files are created when the gate rejects.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { APP_VERSION } from "../../../version.js";
+import { buildVBundle } from "../vbundle-builder.js";
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { commitImport } from "../vbundle-importer.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function freshWorkspace(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "vbundle-import-version-compat-")),
+  );
+  return join(parent, "workspace");
+}
+
+function cleanupWorkspaceParent(workspaceDir: string): void {
+  try {
+    rmSync(join(workspaceDir, ".."), { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/** Recursively yields every regular file under `root` as a relative path. */
+function* walkFiles(root: string): Generator<string> {
+  if (!existsSync(root)) return;
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(abs);
+      else if (entry.isFile()) yield relative(root, abs);
+    }
+  }
+}
+
+function buildBundleWithMinRuntimeVersion(
+  minRuntimeVersion: string,
+): Uint8Array {
+  const dbBytes = new TextEncoder().encode("db-payload");
+  const configJson = JSON.stringify({ version: 1 });
+  const { archive } = buildVBundle({
+    files: [
+      { path: "workspace/data/db/assistant.db", data: dbBytes },
+      {
+        path: "workspace/config.json",
+        data: new TextEncoder().encode(configJson),
+      },
+    ],
+    ...defaultV1Options(),
+    compatibility: {
+      min_runtime_version: minRuntimeVersion,
+      max_runtime_version: null,
+    },
+  });
+  return archive;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("commitImport runtime-version compat gate", () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = freshWorkspace();
+    mkdirSync(workspaceDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanupWorkspaceParent(workspaceDir);
+  });
+
+  test("compatible bundle imports normally", () => {
+    const archive = buildBundleWithMinRuntimeVersion("0.0.1");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(workspaceDir, "data/db/assistant.db"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(true);
+  });
+
+  test("incompatible bundle (above APP_VERSION) returns version_incompatible without writing", () => {
+    const archive = buildBundleWithMinRuntimeVersion("99.0.0");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === "version_incompatible") {
+      expect(result.bundle_compat.min_runtime_version).toBe("99.0.0");
+      expect(result.bundle_compat.max_runtime_version).toBeNull();
+      expect(result.runtime_version).toBe(APP_VERSION);
+    } else {
+      throw new Error(
+        `expected version_incompatible, got ${JSON.stringify(result)}`,
+      );
+    }
+
+    // Fresh workspace stays empty — no bundle files, no backups.
+    expect([...walkFiles(workspaceDir)]).toEqual([]);
+  });
+
+  test("legacy sentinel passes through", () => {
+    const archive = buildBundleWithMinRuntimeVersion("0.0.0-legacy");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(workspaceDir, "data/db/assistant.db"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(true);
+  });
+
+  test("pre-existing workspace files stay untouched on incompatibility", () => {
+    const sentinelPath = join(workspaceDir, "sentinel.txt");
+    const sentinelContent = "keep me";
+    writeFileSync(sentinelPath, sentinelContent);
+
+    const archive = buildBundleWithMinRuntimeVersion("99.0.0");
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("version_incompatible");
+
+    expect(readFileSync(sentinelPath, "utf-8")).toBe(sentinelContent);
+    // Only the seeded sentinel remains — no bundle files, no `*.backup-*`.
+    expect([...walkFiles(workspaceDir)]).toEqual(["sentinel.txt"]);
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -36,10 +36,16 @@ import { Readable } from "node:stream";
 import { gunzipSync, gzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { APP_VERSION } from "../../../version.js";
 import { buildVBundle } from "../vbundle-builder.js";
 import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { LEGACY_RUNTIME_VERSION_SENTINEL } from "../vbundle-import-policy.js";
 import { commitImport } from "../vbundle-importer.js";
-import { streamCommitImport } from "../vbundle-streaming-importer.js";
+import {
+  IMPORT_BACKUP_PREFIX,
+  IMPORT_TEMP_PREFIX,
+  streamCommitImport,
+} from "../vbundle-streaming-importer.js";
 import { canonicalizeJson } from "../vbundle-validator.js";
 import { defaultV1Options } from "./v1-test-helpers.js";
 
@@ -589,6 +595,148 @@ describe("streamCommitImport — failure modes", () => {
 
     expect(readFileSync(join(workspaceDir, "existing.txt"), "utf8")).toBe(
       "keep me\n",
+    );
+    assertNoLeftoverTempDirs();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime-version compat gate — the streaming importer must refuse to
+// populate the temp tree when the bundle's compat range excludes APP_VERSION.
+// ---------------------------------------------------------------------------
+
+describe("streamCommitImport — runtime-version compat gate", () => {
+  let workspaceDir: string;
+  beforeEach(() => {
+    workspaceDir = freshWorkspace();
+  });
+  afterEach(() => {
+    const parent = join(workspaceDir, "..");
+    try {
+      rmSync(parent, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  /**
+   * The streaming importer creates scratch dirs `${workspaceDir}/.import-<uuid>`
+   * and `${workspaceDir}/.pre-import-<ts>-<uuid>` INSIDE workspaceDir (so every
+   * rename during the content-level swap stays on the same filesystem). Scan
+   * for orphan entries with those prefixes inside workspaceDir using the
+   * importer's own constants so this assertion stays in sync with the
+   * importer's actual layout.
+   */
+  function assertNoLeftoverTempDirs(): void {
+    if (!existsSync(workspaceDir)) return;
+    const entries = readdirSync(workspaceDir);
+    const leftover = entries.filter(
+      (name) =>
+        name.startsWith(IMPORT_TEMP_PREFIX) ||
+        name.startsWith(IMPORT_BACKUP_PREFIX),
+    );
+    expect(leftover).toEqual([]);
+  }
+
+  test("incompatible bundle returns version_incompatible without writing the temp tree", async () => {
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "workspace/a.txt",
+          data: new TextEncoder().encode("never-written"),
+        },
+      ],
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: "99.0.0",
+        max_runtime_version: null,
+      },
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    if (result.ok || result.reason !== "version_incompatible") {
+      throw new Error(
+        `expected version_incompatible, got ${JSON.stringify(result)}`,
+      );
+    }
+    expect(result.bundle_compat.min_runtime_version).toBe("99.0.0");
+    expect(result.bundle_compat.max_runtime_version).toBeNull();
+    expect(result.runtime_version).toBe(APP_VERSION);
+
+    // The streaming importer mkdir's `${workspaceDir}/.import-<uuid>` before
+    // reading the manifest, which materializes an empty workspace dir as a
+    // side effect. Verify nothing FROM THE BUNDLE landed there.
+    if (existsSync(workspaceDir)) {
+      expect(readdirSync(workspaceDir)).toEqual([]);
+    }
+    assertNoLeftoverTempDirs();
+  });
+
+  test("legacy sentinel passes through the streaming path", async () => {
+    const fileA = new TextEncoder().encode("legacy-import\n");
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        { path: "workspace/a.txt", data: fileA },
+      ],
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: LEGACY_RUNTIME_VERSION_SENTINEL,
+        max_runtime_version: null,
+      },
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readFileSync(join(workspaceDir, "a.txt"))).toEqual(
+      Buffer.from(fileA),
+    );
+    assertNoLeftoverTempDirs();
+  });
+
+  test("pre-existing workspace files stay untouched on incompatibility", async () => {
+    mkdirSync(workspaceDir, { recursive: true });
+    const seedBytes = new TextEncoder().encode("preserve-me\n");
+    writeFileSync(join(workspaceDir, "seed.txt"), seedBytes);
+
+    const { archive } = buildVBundle({
+      files: [
+        { path: "data/db/assistant.db", data: new Uint8Array() },
+        {
+          path: "workspace/a.txt",
+          data: new TextEncoder().encode("never-written"),
+        },
+      ],
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: "99.0.0",
+        max_runtime_version: null,
+      },
+    });
+
+    const result = await streamCommitImport({
+      source: readableFrom(archive),
+      pathResolver: new DefaultPathResolver(workspaceDir),
+      workspaceDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("version_incompatible");
+
+    expect(readFileSync(join(workspaceDir, "seed.txt"))).toEqual(
+      Buffer.from(seedBytes),
     );
     assertNoLeftoverTempDirs();
   });

--- a/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-streaming-importer.test.ts
@@ -654,6 +654,12 @@ describe("streamCommitImport — runtime-version compat gate", () => {
       },
     });
 
+    // Pre-condition: workspace dir does NOT exist on a fresh filesystem.
+    // The plan invariant requires that the streaming importer gate on
+    // runtime-version compat BEFORE any state mutation, so an
+    // incompatible bundle must leave the filesystem untouched.
+    expect(existsSync(workspaceDir)).toBe(false);
+
     const result = await streamCommitImport({
       source: readableFrom(archive),
       pathResolver: new DefaultPathResolver(workspaceDir),
@@ -669,12 +675,10 @@ describe("streamCommitImport — runtime-version compat gate", () => {
     expect(result.bundle_compat.max_runtime_version).toBeNull();
     expect(result.runtime_version).toBe(APP_VERSION);
 
-    // The streaming importer mkdir's `${workspaceDir}/.import-<uuid>` before
-    // reading the manifest, which materializes an empty workspace dir as a
-    // side effect. Verify nothing FROM THE BUNDLE landed there.
-    if (existsSync(workspaceDir)) {
-      expect(readdirSync(workspaceDir)).toEqual([]);
-    }
+    // Post-condition: workspace dir STILL does not exist. The version
+    // gate now runs before the temp-staging mkdir, so rejecting an
+    // incompatible bundle leaves zero filesystem trace.
+    expect(existsSync(workspaceDir)).toBe(false);
     assertNoLeftoverTempDirs();
   });
 

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -73,3 +73,100 @@ export function partitionWorkspacePreserveSkipDirs(): {
   }
   return { topLevelSkipDirs, dataSubdirSkipDirs };
 }
+
+export const LEGACY_RUNTIME_VERSION_SENTINEL = "0.0.0-legacy";
+
+type SemverTriple = readonly [number, number, number];
+
+function parseSemverTriple(version: string): SemverTriple | null {
+  // Strip optional prerelease/build suffix ("-foo", "+sha"). We treat
+  // "0.7.1-staging.1" as equal-to-release "0.7.1" for gating purposes.
+  // The platform-side check uses packaging.version.Version, which sorts
+  // prereleases BEFORE the corresponding release; matching that exactly
+  // would require a fuller parser — for runtime-side defense-in-depth
+  // this conservative read is sufficient (matches release of the same
+  // base triple).
+  const base = version.split(/[-+]/)[0] ?? version;
+  const parts = base.split(".");
+  if (parts.length !== 3) return null;
+  // Reject components with anything other than ASCII digits to avoid
+  // Number.parseInt's lenient prefix-parse — e.g. "0.8.0foo" would
+  // otherwise coerce to [0, 8, 0] and silently pass the gate, defeating
+  // the parse-failure-fail-open contract in evaluateRuntimeCompatibility.
+  // Leading zeros (e.g. "01.02.03") are intentionally accepted since
+  // they round-trip to the same numeric triple as the un-padded form.
+  if (!parts.every((p) => /^\d+$/.test(p))) return null;
+  const [maj, min, pat] = parts.map((p) => Number(p));
+  if (![maj, min, pat].every((n) => Number.isFinite(n) && n >= 0)) {
+    return null;
+  }
+  return [maj!, min!, pat!] as const;
+}
+
+// -1 if a < b, 0 if equal, +1 if a > b. Returns null on parse failure.
+export function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
+  const ta = parseSemverTriple(a);
+  const tb = parseSemverTriple(b);
+  if (!ta || !tb) return null;
+  for (let i = 0; i < 3; i++) {
+    if (ta[i]! < tb[i]!) return -1;
+    if (ta[i]! > tb[i]!) return +1;
+  }
+  return 0;
+}
+
+export interface RuntimeCompatibility {
+  min_runtime_version: string;
+  max_runtime_version: string | null;
+}
+
+export type RuntimeCompatibilityResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "version_incompatible";
+      bundle_compat: RuntimeCompatibility;
+      runtime_version: string;
+    };
+
+export function formatRuntimeCompatibilityMessage(
+  compat: RuntimeCompatibility,
+  runtimeVersion: string,
+): string {
+  const range = compat.max_runtime_version
+    ? `${compat.min_runtime_version}..${compat.max_runtime_version}`
+    : `${compat.min_runtime_version}+`;
+  return `Bundle requires runtime ${range} but runtime is ${runtimeVersion}`;
+}
+
+export function evaluateRuntimeCompatibility(
+  compat: RuntimeCompatibility,
+  runtimeVersion: string,
+): RuntimeCompatibilityResult {
+  if (compat.min_runtime_version === LEGACY_RUNTIME_VERSION_SENTINEL) {
+    return { ok: true };
+  }
+  const minCmp = compareSemver(runtimeVersion, compat.min_runtime_version);
+  if (minCmp === null) return { ok: true };
+  if (minCmp < 0) {
+    return {
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compat,
+      runtime_version: runtimeVersion,
+    };
+  }
+  if (compat.max_runtime_version !== null) {
+    const maxCmp = compareSemver(runtimeVersion, compat.max_runtime_version);
+    if (maxCmp === null) return { ok: true };
+    if (maxCmp > 0) {
+      return {
+        ok: false,
+        reason: "version_incompatible",
+        bundle_compat: compat,
+        runtime_version: runtimeVersion,
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -134,9 +134,9 @@ export function formatRuntimeCompatibilityMessage(
   runtimeVersion: string,
 ): string {
   const range = compat.max_runtime_version
-    ? `${compat.min_runtime_version}..${compat.max_runtime_version}`
+    ? `${compat.min_runtime_version}–${compat.max_runtime_version}`
     : `${compat.min_runtime_version}+`;
-  return `Bundle requires runtime ${range} but runtime is ${runtimeVersion}`;
+  return `Cannot import: bundle requires runtime ${range}, but this runtime is ${runtimeVersion}. Update your runtime before importing.`;
 }
 
 export function evaluateRuntimeCompatibility(

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -88,6 +88,15 @@ export type ImportCommitResult =
   | { ok: false; reason: "extraction_failed"; message: string }
   | {
       ok: false;
+      reason: "version_incompatible";
+      bundle_compat: {
+        min_runtime_version: string;
+        max_runtime_version: string | null;
+      };
+      runtime_version: string;
+    }
+  | {
+      ok: false;
       reason: "write_failed";
       message: string;
       partial_report?: ImportCommitReport;

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -30,6 +30,7 @@ import { dirname, join, resolve, sep } from "node:path";
 import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
+import { APP_VERSION } from "../../version.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
 import * as policy from "./vbundle-import-policy.js";
 import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
@@ -202,6 +203,24 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
 
     manifest = validation.manifest;
     entryMap = validation.entries;
+  }
+
+  // Defense-in-depth: refuse to import a bundle whose declared compat range
+  // excludes this runtime BEFORE any state mutation. The platform-side gate
+  // is the primary check; this catches legacy bundles whose ExportJob row
+  // predates PR #5470 (compat columns NULL → platform gate skipped) and
+  // any caller that bypasses the platform-issued signed URL flow.
+  const compatResult = policy.evaluateRuntimeCompatibility(
+    manifest.compatibility,
+    APP_VERSION,
+  );
+  if (!compatResult.ok) {
+    return {
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: compatResult.bundle_compat,
+      runtime_version: compatResult.runtime_version,
+    };
   }
 
   // Directories to preserve when clearing the workspace. Derived from the

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -32,6 +32,7 @@ import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import { APP_VERSION } from "../../version.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
+import type { RuntimeCompatibility } from "./vbundle-import-policy.js";
 import * as policy from "./vbundle-import-policy.js";
 import { mergeMetadataPreservingVellum } from "./vbundle-metadata-merge.js";
 import type { ManifestType, VBundleTarEntry } from "./vbundle-validator.js";
@@ -90,10 +91,7 @@ export type ImportCommitResult =
   | {
       ok: false;
       reason: "version_incompatible";
-      bundle_compat: {
-        min_runtime_version: string;
-        max_runtime_version: string | null;
-      };
+      bundle_compat: RuntimeCompatibility;
       runtime_version: string;
     }
   | {

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -278,18 +278,16 @@ export async function streamCommitImport(
   // Compared against `bundleEntryCap`.
   let entryCount = 0;
 
-  // Create the temp workspace dir up front so any failure between here and
-  // the atomic swap can be cleaned up by the catch block below.
-  try {
-    await mkdir(tempWorkspaceDir, { recursive: true });
-  } catch (err) {
-    return {
-      ok: false,
-      reason: "write_failed",
-      message: `Failed to create temp workspace dir "${tempWorkspaceDir}": ${errMessage(err)}`,
-    };
-  }
-
+  // The temp workspace dir is created lazily inside the parse loop AFTER
+  // the manifest's version gate passes (see the `entryIndex === 0` block
+  // below). Creating it up front would materialize `${workspaceDir}` (and
+  // the `.import-<uuid>` subdir) on a fresh filesystem before we knew the
+  // bundle was compatible — violating the plan invariant that importers
+  // gate on runtime-version compat BEFORE any state mutation.
+  //
+  // `cleanupTempDir` is safe whether or not the dir was ever created:
+  // `rm(..., { recursive: true, force: true })` is a no-op on a missing
+  // path.
   const cleanupTempDir = async (): Promise<void> => {
     try {
       await rm(tempWorkspaceDir, { recursive: true, force: true });
@@ -320,11 +318,15 @@ export async function streamCommitImport(
         expected = manifestResult.expected;
 
         // Defense-in-depth: refuse to populate the temp tree when the
-        // bundle's compat range excludes APP_VERSION. Throwing inside the
-        // generator's try block triggers cleanupTempDir() in the catch,
-        // so the empty `${workspaceDir}/.import-<uuid>` is removed and the
-        // real workspace is untouched. Catches legacy bundles whose
-        // ExportJob row predates the platform compat-column rollout
+        // bundle's compat range excludes APP_VERSION. The version gate
+        // runs BEFORE we materialize `${workspaceDir}/.import-<uuid>`
+        // (the mkdir below is sequenced after this check), so on a fresh
+        // filesystem an incompatible bundle leaves zero filesystem trace.
+        // Throwing inside the generator's try block still triggers
+        // cleanupTempDir() in the catch — a safe no-op on a missing path
+        // — and mapThrownToResult translates VersionIncompatibleError into
+        // the version_incompatible result shape. Catches legacy bundles
+        // whose ExportJob row predates the platform compat-column rollout
         // (compat columns NULL → platform gate skipped) and any future
         // drift between the platform gate and the manifest.
         const compatResult = policy.evaluateRuntimeCompatibility(
@@ -347,6 +349,24 @@ export async function streamCommitImport(
             `bundle contains more than ${bundleEntryCap} entries (declared: ${manifest.contents.length})`,
           );
         }
+
+        // Only NOW — after the manifest is parsed, the version gate passes,
+        // and the entry-count ceiling is enforced — do we materialize the
+        // temp staging dir on disk. Doing this lazily preserves the plan
+        // invariant that importers gate on runtime-version compat BEFORE
+        // any state mutation. If this throws, the outer catch runs
+        // cleanupTempDir (a safe no-op on a missing path) and
+        // mapThrownToResult translates the WriteFailedError into the
+        // write_failed shape of ImportCommitResult.
+        try {
+          await mkdir(tempWorkspaceDir, { recursive: true });
+        } catch (err) {
+          throw wrapWriteError(
+            `Failed to create temp workspace dir "${tempWorkspaceDir}"`,
+            err,
+          );
+        }
+
         entryIndex += 1;
         continue;
       }

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -52,6 +52,7 @@ import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js
 import { resetDb } from "../../memory/db-connection.js";
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
+import { APP_VERSION } from "../../version.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
 import * as policy from "./vbundle-import-policy.js";
 import type {
@@ -103,9 +104,13 @@ const DEFAULT_MAX_BUNDLE_ENTRIES = 100_000;
  * this run (via a `Set<string>` built from the backupDir/tempWorkspaceDir
  * basenames), so a user entry that happens to start with one of these
  * prefixes is still swept into the swap.
+ *
+ * Exported so tests asserting "no orphan temp/backup dirs" stay in sync with
+ * the actual layout. Both dirs are created at `${workspaceDir}/<prefix><uuid>`
+ * (i.e. INSIDE workspaceDir, not as a sibling).
  */
-const IMPORT_TEMP_PREFIX = ".import-";
-const IMPORT_BACKUP_PREFIX = ".pre-import-";
+export const IMPORT_TEMP_PREFIX = ".import-";
+export const IMPORT_BACKUP_PREFIX = ".pre-import-";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -313,6 +318,26 @@ export async function streamCommitImport(
         const manifestResult = await readAndValidateManifest(entry);
         manifest = manifestResult.manifest;
         expected = manifestResult.expected;
+
+        // Defense-in-depth: refuse to populate the temp tree when the
+        // bundle's compat range excludes APP_VERSION. Throwing inside the
+        // generator's try block triggers cleanupTempDir() in the catch,
+        // so the empty `${workspaceDir}/.import-<uuid>` is removed and the
+        // real workspace is untouched. Catches legacy bundles whose
+        // ExportJob row predates the platform compat-column rollout
+        // (compat columns NULL → platform gate skipped) and any future
+        // drift between the platform gate and the manifest.
+        const compatResult = policy.evaluateRuntimeCompatibility(
+          manifest.compatibility,
+          APP_VERSION,
+        );
+        if (!compatResult.ok) {
+          throw new VersionIncompatibleError(
+            compatResult.bundle_compat,
+            compatResult.runtime_version,
+          );
+        }
+
         // Entry-count ceiling check. The manifest declares every file the
         // bundle claims to contain, so one check here bounds the work the
         // importer is willing to do for this bundle.
@@ -2400,6 +2425,15 @@ function mapThrownToResult(err: unknown): ImportCommitResult {
     };
   }
 
+  if (err instanceof VersionIncompatibleError) {
+    return {
+      ok: false,
+      reason: "version_incompatible",
+      bundle_compat: err.bundleCompat,
+      runtime_version: err.runtimeVersion,
+    };
+  }
+
   // Errors we raised ourselves for disk-side failures.
   if (err instanceof WriteFailedError) {
     return {
@@ -2429,6 +2463,25 @@ class WriteFailedError extends Error {
 
 function wrapWriteError(prefix: string, cause: unknown): WriteFailedError {
   return new WriteFailedError(`${prefix}: ${errMessage(cause)}`);
+}
+
+/**
+ * Sentinel error thrown when the bundle's manifest declares a runtime-version
+ * compat range that excludes the current `APP_VERSION`. Caught by the same
+ * try/catch that wraps the streaming parse loop so `cleanupTempDir()` runs
+ * before `mapThrownToResult` translates it into the `version_incompatible`
+ * shape of `ImportCommitResult`.
+ */
+class VersionIncompatibleError extends Error {
+  constructor(
+    readonly bundleCompat: policy.RuntimeCompatibility,
+    readonly runtimeVersion: string,
+  ) {
+    super(
+      policy.formatRuntimeCompatibilityMessage(bundleCompat, runtimeVersion),
+    );
+    this.name = "VersionIncompatibleError";
+  }
 }
 
 function errMessage(err: unknown): string {

--- a/assistant/src/runtime/routes/errors.ts
+++ b/assistant/src/runtime/routes/errors.ts
@@ -10,12 +10,27 @@
 export class RouteError extends Error {
   readonly code: string;
   readonly statusCode: number;
+  /**
+   * Optional structured payload surfaced to clients in the standard
+   * error envelope as `error.details`. Use sparingly — only when the
+   * client genuinely needs machine-readable context beyond `code` and
+   * `message` (e.g. mirroring a platform-side response shape).
+   */
+  readonly details?: unknown;
 
-  constructor(message: string, code: string, statusCode: number) {
+  constructor(
+    message: string,
+    code: string,
+    statusCode: number,
+    details?: unknown,
+  ) {
     super(message);
     this.name = "RouteError";
     this.code = code;
     this.statusCode = statusCode;
+    if (details !== undefined) {
+      this.details = details;
+    }
   }
 }
 
@@ -55,8 +70,8 @@ export class NotFoundError extends RouteError {
 }
 
 export class UnprocessableEntityError extends RouteError {
-  constructor(message: string) {
-    super(message, "UNPROCESSABLE_ENTITY", 422);
+  constructor(message: string, details?: unknown) {
+    super(message, "UNPROCESSABLE_ENTITY", 422, details);
     this.name = "UnprocessableEntityError";
   }
 }

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -163,6 +163,7 @@ export function routeDefinitionsToHTTPRoutes(
             err.code as HttpErrorCode,
             err.message,
             err.statusCode,
+            err.details,
           );
         }
         throw err;

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -80,6 +80,7 @@ import {
   InternalError,
   NotFoundError,
   RouteError,
+  UnprocessableEntityError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
@@ -919,6 +920,12 @@ export async function handleMigrationImport(
 
     return importCommitSuccessResult(result.report, credentialsImported);
   } catch (err) {
+    // Preserve typed RouteError instances (e.g. UnprocessableEntityError for
+    // version_incompatible, BadRequestError for validation_failed) — only
+    // wrap genuinely unexpected errors as 500 InternalError.
+    if (err instanceof RouteError) {
+      throw err;
+    }
     log.error({ err }, "Unexpected error during import commit");
     throw new InternalError(
       err instanceof Error ? err.message : "Unexpected import error",
@@ -1022,6 +1029,14 @@ interface GcsImportErrorInit {
   reason?: string;
   errors?: Array<{ code: string; message: string; path?: string }>;
   partial_report?: ImportCommitReport;
+  /** Populated for `version_incompatible` — mirrors the platform's PR #5470
+   *  response shape so the URL-body endpoint can return the same body. */
+  bundle_compat?: {
+    min_runtime_version: string;
+    max_runtime_version: string | null;
+  };
+  /** Populated for `version_incompatible`. */
+  runtime_version?: string;
 }
 
 class GcsImportError extends Error {
@@ -1030,6 +1045,8 @@ class GcsImportError extends Error {
   public readonly reason?: string;
   public readonly errors?: GcsImportErrorInit["errors"];
   public readonly partial_report?: ImportCommitReport;
+  public readonly bundle_compat?: GcsImportErrorInit["bundle_compat"];
+  public readonly runtime_version?: string;
 
   constructor(init: GcsImportErrorInit) {
     super(init.message);
@@ -1046,6 +1063,12 @@ class GcsImportError extends Error {
     }
     if (init.partial_report !== undefined) {
       this.partial_report = init.partial_report;
+    }
+    if (init.bundle_compat !== undefined) {
+      this.bundle_compat = init.bundle_compat;
+    }
+    if (init.runtime_version !== undefined) {
+      this.runtime_version = init.runtime_version;
     }
   }
 }
@@ -1346,8 +1369,10 @@ async function runGcsImport(
       });
     }
     if (result.reason === "version_incompatible") {
-      // Wired by PR 5 — until then the importer never returns this variant,
-      // but we narrow explicitly to keep the union exhaustive.
+      // Returned by commitImport / streamCommitImport when the runtime falls
+      // outside the bundle's compat range. The platform-side gate is the
+      // primary check; this catches legacy bundles whose ExportJob row
+      // predates PR #5470 (compat columns NULL → platform gate skipped).
       throw new GcsImportError({
         code: "version_incompatible",
         message: formatRuntimeCompatibilityMessage(
@@ -1355,6 +1380,8 @@ async function runGcsImport(
           result.runtime_version,
         ),
         reason: result.reason,
+        bundle_compat: result.bundle_compat,
+        runtime_version: result.runtime_version,
       });
     }
     // write_failed
@@ -1455,6 +1482,20 @@ function throwGcsImportError(err: unknown): never {
           errors: err.errors ?? [],
         }),
       );
+    }
+    if (err.code === "version_incompatible") {
+      // 422 (not 500) — the bundle is structurally valid but cannot be
+      // imported on this runtime. Body mirrors the platform's PR #5470
+      // response shape.
+      throw new UnprocessableEntityError(err.message, {
+        reason: "version_incompatible" as const,
+        ...(err.bundle_compat !== undefined && {
+          bundle_compat: err.bundle_compat,
+        }),
+        ...(err.runtime_version !== undefined && {
+          runtime_version: err.runtime_version,
+        }),
+      });
     }
     if (err.code === "extraction_failed") {
       throw new InternalError(err.message);
@@ -1689,13 +1730,25 @@ function throwImportCommitFailure(
   }
 
   if (result.reason === "version_incompatible") {
-    // Wired by PR 5 — until then the importer never returns this variant,
-    // but we narrow explicitly to keep the union exhaustive.
-    throw new InternalError(
+    // Returned by commitImport / streamCommitImport when the runtime falls
+    // outside the bundle's compat range. The platform-side gate is the
+    // primary check; this catches legacy bundles whose ExportJob row
+    // predates PR #5470 (compat columns NULL → platform gate skipped).
+    //
+    // 422 (not 500) — the bundle is structurally valid but cannot be
+    // imported on this runtime; the caller can act on it (upgrade the
+    // runtime, choose a different bundle). Body mirrors the platform's
+    // PR #5470 response shape.
+    throw new UnprocessableEntityError(
       formatRuntimeCompatibilityMessage(
         result.bundle_compat,
         result.runtime_version,
       ),
+      {
+        reason: "version_incompatible" as const,
+        bundle_compat: result.bundle_compat,
+        runtime_version: result.runtime_version,
+      },
     );
   }
 

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -66,6 +66,7 @@ import {
   DefaultPathResolver,
 } from "../migrations/vbundle-import-analyzer.js";
 import {
+  evaluateRuntimeCompatibility,
   formatRuntimeCompatibilityMessage,
   type RuntimeCompatibility,
 } from "../migrations/vbundle-import-policy.js";
@@ -869,6 +870,23 @@ export async function handleMigrationImport(
         reason: "validation_failed",
         errors: validation.errors,
       };
+    }
+
+    // Pre-check runtime-version compat before the DB close/reopen cycle.
+    // commitImport runs the same gate as defense-in-depth for callers that
+    // don't pre-check; we run it here too so an incompatible bundle short-
+    // circuits before resetDb().
+    const compatResult = evaluateRuntimeCompatibility(
+      validation.manifest!.compatibility,
+      APP_VERSION,
+    );
+    if (!compatResult.ok) {
+      throwImportCommitFailure({
+        ok: false,
+        reason: "version_incompatible",
+        bundle_compat: compatResult.bundle_compat,
+        runtime_version: compatResult.runtime_version,
+      });
     }
 
     const pathResolver = new DefaultPathResolver(

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -65,6 +65,7 @@ import {
   analyzeImport,
   DefaultPathResolver,
 } from "../migrations/vbundle-import-analyzer.js";
+import { formatRuntimeCompatibilityMessage } from "../migrations/vbundle-import-policy.js";
 import {
   commitImport,
   extractCredentialsFromBundle,
@@ -1014,6 +1015,7 @@ interface GcsImportErrorInit {
     | "fetch_failed"
     | "validation_failed"
     | "extraction_failed"
+    | "version_incompatible"
     | "write_failed";
   message: string;
   upstreamStatus?: number;
@@ -1340,6 +1342,18 @@ async function runGcsImport(
       throw new GcsImportError({
         code: "extraction_failed",
         message: result.message,
+        reason: result.reason,
+      });
+    }
+    if (result.reason === "version_incompatible") {
+      // Wired by PR 5 — until then the importer never returns this variant,
+      // but we narrow explicitly to keep the union exhaustive.
+      throw new GcsImportError({
+        code: "version_incompatible",
+        message: formatRuntimeCompatibilityMessage(
+          result.bundle_compat,
+          result.runtime_version,
+        ),
         reason: result.reason,
       });
     }
@@ -1672,6 +1686,17 @@ function throwImportCommitFailure(
 
   if (result.reason === "extraction_failed") {
     throw new InternalError(result.message);
+  }
+
+  if (result.reason === "version_incompatible") {
+    // Wired by PR 5 — until then the importer never returns this variant,
+    // but we narrow explicitly to keep the union exhaustive.
+    throw new InternalError(
+      formatRuntimeCompatibilityMessage(
+        result.bundle_compat,
+        result.runtime_version,
+      ),
+    );
   }
 
   // write_failed

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -65,7 +65,10 @@ import {
   analyzeImport,
   DefaultPathResolver,
 } from "../migrations/vbundle-import-analyzer.js";
-import { formatRuntimeCompatibilityMessage } from "../migrations/vbundle-import-policy.js";
+import {
+  formatRuntimeCompatibilityMessage,
+  type RuntimeCompatibility,
+} from "../migrations/vbundle-import-policy.js";
 import {
   commitImport,
   extractCredentialsFromBundle,
@@ -1031,10 +1034,7 @@ interface GcsImportErrorInit {
   partial_report?: ImportCommitReport;
   /** Populated for `version_incompatible` — mirrors the platform's PR #5470
    *  response shape so the URL-body endpoint can return the same body. */
-  bundle_compat?: {
-    min_runtime_version: string;
-    max_runtime_version: string | null;
-  };
+  bundle_compat?: RuntimeCompatibility;
   /** Populated for `version_incompatible`. */
   runtime_version?: string;
 }
@@ -1045,7 +1045,7 @@ class GcsImportError extends Error {
   public readonly reason?: string;
   public readonly errors?: GcsImportErrorInit["errors"];
   public readonly partial_report?: ImportCommitReport;
-  public readonly bundle_compat?: GcsImportErrorInit["bundle_compat"];
+  public readonly bundle_compat?: RuntimeCompatibility;
   public readonly runtime_version?: string;
 
   constructor(init: GcsImportErrorInit) {

--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -64,6 +64,11 @@ const localRuntimeExportToGcsMock = spyOn(
   "localRuntimeExportToGcs",
 ).mockResolvedValue({ jobId: "platform-export-job-1" });
 
+const localRuntimeIdentityMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeIdentity",
+).mockResolvedValue({ version: "0.6.5" });
+
 const localRuntimePollJobStatusMock = spyOn(
   localRuntimeClient,
   "localRuntimePollJobStatus",
@@ -138,6 +143,8 @@ beforeEach(() => {
   localRuntimeExportToGcsMock.mockResolvedValue({
     jobId: "platform-export-job-1",
   });
+  localRuntimeIdentityMock.mockReset();
+  localRuntimeIdentityMock.mockResolvedValue({ version: "0.6.5" });
   localRuntimePollJobStatusMock.mockReset();
   localRuntimePollJobStatusMock.mockResolvedValue({
     jobId: "platform-export-job-1",
@@ -165,6 +172,7 @@ afterAll(() => {
   getPlatformUrlMock.mockRestore();
   platformRequestSignedUrlMock.mockRestore();
   localRuntimeExportToGcsMock.mockRestore();
+  localRuntimeIdentityMock.mockRestore();
   localRuntimePollJobStatusMock.mockRestore();
   getBackupsDirMock.mockRestore();
   mkdirSyncMock.mockRestore();
@@ -201,7 +209,11 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
 
     // Upload-URL request to the platform.
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-      expect.objectContaining({ operation: "upload" }),
+      expect.objectContaining({
+        operation: "upload",
+        minRuntimeVersion: "0.6.5",
+        maxRuntimeVersion: null,
+      }),
       "platform-token",
       "https://platform.vellum.ai",
     );
@@ -315,7 +327,11 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
     // runtimeUrl. The signed URLs returned by the platform target the
     // GCS bucket the runtime can reach, not the default platform's.
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-      expect.objectContaining({ operation: "upload" }),
+      expect.objectContaining({
+        operation: "upload",
+        minRuntimeVersion: "0.6.5",
+        maxRuntimeVersion: null,
+      }),
       "platform-token",
       "https://staging-platform.vellum.ai",
     );
@@ -487,3 +503,89 @@ describe("vellum backup <platform-managed>: failure cases", () => {
 // backup stopped sending `targetRuntimeVersion` on the download signed-URL
 // request — without that field the platform doesn't run the version gate,
 // so 422 `version_mismatch` is no longer reachable from this code path.
+
+// ---------------------------------------------------------------------------
+// Source-runtime version is sourced from the daemon, not the CLI
+// (Codex P1 regression guard for PR #29436)
+// ---------------------------------------------------------------------------
+describe("upload signed-URL records source runtime version (not CLI version)", () => {
+  test("identity is fetched BEFORE the upload signed-URL request", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    const callOrder: string[] = [];
+    localRuntimeIdentityMock.mockImplementationOnce(async () => {
+      callOrder.push("identity");
+      return { version: "0.5.9" };
+    });
+    platformRequestSignedUrlMock.mockImplementationOnce(async (params) => {
+      callOrder.push("signed-url");
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "uploads/org-1/bundle-abc.vbundle",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    mockGcsDownload(new Uint8Array([1]));
+
+    await backup();
+
+    expect(callOrder[0]).toBe("identity");
+    expect(callOrder[1]).toBe("signed-url");
+
+    expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "upload",
+        minRuntimeVersion: "0.5.9",
+        maxRuntimeVersion: null,
+      }),
+      "platform-token",
+      "https://platform.vellum.ai",
+    );
+  });
+
+  test("identity is fetched against the platform-managed runtime entry with the platform token", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    mockGcsDownload(new Uint8Array([1]));
+
+    await backup();
+
+    expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloud: "vellum",
+        runtimeUrl: "https://platform.vellum.ai",
+        assistantId: "11111111-2222-3333-4444-555555555555",
+      }),
+      "platform-token",
+    );
+  });
+
+  test("identity fetch failure aborts before signed-URL request", async () => {
+    findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);
+    setArgv("my-platform");
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Failed to fetch runtime identity: 503 Service Unavailable"),
+    );
+
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => undefined,
+    );
+    try {
+      await expect(backup()).rejects.toThrow("process.exit:1");
+
+      // Signed-URL must NOT have been requested.
+      expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not fetch runtime identity"),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -230,15 +230,24 @@ describe("vellum backup <platform-managed>: GCS happy path", () => {
       "platform-export-job-1",
     );
 
-    // Download URL keyed off the upload's bundleKey.
+    // Download URL keyed off the upload's bundleKey. We deliberately do
+    // NOT send `targetRuntimeVersion` here — this backup downloads the
+    // bundle to disk for offline storage; there is no target runtime to
+    // gate against, and an older CLI must be able to download newer
+    // assistant backups.
     expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         operation: "download",
         bundleKey: "uploads/org-1/bundle-abc.vbundle",
-      },
+      }),
       "platform-token",
       "https://platform.vellum.ai",
     );
+    const downloadCall = platformRequestSignedUrlMock.mock.calls.find(
+      (c) => (c[0] as { operation: string }).operation === "download",
+    );
+    expect(downloadCall).toBeDefined();
+    expect(downloadCall![0]).not.toHaveProperty("targetRuntimeVersion");
 
     // GCS fetch went directly to the signed download URL with no auth.
     const gcsFetch = globalThis.fetch as unknown as ReturnType<typeof mock>;
@@ -473,3 +482,8 @@ describe("vellum backup <platform-managed>: failure cases", () => {
     }
   });
 });
+
+// NOTE: The `VersionMismatchError handling` describe block was removed when
+// backup stopped sending `targetRuntimeVersion` on the download signed-URL
+// request — without that field the platform doesn't run the version gate,
+// so 422 `version_mismatch` is no longer reachable from this code path.

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -862,7 +862,11 @@ describe("unified GCS flow — four directions", () => {
       // Signed-URL request for upload — pinned to the platform target's URL
       // so upload and download land on the same platform.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.6.5",
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -949,7 +953,11 @@ describe("unified GCS flow — four directions", () => {
       // Platform side: requested an upload URL, kicked off a runtime export to
       // GCS, and polled the unified job status.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.6.5",
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1054,7 +1062,11 @@ describe("unified GCS flow — four directions", () => {
       // lives in one place end-to-end. For local→docker neither side is
       // platform, so we default to getPlatformUrl() (resolved once).
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.6.5",
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1128,7 +1140,11 @@ describe("unified GCS flow — four directions", () => {
       // Export leg: upload-URL (pinned to the same platform as import),
       // then runtime export.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.6.5",
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://platform.vellum.ai",
       );
@@ -1192,7 +1208,11 @@ describe("signed-URL request targets the bundle-owning platform", () => {
       // The signed-URL request for upload MUST target the existing
       // platform assistant's runtimeUrl, not the default platform URL.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        expect.objectContaining({ operation: "upload" }),
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.6.5",
+          maxRuntimeVersion: null,
+        }),
         "platform-token",
         "https://staging-platform.vellum.ai",
       );
@@ -1795,9 +1815,17 @@ describe("target runtime version fetch", () => {
       bundleKey: "platform-bundle-key-abc",
     });
 
-    localRuntimeIdentityMock.mockRejectedValue(
-      new Error("Local runtime identity failed (502): bad gateway"),
-    );
+    // Identity is fetched twice in this flow: once on the source (platform)
+    // for `min_runtime_version` on the upload signed-URL, then once on the
+    // target (local) for `targetRuntimeVersion` on the download signed-URL.
+    // Succeed on the source call so the flow gets as far as the target
+    // identity fetch — that's the failure this test is exercising.
+    localRuntimeIdentityMock.mockImplementation(async (entry) => {
+      if (entry.cloud === "local") {
+        throw new Error("Local runtime identity failed (502): bad gateway");
+      }
+      return { version: "0.6.5" };
+    });
 
     const restoreFetch = installTrackingFetch();
     try {
@@ -2439,6 +2467,185 @@ describe("auth + transient-error resilience", () => {
     } finally {
       restoreFetch();
       warnSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source-runtime version is sourced from the daemon, not the CLI
+// (Codex P1 regression guard for PR #29436)
+// ---------------------------------------------------------------------------
+
+describe("upload signed-URL records source runtime version (not CLI version)", () => {
+  test("local source: identity is fetched BEFORE the upload signed-URL request", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    // Distinguish the daemon's version from anything else hardcoded.
+    localRuntimeIdentityMock.mockResolvedValue({ version: "0.5.9" });
+
+    // Order tracker: capture which mock was called first.
+    const callOrder: string[] = [];
+    localRuntimeIdentityMock.mockImplementationOnce(async () => {
+      callOrder.push("identity");
+      return { version: "0.5.9" };
+    });
+    platformRequestSignedUrlMock.mockImplementationOnce(async (params) => {
+      callOrder.push("signed-url");
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      expect(callOrder[0]).toBe("identity");
+      expect(callOrder[1]).toBe("signed-url");
+
+      // Upload request stamps minRuntimeVersion with the daemon's version,
+      // NOT cliPkg.version.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.5.9",
+          maxRuntimeVersion: null,
+        }),
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("local source: identity fetch failure aborts before signed-URL request", async () => {
+    setArgv("--from", "my-local", "--platform");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Failed to fetch runtime identity: 503 Service Unavailable"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Must NOT have proceeded to signed URL or export.
+      expect(platformRequestSignedUrlMock).not.toHaveBeenCalled();
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not fetch runtime identity"),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform source: managed runtime's identity is fetched and recorded", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle",
+    });
+
+    localRuntimeIdentityMock.mockResolvedValue({ version: "0.7.2" });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      // Identity was fetched against the platform-managed runtime entry
+      // (cloud=vellum) with the platform token — not via guardian token.
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cloud: "vellum",
+          runtimeUrl: "https://platform.vellum.ai",
+          assistantId: "my-platform",
+        }),
+        "platform-token",
+      );
+
+      // The recorded version came from the platform runtime, not the CLI.
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation: "upload",
+          minRuntimeVersion: "0.7.2",
+          maxRuntimeVersion: null,
+        }),
+        "platform-token",
+        "https://platform.vellum.ai",
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("platform source: identity fetch failure aborts before signed-URL request", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Failed to fetch runtime identity: 502 Bad Gateway"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Signed-URL upload request must not have happened.
+      const uploadCalls = platformRequestSignedUrlMock.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { operation: string }).operation === "upload",
+      );
+      expect(uploadCalls.length).toBe(0);
+
+      // Runtime export was never kicked off.
+      expect(localRuntimeExportToGcsMock).not.toHaveBeenCalled();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not fetch runtime identity"),
+      );
+    } finally {
+      restoreFetch();
     }
   });
 });

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -196,6 +196,15 @@ const localRuntimeImportFromGcsMock = spyOn(
   "localRuntimeImportFromGcs",
 ).mockResolvedValue({ jobId: "local-import-job-1" });
 
+// Default to a fixed version string. Tests that exercise the version-gate
+// surface override this mock per-case to assert the value flows from the
+// target runtime's `/v1/identity` (NOT from `cliPkg.version`) into the
+// download signed-URL request.
+const localRuntimeIdentityMock = spyOn(
+  localRuntimeClient,
+  "localRuntimeIdentity",
+).mockResolvedValue({ version: "0.6.5" });
+
 const localRuntimePollJobStatusMock = spyOn(
   localRuntimeClient,
   "localRuntimePollJobStatus",
@@ -297,6 +306,7 @@ afterAll(() => {
   computeDeviceIdMock.mockRestore();
   localRuntimeExportToGcsMock.mockRestore();
   localRuntimeImportFromGcsMock.mockRestore();
+  localRuntimeIdentityMock.mockRestore();
   localRuntimePollJobStatusMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   delete process.env.VELLUM_LOCKFILE_DIR;
@@ -446,6 +456,8 @@ beforeEach(() => {
   localRuntimeImportFromGcsMock.mockResolvedValue({
     jobId: "local-import-job-1",
   });
+  localRuntimeIdentityMock.mockReset();
+  localRuntimeIdentityMock.mockResolvedValue({ version: "0.6.5" });
   localRuntimePollJobStatusMock.mockReset();
   localRuntimePollJobStatusMock.mockImplementation(defaultLocalRuntimePollImpl);
 
@@ -974,13 +986,23 @@ describe("unified GCS flow — four directions", () => {
       // platform's bundle_key. The URL must target the SOURCE platform
       // (where the bundle was written) — pinned so a lockfile change
       // can't split upload and download across instances.
+      //
+      // `targetRuntimeVersion` MUST come from the target runtime's
+      // `/v1/identity` (mocked to "0.6.5"), NOT from the CLI's package
+      // version. The local target's daemon can be on a different version
+      // than the CLI orchestrating the teleport.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           operation: "download",
           bundleKey: "platform-exports/org-1/bundle-abc.vbundle",
-        },
+          targetRuntimeVersion: "0.6.5",
+        }),
         "platform-token",
         "https://platform.vellum.ai",
+      );
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({ cloud: "local" }),
+        expect.any(String),
       );
 
       // Runtime import-from-gcs was kicked off with that URL.
@@ -1039,13 +1061,20 @@ describe("unified GCS flow — four directions", () => {
       expect(localRuntimeExportToGcsMock).toHaveBeenCalled();
 
       // Import: download-URL for the docker target, then runtime import.
+      // targetRuntimeVersion comes from the docker target's runtime
+      // identity (mocked to "0.6.5"), not from cliPkg.version.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           operation: "download",
           bundleKey: "bundle-key-123",
-        },
+          targetRuntimeVersion: "0.6.5",
+        }),
         "platform-token",
         "https://platform.vellum.ai",
+      );
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({ cloud: "docker" }),
+        expect.any(String),
       );
       expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1224,8 +1253,14 @@ describe("signed-URL request targets the bundle-owning platform", () => {
 
       // The download URL must be requested from the SOURCE platform (where
       // the bundle was written by the runtime export), not the default.
+      // targetRuntimeVersion comes from the local target's `/v1/identity`
+      // (mocked to "0.6.5"), not from cliPkg.version.
       expect(platformRequestSignedUrlMock).toHaveBeenCalledWith(
-        { operation: "download", bundleKey: "dev-bundle-key" },
+        expect.objectContaining({
+          operation: "download",
+          bundleKey: "dev-bundle-key",
+          targetRuntimeVersion: "0.6.5",
+        }),
         "platform-token",
         "https://dev-platform.vellum.ai",
       );
@@ -1518,6 +1553,266 @@ describe("MigrationInProgressError handling", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining("already in progress"),
       );
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VersionMismatchError handling — 422 from platformRequestSignedUrl on the
+// download leg is terminal: surface a friendly message + exit 1, no retry.
+// ---------------------------------------------------------------------------
+
+describe("VersionMismatchError handling", () => {
+  test("local target: 422 on download signed-URL exits 1 with friendly message", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    // Upload signed-URL succeeds; download signed-URL throws version-mismatch.
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new platformClient.VersionMismatchError(
+          { min_runtime_version: "99.0.0", max_runtime_version: null },
+          "0.7.1",
+        );
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      // Friendly message uses the prefix from VersionMismatchError.formatMessage.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot import: bundle requires runtime"),
+      );
+
+      // Terminal: no retry of the download signed-URL request.
+      const downloadCalls = platformRequestSignedUrlMock.mock.calls.filter(
+        (c) => (c[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadCalls).toHaveLength(1);
+
+      // Runtime import-from-gcs must NOT be kicked off after the 422.
+      expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("docker target: 422 on download signed-URL exits 1 with friendly message", async () => {
+    setArgv("--from", "my-local", "--docker");
+
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    const dockerEntry = makeEntry("new-docker", {
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7822",
+    });
+
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+
+    loadAllAssistantsMock.mockImplementation(() => {
+      if (hatchDockerMock.mock.calls.length > 0) {
+        return [localEntry, dockerEntry];
+      }
+      return [localEntry];
+    });
+
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new platformClient.VersionMismatchError(
+          { min_runtime_version: "99.0.0", max_runtime_version: null },
+          "0.7.1",
+        );
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot import: bundle requires runtime"),
+      );
+
+      expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("non-VersionMismatchError on download signed-URL re-raises", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    platformRequestSignedUrlMock.mockImplementation(async (params) => {
+      if (params.operation === "download") {
+        throw new Error("network blew up");
+      }
+      return {
+        url: "https://storage.googleapis.com/bucket/signed-upload",
+        bundleKey: params.bundleKey ?? "bundle-key-123",
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      };
+    });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("network blew up");
+    } finally {
+      restoreFetch();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Target-runtime version fetch — the download signed-URL request must use
+// the TARGET runtime's reported version, not the orchestrating CLI's
+// version (which can diverge when the target was upgraded independently).
+// ---------------------------------------------------------------------------
+
+describe("target runtime version fetch", () => {
+  test("local target: targetRuntimeVersion comes from /v1/identity, not cliPkg", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    // Choose a version unlikely to match cliPkg.version so a regression
+    // would be obvious.
+    localRuntimeIdentityMock.mockResolvedValue({ version: "1.2.3-runtime" });
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+
+      const downloadCall = platformRequestSignedUrlMock.mock.calls.find(
+        (c) => (c[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadCall).toBeDefined();
+      expect(downloadCall![0]).toMatchObject({
+        targetRuntimeVersion: "1.2.3-runtime",
+      });
+
+      // Identity was fetched against the TARGET (local) entry, not the
+      // platform source.
+      expect(localRuntimeIdentityMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cloud: "local",
+          assistantId: "my-local",
+        }),
+        expect.any(String),
+      );
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("identity fetch failure aborts before requesting download URL", async () => {
+    setArgv("--from", "my-platform", "--local", "my-local");
+
+    const platformEntry = makeEntry("my-platform", {
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+    });
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+
+    findAssistantByNameMock.mockImplementation((name: string) => {
+      if (name === "my-platform") return platformEntry;
+      if (name === "my-local") return localEntry;
+      return null;
+    });
+
+    platformPollJobStatusMock.mockResolvedValue({
+      jobId: "platform-export-job-1",
+      type: "export",
+      status: "complete",
+      bundleKey: "platform-bundle-key-abc",
+    });
+
+    localRuntimeIdentityMock.mockRejectedValue(
+      new Error("Local runtime identity failed (502): bad gateway"),
+    );
+
+    const restoreFetch = installTrackingFetch();
+    try {
+      await expect(teleport()).rejects.toThrow("process.exit:1");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not read target runtime version"),
+      );
+
+      // No download signed-URL request was made — we aborted before that.
+      const downloadCalls = platformRequestSignedUrlMock.mock.calls.filter(
+        (c) => (c[0] as { operation: string }).operation === "download",
+      );
+      expect(downloadCalls).toHaveLength(0);
+      expect(localRuntimeImportFromGcsMock).not.toHaveBeenCalled();
     } finally {
       restoreFetch();
     }

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -9,6 +9,7 @@ import { pollJobUntilDone } from "../lib/job-polling.js";
 import {
   MigrationInProgressError,
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimePollJobStatus,
 } from "../lib/local-runtime-client.js";
 import {
@@ -232,9 +233,30 @@ async function backupPlatform(
   // signed-download request.
   let exportPlatformToken = platformToken;
 
+  // Step 0 — Ask the source runtime which version it's running. The bundle
+  // is produced by the daemon (not the CLI), and the CLI version can drift
+  // from the daemon version, so the daemon's version is the authoritative
+  // value to record as the bundle's `min_runtime_version`. Stamping with
+  // `cliPkg.version` here would record an inaccurate compatibility band on
+  // the signed-URL request.
+  let runtimeIdentity: { version: string };
+  try {
+    runtimeIdentity = await localRuntimeIdentity(entry, exportPlatformToken);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `Error: Could not fetch runtime identity from '${name}': ${msg}`,
+    );
+    process.exit(1);
+  }
+
   // Step 1 — Request a signed upload URL.
   const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-    { operation: "upload" },
+    {
+      operation: "upload",
+      minRuntimeVersion: runtimeIdentity.version,
+      maxRuntimeVersion: null,
+    },
     exportPlatformToken,
     platformUrl,
   );

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -289,8 +289,19 @@ async function backupPlatform(
   // poll-loop 401 refresh doesn't get clobbered here — otherwise a long
   // export that recovered mid-poll via re-auth would still 401 on the
   // download-URL request and abort an otherwise successful run.
+  //
+  // We deliberately do NOT send `targetRuntimeVersion` here. This flow
+  // saves the bundle to disk for offline storage; there is no target
+  // runtime to gate against, and the user can later restore the file
+  // into any compatible runtime. Sending the CLI's version would
+  // incorrectly block older CLIs from backing up newer assistants.
+  // The platform treats `target_runtime_version` as optional and skips
+  // the version check when it's omitted.
   const { url: bundleUrl } = await platformRequestSignedUrl(
-    { operation: "download", bundleKey },
+    {
+      operation: "download",
+      bundleKey,
+    },
     exportPlatformToken,
     platformUrl,
   );

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -179,7 +179,13 @@ async function restorePlatform(
     process.exit(1);
   }
 
-  // Step 1.5 — Upload to GCS via signed URL
+  // Step 1.5 — Upload to GCS via signed URL.
+  // We deliberately omit min/max runtime version here: restore uploads an
+  // arbitrary .vbundle from disk (often produced by a different runtime
+  // than the one we'd query right now), and the bundle's own manifest is
+  // the authority on its compatibility band. The platform skips the
+  // version gate when these fields are absent and re-derives compat from
+  // the manifest when it processes the import.
   const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
     { operation: "upload" },
     token,

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -256,13 +256,17 @@ async function getAccessToken(
 
 /**
  * Detect a 401 Unauthorized raised by `localRuntimeExportToGcs` /
- * `localRuntimeImportFromGcs`. Both throw Error with a message of the form
- * `"Local runtime <op> failed (401): ..."` when the gateway rejects the
- * cached guardian token.
+ * `localRuntimeImportFromGcs` / `localRuntimeIdentity`. They throw Error
+ * with a message of the form `"Local runtime <op> failed (401): ..."` or
+ * `"Failed to fetch runtime identity: 401 ..."` when the gateway rejects
+ * the cached guardian token.
  */
 function isRuntime401(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return /Local runtime [^(]*failed \(401\)/.test(msg);
+  return (
+    /Local runtime [^(]*failed \(401\)/.test(msg) ||
+    /Failed to fetch runtime identity: 401\b/.test(msg)
+  );
 }
 
 /**
@@ -369,13 +373,40 @@ async function exportFromAssistant(
   }
 
   if (cloud === "local" || cloud === "docker") {
+    // Ask the source runtime which version it's running before requesting
+    // the signed upload URL. The bundle is produced by the daemon (not the
+    // CLI), so the daemon's version is what defines the bundle's
+    // `min_runtime_version`. Stamping with `cliPkg.version` instead would
+    // record an inaccurate compatibility band whenever the CLI/daemon have
+    // drifted (a normal case in real usage — `vellum upgrade` swaps the
+    // daemon, the CLI is updated separately).
+    let sourceRuntimeVersion: string;
+    try {
+      const identity = await callRuntimeWithAuthRetry(
+        entry.runtimeUrl,
+        entry.assistantId,
+        async (token) => localRuntimeIdentity(entry, token),
+      );
+      sourceRuntimeVersion = identity.version;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `Error: Could not fetch runtime identity from '${entry.assistantId}': ${msg}`,
+      );
+      process.exit(1);
+    }
+
     // Request a signed upload URL from the platform instance that will
     // eventually own the bundle (i.e. the one the importer will read from).
     // Passing the target's runtime URL here keeps upload and download on
     // the same platform — otherwise a non-default/stale platform URL would
     // cause the import to look at an empty object.
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-      { operation: "upload" },
+      {
+        operation: "upload",
+        minRuntimeVersion: sourceRuntimeVersion,
+        maxRuntimeVersion: null,
+      },
       platformToken,
       bundlePlatformUrl,
     );
@@ -442,6 +473,24 @@ async function exportFromAssistant(
   }
 
   if (cloud === "vellum") {
+    // Ask the managed runtime which version it's running so the signed-URL
+    // request records the bundle's actual `min_runtime_version`. The
+    // platform-managed runtime is the exporter; the CLI version is
+    // unrelated. Routed via the wildcard proxy with platform-token auth
+    // (resolveRuntimeUrl + migrationRequestHeaders inside
+    // localRuntimeIdentity).
+    let sourceRuntimeVersion: string;
+    try {
+      const identity = await localRuntimeIdentity(entry, platformToken);
+      sourceRuntimeVersion = identity.version;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `Error: Could not fetch runtime identity from '${entry.assistantId}': ${msg}`,
+      );
+      process.exit(1);
+    }
+
     // Platform source — request a signed upload URL on the same platform
     // instance the bundle will eventually be imported from, then ask the
     // managed runtime to export directly to GCS. The runtime endpoint is
@@ -451,7 +500,11 @@ async function exportFromAssistant(
     // pick that shape for `cloud === "vellum"` and `migrationRequestHeaders`
     // to send platform-token auth (no guardian-token bootstrap).
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
-      { operation: "upload" },
+      {
+        operation: "upload",
+        minRuntimeVersion: sourceRuntimeVersion,
+        maxRuntimeVersion: null,
+      },
       platformToken,
       bundlePlatformUrl,
     );

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -21,6 +21,7 @@ import {
   platformImportBundleFromGcs,
   platformImportPreflightFromGcs,
   platformRequestSignedUrl,
+  VersionMismatchError,
   ensureSelfHostedLocalRegistration,
   readGatewayCredential,
   reprovisionAssistantApiKey,
@@ -30,6 +31,7 @@ import {
 } from "../lib/platform-client.js";
 import {
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimeImportFromGcs,
   localRuntimePollJobStatus,
   MigrationInProgressError,
@@ -659,11 +661,56 @@ async function importToAssistant(
     // never touches the bytes. The URL must target the same platform the
     // bundle was uploaded to; otherwise the object won't exist on this
     // platform's GCS bucket.
-    const { url: bundleUrl } = await platformRequestSignedUrl(
-      { operation: "download", bundleKey },
-      platformToken,
-      bundlePlatformUrl,
-    );
+    //
+    // The platform's vbundle version gate compares the **target runtime's**
+    // version against the bundle's compatibility range. The CLI and the
+    // target assistant's daemon can diverge (assistants upgrade
+    // independently), so we MUST query the target runtime's `/v1/identity`
+    // for its version rather than sending `cliPkg.version`. Sending the CLI
+    // version here would falsely 422 a valid import (or pass a bundle the
+    // target can't actually load) whenever the two drift apart.
+    let targetRuntimeVersion: string;
+    try {
+      const identity = await callRuntimeWithAuthRetry(
+        entry.runtimeUrl,
+        entry.assistantId,
+        (token) => localRuntimeIdentity(entry, token),
+      );
+      targetRuntimeVersion = identity.version;
+    } catch (err) {
+      // Surface and abort — silently falling back to `cliPkg.version` would
+      // re-introduce the bug this code is fixing. If the runtime is
+      // unreachable, the import would fail downstream anyway.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `Error: Could not read target runtime version from '${entry.assistantId}': ${msg}`,
+      );
+      console.error(`Try: vellum wake ${entry.assistantId}`);
+      process.exit(1);
+    }
+
+    let bundleUrl: string;
+    try {
+      const result = await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey,
+          targetRuntimeVersion,
+        },
+        platformToken,
+        bundlePlatformUrl,
+      );
+      bundleUrl = result.url;
+    } catch (err) {
+      if (err instanceof VersionMismatchError) {
+        // 422 version_mismatch is terminal — the bundle's runtime range and
+        // the target runtime's version don't overlap. Surface the
+        // platform-formatted message and exit; do NOT retry.
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
+    }
 
     console.log("Importing data...");
 

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -481,12 +481,19 @@ describe("vellum-cloud routing through wildcard proxy", () => {
 });
 
 describe("localRuntimeIdentity", () => {
-  test("local entry: GETs /v1/identity with Bearer auth and returns the version", async () => {
+  test("local entry: GETs /v1/health with Bearer auth and returns the version", async () => {
     const { calls, fetchMock } = captureFetch(() => {
-      return new Response(JSON.stringify({ version: "0.6.5" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({
+          status: "healthy",
+          timestamp: "2025-01-01T00:00:00Z",
+          version: "0.6.5",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     });
     globalThis.fetch = fetchMock;
 
@@ -494,12 +501,29 @@ describe("localRuntimeIdentity", () => {
 
     expect(result.version).toBe("0.6.5");
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/identity`);
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/health`);
     expect(calls[0]!.method).toBe("GET");
     expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
   });
 
-  test("vellum entry: GETs /v1/assistants/<id>/identity through the wildcard proxy", async () => {
+  test("GETs /v1/health, not /v1/identity (works on pre-onboarding runtimes)", async () => {
+    // Regression guard: /v1/identity reads IDENTITY.md (written during
+    // onboarding, NOT hatch) and 404s on freshly-hatched targets. /v1/health
+    // returns the version field unconditionally, so it's the right source.
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: "0.7.0" }), {
+        status: 200,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await localRuntimeIdentity(ENTRY, TOKEN);
+
+    expect(calls[0]!.url.endsWith("/v1/health")).toBe(true);
+    expect(calls[0]!.url).not.toContain("/v1/identity");
+  });
+
+  test("vellum entry: GETs /v1/assistants/<id>/health through the wildcard proxy", async () => {
     const { calls, fetchMock } = captureFetch(() => {
       return new Response(JSON.stringify({ version: "0.7.2" }), {
         status: 200,
@@ -511,7 +535,7 @@ describe("localRuntimeIdentity", () => {
 
     expect(result.version).toBe("0.7.2");
     expect(calls[0]!.url).toBe(
-      `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity`,
+      `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/health`,
     );
     expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
   });
@@ -577,14 +601,14 @@ describe("localRuntimeIdentity", () => {
     const PLATFORM_URL = "https://platform.vellum.ai";
     const ASSISTANT_ID = "11111111-2222-3333-4444-555555555555";
 
-    let identityCalls = 0;
+    let healthCalls = 0;
     const orgIdFetchedAs: string[] = [];
 
     const fetchMock = mock(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.endsWith("/v1/organizations/")) {
         // Each org-ID fetch returns a different ID to prove that the
-        // second identity request DID re-resolve the org rather than
+        // second health request DID re-resolve the org rather than
         // reuse a stale cache entry.
         orgIdFetchedAs.push(`org-${orgIdFetchedAs.length + 1}`);
         return new Response(
@@ -594,9 +618,9 @@ describe("localRuntimeIdentity", () => {
           { status: 200 },
         );
       }
-      if (urlStr.endsWith(`/v1/assistants/${ASSISTANT_ID}/identity`)) {
-        identityCalls += 1;
-        if (identityCalls === 1) {
+      if (urlStr.endsWith(`/v1/assistants/${ASSISTANT_ID}/health`)) {
+        healthCalls += 1;
+        if (healthCalls === 1) {
           return new Response("unauthorized", { status: 401 });
         }
         return new Response(JSON.stringify({ version: "0.7.4" }), {
@@ -617,7 +641,7 @@ describe("localRuntimeIdentity", () => {
     );
 
     expect(result.version).toBe("0.7.4");
-    expect(identityCalls).toBe(2);
+    expect(healthCalls).toBe(2);
     // Two org-ID fetches: the first to satisfy the initial authHeaders
     // call, the second after the 401-driven cache invalidation.
     expect(orgIdFetchedAs).toEqual(["org-1", "org-2"]);

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -4,6 +4,7 @@ import type { AssistantEntry } from "../assistant-config.js";
 import {
   MigrationInProgressError,
   localRuntimeExportToGcs,
+  localRuntimeIdentity,
   localRuntimeImportFromGcs,
   localRuntimePollJobStatus,
 } from "../local-runtime-client.js";
@@ -476,5 +477,81 @@ describe("vellum-cloud routing through wildcard proxy", () => {
     if (status.status === "complete") {
       expect(status.bundleKey).toBe("exports/org-1/x.vbundle");
     }
+  });
+});
+
+describe("localRuntimeIdentity", () => {
+  test("local: GETs /v1/identity with Bearer auth and returns version", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          name: "Test",
+          role: "",
+          personality: "",
+          emoji: "",
+          home: "",
+          version: "0.6.5",
+          createdAt: "2025-01-01T00:00:00Z",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeIdentity(ENTRY, TOKEN);
+
+    expect(result).toEqual({ version: "0.6.5" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/identity`);
+    expect(calls[0]!.method).toBe("GET");
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  test("vellum: routes through wildcard proxy /v1/assistants/<id>/identity", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          name: "Test",
+          role: "",
+          personality: "",
+          emoji: "",
+          home: "",
+          version: "0.7.2",
+          createdAt: "2025-01-01T00:00:00Z",
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await localRuntimeIdentity(VELLUM_ENTRY, VAK_TOKEN);
+
+    expect(result).toEqual({ version: "0.7.2" });
+    expect(calls[0]!.url).toBe(
+      `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity`,
+    );
+    expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
+  });
+
+  test("non-2xx throws with status + body so callers can surface", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("unreachable", { status: 502 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(/502/);
+  });
+
+  test("missing version field throws (we never silently degrade)", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ name: "Test", role: "" }), {
+        status: 200,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /no version field/,
+    );
   });
 });

--- a/cli/src/lib/__tests__/local-runtime-client.test.ts
+++ b/cli/src/lib/__tests__/local-runtime-client.test.ts
@@ -481,77 +481,162 @@ describe("vellum-cloud routing through wildcard proxy", () => {
 });
 
 describe("localRuntimeIdentity", () => {
-  test("local: GETs /v1/identity with Bearer auth and returns version", async () => {
+  test("local entry: GETs /v1/identity with Bearer auth and returns the version", async () => {
     const { calls, fetchMock } = captureFetch(() => {
-      return new Response(
-        JSON.stringify({
-          name: "Test",
-          role: "",
-          personality: "",
-          emoji: "",
-          home: "",
-          version: "0.6.5",
-          createdAt: "2025-01-01T00:00:00Z",
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify({ version: "0.6.5" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
     });
     globalThis.fetch = fetchMock;
 
     const result = await localRuntimeIdentity(ENTRY, TOKEN);
 
-    expect(result).toEqual({ version: "0.6.5" });
+    expect(result.version).toBe("0.6.5");
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe(`${RUNTIME_URL}/v1/identity`);
     expect(calls[0]!.method).toBe("GET");
     expect(calls[0]!.headers.Authorization).toBe(`Bearer ${TOKEN}`);
   });
 
-  test("vellum: routes through wildcard proxy /v1/assistants/<id>/identity", async () => {
+  test("vellum entry: GETs /v1/assistants/<id>/identity through the wildcard proxy", async () => {
     const { calls, fetchMock } = captureFetch(() => {
-      return new Response(
-        JSON.stringify({
-          name: "Test",
-          role: "",
-          personality: "",
-          emoji: "",
-          home: "",
-          version: "0.7.2",
-          createdAt: "2025-01-01T00:00:00Z",
-        }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ version: "0.7.2" }), {
+        status: 200,
+      });
     });
     globalThis.fetch = fetchMock;
 
     const result = await localRuntimeIdentity(VELLUM_ENTRY, VAK_TOKEN);
 
-    expect(result).toEqual({ version: "0.7.2" });
+    expect(result.version).toBe("0.7.2");
     expect(calls[0]!.url).toBe(
       `https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity`,
     );
     expect(calls[0]!.headers.Authorization).toBe(`Bearer ${VAK_TOKEN}`);
   });
 
-  test("non-2xx throws with status + body so callers can surface", async () => {
+  test("non-2xx status throws with status + statusText", async () => {
     const { fetchMock } = captureFetch(() => {
-      return new Response("unreachable", { status: 502 });
-    });
-    globalThis.fetch = fetchMock;
-
-    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(/502/);
-  });
-
-  test("missing version field throws (we never silently degrade)", async () => {
-    const { fetchMock } = captureFetch(() => {
-      return new Response(JSON.stringify({ name: "Test", role: "" }), {
-        status: 200,
+      return new Response("nope", {
+        status: 503,
+        statusText: "Service Unavailable",
       });
     });
     globalThis.fetch = fetchMock;
 
     await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
-      /no version field/,
+      /Failed to fetch runtime identity: 503/,
     );
+  });
+
+  test("missing version in body throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Runtime identity response missing version/,
+    );
+  });
+
+  test("non-string version in body throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: 123 }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Runtime identity response missing version/,
+    );
+  });
+
+  test("empty-string version in body throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ version: "" }), { status: 200 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Runtime identity response missing version/,
+    );
+  });
+
+  // ---------------------------------------------------------------------
+  // 401-retry parity with platformRequestSignedUrl (Codex P2 regression
+  // guard). localRuntimeIdentity is the first network call in the
+  // backup/teleport export flow for vellum-cloud assistants, so a stale
+  // Vellum-Organization-Id cache entry would surface as a hard abort
+  // before any other helper got a chance to clear the cache and retry.
+  // ---------------------------------------------------------------------
+
+  test("vellum entry: retries once after 401 with a fresh org-ID lookup", async () => {
+    // Use a non-vak session token so authHeaders fetches + caches an org ID.
+    const SESSION_TOKEN = "session-abcdef";
+    const PLATFORM_URL = "https://platform.vellum.ai";
+    const ASSISTANT_ID = "11111111-2222-3333-4444-555555555555";
+
+    let identityCalls = 0;
+    const orgIdFetchedAs: string[] = [];
+
+    const fetchMock = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/v1/organizations/")) {
+        // Each org-ID fetch returns a different ID to prove that the
+        // second identity request DID re-resolve the org rather than
+        // reuse a stale cache entry.
+        orgIdFetchedAs.push(`org-${orgIdFetchedAs.length + 1}`);
+        return new Response(
+          JSON.stringify({
+            results: [{ id: orgIdFetchedAs[orgIdFetchedAs.length - 1]! }],
+          }),
+          { status: 200 },
+        );
+      }
+      if (urlStr.endsWith(`/v1/assistants/${ASSISTANT_ID}/identity`)) {
+        identityCalls += 1;
+        if (identityCalls === 1) {
+          return new Response("unauthorized", { status: 401 });
+        }
+        return new Response(JSON.stringify({ version: "0.7.4" }), {
+          status: 200,
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const result = await localRuntimeIdentity(
+      {
+        cloud: "vellum",
+        runtimeUrl: PLATFORM_URL,
+        assistantId: ASSISTANT_ID,
+      },
+      SESSION_TOKEN,
+    );
+
+    expect(result.version).toBe("0.7.4");
+    expect(identityCalls).toBe(2);
+    // Two org-ID fetches: the first to satisfy the initial authHeaders
+    // call, the second after the 401-driven cache invalidation.
+    expect(orgIdFetchedAs).toEqual(["org-1", "org-2"]);
+  });
+
+  test("local entry: does NOT retry after 401 (guardian-token refresh is the caller's job via callRuntimeWithAuthRetry)", async () => {
+    let identityCalls = 0;
+    const fetchMock = mock(async () => {
+      identityCalls += 1;
+      return new Response("unauthorized", {
+        status: 401,
+        statusText: "Unauthorized",
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    await expect(localRuntimeIdentity(ENTRY, TOKEN)).rejects.toThrow(
+      /Failed to fetch runtime identity: 401/,
+    );
+    expect(identityCalls).toBe(1);
   });
 });

--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   platformPollJobStatus,
   platformRequestSignedUrl,
+  VersionMismatchError,
   type UnifiedJobStatus,
 } from "../platform-client.js";
 
@@ -289,6 +290,240 @@ describe("platformRequestSignedUrl", () => {
     // Session tokens use X-Session-Token, not Bearer.
     expect(signedUrlCalls[0]!.headers["X-Session-Token"]).toBe(SESSION_TOKEN);
     expect(signedUrlCalls[0]!.headers.Authorization).toBeUndefined();
+  });
+
+  test("upload operation with min/max runtime versions → posts them in body", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/v",
+          bundle_key: "bundles/v.tar.gz",
+          expires_at: "2026-04-22T05:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    await platformRequestSignedUrl(
+      {
+        operation: "upload",
+        minRuntimeVersion: "1.2.3",
+        maxRuntimeVersion: null,
+      },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(calls[0]!.body).toEqual({
+      operation: "upload",
+      min_runtime_version: "1.2.3",
+      max_runtime_version: null,
+    });
+  });
+
+  test("download operation with target_runtime_version → posts it in body", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/dl-v",
+          bundle_key: "bundles/dl-v.tar.gz",
+          expires_at: "2026-04-22T06:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    await platformRequestSignedUrl(
+      {
+        operation: "download",
+        bundleKey: "bundles/dl-v.tar.gz",
+        targetRuntimeVersion: "2.0.0",
+      },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(calls[0]!.body).toEqual({
+      operation: "download",
+      bundle_key: "bundles/dl-v.tar.gz",
+      target_runtime_version: "2.0.0",
+    });
+  });
+
+  test("download 422 with version_mismatch body → throws VersionMismatchError", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          reason: "version_mismatch",
+          bundle_compat: {
+            min_runtime_version: "2.0.0",
+            max_runtime_version: "2.5.0",
+          },
+          target_runtime_version: "1.9.0",
+        }),
+        { status: 422 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey: "bundles/foo.tar.gz",
+          targetRuntimeVersion: "1.9.0",
+        },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(VersionMismatchError);
+    expect(caught).toBeInstanceOf(Error);
+    const err = caught as VersionMismatchError;
+    expect(err.bundleCompat).toEqual({
+      min_runtime_version: "2.0.0",
+      max_runtime_version: "2.5.0",
+    });
+    expect(err.targetRuntimeVersion).toBe("1.9.0");
+    expect(err.message).toBe(
+      "Cannot import: bundle requires runtime 2.0.0–2.5.0, but this runtime is 1.9.0. Update your runtime before importing.",
+    );
+  });
+
+  test("download 422 with version_mismatch and null max_runtime_version → '+' suffix in message", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          reason: "version_mismatch",
+          bundle_compat: {
+            min_runtime_version: "3.0.0",
+            max_runtime_version: null,
+          },
+          target_runtime_version: "2.9.0",
+        }),
+        { status: 422 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey: "bundles/foo.tar.gz",
+          targetRuntimeVersion: "2.9.0",
+        },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(VersionMismatchError);
+    const err = caught as VersionMismatchError;
+    expect(err.message).toBe(
+      "Cannot import: bundle requires runtime 3.0.0+, but this runtime is 2.9.0. Update your runtime before importing.",
+    );
+  });
+
+  test("download 422 with arbitrary body (no reason field) → falls through to generic Error", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response(JSON.stringify({ detail: "validation failed" }), {
+        status: 422,
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        { operation: "download", bundleKey: "bundles/foo.tar.gz" },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(VersionMismatchError);
+    expect((caught as Error).message).toBe("validation failed");
+  });
+
+  test("422 is NOT retried after a 401", async () => {
+    let callCount = 0;
+    const { calls, fetchMock } = captureFetch(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ detail: "unauthorized" }), {
+          status: 401,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          reason: "version_mismatch",
+          bundle_compat: {
+            min_runtime_version: "2.0.0",
+            max_runtime_version: "2.5.0",
+          },
+          target_runtime_version: "1.9.0",
+        }),
+        { status: 422 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    let caught: unknown;
+    try {
+      await platformRequestSignedUrl(
+        {
+          operation: "download",
+          bundleKey: "bundles/foo.tar.gz",
+          targetRuntimeVersion: "1.9.0",
+        },
+        VAK_TOKEN,
+        PLATFORM_URL,
+      );
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(calls).toHaveLength(2);
+    expect(caught).toBeInstanceOf(VersionMismatchError);
+  });
+
+  test("non-422 download path remains unchanged (regression pin on body shape)", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({
+          url: "https://storage.example/signed/dl-xyz",
+          bundle_key: "bundles/xyz.tar.gz",
+          expires_at: "2026-04-22T02:00:00Z",
+        }),
+        { status: 201 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await platformRequestSignedUrl(
+      { operation: "download", bundleKey: "bundles/xyz.tar.gz" },
+      VAK_TOKEN,
+      PLATFORM_URL,
+    );
+
+    expect(result.url).toBe("https://storage.example/signed/dl-xyz");
+    expect(calls[0]!.body).toEqual({
+      operation: "download",
+      bundle_key: "bundles/xyz.tar.gz",
+    });
   });
 
   test("5xx error response → surfaces platform detail message", async () => {

--- a/cli/src/lib/__tests__/runtime-url.test.ts
+++ b/cli/src/lib/__tests__/runtime-url.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { AssistantEntry } from "../assistant-config.js";
-import { resolveRuntimeMigrationUrl } from "../runtime-url.js";
+import {
+  resolveRuntimeMigrationUrl,
+  resolveRuntimeUrl,
+} from "../runtime-url.js";
 
 function makeEntry(
   overrides: Partial<AssistantEntry> & {
@@ -82,6 +85,41 @@ describe("resolveRuntimeMigrationUrl", () => {
     });
     expect(resolveRuntimeMigrationUrl(entry, "export-to-gcs")).toBe(
       "http://10.0.0.5:7821/v1/migrations/export-to-gcs",
+    );
+  });
+});
+
+describe("resolveRuntimeUrl", () => {
+  test("local cloud uses gateway-loopback /v1/<subpath>", () => {
+    const entry = makeEntry({
+      cloud: "local",
+      runtimeUrl: "http://localhost:7821",
+      assistantId: "ast-local-1",
+    });
+    expect(resolveRuntimeUrl(entry, "identity")).toBe(
+      "http://localhost:7821/v1/identity",
+    );
+  });
+
+  test("docker cloud uses gateway-loopback /v1/<subpath>", () => {
+    const entry = makeEntry({
+      cloud: "docker",
+      runtimeUrl: "http://localhost:7831",
+      assistantId: "ast-docker-1",
+    });
+    expect(resolveRuntimeUrl(entry, "identity")).toBe(
+      "http://localhost:7831/v1/identity",
+    );
+  });
+
+  test("vellum cloud uses wildcard-proxy /v1/assistants/<id>/<subpath>", () => {
+    const entry = makeEntry({
+      cloud: "vellum",
+      runtimeUrl: "https://platform.vellum.ai",
+      assistantId: "11111111-2222-3333-4444-555555555555",
+    });
+    expect(resolveRuntimeUrl(entry, "identity")).toBe(
+      "https://platform.vellum.ai/v1/assistants/11111111-2222-3333-4444-555555555555/identity",
     );
   });
 });

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -7,6 +7,27 @@ import {
 import { resolveRuntimeMigrationUrl } from "./runtime-url.js";
 
 /**
+ * Build the URL for a non-migration runtime endpoint, taking topology into
+ * account. Mirrors {@link resolveRuntimeMigrationUrl} but for
+ * `/v1/<subpath>` endpoints (e.g. `/v1/identity`).
+ *
+ * - Local/docker assistants: `{runtimeUrl}/v1/<subpath>` (the gateway forwards
+ *   to the runtime; auth is guardian-token bearer).
+ * - Platform-managed (cloud="vellum"): the wildcard runtime proxy at
+ *   `{platformUrl}/v1/assistants/<id>/<subpath>` forwards arbitrary runtime
+ *   paths to the managed runtime, authenticated by the platform token.
+ */
+function resolveRuntimeUrl(
+  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
+  subpath: string,
+): string {
+  if (entry.cloud === "vellum") {
+    return `${entry.runtimeUrl}/v1/assistants/${entry.assistantId}/${subpath}`;
+  }
+  return `${entry.runtimeUrl}/v1/${subpath}`;
+}
+
+/**
  * Thrown when the local runtime returns 409 for an export/import request
  * because another migration of the same type is already in-flight. The
  * caller can inspect {@link existingJobId} and decide whether to poll the
@@ -228,4 +249,52 @@ export async function localRuntimePollJobStatus(
     typeof parseUnifiedJobStatus
   >[0];
   return parseUnifiedJobStatus(raw);
+}
+
+/**
+ * The subset of `/v1/identity` we care about. The runtime's full response
+ * includes additional fields (name, role, etc.) — we only model `version`
+ * here because that's all the CLI consumes today.
+ */
+export interface RuntimeIdentity {
+  version: string;
+}
+
+/**
+ * Fetch the target runtime's `/v1/identity` so callers can read its
+ * APP_VERSION. Used by `vellum teleport` to gate bundle imports on the
+ * version of the **target** assistant runtime — which can diverge from the
+ * orchestrating CLI's version when the target was upgraded independently.
+ *
+ * For local/docker assistants this GETs `{runtimeUrl}/v1/identity` with
+ * guardian-token bearer auth. For platform-managed (cloud="vellum")
+ * assistants the URL is rewritten to the wildcard runtime proxy shape
+ * `{platformUrl}/v1/assistants/<assistantId>/identity` and authenticated via
+ * the platform token. Throws on non-2xx so callers can surface the failure
+ * (we never silently fall back — see teleport.ts call site).
+ */
+export async function localRuntimeIdentity(
+  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
+  token: string,
+): Promise<RuntimeIdentity> {
+  const response = await fetch(resolveRuntimeUrl(entry, "identity"), {
+    headers: await migrationRequestHeaders(entry, token),
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => "");
+    throw new Error(
+      `Local runtime identity failed (${response.status}): ${
+        errText || response.statusText
+      }`,
+    );
+  }
+
+  const json = (await response.json()) as { version?: unknown };
+  if (typeof json.version !== "string" || json.version.length === 0) {
+    throw new Error(
+      `Local runtime identity returned no version field (got ${JSON.stringify(json.version)})`,
+    );
+  }
+  return { version: json.version };
 }

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -235,25 +235,32 @@ export async function localRuntimePollJobStatus(
 }
 
 /**
- * The subset of `/v1/identity` we care about. The runtime's full response
- * includes additional fields (name, role, etc.) — we only model `version`
- * here because that's all the CLI consumes today.
+ * The subset of `/v1/health` we care about. The runtime's full response
+ * includes additional fields (status, disk, memory, cpu, migrations, etc.)
+ * — we only model `version` here because that's all the CLI consumes today.
  */
 export interface RuntimeIdentity {
   version: string;
 }
 
 /**
- * Fetch the target runtime's `/v1/identity` so callers can read its
- * APP_VERSION. Used by `vellum teleport` and `vellum backup` to stamp the
- * exported bundle's `min_runtime_version` with the version of the runtime
- * that actually produced it — which can diverge from the orchestrating CLI's
- * version when the target was upgraded independently.
+ * Fetch the target runtime's APP_VERSION via `/v1/health`. Used by
+ * `vellum teleport` and `vellum backup` to stamp the exported bundle's
+ * `min_runtime_version` with the version of the runtime that actually
+ * produced it — which can diverge from the orchestrating CLI's version when
+ * the target was upgraded independently.
  *
- * For local/docker assistants this GETs `{runtimeUrl}/v1/identity` with
+ * GETs `/v1/health` (not `/v1/identity`) so the call works on freshly-
+ * hatched runtimes that haven't completed onboarding. The `/v1/identity`
+ * handler reads `IDENTITY.md` from the workspace and 404s if it's missing
+ * — and `IDENTITY.md` is only written during onboarding, not hatch. The
+ * `/v1/health` handler returns the same `version` field unconditionally
+ * (no filesystem reads), so it's safe to call against any running runtime.
+ *
+ * For local/docker assistants this GETs `{runtimeUrl}/v1/health` with
  * guardian-token bearer auth. For platform-managed (cloud="vellum")
  * assistants the URL is rewritten to the wildcard runtime proxy shape
- * `{platformUrl}/v1/assistants/<assistantId>/identity` and authenticated via
+ * `{platformUrl}/v1/assistants/<assistantId>/health` and authenticated via
  * the platform token.
  *
  * For the vellum target this is the FIRST network call in the
@@ -265,6 +272,10 @@ export interface RuntimeIdentity {
  * `callRuntimeWithAuthRetry` by callers for guardian-token refresh, so the
  * retry is intentionally vellum-only.
  *
+ * The function name is intentionally retained ("identity-ish info about the
+ * runtime") even though the implementation now hits `/v1/health` — renaming
+ * would force changes in 4+ callsites for no behavioral benefit.
+ *
  * Throws on non-2xx so callers can surface the failure (we never silently
  * fall back — see teleport.ts call site).
  */
@@ -272,7 +283,7 @@ export async function localRuntimeIdentity(
   entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
   token: string,
 ): Promise<RuntimeIdentity> {
-  const url = resolveRuntimeUrl(entry, "identity");
+  const url = resolveRuntimeUrl(entry, "health");
   const doRequest = async (): Promise<Response> =>
     fetch(url, {
       method: "GET",

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -1,31 +1,14 @@
 import type { AssistantEntry } from "./assistant-config.js";
 import {
   authHeaders,
+  invalidateOrgIdCache,
   parseUnifiedJobStatus,
   type UnifiedJobStatus,
 } from "./platform-client.js";
-import { resolveRuntimeMigrationUrl } from "./runtime-url.js";
-
-/**
- * Build the URL for a non-migration runtime endpoint, taking topology into
- * account. Mirrors {@link resolveRuntimeMigrationUrl} but for
- * `/v1/<subpath>` endpoints (e.g. `/v1/identity`).
- *
- * - Local/docker assistants: `{runtimeUrl}/v1/<subpath>` (the gateway forwards
- *   to the runtime; auth is guardian-token bearer).
- * - Platform-managed (cloud="vellum"): the wildcard runtime proxy at
- *   `{platformUrl}/v1/assistants/<id>/<subpath>` forwards arbitrary runtime
- *   paths to the managed runtime, authenticated by the platform token.
- */
-function resolveRuntimeUrl(
-  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
-  subpath: string,
-): string {
-  if (entry.cloud === "vellum") {
-    return `${entry.runtimeUrl}/v1/assistants/${entry.assistantId}/${subpath}`;
-  }
-  return `${entry.runtimeUrl}/v1/${subpath}`;
-}
+import {
+  resolveRuntimeMigrationUrl,
+  resolveRuntimeUrl,
+} from "./runtime-url.js";
 
 /**
  * Thrown when the local runtime returns 409 for an export/import request
@@ -262,39 +245,57 @@ export interface RuntimeIdentity {
 
 /**
  * Fetch the target runtime's `/v1/identity` so callers can read its
- * APP_VERSION. Used by `vellum teleport` to gate bundle imports on the
- * version of the **target** assistant runtime — which can diverge from the
- * orchestrating CLI's version when the target was upgraded independently.
+ * APP_VERSION. Used by `vellum teleport` and `vellum backup` to stamp the
+ * exported bundle's `min_runtime_version` with the version of the runtime
+ * that actually produced it — which can diverge from the orchestrating CLI's
+ * version when the target was upgraded independently.
  *
  * For local/docker assistants this GETs `{runtimeUrl}/v1/identity` with
  * guardian-token bearer auth. For platform-managed (cloud="vellum")
  * assistants the URL is rewritten to the wildcard runtime proxy shape
  * `{platformUrl}/v1/assistants/<assistantId>/identity` and authenticated via
- * the platform token. Throws on non-2xx so callers can surface the failure
- * (we never silently fall back — see teleport.ts call site).
+ * the platform token.
+ *
+ * For the vellum target this is the FIRST network call in the
+ * teleport/backup export flow, so a stale `Vellum-Organization-Id` cache
+ * entry would surface as a hard abort before any retry-friendly call (like
+ * `platformRequestSignedUrl`) gets a chance to recover. Mirror that helper's
+ * one-shot 401-retry: invalidate the org-ID cache and retry once. Local /
+ * docker entries do not use the org-ID cache and are wrapped in
+ * `callRuntimeWithAuthRetry` by callers for guardian-token refresh, so the
+ * retry is intentionally vellum-only.
+ *
+ * Throws on non-2xx so callers can surface the failure (we never silently
+ * fall back — see teleport.ts call site).
  */
 export async function localRuntimeIdentity(
   entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
   token: string,
 ): Promise<RuntimeIdentity> {
-  const response = await fetch(resolveRuntimeUrl(entry, "identity"), {
-    headers: await migrationRequestHeaders(entry, token),
-  });
+  const url = resolveRuntimeUrl(entry, "identity");
+  const doRequest = async (): Promise<Response> =>
+    fetch(url, {
+      method: "GET",
+      headers: await migrationRequestHeaders(entry, token),
+    });
+
+  let response = await doRequest();
+  if (response.status === 401 && entry.cloud === "vellum") {
+    // `entry.runtimeUrl` is the platform host for vellum-cloud entries
+    // (the wildcard runtime proxy lives there). Pass it as the cache key
+    // platformUrl so we invalidate the same entry that authHeaders cached.
+    invalidateOrgIdCache(token, entry.runtimeUrl);
+    response = await doRequest();
+  }
 
   if (!response.ok) {
-    const errText = await response.text().catch(() => "");
     throw new Error(
-      `Local runtime identity failed (${response.status}): ${
-        errText || response.statusText
-      }`,
+      `Failed to fetch runtime identity: ${response.status} ${response.statusText}`,
     );
   }
-
-  const json = (await response.json()) as { version?: unknown };
-  if (typeof json.version !== "string" || json.version.length === 0) {
-    throw new Error(
-      `Local runtime identity returned no version field (got ${JSON.stringify(json.version)})`,
-    );
+  const body = (await response.json()) as { version?: unknown };
+  if (typeof body.version !== "string" || !body.version) {
+    throw new Error("Runtime identity response missing version");
   }
-  return { version: json.version };
+  return { version: body.version };
 }

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -806,6 +806,45 @@ export function parseUnifiedJobStatus(
   };
 }
 
+export interface BundleCompatibility {
+  min_runtime_version: string;
+  max_runtime_version: string | null;
+}
+
+/**
+ * Thrown by platformRequestSignedUrl when the platform rejects a download
+ * signed-URL request because the target runtime version is outside the
+ * ExportJob's [min_runtime_version, max_runtime_version] band. Terminal
+ * — callers must NOT retry; surface to the user and abort the
+ * teleport/restore wizard.
+ */
+export class VersionMismatchError extends Error {
+  readonly bundleCompat: BundleCompatibility;
+  readonly targetRuntimeVersion: string;
+
+  constructor(bundleCompat: BundleCompatibility, targetRuntimeVersion: string) {
+    super(
+      VersionMismatchError.formatMessage(bundleCompat, targetRuntimeVersion),
+    );
+    this.name = "VersionMismatchError";
+    this.bundleCompat = bundleCompat;
+    this.targetRuntimeVersion = targetRuntimeVersion;
+  }
+
+  static formatMessage(
+    compat: BundleCompatibility,
+    targetRuntimeVersion: string,
+  ): string {
+    const range = compat.max_runtime_version
+      ? `${compat.min_runtime_version}–${compat.max_runtime_version}`
+      : `${compat.min_runtime_version}+`;
+    return (
+      `Cannot import: bundle requires runtime ${range}, but this runtime is ${targetRuntimeVersion}. ` +
+      `Update your runtime before importing.`
+    );
+  }
+}
+
 /**
  * Request a signed URL from the platform for either uploading a new bundle
  * or downloading an existing one. Calls `POST /v1/migrations/signed-url/`.
@@ -817,6 +856,9 @@ export function parseUnifiedJobStatus(
  *
  * Retries once with a fresh org-ID cache on 401 to match the retry pattern
  * used by other authenticated platform helpers.
+ *
+ * Throws {@link VersionMismatchError} on a 422 `version_mismatch` response,
+ * which is terminal — callers must NOT retry.
  */
 export async function platformRequestSignedUrl(
   params: {
@@ -824,6 +866,11 @@ export async function platformRequestSignedUrl(
     bundleKey?: string;
     contentType?: string;
     contentLength?: number;
+    // Source-side, upload only: runtime version that produced the bundle.
+    minRuntimeVersion?: string;
+    maxRuntimeVersion?: string | null;
+    // Target-side, download only: runtime version that will import.
+    targetRuntimeVersion?: string;
   },
   token: string,
   platformUrl?: string,
@@ -839,6 +886,17 @@ export async function platformRequestSignedUrl(
   if (params.contentType !== undefined) body.content_type = params.contentType;
   if (params.contentLength !== undefined) {
     body.content_length = params.contentLength;
+  }
+  if (params.minRuntimeVersion !== undefined) {
+    body.min_runtime_version = params.minRuntimeVersion;
+  }
+  if (params.maxRuntimeVersion !== undefined) {
+    // Explicit null is the documented "no upper bound" sentinel; keep it
+    // in the payload rather than stripping to undefined.
+    body.max_runtime_version = params.maxRuntimeVersion;
+  }
+  if (params.targetRuntimeVersion !== undefined) {
+    body.target_runtime_version = params.targetRuntimeVersion;
   }
 
   const doRequest = async (): Promise<Response> =>
@@ -874,9 +932,28 @@ export async function platformRequestSignedUrl(
     };
   }
 
+  // Non-success body. Read once and reuse for both the 422 version-mismatch
+  // branch and the generic-error fallthrough — `response.json()` consumes
+  // the body, so a second read would always return undefined.
   const errorBody = (await response.json().catch(() => ({}))) as {
     detail?: string;
+    reason?: string;
+    bundle_compat?: BundleCompatibility;
+    target_runtime_version?: string;
   };
+
+  if (
+    response.status === 422 &&
+    errorBody.reason === "version_mismatch" &&
+    errorBody.bundle_compat &&
+    typeof errorBody.target_runtime_version === "string"
+  ) {
+    throw new VersionMismatchError(
+      errorBody.bundle_compat,
+      errorBody.target_runtime_version,
+    );
+  }
+
   throw new Error(
     errorBody.detail ??
       `Failed to request signed URL: ${response.status} ${response.statusText}`,

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -100,6 +100,23 @@ const orgIdCache = new Map<string, { orgId: string; expiresAt: number }>();
 const ORG_ID_CACHE_TTL_MS = 60_000; // 60 seconds
 
 /**
+ * Drop the cached org ID for a given (token, platformUrl) pair. Used by the
+ * one-shot 401-retry path: a 401 on a session-token request frequently means
+ * the cached `Vellum-Organization-Id` header is stale (e.g. user switched
+ * orgs in another tab). Clearing the entry forces the next `authHeaders`
+ * call to refetch the org ID from the platform.
+ *
+ * Exported so other modules (e.g. local-runtime-client) can implement the
+ * same retry pattern without needing direct access to the cache map.
+ */
+export function invalidateOrgIdCache(
+  token: string,
+  platformUrl?: string,
+): void {
+  orgIdCache.delete(`${token}::${platformUrl ?? ""}`);
+}
+
+/**
  * Returns the full set of headers needed for an authenticated platform
  * API request:
  *
@@ -913,7 +930,7 @@ export async function platformRequestSignedUrl(
     // lookup. For session-token callers, a 401 frequently means the
     // cached org ID is stale — calling doRequest() again without clearing
     // the cache would just send the same stale header and fail again.
-    orgIdCache.delete(`${token}::${platformUrl ?? ""}`);
+    invalidateOrgIdCache(token, platformUrl);
     response = await doRequest();
   }
 

--- a/cli/src/lib/runtime-url.ts
+++ b/cli/src/lib/runtime-url.ts
@@ -28,3 +28,25 @@ export function resolveRuntimeMigrationUrl(
   }
   return `${entry.runtimeUrl}/v1/migrations/${subpath}`;
 }
+
+/**
+ * Resolve the URL for a generic runtime endpoint under `/v1/<subpath>`,
+ * taking the assistant's topology into account.
+ *
+ * - For local/docker assistants, `runtimeUrl` is the loopback gateway and
+ *   the runtime serves `/v1/<subpath>` directly.
+ * - For platform-managed (cloud="vellum") assistants the path is rewritten
+ *   to the wildcard runtime proxy:
+ *   `{platformUrl}/v1/assistants/<assistantId>/<subpath>`.
+ *
+ * The `subpath` is appended verbatim (e.g. `"identity"`).
+ */
+export function resolveRuntimeUrl(
+  entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
+  subpath: string,
+): string {
+  if (entry.cloud === "vellum") {
+    return `${entry.runtimeUrl}/v1/assistants/${entry.assistantId}/${subpath}`;
+  }
+  return `${entry.runtimeUrl}/v1/${subpath}`;
+}

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -17,6 +17,7 @@ export {
 
 export {
   ipcCall,
+  IpcCallError,
   PersistentIpcClient,
 } from "./ipc-client.js";
 

--- a/packages/gateway-client/src/ipc-client.ts
+++ b/packages/gateway-client/src/ipc-client.ts
@@ -14,6 +14,38 @@ import type { IpcRequest, IpcResponse, Logger } from "./types.js";
 import { noopLogger } from "./types.js";
 
 // ---------------------------------------------------------------------------
+// Error surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Error class thrown by `PersistentIpcClient.call` when the daemon returns
+ * a structured error envelope (i.e. `RouteError`-derived). Mirrors the HTTP
+ * adapter's `error.details` shape so IPC callers can branch on `errorCode`
+ * or recover machine-readable `errorDetails` (e.g. `version_incompatible`).
+ */
+export class IpcCallError extends Error {
+  readonly statusCode?: number;
+  readonly errorCode?: string;
+  readonly errorDetails?: unknown;
+
+  constructor(
+    message: string,
+    fields: {
+      statusCode?: number;
+      errorCode?: string;
+      errorDetails?: unknown;
+    } = {},
+  ) {
+    super(message);
+    this.name = "IpcCallError";
+    if (fields.statusCode !== undefined) this.statusCode = fields.statusCode;
+    if (fields.errorCode !== undefined) this.errorCode = fields.errorCode;
+    if (fields.errorDetails !== undefined)
+      this.errorDetails = fields.errorDetails;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
@@ -294,7 +326,13 @@ export class PersistentIpcClient {
             this.pending.delete(msg.id);
             clearTimeout(entry.timer);
             if (msg.error) {
-              entry.reject(new Error(msg.error));
+              entry.reject(
+                new IpcCallError(msg.error, {
+                  statusCode: msg.statusCode,
+                  errorCode: msg.errorCode,
+                  errorDetails: msg.errorDetails,
+                }),
+              );
             } else {
               entry.resolve(msg.result);
             }

--- a/packages/gateway-client/src/types.ts
+++ b/packages/gateway-client/src/types.ts
@@ -105,6 +105,17 @@ export interface IpcResponse {
   id: string;
   result?: unknown;
   error?: string;
+  /** HTTP-style status code mirrored from `RouteError.statusCode`. */
+  statusCode?: number;
+  /** Machine-readable error code (e.g. "UNPROCESSABLE_ENTITY"). */
+  errorCode?: string;
+  /**
+   * Structured error payload mirroring `RouteError.details` — present only
+   * when the originating error carried a `details` field. Mirrors the HTTP
+   * adapter's `error.details` envelope so IPC clients can recover the same
+   * machine-readable context as HTTP clients.
+   */
+  errorDetails?: unknown;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Wires the runtime half of the upload-time version-compatibility gate that platform PR #5470 shipped. Source CLIs emit `min_runtime_version` / `max_runtime_version` on signed-URL upload, target CLIs send `target_runtime_version` on signed-URL download, the new platform 422 `version_mismatch` becomes a structured CLI error (`VersionMismatchError`), and both vbundle importers add a defense-in-depth semver check that fails fast — before any state mutation — when the running runtime falls outside the bundle's compat range.

## Self-review result

PASS — 6 plan PRs + 4 round-1 fix PRs (3 cycle-1 review fixes during Waves 1/2; 4 self-review gap fixes after Phase 3).

## Plan PRs (in dependency order)

- **#29432** — `platformRequestSignedUrl` accepts `minRuntimeVersion`, `maxRuntimeVersion`, `targetRuntimeVersion`; throws `VersionMismatchError` on 422 `version_mismatch`.
- **#29433** — `evaluateRuntimeCompatibility` predicate + inline `compareSemver` (handles `0.10.0 > 0.9.0` correctly without a `semver` dep). `LEGACY_RUNTIME_VERSION_SENTINEL` short-circuit. `ImportCommitResult.version_incompatible` variant.
- **#29436** — Source CLIs (teleport upload ×2, backup upload, restore upload) emit min/max runtime version. **Deviation from plan**: source version sourced from the runtime's `/v1/health` endpoint via the new `localRuntimeIdentity` helper (not `cliPkg.version`) since CLI/daemon can diverge — caught by Codex review. `restore.ts` upload omits version fields entirely (bundle's manifest is authoritative).
- **#29437** — Target CLIs (teleport download) send `target_runtime_version`, catch `VersionMismatchError`, exit 1 with friendly message. **Deviation from plan**: backup download omits `target_runtime_version` entirely — backup-to-disk has no target runtime to gate against (caught by Codex review).
- **#29438** — `commitImport` gates on runtime-version compat before any state mutation. Returns `version_incompatible` shape on failure. Surfaces as 422 `UnprocessableEntityError` over HTTP and IPC (with `RouteError.details` forwarded through both adapters).
- **#29439** — `streamCommitImport` gates on runtime-version compat before tree population. `VersionIncompatibleError` thrown after manifest parse, translated to the `version_incompatible` variant by the existing `mapThrownToResult` path.

## Fix PRs

- **#29456** — Re-export `IpcCallError` from `@vellumai/gateway-client` index.
- **#29457** — `localRuntimeIdentity` uses `/v1/health` (not `/v1/identity`) so it works on freshly-hatched targets that haven't completed onboarding.
- **#29458** — Defer streaming-importer `mkdir(tempWorkspaceDir)` until AFTER the version gate; an incompatible bundle now leaves zero filesystem trace.
- **#29459** — Align `formatRuntimeCompatibilityMessage` with `VersionMismatchError.formatMessage` (en-dash range + remediation hint). Reuse the canonical `RuntimeCompatibility` type instead of re-declaring the shape inline.

## Hard constraints (all met)

- Platform never unbundles. ✓ (Reminder only — enforced platform-side.)
- Backwards compat: legacy bundles with `min_runtime_version: "0.0.0-legacy"` import cleanly. ✓ (Sentinel skip in `evaluateRuntimeCompatibility`.)
- 422 is terminal — no retry. ✓
- Defense-in-depth fires before any state mutation. ✓ (Verified by `vbundle-import-version-compat.test.ts` and `vbundle-streaming-importer.test.ts` — pre-existing files survive, no orphan temp dirs.)
- Semver, not lexical. ✓ (`compareSemver("0.10.0", "0.9.0") === 1` asserted; strict `/^\d+$/` per-component parser rejects malformed input.)

## Out of scope

No platform-side changes. No manifest schema or builder changes. Wizard pre-flight version display deferred.

Part of plan: `vbundle-version-gate.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->