### PR TITLE
feat(macos): add `PlatformMigrationClient.requestSignedDownloadUrl`

### DIFF
--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -43,6 +43,7 @@ public enum PlatformMigrationClient {
         case signedUrlsNotAvailable
         case requestFailed(statusCode: Int, detail: String)
         case uploadFailed(statusCode: Int)
+        case versionMismatch(minVersion: String, maxVersion: String?, targetVersion: String)
 
         public var errorDescription: String? {
             switch self {
@@ -54,6 +55,14 @@ public enum PlatformMigrationClient {
                 return "Migration request failed (HTTP \(statusCode)): \(detail)"
             case .uploadFailed(let statusCode):
                 return "Bundle upload failed (HTTP \(statusCode))."
+            case .versionMismatch(let minVersion, let maxVersion, let targetVersion):
+                let range: String
+                if let maxVersion {
+                    range = "\(minVersion)–\(maxVersion)"
+                } else {
+                    range = "\(minVersion)+"
+                }
+                return "Cannot import: bundle requires runtime \(range), but this local runtime is \(targetVersion). Update your local runtime before importing."
             }
         }
     }
@@ -100,6 +109,80 @@ public enum PlatformMigrationClient {
 
         let decoder = JSONDecoder()
         return try decoder.decode(SignedUrlResponse.self, from: data)
+    }
+
+    /// Requests a signed download URL from the platform's unified signed-URL endpoint.
+    ///
+    /// POSTs to `/v1/migrations/signed-url/` with
+    /// `{"operation": "download", "bundle_key": ..., "target_runtime_version": ...}`.
+    /// The platform validates the bundle's runtime-compat range against the
+    /// target runtime version and rejects with HTTP 422 + `reason: "version_mismatch"`
+    /// when there is no overlap.
+    ///
+    /// - Parameters:
+    ///   - bundleKey: The bundle key returned by `requestSignedUploadUrl()` (and
+    ///     filled by a prior `migrations/export-to-gcs` runtime export).
+    ///   - targetRuntimeVersion: The runtime version that will perform the import.
+    ///     Used by the platform to enforce the bundle's compat range.
+    /// - Returns: The signed download URL string.
+    /// - Throws: `PlatformMigrationError.versionMismatch` on 422 `version_mismatch`,
+    ///   or `PlatformMigrationError.requestFailed` on other non-2xx responses.
+    public static func requestSignedDownloadUrl(
+        bundleKey: String,
+        targetRuntimeVersion: String
+    ) async throws -> String {
+        let (baseURL, token, orgId) = try resolveAuthContext()
+
+        guard let url = URL(string: "\(baseURL)/v1/migrations/signed-url/") else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "operation": "download",
+            "bundle_key": bundleKey,
+            "target_runtime_version": targetRuntimeVersion,
+        ])
+
+        // 422 is a permanent semantic signal (version_mismatch), not a transient
+        // server error — mark it non-retryable so executeWithRetry doesn't burn
+        // attempts retrying a deterministic rejection.
+        let (data, statusCode) = try await executeWithRetry(
+            request: request,
+            label: "signed-url-download",
+            nonRetryableStatusCodes: [422]
+        )
+
+        if statusCode == 422 {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               (json["reason"] as? String) == "version_mismatch",
+               let compat = json["bundle_compat"] as? [String: Any],
+               let minVersion = compat["min_runtime_version"] as? String,
+               let targetVersion = json["target_runtime_version"] as? String {
+                let maxVersion = compat["max_runtime_version"] as? String
+                throw PlatformMigrationError.versionMismatch(
+                    minVersion: minVersion,
+                    maxVersion: maxVersion,
+                    targetVersion: targetVersion
+                )
+            }
+        }
+
+        guard statusCode == 200 || statusCode == 201 else {
+            let detail = String(data: data, encoding: .utf8) ?? "No response body"
+            throw PlatformMigrationError.requestFailed(statusCode: statusCode, detail: detail)
+        }
+
+        struct DownloadUrlResponse: Decodable {
+            let url: String
+        }
+        return try JSONDecoder().decode(DownloadUrlResponse.self, from: data).url
     }
 
     /// Uploads binary bundle data to a GCS signed URL.

--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -283,3 +283,233 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
         return data
     }
 }
