### PR TITLE
feat(macos): add `PlatformMigrationClient.downloadFromSignedUrl`

### DIFF
--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -183,6 +183,84 @@ public enum PlatformMigrationClient {
         throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Unexpected retry loop exit")
     }
 
+    /// Downloads bundle data from a GCS signed URL.
+    ///
+    /// Mirrors `uploadToSignedUrl(_:bundleData:onProgress:)` in reverse: the
+    /// caller passes a signed download URL (from `requestSignedDownloadUrl`)
+    /// and gets back the raw bundle bytes suitable for piping into
+    /// `migrations/import` on a local runtime.
+    ///
+    /// Retries on transient 5xx server errors (500/502/503/504) with the same
+    /// 1s/2s/4s exponential backoff used elsewhere in this client.
+    ///
+    /// - Parameters:
+    ///   - url: The signed download URL.
+    ///   - onProgress: Optional closure called on the main actor with values
+    ///     from 0.0 to 1.0 representing the fraction of bytes received.
+    /// - Returns: The full bundle data.
+    /// - Throws: `PlatformMigrationError.requestFailed` on a non-2xx status,
+    ///   or any error thrown by `URLSession`.
+    public static func downloadFromSignedUrl(
+        _ url: String,
+        onProgress: (@MainActor (Double) -> Void)? = nil
+    ) async throws -> Data {
+        guard let downloadURL = URL(string: url) else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: downloadURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 3600
+
+        let delegate: DownloadProgressDelegate?
+        let session: URLSession
+        if let onProgress {
+            let d = DownloadProgressDelegate(onProgress: onProgress)
+            delegate = d
+            session = URLSession(configuration: .default, delegate: d, delegateQueue: nil)
+        } else {
+            delegate = nil
+            session = URLSession.shared
+        }
+        defer {
+            delegate?.reset()
+            if delegate != nil {
+                session.finishTasksAndInvalidate()
+            }
+        }
+
+        let urlPath = logPath(from: downloadURL)
+
+        for attempt in 0...maxRetries {
+            log.info("GET \(urlPath, privacy: .public)\(attempt > 0 ? " (retry \(attempt)/\(maxRetries))" : "")")
+            let (data, response) = try await session.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            log.info("GET \(urlPath, privacy: .public) → \(statusCode)")
+
+            if attempt < maxRetries && retryableStatusCodes.contains(statusCode) {
+                let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
+                log.warning("Transient server error (\(statusCode)) — retrying in \(1 << attempt)s")
+                try await Task.sleep(nanoseconds: delay)
+                delegate?.reset()
+                await onProgress?(0)
+                continue
+            }
+
+            guard (200..<300).contains(statusCode) else {
+                throw PlatformMigrationError.requestFailed(
+                    statusCode: statusCode,
+                    detail: "Bundle download failed"
+                )
+            }
+            // Ensure the progress reaches 1.0 even if the delegate's last
+            // didReceive event was throttled out by the 0.01-step gate.
+            await onProgress?(1.0)
+            return data
+        }
+
+        throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Unexpected retry loop exit")
+    }
+
     /// Triggers a GCS-based import on the platform after the bundle has been uploaded.
     ///
     /// - Parameter bundleKey: The bundle key returned by `requestSignedUploadUrl()`.
