### PR TITLE
ci(build-chrome-extension): add ref input to build any branch from main

### DIFF
--- a/.github/workflows/build-chrome-extension.yaml
+++ b/.github/workflows/build-chrome-extension.yaml
@@ -1,13 +1,23 @@
 name: Build Chrome Extension
 
-# Manually triggered build of the Chrome extension against a target branch.
+# Manually triggered build of the Chrome extension against a target ref.
 # Mirrors the build-chrome-extension job in release.yml and produces the same
 # two artifacts (chrome-extension-crx, chrome-extension-zip) for download from
 # the workflow run page.
+#
+# Always dispatch this workflow from `main` (the "Use workflow from" dropdown).
+# Specify the branch / tag / SHA you actually want to build via the `ref`
+# input. Dispatching directly from an older branch only works if that branch
+# already contains this workflow file — which most don't.
 
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build (defaults to the dispatch ref, typically main)'
+        required: false
+        type: string
+        default: ''
       environment:
         description: 'VELLUM_ENVIRONMENT to bake into the bundle'
         required: false
@@ -19,13 +29,13 @@ on:
           - dev
           - local
       version:
-        description: 'Version to stamp in manifest.json (defaults to the value already in manifest.json on the target branch)'
+        description: 'Version to stamp in manifest.json (defaults to the value already in manifest.json on the target ref)'
         required: false
         type: string
         default: ''
 
 concurrency:
-  group: build-chrome-extension-${{ github.ref }}
+  group: build-chrome-extension-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -34,6 +44,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
## Summary
- Add a `ref` input to the manual Chrome-extension build workflow and pass it to `actions/checkout`, so users dispatch from `main` (where the workflow exists) and target any branch / tag / SHA.
- Without this, GitHub rejects dispatch on branches that pre-date the workflow file with "Workflow does not exist or does not have a workflow_dispatch trigger in this branch."
- Concurrency key now follows the requested ref instead of the dispatch ref.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->