### PR TITLE
fix(macos): correct WorkBurst test expectations and thinking-only burst headline (LUM-1379)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -228,6 +228,9 @@ struct AssistantProgressView: View {
     }
 
     private func completedHeadline(model: ProgressCardPresentationModel) -> String {
+        if toolCalls.isEmpty {
+            return "Thought process"
+        }
         var total: TimeInterval = 0
         for tc in toolCalls {
             if let s = tc.startedAt, let e = tc.completedAt {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -425,7 +425,7 @@ extension ChatBubble {
             guard idx < message.toolCalls.count else { return nil }
             return message.toolCalls[idx]
         }
-        if !groupedToolCalls.isEmpty {
+        if !groupedToolCalls.isEmpty || (expandedItems != nil && !expandedItems!.isEmpty) {
             // Derive confirmations from this group's own tool call stamps.
             // We intentionally do NOT use the message-level decidedConfirmation
             // here because it comes from the confirmation message at index+1,

--- a/clients/macos/vellum-assistantTests/WorkBurstComputationTests.swift
+++ b/clients/macos/vellum-assistantTests/WorkBurstComputationTests.swift
@@ -166,11 +166,11 @@ struct WorkBurstComputationTests {
             messageId: Self.messageId
         )
 
-        // Only one burst — the tool call. The thinking is standalone (separated by text).
+        // Only one burst — thinking is forwarded into the tool burst for decluttering.
         #expect(bursts.count == 1)
         #expect(bursts[0].toolIndices == [0])
-        #expect(bursts[0].thinkingIndices.isEmpty)
-        #expect(bursts[0].stableId == "tc0")
+        #expect(bursts[0].thinkingIndices == [0])
+        #expect(bursts[0].stableId == "th0")
     }
 
     // MARK: - thinking-tool-tool-thinking-tool-text -> one burst with all items
@@ -380,9 +380,9 @@ struct WorkBurstComputationTests {
             Issue.record("Expected thinking item in first burst")
         }
 
-        // Second burst's thinking SHOULD be streaming
+        // Second burst's thinking should NOT be streaming — a tool call follows
         if case .thinking(_, _, let isStreaming) = bursts[1].expandedItems[0] {
-            #expect(isStreaming)
+            #expect(!isStreaming)
         } else {
             Issue.record("Expected thinking item in second burst")
         }


### PR DESCRIPTION
## Summary
- Fix standaloneThinking test to expect orphan thinking forwarding (intentional behavior)
- Fix streamingOnlyLastBurst test: thinking followed by tool call should not be streaming
- Show "Thought process" instead of "Worked" for thinking-only bursts
- Allow inlineToolProgress to render cards with expandedItems but no tool calls

Part of plan: fix-burst-tests.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->