### PR TITLE
fix(auth): add route policy for memory/v2/fit-anisotropy

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -434,6 +434,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     endpoint: "memory/v2/rebuild-corpus-stats:POST",
     scopes: ["settings.write"],
   },
+  { endpoint: "memory/v2/fit-anisotropy:POST", scopes: ["settings.write"] },
 
   // Trust rule listing
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },


### PR DESCRIPTION
## Summary
- Adds the missing `memory/v2/fit-anisotropy:POST` entry to `route-policy.ts` so the route policy coverage guard test passes.
- The endpoint was introduced in #29465 (anisotropy correction for embedding cosines) but the policy entry was missed, breaking CI on `main`.
- Scoped to `settings.write` to match the sibling `memory/v2/rebuild-corpus-stats:POST` entry — both perform calibration/index writes triggered from the same admin CLI.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25299574700/job/74164095663
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->