### PR TITLE
fix(macos): rename "Task" to "Action" in Logs & Usage dimension picker

### DIFF
--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -154,7 +154,7 @@ public enum UsageGroupByDimension: String, CaseIterable, Sendable {
 
     public var displayName: String {
         switch self {
-        case .callSite: return "Task"
+        case .callSite: return "Action"
         case .inferenceProfile: return "Profile"
         case .actor: return "Actor (Legacy)"
         case .provider: return "Provider"


### PR DESCRIPTION
Changes the "Task" option in the Logs & Usage → Usage → Inference Usage group-by dropdown to "Action". Also updates the chart title from "Daily Trend by Task" → "Daily Trend by Action" (derived from `displayName`).

**Change**: `UsageDashboardStore.swift` — `case .callSite: return "Task"` → `case .callSite: return "Action"`

Wire format (`call_site`) is unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->