@@ -343,6 +421,46 @@ public enum PlatformMigrationClient {
         /// in-flight callbacks from the previous attempt are discarded.
         func reset() {
             lastReportedFraction = 0.0
+            generation += 1
+        }
+    }
+
+    /// Tracks download progress and dispatches throttled updates to the main actor.
+    /// Mirrors `UploadProgressDelegate` but for response data instead of request body.
+    private class DownloadProgressDelegate: NSObject, URLSessionDataDelegate {
+        private let onProgress: @MainActor (Double) -> Void
+        private var lastReportedFraction: Double = 0.0
+        private var generation: Int = 0
+        private var bytesReceived: Int64 = 0
+
+        init(onProgress: @escaping @MainActor (Double) -> Void) {
+            self.onProgress = onProgress
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            didReceive data: Data
+        ) {
+            bytesReceived += Int64(data.count)
+            let total = dataTask.countOfBytesExpectedToReceive
+            guard total > 0 else { return }
+            let progress = Double(bytesReceived) / Double(total)
+            guard progress - lastReportedFraction >= 0.01 || progress >= 1.0 else { return }
+            lastReportedFraction = progress
+            let callback = self.onProgress
+            let gen = self.generation
+            Task { [weak self] in
+                guard self?.generation == gen else { return }
+                await callback(progress)
+            }
+        }
+
+        /// Resets throttle and increments the generation counter so any
+        /// in-flight callbacks from the previous attempt are discarded.
+        func reset() {
+            lastReportedFraction = 0.0
+            bytesReceived = 0
             generation += 1
         }
     }

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -233,7 +233,7 @@ public enum PlatformMigrationClient {
 
         for attempt in 0...maxRetries {
             log.info("GET \(urlPath, privacy: .public)\(attempt > 0 ? " (retry \(attempt)/\(maxRetries))" : "")")
-            let (data, response) = try await session.data(for: request)
+            let (data, response) = try await session.data(for: request, delegate: delegate)
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
             log.info("GET \(urlPath, privacy: .public) → \(statusCode)")
 

--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -283,3 +283,123 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
         return data
     }
 }
+
+@MainActor
+final class PlatformMigrationClientDownloadFromSignedUrlTests: XCTestCase {
+    private var previousToken: String?
+
+    override func setUp() {
+        super.setUp()
+        JobStatusURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(JobStatusURLProtocol.self)
+        previousToken = SessionTokenManager.getToken()
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(JobStatusURLProtocol.self)
+        JobStatusURLProtocol.requestHandler = nil
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+        super.tearDown()
+    }
+
+    func testDownloadFromSignedUrlGetsAndReturnsBytes() async throws {
+        let observed = ObservedRequest()
+        let stubBytes = Data([0xAA, 0xBB, 0xCC])
+        JobStatusURLProtocol.requestHandler = { request in
+            observed.url = request.url
+            observed.method = request.httpMethod
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, stubBytes)
+        }
+
+        let data = try await PlatformMigrationClient.downloadFromSignedUrl("https://storage.example/dl")
+
+        XCTAssertEqual(data, stubBytes)
+        XCTAssertEqual(observed.method, "GET")
+    }
+
+    func testDownloadFromSignedUrlReportsProgressTo1Point0OnSuccess() async throws {
+        let stubBytes = Data([0xAA, 0xBB, 0xCC])
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, stubBytes)
+        }
+
+        let holder = ProgressHolder()
+        _ = try await PlatformMigrationClient.downloadFromSignedUrl(
+            "https://storage.example/dl",
+            onProgress: { value in
+                holder.update(value)
+            }
+        )
+
+        let highest = await holder.highest
+        XCTAssertEqual(highest, 1.0, accuracy: 0.0001)
+    }
+
+    func testDownloadFromSignedUrlThrowsRequestFailedOnNon2xx() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"not found"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.downloadFromSignedUrl("https://storage.example/dl")
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 404)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testDownloadFromSignedUrlInvalidUrlThrowsRequestFailed() async {
+        do {
+            _ = try await PlatformMigrationClient.downloadFromSignedUrl("")
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 0)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}
+
+/// Captures the highest progress fraction observed across `onProgress` callbacks.
+@MainActor
+private final class ProgressHolder {
+    private(set) var highest: Double = 0.0
+
+    func update(_ value: Double) {
+        if value > highest { highest = value }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PlatformMigrationClient.downloadFromSignedUrl(_:onProgress:)` for GCS signed-URL downloads.
- Adds private `DownloadProgressDelegate` mirroring `UploadProgressDelegate` but for received bytes.
- Adds unit tests for happy path, progress reporting, non-2xx, and invalid URL.

Part of plan: teleport-platform-to-local.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->