### PR TITLE
fix: align staging process name and broaden app kill patterns

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -31,9 +31,9 @@ The user may pass `$ARGUMENTS` to control branch behavior:
    vellum ps
    ```
 
-2. Kill the macOS app and any stale file-watcher processes first (old `build.sh run` watchers will detect git-pulled Swift changes and bounce the app repeatedly):
+2. Kill the macOS app and any stale file-watcher processes first (old `build.sh run` watchers will detect git-pulled Swift changes and bounce the app repeatedly). Use `-f` to match against the full command line, catching all environment variants (`Vellum`, `Vellum Local`, `Vellum Dev`, etc.):
    ```bash
-   pkill -x "Vellum" || true
+   pkill -f "Vellum.*\.app/Contents/MacOS/" || true
    pkill -f "build\.sh run" || true
    ```
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -784,6 +784,12 @@ if [ -z "${BUNDLE_DISPLAY_NAME:-}" ] && [ -f "$_DOCK_LABEL_FILE" ]; then
     fi
 fi
 BUNDLE_DISPLAY_NAME="${BUNDLE_DISPLAY_NAME:-$_DEFAULT_DISPLAY_NAME}"
+# macOS stores process names in p_comm[MAXCOMLEN+1] where MAXCOMLEN=16.
+# Names longer than 16 characters are silently truncated by the kernel,
+# which breaks pgrep -x matching and the instance-kill logic below.
+if [ "${#BUNDLE_DISPLAY_NAME}" -gt 16 ]; then
+    echo "Warning: BUNDLE_DISPLAY_NAME '${BUNDLE_DISPLAY_NAME}' is ${#BUNDLE_DISPLAY_NAME} chars (max 16 for pgrep -x)" >&2
+fi
 APP_DIR="$SCRIPT_DIR/dist/$BUNDLE_DISPLAY_NAME.app"
 CONTENTS="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS/MacOS"

--- a/scripts/mac-mini-cleanup.sh
+++ b/scripts/mac-mini-cleanup.sh
@@ -140,7 +140,7 @@ step_remove_cli_symlinks() {
 
 step_remove_vellum_apps() {
     VELLUM_APP_REMOVED=false
-    for app in "/Applications/Vellum.app" "/Applications/Vellum (Staging).app"; do
+    for app in "/Applications/Vellum.app" "/Applications/Vellum Staging.app" "/Applications/Vellum (Staging).app"; do
         if [ -d "$app" ]; then
             rm -rf "$app"
             echo "       ✅ Removed $app"

--- a/scripts/staging-release.sh
+++ b/scripts/staging-release.sh
@@ -2,8 +2,8 @@
 #
 # staging-release.sh — Build a staging release DMG and upload it to a Mac mini.
 #
-# Runs `./build.sh release` with BUNDLE_DISPLAY_NAME="Vellum (Staging)" so
-# that "(Staging)" appears in the About Vellum modal, then packages the
+# Runs `./build.sh release` with BUNDLE_DISPLAY_NAME="Vellum Staging" so
+# that "Staging" appears in the app name, then packages the
 # resulting .app into a DMG, SCPs it to a Mac mini, and installs the app
 # into /Applications.
 #
@@ -140,7 +140,7 @@ MACOS_BUILD_DIR="$SCRIPT_DIR/../clients/macos"
 # 1. Build the staging release
 # ---------------------------------------------------------------------------
 
-export BUNDLE_DISPLAY_NAME="Vellum (Staging)"
+export BUNDLE_DISPLAY_NAME="Vellum Staging"
 export COMMIT_SHA="${COMMIT_SHA:-$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || echo "")}"
 
 if [ "$INTEL_BUILD" = true ]; then
@@ -195,7 +195,7 @@ if command -v create-dmg &>/dev/null; then
   fi
 
   create-dmg \
-    --volname "Vellum (Staging)" \
+    --volname "Vellum Staging" \
     "${DMG_BG_ARGS[@]}" \
     --window-pos 200 120 \
     --window-size 660 400 \
@@ -218,7 +218,7 @@ if command -v create-dmg &>/dev/null; then
   }
 else
   echo "(create-dmg not found, using hdiutil -- install via 'brew install create-dmg' for nicer DMGs)"
-  hdiutil create -volname "Vellum (Staging)" -srcfolder "$DMG_STAGING" -ov -format UDZO "$DMG_PATH"
+  hdiutil create -volname "Vellum Staging" -srcfolder "$DMG_STAGING" -ov -format UDZO "$DMG_PATH"
 fi
 
 echo "DMG created: $DMG_PATH"
@@ -273,7 +273,7 @@ if [ "$LOCAL_INSTALL" = true ]; then
   echo "Installing into /Applications locally..."
 
   # Kill running staging instance if any
-  pkill -x "Vellum (Staging)" 2>/dev/null || true
+  pkill -x "Vellum Staging" 2>/dev/null || true
   sleep 1
 
   # Mount, copy to /Applications, unmount
@@ -283,8 +283,8 @@ if [ "$LOCAL_INSTALL" = true ]; then
     exit 1
   fi
 
-  rm -rf "/Applications/Vellum (Staging).app"
-  cp -R "$MOUNT_POINT/Vellum (Staging).app" "/Applications/Vellum (Staging).app"
+  rm -rf "/Applications/Vellum Staging.app"
+  cp -R "$MOUNT_POINT/Vellum Staging.app" "/Applications/Vellum Staging.app"
   hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
 
   echo "Done! Staging app installed to /Applications locally"
@@ -300,7 +300,7 @@ set -euo pipefail
 DMG="/tmp/vellum-assistant-staging.dmg"
 
 # Kill running staging instance if any
-pkill -x "Vellum (Staging)" 2>/dev/null || true
+pkill -x "Vellum Staging" 2>/dev/null || true
 sleep 1
 
 # Mount, copy to /Applications, unmount
@@ -310,12 +310,12 @@ if [ -z "$MOUNT_POINT" ]; then
   exit 1
 fi
 
-rm -rf "/Applications/Vellum (Staging).app"
-cp -R "$MOUNT_POINT/Vellum (Staging).app" "/Applications/Vellum (Staging).app"
+rm -rf "/Applications/Vellum Staging.app"
+cp -R "$MOUNT_POINT/Vellum Staging.app" "/Applications/Vellum Staging.app"
 hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true
 rm -f "$DMG"
 
-echo "Installed: /Applications/Vellum (Staging).app"
+echo "Installed: /Applications/Vellum Staging.app"
 REMOTE_SCRIPT
 
   echo "Done! Staging app installed to /Applications on ${SCP_HOST}"


### PR DESCRIPTION
## Why needed

Deep investigation into process naming across both repos revealed four inconsistencies that cause silent failures or drift:

1. **`staging-release.sh` uses `"Vellum (Staging)"` but everything else uses `"Vellum Staging"`** — the manual staging release script produces differently-named apps than CI (`release.yml`), Playwright workflows, and QA fixtures. Any tooling expecting the CI name won't match apps produced by the manual script.

2. **`.claude/skills/update/SKILL.md` uses `pkill -x "Vellum"`** — this only kills the production-named app. If a developer is running `"Vellum Local"` (from `vel up`) or `"Vellum Dev"` (from plain `./build.sh`), the old process survives the update, and the subsequent `build.sh run` + `open` triggers the single-instance guard (the exact bug fixed in PR #29513).

3. **No validation on custom dock-display-name length** — macOS stores process names in `p_comm[MAXCOMLEN+1]` where [`MAXCOMLEN=16`](https://github.com/apple/darwin-xnu/blob/main/bsd/sys/param.h). Names longer than 16 characters are silently truncated by the kernel, which breaks `pgrep -x` matching and the instance-kill logic. No warning existed.

4. **`mac-mini-cleanup.sh` only cleans up `"Vellum (Staging).app"`** — after the staging name change, new staging deploys produce `"Vellum Staging.app"`, so the cleanup script would leave them behind.

## What changed

### `scripts/staging-release.sh`
- `BUNDLE_DISPLAY_NAME="Vellum (Staging)"` → `"Vellum Staging"` to match CI release workflow (`release.yml` line 1470) and Playwright expectations (`playwright.yaml` line 198)
- Updated all 10 references: `--volname`, `pkill`, `rm -rf`, `cp -R`, and the header comment

### `.claude/skills/update/SKILL.md`
- `pkill -x "Vellum"` → `pkill -f "Vellum.*\.app/Contents/MacOS/"` which matches the executable path inside any Vellum `.app` bundle regardless of environment suffix (`Vellum`, `Vellum Local`, `Vellum Dev`, `Vellum Staging`)

### `clients/macos/build.sh`
- Added a warning when `BUNDLE_DISPLAY_NAME` exceeds 16 characters, explaining the `pgrep -x` MAXCOMLEN constraint

### `scripts/mac-mini-cleanup.sh`
- Added `"/Applications/Vellum Staging.app"` to the cleanup array alongside the old `"Vellum (Staging).app"` (kept for transition — existing Mac minis may still have the old-named app)

## Why safe

- **staging-release.sh**: The name change aligns the manual script with CI's existing behavior. No other tooling references `"Vellum (Staging)"` — the parenthesized name was an artifact from before environment-specific naming was standardized in commit `1a1d68ef1f`.
- **SKILL.md**: The `-f` flag matches against the full command line (process path), which is always available and not subject to MAXCOMLEN truncation. The regex `Vellum.*\.app/Contents/MacOS/` is specific enough to avoid matching non-app processes.
- **build.sh**: The MAXCOMLEN check is a warning only — it doesn't change behavior, just surfaces information that was previously invisible.
- **mac-mini-cleanup.sh**: Additive change — adds the new name to the cleanup list while keeping the old name for transition.

## Alternatives considered

- **`pkill -x "$BUNDLE_DISPLAY_NAME"` in SKILL.md**: Rejected because the update skill runs from the vellum-assistant repo, not the platform repo, and doesn't have access to `getMacOSProcessName()`. It also doesn't know the current environment at kill time (the env is determined by build.sh later). The `-f` path pattern is more robust.
- **Truncating names > 16 chars automatically in build.sh**: Rejected because silently truncating a user-chosen name is worse than warning. The user should choose a shorter name intentionally.
- **Using `killall` instead of `pkill`**: Rejected because `killall` on macOS matches by process name (same MAXCOMLEN limitation), and `pkill -f` provides regex matching against the full path.

## References

- [XNU `MAXCOMLEN` definition](https://github.com/apple/darwin-xnu/blob/main/bsd/sys/param.h) — `#define MAXCOMLEN 16`
- [Apple `pgrep` source](https://github.com/apple-oss-distributions/adv_cmds/blob/main/pkill/pkill.c) — uses `SYSMON_ATTR_PROC_COMM` (kernel `p_comm`, subject to MAXCOMLEN)
- [.NET runtime PR #96287](https://github.com/dotnet/runtime/pull/96287) — documents the 15/16-char `pbi_comm` truncation issue on macOS

## Root cause analysis

1. **How did the code get into this state?** The `staging-release.sh` script predates the environment-specific naming convention introduced in `1a1d68ef1f`. When that commit standardized names to `"Vellum <Env>"` (no parentheses), the manual script wasn't updated. The update skill was written with only the production name in mind.

2. **What mistakes or decisions led to it?** No single source of truth for staging app names — the CI workflow and manual script evolved independently. The update skill was added without considering non-production environments.

3. **Were there warning signs we missed?** The Playwright workflow comment at line 196 (`# Only staging-tagged builds ship "Vellum Staging.app"`) explicitly documents the expected name, which already conflicted with the manual script.

4. **What can we do to prevent this?** The MAXCOMLEN warning is a concrete preventive measure. For name consistency, the existing `BUNDLE_DISPLAY_NAME` variable in build.sh serves as the single source of truth — the staging-release.sh override just needs to stay aligned.

5. **Should we update AGENTS.md?** Not for this change — the naming convention is already implicit in build.sh's environment logic and doesn't need a separate documentation rule that could go stale.

## Test plan

- Verified all `"Vellum (Staging)"` references replaced by searching: `grep -rn "Vellum (Staging)" scripts/staging-release.sh` returns empty
- Verified the `pkill -f` pattern matches expected paths: `"Vellum Local.app/Contents/MacOS/Vellum Local"`, `"Vellum.app/Contents/MacOS/Vellum"`, `"Vellum Dev.app/Contents/MacOS/Vellum Dev"`
- Verified MAXCOMLEN warning triggers: `BUNDLE_DISPLAY_NAME="Vellum Production Plus"` (22 chars) would print the warning
- Verified `mac-mini-cleanup.sh` now includes both `"Vellum Staging.app"` and legacy `"Vellum (Staging).app"`
- No Swift code changed — no Xcode build needed

Link to Devin session: https://app.devin.ai/sessions/6a69b4f6e6da4fa190bb98c6ac2c66fa
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->