### PR TITLE
fix(daemon): persist ui_surface_update changes to message content blocks

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -26,6 +26,7 @@ mock.module("../memory/conversation-crud.js", () => ({
 // the mocked persistence functions.
 const {
   cancelPendingSurfaceDataPersists,
+  flushPendingSurfaceDataPersists,
   createSurfaceMutex,
   flushSurfaceDataPersist,
   markSurfaceCompleted,
@@ -313,5 +314,91 @@ describe("ui_surface_update persistence", () => {
     await new Promise((r) => setTimeout(r, 600));
 
     expect(writes).toHaveLength(0);
+  });
+
+  test("flushPendingSurfaceDataPersists writes pending updates synchronously and clears timers", async () => {
+    const surfaceId = "surface-flush-pending-1";
+    seedRows([
+      {
+        id: "msg-flush-pending",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId,
+            surfaceType: "card",
+            data: { title: "x", body: "" },
+          },
+        ],
+      },
+    ]);
+
+    scheduleSurfaceDataPersist("conv-persist-1", surfaceId, {
+      title: "x",
+      body: "shutdown-flush",
+    } as SurfaceData);
+
+    // Write should not have fired yet (debounce hasn't elapsed).
+    expect(writes).toHaveLength(0);
+
+    flushPendingSurfaceDataPersists("conv-persist-1");
+
+    // Synchronous flush — write lands immediately with the latest data.
+    expect(writes).toHaveLength(1);
+    expect(writes[0].id).toBe("msg-flush-pending");
+    const block = (writes[0].content as Array<Record<string, unknown>>).find(
+      (b) => b.type === "ui_surface",
+    )!;
+    expect((block.data as Record<string, unknown>).body).toBe("shutdown-flush");
+
+    // Timer is cleared — waiting past the debounce window doesn't fire again.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(writes).toHaveLength(1);
+  });
+
+  test("flushPendingSurfaceDataPersists scoped to one conversation leaves other conversations' timers alone", async () => {
+    const surfaceA = "surface-flush-scoped-a";
+    const surfaceB = "surface-flush-scoped-b";
+    seedRows([
+      {
+        id: "msg-scoped-a",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: surfaceA,
+            surfaceType: "card",
+            data: { title: "x", body: "" },
+          },
+        ],
+      },
+      {
+        id: "msg-scoped-b",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId: surfaceB,
+            surfaceType: "card",
+            data: { title: "x", body: "" },
+          },
+        ],
+      },
+    ]);
+
+    scheduleSurfaceDataPersist("conv-persist-1", surfaceA, {
+      title: "x",
+      body: "a",
+    } as SurfaceData);
+    scheduleSurfaceDataPersist("conv-other", surfaceB, {
+      title: "x",
+      body: "b",
+    } as SurfaceData);
+
+    flushPendingSurfaceDataPersists("conv-persist-1");
+
+    // Only conv-persist-1's surface flushed; conv-other's still pending.
+    expect(writes).toHaveLength(1);
+    expect(writes[0].id).toBe("msg-scoped-a");
+
+    // Cleanup the other conversation's timer.
+    cancelPendingSurfaceDataPersists("conv-other");
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock the persistence layer the surface helpers reach into so we can
+// observe writes without touching SQLite. We swap this out per test by
+// re-assigning the spies recorded on the closure below.
+let getMessagesImpl: (conversationId: string) => Array<{
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+}> = () => [];
+let updateMessageContentSpy: (id: string, content: string) => void = () => {};
+
+const realCrud = await import("../memory/conversation-crud.js");
+
+mock.module("../memory/conversation-crud.js", () => ({
+  ...realCrud,
+  getMessages: (conversationId: string) => getMessagesImpl(conversationId),
+  updateMessageContent: (id: string, content: string) =>
+    updateMessageContentSpy(id, content),
+}));
+
+// Imports must come AFTER mock.module so the surface module picks up
+// the mocked persistence functions.
+const {
+  cancelPendingSurfaceDataPersists,
+  createSurfaceMutex,
+  flushSurfaceDataPersist,
+  markSurfaceCompleted,
+  scheduleSurfaceDataPersist,
+  surfaceProxyResolver,
+} = await import("../daemon/conversation-surfaces.js");
+
+import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
+import type {
+  CardSurfaceData,
+  ServerMessage,
+  SurfaceData,
+  SurfaceType,
+} from "../daemon/message-protocol.js";
+
+function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
+  return {
+    conversationId: "conv-persist-1",
+    traceEmitter: { emit: () => {} },
+    sendToClient: (msg) => sent.push(msg),
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map<
+      string,
+      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    >(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "ok",
+    withSurface: createSurfaceMutex(),
+  };
+}
+
+function seedRows(rows: Array<{ id: string; content: unknown }>): void {
+  getMessagesImpl = () =>
+    rows.map((r) => ({
+      id: r.id,
+      conversationId: "conv-persist-1",
+      role: "assistant",
+      content:
+        typeof r.content === "string" ? r.content : JSON.stringify(r.content),
+      createdAt: 0,
+      metadata: null,
+    }));
+}
+
+describe("ui_surface_update persistence", () => {
+  let writes: Array<{ id: string; content: unknown }> = [];
+
+  beforeEach(() => {
+    writes = [];
+    updateMessageContentSpy = (id: string, content: string) => {
+      writes.push({ id, content: JSON.parse(content) });
+    };
+    getMessagesImpl = () => [];
+    // Make sure module-level pending timers from a previous test don't
+    // leak into this one.
+    cancelPendingSurfaceDataPersists();
+  });
+
+  afterEach(() => {
+    cancelPendingSurfaceDataPersists();
+  });
+
+  test("ui_update schedules a debounced DB write that lands within ~600ms", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    // Seed an existing in-memory surface and a persisted message that
+    // contains the matching ui_surface block.
+    const surfaceId = "surface-debounced-1";
+    const initial: CardSurfaceData = {
+      title: "Health check",
+      body: "",
+      template: "task_progress",
+      templateData: { status: "in_progress", steps: [] },
+    };
+    ctx.surfaceState.set(surfaceId, { surfaceType: "card", data: initial });
+    seedRows([
+      {
+        id: "msg-1",
+        content: [
+          { type: "text", text: "running" },
+          {
+            type: "ui_surface",
+            surfaceId,
+            surfaceType: "card",
+            data: initial,
+          },
+        ],
+      },
+    ]);
+
+    const result = await surfaceProxyResolver(ctx, "ui_update", {
+      surface_id: surfaceId,
+      data: { templateData: { status: "completed" } },
+    });
+    expect(result.isError).toBe(false);
+
+    // Write must not have happened synchronously.
+    expect(writes).toHaveLength(0);
+
+    // After the debounce window the write lands.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(writes).toHaveLength(1);
+    expect(writes[0].id).toBe("msg-1");
+    const persistedBlocks = writes[0].content as Array<Record<string, unknown>>;
+    const persistedSurface = persistedBlocks.find(
+      (b) => b.type === "ui_surface",
+    );
+    expect(persistedSurface).toBeDefined();
+    const persistedData = persistedSurface!.data as CardSurfaceData;
+    expect((persistedData.templateData as Record<string, unknown>).status).toBe(
+      "completed",
+    );
+  });
+
+  test("multiple rapid updates collapse to a single DB write", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const surfaceId = "surface-debounced-2";
+    const initial: CardSurfaceData = {
+      title: "Health check",
+      body: "",
+      template: "task_progress",
+      templateData: { status: "in_progress", steps: [] },
+    };
+    ctx.surfaceState.set(surfaceId, { surfaceType: "card", data: initial });
+    seedRows([
+      {
+        id: "msg-2",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId,
+            surfaceType: "card",
+            data: initial,
+          },
+        ],
+      },
+    ]);
+
+    for (const status of ["a", "b", "c", "d"]) {
+      // Patches arrive faster than the debounce window.
+      await surfaceProxyResolver(ctx, "ui_update", {
+        surface_id: surfaceId,
+        data: { templateData: { status } },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // Wait past the debounce window after the LAST update.
+    await new Promise((r) => setTimeout(r, 600));
+
+    expect(writes).toHaveLength(1);
+    const persistedSurface = (
+      writes[0].content as Array<Record<string, unknown>>
+    ).find((b) => b.type === "ui_surface");
+    const persistedData = persistedSurface!.data as CardSurfaceData;
+    expect((persistedData.templateData as Record<string, unknown>).status).toBe(
+      "d",
+    );
+  });
+
+  test("markSurfaceCompleted force-flushes any pending debounced write", async () => {
+    const surfaceId = "surface-flush-1";
+    const initial: CardSurfaceData = {
+      title: "x",
+      body: "",
+      template: "task_progress",
+      templateData: { status: "in_progress" },
+    };
+    seedRows([
+      {
+        id: "msg-flush",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId,
+            surfaceType: "card",
+            data: initial,
+          },
+        ],
+      },
+    ]);
+
+    // Schedule a debounced persist directly.
+    scheduleSurfaceDataPersist("conv-persist-1", surfaceId, {
+      ...initial,
+      templateData: { status: "completed" },
+    } as SurfaceData);
+
+    expect(writes).toHaveLength(0);
+
+    // Calling markSurfaceCompleted should immediately flush the pending
+    // data persist AND apply its own completion patch — two writes
+    // against the same row, with the completion landing last.
+    markSurfaceCompleted({ conversationId: "conv-persist-1" }, surfaceId, "ok");
+
+    expect(writes.length).toBeGreaterThanOrEqual(2);
+    const finalBlocks = writes[writes.length - 1].content as Array<
+      Record<string, unknown>
+    >;
+    const finalSurface = finalBlocks.find((b) => b.type === "ui_surface")!;
+    expect(finalSurface.completed).toBe(true);
+    expect(finalSurface.completionSummary).toBe("ok");
+  });
+
+  test("flushSurfaceDataPersist fires the latest data immediately", () => {
+    const surfaceId = "surface-flush-2";
+    seedRows([
+      {
+        id: "msg-flush-2",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId,
+            surfaceType: "card",
+            data: { title: "x", body: "" },
+          },
+        ],
+      },
+    ]);
+    scheduleSurfaceDataPersist("conv-persist-1", surfaceId, {
+      title: "x",
+      body: "later",
+    } as SurfaceData);
+
+    expect(writes).toHaveLength(0);
+    flushSurfaceDataPersist(surfaceId);
+    expect(writes).toHaveLength(1);
+    const block = (writes[0].content as Array<Record<string, unknown>>).find(
+      (b) => b.type === "ui_surface",
+    );
+    expect((block!.data as Record<string, unknown>).body).toBe("later");
+  });
+
+  test("update arriving before the message is persisted is safely skipped", async () => {
+    const surfaceId = "surface-orphan-1";
+    // No rows seeded — simulates mid-stream before message_complete persists.
+    seedRows([]);
+
+    scheduleSurfaceDataPersist("conv-persist-1", surfaceId, {
+      title: "x",
+      body: "",
+    } as SurfaceData);
+
+    await new Promise((r) => setTimeout(r, 600));
+
+    // No write — and no crash.
+    expect(writes).toHaveLength(0);
+  });
+
+  test("cancelPendingSurfaceDataPersists clears scoped timers without firing", async () => {
+    const surfaceId = "surface-cancel-1";
+    seedRows([
+      {
+        id: "msg-cancel",
+        content: [
+          {
+            type: "ui_surface",
+            surfaceId,
+            surfaceType: "card",
+            data: { title: "x", body: "" },
+          },
+        ],
+      },
+    ]);
+
+    scheduleSurfaceDataPersist("conv-persist-1", surfaceId, {
+      title: "x",
+      body: "queued",
+    } as SurfaceData);
+
+    cancelPendingSurfaceDataPersists("conv-persist-1");
+    await new Promise((r) => setTimeout(r, 600));
+
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -164,6 +164,10 @@ export function flushSurfaceDataPersist(surfaceId: string): void {
 /**
  * Cancel all pending debounced persists. Called on conversation
  * teardown to avoid timers firing against torn-down state.
+ *
+ * Use `flushPendingSurfaceDataPersists` instead on a clean shutdown
+ * path where the latest in-flight surface state should still be
+ * written before teardown.
  */
 export function cancelPendingSurfaceDataPersists(
   conversationId?: string,
@@ -172,6 +176,22 @@ export function cancelPendingSurfaceDataPersists(
     if (conversationId && pending.conversationId !== conversationId) continue;
     clearTimeout(pending.timer);
     pendingSurfacePersists.delete(surfaceId);
+  }
+}
+
+/**
+ * Synchronously flush all pending debounced persists, optionally scoped
+ * to a single conversation. Called on clean conversation teardown so an
+ * update that arrived inside the 500ms debounce window still lands in
+ * the DB before the conversation goes away. Each entry is removed from
+ * the pending map after its write fires.
+ */
+export function flushPendingSurfaceDataPersists(conversationId?: string): void {
+  for (const [surfaceId, pending] of pendingSurfacePersists) {
+    if (conversationId && pending.conversationId !== conversationId) continue;
+    clearTimeout(pending.timer);
+    pendingSurfacePersists.delete(surfaceId);
+    persistSurfaceData(pending.conversationId, surfaceId, pending.data);
   }
 }
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -54,6 +54,128 @@ const log = getLogger("conversation-surfaces");
 const MAX_UNDO_DEPTH = 10;
 
 /**
+ * Debounce window for persisting `ui_surface_update` data back to the
+ * message row. Surfaces typically receive bursts of updates (e.g. a
+ * Workspace Health Check ticking off items rapidly) — collapsing them
+ * to a single DB write avoids hammering SQLite while still bounding the
+ * "lost work on crash" window to ~half a second.
+ */
+const SURFACE_PERSIST_DEBOUNCE_MS = 500;
+
+/**
+ * In-flight debounced persist timers keyed by `surfaceId`. Surface IDs
+ * are UUIDs and globally unique, so a module-level map is safe across
+ * conversations. Each entry holds the latest data snapshot — newer
+ * updates clobber older ones since the persisted row carries the full
+ * merged state, not a delta.
+ */
+const pendingSurfacePersists = new Map<
+  string,
+  {
+    timer: ReturnType<typeof setTimeout>;
+    conversationId: string;
+    data: SurfaceData;
+  }
+>();
+
+/**
+ * Persist the latest `data` for a `ui_surface` content block by
+ * scanning the conversation's messages for one containing the given
+ * `surfaceId` and patching its `data` field. Mirrors the scan-and-patch
+ * pattern in `markSurfaceCompleted`.
+ *
+ * Safe to call before the assistant message has been persisted (mid-stream):
+ * the scan simply finds nothing and bails. The next update after
+ * `handleMessageComplete` runs will pick up the now-persisted row.
+ */
+function persistSurfaceData(
+  conversationId: string,
+  surfaceId: string,
+  data: SurfaceData,
+): void {
+  try {
+    const rows = getMessages(conversationId);
+    for (let r = rows.length - 1; r >= 0; r--) {
+      let parsed: unknown[];
+      try {
+        const result = JSON.parse(rows[r].content);
+        if (!Array.isArray(result)) continue;
+        parsed = result;
+      } catch {
+        // Plain-text content rows — skip and keep scanning.
+        continue;
+      }
+      let found = false;
+      for (const pb of parsed) {
+        const rb = pb as Record<string, unknown>;
+        if (rb.type === "ui_surface" && rb.surfaceId === surfaceId) {
+          rb.data = data;
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        updateMessageContent(rows[r].id, JSON.stringify(parsed));
+        return;
+      }
+    }
+  } catch (err) {
+    log.debug(
+      { err, surfaceId, conversationId },
+      "Failed to persist surface data update",
+    );
+  }
+}
+
+/**
+ * Schedule a debounced write of the merged surface data back to the
+ * persisted message row. Repeated calls within the debounce window
+ * collapse to a single write carrying the latest data.
+ */
+export function scheduleSurfaceDataPersist(
+  conversationId: string,
+  surfaceId: string,
+  data: SurfaceData,
+): void {
+  const existing = pendingSurfacePersists.get(surfaceId);
+  if (existing) {
+    clearTimeout(existing.timer);
+  }
+  const timer = setTimeout(() => {
+    pendingSurfacePersists.delete(surfaceId);
+    persistSurfaceData(conversationId, surfaceId, data);
+  }, SURFACE_PERSIST_DEBOUNCE_MS);
+  pendingSurfacePersists.set(surfaceId, { timer, conversationId, data });
+}
+
+/**
+ * Force-flush any pending debounced persist for `surfaceId`. Called on
+ * surface completion so the final state is durable before the surface
+ * record transitions to `completed`.
+ */
+export function flushSurfaceDataPersist(surfaceId: string): void {
+  const pending = pendingSurfacePersists.get(surfaceId);
+  if (!pending) return;
+  clearTimeout(pending.timer);
+  pendingSurfacePersists.delete(surfaceId);
+  persistSurfaceData(pending.conversationId, surfaceId, pending.data);
+}
+
+/**
+ * Cancel all pending debounced persists. Called on conversation
+ * teardown to avoid timers firing against torn-down state.
+ */
+export function cancelPendingSurfaceDataPersists(
+  conversationId?: string,
+): void {
+  for (const [surfaceId, pending] of pendingSurfacePersists) {
+    if (conversationId && pending.conversationId !== conversationId) continue;
+    clearTimeout(pending.timer);
+    pendingSurfacePersists.delete(surfaceId);
+  }
+}
+
+/**
  * Mark a `ui_surface` content block as completed in the database so that
  * history reconstruction preserves the completion state.  Also updates
  * in-memory messages when available.
@@ -63,6 +185,10 @@ export function markSurfaceCompleted(
   surfaceId: string,
   summary: string,
 ): void {
+  // Force-flush any pending debounced data persist so the completion
+  // patch lands on top of the latest data instead of racing with it.
+  flushSurfaceDataPersist(surfaceId);
+
   // Update in-memory messages when available so subsequent reads within
   // this session see the change without waiting for DB.
   if (ctx.messages) {
@@ -1784,7 +1910,8 @@ export async function surfaceProxyResolver(
     const reasoning =
       typeof input.reasoning === "string" ? input.reasoning : undefined;
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -2076,6 +2203,12 @@ export async function surfaceProxyResolver(
     if (idx !== -1) {
       ctx.currentTurnSurfaces[idx].data = mergedData;
     }
+
+    // Persist the merged data back to the assistant message's
+    // `ui_surface` content block so a refresh / restart shows the
+    // current state instead of the original creation-time snapshot.
+    // Debounced to coalesce bursts of rapid updates.
+    scheduleSurfaceDataPersist(ctx.conversationId, surfaceId, mergedData);
 
     return { content: "Surface updated", isError: false };
   }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -105,8 +105,8 @@ import {
 } from "./conversation-runtime-assembly.js";
 import type { SkillProjectionCache } from "./conversation-skill-tools.js";
 import {
-  cancelPendingSurfaceDataPersists,
   createSurfaceMutex,
+  flushPendingSurfaceDataPersists,
   handleSurfaceAction as handleSurfaceActionImpl,
   handleSurfaceUndo as handleSurfaceUndoImpl,
   type SurfaceActionResult,
@@ -765,9 +765,11 @@ export class Conversation {
       clearTimeout(timer);
     }
     this.recentlyCompletedStandaloneSurfaces.clear();
-    // Cancel any pending debounced surface-data persists for this
-    // conversation so timers don't fire against torn-down state.
-    cancelPendingSurfaceDataPersists(this.conversationId);
+    // Flush any pending debounced surface-data persists for this
+    // conversation so updates that arrived inside the debounce window
+    // still land in the DB before teardown. Flushing also clears the
+    // pending entries, so no separate cancel call is needed.
+    flushPendingSurfaceDataPersists(this.conversationId);
     // Only dispose the per-conversation CU and app-control proxies.
     // Bash/File/Transfer are singletons — their lifecycle is managed by
     // static disposeInstance().

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -105,6 +105,7 @@ import {
 } from "./conversation-runtime-assembly.js";
 import type { SkillProjectionCache } from "./conversation-skill-tools.js";
 import {
+  cancelPendingSurfaceDataPersists,
   createSurfaceMutex,
   handleSurfaceAction as handleSurfaceActionImpl,
   handleSurfaceUndo as handleSurfaceUndoImpl,
@@ -764,6 +765,9 @@ export class Conversation {
       clearTimeout(timer);
     }
     this.recentlyCompletedStandaloneSurfaces.clear();
+    // Cancel any pending debounced surface-data persists for this
+    // conversation so timers don't fire against torn-down state.
+    cancelPendingSurfaceDataPersists(this.conversationId);
     // Only dispose the per-conversation CU and app-control proxies.
     // Bash/File/Transfer are singletons — their lifecycle is managed by
     // static disposeInstance().


### PR DESCRIPTION
## Summary
Surfaces (e.g., Workspace Health Check) lost their checked/result state on page refresh because `ui_surface_update` events updated only in-memory `ctx.currentTurnSurfaces[idx].data` and emitted SSE — never writing back to the persisted message content. On reload, clients fetched the original surface data from creation time.

This patches the persisted assistant message's `ui_surface` content block via `updateMessageContent()` (same path `markSurfaceCompleted` already uses) on every update, debounced at 500ms to avoid hammering the DB on rapid-fire updates. `markSurfaceCompleted` force-flushes any pending debounced write so the final state is always durable. Pending timers are cancelled on context teardown.

## Test plan
- [ ] Unit tests: debounce collapses rapid updates to one write; completion forces flush; pre-persist update is safely skipped.
- [ ] Manual: trigger a Workspace Health Check, refresh the web client mid-flight, confirm the latest checked/result state is shown (instead of the empty creation-time state).

## Out of scope
- `updated_at` schema column (orthogonal cleanup affecting all 4 in-place patch paths).
- `indexMessageNow()` re-fire on patch (surface state not valuable as search content).
- `syncMessageToDisk()` on patch (matches existing convention; disk-view only consulted on disaster recovery).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->