### PR TITLE
test(app-control): add missing pendingInteractions.register to host-proxy test mocks

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
@@ -23,6 +23,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 }));
 
 mock.module("../runtime/pending-interactions.js", () => ({
+  register: () => undefined,
   resolve: () => undefined,
   get: () => undefined,
   getByKind: () => [],

--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -15,6 +15,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 }));
 
 mock.module("../runtime/pending-interactions.js", () => ({
+  register: () => undefined,
   resolve: (requestId: string) => {
     resolvedInteractionIds.push(requestId);
     return undefined;

--- a/assistant/src/__tests__/host-proxy-base.test.ts
+++ b/assistant/src/__tests__/host-proxy-base.test.ts
@@ -13,6 +13,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
 }));
 
 mock.module("../runtime/pending-interactions.js", () => ({
+  register: () => undefined,
   resolve: (requestId: string) => {
     resolvedInteractionIds.push(requestId);
     return undefined;


### PR DESCRIPTION
## Summary
- Three host-proxy unit tests (\`host-proxy-base\`, \`host-app-control-proxy\`, \`conversation-surfaces-app-control\`) mock \`runtime/pending-interactions.js\` but omitted the \`register\` export.
- After PR #29476 made \`HostProxyBase.dispatchRequest\` call \`pendingInteractions.register(...)\`, every test in those files failed with \`TypeError: pendingInteractions.register is not a function\`.
- Add \`register: () => undefined\` to each mock so the real module surface is matched.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25310423834/job/74195757593
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->