### PR TITLE
fix(macos/build): use read -r for PID parsing in instance kill logic

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -2197,8 +2197,8 @@ if [ "$CMD" = "run" ]; then
     # third-party app named "Vellum" (e.g. vellum.pub) is also ignored.
     _kill_targets=""
     while IFS= read -r line; do
-        pid=${line%% *}
-        exe_path=${line#* }
+        read -r pid exe_path <<< "$line"
+        [ -n "$pid" ] || continue
         case "$exe_path" in
             */Contents/MacOS/*) ;;
             *) continue ;;
@@ -2218,7 +2218,7 @@ if [ "$CMD" = "run" ]; then
         for i in {1..20}; do
             still_running=false
             while IFS= read -r pid_line; do
-                _pid=${pid_line%% *}
+                read -r _pid _ <<< "$pid_line"
                 kill -0 "$_pid" 2>/dev/null && still_running=true && break
             done <<< "$_kill_targets"
             $still_running || break
@@ -2231,8 +2231,8 @@ if [ "$CMD" = "run" ]; then
             echo "Force-killing remaining instance(s)..."
             survivors=""
             while IFS= read -r line; do
-                pid=${line%% *}
-                exe_path=${line#* }
+                read -r pid exe_path <<< "$line"
+                [ -n "$pid" ] || continue
                 case "$exe_path" in
                     */Contents/MacOS/*) ;;
                     *) continue ;;
@@ -2421,8 +2421,8 @@ if [ "$RELEASE_APP_MODE" = true ]; then
     # a dev build doesn't kill production or vice versa).
     _install_targets=""
     while IFS= read -r line; do
-        pid=${line%% *}
-        exe_path=${line#* }
+        read -r pid exe_path <<< "$line"
+        [ -n "$pid" ] || continue
         case "$exe_path" in
             */Contents/MacOS/*) ;;
             *) continue ;;


### PR DESCRIPTION
## Prompt / plan

Fix the PID parsing bug in `build.sh` that prevents the kill-before-relaunch logic from terminating existing app instances during watcher-triggered rebuilds.

## Why this change is needed

The kill-before-relaunch logic in `build.sh run` silently fails to terminate the existing app instance when the file watcher triggers a rebuild. The old process survives, so `open "$APP_DIR"` either activates stale code or launches a new instance that the single-instance guard (`AppDelegate`) immediately terminates — leaving the user on old code until they manually quit and reopen.

## What changed

Replaced `${line%% *}` / `${line#* }` with `read -r pid exe_path <<< "$line"` at all four `ps` output parsing sites. Added `[ -n "$pid" ] || continue` guards for empty-line safety.

**Locations fixed:**
1. Primary kill scan (line 2200)
2. Wait-loop PID check (line 2221)
3. Force-kill re-scan (line 2234)
4. Install-to-Applications kill (line 2424)

## Why this is safe

- `read -r` is the [standard bash idiom](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-read) for whitespace-delimited field splitting. It strips leading whitespace and assigns the remainder to the last variable, correctly handling paths with spaces.
- The `IFS=` on the outer `while IFS= read -r line` loop is scoped to that `read` command only ([bash manual: Simple Command Expansion](https://www.gnu.org/software/bash/manual/html_node/Simple-Command-Expansion.html)), so the inner `read -r` uses the default IFS (space/tab/newline).
- The surrounding bundle-ID matching logic (`plutil -extract CFBundleIdentifier`) is unchanged — kills are still scoped by `$BUNDLE_ID`, so production and dev instances remain isolated.

## Benefits

- Watcher-triggered rebuilds now correctly kill the old instance before launching the new one
- No more stale code after incremental rebuilds
- No more phantom dock icon bounces from the guard killing the new instance

## Alternatives considered

| Approach | Why rejected |
|---|---|
| **`osascript -e 'quit app id "$BUNDLE_ID"'`** | AppleScript's `tell application id` can [launch the app if not running](https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptLangGuide/reference/ASLR_cmds.html). Would need a System Events pre-check requiring Automation permissions. |
| **`xcrun swift -` with `NSRunningApplication.terminate()`** | ~1–2s Swift runtime startup per invocation. Overkill for a bash build script when the existing architecture just has a parsing bug. [NSRunningApplication docs](https://developer.apple.com/documentation/appkit/nsrunningapplication) |
| **Revert to `pkill -x "$BUNDLE_DISPLAY_NAME"`** | Was the pre-`a80d99a45e` approach. Since display names are now environment-specific, the original scoping concern is resolved. But loses protection against killing a third-party app named "Vellum" (e.g. [vellum.pub](https://vellum.pub)) or a custom dock-display-name that collides with another environment. |
| **`awk '{print $1}'` instead of `read -r`** | Works for PID extraction but doesn't cleanly give both PID and exe_path in a single pass. `read -r` is more idiomatic and handles the two-variable split directly. |

## Root cause analysis

1. **How did the code get into this state?** The `${line%% *}` pattern was introduced in `b72e88de45` (Apr 8) for sibling detection as a secondary check, alongside the primary `pkill -x` kill. The pattern was never tested against actual `ps` output, which right-justifies PIDs with leading whitespace. The bug was latent until `a80d99a45e` (Apr 16) removed `pkill` and made the `ps` parsing the sole kill mechanism.

2. **What mistakes or decisions led to it?** The `ps -o pid=` output format on macOS was not verified — it right-justifies PIDs in a fixed-width column with leading spaces even when the header is suppressed via `=`. The bash `${line%% *}` pattern (remove longest suffix matching `" *"`) removes the entire line when it starts with spaces, producing an empty string.

3. **Were there warning signs we missed?** The same broken parsing pattern was copy-pasted to 4 locations without being extracted into a helper function. The code silently produced empty PIDs without error, making the failure invisible during development and testing.

4. **What can we do to prevent this pattern from recurring?** Use `read -r` for whitespace-delimited parsing in bash. The `${var%% *}` / `${var#* }` patterns are unreliable when input has leading whitespace.

5. **Should we add a guideline to AGENTS.md?** No — this is narrow enough that a code comment at the call site is more durable than an AGENTS.md rule. The fix itself serves as documentation.

## Test plan

- Verified `read -r pid exe_path <<< "$line"` handles all edge cases:
  - Leading spaces: `"    999 /path"` → pid=`999`, exe_path=`/path`
  - No leading spaces: `"12345 /path"` → pid=`12345`, exe_path=`/path`
  - Single-digit PID: `"      1 /sbin/launchd"` → pid=`1`, exe_path=`/sbin/launchd`
  - Path with spaces: `"  999 /path/to/Vellum Local.app/Contents/MacOS/Vellum Local"` → correctly split
  - Empty lines: pid=`""`, caught by `[ -n "$pid" ] || continue` guard
- CI does not run macOS builds; manual verification on macOS recommended

Link to Devin session: https://app.devin.ai/sessions/6a69b4f6e6da4fa190bb98c6ac2c66fa
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
