### PR TITLE
refactor(macos): replace Uninstall button with Retire Assistant in settings

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -984,65 +984,6 @@ extension AppDelegate {
         }
     }
 
-    // MARK: - Uninstall
-
-    /// Retires all local assistants registered in the lockfile, then moves
-    /// the application bundle to the Trash and terminates.
-    ///
-    /// Shows a confirmation alert before proceeding. Each local assistant is
-    /// retired sequentially via the CLI; failures are logged but do not block
-    /// subsequent retires or the final app removal.
-    public func performUninstall() {
-        let alert = NSAlert()
-        alert.messageText = "Uninstall Vellum"
-        alert.informativeText = "This will retire all local assistants and move Vellum to the Trash. This action cannot be undone."
-        alert.alertStyle = .critical
-        alert.addButton(withTitle: "Uninstall")
-        alert.addButton(withTitle: "Cancel")
-
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-
-        Task {
-            let allAssistants = LockfileAssistant.loadAll()
-            let localAssistants = allAssistants.filter { !$0.isRemote || $0.isDocker || $0.isAppleContainer }
-
-            // Disconnect SSE before retiring so the reconnect loop doesn't
-            // hit a half-torn-down gateway and produce 502 errors.
-            connectionManager.disconnect()
-
-            // Retire each local assistant so cloud resources are cleaned up.
-            for assistant in localAssistants {
-                let client = AssistantManagementClient.create(for: assistant)
-                do {
-                    log.info("Retiring local assistant '\(assistant.assistantId, privacy: .public)' as part of uninstall")
-                    try await client.retire(name: assistant.assistantId)
-                } catch {
-                    log.error("Failed to retire '\(assistant.assistantId, privacy: .public)' during uninstall: \(error.localizedDescription)")
-                }
-            }
-
-            // Stop any remaining assistant processes.
-            await vellumCli.stop()
-
-            // Move the app bundle to the Trash.
-            let bundleURL = Bundle.main.bundleURL
-            do {
-                try FileManager.default.trashItem(at: bundleURL, resultingItemURL: nil)
-                log.info("Moved app bundle to Trash")
-            } catch {
-                log.error("Failed to move app to Trash: \(error.localizedDescription)")
-                let failAlert = NSAlert()
-                failAlert.messageText = "Could Not Remove Vellum"
-                failAlert.informativeText = "All assistants have been retired, but the app could not be moved to the Trash: \(error.localizedDescription)\n\nYou can manually drag Vellum to the Trash."
-                failAlert.alertStyle = .warning
-                failAlert.addButton(withTitle: "OK")
-                failAlert.runModal()
-            }
-
-            NSApp.terminate(nil)
-        }
-    }
-
     // MARK: - Shared teardown helpers
 
     /// Resets hotkey registration state so hotkeys are properly re-registered

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -12,6 +12,8 @@ struct SettingsGeneralTab: View {
     var onSignIn: (() -> Void)?
 
     @State private var showingDeleteAccountConfirm: Bool = false
+    @State private var showingRetireConfirmation: Bool = false
+    @State private var isRetiring: Bool = false
 
     // -- Software Update state --
     @State private var healthz: DaemonHealthz?
@@ -72,7 +74,9 @@ struct SettingsGeneralTab: View {
             }
             SettingsAppearanceTab(store: store)
             OpenSourceSettingsCard()
-            uninstallSection
+            if !lockfileAssistants.isEmpty {
+                retireAssistantSection
+            }
             if Self.shouldShowDangerZone(isAuthenticated: authManager.currentUser != nil) {
                 dangerZoneSection
             }
@@ -167,6 +171,40 @@ struct SettingsGeneralTab: View {
                     showingDeleteAccountConfirm = false
                 }
             )
+        }
+        .alert("Retire Assistant", isPresented: $showingRetireConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Retire", role: .destructive) {
+                isRetiring = true
+                Task {
+                    let completed = await AppDelegate.shared?.performRetireAsync() ?? false
+                    if !completed {
+                        isRetiring = false
+                    }
+                }
+            }
+        } message: {
+            if lockfileAssistants.count > 1 {
+                Text("This will stop the current assistant and switch to another. The retired assistant's lockfile entry will be removed.")
+            } else {
+                Text("This will stop the assistant, remove local data, and return to initial setup. This action cannot be undone.")
+            }
+        }
+        .sheet(isPresented: $isRetiring) {
+            VStack(spacing: VSpacing.lg) {
+                ProgressView()
+                    .controlSize(.regular)
+                    .progressViewStyle(.circular)
+                Text("Retiring assistant...")
+                    .font(VFont.bodyMediumDefault)
+                    .foregroundStyle(VColor.contentDefault)
+                Text("Stopping the assistant and removing local data.")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+            }
+            .padding(VSpacing.xxl)
+            .frame(minWidth: 260)
+            .interactiveDismissDisabled()
         }
     }
 
@@ -331,15 +369,17 @@ struct SettingsGeneralTab: View {
         return String(format: "%.0f MB", mb)
     }
 
-    // MARK: - Uninstall
+    // MARK: - Retire Assistant
 
-    private var uninstallSection: some View {
+    private var retireAssistantSection: some View {
         SettingsCard(
-            title: "Uninstall",
-            subtitle: "Stops all assistants, archives your data, and moves Vellum to the Trash"
+            title: "Retire Assistant",
+            subtitle: lockfileAssistants.count > 1
+                ? "Stops the current assistant and switches to another."
+                : "Stops the assistant, removes local data, and returns to initial setup."
         ) {
-            VButton(label: "Uninstall Vellum", style: .danger) {
-                AppDelegate.shared?.performUninstall()
+            VButton(label: "Retire", style: .danger) {
+                showingRetireConfirmation = true
             }
         }
     }


### PR DESCRIPTION
## Summary
- Removes the **Uninstall Vellum** button (and its dead `performUninstall()` implementation) from the General settings tab — the placement next to **Delete account** made the destructive action ambiguous.
- Adds a user-facing **Retire Assistant** card to the General settings tab, gated on the user having at least one assistant in their lockfile. Mirrors the confirmation alert + in-progress sheet from the developer-tab implementation, wired to the existing `AppDelegate.performRetireAsync()`.
- The flag-gated **Delete account** card in the Danger Zone is unchanged.

User-facing settings now expose two clearly distinct destructive actions: **Retire Assistant** (per-assistant teardown) and **Delete account** (full account deletion via the platform `account-deletion` flow).

## Test plan
- [ ] Existing `DeleteAccountTests` (8) still pass: `./build.sh test --filter DeleteAccountTests`
- [ ] With ≥1 assistant in the lockfile, the Retire Assistant card appears in General → confirm + retire reaches onboarding (single-assistant) or switches to a sibling (multi-assistant)
- [ ] With no assistants, the Retire Assistant card is hidden
- [ ] Uninstall card no longer appears anywhere in settings
- [ ] Danger Zone delete-account flow continues to work behind the `account-deletion` client flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->