### PR TITLE
fix(macos): highlight matching message when navigating Cmd+F results (LUM-1278)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -25,6 +25,7 @@ struct PrecomputedCacheKey: Equatable {
     /// rendered slice is different — so the projection cache invalidates
     /// whenever the window starts on a different message.
     let firstVisibleMessageId: UUID?
+    let highlightedMessageId: UUID?
 }
 
 // MARK: - Scroll Geometry Snapshot

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -84,7 +84,8 @@ extension MessageListView {
             assistantActivityReason: assistantActivityReason,
             activeSubagentFingerprint: Self.computeSubagentFingerprint(activeSubagents),
             displayedMessageCount: displayedMessageCount,
-            firstVisibleMessageId: liveMessages.first?.id
+            firstVisibleMessageId: liveMessages.first?.id,
+            highlightedMessageId: highlightedMessageId
         )
 
         // Return cached projection when the key matches and the row count

--- a/clients/macos/vellum-assistantTests/MessageListProjectionCacheTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListProjectionCacheTests.swift
@@ -41,9 +41,57 @@ final class MessageListProjectionCacheTests: XCTestCase {
         XCTAssertEqual(sharedScrollState.messageListVersion, 2)
     }
 
+    func testChangingHighlightedMessageIdInvalidatesProjectionCache() {
+        let messageId = UUID()
+        let sharedScrollState = MessageListScrollState()
+
+        let message = ChatMessage(
+            id: messageId,
+            role: .assistant,
+            text: "Hello",
+            isStreaming: false
+        )
+
+        // First projection with no highlighted message.
+        let view1 = makeView(messages: [message], messagesRevision: 1)
+        view1.scrollState = sharedScrollState
+        let projection1 = view1.derivedState
+
+        // Capture the cache key after the first projection (highlightedMessageId == nil).
+        let keyWithoutHighlight = sharedScrollState.derivedStateCache.cachedProjectionKey
+
+        // Second projection with a highlighted message — same content,
+        // different highlightedMessageId.
+        let view2 = makeView(
+            messages: [message],
+            messagesRevision: 1,
+            highlightedMessageId: messageId
+        )
+        view2.scrollState = sharedScrollState
+        let projection2 = view2.derivedState
+
+        // Capture the cache key after the second projection (highlightedMessageId == messageId).
+        let keyWithHighlight = sharedScrollState.derivedStateCache.cachedProjectionKey
+
+        // The two cache keys must differ so the projector re-runs and picks
+        // up the new isHighlighted flag.
+        XCTAssertNotEqual(
+            keyWithoutHighlight,
+            keyWithHighlight,
+            "Changing highlightedMessageId should produce a different cache key"
+        )
+
+        // Verify the projections reflect the highlight state correctly.
+        let rows1Highlighted = projection1.rows.contains { $0.isHighlighted }
+        let rows2Highlighted = projection2.rows.contains { $0.isHighlighted }
+        XCTAssertFalse(rows1Highlighted, "No rows should be highlighted when highlightedMessageId is nil")
+        XCTAssertTrue(rows2Highlighted, "The matching row should be highlighted when highlightedMessageId is set")
+    }
+
     private func makeView(
         messages: [ChatMessage],
-        messagesRevision: UInt64
+        messagesRevision: UInt64,
+        highlightedMessageId: UUID? = nil
     ) -> MessageListView {
         MessageListView(
             messages: messages,
@@ -86,7 +134,7 @@ final class MessageListProjectionCacheTests: XCTestCase {
             loadPreviousMessagePage: nil,
             conversationId: nil,
             anchorMessageId: .constant(nil),
-            highlightedMessageId: .constant(nil),
+            highlightedMessageId: .constant(highlightedMessageId),
             isInteractionEnabled: true,
             containerWidth: 800
         )


### PR DESCRIPTION
## Summary
- Add highlightedMessageId to PrecomputedCacheKey so the projection cache invalidates when a message is highlighted
- This fixes the bug where navigating Cmd+F search results scrolled correctly but never showed the highlight flash
- Root cause: the cache key didn't include highlightedMessageId, so the cached projection (with isHighlighted: false) was always returned
- Add test verifying cache key inequality when highlightedMessageId differs

Part of plan: cmdf-search-highlight-fix.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->