### PR TITLE
feat(macos): platform → local teleport in Settings General tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -10,6 +10,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Telep
 private enum TeleportDestination {
     case docker
     case platform
+    case local
 
     var displayLabel: String {
         switch self {
@@ -17,6 +18,8 @@ private enum TeleportDestination {
             return "Move to Docker"
         case .platform:
             return "Move to Cloud (Platform)"
+        case .local:
+            return "Move to Local"
         }
     }
 
@@ -26,6 +29,8 @@ private enum TeleportDestination {
             return "Run your assistant in a Docker container on this Mac."
         case .platform:
             return "Run your assistant in the cloud, managed by the Vellum platform."
+        case .local:
+            return "Run your assistant locally on this Mac."
         }
     }
 }
@@ -53,6 +58,7 @@ private enum TeleportError: LocalizedError {
     case noOrganizations
     case multipleOrganizations
     case existingPlatformAssistant(id: String)
+    case versionMismatch(message: String)
 
     var errorDescription: String? {
         switch self {
@@ -78,6 +84,8 @@ private enum TeleportError: LocalizedError {
             return "Multiple organizations found — please select one in account settings first"
         case .existingPlatformAssistant(let id):
             return "You already have a platform assistant '\(id)'. Retire it first, then retry the teleport."
+        case .versionMismatch(let message):
+            return message
         }
     }
 }
@@ -104,7 +112,9 @@ struct TeleportSection: View {
 
     var body: some View {
         Group {
-            if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
+            if assistant.isRemote && !assistant.isDocker && !assistant.isManaged {
+                // Out of scope: remote-but-not-docker-not-managed assistants
+                // (e.g. apple-container) — leave teleport hidden for now.
                 EmptyView()
             } else {
                 teleportContent
@@ -172,7 +182,9 @@ struct TeleportSection: View {
 
     @ViewBuilder
     private var destinationPicker: some View {
-        if assistant.cloud.lowercased() == "local" || assistant.isDocker {
+        if assistant.isManaged {
+            destinationButton(for: .local)
+        } else if assistant.cloud.lowercased() == "local" || assistant.isDocker {
             destinationButton(for: .platform)
         }
     }
@@ -334,6 +346,8 @@ struct TeleportSection: View {
                 try await teleportLocalToDocker()
             case (true, .platform):
                 try await teleportDockerToPlatform()
+            case (_, .local) where assistant.isManaged:
+                try await teleportPlatformToLocal()
             default:
                 throw TeleportError.invalidURL
             }
@@ -614,6 +628,172 @@ struct TeleportSection: View {
 
         // Step 7 — Verification phase (do NOT retire or switch yet)
         phase = .verifying
+    }
+
+    // MARK: - Platform -> Local
+
+    private func teleportPlatformToLocal() async throws {
+        // Step 1 — Request a signed upload URL so the platform runtime
+        // has a GCS slot to stream the export bundle into.
+        phase = .transferring(step: "Preparing export...")
+        let uploadInfo = try await PlatformMigrationClient.requestSignedUploadUrl()
+
+        // Step 2 — Tell the platform runtime to export to that signed URL.
+        // The export is async — runtime returns 202 + job_id, then uploads
+        // the bundle to GCS in the background.
+        phase = .transferring(step: "Exporting cloud data...")
+        let exportResponse = try await GatewayHTTPClient.withAssistant(assistant.assistantId) {
+            try await GatewayHTTPClient.post(
+                path: "migrations/export-to-gcs",
+                json: ["upload_url": uploadInfo.uploadUrl],
+                timeout: 3600,
+                unprefixed: true
+            )
+        }
+        guard exportResponse.isSuccess || exportResponse.statusCode == 202 else {
+            throw TeleportError.exportFailed(statusCode: exportResponse.statusCode)
+        }
+        guard let exportJson = (try? JSONSerialization.jsonObject(with: exportResponse.data)) as? [String: Any],
+              let exportJobId = exportJson["job_id"] as? String else {
+            throw TeleportError.exportFailed(statusCode: exportResponse.statusCode)
+        }
+
+        // Step 3 — Poll the platform job-status endpoint until the export
+        // job completes.
+        try await pollExportJob(jobId: exportJobId)
+
+        // Step 4 — Resolve the target local runtime version for the
+        // version-compat gate. Use the bundled app's short version string;
+        // on macOS the local runtime is bundled with the app, so the app
+        // version is the runtime version that will perform the import.
+        let targetRuntimeVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+
+        // Step 5 — Request a signed download URL from the platform. The
+        // platform validates the bundle's compat range against the target
+        // runtime version and rejects with 422 + version_mismatch if there's
+        // no overlap.
+        phase = .transferring(step: "Preparing import...")
+        let downloadUrl: String
+        do {
+            downloadUrl = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: uploadInfo.bundleKey,
+                targetRuntimeVersion: targetRuntimeVersion
+            )
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .versionMismatch = error {
+                throw TeleportError.versionMismatch(message: error.localizedDescription)
+            }
+            throw error
+        }
+
+        // Step 6 — Download the bundle bytes from GCS.
+        phase = .transferring(step: "Downloading data...")
+        let bundleData = try await PlatformMigrationClient.downloadFromSignedUrl(
+            downloadUrl,
+            onProgress: { self.transferProgress = $0 }
+        )
+        transferProgress = nil
+
+        // Step 7 — Resolve or hatch a local assistant.
+        phase = .transferring(step: "Preparing local assistant...")
+        var localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isManaged && !$0.isDocker })
+        if localAssistant == nil {
+            let config = VellumCli.RemoteHatchConfig(remote: "local")
+            try await AppDelegate.shared?.vellumCli.runRemoteHatch(config: config) { _ in }
+            localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isManaged && !$0.isDocker })
+        }
+        guard let resolvedLocal = localAssistant else {
+            throw TeleportError.localAssistantNotFound
+        }
+
+        // Step 8 — Wait for the local gateway to be reachable (up to 30s).
+        phase = .transferring(step: "Waiting for local assistant...")
+        for i in 0..<30 {
+            if await HealthCheckClient.isReachable(for: resolvedLocal, timeout: 1) {
+                break
+            }
+            if i == 29 {
+                throw TeleportError.localAssistantNotFound
+            }
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        // Step 9 — Bootstrap an actor token against the local gateway and
+        // swap it in for the import. Save and restore the original so the
+        // managed assistant keeps working during the verification phase.
+        phase = .transferring(step: "Authenticating with local assistant...")
+        let originalActorToken = ActorTokenManager.getToken()
+        let actorToken = try await bootstrapActorToken(targetAssistantId: resolvedLocal.assistantId)
+        ActorTokenManager.setToken(actorToken)
+        defer {
+            if let originalActorToken {
+                ActorTokenManager.setToken(originalActorToken)
+            } else {
+                ActorTokenManager.deleteToken()
+            }
+        }
+
+        // Step 10 — Import the bundle bytes to the local assistant.
+        phase = .transferring(step: "Importing data...")
+        let importResponse = try await GatewayHTTPClient.withAssistant(resolvedLocal.assistantId) {
+            try await GatewayHTTPClient.post(
+                path: "migrations/import",
+                body: bundleData,
+                contentType: "application/octet-stream",
+                timeout: 3600,
+                unprefixed: true
+            )
+        }
+        guard importResponse.isSuccess else {
+            throw TeleportError.importFailed(message: "HTTP \(importResponse.statusCode)")
+        }
+        if let importJson = try? JSONSerialization.jsonObject(with: importResponse.data) as? [String: Any],
+           let success = importJson["success"] as? Bool, !success {
+            let errorMsg = (importJson["error"] as? String) ?? "Import reported failure"
+            throw TeleportError.importFailed(message: errorMsg)
+        }
+
+        // Step 11 — Hand off to the verification banner. `confirmAndSwitch`
+        // already retires the managed assistant via the existing
+        // `original.isManaged` branch, so no new retire logic here.
+        targetAssistant = resolvedLocal
+        transferTask = nil
+        phase = .verifying
+    }
+
+    /// Polls the platform's job-status endpoint for an export job until it
+    /// reports `complete` or `failed`. Mirrors the polling block in
+    /// `importBundleToManaged` (5s interval, 60min timeout, 5xx-only retry).
+    private func pollExportJob(jobId: String) async throws {
+        let pollInterval: UInt64 = 5_000_000_000
+        let timeout: TimeInterval = 3600
+        let start = Date()
+
+        while Date().timeIntervalSince(start) < timeout {
+            try await Task.sleep(nanoseconds: pollInterval)
+
+            let status: PlatformMigrationClient.JobStatus
+            do {
+                status = try await PlatformMigrationClient.pollJobStatus(jobId: jobId)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let error as PlatformMigrationClient.PlatformMigrationError {
+                if case .requestFailed(let statusCode, _) = error, (500..<600).contains(statusCode) {
+                    continue
+                }
+                throw error
+            } catch {
+                continue
+            }
+
+            if status.status == "complete" {
+                return
+            }
+            if status.status == "failed" {
+                throw TeleportError.exportFailed(statusCode: 0)
+            }
+        }
+        throw TeleportError.exportTimedOut
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -51,6 +51,7 @@ private enum TeleportError: LocalizedError {
     case notSignedIn
     case exportFailed(statusCode: Int)
     case exportTimedOut
+    case exportJobFailed(message: String)
     case importFailed(message: String)
     case managedEntryNotFound
     case localAssistantNotFound
@@ -70,6 +71,8 @@ private enum TeleportError: LocalizedError {
             return "Export failed (HTTP \(statusCode))"
         case .exportTimedOut:
             return "Export timed out"
+        case .exportJobFailed(let message):
+            return "Export failed: \(message)"
         case .importFailed(let message):
             return "Import failed: \(message)"
         case .managedEntryNotFound:
@@ -793,7 +796,7 @@ struct TeleportSection: View {
                 return
             }
             if status.status == "failed" {
-                throw TeleportError.exportFailed(statusCode: 0)
+                throw TeleportError.exportJobFailed(message: status.error ?? "Export job failed")
             }
         }
         throw TeleportError.exportTimedOut

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -696,11 +696,14 @@ struct TeleportSection: View {
 
         // Step 7 — Resolve or hatch a local assistant.
         phase = .transferring(step: "Preparing local assistant...")
-        var localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isManaged && !$0.isDocker })
+        var localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
         if localAssistant == nil {
             let config = VellumCli.RemoteHatchConfig(remote: "local")
             try await AppDelegate.shared?.vellumCli.runRemoteHatch(config: config) { _ in }
-            localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isManaged && !$0.isDocker })
+            localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
+        } else {
+            // Wake existing local assistant in case it's sleeping
+            try await AppDelegate.shared?.vellumCli.wake(name: localAssistant!.assistantId)
         }
         guard let resolvedLocal = localAssistant else {
             throw TeleportError.localAssistantNotFound


### PR DESCRIPTION
## Summary
- Adds `TeleportDestination.local` and `TeleportError.versionMismatch`.
- Replaces the `isManaged → EmptyView` early return so managed assistants now see a 'Move to Local' button.
- Implements `teleportPlatformToLocal()` and a private `pollExportJob` helper, mirroring the existing local→platform path in reverse.

Part of plan: teleport-platform-to-local.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->