### PR TITLE
feat(macos): highlight matching text inline in Cmd+F search (LUM-1278)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -42,6 +42,7 @@ struct ChatBubble: View, Equatable {
             && lhs.isTTSEnabled == rhs.isTTSEnabled
             && lhs.hideInlineAvatar == rhs.hideInlineAvatar
             && lhs.activeSurfaceId == rhs.activeSurfaceId
+            && lhs.searchQuery == rhs.searchQuery
     }
     let message: ChatMessage
     /// Decided confirmation from the next message, rendered as a compact chip at the bottom.
@@ -93,6 +94,7 @@ struct ChatBubble: View, Equatable {
     /// When true, suppress the inline avatar on this bubble because
     /// `thinkingAvatarRow` is rendering one below the thinking indicator.
     var hideInlineAvatar: Bool = false
+    var searchQuery: String = ""
     /// Owned but never read in this body — only ChatBubbleOverflowMenu reads it,
     /// so hover changes invalidate only the overflow menu, not this view.
     @State private var hoverState = ChatBubbleHoverState()
@@ -152,7 +154,8 @@ struct ChatBubble: View, Equatable {
         processingStatusText: String? = nil,
         isStreamingContinuation: Bool = false,
         activeSurfaceId: String? = nil,
-        hideInlineAvatar: Bool = false
+        hideInlineAvatar: Bool = false,
+        searchQuery: String = ""
     ) {
         self.message = message
         self.decidedConfirmation = decidedConfirmation
@@ -180,6 +183,7 @@ struct ChatBubble: View, Equatable {
         self.isStreamingContinuation = isStreamingContinuation
         self.activeSurfaceId = activeSurfaceId
         self.hideInlineAvatar = hideInlineAvatar
+        self.searchQuery = searchQuery
 
         // Eagerly compute interleaved content cache so the first body
         // evaluation uses the correct layout path (no flash).
@@ -908,7 +912,8 @@ struct ChatBubble: View, Equatable {
                         tintColor: isUser ? VColor.contentDefault : VColor.primaryBase,
                         codeTextColor: isUser ? VColor.contentDefault : VColor.systemNegativeStrong,
                         codeBackgroundColor: isUser ? VColor.contentDefault.opacity(0.1) : VColor.surfaceActive,
-                        hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase
+                        hrColor: isUser ? VColor.contentDefault.opacity(0.3) : VColor.borderBase,
+                        searchQuery: searchQuery
                     )
                     .equatable()
                 } else if !message.attachments.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatSearchOverlay.swift
@@ -8,13 +8,13 @@ struct ChatSearchOverlay: View {
     var viewModel: ChatViewModel
     @Binding var isSearchActive: Bool
     @Binding var anchorMessageId: UUID?
+    @Binding var searchQuery: String
 
-    @State private var searchText = ""
     @State private var currentMatchIndex = 0
 
     private var searchMatches: [UUID] {
-        guard isSearchActive, !searchText.isEmpty else { return [] }
-        let query = searchText.lowercased()
+        guard isSearchActive, !searchQuery.isEmpty else { return [] }
+        let query = searchQuery.lowercased()
         return viewModel.messages.filter { $0.text.lowercased().contains(query) }.map(\.id)
     }
 
@@ -22,7 +22,7 @@ struct ChatSearchOverlay: View {
         Group {
             if isSearchActive {
                 ChatSearchBar(
-                    searchText: $searchText,
+                    searchText: $searchQuery,
                     matchCount: searchMatches.count,
                     currentMatchIndex: currentMatchIndex,
                     onPrevious: { navigateMatch(delta: -1) },
@@ -35,7 +35,7 @@ struct ChatSearchOverlay: View {
                 .layoutHangSignpost("chat.searchOverlay")
             }
         }
-        .onChange(of: searchText) {
+        .onChange(of: searchQuery) {
             currentMatchIndex = 0
             scrollToCurrentMatch()
         }
@@ -47,7 +47,7 @@ struct ChatSearchOverlay: View {
         }
         .onChange(of: isSearchActive) { _, active in
             if !active {
-                searchText = ""
+                searchQuery = ""
                 currentMatchIndex = 0
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -104,6 +104,7 @@ struct ChatView: View {
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
+    @State private var searchQuery = ""
     @State private var showSkeleton = false
     @State private var skeletonDebounceTask: Task<Void, Never>? = nil
     @State private var diskPressureDismissalRefreshToken = 0
@@ -179,7 +180,8 @@ struct ChatView: View {
             ChatSearchOverlay(
                 viewModel: viewModel,
                 isSearchActive: $isSearchActive,
-                anchorMessageId: $anchorMessageId
+                anchorMessageId: $anchorMessageId,
+                searchQuery: $searchQuery
             )
         }
         .animation(VAnimation.fast, value: isSearchActive)
@@ -360,7 +362,8 @@ struct ChatView: View {
                 anchorMessageId: $anchorMessageId,
                 highlightedMessageId: $highlightedMessageId,
                 isInteractionEnabled: isInteractionEnabled,
-                containerWidth: containerWidth
+                containerWidth: containerWidth,
+                searchQuery: searchQuery
             )
             .animation(nil, value: queuedMessages.isEmpty)
 

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -38,6 +38,7 @@ struct MarkdownSegmentView: View, Equatable {
     var codeTextColor: Color = VColor.systemNegativeStrong
     var codeBackgroundColor: Color = VColor.surfaceActive
     var hrColor: Color = VColor.borderBase
+    var searchQuery: String = ""
     #if os(macOS)
     @ObservedObject private var typographyObserver = VFont.typographyObserver
     #endif
@@ -54,6 +55,7 @@ struct MarkdownSegmentView: View, Equatable {
             && lhs.codeTextColor == rhs.codeTextColor
             && lhs.codeBackgroundColor == rhs.codeBackgroundColor
             && lhs.hrColor == rhs.hrColor
+            && lhs.searchQuery == rhs.searchQuery
     }
 
     var body: some View {
@@ -192,8 +194,13 @@ struct MarkdownSegmentView: View, Equatable {
                 isStreamingTail: isStreamingTail
             )
 
+            let displayString = Self.applySearchHighlights(
+                to: measurement.nsAttributedString,
+                query: markdownView.searchQuery
+            )
+
             VSelectableTextView(
-                attributedString: measurement.nsAttributedString,
+                attributedString: displayString,
                 maxWidth: measurement.effectiveMaxWidth,
                 lineSpacing: 4,
                 tintColor: NSColor(markdownView.tintColor),
@@ -204,6 +211,35 @@ struct MarkdownSegmentView: View, Equatable {
                 height: measurement.size.height,
                 alignment: .leading
             )
+        }
+
+        private static func applySearchHighlights(
+            to source: NSAttributedString,
+            query: String
+        ) -> NSAttributedString {
+            guard !query.isEmpty else { return source }
+            let text = source.string
+            let nsText = text as NSString
+            let searchRange = NSRange(location: 0, length: nsText.length)
+            var ranges: [NSRange] = []
+            var start = searchRange.location
+            while start < nsText.length {
+                let found = nsText.range(
+                    of: query,
+                    options: [.caseInsensitive, .diacriticInsensitive],
+                    range: NSRange(location: start, length: nsText.length - start)
+                )
+                if found.location == NSNotFound { break }
+                ranges.append(found)
+                start = found.location + found.length
+            }
+            guard !ranges.isEmpty else { return source }
+            let result = NSMutableAttributedString(attributedString: source)
+            let highlightColor = NSColor.systemYellow.withAlphaComponent(0.4)
+            for range in ranges {
+                result.addAttribute(.backgroundColor, value: highlightColor, range: range)
+            }
+            return result
         }
     }
     #endif

--- a/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageCellView.swift
@@ -33,6 +33,7 @@ struct MessageCellView: View, Equatable {
                   && zip(lhs.providerCatalog, rhs.providerCatalog).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName && $0.models.count == $1.models.count && zip($0.models, $1.models).allSatisfy({ $0.id == $1.id && $0.displayName == $1.displayName }) }))
             && lhs.isTTSEnabled == rhs.isTTSEnabled
             && lhs.mediaEmbedSettings == rhs.mediaEmbedSettings
+            && lhs.searchQuery == rhs.searchQuery
     }
 
     let message: ChatMessage
@@ -76,6 +77,7 @@ struct MessageCellView: View, Equatable {
     let configuredProviders: Set<String>
     let providerCatalog: [ProviderCatalogEntry]
     let providerCatalogHash: Int
+    let searchQuery: String
 
     static func hashCatalog(_ catalog: [ProviderCatalogEntry]) -> Int {
         var hasher = Hasher()
@@ -133,7 +135,8 @@ struct MessageCellView: View, Equatable {
                 processingStatusText: processingStatusText,
                 isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
-                hideInlineAvatar: hideInlineAvatar
+                hideInlineAvatar: hideInlineAvatar,
+                searchQuery: searchQuery
             )
             .equatable()
         }
@@ -225,7 +228,8 @@ struct MessageCellView: View, Equatable {
                 processingStatusText: processingStatusText,
                 isStreamingContinuation: isStreamingContinuation,
                 activeSurfaceId: activeSurfaceId,
-                hideInlineAvatar: hideInlineAvatar
+                hideInlineAvatar: hideInlineAvatar,
+                searchQuery: searchQuery
             )
             .equatable()
             .background(

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListContentView.swift
@@ -46,6 +46,7 @@ struct MessageListContentView: View, Equatable {
             && lhs.subagentDetailStore === rhs.subagentDetailStore
             && lhs.assistantStatusText == rhs.assistantStatusText
             && lhs.pinnedLatestTurnAnchorMessageId == rhs.pinnedLatestTurnAnchorMessageId
+            && lhs.searchQuery == rhs.searchQuery
     }
 
     // MARK: - Data properties (compared in ==)
@@ -70,6 +71,7 @@ struct MessageListContentView: View, Equatable {
     let subagentDetailStore: SubagentDetailStore
     let assistantStatusText: String?
     let pinnedLatestTurnAnchorMessageId: UUID?
+    let searchQuery: String
 
     // MARK: - Closures (skipped in ==)
 
@@ -248,7 +250,8 @@ struct MessageListContentView: View, Equatable {
                     selectedModel: selectedModel,
                     configuredProviders: configuredProviders,
                     providerCatalog: providerCatalog,
-                    providerCatalogHash: providerCatalogHash
+                    providerCatalogHash: providerCatalogHash,
+                    searchQuery: searchQuery
                 )
                 .equatable()
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView+DerivedState.swift
@@ -172,6 +172,7 @@ extension MessageListView {
             subagentDetailStore: subagentDetailStore,
             assistantStatusText: assistantStatusText,
             pinnedLatestTurnAnchorMessageId: scrollState.pinnedLatestTurnAnchorMessageId,
+            searchQuery: searchQuery,
             onConfirmationAllow: onConfirmationAllow,
             onConfirmationDeny: onConfirmationDeny,
             onAlwaysAllow: onAlwaysAllow,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -80,6 +80,7 @@ struct MessageListView: View {
     /// Measured width of the full chat pane. `layoutMetrics` derives the
     /// centered transcript column width from this value.
     var containerWidth: CGFloat = 0
+    var searchQuery: String = ""
     var layoutMetrics: MessageListLayoutMetrics {
         MessageListLayoutMetrics(containerWidth: containerWidth)
     }

--- a/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListScrollPerformanceTests.swift
@@ -101,7 +101,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
                     assistantActivityReason: nil,
                     activeSubagentFingerprint: version % 5,
                     displayedMessageCount: version % 1000,
-                    firstVisibleMessageId: nil
+                    firstVisibleMessageId: nil,
+                    highlightedMessageId: nil
                 )
                 // Force an equality check (the hot path in MessageListView.derivedState).
                 if let prev = lastKey {
@@ -397,7 +398,8 @@ final class MessageListScrollPerformanceTests: XCTestCase {
             assistantActivityReason: nil,
             activeSubagentFingerprint: 7,
             displayedMessageCount: 100,
-            firstVisibleMessageId: nil
+            firstVisibleMessageId: nil,
+            highlightedMessageId: nil
         )
         cache.cachedProjection = TranscriptProjector.project(
             messages: buildMessages(count: 5),

--- a/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListTypographyRefreshTests.swift
@@ -49,7 +49,8 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             configuredProviders: [],
             subagentDetailStore: SubagentDetailStore(),
             assistantStatusText: nil,
-            pinnedLatestTurnAnchorMessageId: nil
+            pinnedLatestTurnAnchorMessageId: nil,
+            searchQuery: ""
         )
     }
 
@@ -79,7 +80,8 @@ final class MessageListTypographyRefreshTests: XCTestCase {
             selectedModel: "",
             configuredProviders: [],
             providerCatalog: [],
-            providerCatalogHash: 0
+            providerCatalogHash: 0,
+            searchQuery: ""
         )
     }
 


### PR DESCRIPTION
## Summary
- Thread `searchQuery` from ChatView through the full rendering pipeline to MarkdownSegmentView
- In SelectableRunView, apply yellow background highlights to all case-insensitive matches of the search query in the NSAttributedString after measurement (so layout is unaffected)
- Lift `searchText` from ChatSearchOverlay's local @State to ChatView's @State so both the search overlay and message list can read it

Files touched: ChatView, ChatSearchOverlay, MessageListView, MessageListView+DerivedState, MessageListContentView, MessageCellView, ChatBubble, MarkdownSegmentView, and test files for compilation fixes.

Part of plan: cmdf-search-highlight-fix.md (PR 3 — inline text highlighting)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->