### PR TITLE
feat(proactive-artifact): register LLM call sites and catalog entries

### DIFF
--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -264,6 +264,20 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "General-purpose LLM inference call site for skill use.",
     domain: "skills",
   },
+  proactiveArtifactDecision: {
+    id: "proactiveArtifactDecision",
+    displayName: "Proactive Artifact Decision",
+    description:
+      "Decides what personalized artifact to build for new users based on conversation context.",
+    domain: "agentLoop",
+  },
+  proactiveArtifactBuild: {
+    id: "proactiveArtifactBuild",
+    displayName: "Proactive Artifact Build",
+    description:
+      "Builds the personalized artifact in a background conversation with tool access.",
+    domain: "agentLoop",
+  },
 };
 
 // Source of truth for call-site display metadata. API responses and usage

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -70,6 +70,8 @@ export const LLMCallSiteEnum = z.enum([
   "inference",
   "feedEventCopy",
   "trustRuleSuggestion",
+  "proactiveArtifactDecision",
+  "proactiveArtifactBuild",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 


### PR DESCRIPTION
## Summary
- Add proactiveArtifactDecision and proactiveArtifactBuild to LLMCallSiteEnum
- Add matching entries to CALL_SITE_CATALOG with domain and descriptions

Part of plan: proactive-artifact.md (PR 2 of 6)
Part of JARVIS-698
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->