### PR TITLE
refactor(documents): extract saveDocument into shared service

### DIFF
--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared document persistence service.
+ *
+ * Extracted from documents-routes.ts so that both HTTP route handlers and
+ * background jobs (e.g. proactive artifact generation) can persist documents
+ * without going through the HTTP layer.
+ */
+import { rawRun } from "../memory/raw-query.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("document-store");
+
+// ---------------------------------------------------------------------------
+// Junction table helper
+// ---------------------------------------------------------------------------
+
+/** Insert a document–conversation association (idempotent via INSERT OR IGNORE). */
+export function addDocumentConversation(
+  surfaceId: string,
+  conversationId: string,
+): void {
+  rawRun(
+    /*sql*/ `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    surfaceId,
+    conversationId,
+    Date.now(),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Document persistence
+// ---------------------------------------------------------------------------
+
+export function saveDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  wordCount: number;
+}): { success: true; surfaceId: string } | { success: false; error: string } {
+  try {
+    const now = Date.now();
+    rawRun(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(surface_id) DO UPDATE SET
+         title = excluded.title,
+         content = excluded.content,
+         word_count = excluded.word_count,
+         updated_at = excluded.updated_at`,
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.wordCount,
+      now,
+      now,
+    );
+    log.info(
+      { surfaceId: params.surfaceId, title: params.title },
+      "Saved document",
+    );
+
+    // Best-effort: associate the document with the conversation.
+    // Failures (e.g. migration not yet applied, table missing) must not
+    // cause the save response to report failure — the document itself is
+    // already persisted at this point.
+    try {
+      addDocumentConversation(params.surfaceId, params.conversationId);
+    } catch (err) {
+      log.warn(
+        { err, surfaceId: params.surfaceId },
+        "Failed to record document–conversation association",
+      );
+    }
+
+    return { success: true, surfaceId: params.surfaceId };
+  } catch (error) {
+    log.error({ err: error, surfaceId: params.surfaceId }, "Save error");
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -6,7 +6,8 @@
  */
 import { z } from "zod";
 
-import { rawAll, rawGet, rawRun } from "../../memory/raw-query.js";
+import { saveDocument } from "../../documents/document-store.js";
+import { rawAll, rawGet } from "../../memory/raw-query.js";
 import { getLogger } from "../../util/logger.js";
 import { renderMarkdownToPDF } from "./document-pdf-renderer.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -26,80 +27,6 @@ interface DocumentRow {
 }
 
 type DocumentListRow = Omit<DocumentRow, "content">;
-
-// ---------------------------------------------------------------------------
-// Junction table helper
-// ---------------------------------------------------------------------------
-
-/** Insert a document–conversation association (idempotent via INSERT OR IGNORE). */
-function addDocumentConversation(
-  surfaceId: string,
-  conversationId: string,
-): void {
-  rawRun(
-    /*sql*/ `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
-    surfaceId,
-    conversationId,
-    Date.now(),
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Shared business logic (used by both message handlers and HTTP routes)
-// ---------------------------------------------------------------------------
-
-function saveDocument(params: {
-  surfaceId: string;
-  conversationId: string;
-  title: string;
-  content: string;
-  wordCount: number;
-}): { success: true; surfaceId: string } | { success: false; error: string } {
-  try {
-    const now = Date.now();
-    rawRun(
-      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(surface_id) DO UPDATE SET
-         title = excluded.title,
-         content = excluded.content,
-         word_count = excluded.word_count,
-         updated_at = excluded.updated_at`,
-      params.surfaceId,
-      params.conversationId,
-      params.title,
-      params.content,
-      params.wordCount,
-      now,
-      now,
-    );
-    log.info(
-      { surfaceId: params.surfaceId, title: params.title },
-      "Saved document",
-    );
-
-    // Best-effort: associate the document with the conversation.
-    // Failures (e.g. migration not yet applied, table missing) must not
-    // cause the save response to report failure — the document itself is
-    // already persisted at this point.
-    try {
-      addDocumentConversation(params.surfaceId, params.conversationId);
-    } catch (err) {
-      log.warn(
-        { err, surfaceId: params.surfaceId },
-        "Failed to record document–conversation association",
-      );
-    }
-
-    return { success: true, surfaceId: params.surfaceId };
-  } catch (error) {
-    log.error({ err: error, surfaceId: params.surfaceId }, "Save error");
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
-}
 
 function loadDocument(surfaceId: string):
   | {


### PR DESCRIPTION
## Summary
- Extract saveDocument() and addDocumentConversation() from documents-routes.ts into shared assistant/src/documents/document-store.ts
- Update documents-routes.ts to import from shared module
- No behavioral changes — same SQL, same error handling

Part of plan: proactive-artifact.md (PR 4 of 6)
Part of JARVIS-698
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->