### PR TITLE
feat(memory-v2): adaptive sparse weighting based on per-query spread

### DIFF
--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -96,6 +96,9 @@ function printExplainResult(result: MemoryV2ExplainSimilarityResult): void {
     log.info(
       `maxSparse (used for normalization): ${channel.maxSparse.toFixed(4)}`,
     );
+    log.info(
+      `effective: dw=${channel.effectiveDenseWeight.toFixed(3)} sw=${channel.effectiveSparseWeight.toFixed(3)} (sparseSpread=${channel.sparseSpread.toFixed(3)})`,
+    );
     log.info("");
     log.info(
       "slug".padEnd(48) +

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -128,6 +128,26 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Weight on sparse (BM25-style) similarity in the hybrid retrieval score — sparse acts as a discriminator for keyword-rich queries.",
       ),
+    // Adaptive sparse-weighting knobs. Both fields are intentionally
+    // optional with no default — the schema serialiser drops absent
+    // optionals so these stay invisible to operators who never tune them.
+    // The defaults live in `effectiveWeights` (sim.ts).
+    min_sparse_spread: z
+      .number({ error: "memory.v2.min_sparse_spread must be a number" })
+      .min(0, "memory.v2.min_sparse_spread must be >= 0")
+      .max(1, "memory.v2.min_sparse_spread must be <= 1")
+      .optional()
+      .describe(
+        "Adaptive sparse weighting: when the spread (max - min) of normalized sparse scores across the candidate hit set falls below this, sparse contribution collapses to 0. Linear interpolation between this and `full_sparse_spread`. Optional escape hatch — leave unset to use the built-in default.",
+      ),
+    full_sparse_spread: z
+      .number({ error: "memory.v2.full_sparse_spread must be a number" })
+      .min(0, "memory.v2.full_sparse_spread must be >= 0")
+      .max(1, "memory.v2.full_sparse_spread must be <= 1")
+      .optional()
+      .describe(
+        "Adaptive sparse weighting: at or above this spread, sparse weight stays at the configured `sparse_weight`. Optional escape hatch — leave unset to use the built-in default.",
+      ),
     bm25_k1: z
       .number({ error: "memory.v2.bm25_k1 must be a number" })
       .min(0, "memory.v2.bm25_k1 must be >= 0")

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -159,7 +159,8 @@ mock.module("@qdrant/js-client-rest", () => ({
   QdrantClient: MockQdrantClient,
 }));
 
-const { simBatch, simSkillBatch, clamp01 } = await import("../sim.js");
+const { simBatch, simSkillBatch, clamp01, effectiveWeights } =
+  await import("../sim.js");
 const { _resetMemoryV2SkillQdrantForTests } =
   await import("../skill-qdrant.js");
 const { _resetMemoryV2QdrantForTests } = await import("../qdrant.js");
@@ -227,6 +228,120 @@ afterEach(resetState);
 // ---------------------------------------------------------------------------
 // clamp01
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// effectiveWeights — adaptive sparse weighting
+// ---------------------------------------------------------------------------
+
+describe("effectiveWeights", () => {
+  // The helper takes a generic config, but only reads
+  // `memory.v2.min_sparse_spread` / `full_sparse_spread`. Build a minimal
+  // shape so test cases can opt into custom thresholds vs the built-in
+  // defaults (0.2 / 0.5).
+  function configWithSpreadOverrides(
+    min?: number,
+    full?: number,
+  ): AssistantConfig {
+    return {
+      memory: { v2: { min_sparse_spread: min, full_sparse_spread: full } },
+    } as unknown as AssistantConfig;
+  }
+  const baseConfig = configWithSpreadOverrides();
+
+  test("returns base weights when sparse weight is zero", () => {
+    const result = effectiveWeights(
+      [{ sparseScore: 1 }, { sparseScore: 2 }],
+      2,
+      1.0,
+      0.0,
+      baseConfig,
+    );
+    expect(result.dense).toBe(1.0);
+    expect(result.sparse).toBe(0);
+  });
+
+  test("returns base weights when fewer than 2 sparse-bearing hits", () => {
+    // Single sparse-bearing hit — spread is undefined.
+    const result = effectiveWeights(
+      [{ sparseScore: 5 }, {}],
+      5,
+      0.7,
+      0.3,
+      baseConfig,
+    );
+    expect(result.dense).toBeCloseTo(0.7);
+    expect(result.sparse).toBeCloseTo(0.3);
+    expect(result.spread).toBe(0);
+  });
+
+  test("collapses sparse weight to 0 when spread is below min_sparse_spread", () => {
+    // Three hits with sparseNorm = {0.95, 0.97, 1.0} → spread 0.05 < 0.2.
+    const hits = [
+      { sparseScore: 9.5 },
+      { sparseScore: 9.7 },
+      { sparseScore: 10 },
+    ];
+    const result = effectiveWeights(hits, 10, 0.7, 0.3, baseConfig);
+    expect(result.spread).toBeCloseTo(0.05, 6);
+    expect(result.sparse).toBeCloseTo(0, 6);
+    // Dense compensates: gets the full sparse weight added back.
+    expect(result.dense).toBeCloseTo(1.0, 6);
+  });
+
+  test("preserves base weights when spread reaches full_sparse_spread", () => {
+    // sparseNorm = {0.5, 1.0} → spread 0.5 === default full threshold.
+    const hits = [{ sparseScore: 5 }, { sparseScore: 10 }];
+    const result = effectiveWeights(hits, 10, 0.7, 0.3, baseConfig);
+    expect(result.spread).toBeCloseTo(0.5, 6);
+    expect(result.sparse).toBeCloseTo(0.3, 6);
+    expect(result.dense).toBeCloseTo(0.7, 6);
+  });
+
+  test("interpolates linearly between min and full thresholds", () => {
+    // sparseNorm = {0.65, 1.0} → spread 0.35; midway between 0.2 and 0.5
+    // → factor = 0.5; effSparse = 0.5 * 0.3 = 0.15; effDense = 0.7 + 0.15.
+    const hits = [{ sparseScore: 6.5 }, { sparseScore: 10 }];
+    const result = effectiveWeights(hits, 10, 0.7, 0.3, baseConfig);
+    expect(result.spread).toBeCloseTo(0.35, 6);
+    expect(result.sparse).toBeCloseTo(0.15, 6);
+    expect(result.dense).toBeCloseTo(0.85, 6);
+  });
+
+  test("config overrides min and full thresholds", () => {
+    // Custom: min=0.0, full=1.0 — spread is now in [0, 1] linearly.
+    const config = configWithSpreadOverrides(0.0, 1.0);
+    const hits = [{ sparseScore: 8 }, { sparseScore: 10 }];
+    const result = effectiveWeights(hits, 10, 0.7, 0.3, config);
+    // spread 0.2; factor = 0.2; effSparse = 0.06.
+    expect(result.spread).toBeCloseTo(0.2, 6);
+    expect(result.sparse).toBeCloseTo(0.06, 6);
+    expect(result.dense).toBeCloseTo(0.94, 6);
+  });
+
+  test("falls back to base weights when full <= min (degenerate config)", () => {
+    const config = configWithSpreadOverrides(0.5, 0.3);
+    const hits = [{ sparseScore: 5 }, { sparseScore: 10 }];
+    const result = effectiveWeights(hits, 10, 0.7, 0.3, config);
+    expect(result.sparse).toBeCloseTo(0.3, 6);
+    expect(result.dense).toBeCloseTo(0.7, 6);
+  });
+
+  test("dense + sparse always equals baseDense + baseSparse", () => {
+    // Property check: total weight is preserved across the spread spectrum
+    // so `fused` stays interpretable as a [0, 1] similarity regardless of
+    // how aggressively sparse is collapsed.
+    const cases = [
+      [{ sparseScore: 1 }, { sparseScore: 1.05 }], // tiny spread
+      [{ sparseScore: 1 }, { sparseScore: 5 }], // mid spread
+      [{ sparseScore: 1 }, { sparseScore: 10 }], // full spread
+    ];
+    for (const hits of cases) {
+      const maxSparse = Math.max(...hits.map((h) => h.sparseScore));
+      const result = effectiveWeights(hits, maxSparse, 0.7, 0.3, baseConfig);
+      expect(result.dense + result.sparse).toBeCloseTo(1.0, 6);
+    }
+  });
+});
 
 describe("clamp01", () => {
   test("passes values already in [0, 1] through unchanged", () => {

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -40,6 +40,79 @@ import { generateBm25QueryEmbedding } from "./sparse-bm25.js";
 export const clamp01 = clampUnitInterval;
 
 /**
+ * Built-in defaults for adaptive sparse weighting. Live here (not in the
+ * config schema) so operators don't see two new knobs in their config until
+ * they actually want to tune them.
+ *
+ * Below `MIN_SPREAD`, the sparse channel is treated as no-signal (its scores
+ * are uniform across the candidate set, so it can't rank anything) and the
+ * sparse weight collapses to 0. At or above `FULL_SPREAD`, sparse weight
+ * stays at its configured value. Linear interpolation between.
+ */
+const ADAPTIVE_SPARSE_MIN_SPREAD = 0.2;
+const ADAPTIVE_SPARSE_FULL_SPREAD = 0.5;
+
+/**
+ * Per-query effective dense + sparse weights, derived from the configured
+ * base weights and the spread of normalized sparse scores across the hit
+ * set. When the sparse channel can't discriminate (low spread or fewer
+ * than two sparse-bearing candidates), its weight collapses and dense
+ * weight is boosted to compensate so `dense + sparse` still equals
+ * `baseDense + baseSparse` and `fused` stays interpretable as a [0, 1]
+ * similarity.
+ *
+ * Pure function — exported so the diagnostic surface in
+ * `memory-v2-routes.explain-similarity` can show the effective weights and
+ * the measured spread alongside per-channel score statistics.
+ */
+export function effectiveWeights(
+  hits: ReadonlyArray<{ sparseScore?: number }>,
+  maxSparse: number,
+  baseDense: number,
+  baseSparse: number,
+  config: AssistantConfig,
+): { dense: number; sparse: number; spread: number } {
+  // Short-circuit when the channel is already disabled or unscored. Returning
+  // base weights here keeps `fused` numerically identical to today's output
+  // for the no-sparse-signal cases the existing tests assume.
+  if (baseSparse === 0 || maxSparse === 0) {
+    return { dense: baseDense, sparse: baseSparse, spread: 0 };
+  }
+  let min = Infinity;
+  let max = -Infinity;
+  let count = 0;
+  for (const h of hits) {
+    if (h.sparseScore === undefined) continue;
+    const norm = h.sparseScore / maxSparse;
+    if (norm < min) min = norm;
+    if (norm > max) max = norm;
+    count++;
+  }
+  // With < 2 sparse-bearing hits the spread is undefined — fall back to base
+  // weights so single-hit retrievals still surface their sparse contribution
+  // (and the existing fusion-math tests stay green).
+  if (count < 2) {
+    return { dense: baseDense, sparse: baseSparse, spread: 0 };
+  }
+  const spread = max - min;
+
+  const minSpread =
+    config.memory.v2.min_sparse_spread ?? ADAPTIVE_SPARSE_MIN_SPREAD;
+  const fullSpread =
+    config.memory.v2.full_sparse_spread ?? ADAPTIVE_SPARSE_FULL_SPREAD;
+  // Degenerate config (full <= min): no interpolation range. Don't try to
+  // adapt; trust the operator's base weights and report the measured spread
+  // for diagnostics.
+  if (fullSpread <= minSpread) {
+    return { dense: baseDense, sparse: baseSparse, spread };
+  }
+  const factor = clamp01((spread - minSpread) / (fullSpread - minSpread));
+  const sparse = baseSparse * factor;
+  const dense = baseDense + (baseSparse - sparse);
+  return { dense, sparse, spread };
+}
+
+/**
  * Compute hybrid (dense + sparse) similarity scores between a query text and
  * a fixed set of candidate concept-page slugs.
  *
@@ -105,8 +178,15 @@ export async function simBatch(
   }
 
   const maxSparse = computeMaxSparse(hits);
-  const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
+  const { dense_weight: baseDense, sparse_weight: baseSparse } =
     config.memory.v2;
+  const { dense: denseWeight, sparse: sparseWeight } = effectiveWeights(
+    hits,
+    maxSparse,
+    baseDense,
+    baseSparse,
+    config,
+  );
 
   const scores = new Map<string, number>();
   for (const hit of hits) {
@@ -183,8 +263,15 @@ export async function simSkillBatch(
   }
 
   const maxSparse = computeMaxSparse(filtered);
-  const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
+  const { dense_weight: baseDense, sparse_weight: baseSparse } =
     config.memory.v2;
+  const { dense: denseWeight, sparse: sparseWeight } = effectiveWeights(
+    filtered,
+    maxSparse,
+    baseDense,
+    baseSparse,
+    config,
+  );
 
   const scores = new Map<string, number>();
   for (const hit of filtered) {

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -36,6 +36,7 @@ import {
   hybridQueryConceptPages,
   sampleConceptPageDenseVectors,
 } from "../../memory/v2/qdrant.js";
+import { effectiveWeights } from "../../memory/v2/sim.js";
 import { seedV2SkillEntries } from "../../memory/v2/skill-store.js";
 import {
   generateBm25QueryEmbedding,
@@ -280,6 +281,16 @@ export interface MemoryV2ExplainSimilarityChannel {
   channel: "user" | "assistant" | "now";
   textPreview: string;
   maxSparse: number;
+  /**
+   * Spread (max - min) of normalized sparse scores across this channel's
+   * hits. Drives adaptive sparse weighting — low spread means the sparse
+   * channel can't discriminate, so its weight collapses for this query.
+   */
+  sparseSpread: number;
+  /** Sparse weight after adaptive collapse (≤ the configured base). */
+  effectiveSparseWeight: number;
+  /** Dense weight after adaptive compensation (≥ the configured base). */
+  effectiveDenseWeight: number;
   rows: MemoryV2ExplainSimilarityRow[];
   stats: {
     dense: MemoryV2ExplainSimilarityStats;
@@ -341,13 +352,23 @@ async function scoreChannel(
     }
   }
 
+  // Mirror simBatch's adaptive weighting so the printed `fused` matches what
+  // production retrieval would actually score for this query — otherwise
+  // operators staring at the diagnostic would see different numbers than
+  // the activation pipeline saw.
+  const {
+    dense: effDense,
+    sparse: effSparse,
+    spread: sparseSpread,
+  } = effectiveWeights(hits, maxSparse, denseWeight, sparseWeight, config);
+
   const rows: MemoryV2ExplainSimilarityRow[] = hits.map((hit) => {
     const dense = hit.denseScore ?? 0;
     const sparseNorm =
       hit.sparseScore !== undefined && maxSparse > 0
         ? hit.sparseScore / maxSparse
         : 0;
-    const fusedRaw = denseWeight * dense + sparseWeight * sparseNorm;
+    const fusedRaw = effDense * dense + effSparse * sparseNorm;
     const fused = Math.max(0, Math.min(1, fusedRaw));
     return {
       slug: hit.slug,
@@ -375,6 +396,9 @@ async function scoreChannel(
     channel,
     textPreview: text.length > 120 ? `${text.slice(0, 120)}…` : text,
     maxSparse,
+    sparseSpread,
+    effectiveSparseWeight: effSparse,
+    effectiveDenseWeight: effDense,
     rows,
     stats: {
       dense: summarizeStats(denseValues),


### PR DESCRIPTION
## Summary
- Adds \`effectiveWeights(hits, maxSparse, baseDense, baseSparse, config)\` in \`assistant/src/memory/v2/sim.ts\` that derives per-query weights from the spread of normalized sparse scores. \`simBatch\` and \`simSkillBatch\` route their fusion math through it; the diagnostic \`scoreChannel\` in \`memory-v2-routes.ts\` mirrors the call so \`assistant memory v2 explain\` shows the same fused values production retrieval actually computes.
- Two new optional config fields (\`memory.v2.min_sparse_spread\`, \`memory.v2.full_sparse_spread\`) gate the interpolation thresholds. Both are \`.optional()\` with no default — operators only see them in their config if they've explicitly overridden. Built-in defaults (0.2 / 0.5) live in sim.ts so the knobs stay invisible by default.
- \`assistant memory v2 explain\` CLI now prints \`effective: dw=… sw=… (sparseSpread=…)\` per channel so operators can see when adaptive weighting kicks in.
- 8 new unit tests in \`sim.test.ts\` cover the helper across the spectrum: zero base sparse, < 2 sparse hits, below-min spread, at-full spread, mid-interpolation, custom config overrides, degenerate config, and a property check that \`dense + sparse\` always equals the base sum.

## Original prompt
it. for the config knobs let's leave them out of config by default unless they've been overridden
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->