### PR TITLE
fix(macos): fix Cmd+F search bar width and highlight flash (LUM-1278)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -42,6 +42,7 @@ struct ChatBubble: View, Equatable {
             && lhs.isTTSEnabled == rhs.isTTSEnabled
             && lhs.hideInlineAvatar == rhs.hideInlineAvatar
             && lhs.activeSurfaceId == rhs.activeSurfaceId
+            && lhs.searchQuery == rhs.searchQuery
     }
     let message: ChatMessage
     /// Decided confirmation from the next message, rendered as a compact chip at the bottom.
@@ -93,6 +94,7 @@ struct ChatBubble: View, Equatable {
     /// When true, suppress the inline avatar on this bubble because
     /// `thinkingAvatarRow` is rendering one below the thinking indicator.
     var hideInlineAvatar: Bool = false
+    var searchQuery: String = ""
     /// Owned but never read in this body — only ChatBubbleOverflowMenu reads it,
     /// so hover changes invalidate only the overflow menu, not this view.
     @State private var hoverState = ChatBubbleHoverState()
@@ -152,7 +154,8 @@ struct ChatBubble: View, Equatable {
         processingStatusText: String? = nil,
         isStreamingContinuation: Bool = false,
         activeSurfaceId: String? = nil,
-        hideInlineAvatar: Bool = false
+        hideInlineAvatar: Bool = false,
+        searchQuery: String = ""
     ) {
         self.message = message
         self.decidedConfirmation = decidedConfirmation
@@ -180,6 +183,7 @@ struct ChatBubble: View, Equatable {
         self.isStreamingContinuation = isStreamingContinuation
         self.activeSurfaceId = activeSurfaceId
         self.hideInlineAvatar = hideInlineAvatar
+        self.searchQuery = searchQuery
 
         // Eagerly compute interleaved content cache so the first body
         // evaluation uses the correct layout path (no flash).
@@ -908,7 +912,8 @@ struct ChatBubble: View, Equatable {
                         tintColor: isUser ? VColor.contentDefault : VColor.primaryBase,
                         codeTextColor: isUser ? VColor.contentDefault : VColor.systemNegativeStrong,
                         codeBackgroundColor: isUser ? VColor.contentDefault.opacity(0.1) : VColor.surfaceActive,
-                        hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase
+                        hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase,
+                        searchQuery: searchQuery
                     )
                     .equatable()
                 } else if !message.attachments.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -65,7 +65,8 @@ extension ChatBubble {
                 segments: segments,
                 isStreaming: streaming,
                 typographyGeneration: typographyGeneration,
-                maxContentWidth: bubbleMaxWidth
+                maxContentWidth: bubbleMaxWidth,
+                searchQuery: searchQuery
             )
                 .equatable()
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchBar.swift
@@ -57,6 +57,7 @@ struct ChatSearchBar: View {
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .frame(height: 32)
+        .widthCap(280)
         .background(VColor.surfaceOverlay)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .vShadow(VShadow.sm)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
@@ -12,10 +12,14 @@ struct ChatSearchOverlay: View {
 
     @State private var currentMatchIndex = 0
 
-    private var searchMatches: [UUID] {
+    struct SearchMatch {
+        let messageId: UUID
+        let range: NSRange
+    }
+
+    private var searchMatches: [SearchMatch] {
         guard isSearchActive, !searchQuery.isEmpty else { return [] }
-        let query = searchQuery.lowercased()
-        return viewModel.messages.filter { $0.text.lowercased().contains(query) }.map(\.id)
+        return Self.searchMatches(in: viewModel.messages, query: searchQuery)
     }
 
     var body: some View {
@@ -63,6 +67,35 @@ struct ChatSearchOverlay: View {
     private func scrollToCurrentMatch() {
         let matches = searchMatches
         guard !matches.isEmpty, currentMatchIndex < matches.count else { return }
-        anchorMessageId = matches[currentMatchIndex]
+        anchorMessageId = matches[currentMatchIndex].messageId
+    }
+
+    static func searchMatches(in messages: [ChatMessage], query: String) -> [SearchMatch] {
+        guard !query.isEmpty else { return [] }
+        return messages.flatMap { message in
+            occurrenceRanges(in: message.text, query: query).map { range in
+                SearchMatch(messageId: message.id, range: range)
+            }
+        }
+    }
+
+    static func occurrenceRanges(in text: String, query: String) -> [NSRange] {
+        guard !query.isEmpty else { return [] }
+        let nsText = text as NSString
+        var ranges: [NSRange] = []
+        var start = 0
+
+        while start < nsText.length {
+            let found = nsText.range(
+                of: query,
+                options: [.caseInsensitive, .diacriticInsensitive],
+                range: NSRange(location: start, length: nsText.length - start)
+            )
+            guard found.location != NSNotFound, found.length > 0 else { break }
+            ranges.append(found)
+            start = found.location + found.length
+        }
+
+        return ranges
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
@@ -8,13 +8,13 @@ struct ChatSearchOverlay: View {
     var viewModel: ChatViewModel
     @Binding var isSearchActive: Bool
     @Binding var anchorMessageId: UUID?
+    @Binding var searchQuery: String
 
-    @State private var searchText = ""
     @State private var currentMatchIndex = 0
 
     private var searchMatches: [UUID] {
-        guard isSearchActive, !searchText.isEmpty else { return [] }
-        let query = searchText.lowercased()
+        guard isSearchActive, !searchQuery.isEmpty else { return [] }
+        let query = searchQuery.lowercased()
         return viewModel.messages.filter { $0.text.lowercased().contains(query) }.map(\.id)
     }
 
@@ -22,7 +22,7 @@ struct ChatSearchOverlay: View {
         Group {
             if isSearchActive {
                 ChatSearchBar(
-                    searchText: $searchText,
+                    searchText: $searchQuery,
                     matchCount: searchMatches.count,
                     currentMatchIndex: currentMatchIndex,
                     onPrevious: { navigateMatch(delta: -1) },
@@ -35,7 +35,7 @@ struct ChatSearchOverlay: View {
                 .layoutHangSignpost("chat.searchOverlay")
             }
         }
-        .onChange(of: searchText) {
+        .onChange(of: searchQuery) {
             currentMatchIndex = 0
             scrollToCurrentMatch()
         }
@@ -47,7 +47,7 @@ struct ChatSearchOverlay: View {
         }
         .onChange(of: isSearchActive) { _, active in
             if !active {
-                searchText = ""
+                searchQuery = ""
                 currentMatchIndex = 0
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -104,6 +104,7 @@ struct ChatView: View {
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
+    @State private var searchQuery = ""
     @State private var showSkeleton = false
     @State private var skeletonDebounceTask: Task<Void, Never>? = nil
     @State private var diskPressureDismissalRefreshToken = 0
@@ -179,7 +180,8 @@ struct ChatView: View {
             ChatSearchOverlay(
                 viewModel: viewModel,
                 isSearchActive: $isSearchActive,
-                anchorMessageId: $anchorMessageId
+                anchorMessageId: $anchorMessageId,
+                searchQuery: $searchQuery
             )
         }
         .animation(VAnimation.fast, value: isSearchActive)
@@ -360,7 +362,8 @@ struct ChatView: View {
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 isInteractionEnabled: isInteractionEnabled,
-                containerWidth: containerWidth
+                containerWidth: containerWidth,
+                searchQuery: searchQuery
             )
             .animation(nil, value: queuedMessages.isEmpty)
 

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -38,6 +38,7 @@ struct MarkdownSegmentView: View, Equatable {
     var codeTextColor: Color = VColor.systemNegativeStrong
     var codeBackgroundColor: Color = VColor.surfaceActive
     var hrColor: Color = VColor.borderBase
+    var searchQuery: String = ""
     #if os(macOS)
     @ObservedObject private var typographyObserver = VFont.typographyObserver
     #endif
@@ -54,6 +55,7 @@ struct MarkdownSegmentView: View, Equatable {
             && lhs.codeTextColor == rhs.codeTextColor
             && lhs.codeBackgroundColor == rhs.codeBackgroundColor
             && lhs.hrColor == rhs.hrColor
+            && lhs.searchQuery == rhs.searchQuery
     }
 
     var body: some View {
@@ -192,8 +194,13 @@ struct MarkdownSegmentView: View, Equatable {
                 isStreamingTail: isStreamingTail
             )
 
+            let displayString = Self.applySearchHighlights(
+                to: measurement.nsAttributedString,
+                query: markdownView.searchQuery
+            )
+
             VSelectableTextView(
-                attributedString: measurement.nsAttributedString,
+                attributedString: displayString,
                 maxWidth: measurement.effectiveMaxWidth,
                 lineSpacing: 4,
                 tintColor: NSColor(markdownView.tintColor),
@@ -204,6 +211,35 @@ struct MarkdownSegmentView: View, Equatable {
                 height: measurement.size.height,
                 alignment: .leading
             )
+        }
+
+        private static func applySearchHighlights(
+            to source: NSAttributedString,
+            query: String
+        ) -> NSAttributedString {
+            guard !query.isEmpty else { return source }
+            let text = source.string
+            let nsText = text as NSString
+            let searchRange = NSRange(location: 0, length: nsText.length)
+            var ranges: [NSRange] = []
+            var start = searchRange.location
+            while start < nsText.length {
+                let found = nsText.range(
+                    of: query,
+                    options: [.caseInsensitive, .diacriticInsensitive],
+                    range: NSRange(location: start, length: nsText.length - start)
+                )
+                if found.location == NSNotFound { break }
+                ranges.append(found)
+                start = found.location + found.length
+            }
+            guard !ranges.isEmpty else { return source }
+            let result = NSMutableAttributedString(attributedString: source)
+            let highlightColor = NSColor.systemYellow.withAlphaComponent(0.4)
+            for range in ranges {
+                result.addAttribute(.backgroundColor, value: highlightColor, range: range)
+            }
+            return result
         }
     }
     #endif

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -33,6 +33,7 @@ struct MessageCellView: View, Equatable {
                   && zip(lhs.providerCatalog, rhs.providerCatalog).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName && $0.models.count == $1.models.count && zip($0.models, $1.models).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName }) }))
             && lhs.isTTSEnabled == rhs.isTTSEnabled
             && lhs.mediaEmbedSettings == rhs.mediaEmbedSettings
+            && lhs.searchQuery == rhs.searchQuery
     }
 
     let message: ChatMessage
@@ -76,6 +77,7 @@ struct MessageCellView: View, Equatable {
     let configuredProviders: Set<String>
     let providerCatalog: [ProviderCatalogEntry]
     let providerCatalogHash: Int
+    let searchQuery: String
 
     static func hashCatalog(_ catalog: [ProviderCatalogEntry]) -> Int {
         var hasher = Hasher()
@@ -133,7 +135,8 @@ struct MessageCellView: View, Equatable {
                 processingStatusText: processingStatusText,
                 isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
-                hideInlineAvatar: hideInlineAvatar
+                hideInlineAvatar: hideInlineAvatar,
+                searchQuery: searchQuery
             )
             .equatable()
         }
@@ -225,7 +228,8 @@ struct MessageCellView: View, Equatable {
                 processingStatusText: processingStatusText,
                 isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
-                hideInlineAvatar: hideInlineAvatar
+                hideInlineAvatar: hideInlineAvatar,
+                searchQuery: searchQuery
             )
             .equatable()
             .background(

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -46,6 +46,7 @@ struct MessageListContentView: View, Equatable {
             && lhs.subagentDetailStore === rhs.subagentDetailStore
             && lhs.assistantStatusText == rhs.assistantStatusText
             && lhs.pinnedLatestTurnAnchorMessageId == rhs.pinnedLatestTurnAnchorMessageId
+            && lhs.searchQuery == rhs.searchQuery
     }
 
     // MARK: - Data properties (compared in ==)
@@ -70,6 +71,7 @@ struct MessageListContentView: View, Equatable {
     let subagentDetailStore: SubagentDetailStore
     let assistantStatusText: String?
     let pinnedLatestTurnAnchorMessageId: UUID?
+    let searchQuery: String
 
     // MARK: - Closures (skipped in ==)
 
@@ -248,7 +250,8 @@ struct MessageListContentView: View, Equatable {
                     selectedModel: selectedModel,
                     configuredProviders: configuredProviders,
                     providerCatalog: providerCatalog,
-                    providerCatalogHash: providerCatalogHash
+                    providerCatalogHash: providerCatalogHash,
+                    searchQuery: searchQuery
                 )
                 .equatable()
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListTypes.swift
@@ -25,6 +25,7 @@ struct PrecomputedCacheKey: Equatable {
     /// rendered slice is different — so the projection cache invalidates
     /// whenever the window starts on a different message.
     let firstVisibleMessageId: UUID?
+    let highlightedMessageId: UUID?
 }
 
 // MARK: - Scroll Geometry Snapshot

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -84,7 +84,8 @@ extension MessageListView {
             assistantActivityReason: assistantActivityReason,
             activeSubagentFingerprint: Self.computeSubagentFingerprint(activeSubagents),
             displayedMessageCount: displayedMessageCount,
-            firstVisibleMessageId: liveMessages.first?.id
+            firstVisibleMessageId: liveMessages.first?.id,
+            highlightedMessageId: highlightedMessageId
         )
 
         // Return cached projection when the key matches and the row count

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -172,6 +172,7 @@ extension MessageListView {
             subagentDetailStore: subagentDetailStore,
             assistantStatusText: assistantStatusText,
             pinnedLatestTurnAnchorMessageId: scrollState.pinnedLatestTurnAnchorMessageId,
+            searchQuery: searchQuery,
             onConfirmationAllow: onConfirmationAllow,
             onConfirmationDeny: onConfirmationDeny,
             onAlwaysAllow: onAlwaysAllow,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -80,6 +80,7 @@ struct MessageListView: View {
     /// Measured width of the full chat pane. `layoutMetrics` derives the
     /// centered transcript column width from this value.
     var containerWidth: CGFloat = 0
+    var searchQuery: String = ""
     var layoutMetrics: MessageListLayoutMetrics {
         MessageListLayoutMetrics(containerWidth: containerWidth)
     }

--- a/clients/macos/vellum-assistantTests/ChatSearchOverlayTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatSearchOverlayTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ChatSearchOverlayTests: XCTestCase {
+    func testSearchMatchesCountsEveryOccurrenceAcrossMessages() {
+        let firstMessageId = UUID()
+        let secondMessageId = UUID()
+        let thirdMessageId = UUID()
+        let messages = [
+            ChatMessage(
+                id: firstMessageId,
+                role: .user,
+                text: "app app",
+                isStreaming: false
+            ),
+            ChatMessage(
+                id: secondMessageId,
+                role: .assistant,
+                text: "application app",
+                isStreaming: false
+            ),
+            ChatMessage(
+                id: thirdMessageId,
+                role: .assistant,
+                text: "no matching text",
+                isStreaming: false
+            )
+        ]
+
+        let matches = ChatSearchOverlay.searchMatches(in: messages, query: "app")
+
+        XCTAssertEqual(matches.count, 4)
+        XCTAssertEqual(
+            matches.map(\.messageId),
+            [firstMessageId, firstMessageId, secondMessageId, secondMessageId]
+        )
+        XCTAssertEqual(matches.map(\.range.location), [0, 4, 0, 12])
+    }
+
+    func testOccurrenceRangesMatchHighlightSearchSemantics() {
+        let ranges = ChatSearchOverlay.occurrenceRanges(
+            in: "Résumé resume RESUME",
+            query: "resume"
+        )
+
+        XCTAssertEqual(ranges.count, 3)
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageListProjectionCacheTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListProjectionCacheTests.swift
@@ -41,9 +41,57 @@ final class MessageListProjectionCacheTests: XCTestCase {
         XCTAssertEqual(sharedScrollState.messageListVersion, 2)
     }
 
+    func testChangingHighlightedMessageIdInvalidatesProjectionCache() {
+        let messageId = UUID()
+        let sharedScrollState = MessageListScrollState()
+
+        let message = ChatMessage(
+            id: messageId,
+            role: .assistant,
+            text: "Hello",
+            isStreaming: false
+        )
+
+        // First projection with no highlighted message.
+        let view1 = makeView(messages: [message], messagesRevision: 1)
+        view1.scrollState = sharedScrollState
+        let projection1 = view1.derivedState
+
+        // Capture the cache key after the first projection (highlightedMessageId == nil).
+        let keyWithoutHighlight = sharedScrollState.derivedStateCache.cachedProjectionKey
+
+        // Second projection with a highlighted message — same content,
+        // different highlightedMessageId.
+        let view2 = makeView(
+            messages: [message],
+            messagesRevision: 1,
+            highlightedMessageId: messageId
+        )
+        view2.scrollState = sharedScrollState
+        let projection2 = view2.derivedState
+
+        // Capture the cache key after the second projection (highlightedMessageId == messageId).
+        let keyWithHighlight = sharedScrollState.derivedStateCache.cachedProjectionKey
+
+        // The two cache keys must differ so the projector re-runs and picks
+        // up the new isHighlighted flag.
+        XCTAssertNotEqual(
+            keyWithoutHighlight,
+            keyWithHighlight,
+            "Changing highlightedMessageId should produce a different cache key"
+        )
+
+        // Verify the projections reflect the highlight state correctly.
+        let rows1Highlighted = projection1.rows.contains { $0.isHighlighted }
+        let rows2Highlighted = projection2.rows.contains { $0.isHighlighted }
+        XCTAssertFalse(rows1Highlighted, "No rows should be highlighted when highlightedMessageId is nil")
+        XCTAssertTrue(rows2Highlighted, "The matching row should be highlighted when highlightedMessageId is set")
+    }
+
     private func makeView(
         messages: [ChatMessage],
-        messagesRevision: UInt64
+        messagesRevision: UInt64,
+        highlightedMessageId: UUID? = nil
     ) -> MessageListView {
         MessageListView(
             messages: messages,
@@ -86,7 +134,7 @@ final class MessageListProjectionCacheTests: XCTestCase {
             loadPreviousMessagePage: nil,
             conversationId: nil,
             anchorMessageId: .constant(nil),
-            highlightedMessageId: .constant(nil),
+            highlightedMessageId: .constant(highlightedMessageId),
             isInteractionEnabled: true,
             containerWidth: 800
         )

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -101,7 +101,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
                     assistantActivityReason: nil,
                     activeSubagentFingerprint: version % 5,
                     displayedMessageCount: version % 1000,
-                    firstVisibleMessageId: nil
+                    firstVisibleMessageId: nil,
+                    highlightedMessageId: nil
                 )
                 // Force an equality check (the hot path in MessageListView.derivedState).
                 if let prev = lastKey {
@@ -397,7 +398,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             assistantActivityReason: nil,
             activeSubagentFingerprint: 7,
             displayedMessageCount: 100,
-            firstVisibleMessageId: nil
+            firstVisibleMessageId: nil,
+            highlightedMessageId: nil
         )
         cache.cachedProjection = TranscriptProjector.project(
             messages: buildMessages(count: 5),

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -49,7 +49,8 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             configuredProviders: [],
             subagentDetailStore: SubagentDetailStore(),
             assistantStatusText: nil,
-            pinnedLatestTurnAnchorMessageId: nil
+            pinnedLatestTurnAnchorMessageId: nil,
+            searchQuery: ""
         )
     }
 
@@ -79,7 +80,8 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             selectedModel: "",
             configuredProviders: [],
             providerCatalog: [],
-            providerCatalogHash: 0
+            providerCatalogHash: 0,
+            searchQuery: ""
         )
     }
 


### PR DESCRIPTION
## Summary
Fixes two bugs in the Cmd+F in-chat search and adds inline text highlighting:
1. **Search bar too wide** — Added `.widthCap(280)` to `ChatSearchBar` to prevent it from expanding to fill the full chat width
2. **No highlight on search navigation** — Added `highlightedMessageId` to `PrecomputedCacheKey` so the projection cache invalidates when a message is highlighted, fixing the bug where scrolling worked but the highlight flash never appeared
3. **Inline text highlighting** — Thread `searchQuery` through the full rendering pipeline to MarkdownSegmentView; apply yellow background highlights to all matching text in the NSAttributedString

## Self-review result
PASS — all 3 review passes (external feedback, plan faithfulness, integration) passed with no gaps

## PRs merged into feature branch
- #29494: fix(macos): constrain Cmd+F search bar to max width (LUM-1278)
- #29493: fix(macos): highlight matching message when navigating Cmd+F results (LUM-1278)
- #29501: feat(macos): highlight matching text inline in Cmd+F search (LUM-1278)

Part of plan: cmdf-search-highlight-fix.md