### PR TITLE
feat(proactive-artifact): wire trigger post-turn with correct timing and broadcast access

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -106,6 +106,11 @@ import type {
   TurnContext as PluginTurnContext,
 } from "../plugins/types.js";
 import { PluginExecutionError, PluginTimeoutError } from "../plugins/types.js";
+import {
+  hasProactiveArtifactCompleted,
+  runProactiveArtifactJob,
+  tryClaimProactiveArtifactTrigger,
+} from "../proactive-artifact/index.js";
 import type {
   ContentBlock,
   Message,
@@ -113,6 +118,7 @@ import type {
 } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { getSubagentManager } from "../subagent/index.js";
@@ -2873,6 +2879,36 @@ export async function runAgentLoopImpl(
             { err: feedErr, conversationId: ctx.conversationId },
             "Failed to build home-feed event for background conversation",
           );
+        }
+
+        // Proactive artifact: fire once when the processed turn was the 4th user message.
+        {
+          const paConv = getConversation(ctx.conversationId);
+          if (paConv && paConv.conversationType === "standard") {
+            void (async () => {
+              try {
+                if (hasProactiveArtifactCompleted()) return;
+                const userMsg = getMessageById(
+                  userMessageId,
+                  ctx.conversationId,
+                );
+                if (!userMsg) return;
+                if (!tryClaimProactiveArtifactTrigger(userMsg.createdAt))
+                  return;
+                await runProactiveArtifactJob({
+                  conversationId: ctx.conversationId,
+                  userMessageCutoff: userMsg.createdAt,
+                  assistantMessageId: state.lastAssistantMessageId,
+                  broadcastMessage,
+                });
+              } catch (err) {
+                log.warn(
+                  { err, conversationId: ctx.conversationId },
+                  "Proactive artifact trigger failed",
+                );
+              }
+            })();
+          }
         }
       }
     }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2882,9 +2882,14 @@ export async function runAgentLoopImpl(
         }
 
         // Proactive artifact: fire once when the processed turn was the 4th user message.
+        // Only trigger for real user-authored turns (not subagent/system messages).
         {
           const paConv = getConversation(ctx.conversationId);
-          if (paConv && paConv.conversationType === "standard") {
+          if (
+            paConv &&
+            paConv.conversationType === "standard" &&
+            options?.isUserMessage
+          ) {
             void (async () => {
               try {
                 if (hasProactiveArtifactCompleted()) return;

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -62,6 +62,7 @@ import {
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
+import { backfillGuardIfNeeded } from "../proactive-artifact/index.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
@@ -1235,6 +1236,12 @@ export async function runDaemon(): Promise<void> {
       },
       "Heartbeat service configured",
     );
+
+    try {
+      backfillGuardIfNeeded();
+    } catch (err) {
+      log.warn({ err }, "Proactive artifact backfill failed");
+    }
 
     // Filing yields to the memory v2 consolidation job when the flag is on —
     // both serve the same role (periodic background memory processing) and

--- a/assistant/src/proactive-artifact/index.ts
+++ b/assistant/src/proactive-artifact/index.ts
@@ -1,0 +1,6 @@
+export { runProactiveArtifactJob } from "./job.js";
+export {
+  backfillGuardIfNeeded,
+  hasProactiveArtifactCompleted,
+  tryClaimProactiveArtifactTrigger,
+} from "./trigger-state.js";


### PR DESCRIPTION
## Summary
- Add barrel export index.ts for proactive-artifact module
- Wire trigger into conversation-agent-loop.ts post-message_complete path
- Add startup backfill in lifecycle.ts

Part of plan: proactive-artifact.md (PR 6 of 6)
Closes JARVIS-698
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->