### PR TITLE
fix(vbundle-importer): await backup dir cleanup on success path

### DIFF
--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -1322,11 +1322,13 @@ export async function streamCommitImport(
     log.warn({ err }, "invalidateConfigCache threw after import");
   }
 
-  // Attempt to remove the backup dir (best-effort). Leaving it around is not
-  // a correctness issue, only a disk-space one, so we swallow errors. The
+  // Remove the backup dir (best-effort). Leaving it around is not a
+  // correctness issue, only a disk-space one, so we swallow errors. The
   // backup dir now always exists once swap succeeds — we created it during
-  // swapWorkspaceContents to hold the pre-import live entries.
-  rm(backupDir, { recursive: true, force: true }).catch((err) => {
+  // swapWorkspaceContents to hold the pre-import live entries. Awaited so
+  // callers (and tests) observe a workspace free of `.pre-import-*`
+  // residue once this function returns.
+  await rm(backupDir, { recursive: true, force: true }).catch((err) => {
     log.warn({ err, backupDir }, "Failed to remove pre-import backup dir");
   });
 


### PR DESCRIPTION
## Summary
- The streaming bundle importer's success path called `rm(backupDir, …)` without `await`, so `.pre-import-*` directories could outlive the call.
- This raced with the `legacy sentinel passes through the streaming path` test (and could leak briefly into production callers right after import).
- Awaiting the rm makes the workspace quiescent before `streamCommitImport` returns. The `.catch()` is preserved — leaving a backup dir is still only a disk-space issue, not a correctness one.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25334156193/job/74275014132
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->