### PR TITLE
[codex] Stabilize assistant hatched date

### DIFF
--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -25,9 +25,13 @@ mock.module("../util/logger.js", () => ({
 import {
   handleDetailedHealth,
   ROUTES,
-  selectIdentityCreatedAt,
 } from "../runtime/routes/identity-routes.js";
 import { getWorkspaceDir } from "../util/platform.js";
+import {
+  getHatchedSidecarPath,
+  resolveHatchedAtReadOnly,
+  selectHatchedAtFromStats,
+} from "../workspace/hatched-date.js";
 
 // ── Env helpers ─────────────────────────────────────────────────────────
 
@@ -122,6 +126,9 @@ beforeEach(() => {
   if (existsSync(profilerRunsDir)) {
     rmSync(profilerRunsDir, { recursive: true, force: true });
   }
+
+  rmSync(getHatchedSidecarPath(), { force: true });
+  rmSync(join(getWorkspaceDir(), "IDENTITY.md"), { force: true });
 });
 
 afterEach(() => {
@@ -336,7 +343,7 @@ describe("identity routes — createdAt selection", () => {
     const mtime = new Date("2026-05-01T14:49:47.519Z");
 
     expect(
-      selectIdentityCreatedAt({
+      selectHatchedAtFromStats({
         birthtime: new Date(0),
         mtime,
       })?.toISOString(),
@@ -348,18 +355,38 @@ describe("identity routes — createdAt selection", () => {
     const mtime = new Date("2026-05-01T14:49:47.519Z");
 
     expect(
-      selectIdentityCreatedAt({
+      selectHatchedAtFromStats({
         birthtime,
         mtime,
       })?.toISOString(),
     ).toBe(birthtime.toISOString());
   });
 
+  test("returns undefined when both birthtime and mtime are the Unix epoch", () => {
+    expect(
+      selectHatchedAtFromStats({
+        birthtime: new Date(0),
+        mtime: new Date(0),
+      }),
+    ).toBeUndefined();
+  });
+
+  test("read-only resolver falls back to current time without writing sidecar", () => {
+    const now = new Date("2026-05-04T12:00:00.000Z");
+
+    expect(
+      resolveHatchedAtReadOnly(
+        join(getWorkspaceDir(), "missing-identity.md"),
+        now,
+      ),
+    ).toBe(now.toISOString());
+    expect(existsSync(getHatchedSidecarPath())).toBe(false);
+  });
+
   test("/identity uses persisted hatched sidecar instead of live file metadata", () => {
     const workspaceDir = getWorkspaceDir();
     const dataDir = join(workspaceDir, "data");
     const identityPath = join(workspaceDir, "IDENTITY.md");
-    const sidecarPath = join(dataDir, "hatched.json");
     const persistedHatchedAt = "2026-05-01T14:49:47.519Z";
 
     mkdirSync(dataDir, { recursive: true });
@@ -369,7 +396,7 @@ describe("identity routes — createdAt selection", () => {
       "utf-8",
     );
     writeFileSync(
-      sidecarPath,
+      getHatchedSidecarPath(),
       JSON.stringify({ hatchedAt: persistedHatchedAt }),
       "utf-8",
     );
@@ -381,5 +408,23 @@ describe("identity routes — createdAt selection", () => {
 
     const body = route!.handler({}) as { createdAt?: string };
     expect(body.createdAt).toBe(persistedHatchedAt);
+  });
+
+  test("/identity does not write hatched sidecar on read", () => {
+    const identityPath = join(getWorkspaceDir(), "IDENTITY.md");
+    writeFileSync(
+      identityPath,
+      "# Identity\n\n- **Name:** Example Assistant\n",
+      "utf-8",
+    );
+
+    const route = ROUTES.find(
+      (candidate) => candidate.operationId === "identity",
+    );
+    expect(route).toBeDefined();
+
+    const body = route!.handler({}) as { createdAt?: string };
+    expect(Date.parse(body.createdAt ?? "")).toBeGreaterThan(0);
+    expect(existsSync(getHatchedSidecarPath())).toBe(false);
   });
 });

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -22,7 +22,11 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { handleDetailedHealth } from "../runtime/routes/identity-routes.js";
+import {
+  handleDetailedHealth,
+  ROUTES,
+  selectIdentityCreatedAt,
+} from "../runtime/routes/identity-routes.js";
 import { getWorkspaceDir } from "../util/platform.js";
 
 // ── Env helpers ─────────────────────────────────────────────────────────
@@ -324,5 +328,58 @@ describe("identity routes — health endpoint", () => {
       expect(last).toBeDefined();
       expect(last.runId).toBe("newer-completed");
     });
+  });
+});
+
+describe("identity routes — createdAt selection", () => {
+  test("falls back to mtime when birthtime is the Unix epoch", () => {
+    const mtime = new Date("2026-05-01T14:49:47.519Z");
+
+    expect(
+      selectIdentityCreatedAt({
+        birthtime: new Date(0),
+        mtime,
+      })?.toISOString(),
+    ).toBe(mtime.toISOString());
+  });
+
+  test("prefers birthtime when it is valid", () => {
+    const birthtime = new Date("2026-04-30T12:00:00.000Z");
+    const mtime = new Date("2026-05-01T14:49:47.519Z");
+
+    expect(
+      selectIdentityCreatedAt({
+        birthtime,
+        mtime,
+      })?.toISOString(),
+    ).toBe(birthtime.toISOString());
+  });
+
+  test("/identity uses persisted hatched sidecar instead of live file metadata", () => {
+    const workspaceDir = getWorkspaceDir();
+    const dataDir = join(workspaceDir, "data");
+    const identityPath = join(workspaceDir, "IDENTITY.md");
+    const sidecarPath = join(dataDir, "hatched.json");
+    const persistedHatchedAt = "2026-05-01T14:49:47.519Z";
+
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      identityPath,
+      "# Identity\n\n- **Name:** Example Assistant\n",
+      "utf-8",
+    );
+    writeFileSync(
+      sidecarPath,
+      JSON.stringify({ hatchedAt: persistedHatchedAt }),
+      "utf-8",
+    );
+
+    const route = ROUTES.find(
+      (candidate) => candidate.operationId === "identity",
+    );
+    expect(route).toBeDefined();
+
+    const body = route!.handler({}) as { createdAt?: string };
+    expect(body.createdAt).toBe(persistedHatchedAt);
   });
 });

--- a/assistant/src/home/__tests__/relationship-state-writer.test.ts
+++ b/assistant/src/home/__tests__/relationship-state-writer.test.ts
@@ -432,6 +432,12 @@ describe("relationship-state-writer", () => {
       // Also sanity: it must be a real, recent date (not the epoch
       // sentinel we emit when stat fails).
       expect(Date.parse(first.hatchedDate)).toBeGreaterThan(0);
+      const sidecarPath = join(workspaceDir, "data", "hatched.json");
+      expect(existsSync(sidecarPath)).toBe(true);
+      const sidecar = JSON.parse(readFileSync(sidecarPath, "utf-8")) as {
+        hatchedAt: string;
+      };
+      expect(sidecar.hatchedAt).toBe(first.hatchedDate);
     });
 
     test("honors an explicit Hatched bullet in IDENTITY.md over file birthtime", async () => {
@@ -488,9 +494,10 @@ describe("relationship-state-writer", () => {
       expect(state.hatchedDate).toBe("2025-01-15T00:00:00.000Z");
     });
 
-    test("IDENTITY.md birthtime takes precedence over the sidecar", async () => {
-      // Seed a stale sidecar and then an IDENTITY.md without an
-      // explicit Hatched bullet — birthtime wins over the sidecar.
+    test("sidecar takes precedence over IDENTITY.md metadata", async () => {
+      // Seed an existing sidecar and then an IDENTITY.md without an
+      // explicit Hatched bullet — the persisted sidecar wins so the
+      // date remains stable across later identity edits.
       mkdirSync(join(workspaceDir, "data"), { recursive: true });
       writeFileSync(
         join(workspaceDir, "data", "hatched.json"),
@@ -500,12 +507,7 @@ describe("relationship-state-writer", () => {
       writeFile("IDENTITY.md", "- **Name:** Sage\n- **Role:** Assistant\n");
 
       const state = (await computeRelationshipState()) as RelationshipStateLike;
-      // The sidecar value is 2020-06-01 but IDENTITY.md was just
-      // written, so birthtime will be a much more recent date.
-      expect(state.hatchedDate).not.toBe("2020-06-01T00:00:00.000Z");
-      expect(Date.parse(state.hatchedDate)).toBeGreaterThan(
-        Date.parse("2020-06-01T00:00:00.000Z"),
-      );
+      expect(state.hatchedDate).toBe("2020-06-01T00:00:00.000Z");
     });
   });
 

--- a/assistant/src/home/relationship-state-writer.ts
+++ b/assistant/src/home/relationship-state-writer.ts
@@ -18,13 +18,7 @@
  * a missing or unreadable file degrades gracefully to an empty string.
  */
 
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { countConversations as countConversationsDb } from "../memory/conversation-queries.js";
@@ -39,6 +33,7 @@ import {
   getWorkspaceDir,
   getWorkspacePromptPath,
 } from "../util/platform.js";
+import { resolveAndPersistHatchedAt } from "../workspace/hatched-date.js";
 import { computeProgressPercent, computeTier } from "./progress-formula.js";
 import {
   type Capability,
@@ -149,11 +144,12 @@ function readOnboardingSidecar(): OnboardingContext | null {
  * Reads USER.md / SOUL.md / IDENTITY.md, queries the oauth connection
  * store, and counts conversations via the DB-authoritative helper.
  *
- * Side effect: on the very first call when IDENTITY.md cannot provide
- * a hatched date, `resolveFallbackHatchedDate` persists a one-time
- * `data/hatched.json` sidecar so subsequent calls return a monotonic
- * timestamp. All other paths are read-only. Callers that want to
- * persist the full snapshot should use `writeRelationshipState()`.
+ * Side effect: on the very first call without an explicit Hatched
+ * bullet or existing hatched sidecar, the shared resolver persists a
+ * one-time `data/hatched.json` value seeded from IDENTITY.md metadata
+ * or a real current timestamp. All other paths are read-only. Callers
+ * that want to persist the full snapshot should use
+ * `writeRelationshipState()`.
  */
 export async function computeRelationshipState(): Promise<RelationshipState> {
   // Persona source-of-truth:
@@ -683,73 +679,16 @@ function countConversations(): number {
 }
 
 /**
- * Filename for the hatched-date sidecar, used as a stable fallback
- * when IDENTITY.md is missing / unreadable / has no explicit hatched
- * bullet and file stat is unavailable. Lives under the workspace
- * data dir alongside `relationship-state.json`.
- */
-const HATCHED_SIDECAR_FILENAME = "hatched.json";
-
-function getHatchedSidecarPath(): string {
-  return join(getDataDir(), HATCHED_SIDECAR_FILENAME);
-}
-
-/**
- * Resolve a stable hatched-date fallback timestamp.
- *
- * The Swift client, OpenAPI schema, and UI have no special handling
- * for a Unix-epoch sentinel — they'll render "1/1/1970" to the user.
- * Instead, we use `new Date().toISOString()` the first time a
- * fallback is needed and persist it to a small sidecar file
- * (`data/hatched.json`). Subsequent calls read the sidecar first, so
- * the returned timestamp is monotonic across writes and the
- * `hatchedDate` field never drifts once initialized.
- *
- * Never throws — a sidecar read/write failure still yields a valid
- * (though non-stable) `now` timestamp, which is still far better than
- * the epoch sentinel.
- */
-function resolveFallbackHatchedDate(): string {
-  const path = getHatchedSidecarPath();
-  try {
-    if (existsSync(path)) {
-      const parsed = JSON.parse(readFileSync(path, "utf-8")) as {
-        hatchedAt?: string;
-      };
-      if (parsed.hatchedAt && !isNaN(Date.parse(parsed.hatchedAt))) {
-        return parsed.hatchedAt;
-      }
-    }
-  } catch {
-    // Fall through to write a fresh sidecar.
-  }
-  const now = new Date().toISOString();
-  try {
-    mkdirSync(getDataDir(), { recursive: true });
-    writeFileSync(path, JSON.stringify({ hatchedAt: now }, null, 2), "utf-8");
-  } catch {
-    // If even the sidecar write fails, return `now` anyway — the
-    // caller will just get a fresh-looking date on every call. Not
-    // ideal, but far better than the epoch sentinel.
-  }
-  return now;
-}
-
-/**
  * Pull `assistantName` and `hatchedDate` from IDENTITY.md.
  *
  * IDENTITY.md is a freeform markdown file, so for the name we scan
  * bullet lines for any recognizable `name` label (`Name`,
  * `Assistant Name`, `Preferred Name`, etc.). For the hatched date we
- * prefer any explicit `hatched:` / `birth:` bullet, then fall back to
- * the file's `stat.birthtime` (matching the pattern already
- * established by `identity-routes.ts`), and finally to `stat.mtime`
- * if birthtime is unavailable. We never fall back to `new Date()`
- * directly — `writeRelationshipState()` is called on every turn
- * boundary, so a raw `Date.now()` fallback would cause `hatchedDate`
- * to drift forward on every write. Instead, when nothing else is
- * readable we resolve via `resolveFallbackHatchedDate()` which
- * persists a stable timestamp to a sidecar file on first use.
+ * prefer any explicit `hatched:` / `birth:` bullet, then use the
+ * shared hatched-date resolver. That resolver reads an existing
+ * `data/hatched.json` sidecar first, otherwise seeds it from valid
+ * IDENTITY.md birthtime/mtime or a real current timestamp. This keeps
+ * `hatchedDate` stable without writing from read-only HTTP handlers.
  */
 function parseIdentity(identityPath: string): {
   assistantName: string;
@@ -792,24 +731,10 @@ function parseIdentity(identityPath: string): {
     return { assistantName, hatchedDate: explicitHatched };
   }
 
-  // Stable fallback: use the IDENTITY.md file birth time so the
-  // relationship start date is monotonic across turns. Matches the
-  // approach used by `identity-routes.ts` for the Settings UI.
-  try {
-    const stats = statSync(identityPath);
-    const candidate =
-      stats.birthtime.getTime() > 0 ? stats.birthtime : stats.mtime;
-    if (candidate.getTime() > 0) {
-      return { assistantName, hatchedDate: candidate.toISOString() };
-    }
-  } catch {
-    // File missing or unreadable — fall through to the sidecar.
-  }
-
-  // Last-ditch fallback: `resolveFallbackHatchedDate` returns a stable,
-  // real timestamp (persisted to `data/hatched.json` on first call) so
-  // the wire contract always carries a valid ISO date.
-  return { assistantName, hatchedDate: resolveFallbackHatchedDate() };
+  return {
+    assistantName,
+    hatchedDate: resolveAndPersistHatchedAt(identityPath),
+  };
 }
 
 /**

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -3,16 +3,8 @@
  */
 
 import { spawnSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  statfsSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, statfsSync } from "node:fs";
 import { availableParallelism, cpus, totalmem } from "node:os";
-import { join } from "node:path";
 
 import { z } from "zod";
 
@@ -25,11 +17,11 @@ import { parseIdentityFields } from "../../daemon/handlers/identity.js";
 import { getProfilerRuntimeStatus } from "../../daemon/profiler-run-store.js";
 import { getMaxMigrationVersion } from "../../memory/migrations/registry.js";
 import {
-  getDataDir,
   getWorkspaceDir,
   getWorkspacePromptPath,
 } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
+import { resolveHatchedAtReadOnly } from "../../workspace/hatched-date.js";
 import { WORKSPACE_MIGRATIONS } from "../../workspace/migrations/registry.js";
 import { getLastWorkspaceMigrationId } from "../../workspace/migrations/runner.js";
 import { NotFoundError } from "./errors.js";
@@ -510,71 +502,8 @@ function getIdentity() {
   };
 }
 
-const HATCHED_SIDECAR_FILENAME = "hatched.json";
-
-function getHatchedSidecarPath(): string {
-  return join(getDataDir(), HATCHED_SIDECAR_FILENAME);
-}
-
-function readHatchedAtSidecar(): string | undefined {
-  try {
-    const parsed = JSON.parse(
-      readFileSync(getHatchedSidecarPath(), "utf-8"),
-    ) as { hatchedAt?: unknown };
-    const parsedTime =
-      typeof parsed.hatchedAt === "string" ? Date.parse(parsed.hatchedAt) : NaN;
-    if (
-      typeof parsed.hatchedAt === "string" &&
-      !isNaN(parsedTime) &&
-      parsedTime > 0
-    ) {
-      return parsed.hatchedAt;
-    }
-  } catch {
-    // Fall through to filesystem metadata.
-  }
-  return undefined;
-}
-
-function writeHatchedAtSidecar(hatchedAt: string): void {
-  try {
-    mkdirSync(getDataDir(), { recursive: true });
-    writeFileSync(
-      getHatchedSidecarPath(),
-      JSON.stringify({ hatchedAt }, null, 2),
-      "utf-8",
-    );
-  } catch {
-    // Best-effort stability; the caller still returns a valid timestamp.
-  }
-}
-
-export function selectIdentityCreatedAt(stats: {
-  birthtime: Date;
-  mtime: Date;
-}): Date | undefined {
-  const candidates = [stats.birthtime, stats.mtime];
-  return candidates.find((candidate) => candidate.getTime() > 0);
-}
-
 function resolveIdentityCreatedAt(identityPath: string): string | undefined {
-  const sidecarHatchedAt = readHatchedAtSidecar();
-  if (sidecarHatchedAt) return sidecarHatchedAt;
-
-  try {
-    const stats = statSync(identityPath);
-    const createdAt = selectIdentityCreatedAt(stats)?.toISOString();
-    if (createdAt) {
-      writeHatchedAtSidecar(createdAt);
-      return createdAt;
-    }
-  } catch {
-    // Fall through to a stable real timestamp.
-  }
-
-  const now = new Date().toISOString();
-  writeHatchedAtSidecar(now);
-  return now;
+  return resolveHatchedAtReadOnly(identityPath);
 }
 
 function getIdentityIntro() {

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -3,8 +3,16 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statfsSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statfsSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { availableParallelism, cpus, totalmem } from "node:os";
+import { join } from "node:path";
 
 import { z } from "zod";
 
@@ -17,6 +25,7 @@ import { parseIdentityFields } from "../../daemon/handlers/identity.js";
 import { getProfilerRuntimeStatus } from "../../daemon/profiler-run-store.js";
 import { getMaxMigrationVersion } from "../../memory/migrations/registry.js";
 import {
+  getDataDir,
   getWorkspaceDir,
   getWorkspacePromptPath,
 } from "../../util/platform.js";
@@ -488,13 +497,7 @@ function getIdentity() {
 
   const version = APP_VERSION;
 
-  let createdAt: string | undefined;
-  try {
-    const stats = statSync(identityPath);
-    createdAt = stats.birthtime.toISOString();
-  } catch {
-    // ignore
-  }
+  const createdAt = resolveIdentityCreatedAt(identityPath);
 
   return {
     name: fields.name ?? "",
@@ -505,6 +508,73 @@ function getIdentity() {
     version,
     createdAt,
   };
+}
+
+const HATCHED_SIDECAR_FILENAME = "hatched.json";
+
+function getHatchedSidecarPath(): string {
+  return join(getDataDir(), HATCHED_SIDECAR_FILENAME);
+}
+
+function readHatchedAtSidecar(): string | undefined {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(getHatchedSidecarPath(), "utf-8"),
+    ) as { hatchedAt?: unknown };
+    const parsedTime =
+      typeof parsed.hatchedAt === "string" ? Date.parse(parsed.hatchedAt) : NaN;
+    if (
+      typeof parsed.hatchedAt === "string" &&
+      !isNaN(parsedTime) &&
+      parsedTime > 0
+    ) {
+      return parsed.hatchedAt;
+    }
+  } catch {
+    // Fall through to filesystem metadata.
+  }
+  return undefined;
+}
+
+function writeHatchedAtSidecar(hatchedAt: string): void {
+  try {
+    mkdirSync(getDataDir(), { recursive: true });
+    writeFileSync(
+      getHatchedSidecarPath(),
+      JSON.stringify({ hatchedAt }, null, 2),
+      "utf-8",
+    );
+  } catch {
+    // Best-effort stability; the caller still returns a valid timestamp.
+  }
+}
+
+export function selectIdentityCreatedAt(stats: {
+  birthtime: Date;
+  mtime: Date;
+}): Date | undefined {
+  const candidates = [stats.birthtime, stats.mtime];
+  return candidates.find((candidate) => candidate.getTime() > 0);
+}
+
+function resolveIdentityCreatedAt(identityPath: string): string | undefined {
+  const sidecarHatchedAt = readHatchedAtSidecar();
+  if (sidecarHatchedAt) return sidecarHatchedAt;
+
+  try {
+    const stats = statSync(identityPath);
+    const createdAt = selectIdentityCreatedAt(stats)?.toISOString();
+    if (createdAt) {
+      writeHatchedAtSidecar(createdAt);
+      return createdAt;
+    }
+  } catch {
+    // Fall through to a stable real timestamp.
+  }
+
+  const now = new Date().toISOString();
+  writeHatchedAtSidecar(now);
+  return now;
 }
 
 function getIdentityIntro() {

--- a/assistant/src/workspace/hatched-date.ts
+++ b/assistant/src/workspace/hatched-date.ts
@@ -1,0 +1,86 @@
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getDataDir } from "../util/platform.js";
+
+const HATCHED_SIDECAR_FILENAME = "hatched.json";
+
+export function getHatchedSidecarPath(): string {
+  return join(getDataDir(), HATCHED_SIDECAR_FILENAME);
+}
+
+function normalizeHatchedAt(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+
+  const parsedTime = Date.parse(value);
+  if (isNaN(parsedTime) || parsedTime <= 0) return undefined;
+
+  return new Date(parsedTime).toISOString();
+}
+
+export function readHatchedAtSidecar(): string | undefined {
+  try {
+    const parsed = JSON.parse(
+      readFileSync(getHatchedSidecarPath(), "utf-8"),
+    ) as { hatchedAt?: unknown };
+    return normalizeHatchedAt(parsed.hatchedAt);
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeHatchedAtSidecar(hatchedAt: string): void {
+  const normalized = normalizeHatchedAt(hatchedAt);
+  if (!normalized) return;
+
+  try {
+    mkdirSync(getDataDir(), { recursive: true });
+    writeFileSync(
+      getHatchedSidecarPath(),
+      JSON.stringify({ hatchedAt: normalized }, null, 2),
+      "utf-8",
+    );
+  } catch {
+    // Best-effort stability; callers still return a valid timestamp.
+  }
+}
+
+export function selectHatchedAtFromStats(stats: {
+  birthtime: Date;
+  mtime: Date;
+}): Date | undefined {
+  const candidates = [stats.birthtime, stats.mtime];
+  return candidates.find((candidate) => candidate.getTime() > 0);
+}
+
+function readIdentityFileHatchedAt(identityPath: string): string | undefined {
+  try {
+    return selectHatchedAtFromStats(statSync(identityPath))?.toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveHatchedAtReadOnly(
+  identityPath: string,
+  now: Date = new Date(),
+): string {
+  return (
+    readHatchedAtSidecar() ??
+    readIdentityFileHatchedAt(identityPath) ??
+    now.toISOString()
+  );
+}
+
+export function resolveAndPersistHatchedAt(
+  identityPath: string,
+  now: Date = new Date(),
+): string {
+  const sidecarHatchedAt = readHatchedAtSidecar();
+  if (sidecarHatchedAt) return sidecarHatchedAt;
+
+  const hatchedAt =
+    readIdentityFileHatchedAt(identityPath) ?? now.toISOString();
+  writeHatchedAtSidecar(hatchedAt);
+  return hatchedAt;
+}


### PR DESCRIPTION
## Summary

- Stabilize `/identity.createdAt` by persisting a `data/hatched.json` sidecar.
- Seed the sidecar from valid `IDENTITY.md` birthtime, falling back to valid mtime, and reject Unix-epoch timestamps.
- Add regression coverage for epoch birthtime fallback and sidecar precedence.

## Root Cause

Some production filesystems can report `IDENTITY.md` birthtime as Unix epoch. The macOS Identity panel formats `/identity.createdAt`, so that epoch timestamp rendered as `31 Dec 1969` in local time.

## Validation

- `cd assistant && bun test src/__tests__/identity-routes.test.ts`
- `cd assistant && bunx tsc --noEmit`
- pre-commit hook formatting, lint, and type-check
- pre-push hook assistant type-check and lint

Closes JARVIS-653