+
+@MainActor
+final class PlatformMigrationClientSignedDownloadUrlTests: XCTestCase {
+    private var previousToken: String?
+
+    override func setUp() {
+        super.setUp()
+        JobStatusURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(JobStatusURLProtocol.self)
+        previousToken = SessionTokenManager.getToken()
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(JobStatusURLProtocol.self)
+        JobStatusURLProtocol.requestHandler = nil
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+        super.tearDown()
+    }
+
+    func testRequestSignedDownloadUrlPostsOperationDownloadWithBundleKeyAndTargetVersion() async throws {
+        let observed = ObservedRequest()
+        JobStatusURLProtocol.requestHandler = { request in
+            observed.url = request.url
+            observed.method = request.httpMethod
+            observed.sessionTokenHeader = request.value(forHTTPHeaderField: "X-Session-Token")
+            if let stream = request.httpBodyStream {
+                observed.body = Self.readAll(from: stream)
+            } else {
+                observed.body = request.httpBody
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 201,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"url":"https://storage.example/dl","bundle_key":"bundles/dl-v.tar.gz","expires_at":"2026-05-01T00:00:00Z"}"#
+            return (response, Data(body.utf8))
+        }
+
+        let url = try await PlatformMigrationClient.requestSignedDownloadUrl(
+            bundleKey: "bundles/dl-v.tar.gz",
+            targetRuntimeVersion: "2.0.0"
+        )
+
+        let observedURL = try XCTUnwrap(observed.url)
+        XCTAssertTrue(
+            observedURL.absoluteString.hasSuffix("/v1/migrations/signed-url/"),
+            "Expected URL to end with unified signed-url path; got \(observedURL.absoluteString)"
+        )
+        XCTAssertEqual(observed.method, "POST")
+        XCTAssertEqual(observed.sessionTokenHeader, "test-session-token")
+
+        let bodyData = try XCTUnwrap(observed.body)
+        let bodyJson = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        )
+        XCTAssertEqual(bodyJson["operation"] as? String, "download")
+        XCTAssertEqual(bodyJson["bundle_key"] as? String, "bundles/dl-v.tar.gz")
+        XCTAssertEqual(bodyJson["target_runtime_version"] as? String, "2.0.0")
+
+        XCTAssertEqual(url, "https://storage.example/dl")
+    }
+
+    func testRequestSignedDownloadUrlAcceptsStatus200() async throws {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"url":"https://storage.example/dl","bundle_key":"bundles/dl-v.tar.gz","expires_at":"2026-05-01T00:00:00Z"}"#
+            return (response, Data(body.utf8))
+        }
+
+        let url = try await PlatformMigrationClient.requestSignedDownloadUrl(
+            bundleKey: "bundles/dl-v.tar.gz",
+            targetRuntimeVersion: "2.0.0"
+        )
+        XCTAssertEqual(url, "https://storage.example/dl")
+    }
+
+    func testRequestSignedDownloadUrlThrowsVersionMismatchOn422() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"reason":"version_mismatch","bundle_compat":{"min_runtime_version":"2.0.0","max_runtime_version":"2.5.0"},"target_runtime_version":"1.9.0"}"#
+            return (response, Data(body.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "1.9.0"
+            )
+            XCTFail("Expected versionMismatch to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .versionMismatch(let minVersion, let maxVersion, let targetVersion) = error {
+                XCTAssertEqual(minVersion, "2.0.0")
+                XCTAssertEqual(maxVersion, "2.5.0")
+                XCTAssertEqual(targetVersion, "1.9.0")
+                XCTAssertEqual(
+                    error.errorDescription,
+                    "Cannot import: bundle requires runtime 2.0.0–2.5.0, but this local runtime is 1.9.0. Update your local runtime before importing."
+                )
+            } else {
+                XCTFail("Expected .versionMismatch, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRequestSignedDownloadUrlVersionMismatchWithNullMaxUsesPlusSuffix() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"reason":"version_mismatch","bundle_compat":{"min_runtime_version":"3.0.0","max_runtime_version":null},"target_runtime_version":"2.9.0"}"#
+            return (response, Data(body.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "2.9.0"
+            )
+            XCTFail("Expected versionMismatch to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .versionMismatch(let minVersion, let maxVersion, let targetVersion) = error {
+                XCTAssertEqual(minVersion, "3.0.0")
+                XCTAssertNil(maxVersion)
+                XCTAssertEqual(targetVersion, "2.9.0")
+                let description = error.errorDescription ?? ""
+                XCTAssertTrue(
+                    description.hasSuffix("requires runtime 3.0.0+, but this local runtime is 2.9.0. Update your local runtime before importing."),
+                    "Unexpected description: \(description)"
+                )
+            } else {
+                XCTFail("Expected .versionMismatch, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRequestSignedDownloadUrl422WithoutVersionMismatchPayloadFallsThroughToRequestFailed() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"validation failed"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "2.0.0"
+            )
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 422)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRequestSignedDownloadUrlThrowsRequestFailedOnNon200() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"server error"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "2.0.0"
+            )
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 500)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    private static func readAll(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: 4096)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PlatformMigrationClient.requestSignedDownloadUrl(bundleKey:targetRuntimeVersion:)` for download-side signed URL flows.
- Adds `PlatformMigrationError.versionMismatch` case with CLI-matching error message format.
- Adds unit tests covering happy path, 422 version mismatch (with and without max_version), and non-200 errors.

Part of plan: teleport-platform-to-local.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->