### PR TITLE
chore(openapi): regenerate spec for memory/v2/fit-anisotropy endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7138,6 +7138,41 @@ paths:
                 - userText
                 - top
               additionalProperties: false
+  /v1/memory/v2/fit-anisotropy:
+    post:
+      operationId: memory_v2_fitanisotropy_post
+      summary: Fit the embedding anisotropy correction for memory v2
+      description:
+        Samples stored dense vectors from the concept-page Qdrant collection, fits a corpus mean + top-k principal
+        components (Mu & Viswanath 'all-but-the-top'), and persists the calibration so subsequent embeds and queries
+        apply the correction. Run `assistant memory v2 reembed` after fitting so stored vectors are written under the
+        new calibration — until then, queries (corrected) and stored vectors (uncorrected) live in different spaces.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                k:
+                  default: 1
+                  type: integer
+                  minimum: 1
+                  maximum: 16
+                sample:
+                  default: 5000
+                  type: integer
+                  minimum: 1
+                  maximum: 100000
+              required:
+                - k
+                - sample
+              additionalProperties: false
   /v1/memory/v2/rebuild-corpus-stats:
     post:
       operationId: memory_v2_rebuildcorpusstats_post


### PR DESCRIPTION
## Summary
- Regenerate \`assistant/openapi.yaml\` to include the \`POST /v1/memory/v2/fit-anisotropy\` endpoint added in #29465.
- Fixes the failing \`OpenAPI Spec Check\` job in \`CI Main Assistant Checks\` on \`main\`.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25299574700/job/74164095679
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->