### PR TITLE
feat(githooks): add commit-msg hook for generic-examples patterns

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -51,6 +51,27 @@ If you need to bypass this check in exceptional cases:
 git commit --no-verify
 ```
 
+### commit-msg
+
+Runs the same generic-examples patterns as `pre-commit`, but against the commit message text itself rather than the staged diff.
+
+**What it checks:**
+
+- **Generic-examples rule on commit messages** — Runs `scripts/check-generic-examples.ts --commit-msg <path>` against the message git is about to record. The same shape patterns and any private patterns (`VELLUM_CONTENT_CHECK_PATTERNS`) apply.
+
+**Behavior:**
+
+- Comment lines (lines starting with `#`) are stripped before scanning, since git removes them from the recorded commit anyway.
+- Content below the `# ------------------------ >8 ------------------------` scissors line (used by `git commit -v`) is ignored, since git also drops it.
+<!-- generic-examples:ignore-next-line — illustrative example of what the rule flags -->
+- Patterns are quote-anchored — they catch quoted/back-ticked emails and phone numbers (e.g., `Updated "alice@gmail.com" to be hashed`), not bare prose. Angle-bracketed trailers like `Co-Authored-By: Claude <noreply@anthropic.com>` are not flagged.
+- Same suppression syntax as `pre-commit`: `generic-examples:ignore-line` / `generic-examples:ignore-next-line` (note that the marker survives into the recorded message).
+
+**Bypass (not recommended):**
+```bash
+git commit --no-verify
+```
+
 ### pre-push
 
 Runs before pushing to catch issues that would fail CI.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Generic-examples scan for commit messages.
+#
+# Mirrors the pre-commit hook's check, but against the message text in $1
+# (the path git passes to a commit-msg hook). See scripts/check-generic-examples.ts.
+
+set -euo pipefail
+
+REPO="$(git rev-parse --show-toplevel)"
+GE_BUN="${BUN:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}"
+
+if [ ! -x "$GE_BUN" ]; then
+  printf '\033[1;33m⚠️  bun not found — skipping generic-examples check on commit message\033[0m\n' >&2
+  exit 0
+fi
+
+exec "$GE_BUN" "$REPO/scripts/check-generic-examples.ts" --commit-msg "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Never include personal user data — real names, emails, phone numbers, account 
 
 This applies even when the data is the author's own — examples get copied by future contributors, and real data propagates through forks, screenshots, and logs.
 
-**Enforcement:** the pre-commit hook runs `scripts/check-generic-examples.ts` against staged changes. The in-repo patterns are shape-based (non-example emails, phones outside `555-01xx`). Contributors who want to block additional project-specific terms on their own machine can drop them into a local config — see `scripts/generic-examples/README.md`. Inline suppression: add `// generic-examples:ignore-next-line — reason: <why>` on the line above.
+**Enforcement:** the pre-commit hook runs `scripts/check-generic-examples.ts` against staged changes, and the commit-msg hook runs the same patterns against the commit message itself (with `#` comment lines and the `git commit -v` scissors region stripped first). The in-repo patterns are shape-based (non-example emails, phones outside `555-01xx`) and quote-anchored — they catch quoted or back-ticked occurrences, not bare prose. Contributors who want to block additional project-specific terms on their own machine can drop them into a local config — see `scripts/generic-examples/README.md`. Inline suppression: add `// generic-examples:ignore-next-line — reason: <why>` on the line above.
 
 ## Backwards Compatibility
 

