### PR TITLE
feat(proactive-artifact): add count-first atomic trigger claim and startup backfill

### DIFF
--- a/assistant/src/proactive-artifact/trigger-state.test.ts
+++ b/assistant/src/proactive-artifact/trigger-state.test.ts
@@ -1,0 +1,261 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { initializeDb } from "../memory/db-init.js";
+import { rawRun } from "../memory/raw-query.js";
+import { getDataDir } from "../util/platform.js";
+
+initializeDb();
+
+import {
+  backfillGuardIfNeeded,
+  getUserMessageCountUpTo,
+  hasProactiveArtifactCompleted,
+  tryClaimProactiveArtifactTrigger,
+} from "./trigger-state.js";
+
+let seedId = 0;
+
+function guardPath(): string {
+  return join(getDataDir(), ".proactive-artifact-completed");
+}
+
+function seedUserMessage(createdAt: number): void {
+  const id = ++seedId;
+  const convId = `test-conv-${id}`;
+  rawRun(
+    `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, source)
+     VALUES (?, ?, ?, ?, 'standard', 'user')`,
+    convId,
+    `Test ${id}`,
+    createdAt,
+    createdAt,
+  );
+  rawRun(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at)
+     VALUES (?, ?, 'user', 'hello', ?)`,
+    `test-msg-${id}`,
+    convId,
+    createdAt,
+  );
+}
+
+function removeGuard(): void {
+  try {
+    rmSync(guardPath(), { force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+describe("trigger-state", () => {
+  beforeEach(() => {
+    rawRun("DELETE FROM messages");
+    rawRun("DELETE FROM conversations");
+    removeGuard();
+    seedId = 0;
+  });
+
+  describe("getUserMessageCountUpTo", () => {
+    test("returns 0 when no messages exist", () => {
+      expect(getUserMessageCountUpTo(Date.now())).toBe(0);
+    });
+
+    test("counts only user messages in standard conversations", () => {
+      const now = 1000;
+      seedUserMessage(now);
+      seedUserMessage(now + 1);
+
+      // Insert a non-user message
+      const convId = "non-user-conv";
+      rawRun(
+        `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, source)
+         VALUES (?, ?, ?, ?, 'standard', 'user')`,
+        convId,
+        "Non-user",
+        now + 2,
+        now + 2,
+      );
+      rawRun(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at)
+         VALUES (?, ?, 'assistant', 'hi', ?)`,
+        "assistant-msg",
+        convId,
+        now + 2,
+      );
+
+      // Insert a user message in a non-standard conversation
+      const bgConvId = "bg-conv";
+      rawRun(
+        `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, source)
+         VALUES (?, ?, ?, ?, 'background', 'user')`,
+        bgConvId,
+        "Background",
+        now + 3,
+        now + 3,
+      );
+      rawRun(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at)
+         VALUES (?, ?, 'user', 'hello', ?)`,
+        "bg-msg",
+        bgConvId,
+        now + 3,
+      );
+
+      expect(getUserMessageCountUpTo(now + 10)).toBe(2);
+    });
+
+    test("respects beforeOrAt filter", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+
+      expect(getUserMessageCountUpTo(150)).toBe(1);
+      expect(getUserMessageCountUpTo(250)).toBe(2);
+      expect(getUserMessageCountUpTo(350)).toBe(3);
+    });
+
+    test("caps at 5 due to LIMIT", () => {
+      for (let i = 1; i <= 10; i++) {
+        seedUserMessage(i * 100);
+      }
+      expect(getUserMessageCountUpTo(Date.now())).toBe(5);
+    });
+  });
+
+  describe("tryClaimProactiveArtifactTrigger", () => {
+    test("returns false at count 1, 2, 3 and does NOT write guard", () => {
+      seedUserMessage(100);
+      expect(tryClaimProactiveArtifactTrigger(100)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+
+      seedUserMessage(200);
+      expect(tryClaimProactiveArtifactTrigger(200)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+
+      seedUserMessage(300);
+      expect(tryClaimProactiveArtifactTrigger(300)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("returns true at count exactly 4 and writes guard", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+      expect(existsSync(guardPath())).toBe(true);
+    });
+
+    test("returns false on second call at count 4 (EEXIST from wx)", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(false);
+    });
+
+    test("returns false at count 5+ and does NOT write guard", () => {
+      for (let i = 1; i <= 6; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      expect(tryClaimProactiveArtifactTrigger(600)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("count > 4 does not write guard — preserves 4th-turn trigger window", () => {
+      for (let i = 1; i <= 5; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      // Query at timestamp that sees all 5
+      expect(tryClaimProactiveArtifactTrigger(500)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("concurrent calls: only one returns true", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+
+      const results = [
+        tryClaimProactiveArtifactTrigger(400),
+        tryClaimProactiveArtifactTrigger(400),
+        tryClaimProactiveArtifactTrigger(400),
+      ];
+
+      expect(results.filter((r) => r === true)).toHaveLength(1);
+      expect(results.filter((r) => r === false)).toHaveLength(2);
+    });
+
+    test("rapid 5th-message race: 4th message trigger still fires correctly", () => {
+      // Messages 1-4 exist at timestamps 100-400
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+      // 5th message arrives at 500 (processed first due to race)
+      seedUserMessage(500);
+
+      // The 4th message's turn uses its own created_at (400)
+      // At that timestamp, count is 4, so it should trigger
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+    });
+  });
+
+  describe("hasProactiveArtifactCompleted", () => {
+    test("returns false when guard does not exist", () => {
+      expect(hasProactiveArtifactCompleted()).toBe(false);
+    });
+
+    test("returns true when guard exists", () => {
+      mkdirSync(join(getDataDir()), { recursive: true });
+      writeFileSync(guardPath(), new Date().toISOString());
+      expect(hasProactiveArtifactCompleted()).toBe(true);
+    });
+  });
+
+  describe("backfillGuardIfNeeded", () => {
+    test("creates guard when count >= 5", () => {
+      for (let i = 1; i <= 6; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      backfillGuardIfNeeded();
+      expect(existsSync(guardPath())).toBe(true);
+    });
+
+    test("is no-op when count < 5", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+
+      backfillGuardIfNeeded();
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("is no-op when guard already exists", () => {
+      for (let i = 1; i <= 6; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      mkdirSync(join(getDataDir()), { recursive: true });
+      writeFileSync(guardPath(), "already-exists");
+      backfillGuardIfNeeded();
+      // File content should not have changed
+      expect(readFileSync(guardPath(), "utf-8")).toBe("already-exists");
+    });
+  });
+});

--- a/assistant/src/proactive-artifact/trigger-state.ts
+++ b/assistant/src/proactive-artifact/trigger-state.ts
@@ -1,0 +1,99 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { rawGet } from "../memory/raw-query.js";
+import { getLogger } from "../util/logger.js";
+import { getDataDir } from "../util/platform.js";
+
+const log = getLogger("proactive-artifact-trigger");
+
+function guardPath(): string {
+  return join(getDataDir(), ".proactive-artifact-completed");
+}
+
+/**
+ * Count user messages in standard conversations with created_at <= beforeOrAt.
+ * LIMIT 5 caps scan cost since we only care about the threshold around 4.
+ */
+export function getUserMessageCountUpTo(beforeOrAt: number): number {
+  const row = rawGet<{ c: number }>(
+    `SELECT COUNT(*) AS c FROM (
+      SELECT 1 FROM messages m
+      JOIN conversations c ON m.conversation_id = c.id
+      WHERE m.role = 'user'
+        AND c.conversation_type = 'standard'
+        AND m.created_at <= ?
+      LIMIT 5
+    ) sub`,
+    beforeOrAt,
+  );
+  return row?.c ?? 0;
+}
+
+/**
+ * Fast-path check to avoid the COUNT query on every turn.
+ * Returns true if the proactive artifact trigger has already fired.
+ */
+export function hasProactiveArtifactCompleted(): boolean {
+  return existsSync(guardPath());
+}
+
+/**
+ * Atomic check-and-claim with correct count-first ordering.
+ *
+ * Returns true if this call successfully claimed the trigger (count === 4
+ * and exclusive file create succeeded). Returns false in all other cases.
+ *
+ * Count > 4 returns false WITHOUT writing the guard — this preserves the
+ * 4th-turn trigger window when the 5th message races ahead.
+ */
+export function tryClaimProactiveArtifactTrigger(
+  userMessageCreatedAt: number,
+): boolean {
+  const count = getUserMessageCountUpTo(userMessageCreatedAt);
+
+  if (count < 4) {
+    return false;
+  }
+
+  if (count > 4) {
+    return false;
+  }
+
+  // count === 4 — attempt exclusive guard write
+  try {
+    mkdirSync(dirname(guardPath()), { recursive: true });
+    writeFileSync(guardPath(), new Date().toISOString(), { flag: "wx" });
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && err.code === "EEXIST") {
+      return false;
+    }
+    log.warn({ err }, "Failed to write proactive artifact guard file");
+    return false;
+  }
+}
+
+/**
+ * Called at daemon startup. If the guard file does not exist and the user
+ * already has >= 5 messages, write the guard. This handles existing users
+ * who had >4 messages before the feature existed.
+ */
+export function backfillGuardIfNeeded(): void {
+  if (hasProactiveArtifactCompleted()) {
+    return;
+  }
+
+  const count = getUserMessageCountUpTo(Date.now());
+  if (count >= 5) {
+    try {
+      mkdirSync(dirname(guardPath()), { recursive: true });
+      writeFileSync(guardPath(), new Date().toISOString(), { flag: "wx" });
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && err.code === "EEXIST") {
+        return;
+      }
+      log.warn({ err }, "Failed to backfill proactive artifact guard file");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add atomic trigger claim with count-first ordering and exclusive wx file create
- Add startup backfill for existing users with >4 messages
- Add comprehensive tests for trigger state logic

Part of plan: proactive-artifact.md (PR 1 of 6)
Part of JARVIS-698
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->