### PR TITLE
fix(slack): render bot mentions in prose instead of stripping them

### DIFF
--- a/gateway/src/__tests__/slack-display-name.test.ts
+++ b/gateway/src/__tests__/slack-display-name.test.ts
@@ -259,7 +259,9 @@ describe("normalizeSlackAppMention with display name", () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("@Leo please look");
+    expect(result!.event.message.content).toBe(
+      "@unknown-user @Leo please look",
+    );
     expect(result!.event.message.content).not.toContain("<@ULEO>");
     expect(result!.event.message.content).not.toContain("ULEO");
   });
@@ -285,7 +287,9 @@ describe("normalizeSlackAppMention with display name", () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("@unknown-user please look");
+    expect(result!.event.message.content).toBe(
+      "@unknown-user @unknown-user please look",
+    );
     expect(result!.event.message.content).not.toContain("<@UFAIL>");
     expect(result!.event.message.content).not.toContain("UFAIL");
   });

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect } from "bun:test";
 import {
-  stripBotMention,
   normalizeSlackAppMention,
   normalizeSlackChannelMessage,
   normalizeSlackDirectMessage,
@@ -52,42 +51,6 @@ function makeEvent(
   };
 }
 
-describe("stripBotMention", () => {
-  test("strips a single leading bot mention", () => {
-    expect(stripBotMention("<@U123BOT> hello world")).toBe("hello world");
-  });
-
-  test("strips repeated leading bot mentions while preserving a following human mention", () => {
-    expect(
-      stripBotMention("<@U123BOT> <@U123BOT> <@U456OTHER> hello", "U123BOT"),
-    ).toBe("<@U456OTHER> hello");
-  });
-
-  test("fallback strips only the first leading mention", () => {
-    expect(stripBotMention("<@U123BOT> <@U456OTHER> hello")).toBe(
-      "<@U456OTHER> hello",
-    );
-  });
-
-  test("falls back to original text when stripping produces empty string", () => {
-    expect(stripBotMention("<@U123BOT>")).toBe("<@U123BOT>");
-  });
-
-  test("falls back to original trimmed text when stripping produces whitespace only", () => {
-    expect(stripBotMention("<@U123BOT>   ")).toBe("<@U123BOT>");
-  });
-
-  test("returns text unchanged when no leading mention", () => {
-    expect(stripBotMention("hello world")).toBe("hello world");
-  });
-
-  test("does not strip mid-text mentions", () => {
-    expect(stripBotMention("hello <@U123BOT> world")).toBe(
-      "hello <@U123BOT> world",
-    );
-  });
-});
-
 describe("normalizeSlackAppMention", () => {
   test("normalizes app_mention event with sourceChannel 'slack'", async () => {
     const config = makeConfig();
@@ -129,16 +92,23 @@ describe("normalizeSlackAppMention", () => {
     expect(result!.event.message.externalMessageId).toBe("1700000000.000100");
   });
 
-  test("mention stripping: '<@U123BOT> hello world' becomes 'hello world'", async () => {
+  test("renders the bot's mention using the resolved label", async () => {
     const config = makeConfig();
     const event = makeEvent({ text: "<@U123BOT> hello world" });
-    const result = await normalizeSlackAppMention(event, "evt-005", config);
+    const result = await normalizeSlackAppMention(
+      event,
+      "evt-005",
+      config,
+      "U123BOT",
+      undefined,
+      { userLabels: { U123BOT: "vex" } },
+    );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("hello world");
+    expect(result!.event.message.content).toBe("@vex hello world");
   });
 
-  test("mention stripping with empty result falls back to original text", async () => {
+  test("renders the bot's mention with the unknown-user fallback when unresolved", async () => {
     const config = makeConfig();
     const event = makeEvent({ text: "<@U123BOT>" });
     const result = await normalizeSlackAppMention(event, "evt-006", config);
@@ -147,7 +117,7 @@ describe("normalizeSlackAppMention", () => {
     expect(result!.event.message.content).toBe("@unknown-user");
   });
 
-  test("renders a human mention after stripping the app mention", async () => {
+  test("renders bot and human mentions side by side", async () => {
     const config = makeConfig();
     const event = makeEvent({ text: "<@UBOT> <@ULEO> can you check?" });
     const result = await normalizeSlackAppMention(
@@ -156,11 +126,11 @@ describe("normalizeSlackAppMention", () => {
       config,
       "UBOT",
       undefined,
-      { userLabels: { ULEO: "leo" } },
+      { userLabels: { UBOT: "vex", ULEO: "leo" } },
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("@leo can you check?");
+    expect(result!.event.message.content).toBe("@vex @leo can you check?");
   });
 
   test("renders unresolved user mentions with the unknown-user fallback", async () => {
@@ -174,7 +144,9 @@ describe("normalizeSlackAppMention", () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("@unknown-user can you check?");
+    expect(result!.event.message.content).toBe(
+      "@unknown-user @unknown-user can you check?",
+    );
   });
 
   test("thread_ts is preserved in return value", async () => {
@@ -295,7 +267,7 @@ describe("Slack inbound mention rendering", () => {
     expect(result!.event.message.conversationExternalId).toBe("D_DIRECT1");
   });
 
-  test("channel messages strip only the configured bot mention and render remaining mentions", () => {
+  test("channel messages render bot and human mentions inline", () => {
     const config = makeConfig();
     const event = makeChannelMessageEvent({
       text: "<@UBOT> <@ULEO> hello",
@@ -306,16 +278,16 @@ describe("Slack inbound mention rendering", () => {
       config,
       "UBOT",
       undefined,
-      { userLabels: { ULEO: "leo" } },
+      { userLabels: { UBOT: "vex", ULEO: "leo" } },
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("@leo hello");
+    expect(result!.event.message.content).toBe("@vex @leo hello");
     expect(result!.event.actor.actorExternalId).toBe("U_USER123");
     expect(result!.event.message.conversationExternalId).toBe("C_CHANNEL1");
   });
 
-  test("channel messages without bot user ID strip only the first leading mention fallback", () => {
+  test("channel messages render with unknown-user fallback when bot label is missing", () => {
     const config = makeConfig();
     const event = makeChannelMessageEvent({
       text: "<@UBOT> <@ULEO> hello",
@@ -330,10 +302,10 @@ describe("Slack inbound mention rendering", () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("@leo hello");
+    expect(result!.event.message.content).toBe("@unknown-user @leo hello");
   });
 
-  test("message edits render mentions and preserve edit metadata", () => {
+  test("message edits render bot and human mentions and preserve edit metadata", () => {
     const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
@@ -347,11 +319,11 @@ describe("Slack inbound mention rendering", () => {
       "evt-edit-render",
       config,
       "UBOT",
-      { userLabels: { ULEO: "leo" } },
+      { userLabels: { UBOT: "vex", ULEO: "leo" } },
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("@leo edited");
+    expect(result!.event.message.content).toBe("@vex @leo edited");
     expect(result!.event.message.isEdit).toBe(true);
     expect(result!.event.message.externalMessageId).toBe("evt-edit-render");
     expect(result!.event.source.messageId).toBe("1700000000.000100");
@@ -424,7 +396,7 @@ describe("normalizeSlackMessageEdit", () => {
     expect(result).toBeNull();
   });
 
-  test("strips bot mention from edited text", () => {
+  test("renders bot mention in edited text", () => {
     const config = makeConfig();
     const event = makeMessageChangedEvent({
       message: {
@@ -433,10 +405,18 @@ describe("normalizeSlackMessageEdit", () => {
         ts: "1700000000.000100",
       },
     });
-    const result = normalizeSlackMessageEdit(event, "evt-104", config);
+    const result = normalizeSlackMessageEdit(
+      event,
+      "evt-104",
+      config,
+      "U123BOT",
+      {
+        userLabels: { U123BOT: "vex" },
+      },
+    );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.content).toBe("edited content");
+    expect(result!.event.message.content).toBe("@vex edited content");
   });
 
   test("sets actor.actorExternalId from edited message user", () => {

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -293,7 +293,7 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted).toHaveLength(2);
       expect(emitted[0].event.source.updateId).toBe("Ev-race-mention");
       expect(emitted[0].event.message.content).toBe(
-        "@Example User can you help here?",
+        "@Example User @Example User can you help here?",
       );
       expect(emitted[1].event.source.updateId).toBe("Ev-race-reply");
       expect(emitted[1].event.message.content).toBe(
@@ -644,7 +644,9 @@ describe("SlackSocketModeClient thread tracking", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.message.content).toBe("@Leo please look");
+      expect(emitted[0].event.message.content).toBe(
+        "@Example User @Leo please look",
+      );
       expect(emitted[0].event.message.content).not.toContain("<@ULEO>");
       expect(emitted[0].event.message.content).not.toContain("ULEO");
     } finally {

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -802,7 +802,7 @@ describe("attachment extraction in normalize functions", () => {
         expect(result!.slackFiles).toBeDefined();
       });
 
-      it("normalizes channel file_share mentions after stripping only the bot mention", () => {
+      it("normalizes channel file_share mentions and renders the bot mention", () => {
         const config = makeConfig();
         const event = makeChannelEvent({
           subtype: "file_share",
@@ -821,11 +821,11 @@ describe("attachment extraction in normalize functions", () => {
           config,
           "UBOT",
           undefined,
-          { userLabels: { ULEO: "leo" } },
+          { userLabels: { UBOT: "vex", ULEO: "leo" } },
         );
 
         expect(result).not.toBeNull();
-        expect(result!.event.message.content).toBe("@leo shared this");
+        expect(result!.event.message.content).toBe("@vex @leo shared this");
         expect(result!.event.message.content).not.toContain("ULEO");
         expect(result!.event.message.attachments).toHaveLength(1);
         expect(result!.event.message.attachments![0]).toEqual({

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,8 +1,4 @@
-import {
-  renderSlackTextForModel,
-  stripLeadingSlackMentionFallback,
-  stripLeadingSlackUserMention,
-} from "@vellumai/slack-text";
+import { renderSlackTextForModel } from "@vellumai/slack-text";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
@@ -281,54 +277,16 @@ export interface SlackMessageDeletedEvent {
 }
 
 export type SlackTextRenderContext = {
-  botUserId?: string;
   userLabels?: Record<string, string>;
 };
-
-/**
- * Strip leading bot-mention tokens from Slack message text.
- *
- * When the bot user ID is known, only that exact mention is stripped. Without a
- * bot user ID, strip just one leading mention as an app_mention compatibility
- * fallback.
- */
-export function stripBotMention(text: string, botUserId?: string): string {
-  const stripped = botUserId
-    ? stripLeadingSlackUserMention(text, botUserId)
-    : stripLeadingSlackMentionFallback(text);
-  return stripped.trim() || text.trim();
-}
 
 function renderSlackInboundText(
   text: string,
   context: SlackTextRenderContext = {},
-  options: {
-    stripLeadingBotMention?: boolean;
-    fallbackStripFirstMention?: boolean;
-  } = {},
 ): string {
-  let stripped = text;
-  if (options.stripLeadingBotMention) {
-    stripped = context.botUserId
-      ? stripBotMention(text, context.botUserId)
-      : options.fallbackStripFirstMention
-        ? stripBotMention(text)
-        : text.trim();
-  }
-
-  return renderSlackTextForModel(stripped, {
+  return renderSlackTextForModel(text, {
     userLabels: context.userLabels,
   });
-}
-
-function withBotUserId(
-  botUserId: string | undefined,
-  context: SlackTextRenderContext | undefined,
-): SlackTextRenderContext {
-  return {
-    ...context,
-    botUserId: context?.botUserId ?? botUserId,
-  };
 }
 
 function extractSlackAttachments(files: SlackFile[] | undefined): Array<{
@@ -426,10 +384,7 @@ export function normalizeSlackDirectMessage(
     botToken && event.user
       ? resolveSlackUserSync(event.user, botToken)
       : undefined;
-  const content = renderSlackInboundText(
-    event.text,
-    withBotUserId(botUserId, renderContext),
-  );
+  const content = renderSlackInboundText(event.text, renderContext);
 
   return {
     event: {
@@ -487,11 +442,7 @@ export function normalizeSlackChannelMessage(
   const routing = resolveAssistant(config, event.channel, event.user);
   if (isRejection(routing)) return null;
 
-  const content = renderSlackInboundText(
-    event.text,
-    withBotUserId(botUserId, renderContext),
-    { stripLeadingBotMention: true, fallbackStripFirstMention: true },
-  );
+  const content = renderSlackInboundText(event.text, renderContext);
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
@@ -556,14 +507,7 @@ export function normalizeSlackAppMention(
     return null;
   }
 
-  const content = renderSlackInboundText(
-    event.text,
-    withBotUserId(botUserId, renderContext),
-    {
-      stripLeadingBotMention: true,
-      fallbackStripFirstMention: true,
-    },
-  );
+  const content = renderSlackInboundText(event.text, renderContext);
   const externalMessageId =
     event.client_msg_id ?? event.ts ?? `${event.channel}:${event.ts}`;
 
@@ -876,14 +820,7 @@ export function normalizeSlackMessageEdit(
   }
   if (isRejection(routing)) return null;
 
-  const content = renderSlackInboundText(
-    edited.text,
-    withBotUserId(botUserId, renderContext),
-    {
-      stripLeadingBotMention: true,
-      fallbackStripFirstMention: !botUserId,
-    },
-  );
+  const content = renderSlackInboundText(edited.text, renderContext);
 
   // Each edit event gets a unique externalMessageId so the dedup pipeline
   // does not discard subsequent edits of the same Slack message.

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -762,7 +762,6 @@ export class SlackSocketModeClient {
         if (!userInfo) return undefined;
         return userInfo.displayName || userInfo.username;
       },
-      { ignoredUserIds: [this.config.botUserId] },
     );
   }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -875,10 +875,7 @@ export class SlackSocketModeClient {
   ): Promise<void> {
     const text = this.extractTextBearingContent(event);
     const userLabels = text ? await this.resolveMentionLabelsForText(text) : {};
-    const renderContext = {
-      botUserId: this.config.botUserId,
-      userLabels,
-    };
+    const renderContext = { userLabels };
 
     let normalized: NormalizedSlackEvent | null;
     if (isReactionAdded) {

--- a/packages/slack-text/src/index.test.ts
+++ b/packages/slack-text/src/index.test.ts
@@ -4,8 +4,6 @@ import {
   buildSlackUserLabelMap,
   extractSlackUserMentionIds,
   renderSlackTextForModel,
-  stripLeadingSlackMentionFallback,
-  stripLeadingSlackUserMention,
 } from "./index.js";
 
 describe("extractSlackUserMentionIds", () => {
@@ -13,34 +11,6 @@ describe("extractSlackUserMentionIds", () => {
     expect(
       extractSlackUserMentionIds("<@U123> hi <@W456> and <@U123> again")
     ).toEqual(["U123", "W456"]);
-  });
-});
-
-describe("stripLeadingSlackUserMention", () => {
-  test("strips only leading mentions for the exact bot ID", () => {
-    expect(stripLeadingSlackUserMention("<@U111> <@U222> hi", "U111")).toBe(
-      "<@U222> hi"
-    );
-  });
-
-  test("strips repeated leading mentions for the exact bot ID", () => {
-    expect(stripLeadingSlackUserMention(" <@U111> <@U111> hi", "U111")).toBe(
-      "hi"
-    );
-  });
-
-  test("preserves text when the leading mention is a different user", () => {
-    expect(stripLeadingSlackUserMention("<@U222> hi <@U111>", "U111")).toBe(
-      "<@U222> hi <@U111>"
-    );
-  });
-});
-
-describe("stripLeadingSlackMentionFallback", () => {
-  test("strips only the first leading Slack user mention", () => {
-    expect(stripLeadingSlackMentionFallback(" <@U111> <@U222> hi")).toBe(
-      "<@U222> hi"
-    );
   });
 });
 
@@ -123,19 +93,32 @@ describe("renderSlackTextForModel", () => {
 });
 
 describe("buildSlackUserLabelMap", () => {
-  test("dedupes mentioned users across text inputs and ignores configured IDs", async () => {
+  test("dedupes mentioned users across text inputs and resolves them in parallel", async () => {
     const resolved: string[] = [];
     const labels = await buildSlackUserLabelMap(
       ["<@U123> hi <@U999>", undefined, "<@U123> and <@W456>"],
       async (userId) => {
         resolved.push(userId);
+        if (userId === "U999") return "Charlie";
         return userId === "W456" ? "Bob" : "Alice";
-      },
-      { ignoredUserIds: ["U999"] }
+      }
     );
 
-    expect(resolved).toEqual(["U123", "W456"]);
-    expect(labels).toEqual({ U123: "Alice", W456: "Bob" });
+    expect(resolved.sort()).toEqual(["U123", "U999", "W456"]);
+    expect(labels).toEqual({ U123: "Alice", U999: "Charlie", W456: "Bob" });
+  });
+
+  test("resolves bot and human user mentions together", async () => {
+    const labels = await buildSlackUserLabelMap(
+      ["<@UBOT> can you help <@ULEO> with the deploy?"],
+      async (userId) => {
+        if (userId === "UBOT") return "vex";
+        if (userId === "ULEO") return "leo";
+        return undefined;
+      }
+    );
+
+    expect(labels).toEqual({ UBOT: "vex", ULEO: "leo" });
   });
 
   test("omits unresolved labels and labels equal to the Slack user ID", async () => {

--- a/packages/slack-text/src/index.ts
+++ b/packages/slack-text/src/index.ts
@@ -5,12 +5,7 @@ export interface RenderSlackTextOptions {
   channelFallbackLabel?: string;
 }
 
-export interface BuildSlackUserLabelMapOptions {
-  ignoredUserIds?: Iterable<string | undefined>;
-}
-
 const SLACK_USER_MENTION_RE = /<@([UW][A-Z0-9]+)>/g;
-const LEADING_SLACK_USER_MENTION_RE = /^\s*<@[UW][A-Z0-9]+>\s*/;
 
 export function extractSlackUserMentionIds(text: string): string[] {
   const seen = new Set<string>();
@@ -25,30 +20,6 @@ export function extractSlackUserMentionIds(text: string): string[] {
   }
 
   return ids;
-}
-
-export function stripLeadingSlackUserMention(
-  text: string,
-  userId: string
-): string {
-  if (!isSlackUserId(userId)) {
-    return text;
-  }
-
-  const mention = `<@${userId}>`;
-  let stripped = text;
-
-  while (true) {
-    const next = stripLeadingExactToken(stripped, mention);
-    if (next === stripped) {
-      return stripped;
-    }
-    stripped = next;
-  }
-}
-
-export function stripLeadingSlackMentionFallback(text: string): string {
-  return text.replace(LEADING_SLACK_USER_MENTION_RE, "");
 }
 
 export function renderSlackTextForModel(
@@ -78,21 +49,15 @@ export function renderSlackTextForModel(
 
 export async function buildSlackUserLabelMap(
   texts: Iterable<string | undefined>,
-  resolveLabel: (userId: string) => Promise<string | undefined | null>,
-  options: BuildSlackUserLabelMapOptions = {}
+  resolveLabel: (userId: string) => Promise<string | undefined | null>
 ): Promise<Record<string, string>> {
-  const ignored = new Set(
-    [...(options.ignoredUserIds ?? [])].filter(
-      (id): id is string => typeof id === "string" && id.length > 0
-    )
-  );
   const ids: string[] = [];
   const seen = new Set<string>();
 
   for (const text of texts) {
     if (!text) continue;
     for (const id of extractSlackUserMentionIds(text)) {
-      if (ignored.has(id) || seen.has(id)) continue;
+      if (seen.has(id)) continue;
       seen.add(id);
       ids.push(id);
     }
@@ -213,17 +178,6 @@ function sanitizeOptionalLabel(label: string | undefined): string | undefined {
     .trim()
     .replace(/^[@#]+/, "")
     .trim();
-}
-
-function stripLeadingExactToken(text: string, token: string): string {
-  const leadingWhitespaceLength = text.length - text.trimStart().length;
-  const afterWhitespace = text.slice(leadingWhitespaceLength);
-
-  if (!afterWhitespace.startsWith(token)) {
-    return text;
-  }
-
-  return afterWhitespace.slice(token.length).trimStart();
 }
 
 function isSlackUserId(value: string): boolean {


### PR DESCRIPTION
## Prompt / plan

Closes LUM-1389.

Slack inbound normalizers were stripping the leading `<@bot>` token from
message text before handing it to the daemon, and the bot's user ID was
excluded from the user-label resolution map (`buildSlackUserLabelMap`'s
`ignoredUserIds` option). Together these meant the daemon could not see
whether a message had directly tagged the bot: the structural mention
had been erased, and any non-leading `<@bot>` rendered as
`@unknown-user`. The daemon's `response_discretion` rule was therefore
making engagement decisions on prose that no longer reflected the
original Slack message.

This PR fixes the root cause directly:

- **Drop the strip plumbing entirely** —
  `stripBotMention`, `stripLeadingSlackUserMention`,
  `stripLeadingSlackMentionFallback`, and the
  `stripLeadingBotMention` / `fallbackStripFirstMention` options on
  `renderSlackInboundText`. Three normalizer call sites
  (`normalizeSlackChannelMessage`, `normalizeSlackAppMention`,
  `normalizeSlackMessageEdit`) now delegate to
  `renderSlackTextForModel` directly.
- **Drop the `ignoredUserIds` option on `buildSlackUserLabelMap`** — the
  bot is no longer special-cased. Its display name is resolved through
  the same `users.info` path as any human user, populated into
  `userLabels`, and rendered as `@<bot-name>` wherever Slack delivered
  `<@bot>`. The daemon now reads the same prose a human reads in Slack.
- **Backfill alignment** — `assistant/src/messaging/providers/slack/adapter.ts`
  already calls `buildSlackUserLabelMap` without `ignoredUserIds`, so
  live ingress and historical backfill now agree on bot-mention
  rendering.

### Why this was the right fix

The previous live-ingress behavior — strip leading bot mention, hide bot
from label resolution — predates Slack mention display-name rendering.
Once display-name rendering landed, leaving the strip in place started
to silently destroy information the daemon needed in order to answer
the simple question: *was the bot directly tagged in this message?* The
fix follows the AGENTS.md
[Assistant-Driven Judgement](https://github.com/vellum-ai/vellum-assistant/blob/main/AGENTS.md#assistant-driven-judgement)
principle: the gateway delivers what the user actually wrote (with
mentions resolved to display names) and lets the daemon make the
engagement call.

### Why this is safe

- **No new wire-protocol fields**, no daemon-side plumbing, no
  `<turn_context>` schema changes.
- The backfill normalizer already used the resolution path this PR
  switches the gateway to, so the live-ingress path is now consistent
  with what we replay from history rather than diverging from it.
- `users.info` works for bot users transparently — no new Slack
  scopes required.
- The only API-shape change is removing the optional `ignoredUserIds`
  option from `buildSlackUserLabelMap`. Internal usage was a single
  call site (the bot exclusion being removed) plus one test.

### Alternatives considered

- **Surface a structural `directlyAddressed` boolean from the gateway
  through to a `<turn_context>` field next to a soft `response_discretion`
  rule.** Rejected: it added a new daemon-side field, two new code
  paths in `conversation-runtime-assembly`, retry-sweep alignment, and
  a prompt rule whose narrowness had to be calibrated against
  JARVIS-669 — all to convey information the gateway could simply
  preserve in the prose. The prose-fix removes ~150 lines net and
  produces a model input that matches what a human sees in Slack.
- **Resolve the bot via a separate startup-cached `auth.test` call and
  inject `userLabels[botUserId] = botDisplayName`.** Rejected: the
  same `users.info` resolver used for humans already works for bot
  users, hits the same in-memory cache, and parallelizes with
  human-mention resolution under the existing `Promise.all`. Adding a
  startup-time special case would be unnecessary code.
- **Keep `ignoredUserIds` for future generic use.** Rejected: only one
  caller exists, the assistant-side equivalent never used it, and YAGNI.
  Easy to reintroduce later if a real use case appears.

### Root cause analysis

1. **How did the code get into this state?** Stripping the leading
   bot mention was an early UX choice (so the daemon would see clean
   prose, not Slack's raw `<@U…>` token). When mention display-name
   rendering landed later, the strip stopped serving any purpose — the
   user-readable form `@<bot-name>` would have been better in every
   case — but the strip was left in place. Separately, the bot was
   added to `ignoredUserIds` for `buildSlackUserLabelMap` without a
   documented rationale; it was likely an inadvertent optimization,
   since the leading bot mention was always being stripped anyway.
2. **What mistakes or decisions led to it?** Two changes were made in
   isolation: the original strip and the later display-name rendering.
   Neither revisited the strip. The `ignoredUserIds` carve-out was
   added without a written reason in the commit/PR record.
3. **Were there warning signs we missed?** Yes — the assistant-side
   backfill normalizer never excluded the bot from label resolution,
   creating a silent divergence between live ingress and historical
   backfill. Also, the existing test `renders unresolved user mentions
   with the unknown-user fallback` was effectively documenting the
   bug as expected behavior (a non-leading `<@bot>` rendering as
   `@unknown-user`).
4. **What can we do to prevent this pattern from recurring?** Treat
   the gateway → daemon contract as "what a human reads, plus
   structured metadata where it's needed." When in doubt, prefer
   preserving prose over destroying it; reach for a structural signal
   only when the prose genuinely cannot carry the information.
5. **Should we add/remove/change a guideline in AGENTS.md?** No new
   rule needed for this case — the existing
   [Assistant-Driven Judgement](https://github.com/vellum-ai/vellum-assistant/blob/main/AGENTS.md#assistant-driven-judgement)
   guidance already covers it. The earlier instinct to add a soft
   `response_discretion` rule was sound; the issue was that it was
   compensating for prose the gateway had erased rather than fixing
   the erasure.

## Test plan

- `bunx tsc --noEmit` clean in `packages/slack-text/`, `gateway/`, and
  `assistant/`.
- `bun test packages/slack-text/src/index.test.ts` — 13 pass.
- `bun test gateway/src/__tests__/slack-normalize.test.ts gateway/src/slack/normalize.test.ts`
  — 106 pass.
- New tests in `packages/slack-text/src/index.test.ts` cover the
  parallel-resolution path for mixed bot+human mentions.
- New tests in `gateway/src/__tests__/slack-normalize.test.ts` assert
  that `<@UBOT> hello world` → `@vex hello world`, that mixed
  bot+human mentions render correctly, and that an unresolved bot
  mention falls back to `@unknown-user`.
- Existing strip-asserting tests have been updated to assert the new
  rendered behavior (e.g. `<@UBOT> <@ULEO> shared this` →
  `@vex @leo shared this`).
- CI: lint, typecheck, full test suite.

Link to Devin session: https://app.devin.ai/sessions/14ada838f84144dbaaaba7bab80aefc6
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->