### PR TITLE
docs(macos): fix incorrect app bundle path in AGENTS.md

### DIFF
--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -15,7 +15,7 @@ A native macOS menu bar app that controls your Mac via accessibility APIs and CG
 Single build script: `./build.sh` wraps SwiftPM → `.app` bundle → codesign. No Xcode project needed.
 
 ```bash
-# Build debug .app bundle (→ dist/<BUNDLE_DISPLAY_NAME>.app, e.g. dist/Vellum Local.app)
+# Build debug .app bundle (→ dist/<BUNDLE_DISPLAY_NAME>.app, e.g. Vellum Dev.app or Vellum Local.app via vel up)
 ./build.sh
 
 # Build + launch

--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -15,7 +15,7 @@ A native macOS menu bar app that controls your Mac via accessibility APIs and CG
 Single build script: `./build.sh` wraps SwiftPM → `.app` bundle → codesign. No Xcode project needed.
 
 ```bash
-# Build debug .app bundle (→ dist/vellum-assistant.app)
+# Build debug .app bundle (→ dist/<BUNDLE_DISPLAY_NAME>.app, e.g. dist/Vellum Local.app)
 ./build.sh
 
 # Build + launch


### PR DESCRIPTION
## Prompt / plan

Fix incorrect build output path documented in `clients/macos/AGENTS.md`.

## Why this change is needed

The AGENTS.md code comment says the build output is `dist/vellum-assistant.app`, but the actual path is `dist/<BUNDLE_DISPLAY_NAME>.app` — which defaults to `dist/Vellum Local.app` for local dev builds. This misleads developers and agents looking for the built artifact.

## What changed

Updated the comment from:
```
# Build debug .app bundle (→ dist/vellum-assistant.app)
```
to:
```
# Build debug .app bundle (→ dist/<BUNDLE_DISPLAY_NAME>.app, e.g. dist/Vellum Local.app)
```

## Why this is safe

Documentation-only change — no code affected.

## Root cause analysis

1. **How did the code get into this state?** The comment predates the environment-specific display name changes. When `BUNDLE_DISPLAY_NAME` was introduced to support per-environment app names, the AGENTS.md comment was not updated.

2. **What mistakes or decisions led to it?** The documentation was treated as static rather than being updated alongside the code changes that introduced `BUNDLE_DISPLAY_NAME`.

3. **Were there warning signs we missed?** The actual build output path has been `dist/Vellum Local.app` (or similar) for all non-production builds since the display name changes landed, but the stale comment was not caught in review.

4. **What can we do to prevent this pattern from recurring?** When changing build output paths or naming conventions, grep documentation files for references to the old names.

5. **Should we add a guideline to AGENTS.md?** No — the fix itself corrects the documentation.

## Test plan

Documentation-only change — no code affected.

Link to Devin session: https://app.devin.ai/sessions/6a69b4f6e6da4fa190bb98c6ac2c66fa
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
