### PR TITLE
fix(macos): center conversation-switch loading skeleton

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1110,6 +1110,7 @@ struct ActiveChatViewWrapper: View {
 private struct ConversationSwitchLoadingView: View {
     var body: some View {
         HStack(spacing: 0) {
+            Spacer(minLength: 0)
             VStack(spacing: 0) {
                 ChatLoadingSkeleton()
                     .padding(VSpacing.lg)


### PR DESCRIPTION
## Summary
- Add a leading `Spacer(minLength: 0)` to `ConversationSwitchLoadingView` so the loading skeleton centers like the real chat column instead of pinning to the left edge.
- Mirrors the leading-and-trailing Spacer pattern already used in `MessageListView`.

## Original prompt
The loading state should be centered like the chat instead of left aligned
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->