### PR TITLE
feat(memory-v2): anisotropy correction for embedding cosines

### DIFF
--- a/assistant/src/cli/commands/__tests__/memory-v2.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v2.test.ts
@@ -147,6 +147,7 @@ describe("subcommand registration", () => {
     expect(subcommandNames).toEqual([
       "activation",
       "explain",
+      "fit-anisotropy",
       "migrate",
       "rebuild-corpus-stats",
       "reembed",

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -38,6 +38,7 @@ import type {
   MemoryV2BackfillResult,
   MemoryV2ExplainSimilarityResult,
   MemoryV2ExplainSimilarityStats,
+  MemoryV2FitAnisotropyResult,
   MemoryV2RebuildCorpusStatsResult,
   MemoryV2ReembedSkillsResult,
   MemoryV2ValidateResult,
@@ -187,13 +188,18 @@ Subcommands fall into three groups:
     validate         Print a diagnostic report of orphan outgoing-edge
                      targets, oversized pages, and parse failures.
 
+  Calibration:
+    fit-anisotropy   Fit Mu & Viswanath's all-but-the-top correction so
+                     embedding cosines stop clustering in a narrow band.
+
 Examples:
   $ assistant memory v2 validate
   $ assistant memory v2 migrate
   $ assistant memory v2 migrate --force
   $ assistant memory v2 reembed
   $ assistant memory v2 reembed-skills
-  $ assistant memory v2 activation`,
+  $ assistant memory v2 activation
+  $ assistant memory v2 fit-anisotropy`,
   );
 
   // ── migrate ───────────────────────────────────────────────────────────
@@ -432,6 +438,99 @@ Examples:
       log.info(`Rebuilt BM25 corpus stats: ${r.totalDocs} docs.`);
       log.info(`  avg doc length: ${r.avgDl.toFixed(2)} tokens`);
       log.info(`  vocabulary buckets: ${r.vocabularyBuckets.toLocaleString()}`);
+    });
+
+  // ── fit-anisotropy ────────────────────────────────────────────────────
+
+  v2.command("fit-anisotropy")
+    .description(
+      "Fit the embedding anisotropy correction (Mu & Viswanath 'all-but-the-top')",
+    )
+    .option(
+      "--k <n>",
+      "Number of leading principal components to project out (default 1; raise to 2-3 only if PC2/PC3 also explain >5% variance)",
+      "1",
+    )
+    .option(
+      "--sample <n>",
+      "Maximum stored dense vectors to pull for the fit (default 5000)",
+      "5000",
+    )
+    .addHelpText(
+      "after",
+      `
+Modern transformer embeddings (Gemini in particular) are anisotropic — every
+vector lives in a narrow cone of the embedding space, which compresses cosine
+similarities into a tight band (typically 0.4-0.7) and lets a few dominant
+directions drown out semantic signal.
+
+This command samples stored dense vectors from the concept-page Qdrant
+collection, fits a corpus mean + top-k principal components, and persists the
+calibration. Subsequent embeds and queries apply the correction automatically:
+
+  vec' = vec - mean
+  for each pc_i: vec' = vec' - (vec' · pc_i) pc_i
+  vec' = vec' / ||vec'||
+
+After fitting, run 'assistant memory v2 reembed' to re-process every stored
+concept page through the new calibration. Until then, queries are corrected
+but stored vectors are not — the score range stays the same and retrieval may
+degrade. The calibration is keyed by (provider, model, dim), so changing
+embedding model invalidates it.
+
+Recommended k:
+  k=1   safest default. Removes the dominant common direction.
+  k=2-3 only when explained-variance ratios show PC2/PC3 each above ~5%.
+  k>3   not justified without a labeled retrieval eval set.
+
+Examples:
+  $ assistant memory v2 fit-anisotropy
+  $ assistant memory v2 fit-anisotropy --k 2
+  $ assistant memory v2 fit-anisotropy --sample 10000`,
+    )
+    .action(async (opts: { k: string; sample: string }) => {
+      const k = Number.parseInt(opts.k, 10);
+      const sample = Number.parseInt(opts.sample, 10);
+      if (!Number.isFinite(k) || k < 1) {
+        log.error("--k must be a positive integer");
+        process.exitCode = 1;
+        return;
+      }
+      if (!Number.isFinite(sample) || sample < 1) {
+        log.error("--sample must be a positive integer");
+        process.exitCode = 1;
+        return;
+      }
+
+      const result = await cliIpcCall<MemoryV2FitAnisotropyResult>(
+        "memory_v2_fit_anisotropy",
+        { body: { k, sample } },
+      );
+
+      if (!result.ok) {
+        log.error(result.error ?? "Failed to fit anisotropy calibration");
+        process.exitCode = 1;
+        return;
+      }
+
+      const r = result.result!;
+      log.info(
+        `Fit anisotropy calibration: ${r.provider}/${r.model} (dim=${r.dim})`,
+      );
+      log.info(`  samples: ${r.sampleCount}`);
+      log.info(`  total variance: ${r.totalVariance.toFixed(6)}`);
+      log.info("  explained variance per component:");
+      for (let i = 0; i < r.componentVariance.length; i++) {
+        const ratio = (r.explainedVarianceRatio[i] * 100).toFixed(2);
+        log.info(
+          `    PC${i + 1}: ${r.componentVariance[i].toFixed(6)} (${ratio}%)`,
+        );
+      }
+      log.info(`  written to: ${r.path}`);
+      log.info("");
+      log.info(
+        "Next step: run 'assistant memory v2 reembed' so every stored concept page is re-written under the new calibration. Until then, query-side correction operates on stored vectors that were embedded without it.",
+      );
     });
 
   // ── validate ──────────────────────────────────────────────────────────

--- a/assistant/src/memory/anisotropy.test.ts
+++ b/assistant/src/memory/anisotropy.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type AnisotropyCalibration,
+  applyAnisotropyCorrection,
+  explainedVarianceRatio,
+  fitAnisotropyCalibration,
+} from "./anisotropy.js";
+
+const META = { provider: "gemini" as const, model: "test-model" };
+
+function dot(a: readonly number[], b: readonly number[]): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += a[i] * b[i];
+  return s;
+}
+
+function l2Norm(v: readonly number[]): number {
+  return Math.sqrt(dot(v, v));
+}
+
+function l2Normalize(v: readonly number[]): number[] {
+  const n = l2Norm(v);
+  if (n === 0) return [...v];
+  return v.map((x) => x / n);
+}
+
+/**
+ * Build a synthetic anisotropic corpus: every sample lives close to a fixed
+ * direction `axis`, with small Gaussian-ish noise injected in the orthogonal
+ * subspace. This gives us a known top-1 PC the fit must recover.
+ */
+function buildAnisotropicCorpus(
+  n: number,
+  dim: number,
+  axis: readonly number[],
+  noiseScale: number,
+): number[][] {
+  const ax = l2Normalize(axis);
+  const out: number[][] = [];
+  let seed = 42;
+  const rand = () => {
+    // Tiny deterministic LCG so tests don't depend on Math.random.
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+  for (let i = 0; i < n; i++) {
+    const v = new Array<number>(dim);
+    // Strong common direction component, slightly varied per sample.
+    const along = 1 + (rand() - 0.5) * 0.1;
+    for (let j = 0; j < dim; j++) v[j] = along * ax[j];
+    // Orthogonal noise.
+    for (let j = 0; j < dim; j++) v[j] += (rand() - 0.5) * noiseScale;
+    out.push(v);
+  }
+  return out;
+}
+
+describe("fitAnisotropyCalibration", () => {
+  test("recovers the dominant direction of an anisotropic corpus", () => {
+    const dim = 16;
+    const axis = new Array<number>(dim)
+      .fill(0)
+      .map((_, i) => (i === 0 ? 1 : 0));
+    const corpus = buildAnisotropicCorpus(200, dim, axis, 0.05);
+
+    const calib = fitAnisotropyCalibration(corpus, 1, META);
+
+    expect(calib.components.length).toBe(1);
+    expect(calib.components[0].length).toBe(dim);
+    // PC1 should align with the planted axis (sign-agnostic).
+    const alignment = Math.abs(dot(calib.components[0], axis));
+    expect(alignment).toBeGreaterThan(0.95);
+  });
+
+  test("captures most variance in PC1 for a strongly anisotropic corpus", () => {
+    const dim = 16;
+    const axis = new Array<number>(dim)
+      .fill(0)
+      .map((_, i) => (i === 0 ? 1 : 0));
+    const corpus = buildAnisotropicCorpus(200, dim, axis, 0.02);
+
+    const calib = fitAnisotropyCalibration(corpus, 3, META);
+    const ratios = explainedVarianceRatio(calib);
+
+    // Spectrum is monotonically non-increasing.
+    expect(ratios[0]).toBeGreaterThanOrEqual(ratios[1]);
+    expect(ratios[1]).toBeGreaterThanOrEqual(ratios[2]);
+    // PC1 should dwarf PC2 by an order of magnitude when noise is small.
+    expect(ratios[0]).toBeGreaterThan(ratios[1] * 10);
+  });
+
+  test("returns mean and dim metadata", () => {
+    const dim = 8;
+    const corpus = [
+      [1, 1, 0, 0, 0, 0, 0, 0],
+      [3, 3, 0, 0, 0, 0, 0, 0],
+    ];
+    const calib = fitAnisotropyCalibration(corpus, 1, META);
+    expect(calib.dim).toBe(dim);
+    expect(calib.mean[0]).toBeCloseTo(2);
+    expect(calib.mean[1]).toBeCloseTo(2);
+    expect(calib.mean[2]).toBeCloseTo(0);
+    expect(calib.sampleCount).toBe(2);
+    expect(calib.provider).toBe("gemini");
+    expect(calib.model).toBe("test-model");
+  });
+
+  test("rejects empty input, bad k, and ragged rows", () => {
+    expect(() => fitAnisotropyCalibration([], 1, META)).toThrow(/no vectors/);
+    expect(() => fitAnisotropyCalibration([[1, 2, 3]], 0, META)).toThrow(
+      /positive integer/,
+    );
+    expect(() =>
+      fitAnisotropyCalibration(
+        [
+          [1, 2],
+          [3, 4, 5],
+        ],
+        1,
+        META,
+      ),
+    ).toThrow(/dim/);
+    expect(() => fitAnisotropyCalibration([[1, 2]], 5, META)).toThrow(
+      /exceeds/,
+    );
+  });
+});
+
+describe("applyAnisotropyCorrection", () => {
+  test("output has unit L2 norm", () => {
+    const corpus = buildAnisotropicCorpus(
+      100,
+      8,
+      [1, 0, 0, 0, 0, 0, 0, 0],
+      0.05,
+    );
+    const calib = fitAnisotropyCalibration(corpus, 1, META);
+
+    const corrected = applyAnisotropyCorrection(corpus[0], calib);
+    expect(l2Norm(corrected)).toBeCloseTo(1, 6);
+  });
+
+  test("removes projection onto the dominant direction", () => {
+    const dim = 8;
+    const axis = [1, 0, 0, 0, 0, 0, 0, 0];
+    const corpus = buildAnisotropicCorpus(200, dim, axis, 0.02);
+    const calib = fitAnisotropyCalibration(corpus, 1, META);
+
+    // Pick a vector that points strongly along the planted axis.
+    const sample = [...axis];
+    const corrected = applyAnisotropyCorrection(sample, calib);
+
+    // After removing PC1 (which is ~axis), the projection back onto axis
+    // should be nearly zero — the sample is in the deflated subspace.
+    expect(Math.abs(dot(corrected, axis))).toBeLessThan(0.05);
+  });
+
+  test("spreads cosine similarities for vectors in the cone", () => {
+    const dim = 16;
+    const axis = new Array<number>(dim)
+      .fill(0)
+      .map((_, i) => (i === 0 ? 1 : 0));
+    const corpus = buildAnisotropicCorpus(300, dim, axis, 0.1);
+    const calib = fitAnisotropyCalibration(corpus, 1, META);
+
+    // Compute pairwise cosines on raw vs corrected vectors. The corrected
+    // distribution should have noticeably larger spread (max - min) — the
+    // whole point of the correction.
+    function spread(vectors: number[][]): number {
+      const sims: number[] = [];
+      for (let i = 0; i < vectors.length; i++) {
+        const a = l2Normalize(vectors[i]);
+        for (let j = i + 1; j < vectors.length; j++) {
+          const b = l2Normalize(vectors[j]);
+          sims.push(dot(a, b));
+        }
+      }
+      let min = Infinity;
+      let max = -Infinity;
+      for (const s of sims) {
+        if (s < min) min = s;
+        if (s > max) max = s;
+      }
+      return max - min;
+    }
+
+    const rawSpread = spread(corpus.slice(0, 30));
+    const correctedSpread = spread(
+      corpus.slice(0, 30).map((v) => applyAnisotropyCorrection(v, calib)),
+    );
+
+    expect(correctedSpread).toBeGreaterThan(rawSpread * 2);
+  });
+
+  test("rejects mismatched dim", () => {
+    const calib: AnisotropyCalibration = {
+      provider: "gemini",
+      model: "x",
+      dim: 4,
+      mean: [0, 0, 0, 0],
+      components: [[1, 0, 0, 0]],
+      componentVariance: [1],
+      totalVariance: 1,
+      sampleCount: 1,
+      fitAt: 0,
+    };
+    expect(() => applyAnisotropyCorrection([1, 2, 3], calib)).toThrow(/dim/);
+  });
+});
+
+describe("explainedVarianceRatio", () => {
+  test("returns zeros when totalVariance is zero", () => {
+    const calib: AnisotropyCalibration = {
+      provider: "gemini",
+      model: "x",
+      dim: 2,
+      mean: [0, 0],
+      components: [[1, 0]],
+      componentVariance: [0],
+      totalVariance: 0,
+      sampleCount: 1,
+      fitAt: 0,
+    };
+    expect(explainedVarianceRatio(calib)).toEqual([0]);
+  });
+
+  test("each ratio is variance/total", () => {
+    const calib: AnisotropyCalibration = {
+      provider: "gemini",
+      model: "x",
+      dim: 2,
+      mean: [0, 0],
+      components: [
+        [1, 0],
+        [0, 1],
+      ],
+      componentVariance: [3, 1],
+      totalVariance: 4,
+      sampleCount: 100,
+      fitAt: 0,
+    };
+    const ratios = explainedVarianceRatio(calib);
+    expect(ratios[0]).toBeCloseTo(0.75);
+    expect(ratios[1]).toBeCloseTo(0.25);
+  });
+});

--- a/assistant/src/memory/anisotropy.ts
+++ b/assistant/src/memory/anisotropy.ts
@@ -1,0 +1,443 @@
+// ---------------------------------------------------------------------------
+// Embedding anisotropy correction (Mu & Viswanath "all-but-the-top")
+// ---------------------------------------------------------------------------
+//
+// Modern transformer-based embedding models (Gemini's `gemini-embedding-2`
+// being the most pronounced offender) produce vectors that occupy a narrow
+// cone of the embedding space rather than spreading over the unit sphere.
+// The downstream effect is that cosine similarities cluster in a compressed
+// range — typically 0.4–0.7 for Gemini — which (a) makes absolute thresholds
+// meaningless and (b) lets a few dominant directions drown out semantic
+// signal.
+//
+// The fix: compute the corpus mean and its top-k principal components, then
+// post-process every embedding via
+//
+//     vec' = vec - mean
+//     for each pc_i: vec' = vec' - (vec' · pc_i) pc_i
+//     vec' = vec' / ||vec'||
+//
+// k = 1 is the safest starting point and reliably restores spread without
+// risking semantic signal — see Mu & Viswanath 2018.
+//
+// ── Storage ────────────────────────────────────────────────────────────────
+//
+// Calibrations are persisted as JSON under
+// `<workspace>/data/anisotropy/<provider>-<model>-<dim>.json` so each
+// (provider, model, dim) tuple has its own. A loaded calibration is cached
+// in-process; `clearAnisotropyCacheForTests` resets the module cache.
+//
+// ── Sphere-vs-raw inputs ───────────────────────────────────────────────────
+//
+// Qdrant pre-normalises vectors at insert time when the collection uses the
+// Cosine distance, so the data we scroll for fitting lives on the unit
+// sphere. Gemini's API, by contrast, returns raw (un-normalised) vectors at
+// query time. To keep the fit and apply paths consistent we L2-normalise the
+// input before applying the correction, regardless of source.
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getDataDir } from "../util/platform.js";
+import type { EmbeddingProviderName } from "./embedding-types.js";
+
+/** Persisted anisotropy fit for a single (provider, model, dim) tuple. */
+export interface AnisotropyCalibration {
+  provider: EmbeddingProviderName;
+  model: string;
+  /** Dimensionality of the embedding vectors this calibration applies to. */
+  dim: number;
+  /** Per-dimension mean across the fit sample. Length === `dim`. */
+  mean: number[];
+  /**
+   * Top-k principal components to project out. Stored as an array of
+   * unit-length d-vectors, one per component, in descending eigenvalue order.
+   * `components.length` is the operator-chosen `k` (typically 1, possibly 2-3).
+   */
+  components: number[][];
+  /**
+   * Per-component variance (eigenvalues): `‖X v_i‖² / (N - 1)`. Same length
+   * as `components`. Useful to validate the fit (PC1 should explain a clear
+   * majority of variance for a truly anisotropic embedder).
+   */
+  componentVariance: number[];
+  /**
+   * Total variance across all directions: `Σ_i ‖x_i - mean‖² / (N - 1)`.
+   * Combine with `componentVariance` to compute the explained-variance ratio
+   * per PC — i.e. how much of the corpus variance each PC accounts for.
+   */
+  totalVariance: number;
+  /** Number of vectors used to compute this fit. */
+  sampleCount: number;
+  /** Wall-clock millis when the fit was computed (Date.now()). */
+  fitAt: number;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Fit a calibration: corpus mean + top-k principal components via power
+ * iteration with Gram-Schmidt deflation.
+ *
+ * `vectors` is treated as a row-major data matrix (each entry is one sample).
+ * `k` is the number of leading principal components to extract (≥ 1).
+ *
+ * Returns the calibration without persisting it. Use `saveCalibration` to
+ * write it under `<workspace>/data/anisotropy/`.
+ *
+ * Throws when `vectors` is empty, `k` is non-positive, or the row dimensions
+ * disagree — these are caller bugs, not transient failures.
+ */
+export function fitAnisotropyCalibration(
+  vectors: readonly (readonly number[])[],
+  k: number,
+  meta: { provider: EmbeddingProviderName; model: string },
+): AnisotropyCalibration {
+  if (vectors.length === 0) {
+    throw new Error("fitAnisotropyCalibration: no vectors supplied");
+  }
+  if (k < 1 || !Number.isInteger(k)) {
+    throw new Error(
+      `fitAnisotropyCalibration: k must be a positive integer, got ${k}`,
+    );
+  }
+  const dim = vectors[0].length;
+  if (dim === 0) {
+    throw new Error("fitAnisotropyCalibration: vectors are zero-dimensional");
+  }
+  for (let i = 1; i < vectors.length; i++) {
+    if (vectors[i].length !== dim) {
+      throw new Error(
+        `fitAnisotropyCalibration: vector ${i} has dim ${vectors[i].length}, expected ${dim}`,
+      );
+    }
+  }
+  if (k > dim) {
+    throw new Error(
+      `fitAnisotropyCalibration: requested k=${k} exceeds embedding dim=${dim}`,
+    );
+  }
+
+  const n = vectors.length;
+  // Flatten into a contiguous Float64Array for cache locality during the
+  // O(k · iter · n · d) inner loop. Centre each row in place against the
+  // running mean once it's computed.
+  const data = new Float64Array(n * dim);
+  for (let i = 0; i < n; i++) {
+    const row = vectors[i];
+    for (let j = 0; j < dim; j++) {
+      data[i * dim + j] = row[j];
+    }
+  }
+
+  const mean = new Float64Array(dim);
+  for (let i = 0; i < n; i++) {
+    const base = i * dim;
+    for (let j = 0; j < dim; j++) {
+      mean[j] += data[base + j];
+    }
+  }
+  for (let j = 0; j < dim; j++) {
+    mean[j] /= n;
+  }
+
+  // Centre rows in place. After this `data` represents X = X_raw - mean.
+  for (let i = 0; i < n; i++) {
+    const base = i * dim;
+    for (let j = 0; j < dim; j++) {
+      data[base + j] -= mean[j];
+    }
+  }
+
+  // Total variance: tr(X^T X) / (n - 1) = Σ_i ‖x_i‖² / (n - 1).
+  // Use n-1 for sample variance; falls back to 1 when n === 1 to avoid div0.
+  const denom = Math.max(1, n - 1);
+  let totalVariance = 0;
+  for (let i = 0; i < n * dim; i++) {
+    totalVariance += data[i] * data[i];
+  }
+  totalVariance /= denom;
+
+  const components: Float64Array[] = [];
+  const componentVariance: number[] = [];
+  for (let pcIdx = 0; pcIdx < k; pcIdx++) {
+    const v = powerIteration(data, n, dim, components);
+    // Eigenvalue λ = ‖X v‖² / (n - 1).
+    const Xv = matmulXv(data, n, dim, v);
+    let xvSq = 0;
+    for (let i = 0; i < n; i++) xvSq += Xv[i] * Xv[i];
+    components.push(v);
+    componentVariance.push(xvSq / denom);
+  }
+
+  return {
+    provider: meta.provider,
+    model: meta.model,
+    dim,
+    mean: Array.from(mean),
+    components: components.map((c) => Array.from(c)),
+    componentVariance,
+    totalVariance,
+    sampleCount: n,
+    fitAt: Date.now(),
+  };
+}
+
+/**
+ * Apply the all-but-the-top correction to a single embedding vector.
+ *
+ * The input is L2-normalised first so callers don't have to think about
+ * whether the source already lives on the unit sphere (Qdrant pre-normalises
+ * stored vectors under cosine distance; Gemini's API does not). The result
+ * is L2-normalised again so cosine similarity continues to behave like a
+ * dot product.
+ *
+ * Returns a fresh `number[]`; never mutates `vec` or the calibration.
+ */
+export function applyAnisotropyCorrection(
+  vec: readonly number[],
+  calib: AnisotropyCalibration,
+): number[] {
+  if (vec.length !== calib.dim) {
+    throw new Error(
+      `applyAnisotropyCorrection: vec dim ${vec.length} != calibration dim ${calib.dim}`,
+    );
+  }
+
+  const out = new Float64Array(calib.dim);
+  for (let j = 0; j < calib.dim; j++) out[j] = vec[j];
+  l2NormalizeInPlace(out);
+
+  for (let j = 0; j < calib.dim; j++) {
+    out[j] -= calib.mean[j];
+  }
+
+  for (const pc of calib.components) {
+    let proj = 0;
+    for (let j = 0; j < calib.dim; j++) proj += out[j] * pc[j];
+    for (let j = 0; j < calib.dim; j++) out[j] -= proj * pc[j];
+  }
+
+  l2NormalizeInPlace(out);
+  return Array.from(out);
+}
+
+/**
+ * Compute the explained-variance ratio for each component. The list is
+ * monotonically non-increasing because power iteration with deflation pulls
+ * the largest eigenvalue first.
+ */
+export function explainedVarianceRatio(calib: AnisotropyCalibration): number[] {
+  if (calib.totalVariance === 0) {
+    return calib.componentVariance.map(() => 0);
+  }
+  return calib.componentVariance.map((v) => v / calib.totalVariance);
+}
+
+// ── Persistence ──────────────────────────────────────────────────────────────
+
+const cache = new Map<string, AnisotropyCalibration | null>();
+
+function calibrationKey(
+  provider: EmbeddingProviderName,
+  model: string,
+  dim: number,
+): string {
+  return `${provider}:${model}:${dim}`;
+}
+
+function calibrationPath(
+  provider: EmbeddingProviderName,
+  model: string,
+  dim: number,
+): string {
+  // Models can contain slashes (`gemini-embedding-2`, `text-embedding-3-large`,
+  // `BAAI/bge-base-en-v1.5`). Replace anything that's not filename-safe with
+  // `_` so the on-disk name is portable across platforms.
+  const safeModel = model.replace(/[^A-Za-z0-9._-]/g, "_");
+  return join(
+    getDataDir(),
+    "anisotropy",
+    `${provider}-${safeModel}-${dim}.json`,
+  );
+}
+
+/**
+ * Convenience: load the calibration and apply it to a vector in one call.
+ * Returns the input untouched when no calibration has been persisted for the
+ * (provider, model, dim) tuple. The intended call site is right at the
+ * boundary between the embedding backend and consumers that store/query
+ * vectors against Qdrant — write paths apply this before upsert, read paths
+ * apply it before search.
+ */
+export async function applyCorrectionIfCalibrated(
+  vec: number[],
+  provider: EmbeddingProviderName,
+  model: string,
+): Promise<number[]> {
+  const calib = await loadCalibration(provider, model, vec.length);
+  if (!calib) return vec;
+  return applyAnisotropyCorrection(vec, calib);
+}
+
+/**
+ * Load the calibration for a (provider, model, dim) tuple. Returns `null`
+ * when no fit has been persisted yet — callers should treat this as
+ * "anisotropy correction is off for this embedder" and pass through raw
+ * vectors. Module-level cached so subsequent calls hit memory.
+ */
+export async function loadCalibration(
+  provider: EmbeddingProviderName,
+  model: string,
+  dim: number,
+): Promise<AnisotropyCalibration | null> {
+  const key = calibrationKey(provider, model, dim);
+  if (cache.has(key)) return cache.get(key) ?? null;
+
+  const path = calibrationPath(provider, model, dim);
+  if (!existsSync(path)) {
+    cache.set(key, null);
+    return null;
+  }
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as AnisotropyCalibration;
+    cache.set(key, parsed);
+    return parsed;
+  } catch {
+    // A corrupt file is treated the same as a missing one: pass-through.
+    // The fit path will overwrite with a valid file on the next run.
+    cache.set(key, null);
+    return null;
+  }
+}
+
+/**
+ * Persist a calibration to disk and refresh the in-process cache so the
+ * next `loadCalibration` returns the new fit without a file read.
+ */
+export async function saveCalibration(
+  calib: AnisotropyCalibration,
+): Promise<string> {
+  const path = calibrationPath(calib.provider, calib.model, calib.dim);
+  await mkdir(join(getDataDir(), "anisotropy"), { recursive: true });
+  await writeFile(path, JSON.stringify(calib), "utf8");
+  cache.set(calibrationKey(calib.provider, calib.model, calib.dim), calib);
+  return path;
+}
+
+/** @internal Test-only: drop the in-process calibration cache. */
+export function clearAnisotropyCacheForTests(): void {
+  cache.clear();
+}
+
+// ── Power iteration internals ────────────────────────────────────────────────
+
+const POWER_ITERATION_MAX = 200;
+const POWER_ITERATION_TOL = 1e-7;
+
+/**
+ * Find the dominant eigenvector of X^T X (with previously-found components
+ * deflated out) via power iteration. Operates on `X v` and `X^T u` separately
+ * so we never materialise the d×d covariance matrix — for d=3072 that would
+ * be ~75 MB and cripple memory locality. Returns a unit-length d-vector.
+ */
+function powerIteration(
+  data: Float64Array,
+  n: number,
+  dim: number,
+  deflate: readonly Float64Array[],
+): Float64Array {
+  // Deterministic init: a fixed unit vector. Power iteration converges from
+  // any non-orthogonal start, and a deterministic seed keeps fit results
+  // reproducible across runs (helpful for debugging and tests).
+  const v = new Float64Array(dim);
+  v[0] = 1;
+  // Project off any previously-found components from the init too, so we
+  // don't waste iterations re-deflating the same direction every step.
+  deflateInPlace(v, deflate);
+  l2NormalizeInPlace(v);
+
+  let prevDot = 0;
+  for (let iter = 0; iter < POWER_ITERATION_MAX; iter++) {
+    const Xv = matmulXv(data, n, dim, v);
+    const next = matmulXTu(data, n, dim, Xv);
+    deflateInPlace(next, deflate);
+    const norm = l2NormalizeInPlace(next);
+    if (norm === 0) {
+      // The remaining variance lives entirely in the deflated subspace —
+      // every direction we can pick is orthogonal to the data. Returning the
+      // current best estimate keeps the spectrum monotonic instead of
+      // emitting NaN downstream.
+      return v;
+    }
+    let dot = 0;
+    for (let j = 0; j < dim; j++) dot += v[j] * next[j];
+    // |dot| approaches 1 as power iteration converges (sign can flip across
+    // iterations, so absolute value).
+    if (Math.abs(Math.abs(dot) - Math.abs(prevDot)) < POWER_ITERATION_TOL) {
+      return next;
+    }
+    prevDot = dot;
+    for (let j = 0; j < dim; j++) v[j] = next[j];
+  }
+  return v;
+}
+
+/** y = X v, where X is n×d row-major. Returns a fresh Float64Array of length n. */
+function matmulXv(
+  data: Float64Array,
+  n: number,
+  dim: number,
+  v: Float64Array,
+): Float64Array {
+  const out = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    const base = i * dim;
+    let acc = 0;
+    for (let j = 0; j < dim; j++) acc += data[base + j] * v[j];
+    out[i] = acc;
+  }
+  return out;
+}
+
+/** y = X^T u, where X is n×d row-major. Returns a fresh Float64Array of length d. */
+function matmulXTu(
+  data: Float64Array,
+  n: number,
+  dim: number,
+  u: Float64Array,
+): Float64Array {
+  const out = new Float64Array(dim);
+  for (let i = 0; i < n; i++) {
+    const base = i * dim;
+    const ui = u[i];
+    for (let j = 0; j < dim; j++) out[j] += data[base + j] * ui;
+  }
+  return out;
+}
+
+/** Subtract every previously-found component from `v` (Gram-Schmidt). */
+function deflateInPlace(
+  v: Float64Array,
+  deflate: readonly Float64Array[],
+): void {
+  for (const pc of deflate) {
+    let proj = 0;
+    const dim = v.length;
+    for (let j = 0; j < dim; j++) proj += v[j] * pc[j];
+    for (let j = 0; j < dim; j++) v[j] -= proj * pc[j];
+  }
+}
+
+/** L2-normalise `v` in place. Returns the original norm so callers can detect zero vectors. */
+function l2NormalizeInPlace(v: Float64Array): number {
+  let norm = 0;
+  for (let j = 0; j < v.length; j++) norm += v[j] * v[j];
+  norm = Math.sqrt(norm);
+  if (norm === 0) return 0;
+  const inv = 1 / norm;
+  for (let j = 0; j < v.length; j++) v[j] *= inv;
+  return norm;
+}

