### PR TITLE
Faster SSE disconnect detection via heartbeat watchdog

### DIFF
--- a/assistant/src/__tests__/assistant-event.test.ts
+++ b/assistant/src/__tests__/assistant-event.test.ts
@@ -4,6 +4,7 @@ import type { AssistantEvent } from "../runtime/assistant-event.js";
 import {
   formatSseFrame,
   formatSseHeartbeat,
+  formatSseHeartbeatWithData,
 } from "../runtime/assistant-event.js";
 
 // ── Type / shape tests ────────────────────────────────────────────────────────
@@ -123,5 +124,14 @@ describe("formatSseHeartbeat", () => {
 
   test("starts with colon (SSE comment marker)", () => {
     expect(formatSseHeartbeat().startsWith(":")).toBe(true);
+  });
+});
+
+describe("formatSseHeartbeatWithData", () => {
+  test("includes both a comment and a data-bearing event", () => {
+    const hb = formatSseHeartbeatWithData();
+    expect(hb).toContain(": heartbeat\n\n");
+    expect(hb).toContain("event: assistant_event\n");
+    expect(hb).toContain('data: {"type":"heartbeat"}\n');
   });
 });

--- a/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
@@ -261,7 +261,8 @@ describe("SSE route — heartbeat", () => {
     reader.cancel();
 
     const text = new TextDecoder().decode(value);
-    expect(text).toBe(": heartbeat\n\n");
+    expect(text).toContain(": heartbeat");
+    expect(text).toContain('{"type":"heartbeat"}');
   });
 
   test("emits multiple heartbeats over time", async () => {
@@ -297,7 +298,11 @@ describe("SSE route — heartbeat", () => {
     reader.cancel();
 
     expect(chunks.length).toBeGreaterThan(0);
-    expect(chunks.every((c) => c === ": heartbeat\n\n")).toBe(true);
+    expect(
+      chunks.every(
+        (c) => c.includes(": heartbeat") && c.includes('{"type":"heartbeat"}'),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -135,10 +135,12 @@ describe("SSE assistant-events endpoint", () => {
     // Read the first frame directly from the stream.
     const reader = stream.getReader();
 
-    // The first chunk is the immediate heartbeat comment enqueued in start().
+    // The first chunk is the immediate heartbeat (comment + data event) enqueued in start().
     const initial = await reader.read();
     expect(initial.done).toBe(false);
-    expect(new TextDecoder().decode(initial.value)).toBe(": heartbeat\n\n");
+    const initialText = new TextDecoder().decode(initial.value);
+    expect(initialText).toContain(": heartbeat");
+    expect(initialText).toContain('{"type":"heartbeat"}');
 
     // The second chunk is the actual assistant event.
     const { value, done } = await reader.read();
@@ -170,10 +172,12 @@ describe("SSE assistant-events endpoint", () => {
 
     const reader = stream.getReader();
 
-    // Consume the initial heartbeat.
+    // Consume the initial heartbeat (comment + data event).
     const heartbeat = await reader.read();
     expect(heartbeat.done).toBe(false);
-    expect(new TextDecoder().decode(heartbeat.value)).toBe(": heartbeat\n\n");
+    const heartbeatText = new TextDecoder().decode(heartbeat.value);
+    expect(heartbeatText).toContain(": heartbeat");
+    expect(heartbeatText).toContain('{"type":"heartbeat"}');
 
     // Publish events with two different conversationIds.
     const eventA = buildAssistantEvent({ type: "pong" }, "conversation-aaa");

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -16,6 +16,7 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 export {
   formatSseFrame,
   formatSseHeartbeat,
+  formatSseHeartbeatWithData,
 } from "@vellumai/skill-host-contracts";
 
 /** Daemon-side specialization of the generic event envelope. */

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -22,7 +22,10 @@ import type { HostProxyCapability } from "../../channels/types.js";
 import { parseInterfaceId, supportsHostProxy } from "../../channels/types.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
-import { formatSseFrame, formatSseHeartbeat } from "../assistant-event.js";
+import {
+  formatSseFrame,
+  formatSseHeartbeatWithData,
+} from "../assistant-event.js";
 import type {
   AssistantEventCallback,
   AssistantEventFilter,
@@ -191,7 +194,7 @@ export function handleSubscribeAssistantEvents(
           return;
         }
 
-        controller.enqueue(encoder.encode(formatSseHeartbeat()));
+        controller.enqueue(encoder.encode(formatSseHeartbeatWithData()));
 
         heartbeatTimer = setInterval(() => {
           try {
@@ -203,7 +206,7 @@ export function handleSubscribeAssistantEvents(
             if (clientId) {
               hub.touchClient(clientId);
             }
-            controller.enqueue(encoder.encode(formatSseHeartbeat()));
+            controller.enqueue(encoder.encode(formatSseHeartbeatWithData()));
           } catch {
             sub.dispose();
             cleanup();

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -37,8 +37,8 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("events-routes");
 
-/** Keep-alive comment sent to idle clients every 7 s by default. */
-const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
+/** Keep-alive comment sent to idle clients every 5 s by default. */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
 
 /**
  * Stream assistant events as Server-Sent Events.

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -61,7 +61,7 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
  *
  * Options (for testing):
  *   hub               -- override the event hub (defaults to process singleton).
- *   heartbeatIntervalMs -- how often to emit keep-alive comments (default 7 s).
+ *   heartbeatIntervalMs -- how often to emit keep-alive comments (default 5 s).
  */
 export function handleSubscribeAssistantEvents(
   args: RouteHandlerArgs,

--- a/cli/src/commands/events.ts
+++ b/cli/src/commands/events.ts
@@ -139,6 +139,9 @@ export async function events(): Promise<void> {
     query,
     headers: getClientRegistrationHeaders(),
   })) {
+    if (!event.message) {
+      continue;
+    }
     if (jsonOutput) {
       console.log(JSON.stringify(event));
     } else {

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -466,12 +466,19 @@ public final class EventStreamClient {
 
                     if line.hasPrefix("data: ") {
                         let payload = String(line.dropFirst(6))
+                        if payload.contains("\"heartbeat\"") {
+                            if let json = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
+                               json["type"] as? String == "heartbeat" {
+                                continue
+                            }
+                        }
                         await self.parseSSEData(payload)
                     }
                 }
 
                 self.cancelHeartbeatWatchdog()
             } catch {
+                self.cancelHeartbeatWatchdog()
                 if !Task.isCancelled {
                     await self.logSSEStreamError(error)
                 }

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -133,6 +133,14 @@ public final class EventStreamClient {
     private var hasConnectedAtLeastOnce = false
     private let sseHandshakeDiagnostics = SSEHandshakeDiagnostics()
 
+    // MARK: - Heartbeat Watchdog
+
+    /// Timeout for the heartbeat watchdog (2× the server heartbeat interval).
+    /// If no SSE line (data or heartbeat comment) arrives within this window,
+    /// the connection is assumed dead and torn down for reconnection.
+    private let heartbeatWatchdogTimeout: TimeInterval = 10.0
+    private var heartbeatWatchdogTask: Task<Void, Never>?
+
     // MARK: - SSE Parse Time Tracking
 
     private var sseParseTimeAccumulator: TimeInterval = 0
@@ -192,6 +200,7 @@ public final class EventStreamClient {
     /// `withTaskCancellationHandler` to the underlying data task, so the Task-local
     /// `URLSession` is torn down by the `defer` block inside `startSSEStream`.
     public func stopSSE() {
+        cancelHeartbeatWatchdog()
         tokenRotationTask?.cancel()
         tokenRotationTask = nil
         sseReconnectTask?.cancel()
@@ -448,14 +457,20 @@ public final class EventStreamClient {
                 }
                 self.hasConnectedAtLeastOnce = true
 
+                self.startHeartbeatWatchdog()
+
                 for try await line in bytes.lines {
                     if Task.isCancelled { break }
+
+                    self.resetHeartbeatWatchdog()
 
                     if line.hasPrefix("data: ") {
                         let payload = String(line.dropFirst(6))
                         await self.parseSSEData(payload)
                     }
                 }
+
+                self.cancelHeartbeatWatchdog()
             } catch {
                 if !Task.isCancelled {
                     await self.logSSEStreamError(error)
@@ -686,6 +701,36 @@ public final class EventStreamClient {
         }
     }
 
+    // MARK: - Heartbeat Watchdog
+
+    /// Arms the heartbeat watchdog. If no SSE line arrives within
+    /// `heartbeatWatchdogTimeout`, the stream is assumed dead and torn down.
+    private func startHeartbeatWatchdog() {
+        cancelHeartbeatWatchdog()
+        heartbeatWatchdogTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: UInt64((self?.heartbeatWatchdogTimeout ?? 10.0) * 1_000_000_000))
+            } catch { return }
+            guard let self, !Task.isCancelled else { return }
+            log.warning("Heartbeat watchdog fired — no SSE activity for \(self.heartbeatWatchdogTimeout, privacy: .public)s, tearing down stream")
+            self.sseTask?.cancel()
+            self.sseTask = nil
+            guard self.shouldReconnect else { return }
+            self.sseReconnectDelay = 1.0
+            self.scheduleSSEReconnect()
+        }
+    }
+
+    /// Resets the heartbeat watchdog timer. Called on every SSE line received.
+    private func resetHeartbeatWatchdog() {
+        startHeartbeatWatchdog()
+    }
+
+    private func cancelHeartbeatWatchdog() {
+        heartbeatWatchdogTask?.cancel()
+        heartbeatWatchdogTask = nil
+    }
+
     // MARK: - SSE Reconnect
 
     private func handleSSEDisconnect() {
@@ -718,6 +763,7 @@ public final class EventStreamClient {
     }
 
     deinit {
+        heartbeatWatchdogTask?.cancel()
         tokenRotationTask?.cancel()
         sseReconnectTask?.cancel()
         sseTask?.cancel()

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -415,10 +415,13 @@ data: {"id":"...","assistantId":"self","conversationId":"conv_xxx","emittedAt":"
 
 ```
 
-Keep-alive heartbeat comments are emitted every 5 seconds to prevent proxy timeouts and enable client-side disconnect detection:
+Keep-alive heartbeats are emitted every 5 seconds to prevent proxy timeouts and enable client-side disconnect detection. Each heartbeat consists of an SSE comment (for proxy keepalive) followed by a data event (for fetch-based clients that cannot observe comment lines):
 
 ```
 : heartbeat
+
+event: assistant_event
+data: {"type":"heartbeat"}
 
 ```
 
@@ -489,6 +492,7 @@ while (true) {
     const dataLine = frame.split('\n').find((l) => l.startsWith('data: '));
     if (!dataLine) continue;
     const event = JSON.parse(dataLine.slice(6));
+    if (event.type === 'heartbeat') continue; // keep-alive, not a real event
     console.log(event.message.type, event.message);
   }
 }

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -415,7 +415,7 @@ data: {"id":"...","assistantId":"self","conversationId":"conv_xxx","emittedAt":"
 
 ```
 
-Keep-alive heartbeat comments are emitted every 30 seconds to prevent proxy timeouts:
+Keep-alive heartbeat comments are emitted every 5 seconds to prevent proxy timeouts and enable client-side disconnect detection:
 
 ```
 : heartbeat

--- a/packages/skill-host-contracts/src/assistant-event.ts
+++ b/packages/skill-host-contracts/src/assistant-event.ts
@@ -84,3 +84,12 @@ export function formatSseFrame(event: AssistantEvent): string {
 export function formatSseHeartbeat(): string {
   return ": heartbeat\n\n";
 }
+
+/**
+ * Format a keep-alive as both an SSE comment (for proxy keepalive) and a
+ * data-bearing event (so fetch-based SSE clients that cannot observe comment
+ * lines can still detect heartbeats for disconnect watchdogs).
+ */
+export function formatSseHeartbeatWithData(): string {
+  return `${formatSseHeartbeat()}event: assistant_event\ndata: ${JSON.stringify({ type: "heartbeat" })}\n\n`;
+}


### PR DESCRIPTION
Lowers the daemon heartbeat interval from 7s to 5s and adds a client-side heartbeat watchdog to the macOS `EventStreamClient`. If no SSE activity arrives within 10s (2× heartbeat), the stream is torn down and an immediate reconnect is triggered — reducing worst-case silent-disconnect detection from 10-60s down to ~10s.

The daemon heartbeat now emits both an SSE comment (for proxy keepalive) and a data event (`{type: "heartbeat"}`) so fetch-based clients that can't observe comment lines can still detect heartbeats. The Swift client filters these data events before `parseSSEData` to avoid unnecessary decode/broadcast overhead. The CLI events command guards against the new non-envelope payload shape.

## Prompt / plan
Lower heartbeat to 5s, add watchdog timers on both macOS and web clients for faster SSE disconnect detection. Web client changes are in a companion PR on vellum-assistant-platform (#5712).

## Test plan
- All 537 pre-push tests pass (the 3 failing tests — `conversation-init.benchmark`, `invite-routes-http`, `tool-execution-pipeline.benchmark` — are pre-existing failures on main)
- SSE heartbeat tests updated to validate the new data-bearing format
- New test added for `formatSseHeartbeatWithData()`
- CI skips macOS build checks — requires local Xcode verification

---

- Requested by: @m-abboud

Link to Devin session: https://app.devin.ai/sessions/ec7dc3264c774509a47a0f297f27f60f
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->