### PR TITLE
Revert "Faster SSE disconnect detection via heartbeat watchdog (#29507)"

### DIFF
--- a/assistant/src/__tests__/assistant-event.test.ts
+++ b/assistant/src/__tests__/assistant-event.test.ts
@@ -4,7 +4,6 @@ import type { AssistantEvent } from "../runtime/assistant-event.js";
 import {
   formatSseFrame,
   formatSseHeartbeat,
-  formatSseHeartbeatWithData,
 } from "../runtime/assistant-event.js";
 
 // ── Type / shape tests ────────────────────────────────────────────────────────
@@ -124,14 +123,5 @@ describe("formatSseHeartbeat", () => {
 
   test("starts with colon (SSE comment marker)", () => {
     expect(formatSseHeartbeat().startsWith(":")).toBe(true);
-  });
-});
-
-describe("formatSseHeartbeatWithData", () => {
-  test("includes both a comment and a data-bearing event", () => {
-    const hb = formatSseHeartbeatWithData();
-    expect(hb).toContain(": heartbeat\n\n");
-    expect(hb).toContain("event: assistant_event\n");
-    expect(hb).toContain('data: {"type":"heartbeat"}\n');
   });
 });

--- a/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
+++ b/assistant/src/__tests__/assistant-events-sse-hardening.test.ts
@@ -261,8 +261,7 @@ describe("SSE route — heartbeat", () => {
     reader.cancel();
 
     const text = new TextDecoder().decode(value);
-    expect(text).toContain(": heartbeat");
-    expect(text).toContain('{"type":"heartbeat"}');
+    expect(text).toBe(": heartbeat\n\n");
   });
 
   test("emits multiple heartbeats over time", async () => {
@@ -298,11 +297,7 @@ describe("SSE route — heartbeat", () => {
     reader.cancel();
 
     expect(chunks.length).toBeGreaterThan(0);
-    expect(
-      chunks.every(
-        (c) => c.includes(": heartbeat") && c.includes('{"type":"heartbeat"}'),
-      ),
-    ).toBe(true);
+    expect(chunks.every((c) => c === ": heartbeat\n\n")).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -135,12 +135,10 @@ describe("SSE assistant-events endpoint", () => {
     // Read the first frame directly from the stream.
     const reader = stream.getReader();
 
-    // The first chunk is the immediate heartbeat (comment + data event) enqueued in start().
+    // The first chunk is the immediate heartbeat comment enqueued in start().
     const initial = await reader.read();
     expect(initial.done).toBe(false);
-    const initialText = new TextDecoder().decode(initial.value);
-    expect(initialText).toContain(": heartbeat");
-    expect(initialText).toContain('{"type":"heartbeat"}');
+    expect(new TextDecoder().decode(initial.value)).toBe(": heartbeat\n\n");
 
     // The second chunk is the actual assistant event.
     const { value, done } = await reader.read();
@@ -172,12 +170,10 @@ describe("SSE assistant-events endpoint", () => {
 
     const reader = stream.getReader();
 
-    // Consume the initial heartbeat (comment + data event).
+    // Consume the initial heartbeat.
     const heartbeat = await reader.read();
     expect(heartbeat.done).toBe(false);
-    const heartbeatText = new TextDecoder().decode(heartbeat.value);
-    expect(heartbeatText).toContain(": heartbeat");
-    expect(heartbeatText).toContain('{"type":"heartbeat"}');
+    expect(new TextDecoder().decode(heartbeat.value)).toBe(": heartbeat\n\n");
 
     // Publish events with two different conversationIds.
     const eventA = buildAssistantEvent({ type: "pong" }, "conversation-aaa");

--- a/assistant/src/runtime/assistant-event.ts
+++ b/assistant/src/runtime/assistant-event.ts
@@ -16,7 +16,6 @@ import type { ServerMessage } from "../daemon/message-protocol.js";
 export {
   formatSseFrame,
   formatSseHeartbeat,
-  formatSseHeartbeatWithData,
 } from "@vellumai/skill-host-contracts";
 
 /** Daemon-side specialization of the generic event envelope. */

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -25,10 +25,7 @@ import { parseInterfaceId, supportsHostProxy } from "../../channels/types.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
-import {
-  formatSseFrame,
-  formatSseHeartbeatWithData,
-} from "../assistant-event.js";
+import { formatSseFrame, formatSseHeartbeat } from "../assistant-event.js";
 import type {
   AssistantEventCallback,
   AssistantEventFilter,
@@ -43,8 +40,8 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("events-routes");
 
-/** Keep-alive comment sent to idle clients every 5 s by default. */
-const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
+/** Keep-alive comment sent to idle clients every 7 s by default. */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
 
 /**
  * Stream assistant events as Server-Sent Events.
@@ -64,7 +61,7 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
  *
  * Options (for testing):
  *   hub               -- override the event hub (defaults to process singleton).
- *   heartbeatIntervalMs -- how often to emit keep-alive comments (default 5 s).
+ *   heartbeatIntervalMs -- how often to emit keep-alive comments (default 7 s).
  */
 export function handleSubscribeAssistantEvents(
   args: RouteHandlerArgs,
@@ -197,7 +194,7 @@ export function handleSubscribeAssistantEvents(
           return;
         }
 
-        controller.enqueue(encoder.encode(formatSseHeartbeatWithData()));
+        controller.enqueue(encoder.encode(formatSseHeartbeat()));
 
         heartbeatTimer = setInterval(() => {
           try {
@@ -209,7 +206,7 @@ export function handleSubscribeAssistantEvents(
             if (clientId) {
               hub.touchClient(clientId);
             }
-            controller.enqueue(encoder.encode(formatSseHeartbeatWithData()));
+            controller.enqueue(encoder.encode(formatSseHeartbeat()));
           } catch {
             sub.dispose();
             cleanup();

--- a/cli/src/commands/events.ts
+++ b/cli/src/commands/events.ts
@@ -139,9 +139,6 @@ export async function events(): Promise<void> {
     query,
     headers: getClientRegistrationHeaders(),
   })) {
-    if (!event.message) {
-      continue;
-    }
     if (jsonOutput) {
       console.log(JSON.stringify(event));
     } else {

--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -133,14 +133,6 @@ public final class EventStreamClient {
     private var hasConnectedAtLeastOnce = false
     private let sseHandshakeDiagnostics = SSEHandshakeDiagnostics()
 
-    // MARK: - Heartbeat Watchdog
-
-    /// Timeout for the heartbeat watchdog (2× the server heartbeat interval).
-    /// If no SSE line (data or heartbeat comment) arrives within this window,
-    /// the connection is assumed dead and torn down for reconnection.
-    private let heartbeatWatchdogTimeout: TimeInterval = 10.0
-    private var heartbeatWatchdogTask: Task<Void, Never>?
-
     // MARK: - SSE Parse Time Tracking
 
     private var sseParseTimeAccumulator: TimeInterval = 0
@@ -200,7 +192,6 @@ public final class EventStreamClient {
     /// `withTaskCancellationHandler` to the underlying data task, so the Task-local
     /// `URLSession` is torn down by the `defer` block inside `startSSEStream`.
     public func stopSSE() {
-        cancelHeartbeatWatchdog()
         tokenRotationTask?.cancel()
         tokenRotationTask = nil
         sseReconnectTask?.cancel()
@@ -457,28 +448,15 @@ public final class EventStreamClient {
                 }
                 self.hasConnectedAtLeastOnce = true
 
-                self.startHeartbeatWatchdog()
-
                 for try await line in bytes.lines {
                     if Task.isCancelled { break }
 
-                    self.resetHeartbeatWatchdog()
-
                     if line.hasPrefix("data: ") {
                         let payload = String(line.dropFirst(6))
-                        if payload.contains("\"heartbeat\"") {
-                            if let json = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
-                               json["type"] as? String == "heartbeat" {
-                                continue
-                            }
-                        }
                         await self.parseSSEData(payload)
                     }
                 }
-
-                self.cancelHeartbeatWatchdog()
             } catch {
-                self.cancelHeartbeatWatchdog()
                 if !Task.isCancelled {
                     await self.logSSEStreamError(error)
                 }
@@ -708,36 +686,6 @@ public final class EventStreamClient {
         }
     }
 
-    // MARK: - Heartbeat Watchdog
-
-    /// Arms the heartbeat watchdog. If no SSE line arrives within
-    /// `heartbeatWatchdogTimeout`, the stream is assumed dead and torn down.
-    private func startHeartbeatWatchdog() {
-        cancelHeartbeatWatchdog()
-        heartbeatWatchdogTask = Task { @MainActor [weak self] in
-            do {
-                try await Task.sleep(nanoseconds: UInt64((self?.heartbeatWatchdogTimeout ?? 10.0) * 1_000_000_000))
-            } catch { return }
-            guard let self, !Task.isCancelled else { return }
-            log.warning("Heartbeat watchdog fired — no SSE activity for \(self.heartbeatWatchdogTimeout, privacy: .public)s, tearing down stream")
-            self.sseTask?.cancel()
-            self.sseTask = nil
-            guard self.shouldReconnect else { return }
-            self.sseReconnectDelay = 1.0
-            self.scheduleSSEReconnect()
-        }
-    }
-
-    /// Resets the heartbeat watchdog timer. Called on every SSE line received.
-    private func resetHeartbeatWatchdog() {
-        startHeartbeatWatchdog()
-    }
-
-    private func cancelHeartbeatWatchdog() {
-        heartbeatWatchdogTask?.cancel()
-        heartbeatWatchdogTask = nil
-    }
-
     // MARK: - SSE Reconnect
 
     private func handleSSEDisconnect() {
@@ -770,7 +718,6 @@ public final class EventStreamClient {
     }
 
     deinit {
-        heartbeatWatchdogTask?.cancel()
         tokenRotationTask?.cancel()
         sseReconnectTask?.cancel()
         sseTask?.cancel()

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -415,7 +415,7 @@ data: {"id":"...","assistantId":"self","conversationId":"conv_xxx","emittedAt":"
 
 ```
 
-Keep-alive heartbeat comments are emitted every 30 seconds to prevent proxy timeouts:
+Keep-alive heartbeat comments are emitted every 7 seconds to prevent proxy timeouts:
 
 ```
 : heartbeat

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -415,13 +415,10 @@ data: {"id":"...","assistantId":"self","conversationId":"conv_xxx","emittedAt":"
 
 ```
 
-Keep-alive heartbeats are emitted every 5 seconds to prevent proxy timeouts and enable client-side disconnect detection. Each heartbeat consists of an SSE comment (for proxy keepalive) followed by a data event (for fetch-based clients that cannot observe comment lines):
+Keep-alive heartbeat comments are emitted every 30 seconds to prevent proxy timeouts:
 
 ```
 : heartbeat
-
-event: assistant_event
-data: {"type":"heartbeat"}
 
 ```
 
@@ -492,7 +489,6 @@ while (true) {
     const dataLine = frame.split('\n').find((l) => l.startsWith('data: '));
     if (!dataLine) continue;
     const event = JSON.parse(dataLine.slice(6));
-    if (event.type === 'heartbeat') continue; // keep-alive, not a real event
     console.log(event.message.type, event.message);
   }
 }

--- a/packages/skill-host-contracts/src/assistant-event.ts
+++ b/packages/skill-host-contracts/src/assistant-event.ts
@@ -84,12 +84,3 @@ export function formatSseFrame(event: AssistantEvent): string {
 export function formatSseHeartbeat(): string {
   return ": heartbeat\n\n";
 }
-
-/**
- * Format a keep-alive as both an SSE comment (for proxy keepalive) and a
- * data-bearing event (so fetch-based SSE clients that cannot observe comment
- * lines can still detect heartbeats for disconnect watchdogs).
- */
-export function formatSseHeartbeatWithData(): string {
-  return `${formatSseHeartbeat()}event: assistant_event\ndata: ${JSON.stringify({ type: "heartbeat" })}\n\n`;
-}


### PR DESCRIPTION
Reverts the heartbeat watchdog changes while we investigate a potential user-facing bug where conversation content switches unexpectedly after ~15 seconds. This restores the 7s heartbeat interval, removes the dual-format heartbeat data event, and removes the macOS/CLI watchdog changes.

---

- Requested by: @m-abboud

Link to Devin session: https://app.devin.ai/sessions/ec7dc3264c774509a47a0f297f27f60f
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->