--- a/assistant/src/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/memory/jobs/embed-concept-page.ts
@@ -24,6 +24,7 @@ import type { AssistantConfig } from "../../config/types.js";
 import { BackendUnavailableError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { getDb } from "../db-connection.js";
 import {
   embedWithBackend,
@@ -203,9 +204,20 @@ export async function embedConceptPageJob(
     }
   }
 
+  // Apply anisotropy correction at the boundary between the (raw) cached
+  // dense vector and the Qdrant collection. Storing raw in SQLite and
+  // corrected in Qdrant means a recalibration just needs a reembed pass —
+  // the cache survives and the (cheap) correction math reruns over each
+  // cached vector. Pass-through when no calibration is fit yet.
+  const correctedDense = await applyCorrectionIfCalibrated(
+    dense,
+    provider,
+    model,
+  );
+
   await upsertConceptPageEmbedding({
     slug,
-    dense,
+    dense: correctedDense,
     sparse,
     updatedAt: now,
   });

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -32,6 +32,7 @@
 //     for the next turn and drop below `epsilon` if no longer relevant.
 
 import type { AssistantConfig } from "../../config/types.js";
+import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import {
   embedWithBackend,
   generateSparseEmbedding,
@@ -125,7 +126,11 @@ export async function selectCandidates(
 
   if (annQueryText.length > 0) {
     const denseResult = await embedWithBackend(config, [annQueryText]);
-    const dense = denseResult.vectors[0];
+    const dense = await applyCorrectionIfCalibrated(
+      denseResult.vectors[0],
+      denseResult.provider,
+      denseResult.model,
+    );
     const sparse = generateSparseEmbedding(annQueryText);
     const limit =
       config.memory.v2.ann_candidate_limit ?? UNLIMITED_ANN_CANDIDATE_LIMIT;

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -321,6 +321,89 @@ export async function hybridQueryConceptPages(
 }
 
 /**
+ * Page through the v2 concept-page collection and return up to `maxSamples`
+ * stored dense vectors. Used by the anisotropy-fit pipeline to compute a
+ * corpus mean + top-k principal components without re-embedding every page.
+ *
+ * Sparse vectors are skipped — anisotropy is a dense-embedding phenomenon, and
+ * pulling the sparse side would just inflate the response. Payload is also
+ * skipped because the fit doesn't need slug identity.
+ *
+ * Returns an empty array when the collection is empty or missing. Caller
+ * decides what to do (typically: surface a "no vectors to fit" error).
+ */
+export async function sampleConceptPageDenseVectors(
+  maxSamples: number,
+): Promise<number[][]> {
+  if (maxSamples <= 0) return [];
+  await ensureConceptPageCollection();
+
+  const client = getClient();
+  const out: number[][] = [];
+  let offset: string | number | undefined = undefined;
+  // Same pagination guard pattern as the rest of the file — bounds the loop
+  // even if Qdrant somehow keeps handing back a non-null offset.
+  const maxIterations = 10_000;
+  const batchSize = Math.min(256, maxSamples);
+
+  for (let i = 0; i < maxIterations; i++) {
+    if (out.length >= maxSamples) break;
+    const remaining = maxSamples - out.length;
+    let result;
+    try {
+      result = await client.scroll(MEMORY_V2_COLLECTION, {
+        limit: Math.min(batchSize, remaining),
+        with_payload: false,
+        // Fetch only the dense named vector — sparse is irrelevant for
+        // anisotropy correction.
+        with_vector: ["dense"],
+        ...(offset !== undefined ? { offset } : {}),
+      });
+    } catch (err) {
+      if (isCollectionMissing(err)) {
+        _collectionReady = false;
+        return out;
+      }
+      throw err;
+    }
+
+    for (const point of result.points) {
+      const v = extractDenseVector(point.vector);
+      if (v) out.push(v);
+      if (out.length >= maxSamples) break;
+    }
+
+    const next = result.next_page_offset;
+    if (next == null) break;
+    offset = typeof next === "string" ? next : (next as number);
+  }
+
+  return out;
+}
+
+/**
+ * Pull the `dense` named-vector payload out of a Qdrant point. Defensively
+ * handles both the named-vector shape (`{ dense: [...] }`) and the legacy
+ * unnamed-vector shape (`number[]`) so older collection layouts don't trip
+ * the sampler. Returns `null` for shapes we don't recognise.
+ */
+function extractDenseVector(vector: unknown): number[] | null {
+  if (Array.isArray(vector)) {
+    if (vector.every((n) => typeof n === "number")) {
+      return vector as number[];
+    }
+    return null;
+  }
+  if (vector && typeof vector === "object") {
+    const dense = (vector as { dense?: unknown }).dense;
+    if (Array.isArray(dense) && dense.every((n) => typeof n === "number")) {
+      return dense as number[];
+    }
+  }
+  return null;
+}
+
+/**
  * Detect "collection not found" errors so callers can reset readiness and
  * retry after an external deletion (e.g. workspace reset).
  */

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -26,6 +26,7 @@
 //   only as a per-turn ordering signal, not compared across turns.
 
 import type { AssistantConfig } from "../../config/types.js";
+import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { embedWithBackend } from "../embedding-backend.js";
 import { clampUnitInterval } from "../validation.js";
 import { hybridQueryConceptPages } from "./qdrant.js";
@@ -85,7 +86,11 @@ export async function simBatch(
   // and the stored doc vectors carry the IDF · TF-saturated weights — Qdrant
   // dot product then yields the BM25 score directly.
   const denseResult = await embedWithBackend(config, [text]);
-  const denseVector = denseResult.vectors[0];
+  const denseVector = await applyCorrectionIfCalibrated(
+    denseResult.vectors[0],
+    denseResult.provider,
+    denseResult.model,
+  );
   const sparseVector = generateBm25QueryEmbedding(text);
 
   const hits = await hybridQueryConceptPages(
@@ -149,7 +154,11 @@ export async function simSkillBatch(
   }
 
   const denseResult = await embedWithBackend(config, [text]);
-  const denseVector = denseResult.vectors[0];
+  const denseVector = await applyCorrectionIfCalibrated(
+    denseResult.vectors[0],
+    denseResult.provider,
+    denseResult.model,
+  );
   const sparseVector = generateBm25QueryEmbedding(text);
 
   const hits = await hybridQuerySkills(

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -25,6 +25,7 @@ import {
   fromSkillSummary,
 } from "../../skills/skill-memory.js";
 import { getLogger } from "../../util/logger.js";
+import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import {
   embedWithBackend,
   generateSparseEmbedding,
@@ -122,9 +123,14 @@ export async function seedV2SkillEntries(): Promise<void> {
 
     // Embed all content strings in one batched call. Sparse vectors are
     // computed in-process (no network).
-    const { vectors: denseVectors } = await embedWithBackend(
+    const embedded = await embedWithBackend(
       config,
       seeds.map((s) => s.content),
+    );
+    const denseVectors = await Promise.all(
+      embedded.vectors.map((v) =>
+        applyCorrectionIfCalibrated(v, embedded.provider, embedded.model),
+      ),
     );
 
     const now = Date.now();

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -8,7 +8,16 @@ import { z } from "zod";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { loadConfig } from "../../config/loader.js";
-import { embedWithBackend } from "../../memory/embedding-backend.js";
+import {
+  applyCorrectionIfCalibrated,
+  explainedVarianceRatio,
+  fitAnisotropyCalibration,
+  saveCalibration,
+} from "../../memory/anisotropy.js";
+import {
+  embedWithBackend,
+  selectEmbeddingBackend,
+} from "../../memory/embedding-backend.js";
 import {
   enqueueMemoryJob,
   type MemoryJobType,
@@ -23,7 +32,10 @@ import {
   readPage,
   renderPageContent,
 } from "../../memory/v2/page-store.js";
-import { hybridQueryConceptPages } from "../../memory/v2/qdrant.js";
+import {
+  hybridQueryConceptPages,
+  sampleConceptPageDenseVectors,
+} from "../../memory/v2/qdrant.js";
 import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
 import {
   generateBm25QueryEmbedding,
@@ -313,7 +325,11 @@ async function scoreChannel(
   config: ReturnType<typeof loadConfig>,
 ): Promise<MemoryV2ExplainSimilarityChannel> {
   const denseResult = await embedWithBackend(config, [text]);
-  const denseVec = denseResult.vectors[0];
+  const denseVec = await applyCorrectionIfCalibrated(
+    denseResult.vectors[0],
+    denseResult.provider,
+    denseResult.model,
+  );
   const sparseVec = generateBm25QueryEmbedding(text);
 
   const hits = await hybridQueryConceptPages(denseVec, sparseVec, top);
@@ -419,6 +435,92 @@ async function handleExplainSimilarity({
   };
 }
 
+// ── Fit anisotropy calibration ──────────────────────────────────────────
+
+const MemoryV2FitAnisotropyParams = z
+  .object({
+    /**
+     * Number of leading principal components to project out at apply time.
+     * `1` is the canonical default for transformer embeddings; raise to 2-3
+     * only when the variance spectrum shows multiple dominant directions.
+     */
+    k: z.number().int().min(1).max(16).default(1),
+    /**
+     * Maximum number of stored vectors to pull from Qdrant for the fit.
+     * 5_000 is plenty for 3072-dim Gemini — power iteration converges fast
+     * and pulling the full corpus would just cost wall-clock time.
+     */
+    sample: z.number().int().min(1).max(100_000).default(5_000),
+  })
+  .strict();
+
+export interface MemoryV2FitAnisotropyResult {
+  provider: string;
+  model: string;
+  dim: number;
+  k: number;
+  sampleCount: number;
+  totalVariance: number;
+  componentVariance: number[];
+  /** `componentVariance[i] / totalVariance` for each component. */
+  explainedVarianceRatio: number[];
+  /** Absolute path the calibration was written to. */
+  path: string;
+}
+
+async function handleFitAnisotropy({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV2FitAnisotropyResult> {
+  const { k, sample } = MemoryV2FitAnisotropyParams.parse(body);
+  const config = loadConfig();
+
+  const selection = await selectEmbeddingBackend(config);
+  if (!selection.backend) {
+    throw new RouteError(
+      `Cannot fit anisotropy calibration: ${selection.reason ?? "no embedding backend configured"}`,
+      "MEMORY_V2_NO_EMBEDDING_BACKEND",
+      409,
+    );
+  }
+
+  const vectors = await sampleConceptPageDenseVectors(sample);
+  if (vectors.length === 0) {
+    throw new RouteError(
+      "Cannot fit anisotropy calibration: the v2 concept-page collection is empty. " +
+        "Embed some concept pages first (run `assistant memory v2 reembed`), then retry.",
+      "MEMORY_V2_NO_VECTORS",
+      409,
+    );
+  }
+  if (vectors.length < k * 4) {
+    // PCA on too-few samples is unstable — refuse rather than hand back
+    // overfit components. The 4× heuristic is conservative; in practice
+    // anisotropy fits stabilise at a few hundred samples per component.
+    throw new RouteError(
+      `Cannot fit k=${k} components from only ${vectors.length} vectors — need at least ${k * 4}. ` +
+        "Embed more concept pages or fit a smaller k.",
+      "MEMORY_V2_INSUFFICIENT_VECTORS",
+      409,
+    );
+  }
+
+  const { provider, model } = selection.backend;
+  const calib = fitAnisotropyCalibration(vectors, k, { provider, model });
+  const path = await saveCalibration(calib);
+
+  return {
+    provider,
+    model,
+    dim: calib.dim,
+    k,
+    sampleCount: calib.sampleCount,
+    totalVariance: calib.totalVariance,
+    componentVariance: calib.componentVariance,
+    explainedVarianceRatio: explainedVarianceRatio(calib),
+    path,
+  };
+}
+
 // ── Route definitions ───────────────────────────────────────────────────
 
 export const ROUTES: RouteDefinition[] = [
@@ -487,5 +589,16 @@ export const ROUTES: RouteDefinition[] = [
       "Walks every concept page on disk, recomputes the document-frequency table and average document length used by the BM25 sparse channel, and atomically swaps the in-memory stats. Run after bulk content imports or to recover from a rebuild that errored at startup. Does not reembed individual page sparse vectors — pair with `assistant memory v2 reembed` when document-side weights need refreshing.",
     tags: ["memory"],
     requestBody: MemoryV2RebuildCorpusStatsParams,
+  },
+  {
+    operationId: "memory_v2_fit_anisotropy",
+    method: "POST",
+    endpoint: "memory/v2/fit-anisotropy",
+    handler: handleFitAnisotropy,
+    summary: "Fit the embedding anisotropy correction for memory v2",
+    description:
+      "Samples stored dense vectors from the concept-page Qdrant collection, fits a corpus mean + top-k principal components (Mu & Viswanath 'all-but-the-top'), and persists the calibration so subsequent embeds and queries apply the correction. Run `assistant memory v2 reembed` after fitting so stored vectors are written under the new calibration — until then, queries (corrected) and stored vectors (uncorrected) live in different spaces.",
+    tags: ["memory"],
+    requestBody: MemoryV2FitAnisotropyParams,
   },
 ];


### PR DESCRIPTION
## Summary
- Adds `assistant/src/memory/anisotropy.ts` implementing Mu & Viswanath's "all-but-the-top" correction via power iteration with Gram-Schmidt deflation, plus a JSON-file calibration store keyed by `(provider, model, dim)`.
- Wires `applyCorrectionIfCalibrated` into all six v2 embedding call sites (`sim.simBatch`, `sim.simSkillBatch`, `activation` ANN candidate selection, `embed-concept-page` write path, `skill-store` seeding, `memory-v2-routes.explain-similarity`). SQLite cache holds raw vectors; Qdrant stores corrected vectors so recalibration just needs a reembed.
- New `assistant memory v2 fit-anisotropy [--k <n>] [--sample <n>]` CLI + IPC route samples stored dense vectors from Qdrant, fits the calibration, persists it, and prints the variance spectrum so operators can pick `k` empirically. Default `k=1` is the safe starting point for transformer embeddings.

## Test plan
- [x] `bun test src/memory/anisotropy.test.ts` — 10 unit tests for fit recovery, math correctness, and end-to-end spread improvement
- [x] `bun test src/cli/commands/__tests__/memory-v2.test.ts` — subcommand registration updated
- [x] `bun test src/memory/v2/__tests__/{sim,activation,qdrant}.test.ts` — wiring doesn't regress existing v2 behavior
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean
- [x] End-to-end on Sidd's corpus: \`health/supplement-stack\` jumped from rank #5 (dense 0.06) to rank #1 (dense 0.49) for "which supplements am I taking?" after \`fit-anisotropy\` + \`reembed\`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->