### PR TITLE
[codex] Retire app_create html shortcut

### DIFF
--- a/assistant/src/__tests__/app-builder-tool-scripts.test.ts
+++ b/assistant/src/__tests__/app-builder-tool-scripts.test.ts
@@ -93,7 +93,7 @@ describe("app-builder skill tool scripts", () => {
 
     test("delegates to executeAppCreate and returns result", async () => {
       const result = await appCreateScript.run(
-        { name: "My App", html: "<p>Hello</p>" },
+        { name: "My App" },
         makeContext(),
       );
       expect(result.isError).toBe(false);
@@ -107,7 +107,7 @@ describe("app-builder skill tool scripts", () => {
         isError: false,
       });
       const result = await appCreateScript.run(
-        { name: "Auto App", html: "<div/>" },
+        { name: "Auto App" },
         makeContext({ proxyToolResolver: proxy }),
       );
       expect(result.isError).toBe(false);
@@ -118,7 +118,7 @@ describe("app-builder skill tool scripts", () => {
 
     test("handles missing proxyToolResolver gracefully", async () => {
       const result = await appCreateScript.run(
-        { name: "No Proxy", html: "<p/>" },
+        { name: "No Proxy" },
         makeContext(),
       );
       expect(result.isError).toBe(false);

--- a/assistant/src/__tests__/app-bundler.test.ts
+++ b/assistant/src/__tests__/app-bundler.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,11 +28,59 @@ const mockApps = new Map<string, Record<string, unknown>>();
 mock.module("../memory/app-store.js", () => ({
   getApp: (id: string) => mockApps.get(id) ?? null,
   getAppsDir: () => testAppsDir,
+  getAppDirPath: (id: string) => join(testAppsDir, id),
+  isMultifileApp: (app: Record<string, unknown>) => app.formatVersion === 2,
 }));
 
 // Mock content-id to avoid pulling in crypto internals
 mock.module("../util/content-id.js", () => ({
   computeContentId: () => "abcd1234abcd1234",
+}));
+
+let compileAppOverride:
+  | ((appDir: string) => Promise<{
+      ok: boolean;
+      errors: Array<{
+        text: string;
+        location?: { file: string; line: number; column: number };
+      }>;
+      warnings: Array<{ text: string }>;
+      durationMs: number;
+    }>)
+  | undefined;
+
+async function compileAppFixture(appDir: string) {
+  if (compileAppOverride) {
+    return compileAppOverride(appDir);
+  }
+
+  const srcDir = join(appDir, "src");
+  const distDir = join(appDir, "dist");
+  rmSync(distDir, { recursive: true, force: true });
+  mkdirSync(distDir, { recursive: true });
+
+  let html = readFileSync(join(srcDir, "index.html"), "utf-8");
+  const cssPath = join(srcDir, "styles.css");
+  if (existsSync(cssPath)) {
+    writeFileSync(join(distDir, "main.css"), readFileSync(cssPath));
+    html = html.replace(
+      "</head>",
+      '  <link rel="stylesheet" href="main.css">\n  </head>',
+    );
+  }
+  html = html.replace(
+    "</body>",
+    '  <script type="module" src="main.js"></script>\n  </body>',
+  );
+
+  writeFileSync(join(distDir, "index.html"), html);
+  writeFileSync(join(distDir, "main.js"), "console.log('compiled');");
+
+  return { ok: true, errors: [], warnings: [], durationMs: 1 };
+}
+
+mock.module("../bundler/app-compiler.js", () => ({
+  compileApp: compileAppFixture,
 }));
 
 // Mock bundle-signer (not exercised in these tests)
@@ -43,6 +97,7 @@ import type { AppManifest } from "../bundler/manifest.js";
 
 describe("packageApp", () => {
   afterEach(() => {
+    compileAppOverride = undefined;
     mockApps.clear();
     try {
       rmSync(testAppsDir, { recursive: true, force: true });
@@ -85,6 +140,29 @@ describe("packageApp", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
       formatVersion: 2,
+    };
+    writeFileSync(join(testAppsDir, `${appId}.json`), JSON.stringify(appDef));
+    mockApps.set(appId, appDef);
+
+    return appDef;
+  }
+
+  function setupLegacyApp(appId: string) {
+    const appDir = join(testAppsDir, appId);
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, "index.html"),
+      "<!DOCTYPE html><html><body><h1>Legacy</h1></body></html>",
+    );
+
+    const appDef = {
+      id: appId,
+      name: "Legacy App",
+      description: "A legacy app",
+      schemaJson: "{}",
+      htmlDefinition: "<unused>",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
     };
     writeFileSync(join(testAppsDir, `${appId}.json`), JSON.stringify(appDef));
     mockApps.set(appId, appDef);
@@ -140,6 +218,17 @@ describe("packageApp", () => {
     const appDir = join(testAppsDir, appId);
     const srcDir = join(appDir, "src");
     mkdirSync(srcDir, { recursive: true });
+    compileAppOverride = async () => ({
+      ok: false,
+      errors: [
+        {
+          text: "Expected identifier",
+          location: { file: "src/main.tsx", line: 1, column: 20 },
+        },
+      ],
+      warnings: [],
+      durationMs: 1,
+    });
 
     // Write intentionally broken source so esbuild fails
     writeFileSync(join(srcDir, "main.tsx"), "const x: number = {{{BROKEN");
@@ -165,6 +254,70 @@ describe("packageApp", () => {
     );
   });
 
+  test("rejects formatVersion 2 apps missing src files before bundling", async () => {
+    const appId = "multi-missing-src";
+    const appDir = join(testAppsDir, appId);
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, "index.html"),
+      "<!DOCTYPE html><html><body><h1>Wrong root</h1></body></html>",
+    );
+
+    const appDef = {
+      id: appId,
+      name: "Missing Source App",
+      schemaJson: "{}",
+      htmlDefinition: "<unused>",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      formatVersion: 2,
+    };
+    writeFileSync(join(testAppsDir, `${appId}.json`), JSON.stringify(appDef));
+    mockApps.set(appId, appDef);
+
+    await expect(packageApp(appId)).rejects.toThrow(
+      /missing src\/index\.html and src\/main\.tsx/,
+    );
+  });
+
+  test("rejects app_create scaffold before sharing", async () => {
+    const appId = "multi-default-scaffold";
+    const appDir = join(testAppsDir, appId);
+    const srcDir = join(appDir, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(
+      join(srcDir, "index.html"),
+      '<!DOCTYPE html><html><body><div id="app"></div></body></html>',
+    );
+    writeFileSync(
+      join(srcDir, "main.tsx"),
+      `import { render } from 'preact';
+
+function App() {
+  return <div>{"Hello, Scaffold!"}</div>;
+}
+
+render(<App />, document.getElementById('app')!);
+`,
+    );
+
+    const appDef = {
+      id: appId,
+      name: "Scaffold App",
+      schemaJson: "{}",
+      htmlDefinition: "<unused>",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      formatVersion: 2,
+    };
+    writeFileSync(join(testAppsDir, `${appId}.json`), JSON.stringify(appDef));
+    mockApps.set(appId, appDef);
+
+    await expect(packageApp(appId)).rejects.toThrow(
+      /still has the default src\/main\.tsx scaffold/,
+    );
+  });
+
   test("app without CSS omits main.css from zip", async () => {
     const appId = "multi-no-css";
     setupApp(appId, { withCss: false });
@@ -176,5 +329,21 @@ describe("packageApp", () => {
     expect(zip.file("index.html")).not.toBeNull();
     expect(zip.file("main.js")).not.toBeNull();
     expect(zip.file("main.css")).toBeNull();
+  });
+
+  test("keeps legacy single-file apps packageable", async () => {
+    const appId = "legacy-single-file";
+    setupLegacyApp(appId);
+
+    const result = await packageApp(appId);
+    const zipData = await readFile(result.bundlePath);
+    const zip = await JSZip.loadAsync(zipData);
+
+    const indexContent = await zip.file("index.html")!.async("string");
+    const manifestJson = await zip.file("manifest.json")!.async("string");
+    const manifest: AppManifest = JSON.parse(manifestJson);
+
+    expect(indexContent).toContain("<h1>Legacy</h1>");
+    expect(manifest.format_version).toBe(1);
   });
 });

--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -104,7 +104,7 @@ describe("executeAppCreate", () => {
     expect(files["src/main.tsx"]).toContain('{"Hello, New App!"}');
   });
 
-  test("with explicit html: uses provided html as src/index.html", async () => {
+  test("rejects retired html shortcut", async () => {
     const files: Record<string, string> = {};
     const app = makeMultifileApp({ name: "Custom App" });
     const store: AppStore = {
@@ -112,21 +112,41 @@ describe("executeAppCreate", () => {
       createApp: () => app,
     };
 
-    const customHtml =
-      '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>';
     const result = await executeAppCreate(
       {
         name: "Custom App",
-        html: customHtml,
+        html: "<!DOCTYPE html><html><body></body></html>",
       },
       store,
     );
 
-    expect(result.isError).toBe(false);
-    // Explicit HTML should be used instead of scaffold
-    expect(files["src/index.html"]).toBe(customHtml);
-    // main.tsx scaffold should still be written
-    expect(files["src/main.tsx"]).toBeDefined();
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain("app_create no longer accepts html");
+    expect(files["src/index.html"]).toBeUndefined();
+    expect(files["src/main.tsx"]).toBeUndefined();
+  });
+
+  test("rejects retired pages shortcut", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "Custom App" });
+    const store = mockStore(app, files);
+
+    const result = await executeAppCreate(
+      {
+        name: "Custom App",
+        pages: {
+          "settings.html": "<!DOCTYPE html><html><body></body></html>",
+        },
+      },
+      store,
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain("app_create no longer accepts pages");
+    expect(files["src/index.html"]).toBeUndefined();
+    expect(files["src/main.tsx"]).toBeUndefined();
   });
 });
 

--- a/assistant/src/__tests__/credential-execution-feature-gates.test.ts
+++ b/assistant/src/__tests__/credential-execution-feature-gates.test.ts
@@ -171,7 +171,7 @@ describe("CES flags do not affect unrelated flags", () => {
     expect(isAssistantFeatureFlagEnabled("browser", config)).toBe(true);
   });
 
-  test("enabling all CES flags does not change app-builder-multifile flag (defaultEnabled: true)", () => {
+  test("enabling all CES flags does not change unrelated default-open flags", () => {
     const overrides: Record<string, boolean> = {};
     for (const key of ALL_CES_FLAG_KEYS) {
       overrides[key] = true;
@@ -179,9 +179,9 @@ describe("CES flags do not affect unrelated flags", () => {
     _setOverridesForTesting(overrides);
     const config = makeConfig();
 
-    // app-builder-multifile defaults to true in the registry and should stay true
-    expect(isAssistantFeatureFlagEnabled("app-builder-multifile", config)).toBe(
-      true,
-    );
+    // Unknown flags default open unless explicitly overridden.
+    expect(
+      isAssistantFeatureFlagEnabled("unrelated-default-open", config),
+    ).toBe(true);
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -19,7 +19,8 @@ afterEach(() => {
 const DECLARED_FLAG_ID = "email-channel";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
 const DECLARED_SKILL_ID = "email-channel";
-const APP_BUILDER_MULTIFILE_FLAG_KEY = "app-builder-multifile";
+const ENABLED_UNDECLARED_FLAG_KEY = "enabled-undeclared-flag";
+const ENABLED_UNDECLARED_SKILL_ID = "enabled-undeclared-skill";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -167,14 +168,14 @@ describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
+      [ENABLED_UNDECLARED_FLAG_KEY]: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
       makeSkill(
-        "app-builder-multifile",
+        ENABLED_UNDECLARED_SKILL_ID,
         "bundled",
-        APP_BUILDER_MULTIFILE_FLAG_KEY,
+        ENABLED_UNDECLARED_FLAG_KEY,
       ),
     ];
     const config = makeConfig();
@@ -183,20 +184,20 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).not.toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("app-builder-multifile");
+    expect(ids).toContain(ENABLED_UNDECLARED_SKILL_ID);
   });
 
   test("flag ON skill appears normally", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: true,
-      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
+      [ENABLED_UNDECLARED_FLAG_KEY]: true,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
       makeSkill(
-        "app-builder-multifile",
+        ENABLED_UNDECLARED_SKILL_ID,
         "bundled",
-        APP_BUILDER_MULTIFILE_FLAG_KEY,
+        ENABLED_UNDECLARED_FLAG_KEY,
       ),
     ];
     const config = makeConfig();
@@ -205,7 +206,7 @@ describe("resolveSkillStates with feature flags", () => {
     const ids = resolved.map((r) => r.summary.id);
 
     expect(ids).toContain(DECLARED_SKILL_ID);
-    expect(ids).toContain("app-builder-multifile");
+    expect(ids).toContain(ENABLED_UNDECLARED_SKILL_ID);
   });
 
   test("declared flag key defaults to registry value (false)", () => {
@@ -257,15 +258,15 @@ describe("resolveSkillStates with feature flags", () => {
   test("multiple skills with mixed flags — persisted overrides respected", () => {
     _setOverridesForTesting({
       [DECLARED_FLAG_KEY]: false,
-      [APP_BUILDER_MULTIFILE_FLAG_KEY]: true,
+      [ENABLED_UNDECLARED_FLAG_KEY]: true,
       deploy: false,
     });
     const catalog = [
       makeSkill(DECLARED_SKILL_ID, "bundled", DECLARED_FLAG_ID),
       makeSkill(
-        "app-builder-multifile",
+        ENABLED_UNDECLARED_SKILL_ID,
         "bundled",
-        APP_BUILDER_MULTIFILE_FLAG_KEY,
+        ENABLED_UNDECLARED_FLAG_KEY,
       ),
       makeSkill("deploy", "bundled", "deploy"),
     ];
@@ -274,8 +275,8 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // email-channel and deploy explicitly false; app-builder-multifile explicitly true
-    expect(ids).toEqual(["app-builder-multifile"]);
+    // email-channel and deploy explicitly false; one unrelated skill explicitly true
+    expect(ids).toEqual([ENABLED_UNDECLARED_SKILL_ID]);
   });
 });
 

--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -17,6 +17,7 @@ import JSZip from "jszip";
 import { getApp, getAppDirPath, isMultifileApp } from "../memory/app-store.js";
 import { computeContentId } from "../util/content-id.js";
 import { getLogger } from "../util/logger.js";
+import { APP_VERSION } from "../version.js";
 import { compileApp } from "./app-compiler.js";
 import type { SigningCallback } from "./bundle-signer.js";
 import { signBundle } from "./bundle-signer.js";
@@ -25,7 +26,6 @@ import { serializeManifest } from "./manifest.js";
 
 const bundlerLog = getLogger("app-bundler");
 
-import { APP_VERSION } from "../version.js";
 const PACKAGE_VERSION = APP_VERSION;
 
 const MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB
@@ -35,6 +35,45 @@ export interface BundleResult {
   manifest: AppManifest;
   /** Base64-encoded PNG of the app icon, if one was generated. */
   iconImageBase64?: string;
+}
+
+function isDefaultMainScaffold(source: string): boolean {
+  const normalized = source.replace(/\s+/g, " ").trim();
+  return (
+    normalized.startsWith(
+      `import { render } from 'preact'; function App() { return <div>{"Hello, `,
+    ) &&
+    normalized.endsWith(
+      `!"}</div>; } render(<App />, document.getElementById('app')!);`,
+    )
+  );
+}
+
+function assertMultifileSourceReady(
+  app: { name: string },
+  appDir: string,
+): void {
+  const srcIndexPath = join(appDir, "src", "index.html");
+  const srcMainPath = join(appDir, "src", "main.tsx");
+  const missing = [
+    !existsSync(srcIndexPath) ? "src/index.html" : null,
+    !existsSync(srcMainPath) ? "src/main.tsx" : null,
+  ].filter((value): value is string => value !== null);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `App "${app.name}" is a multi-file TSX app but is missing ${missing.join(
+        " and ",
+      )}. Write source files under src/ and call app_refresh before sharing.`,
+    );
+  }
+
+  const mainSource = readFileSync(srcMainPath, "utf-8");
+  if (isDefaultMainScaffold(mainSource)) {
+    throw new Error(
+      `App "${app.name}" still has the default src/main.tsx scaffold. Write the real multi-file TSX source and call app_refresh before sharing.`,
+    );
+  }
 }
 
 /**
@@ -82,6 +121,8 @@ export async function packageApp(
   const appDir = getAppDirPath(appId);
 
   if (multifile) {
+    assertMultifileSourceReady(app, appDir);
+
     // Multi-file TSX app: compile src/ -> dist/
     const compileResult = await compileApp(appDir);
     if (!compileResult.ok) {
@@ -97,8 +138,15 @@ export async function packageApp(
     }
 
     const distDir = join(appDir, "dist");
-    const indexHtml = await readFile(join(distDir, "index.html"), "utf-8");
-    const mainJs = await readFile(join(distDir, "main.js"));
+    const distIndexPath = join(distDir, "index.html");
+    const distMainPath = join(distDir, "main.js");
+    if (!existsSync(distIndexPath) || !existsSync(distMainPath)) {
+      throw new Error(
+        `Compilation for app "${app.name}" did not produce dist/index.html and dist/main.js. Check src/index.html and src/main.tsx, then call app_refresh.`,
+      );
+    }
+    const indexHtml = await readFile(distIndexPath, "utf-8");
+    const mainJs = await readFile(distMainPath);
 
     compiledFiles.push({ name: "index.html", data: Buffer.from(indexHtml) });
     compiledFiles.push({ name: "main.js", data: mainJs });

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-builder
-description: Build interactive apps, dashboards, calculators, games, trackers, tools, landing pages, and data visualizations with HTML/CSS/JS
+description: Build interactive apps, dashboards, calculators, games, trackers, tools, landing pages, and data visualizations with Preact/TypeScript/CSS
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🏗️"
@@ -30,11 +30,11 @@ Apps live under `{workspaceDir}/data/apps/`. Each app has a slug-based layout:
 {workspaceDir}/data/apps/
   <slug>.json          # App metadata
   <slug>/              # App directory (contains all app files)
-    index.html         # Main page (entry point rendered in WebView)
-    pages/             # Additional pages
+    index.html         # Legacy single-file entry point (do not create for new apps)
+    pages/             # Legacy additional pages (do not create for new apps)
     records/           # Data records (one JSON file per record)
-    src/               # Source files (multifile TSX apps, formatVersion: 2)
-    dist/              # Compiled output (multifile TSX apps)
+    src/               # Source files (multi-file TSX apps, formatVersion: 2)
+    dist/              # Compiled output (multi-file TSX apps)
   <slug>.preview       # Preview image (auto-generated)
 ```
 
@@ -42,7 +42,7 @@ Apps live under `{workspaceDir}/data/apps/`. Each app has a slug-based layout:
 
 Fields: `id`, `name`, `description`, `icon`, `schemaJson`, `createdAt`, `updatedAt`, `formatVersion`, `dirName`.
 
-**Important:** `htmlDefinition` and `pages` are NOT stored in the metadata JSON — they live as separate files inside the app directory (`index.html` and `pages/`).
+**Important:** Legacy `htmlDefinition` and `pages` content is NOT stored in the metadata JSON — it lives as separate files inside the app directory (`index.html` and `pages/`). Do not create new single-file apps or new `pages/` directories.
 
 ### Records
 
@@ -52,9 +52,9 @@ Each record is a JSON file at `<slug>/records/<uuid>.json` with shape:
 { "id": "<uuid>", "appId": "<app-id>", "data": { ... }, "createdAt": "...", "updatedAt": "..." }
 ```
 
-### Multifile TSX Apps
+### Multi-file TSX Apps
 
-For `formatVersion: 2` apps, source files live under `src/` and compiled output under `dist/`. The build system compiles TSX → JS automatically when `app_refresh` is called.
+All new apps use `formatVersion: 2`: source files live under `src/` and compiled output lives under `dist/`. The build system compiles TSX to JS automatically when `app_refresh` is called.
 
 ## Workflow
 
@@ -69,7 +69,7 @@ For `formatVersion: 2` apps, source files live under `src/` and compiled output 
 
 **Make creative decisions on behalf of the user.** They want to be delighted, not consulted. Pick the accent color. Choose between a dark moody aesthetic or a light airy one. Decide if cards should have glassmorphism or layered shadows. Add a background pattern or gradient. These are YOUR decisions as the designer.
 
-**Prefer multi-file TSX projects** for any non-trivial app. They give you component reuse, TypeScript safety, and cleaner organization. Fall back to single-file HTML only for the simplest one-off pages.
+**Build all new apps as multi-file TSX projects.** They give you component reuse, TypeScript safety, and cleaner organization.
 
 **Only ask questions when the request is genuinely ambiguous** - e.g., "build me an app" with no indication of what kind. Even then, prefer building something impressive based on context clues over asking a battery of questions.
 
@@ -117,7 +117,7 @@ Apps are rendered inside a sandboxed WebView on macOS.
 
 #### Multi-file TSX projects
 
-Build apps as multi-file TSX projects. You get component reuse, TypeScript type-checking, and clean file organization. The build system uses esbuild to bundle everything automatically.
+Build apps as multi-file TSX projects. You get component reuse, TypeScript type-checking, and clean file organization. The build system uses esbuild to bundle everything automatically. Do not create root-level `index.html` files or `pages/` directories for new apps.
 
 **Project structure:**
 
@@ -179,7 +179,7 @@ useEffect(() => {
 }, []);
 ```
 
-**File workflow:** Use `file_write` for each source file. After writing all files, call `app_refresh` once to compile and refresh the UI.
+**File workflow:** Call `app_create` first to create the app record and scaffold, use `file_write` for each source file under `src/`, then call `app_refresh` once to compile and refresh the UI.
 
 **Allowed third-party packages:** `date-fns`, `chart.js`, `lodash-es`, `zod`, `clsx`, `lucide`. Import them directly - esbuild resolves them at build time. No CDN imports. Note: `lucide` is the vanilla JS icon library (not `lucide-react`). Use its `createElement` or `createIcons` API, or manually inline SVG - do not import JSX icon components.
 
@@ -331,9 +331,10 @@ Call `app_create` with:
 - `name`: Short descriptive name
 - `description`: One-sentence summary
 - `schema_json`: JSON schema as string
-- `html`: (optional) Complete HTML document as string for `index.html`. If omitted, a minimal scaffold is created - you can then write `index.html` and other files via `file_write`.
 - `auto_open`: (optional, defaults to `true`) Shows an inline preview card in chat
 - `preview`: Always include - `title` (required), `subtitle`, `description`, `icon` (image URL preferred, emoji fallback), `metrics` (up to 3 key-value pills)
+
+Do not pass `html` or `pages` to `app_create`; those single-file shortcuts are retired. After `app_create` returns the app ID, write the real app source under `src/` and call `app_refresh`.
 
 The app is NOT opened in a workspace panel automatically - users open it via the 'Open App' button on the inline card.
 
@@ -348,7 +349,7 @@ When the user requests changes, prefer **`file_edit`** over rewriting the entire
 
 After making all file changes, call `app_refresh(app_id)` once to compile and refresh the UI. Do NOT call it after every individual file edit — batch your changes first.
 
-Apps can have multiple files (`styles.css`, `app.js`, etc.). Link from `index.html` with standard tags.
+Apps should have multiple source files under `src/` (`styles.css`, components, helpers, etc.). Import CSS and modules from TSX so esbuild includes them in the compiled output.
 
 ## Interaction Standards
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "app_create",
-      "description": "Create a persistent app with a name, optional description, JSON schema, and HTML definition.",
+      "description": "Create a persistent multi-file TSX app scaffold with a name, optional description, and JSON schema. Write source files under src/ with file tools, then call app_refresh.",
       "category": "apps",
       "risk": "low",
       "input_schema": {
@@ -20,17 +20,6 @@
           "schema_json": {
             "type": "string",
             "description": "JSON schema defining the app data structure"
-          },
-          "html": {
-            "type": "string",
-            "description": "Optional HTML definition for the main index.html page. If omitted, a minimal scaffold is created and you can write index.html later via file_write."
-          },
-          "pages": {
-            "type": "object",
-            "description": "Optional additional pages as a mapping of filename to HTML content (e.g. {\"settings.html\": \"<html>...</html>\"}). Navigate between pages with <a href=\"settings.html\">. Do not include index.html here \u2014 use the html parameter instead.",
-            "additionalProperties": {
-              "type": "string"
-            }
           },
           "auto_open": {
             "type": "boolean",

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -77,7 +77,14 @@ export interface AppCreateInput {
   name: string;
   description?: string;
   schema_json?: string;
-  html?: string;
+  /**
+   * Retired single-file shortcut. Kept in the type so legacy or stale callers
+   * get a clear tool error instead of silently creating a v2 app with stale
+   * scaffold content.
+   */
+  html?: unknown;
+  /** Retired single-file multi-page shortcut. */
+  pages?: unknown;
   auto_open?: boolean;
   preview?: Record<string, unknown>;
 }
@@ -90,12 +97,22 @@ export async function executeAppCreate(
   const name = input.name;
   const description = input.description;
   const schemaJson = input.schema_json ?? "{}";
-  // Reject invalid html types (e.g. object/number) so malformed tool calls
-  // surface errors early.
-  if (input.html != null && typeof input.html !== "string") {
+
+  if (Object.prototype.hasOwnProperty.call(input, "html")) {
     return {
       content: JSON.stringify({
-        error: `html must be a string, got ${typeof input.html}`,
+        error:
+          "app_create no longer accepts html. Create the app scaffold, write src/index.html and src/main.tsx with file_write, then call app_refresh.",
+      }),
+      isError: true,
+    };
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "pages")) {
+    return {
+      content: JSON.stringify({
+        error:
+          "app_create no longer accepts pages. Build multi-file TSX apps under src/ and route inside the Preact app instead.",
       }),
       isError: true,
     };
@@ -135,10 +152,7 @@ export async function executeAppCreate(
     .replace(/"/g, "&quot;");
   const jsxSafeName = name.replace(/[<>{}&"']/g, "");
 
-  const indexHtml =
-    typeof input.html === "string"
-      ? input.html
-      : `<!DOCTYPE html>
+  const indexHtml = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -42,7 +42,6 @@ export interface AppStoreWriter {
     icon?: string;
     schemaJson: string;
     htmlDefinition: string;
-    pages?: Record<string, string>;
     formatVersion?: number;
   }): AppDefinition;
   updateApp(


### PR DESCRIPTION
## Summary

Retires the single-file `html` and `pages` shortcuts from `app_create` so new app builds follow the multi-file TSX workflow consistently.

## Root Cause

`app_create` still advertised and accepted single-file HTML inputs even though new apps are format-version-2 multi-file apps. That let stale callers create apps whose real source lived in the wrong place or whose `src/` scaffold stayed untouched, which could make sharing/bundling fail without a useful explanation.

## Changes

- Remove `html` and `pages` from the `app_create` tool schema and app-builder skill instructions.
- Return explicit tool errors when stale callers still pass `html` or `pages`.
- Add bundle-time validation for malformed format-version-2 apps missing `src/index.html` / `src/main.tsx` or still using the default scaffold.
- Preserve package/share support for legacy single-file apps.
- Clean up stale `app-builder-multifile` test references.

## Validation

- `cd assistant && bun test src/__tests__/app-executors.test.ts src/__tests__/app-builder-tool-scripts.test.ts src/__tests__/app-bundler.test.ts src/__tests__/skill-feature-flags.test.ts src/__tests__/credential-execution-feature-gates.test.ts`
- `cd assistant && bunx tsc --noEmit`
- Commit hook: formatting, assistant lint, assistant typecheck
- Pre-push hook: assistant typecheck and lint

Closes JARVIS-662