### PR TITLE
fix: use case-insensitive trimmed title match for app ID capture

### DIFF
--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -220,7 +220,10 @@ Write the source code following the skill instructions, then compile via app_ref
   const match = apps.find(
     (app) =>
       app.createdAt >= buildStartedAt &&
-      app.name.includes(params.artifactTitle),
+      app.name
+        .trim()
+        .toLowerCase()
+        .includes(params.artifactTitle.trim().toLowerCase()),
   );
 
   if (!match) {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for proactive-artifact.md.

**Gap:** Case-sensitive app title matching
**What was expected:** Normalized title match (case-insensitive, trimmed)
**What was found:** app.name.includes(params.artifactTitle) — case-sensitive, no trim
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->