### PR TITLE
fix(macos): route managed migrations/export-to-gcs through assistants/{id}/ proxy

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -649,8 +649,7 @@ struct TeleportSection: View {
             try await GatewayHTTPClient.post(
                 path: "migrations/export-to-gcs",
                 json: ["upload_url": uploadInfo.uploadUrl],
-                timeout: 3600,
-                unprefixed: true
+                timeout: 3600
             )
         }
         guard exportResponse.isSuccess || exportResponse.statusCode == 202 else {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for teleport-platform-to-local.md.

**Gap:** Routing bug — `migrations/export-to-gcs` doesn't reach managed runtime
**What was expected:** Managed runtime calls go through `/v1/assistants/<id>/...` (default `GatewayHTTPClient` prefix).
**What was found:** Step 2 of `teleportPlatformToLocal` passed `unprefixed: true`, producing `/v1/migrations/export-to-gcs` on the platform → 404.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->