--- a/scripts/check-generic-examples.ts
+++ b/scripts/check-generic-examples.ts
@@ -2,16 +2,18 @@
 /**
  * Enforces the "Generic Examples" rule from AGENTS.md: test fixtures,
  * examples, and dialogue data must use generic placeholders rather than
- * real personal data. Runs from the pre-commit hook on staged changes.
+ * real personal data. Runs from the pre-commit hook on staged changes
+ * and from the commit-msg hook on the message text itself.
  *
  * The in-repo patterns are shape-based (email/phone formats). Contributors
  * who want to block additional terms can drop them into a local config
  * outside the repo — see scripts/generic-examples/README.md.
  *
  * Usage:
- *   bun scripts/check-generic-examples.ts              # scan staged changes
- *   bun scripts/check-generic-examples.ts --ci         # scan HEAD..origin/main (for CI use)
- *   bun scripts/check-generic-examples.ts --self-test  # run built-in tests
+ *   bun scripts/check-generic-examples.ts                    # scan staged changes
+ *   bun scripts/check-generic-examples.ts --ci               # scan HEAD..origin/main (for CI use)
+ *   bun scripts/check-generic-examples.ts --commit-msg PATH  # scan a commit message file
+ *   bun scripts/check-generic-examples.ts --self-test        # run built-in tests
  *
  * Bypass a single line: add `// generic-examples:ignore-next-line — reason: X`
  * on the line above. Bypass the whole commit: `git commit --no-verify`.
@@ -129,7 +131,7 @@ interface AddedLine {
 const SKIP_FILE_PATTERNS: RegExp[] = [
   /^scripts\/generic-examples\//,
   /^scripts\/check-generic-examples\.ts$/,
-  /^\.githooks\/pre-commit$/,
+  /^\.githooks\/(pre-commit|commit-msg)$/,
   /\.lock$/,
   /\.lockb$/,
   /package-lock\.json$/,
@@ -190,6 +192,34 @@ function parseUnifiedDiff(diff: string): AddedLine[] {
     }
   }
   return added;
+}
+
+// -------- Commit-message parsing --------
+
+// Git inserts this scissors line via `git commit --verbose` (and friends);
+// everything below it is dropped before the commit is recorded.
+const COMMIT_MSG_SCISSORS = "# ------------------------ >8 ------------------------";
+
+function parseCommitMessage(text: string): AddedLine[] {
+  const result: AddedLine[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw === COMMIT_MSG_SCISSORS) break;
+    // Lines starting with `#` are stripped before the commit is recorded;
+    // skip them so we don't false-positive on guidance text.
+    if (raw.startsWith("#")) continue;
+    // No previousContent tracking: prior-line suppression markers in commit
+    // messages would survive into the recorded message (odd UX). Same-line
+    // `generic-examples:ignore-line` still works via isSuppressed().
+    result.push({
+      file: "(commit message)",
+      line: i + 1,
+      content: raw,
+      previousContent: "",
+    });
+  }
+  return result;
 }
 
 function getDiff(mode: "staged" | "ci"): string {
@@ -357,6 +387,52 @@ const TEST_CASES: TestCase[] = [
   },
 ];
 
+interface CommitMsgTestCase {
+  name: string;
+  text: string;
+  expectPatterns: string[];
+}
+
+const COMMIT_MSG_TEST_CASES: CommitMsgTestCase[] = [
+  {
+    name: "clean message passes",
+    text: 'fix: handle null user\n\nCloses JARVIS-123\n',
+    expectPatterns: [],
+  },
+  {
+    name: "quoted real email in body is flagged",
+    text: 'fix: migrate user\n\nMigrating "alice@gmail.com" to org table.\n',
+    expectPatterns: ["non-example-email"],
+  },
+  {
+    name: "quoted example email in body is OK",
+    text: 'fix: migrate user\n\nMigrating "user@example.com" to org table.\n',
+    expectPatterns: [],
+  },
+  {
+    name: "comment line containing real email is skipped",
+    text: 'fix: bug\n\n# Please enter the commit message. Lines starting with\n# "#" will be ignored. Example: alice@gmail.com\n',
+    expectPatterns: [],
+  },
+  {
+    name: "scissors line truncates scan",
+    text:
+      'fix: bug\n\n' +
+      '# ------------------------ >8 ------------------------\n' +
+      '# Do not modify or remove the line above.\n' +
+      'diff --git a/file.ts b/file.ts\n' +
+      '+const e = "alice@gmail.com";\n',
+    expectPatterns: [],
+  },
+  {
+    name: "Co-Authored-By trailer with angle-bracketed email is OK",
+    text:
+      'fix: bug\n\n' +
+      'Co-Authored-By: Claude <noreply@anthropic.com>\n',
+    expectPatterns: [],
+  },
+];
+
 function runSelfTest(): number {
   let failed = 0;
   for (const tc of TEST_CASES) {
@@ -376,7 +452,19 @@ function runSelfTest(): number {
       );
     }
   }
-  const total = TEST_CASES.length;
+  for (const tc of COMMIT_MSG_TEST_CASES) {
+    const lines = parseCommitMessage(tc.text);
+    const findings = scan(lines, SHAPE_PATTERNS);
+    const got = findings.map((f) => f.pattern).sort();
+    const want = [...tc.expectPatterns].sort();
+    if (JSON.stringify(got) !== JSON.stringify(want)) {
+      failed++;
+      process.stderr.write(
+        `FAIL (commit-msg): ${tc.name}\n  want: ${want.join(", ") || "(none)"}\n  got:  ${got.join(", ") || "(none)"}\n`,
+      );
+    }
+  }
+  const total = TEST_CASES.length + COMMIT_MSG_TEST_CASES.length;
   if (failed === 0) {
     process.stdout.write(`${total}/${total} self-tests passed\n`);
     return 0;
@@ -399,9 +487,45 @@ async function promptContinue(): Promise<boolean> {
   });
 }
 
+async function runCommitMsgMode(path: string): Promise<number> {
+  const absPath = resolve(path);
+  if (!existsSync(absPath)) {
+    process.stderr.write(`error: commit message file not found: ${absPath}\n`);
+    return 1;
+  }
+  const text = readFileSync(absPath, "utf8");
+  const lines = parseCommitMessage(text);
+  if (lines.length === 0) return 0;
+
+  const patterns = [...SHAPE_PATTERNS, ...loadPrivatePatterns()];
+  const findings = scan(lines, patterns);
+  if (findings.length === 0) return 0;
+
+  printFindings(findings);
+
+  const blocks = findings.filter((f) => f.severity === "BLOCK");
+  if (blocks.length > 0) return 1;
+
+  // Warnings only.
+  const proceed = await promptContinue();
+  return proceed ? 0 : 1;
+}
+
 async function main(): Promise<number> {
   const args = process.argv.slice(2);
   if (args.includes("--self-test")) return runSelfTest();
+
+  const commitMsgIdx = args.indexOf("--commit-msg");
+  if (commitMsgIdx >= 0) {
+    const path = args[commitMsgIdx + 1];
+    if (!path) {
+      process.stderr.write(
+        "error: --commit-msg requires a file path argument\n",
+      );
+      return 1;
+    }
+    return runCommitMsgMode(path);
+  }
 
   // Change to repo root so git commands work regardless of cwd.
   try {


### PR DESCRIPTION
## Summary
- Add `.githooks/commit-msg` hook that runs `scripts/check-generic-examples.ts --commit-msg <path>` against the commit message git is about to record.
- Add `--commit-msg <path>` mode to the script with a `parseCommitMessage()` parser that strips `#` comment lines (which git drops anyway) and truncates at the `# >8` scissors region. Reuses existing `scan()`, `isSuppressed()`, `printFindings()`, `loadPrivatePatterns()`.
- Update `.githooks/README.md` with a `commit-msg` section and amend the `AGENTS.md` "Generic Examples → Enforcement" paragraph to reflect the new coverage and the quote-anchored nature of the patterns.
- Self-tests extended (14 total) covering clean messages, quoted real emails (blocked), example-domain emails (OK), `#`-comment stripping, scissors truncation, and angle-bracketed `Co-Authored-By` trailers (OK).

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->