### PR TITLE
fix(macos): constrain Cmd+F search bar to max width (LUM-1278)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
@@ -57,6 +57,7 @@ struct ChatSearchBar: View {
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .frame(height: 32)
+        .frame(maxWidth: 280)
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .vShadow(VShadow.sm)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
@@ -57,7 +57,7 @@ struct ChatSearchBar: View {
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .frame(height: 32)
-        .frame(maxWidth: 280)
+        .widthCap(280)
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .vShadow(VShadow.sm)


### PR DESCRIPTION
## Summary
- Add .frame(maxWidth: 280) to ChatSearchBar to prevent it from expanding to fill the full chat width
- The bar now hugs its content at a compact ~280pt max while still shrinking in narrow windows

Part of plan: cmdf-search-highlight-fix.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->