### PR TITLE
Suppress version mismatch banner in local dev environment

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowVersionMismatchBanner.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowVersionMismatchBanner.swift
@@ -11,7 +11,8 @@ struct MainWindowVersionMismatchBanner: View {
     let windowState: MainWindowState
 
     var body: some View {
-        if connectionManager.versionMismatch && !connectionManager.isUpdateInProgress && !isDismissed {
+        if connectionManager.versionMismatch && !connectionManager.isUpdateInProgress && !isDismissed
+            && VellumEnvironment.current != .local {
             // Suppress when the "Update" pill already covers it (daemon behind + update available)
             if !(updateManager.isServiceGroupUpdateAvailable && isDaemonBehind) {
                 if isDaemonBehind {


### PR DESCRIPTION
In local dev minikube setups, version mismatches between the desktop app and the assistant are expected during development. The warning banner adds noise without actionable value in this context, so suppress it when `VellumEnvironment.current == .local`.

---

## Prompt / plan
Suppress the version mismatch warning banner in the macOS desktop app when running in the local dev minikube setup.

## Test plan
Build in Xcode with `VELLUM_ENVIRONMENT=local` and verify the version mismatch banner no longer appears. CI skips macOS builds.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/ad3a4ca9afb842f888b0fabdec45c790
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->