### PR TITLE
[codex] Sanitize provider-visible dynamic tool names

### DIFF
--- a/assistant/src/__tests__/mcp-abort-signal.test.ts
+++ b/assistant/src/__tests__/mcp-abort-signal.test.ts
@@ -145,6 +145,45 @@ describe("MCP AbortSignal threading", () => {
       expect(tool.getDefinition().name).toBe("mcp__test-server__my-tool");
     });
 
+    test("keeps MCP tool names with trailing whitespace distinct", () => {
+      const fakeManager = { callTool: jest.fn() } as any;
+
+      const plain = createMcpTool(
+        {
+          name: "deploy",
+          description: "Deploy",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "test-server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+      const padded = createMcpTool(
+        {
+          name: "deploy ",
+          description: "Deploy padded",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "test-server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      expect(plain.name).toBe("mcp__test-server__deploy");
+      expect(padded.name).toMatch(/^mcp__test-server__deploy__[a-f0-9]{12}$/);
+      expect(padded.name).not.toBe(plain.name);
+    });
+
     test("exposes provider-safe MCP names while preserving raw execution names", async () => {
       const callToolSpy = jest.fn().mockResolvedValue({
         content: "tool result",

--- a/assistant/src/__tests__/mcp-abort-signal.test.ts
+++ b/assistant/src/__tests__/mcp-abort-signal.test.ts
@@ -122,6 +122,97 @@ describe("MCP AbortSignal threading", () => {
   });
 
   describe("createMcpTool execute", () => {
+    test("keeps safe MCP tool names unchanged", () => {
+      const fakeManager = { callTool: jest.fn() } as any;
+
+      const tool = createMcpTool(
+        {
+          name: "my-tool",
+          description: "A test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "test-server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      expect(tool.name).toBe("mcp__test-server__my-tool");
+      expect(tool.getDefinition().name).toBe("mcp__test-server__my-tool");
+    });
+
+    test("exposes provider-safe MCP names while preserving raw execution names", async () => {
+      const callToolSpy = jest.fn().mockResolvedValue({
+        content: "tool result",
+        isError: false,
+      });
+      const fakeManager = { callTool: callToolSpy } as any;
+
+      const tool = createMcpTool(
+        {
+          name: "create link",
+          description: "Create a Stripe Link CLI resource",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "stripe.link-cli",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      expect(tool.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+      expect(tool.name.startsWith("mcp__stripe_link-cli__create_link__")).toBe(
+        true,
+      );
+      expect(tool.getDefinition().name).toBe(tool.name);
+
+      await tool.execute(
+        { someArg: "value" },
+        {
+          workingDir: "/tmp",
+          conversationId: "conv-1",
+          trustClass: "guardian",
+        },
+      );
+
+      expect(callToolSpy).toHaveBeenCalledWith(
+        "stripe.link-cli",
+        "create link",
+        { someArg: "value" },
+        undefined,
+      );
+    });
+
+    test("caps long MCP names at the provider limit", () => {
+      const fakeManager = { callTool: jest.fn() } as any;
+      const tool = createMcpTool(
+        {
+          name: "x".repeat(180),
+          description: "A test tool",
+          inputSchema: { type: "object", properties: {} },
+        },
+        "server",
+        {
+          transport: { type: "stdio", command: "echo", args: [] },
+          enabled: true,
+          defaultRiskLevel: "high",
+          maxTools: 100,
+        },
+        fakeManager,
+      );
+
+      expect(tool.name).toHaveLength(64);
+      expect(tool.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    });
+
     test("threads context.signal through manager.callTool", async () => {
       const callToolSpy = jest.fn().mockResolvedValue({
         content: "tool result",

--- a/assistant/src/__tests__/plugin-tool-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-tool-contribution.test.ts
@@ -266,6 +266,23 @@ describe("registerPluginTools / unregisterPluginTools helpers", () => {
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  test("registerPluginTools keeps edge-whitespace tool names distinct", () => {
+    const accepted = registerPluginTools("deploy-plugin", [
+      makeFakeTool("deploy"),
+      makeFakeTool(" deploy "),
+    ]);
+
+    expect(accepted).toHaveLength(2);
+    const aliases = accepted.map((tool) => tool.name);
+    expect(new Set(aliases).size).toBe(2);
+    expect(aliases).toContain("deploy");
+
+    const paddedAlias = aliases.find((name) => name !== "deploy");
+    expect(paddedAlias).toMatch(/^deploy__[a-f0-9]{12}$/);
+    expect(getTool("deploy")).toBeDefined();
+    expect(getTool(paddedAlias!)).toBeDefined();
+  });
+
   test("registerPluginTools overwrites any pre-existing ownership metadata", () => {
     // A plugin author could (maliciously or mistakenly) hand in a tool
     // pre-tagged with another skill's or plugin's ID. The helper must

--- a/assistant/src/__tests__/plugin-tool-contribution.test.ts
+++ b/assistant/src/__tests__/plugin-tool-contribution.test.ts
@@ -236,6 +236,36 @@ describe("registerPluginTools / unregisterPluginTools helpers", () => {
     expect(retrieved?.ownerPluginId).toBe("my-plugin");
   });
 
+  test("registerPluginTools exposes provider-safe aliases for unsafe plugin tool names", async () => {
+    const execute = mock(
+      async (
+        _input: Record<string, unknown>,
+        _context: ToolContext,
+      ): Promise<ToolExecutionResult> => ({ content: "ok", isError: false }),
+    );
+    const accepted = registerPluginTools("stripe-plugin", [
+      makeFakeTool("Stripe Link CLI", { execute }),
+    ]);
+
+    expect(accepted).toHaveLength(1);
+    const alias = accepted[0]!.name;
+    expect(alias).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    expect(alias.startsWith("Stripe_Link_CLI__")).toBe(true);
+    expect(getTool(alias)).toBeDefined();
+    expect(accepted[0]!.getDefinition().name).toBe(alias);
+
+    await accepted[0]!.execute(
+      {},
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-1",
+        trustClass: "guardian",
+      },
+    );
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   test("registerPluginTools overwrites any pre-existing ownership metadata", () => {
     // A plugin author could (maliciously or mistakenly) hand in a tool
     // pre-tagged with another skill's or plugin's ID. The helper must

--- a/assistant/src/__tests__/provider-tool-name.test.ts
+++ b/assistant/src/__tests__/provider-tool-name.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isProviderSafeToolName,
+  toProviderSafeToolName,
+} from "../tools/provider-tool-name.js";
+
+describe("provider tool names", () => {
+  test("leaves already-safe names unchanged", () => {
+    expect(toProviderSafeToolName("deploy")).toBe("deploy");
+    expect(isProviderSafeToolName("deploy")).toBe(true);
+  });
+
+  test("preserves raw-name identity for names that differ by edge whitespace", () => {
+    const plain = toProviderSafeToolName("deploy");
+    const padded = toProviderSafeToolName(" deploy ");
+
+    expect(plain).toBe("deploy");
+    expect(padded).toMatch(/^deploy__[a-f0-9]{12}$/);
+    expect(padded).not.toBe(plain);
+    expect(isProviderSafeToolName(padded)).toBe(true);
+  });
+});

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -2,6 +2,7 @@ import type { McpServerConfig } from "../../config/schemas/mcp.js";
 import type { McpServerManager } from "../../mcp/manager.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
+import { toProviderSafeToolName } from "../provider-tool-name.js";
 import { schemaDefinesProperty } from "../schema-transforms.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 
@@ -16,7 +17,7 @@ const riskMap: Record<string, RiskLevel> = {
  * and with core/skill tools.
  */
 function mcpToolName(serverId: string, toolName: string): string {
-  return `mcp__${serverId}__${toolName}`;
+  return toProviderSafeToolName(`mcp__${serverId}__${toolName}`);
 }
 
 export interface McpToolMetadata {

--- a/assistant/src/tools/provider-tool-name.ts
+++ b/assistant/src/tools/provider-tool-name.ts
@@ -10,8 +10,8 @@ export function isProviderSafeToolName(name: string): boolean {
 
 export function toProviderSafeToolName(rawName: string): string {
   const trimmed = rawName.trim();
-  if (isProviderSafeToolName(trimmed)) {
-    return trimmed;
+  if (isProviderSafeToolName(rawName)) {
+    return rawName;
   }
 
   const hash = createHash("sha256")

--- a/assistant/src/tools/provider-tool-name.ts
+++ b/assistant/src/tools/provider-tool-name.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto";
+
+const PROVIDER_TOOL_NAME_MAX_LENGTH = 64;
+const PROVIDER_TOOL_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+const HASH_LENGTH = 12;
+
+export function isProviderSafeToolName(name: string): boolean {
+  return PROVIDER_TOOL_NAME_RE.test(name);
+}
+
+export function toProviderSafeToolName(rawName: string): string {
+  const trimmed = rawName.trim();
+  if (isProviderSafeToolName(trimmed)) {
+    return trimmed;
+  }
+
+  const hash = createHash("sha256")
+    .update(rawName)
+    .digest("hex")
+    .slice(0, HASH_LENGTH);
+  const suffix = `__${hash}`;
+  const maxBaseLength = PROVIDER_TOOL_NAME_MAX_LENGTH - suffix.length;
+  const sanitized =
+    trimmed.replace(/[^a-zA-Z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "tool";
+  const base = sanitized.slice(0, maxBaseLength).replace(/_+$/g, "") || "tool";
+
+  return `${base}${suffix}`;
+}

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -8,6 +8,7 @@ import { hostFileReadTool } from "./host-filesystem/read.js";
 import { hostFileTransferTool } from "./host-filesystem/transfer.js";
 import { hostFileWriteTool } from "./host-filesystem/write.js";
 import { hostShellTool } from "./host-terminal/host-shell.js";
+import { toProviderSafeToolName } from "./provider-tool-name.js";
 import { registerSystemTools } from "./system/register.js";
 import type { Tool } from "./types.js";
 import { allUiSurfaceTools } from "./ui-surface/definitions.js";
@@ -74,6 +75,24 @@ const skillRefCount = new Map<string, number>();
 // match a skill id. Conflict detection on `tools` (keyed by tool name) is
 // separate and covers the case of two extensions choosing the same tool name.
 const pluginRefCount = new Map<string, number>();
+
+function withProviderSafeToolName(tool: Tool): Tool {
+  const safeName = toProviderSafeToolName(tool.name);
+  if (safeName === tool.name) {
+    return tool;
+  }
+
+  return {
+    ...tool,
+    name: safeName,
+    getDefinition(): ToolDefinition {
+      return {
+        ...tool.getDefinition(),
+        name: safeName,
+      };
+    },
+  };
+}
 
 export function registerTool(tool: Tool): void {
   const existing = tools.get(tool.name);
@@ -176,15 +195,17 @@ export function registerPluginTools(
   pluginName: string,
   newTools: Tool[],
 ): Tool[] {
-  const stamped: Tool[] = newTools.map((tool) => ({
-    ...tool,
-    origin: "plugin" as const,
-    ownerPluginId: pluginName,
-    ownerSkillId: undefined,
-    ownerMcpServerId: undefined,
-    ownerSkillBundled: undefined,
-    ownerSkillVersionHash: undefined,
-  }));
+  const stamped: Tool[] = newTools.map((tool) =>
+    withProviderSafeToolName({
+      ...tool,
+      origin: "plugin" as const,
+      ownerPluginId: pluginName,
+      ownerSkillId: undefined,
+      ownerMcpServerId: undefined,
+      ownerSkillBundled: undefined,
+      ownerSkillVersionHash: undefined,
+    }),
+  );
 
   const accepted: Tool[] = [];
   for (const tool of stamped) {


### PR DESCRIPTION
## Summary
- add a shared provider-safe tool-name helper using the strict common provider constraint: `[a-zA-Z0-9_-]` and max 64 characters
- sanitize MCP tool aliases before exposing them to providers while preserving raw server/tool identifiers for execution
- sanitize plugin-contributed tool aliases without changing the underlying plugin execution implementation

## Root cause
Dynamic MCP/plugin tool names could leak raw integration identifiers into provider request payloads. Names containing characters such as dots, spaces, or slashes, or names that exceed provider limits, can violate tool/function name schemas and produce a provider 400 before the assistant can respond.

## Impact
Managed assistants can expose tools from integrations like a Stripe Link CLI without tripping Anthropic/OpenAI schema validation. Existing provider-safe names remain unchanged when they already fit the common provider limit.

## Validation
- `cd assistant && bun test src/__tests__/mcp-abort-signal.test.ts`
- `cd assistant && bun test src/__tests__/plugin-tool-contribution.test.ts`
- `cd assistant && bunx tsc --noEmit`
- commit/pre-push hooks ran formatting, lint, and typecheck successfully; the pre-push hook script emitted two shell warnings but exited 0