### PR TITLE
feat(proactive-artifact): build personalized artifact after 4th user message

### DIFF
--- a/assistant/src/bundler/compiler-tools.ts
+++ b/assistant/src/bundler/compiler-tools.ts
@@ -15,10 +15,11 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { arch, homedir, platform } from "node:os";
+import { arch, platform } from "node:os";
 import { join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
 import { PromiseGuard } from "../util/promise-guard.js";
 
 const log = getLogger("compiler-tools");
@@ -44,7 +45,7 @@ interface VersionManifest {
 }
 
 function getToolsDir(): string {
-  return join(homedir(), ".vellum", "workspace", "compiler-tools");
+  return join(getWorkspaceDir(), "compiler-tools");
 }
 
 const installGuard = new PromiseGuard<void>();

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -264,6 +264,20 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "General-purpose LLM inference call site for skill use.",
     domain: "skills",
   },
+  proactiveArtifactDecision: {
+    id: "proactiveArtifactDecision",
+    displayName: "Proactive Artifact Decision",
+    description:
+      "Decides what personalized artifact to build for new users based on conversation context.",
+    domain: "agentLoop",
+  },
+  proactiveArtifactBuild: {
+    id: "proactiveArtifactBuild",
+    displayName: "Proactive Artifact Build",
+    description:
+      "Builds the personalized artifact in a background conversation with tool access.",
+    domain: "agentLoop",
+  },
 };
 
 // Source of truth for call-site display metadata. API responses and usage

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -70,6 +70,8 @@ export const LLMCallSiteEnum = z.enum([
   "inference",
   "feedEventCopy",
   "trustRuleSuggestion",
+  "proactiveArtifactDecision",
+  "proactiveArtifactBuild",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -106,6 +106,11 @@ import type {
   TurnContext as PluginTurnContext,
 } from "../plugins/types.js";
 import { PluginExecutionError, PluginTimeoutError } from "../plugins/types.js";
+import {
+  hasProactiveArtifactCompleted,
+  runProactiveArtifactJob,
+  tryClaimProactiveArtifactTrigger,
+} from "../proactive-artifact/index.js";
 import type {
   ContentBlock,
   Message,
@@ -113,6 +118,7 @@ import type {
 } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { getSubagentManager } from "../subagent/index.js";
@@ -2873,6 +2879,41 @@ export async function runAgentLoopImpl(
             { err: feedErr, conversationId: ctx.conversationId },
             "Failed to build home-feed event for background conversation",
           );
+        }
+
+        // Proactive artifact: fire once when the processed turn was the 4th user message.
+        // Only trigger for real user-authored turns (not subagent/system messages).
+        {
+          const paConv = getConversation(ctx.conversationId);
+          if (
+            paConv &&
+            paConv.conversationType === "standard" &&
+            options?.isUserMessage
+          ) {
+            void (async () => {
+              try {
+                if (hasProactiveArtifactCompleted()) return;
+                const userMsg = getMessageById(
+                  userMessageId,
+                  ctx.conversationId,
+                );
+                if (!userMsg) return;
+                if (!tryClaimProactiveArtifactTrigger(userMsg.createdAt))
+                  return;
+                await runProactiveArtifactJob({
+                  conversationId: ctx.conversationId,
+                  userMessageCutoff: userMsg.createdAt,
+                  assistantMessageId: state.lastAssistantMessageId,
+                  broadcastMessage,
+                });
+              } catch (err) {
+                log.warn(
+                  { err, conversationId: ctx.conversationId },
+                  "Proactive artifact trigger failed",
+                );
+              }
+            })();
+          }
         }
       }
     }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -62,6 +62,7 @@ import {
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import { loadUserPlugins } from "../plugins/user-loader.js";
+import { backfillGuardIfNeeded } from "../proactive-artifact/index.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { resolveManagedProxyContext } from "../providers/managed-proxy/context.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
@@ -1235,6 +1236,12 @@ export async function runDaemon(): Promise<void> {
       },
       "Heartbeat service configured",
     );
+
+    try {
+      backfillGuardIfNeeded();
+    } catch (err) {
+      log.warn({ err }, "Proactive artifact backfill failed");
+    }
 
     // Filing yields to the memory v2 consolidation job when the flag is on —
     // both serve the same role (periodic background memory processing) and

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared document persistence service.
+ *
+ * Extracted from documents-routes.ts so that both HTTP route handlers and
+ * background jobs (e.g. proactive artifact generation) can persist documents
+ * without going through the HTTP layer.
+ */
+import { rawRun } from "../memory/raw-query.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("document-store");
+
+// ---------------------------------------------------------------------------
+// Junction table helper
+// ---------------------------------------------------------------------------
+
+/** Insert a document–conversation association (idempotent via INSERT OR IGNORE). */
+export function addDocumentConversation(
+  surfaceId: string,
+  conversationId: string,
+): void {
+  rawRun(
+    /*sql*/ `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    surfaceId,
+    conversationId,
+    Date.now(),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Document persistence
+// ---------------------------------------------------------------------------
+
+export function saveDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  wordCount: number;
+}): { success: true; surfaceId: string } | { success: false; error: string } {
+  try {
+    const now = Date.now();
+    rawRun(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(surface_id) DO UPDATE SET
+         title = excluded.title,
+         content = excluded.content,
+         word_count = excluded.word_count,
+         updated_at = excluded.updated_at`,
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.wordCount,
+      now,
+      now,
+    );
+    log.info(
+      { surfaceId: params.surfaceId, title: params.title },
+      "Saved document",
+    );
+
+    // Best-effort: associate the document with the conversation.
+    // Failures (e.g. migration not yet applied, table missing) must not
+    // cause the save response to report failure — the document itself is
+    // already persisted at this point.
+    try {
+      addDocumentConversation(params.surfaceId, params.conversationId);
+    } catch (err) {
+      log.warn(
+        { err, surfaceId: params.surfaceId },
+        "Failed to record document–conversation association",
+      );
+    }
+
+    return { success: true, surfaceId: params.surfaceId };
+  } catch (error) {
+    log.error({ err: error, surfaceId: params.surfaceId }, "Save error");
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/assistant/src/proactive-artifact/aux-message-injector.ts
+++ b/assistant/src/proactive-artifact/aux-message-injector.ts
@@ -1,0 +1,74 @@
+/**
+ * Auxiliary message injection for proactive artifacts.
+ *
+ * Injects an assistant message into a conversation without going through
+ * the normal agent loop. Defers injection while the conversation is
+ * actively processing to preserve chronological message ordering.
+ */
+
+import { createAssistantMessage } from "../agent/message-types.js";
+import { findConversation } from "../daemon/conversation-store.js";
+import { addMessage } from "../memory/conversation-crud.js";
+import type { BroadcastFn } from "../notifications/adapters/macos.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("aux-message-injector");
+const IDLE_POLL_MS = 200;
+const IDLE_TIMEOUT_MS = 60_000;
+
+async function waitForIdle(conversationId: string): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < IDLE_TIMEOUT_MS) {
+    const conv = findConversation(conversationId);
+    if (!conv || !conv.processing) return true;
+    await new Promise((resolve) => setTimeout(resolve, IDLE_POLL_MS));
+  }
+  return false;
+}
+
+export async function injectAuxAssistantMessage(params: {
+  conversationId: string;
+  text: string;
+  broadcastMessage: BroadcastFn;
+}): Promise<void> {
+  const conv = findConversation(params.conversationId);
+  if (conv?.processing) {
+    const reachedIdle = await waitForIdle(params.conversationId);
+    if (!reachedIdle) {
+      log.warn(
+        { conversationId: params.conversationId },
+        "Timed out waiting for conversation idle; injecting anyway",
+      );
+    }
+  }
+
+  const msg = await addMessage(
+    params.conversationId,
+    "assistant",
+    JSON.stringify([{ type: "text", text: params.text }]),
+    undefined,
+    { skipIndexing: true },
+  );
+
+  const current = findConversation(params.conversationId);
+  if (current && !current.processing) {
+    current.getMessages().push(createAssistantMessage(params.text));
+
+    params.broadcastMessage({
+      type: "assistant_text_delta",
+      text: params.text,
+      conversationId: params.conversationId,
+    });
+    params.broadcastMessage({
+      type: "message_complete",
+      conversationId: params.conversationId,
+      messageId: msg.id,
+      source: "aux",
+    });
+  }
+
+  params.broadcastMessage({
+    type: "conversation_list_invalidated",
+    reason: "reordered",
+  });
+}

--- a/assistant/src/proactive-artifact/decision.test.ts
+++ b/assistant/src/proactive-artifact/decision.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type DecisionOutput,
+  formatTranscript,
+  parseDecisionOutput,
+} from "./decision.js";
+
+describe("parseDecisionOutput", () => {
+  test("parses SHOULD_BUILD: yes with all fields correctly", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: app
+ARTIFACT_TITLE: Sarah's Marathon Training Pace Calculator
+ARTIFACT_DESCRIPTION: An interactive pace calculator that accounts for Sarah's goal of a sub-4-hour marathon, her current 9:30/mile easy pace, and the hilly terrain of the Boston course.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toEqual({
+      shouldBuild: true,
+      artifactType: "app",
+      artifactTitle: "Sarah's Marathon Training Pace Calculator",
+      artifactDescription:
+        "An interactive pace calculator that accounts for Sarah's goal of a sub-4-hour marathon, her current 9:30/mile easy pace, and the hilly terrain of the Boston course.",
+    });
+  });
+
+  test("parses SHOULD_BUILD: no with skip reason", () => {
+    const text = `SHOULD_BUILD: no
+SKIP_REASON: The conversation is too early and generic — the user has only asked a factual question with no personal context.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toEqual({
+      shouldBuild: false,
+      skipReason:
+        "The conversation is too early and generic — the user has only asked a factual question with no personal context.",
+    });
+  });
+
+  test("parses SHOULD_BUILD: no without skip reason defaults to 'no reason given'", () => {
+    const text = `SHOULD_BUILD: no`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toEqual({
+      shouldBuild: false,
+      skipReason: "no reason given",
+    });
+  });
+
+  test("returns null for missing SHOULD_BUILD line", () => {
+    const text = `ARTIFACT_TYPE: app
+ARTIFACT_TITLE: Some Title
+ARTIFACT_DESCRIPTION: Some description.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when yes but ARTIFACT_TYPE is missing", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TITLE: Some Title
+ARTIFACT_DESCRIPTION: Some description.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when yes but ARTIFACT_TYPE is invalid", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: widget
+ARTIFACT_TITLE: Some Title
+ARTIFACT_DESCRIPTION: Some description.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when yes but ARTIFACT_TITLE is missing", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: document
+ARTIFACT_DESCRIPTION: Some description.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when yes but ARTIFACT_DESCRIPTION is missing", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: document
+ARTIFACT_TITLE: Some Title`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when yes but ARTIFACT_TITLE is empty", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: app
+ARTIFACT_TITLE:
+ARTIFACT_DESCRIPTION: Some description.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).toBeNull();
+  });
+
+  test("handles multi-line ARTIFACT_DESCRIPTION", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: document
+ARTIFACT_TITLE: Jake's Q3 OKR Tracker
+ARTIFACT_DESCRIPTION: A structured comparison table for Jake's three competing priorities:
+scaling the data pipeline from 10M to 50M events/day,
+hiring two senior engineers by September,
+and reducing p99 latency below 200ms.`;
+
+    const result = parseDecisionOutput(text) as DecisionOutput & {
+      shouldBuild: true;
+    };
+    expect(result).not.toBeNull();
+    expect(result.shouldBuild).toBe(true);
+    expect(result.artifactType).toBe("document");
+    expect(result.artifactTitle).toBe("Jake's Q3 OKR Tracker");
+    expect(result.artifactDescription).toContain(
+      "A structured comparison table",
+    );
+    expect(result.artifactDescription).toContain(
+      "reducing p99 latency below 200ms",
+    );
+  });
+
+  test("handles case-insensitive SHOULD_BUILD value", () => {
+    const text = `SHOULD_BUILD: Yes
+ARTIFACT_TYPE: app
+ARTIFACT_TITLE: Test Title
+ARTIFACT_DESCRIPTION: Test description.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).not.toBeNull();
+    expect(result!.shouldBuild).toBe(true);
+  });
+
+  test("handles case-insensitive ARTIFACT_TYPE value", () => {
+    const text = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: Document
+ARTIFACT_TITLE: Test Title
+ARTIFACT_DESCRIPTION: Test description.`;
+
+    const result = parseDecisionOutput(text);
+    expect(result).not.toBeNull();
+    expect((result as { artifactType: string }).artifactType).toBe("document");
+  });
+});
+
+describe("formatTranscript", () => {
+  test("formats plain text messages correctly", () => {
+    const messages = [
+      { role: "user", content: "Hello, I need help with my project" },
+      {
+        role: "assistant",
+        content: "I'd be happy to help! What kind of project?",
+      },
+      {
+        role: "user",
+        content: "I'm building a fitness tracker for marathon training",
+      },
+    ];
+
+    const result = formatTranscript(messages);
+    expect(result).toBe(
+      `[User]: Hello, I need help with my project
+
+[Assistant]: I'd be happy to help! What kind of project?
+
+[User]: I'm building a fitness tracker for marathon training`,
+    );
+  });
+
+  test("handles JSON content blocks", () => {
+    const messages = [
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "What is 2+2?" }]),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "The answer is 4." },
+          { type: "text", text: "Would you like to know more?" },
+        ]),
+      },
+    ];
+
+    const result = formatTranscript(messages);
+    expect(result).toBe(
+      `[User]: What is 2+2?
+
+[Assistant]: The answer is 4.
+Would you like to know more?`,
+    );
+  });
+
+  test("handles mixed JSON and plain text messages", () => {
+    const messages = [
+      {
+        role: "user",
+        content: JSON.stringify([
+          { type: "text", text: "Help me plan my week" },
+        ]),
+      },
+      { role: "assistant", content: "Sure, what do you have coming up?" },
+    ];
+
+    const result = formatTranscript(messages);
+    expect(result).toBe(
+      `[User]: Help me plan my week
+
+[Assistant]: Sure, what do you have coming up?`,
+    );
+  });
+
+  test("handles unknown roles", () => {
+    const messages = [
+      { role: "system", content: "You are a helpful assistant" },
+    ];
+
+    const result = formatTranscript(messages);
+    expect(result).toBe("[system]: You are a helpful assistant");
+  });
+});

--- a/assistant/src/proactive-artifact/decision.ts
+++ b/assistant/src/proactive-artifact/decision.ts
@@ -1,0 +1,165 @@
+export type DecisionOutput =
+  | { shouldBuild: false; skipReason: string }
+  | {
+      shouldBuild: true;
+      artifactType: "app" | "document";
+      artifactTitle: string;
+      artifactDescription: string;
+    };
+
+export function buildDecisionPrompt(transcript: string): string {
+  return `You are deciding whether to proactively build a personalized artifact for the user based on their conversation so far.
+
+Read the conversation below carefully. Your job:
+1. Identify what the user cares about — their goals, context, specific details they've shared.
+2. Decide: should we build a small interactive app or document that would delight this specific user?
+3. Quality test: Could you have built the same thing for any random person? If yes, too generic — output SHOULD_BUILD: no.
+
+Rules:
+- Only say yes if you can build something SPECIFIC to this user's situation, using details from their conversation.
+- An "app" is a small interactive web application (calculator, tracker, visualizer, planner, etc.)
+- A "document" is a structured reference (checklist, guide, comparison table, template, etc.)
+- The title and description must reference specifics from the conversation — names, numbers, goals, constraints the user mentioned.
+- Do NOT include a MESSAGE field.
+
+Conversation:
+${transcript}
+
+Respond in EXACTLY this format (no extra text before or after):
+
+SHOULD_BUILD: [yes|no]
+SKIP_REASON: [required if no — why this conversation isn't a good fit]
+ARTIFACT_TYPE: [app|document]
+ARTIFACT_TITLE: [specific title seeded with user context]
+ARTIFACT_DESCRIPTION: [1-3 sentence build spec with user-specific details]
+
+If SHOULD_BUILD is no, omit ARTIFACT_TYPE, ARTIFACT_TITLE, and ARTIFACT_DESCRIPTION.
+If SHOULD_BUILD is yes, omit SKIP_REASON.`;
+}
+
+export function parseDecisionOutput(text: string): DecisionOutput | null {
+  const lines = text.trim().split("\n");
+
+  const shouldBuildLine = lines.find((line) =>
+    line.trim().startsWith("SHOULD_BUILD:"),
+  );
+  if (!shouldBuildLine) return null;
+
+  const shouldBuildValue = shouldBuildLine
+    .split(":")
+    .slice(1)
+    .join(":")
+    .trim()
+    .toLowerCase();
+
+  if (shouldBuildValue === "no") {
+    const skipReasonLine = lines.find((line) =>
+      line.trim().startsWith("SKIP_REASON:"),
+    );
+    const skipReason = skipReasonLine
+      ? skipReasonLine.split(":").slice(1).join(":").trim()
+      : "no reason given";
+    return { shouldBuild: false, skipReason };
+  }
+
+  if (shouldBuildValue === "yes") {
+    const artifactTypeLine = lines.find((line) =>
+      line.trim().startsWith("ARTIFACT_TYPE:"),
+    );
+    if (!artifactTypeLine) return null;
+    const artifactType = artifactTypeLine
+      .split(":")
+      .slice(1)
+      .join(":")
+      .trim()
+      .toLowerCase();
+    if (artifactType !== "app" && artifactType !== "document") return null;
+
+    const artifactTitleLine = lines.find((line) =>
+      line.trim().startsWith("ARTIFACT_TITLE:"),
+    );
+    if (!artifactTitleLine) return null;
+    const artifactTitle = artifactTitleLine
+      .split(":")
+      .slice(1)
+      .join(":")
+      .trim();
+    if (!artifactTitle) return null;
+
+    const artifactDescriptionStartIndex = lines.findIndex((line) =>
+      line.trim().startsWith("ARTIFACT_DESCRIPTION:"),
+    );
+    if (artifactDescriptionStartIndex === -1) return null;
+
+    const firstDescLine = lines[artifactDescriptionStartIndex]
+      .split(":")
+      .slice(1)
+      .join(":")
+      .trim();
+
+    // Collect continuation lines (lines after ARTIFACT_DESCRIPTION that aren't other fields)
+    const descriptionParts = [firstDescLine];
+    for (let i = artifactDescriptionStartIndex + 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (
+        line.startsWith("SHOULD_BUILD:") ||
+        line.startsWith("SKIP_REASON:") ||
+        line.startsWith("ARTIFACT_TYPE:") ||
+        line.startsWith("ARTIFACT_TITLE:")
+      ) {
+        break;
+      }
+      descriptionParts.push(line);
+    }
+
+    const artifactDescription = descriptionParts.join("\n").trim();
+    if (!artifactDescription) return null;
+
+    return {
+      shouldBuild: true,
+      artifactType: artifactType as "app" | "document",
+      artifactTitle,
+      artifactDescription,
+    };
+  }
+
+  return null;
+}
+
+export function formatTranscript(
+  messages: Array<{ role: string; content: string }>,
+): string {
+  return messages
+    .map((msg) => {
+      const label =
+        msg.role === "user"
+          ? "[User]"
+          : msg.role === "assistant"
+            ? "[Assistant]"
+            : `[${msg.role}]`;
+      const content = parseContent(msg.content);
+      return `${label}: ${content}`;
+    })
+    .join("\n\n");
+}
+
+function parseContent(content: string): string {
+  // Try to parse as JSON content block array
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((block) => {
+          if (typeof block === "string") return block;
+          if (block.type === "text" && typeof block.text === "string")
+            return block.text;
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+  } catch {
+    // Not JSON, treat as plain text
+  }
+  return content;
+}

--- a/assistant/src/proactive-artifact/index.ts
+++ b/assistant/src/proactive-artifact/index.ts
@@ -1,0 +1,6 @@
+export { runProactiveArtifactJob } from "./job.js";
+export {
+  backfillGuardIfNeeded,
+  hasProactiveArtifactCompleted,
+  tryClaimProactiveArtifactTrigger,
+} from "./trigger-state.js";

--- a/assistant/src/proactive-artifact/index.ts
+++ b/assistant/src/proactive-artifact/index.ts
@@ -2,5 +2,6 @@ export { runProactiveArtifactJob } from "./job.js";
 export {
   backfillGuardIfNeeded,
   hasProactiveArtifactCompleted,
+  releaseProactiveArtifactClaim,
   tryClaimProactiveArtifactTrigger,
 } from "./trigger-state.js";

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -358,7 +358,7 @@ describe("runProactiveArtifactJob", () => {
   });
 
   describe("Phase 2 — Build", () => {
-    test("Phase 2 failure → no message, no notification", async () => {
+    test("Phase 2 failure → releases claim, no message, no notification", async () => {
       rawAllRows = defaultTranscript;
       decisionResponse = decisionYesApp;
       processMessageShouldThrow = true;
@@ -376,6 +376,8 @@ describe("runProactiveArtifactJob", () => {
       expect(addMessageCalls).toHaveLength(0);
       expect(emitSignalCalls).toHaveLength(0);
       expect(broadcastCalls).toHaveLength(0);
+      // Claim released so next turn can retry
+      expect(releaseClaimCalls).toBe(1);
     });
 
     test("successful app: Phase 1 → Phase 2 → app store query → message copy → inject → notify", async () => {
@@ -502,7 +504,7 @@ describe("runProactiveArtifactJob", () => {
       expect(releaseClaimCalls).toBe(0);
     });
 
-    test("app build - no matching app found → treated as build failure", async () => {
+    test("app build - no matching app found → releases claim for retry", async () => {
       rawAllRows = defaultTranscript;
       decisionResponse = decisionYesApp;
       mockApps = []; // no apps in store
@@ -514,14 +516,13 @@ describe("runProactiveArtifactJob", () => {
         broadcastMessage: mockBroadcast,
       });
 
-      // Build attempted
       expect(processMessageCalls).toHaveLength(1);
-      // But failure = no message, no notification
       expect(addMessageCalls).toHaveLength(0);
       expect(emitSignalCalls).toHaveLength(0);
+      expect(releaseClaimCalls).toBe(1);
     });
 
-    test("document build - build provider unavailable → build failure → silence", async () => {
+    test("document build - build provider unavailable → releases claim for retry", async () => {
       rawAllRows = defaultTranscript;
       decisionResponse = decisionYesDocument;
       buildProviderAvailable = false;
@@ -536,6 +537,7 @@ describe("runProactiveArtifactJob", () => {
       // No message, no notification
       expect(addMessageCalls).toHaveLength(0);
       expect(emitSignalCalls).toHaveLength(0);
+      expect(releaseClaimCalls).toBe(1);
     });
   });
 

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -96,9 +96,14 @@ let mockApps: Array<{
   name: string;
   createdAt: number;
 }> = [];
+let addAppConvCalls: Array<{ appId: string; conversationId: string }> = [];
 
 mock.module("../memory/app-store.js", () => ({
   listApps: () => mockApps,
+  addAppConversationId: (appId: string, conversationId: string) => {
+    addAppConvCalls.push({ appId, conversationId });
+    return true;
+  },
 }));
 
 // Document store mock
@@ -179,6 +184,15 @@ mock.module("../agent/message-types.js", () => ({
     role: "assistant",
     content: [{ type: "text", text }],
   }),
+}));
+
+// Trigger state mock
+let releaseClaimCalls = 0;
+
+mock.module("./trigger-state.js", () => ({
+  releaseProactiveArtifactClaim: () => {
+    releaseClaimCalls++;
+  },
 }));
 
 // Trust context mock
@@ -262,9 +276,11 @@ function resetState() {
   processMessageCalls = [];
   processMessageShouldThrow = false;
   mockApps = [];
+  addAppConvCalls = [];
   saveDocumentCalls = [];
   saveDocumentResult = { success: true, surfaceId: "doc-123" };
   addDocConvCalls = [];
+  releaseClaimCalls = 0;
   addMessageCalls = [];
   emitSignalCalls = [];
   broadcastCalls = [];
@@ -285,7 +301,7 @@ afterEach(() => {
 
 describe("runProactiveArtifactJob", () => {
   describe("Phase 1 — Decision", () => {
-    test("shouldBuild:false → no Phase 2, no message, no notification", async () => {
+    test("shouldBuild:false → releases claim, no Phase 2", async () => {
       rawAllRows = defaultTranscript;
       decisionResponse = decisionNo;
 
@@ -296,6 +312,7 @@ describe("runProactiveArtifactJob", () => {
         broadcastMessage: mockBroadcast,
       });
 
+      expect(releaseClaimCalls).toBe(1);
       expect(bootstrapCalls).toHaveLength(0);
       expect(processMessageCalls).toHaveLength(0);
       expect(addMessageCalls).toHaveLength(0);
@@ -303,7 +320,7 @@ describe("runProactiveArtifactJob", () => {
       expect(broadcastCalls).toHaveLength(0);
     });
 
-    test("null (malformed) → silent exit", async () => {
+    test("null (malformed) → releases claim, silent exit", async () => {
       rawAllRows = defaultTranscript;
       decisionResponse = "THIS IS GARBAGE OUTPUT";
 
@@ -314,13 +331,14 @@ describe("runProactiveArtifactJob", () => {
         broadcastMessage: mockBroadcast,
       });
 
+      expect(releaseClaimCalls).toBe(1);
       expect(bootstrapCalls).toHaveLength(0);
       expect(processMessageCalls).toHaveLength(0);
       expect(addMessageCalls).toHaveLength(0);
       expect(emitSignalCalls).toHaveLength(0);
     });
 
-    test("provider unavailable → silent return", async () => {
+    test("provider unavailable → releases claim, silent return", async () => {
       rawAllRows = defaultTranscript;
       decisionProviderAvailable = false;
 
@@ -331,6 +349,7 @@ describe("runProactiveArtifactJob", () => {
         broadcastMessage: mockBroadcast,
       });
 
+      expect(releaseClaimCalls).toBe(1);
       expect(providerSendCalls).toHaveLength(0);
       expect(bootstrapCalls).toHaveLength(0);
       expect(addMessageCalls).toHaveLength(0);
@@ -411,6 +430,11 @@ describe("runProactiveArtifactJob", () => {
       expect(bootstrapCalls[0].conversationType).toBe("background");
       expect(bootstrapCalls[0].source).toBe("proactive_artifact");
 
+      // App associated with user's conversation for Assets chip
+      expect(addAppConvCalls).toHaveLength(1);
+      expect(addAppConvCalls[0].appId).toBe("app-123");
+      expect(addAppConvCalls[0].conversationId).toBe("conv-1");
+
       // Message injection: addMessage called with skipIndexing
       expect(addMessageCalls).toHaveLength(1);
       expect(addMessageCalls[0].opts).toEqual({ skipIndexing: true });
@@ -430,6 +454,9 @@ describe("runProactiveArtifactJob", () => {
       expect(hints.requiresAction).toBe(false);
       // No conversationAffinityHint
       expect(emitSignalCalls[0].conversationAffinityHint).toBeUndefined();
+
+      // Claim NOT released on success — guard stays permanent
+      expect(releaseClaimCalls).toBe(0);
     });
 
     test("successful document: Phase 1 → content gen → saveDocument → message copy → inject → notify", async () => {
@@ -470,6 +497,9 @@ describe("runProactiveArtifactJob", () => {
       // Message injection and notification
       expect(addMessageCalls).toHaveLength(1);
       expect(emitSignalCalls).toHaveLength(1);
+
+      // Claim NOT released on success
+      expect(releaseClaimCalls).toBe(0);
     });
 
     test("app build - no matching app found → treated as build failure", async () => {
@@ -576,6 +606,7 @@ describe("runProactiveArtifactJob", () => {
         broadcastMessage: mockBroadcast,
       });
 
+      expect(releaseClaimCalls).toBe(1);
       expect(providerSendCalls).toHaveLength(0);
       expect(addMessageCalls).toHaveLength(0);
     });

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -1,0 +1,718 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock state ──────────────────────────────────────────────────────────
+
+// Provider mock
+let decisionProviderAvailable = true;
+let buildProviderAvailable = true;
+let decisionResponse = "";
+let buildResponse = "";
+let copyResponse = "";
+let providerSendCalls: Array<{ callSite: string; messages: unknown[] }> = [];
+
+const mockProvider = (callSite: string) => ({
+  name: "mock-provider",
+  sendMessage: async (messages: unknown[]) => {
+    providerSendCalls.push({ callSite, messages });
+    if (callSite === "proactiveArtifactDecision") {
+      return { content: [{ type: "text", text: decisionResponse }] };
+    }
+    if (callSite === "proactiveArtifactBuild") {
+      // copyResponse is used when it's for message copy (second call)
+      const isCopyCall = providerSendCalls.filter(
+        (c) => c.callSite === "proactiveArtifactBuild",
+      ).length;
+      if (isCopyCall > 1) {
+        return { content: [{ type: "text", text: copyResponse }] };
+      }
+      return { content: [{ type: "text", text: buildResponse }] };
+    }
+    return { content: [{ type: "text", text: "" }] };
+  },
+});
+
+mock.module("../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async (callSite: string) => {
+    if (
+      callSite === "proactiveArtifactDecision" &&
+      !decisionProviderAvailable
+    ) {
+      return null;
+    }
+    if (callSite === "proactiveArtifactBuild" && !buildProviderAvailable) {
+      return null;
+    }
+    return mockProvider(callSite);
+  },
+  extractText: (response: { content: Array<{ type: string; text: string }> }) =>
+    response.content.find((b: { type: string }) => b.type === "text")?.text ??
+    "",
+}));
+
+// rawAll mock
+let rawAllRows: Array<{ role: string; content: string }> = [];
+
+mock.module("../memory/raw-query.js", () => ({
+  rawAll: () => rawAllRows,
+  rawRun: () => 0,
+}));
+
+// bootstrapConversation mock
+let bootstrapCalls: Array<Record<string, unknown>> = [];
+
+mock.module("../memory/conversation-bootstrap.js", () => ({
+  bootstrapConversation: (opts: Record<string, unknown>) => {
+    bootstrapCalls.push(opts);
+    return { id: `bg-conv-${bootstrapCalls.length}` };
+  },
+}));
+
+// processMessage mock
+let processMessageCalls: Array<{
+  conversationId: string;
+  prompt: string;
+  options: unknown;
+}> = [];
+let processMessageShouldThrow = false;
+
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: async (
+    conversationId: string,
+    prompt: string,
+    _attachmentIds: unknown,
+    options: unknown,
+  ) => {
+    processMessageCalls.push({ conversationId, prompt, options });
+    if (processMessageShouldThrow) {
+      throw new Error("processMessage failed");
+    }
+    return { messageId: "pm-msg-1" };
+  },
+}));
+
+// App store mock
+let mockApps: Array<{
+  id: string;
+  name: string;
+  createdAt: number;
+}> = [];
+
+mock.module("../memory/app-store.js", () => ({
+  listApps: () => mockApps,
+}));
+
+// Document store mock
+let saveDocumentCalls: Array<Record<string, unknown>> = [];
+let saveDocumentResult: {
+  success: boolean;
+  surfaceId?: string;
+  error?: string;
+} = {
+  success: true,
+  surfaceId: "doc-123",
+};
+let addDocConvCalls: Array<{ surfaceId: string; conversationId: string }> = [];
+
+mock.module("../documents/document-store.js", () => ({
+  saveDocument: (params: Record<string, unknown>) => {
+    saveDocumentCalls.push(params);
+    return saveDocumentResult;
+  },
+  addDocumentConversation: (surfaceId: string, conversationId: string) => {
+    addDocConvCalls.push({ surfaceId, conversationId });
+  },
+}));
+
+// addMessage mock
+let addMessageCalls: Array<{
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata: unknown;
+  opts: unknown;
+}> = [];
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+    metadata: unknown,
+    opts: unknown,
+  ) => {
+    addMessageCalls.push({ conversationId, role, content, metadata, opts });
+    return { id: `msg-${addMessageCalls.length}` };
+  },
+}));
+
+// emitNotificationSignal mock
+let emitSignalCalls: Array<Record<string, unknown>> = [];
+
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emitSignalCalls.push(params);
+    return {
+      signalId: "signal-1",
+      deduplicated: false,
+      dispatched: true,
+      reason: "ok",
+      deliveryResults: [],
+    };
+  },
+}));
+
+// findConversation mock
+type MockConversation = {
+  processing: boolean;
+  messages: unknown[];
+  getMessages: () => unknown[];
+};
+let mockConversations: Map<string, MockConversation> = new Map();
+
+mock.module("../daemon/conversation-store.js", () => ({
+  findConversation: (id: string) => mockConversations.get(id),
+}));
+
+// createAssistantMessage mock
+mock.module("../agent/message-types.js", () => ({
+  createAssistantMessage: (text: string) => ({
+    role: "assistant",
+    content: [{ type: "text", text }],
+  }),
+}));
+
+// Trust context mock
+mock.module("../daemon/trust-context.js", () => ({
+  INTERNAL_GUARDIAN_TRUST_CONTEXT: {
+    sourceChannel: "vellum",
+    trustClass: "guardian",
+  },
+}));
+
+// Logger mock
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// uuid mock — deterministic IDs for testing
+let uuidCounter = 0;
+mock.module("uuid", () => ({
+  v4: () => `test-uuid-${++uuidCounter}`,
+}));
+
+// ── Import SUT after mocks ─────────────────────────────────────────────
+
+const { runProactiveArtifactJob } = await import("./job.js");
+const { injectAuxAssistantMessage } = await import("./aux-message-injector.js");
+const { buildMessageCopyPrompt, parseMessageCopy } =
+  await import("./message-copy.js");
+
+// ── Test helpers ────────────────────────────────────────────────────────
+
+let broadcastCalls: Array<Record<string, unknown>> = [];
+const mockBroadcast: any = (msg: Record<string, unknown>) => {
+  broadcastCalls.push(msg);
+};
+
+const defaultTranscript = [
+  { role: "user", content: "Hello there" },
+  { role: "assistant", content: "Hi! How can I help?" },
+  { role: "user", content: "I need a budget tracker" },
+  { role: "assistant", content: "I can help with that." },
+  { role: "user", content: "I spend about $3000 per month" },
+  { role: "assistant", content: "Got it, that is useful context." },
+  { role: "user", content: "Yes, let us track groceries and rent" },
+  {
+    role: "assistant",
+    content: "Great, I will remember those categories.",
+  },
+];
+
+const decisionYesApp = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: app
+ARTIFACT_TITLE: Budget Tracker
+ARTIFACT_DESCRIPTION: A budget tracking app for monthly expenses around $3000, focusing on groceries and rent.`;
+
+const decisionYesDocument = `SHOULD_BUILD: yes
+ARTIFACT_TYPE: document
+ARTIFACT_TITLE: Monthly Budget Guide
+ARTIFACT_DESCRIPTION: A structured guide for tracking monthly expenses with categories for groceries and rent.`;
+
+const decisionNo = `SHOULD_BUILD: no
+SKIP_REASON: Not enough context to build something specific.`;
+
+function resetState() {
+  decisionProviderAvailable = true;
+  buildProviderAvailable = true;
+  decisionResponse = "";
+  buildResponse = "";
+  copyResponse = "";
+  providerSendCalls = [];
+  rawAllRows = [];
+  bootstrapCalls = [];
+  processMessageCalls = [];
+  processMessageShouldThrow = false;
+  mockApps = [];
+  saveDocumentCalls = [];
+  saveDocumentResult = { success: true, surfaceId: "doc-123" };
+  addDocConvCalls = [];
+  addMessageCalls = [];
+  emitSignalCalls = [];
+  broadcastCalls = [];
+  mockConversations = new Map();
+  uuidCounter = 0;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  resetState();
+});
+
+describe("runProactiveArtifactJob", () => {
+  describe("Phase 1 — Decision", () => {
+    test("shouldBuild:false → no Phase 2, no message, no notification", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionNo;
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      expect(bootstrapCalls).toHaveLength(0);
+      expect(processMessageCalls).toHaveLength(0);
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+      expect(broadcastCalls).toHaveLength(0);
+    });
+
+    test("null (malformed) → silent exit", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = "THIS IS GARBAGE OUTPUT";
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      expect(bootstrapCalls).toHaveLength(0);
+      expect(processMessageCalls).toHaveLength(0);
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+
+    test("provider unavailable → silent return", async () => {
+      rawAllRows = defaultTranscript;
+      decisionProviderAvailable = false;
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      expect(providerSendCalls).toHaveLength(0);
+      expect(bootstrapCalls).toHaveLength(0);
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+  });
+
+  describe("Phase 2 — Build", () => {
+    test("Phase 2 failure → no message, no notification", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesApp;
+      processMessageShouldThrow = true;
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      // processMessage was called (the build attempt happened)
+      expect(processMessageCalls).toHaveLength(1);
+      // But no message injection or notification
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+      expect(broadcastCalls).toHaveLength(0);
+    });
+
+    test("successful app: Phase 1 → Phase 2 → app store query → message copy → inject → notify", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesApp;
+      copyResponse = "MESSAGE: I built a budget tracker for you!";
+
+      const buildStartedAt = Date.now();
+      mockApps = [
+        {
+          id: "app-123",
+          name: "Budget Tracker",
+          createdAt: buildStartedAt + 100,
+        },
+      ];
+
+      // Set up an idle conversation so injection works fully
+      const convMessages: unknown[] = [];
+      mockConversations.set("conv-1", {
+        processing: false,
+        messages: convMessages,
+        getMessages: () => convMessages,
+      });
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      // Phase 1: decision provider called
+      expect(
+        providerSendCalls.some(
+          (c) => c.callSite === "proactiveArtifactDecision",
+        ),
+      ).toBe(true);
+
+      // Phase 2: processMessage called with correct options
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].prompt).toContain("Budget Tracker");
+      expect(processMessageCalls[0].prompt).toContain("auto_open: false");
+      const pmOpts = processMessageCalls[0].options as Record<string, unknown>;
+      expect(pmOpts.callSite).toBe("proactiveArtifactBuild");
+      expect(pmOpts.trustContext).toEqual({
+        sourceChannel: "vellum",
+        trustClass: "guardian",
+      });
+
+      // Bootstrap conversation created for app build
+      expect(bootstrapCalls).toHaveLength(1);
+      expect(bootstrapCalls[0].conversationType).toBe("background");
+      expect(bootstrapCalls[0].source).toBe("proactive_artifact");
+
+      // Message injection: addMessage called with skipIndexing
+      expect(addMessageCalls).toHaveLength(1);
+      expect(addMessageCalls[0].opts).toEqual({ skipIndexing: true });
+      expect(addMessageCalls[0].conversationId).toBe("conv-1");
+
+      // Notification emitted
+      expect(emitSignalCalls).toHaveLength(1);
+      expect(emitSignalCalls[0].sourceEventName).toBe("activity.complete");
+      expect(emitSignalCalls[0].sourceChannel).toBe("vellum");
+      expect(emitSignalCalls[0].dedupeKey).toBe("proactive-artifact");
+      const hints = emitSignalCalls[0].attentionHints as Record<
+        string,
+        unknown
+      >;
+      expect(hints.visibleInSourceNow).toBe(false);
+      expect(hints.isAsyncBackground).toBe(true);
+      expect(hints.requiresAction).toBe(false);
+      // No conversationAffinityHint
+      expect(emitSignalCalls[0].conversationAffinityHint).toBeUndefined();
+    });
+
+    test("successful document: Phase 1 → content gen → saveDocument → message copy → inject → notify", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesDocument;
+      buildResponse =
+        "# Monthly Budget Guide\n\nTrack groceries and rent expenses.";
+      copyResponse =
+        "MESSAGE: I created a monthly budget guide tailored to your needs.";
+
+      mockConversations.set("conv-1", {
+        processing: false,
+        messages: [],
+        getMessages: () => [],
+      });
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      // Document saved via saveDocument (not raw file writes)
+      expect(saveDocumentCalls).toHaveLength(1);
+      expect(saveDocumentCalls[0].title).toBe("Monthly Budget Guide");
+      expect(saveDocumentCalls[0].conversationId).toBe("conv-1");
+      expect(saveDocumentCalls[0].content).toContain("Monthly Budget Guide");
+      expect(
+        (saveDocumentCalls[0].surfaceId as string).startsWith("doc-"),
+      ).toBe(true);
+      expect((saveDocumentCalls[0].wordCount as number) > 0).toBe(true);
+
+      // No bootstrapConversation or processMessage for document path
+      expect(bootstrapCalls).toHaveLength(0);
+      expect(processMessageCalls).toHaveLength(0);
+
+      // Message injection and notification
+      expect(addMessageCalls).toHaveLength(1);
+      expect(emitSignalCalls).toHaveLength(1);
+    });
+
+    test("app build - no matching app found → treated as build failure", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesApp;
+      mockApps = []; // no apps in store
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      // Build attempted
+      expect(processMessageCalls).toHaveLength(1);
+      // But failure = no message, no notification
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+
+    test("document build - build provider unavailable → build failure → silence", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesDocument;
+      buildProviderAvailable = false;
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      // No message, no notification
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+    });
+  });
+
+  describe("Message copy", () => {
+    test("uses fallback message when copy provider unavailable", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesApp;
+      // Build provider is unavailable for copy step, but we need it for
+      // the copy call. Since the same callSite is used, we'll test the
+      // fallback by making the copy return unparseable output.
+      buildProviderAvailable = true;
+      copyResponse = "INVALID OUTPUT WITHOUT MESSAGE PREFIX";
+
+      const buildTime = Date.now();
+      mockApps = [
+        { id: "app-456", name: "Budget Tracker", createdAt: buildTime + 50 },
+      ];
+
+      mockConversations.set("conv-1", {
+        processing: false,
+        messages: [],
+        getMessages: () => [],
+      });
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      // Verify fallback message was used
+      expect(addMessageCalls).toHaveLength(1);
+      const content = JSON.parse(addMessageCalls[0].content);
+      expect(content[0].text).toContain("I made something for you");
+      expect(content[0].text).toContain("Budget Tracker");
+    });
+  });
+
+  describe("Transcript collection", () => {
+    test("dual-condition transcript query uses userMessageCutoff and assistantMessageId", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionNo;
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 5000,
+        assistantMessageId: "asst-msg-99",
+        broadcastMessage: mockBroadcast,
+      });
+
+      // The rawAll mock captures all calls; verify the decision was called
+      // (proving transcript was collected and passed to decision)
+      expect(
+        providerSendCalls.some(
+          (c) => c.callSite === "proactiveArtifactDecision",
+        ),
+      ).toBe(true);
+    });
+
+    test("empty transcript → early return", async () => {
+      rawAllRows = [];
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      expect(providerSendCalls).toHaveLength(0);
+      expect(addMessageCalls).toHaveLength(0);
+    });
+  });
+});
+
+describe("injectAuxAssistantMessage", () => {
+  test("idle conversation: persists with skipIndexing, pushes to getMessages(), broadcasts delta + complete(aux) + list_invalidated", async () => {
+    const messages: unknown[] = [];
+    mockConversations.set("conv-inject-1", {
+      processing: false,
+      messages,
+      getMessages: () => messages,
+    });
+
+    await injectAuxAssistantMessage({
+      conversationId: "conv-inject-1",
+      text: "Here is your artifact!",
+      broadcastMessage: mockBroadcast,
+    });
+
+    // Persisted with skipIndexing
+    expect(addMessageCalls).toHaveLength(1);
+    expect(addMessageCalls[0].conversationId).toBe("conv-inject-1");
+    expect(addMessageCalls[0].role).toBe("assistant");
+    expect(addMessageCalls[0].opts).toEqual({ skipIndexing: true });
+
+    // Pushed to in-memory messages
+    expect(messages).toHaveLength(1);
+
+    // Broadcasts: delta, complete(aux), list_invalidated
+    const deltaMsg = broadcastCalls.find(
+      (c) => c.type === "assistant_text_delta",
+    );
+    expect(deltaMsg).toBeDefined();
+    expect(deltaMsg!.text).toBe("Here is your artifact!");
+    expect(deltaMsg!.conversationId).toBe("conv-inject-1");
+
+    const completeMsg = broadcastCalls.find(
+      (c) => c.type === "message_complete",
+    );
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg!.source).toBe("aux");
+    expect(completeMsg!.messageId).toBeDefined();
+
+    const listMsg = broadcastCalls.find(
+      (c) => c.type === "conversation_list_invalidated",
+    );
+    expect(listMsg).toBeDefined();
+    expect(listMsg!.reason).toBe("reordered");
+  });
+
+  test("processing → idle: waits for processing to become false before persisting", async () => {
+    const messages: unknown[] = [];
+    let processingFlag = true;
+    const conv: MockConversation = {
+      get processing() {
+        return processingFlag;
+      },
+      set processing(v: boolean) {
+        processingFlag = v;
+      },
+      messages,
+      getMessages: () => messages,
+    };
+    mockConversations.set("conv-inject-2", conv);
+
+    // Simulate processing becoming idle after a short delay
+    setTimeout(() => {
+      processingFlag = false;
+    }, 100);
+
+    await injectAuxAssistantMessage({
+      conversationId: "conv-inject-2",
+      text: "Deferred message",
+      broadcastMessage: mockBroadcast,
+    });
+
+    // Should have waited and then injected
+    expect(addMessageCalls).toHaveLength(1);
+    expect(messages).toHaveLength(1);
+    expect(broadcastCalls.some((c) => c.type === "assistant_text_delta")).toBe(
+      true,
+    );
+  });
+
+  test("inactive/unloaded conversation: persists + list_invalidated only", async () => {
+    // No conversation in the store
+    await injectAuxAssistantMessage({
+      conversationId: "conv-inject-4",
+      text: "Offline message",
+      broadcastMessage: mockBroadcast,
+    });
+
+    // Message persisted
+    expect(addMessageCalls).toHaveLength(1);
+    expect(addMessageCalls[0].conversationId).toBe("conv-inject-4");
+
+    // No delta or complete (conversation not loaded)
+    expect(
+      broadcastCalls.filter((c) => c.type === "assistant_text_delta"),
+    ).toHaveLength(0);
+    expect(
+      broadcastCalls.filter((c) => c.type === "message_complete"),
+    ).toHaveLength(0);
+
+    // But list_invalidated IS sent
+    expect(
+      broadcastCalls.filter((c) => c.type === "conversation_list_invalidated"),
+    ).toHaveLength(1);
+  });
+});
+
+describe("message-copy", () => {
+  test("buildMessageCopyPrompt includes all parameters", () => {
+    const prompt = buildMessageCopyPrompt({
+      artifactType: "app",
+      artifactTitle: "Budget Tracker",
+      artifactId: "app-123",
+      transcript: "[User]: I need a budget tool",
+    });
+
+    expect(prompt).toContain("app");
+    expect(prompt).toContain("Budget Tracker");
+    expect(prompt).toContain("app-123");
+    expect(prompt).toContain("I need a budget tool");
+    expect(prompt).toContain("MESSAGE:");
+  });
+
+  test("parseMessageCopy extracts MESSAGE value", () => {
+    expect(parseMessageCopy("MESSAGE: Hello there!")).toBe("Hello there!");
+    expect(
+      parseMessageCopy("MESSAGE: I built something special for you."),
+    ).toBe("I built something special for you.");
+  });
+
+  test("parseMessageCopy returns null for missing MESSAGE", () => {
+    expect(parseMessageCopy("Some random text")).toBeNull();
+    expect(parseMessageCopy("")).toBeNull();
+  });
+
+  test("parseMessageCopy returns null for empty MESSAGE", () => {
+    expect(parseMessageCopy("MESSAGE:   ")).toBeNull();
+  });
+});

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -190,10 +190,14 @@ mock.module("../daemon/trust-context.js", () => ({
 }));
 
 // Logger mock
+let logWarnCalls: Array<{ args: unknown[] }> = [];
+
 mock.module("../util/logger.js", () => ({
   getLogger: () => ({
     info: () => {},
-    warn: () => {},
+    warn: (...args: unknown[]) => {
+      logWarnCalls.push({ args });
+    },
     error: () => {},
     debug: () => {},
   }),
@@ -265,6 +269,7 @@ function resetState() {
   emitSignalCalls = [];
   broadcastCalls = [];
   mockConversations = new Map();
+  logWarnCalls = [];
   uuidCounter = 0;
 }
 
@@ -655,6 +660,66 @@ describe("injectAuxAssistantMessage", () => {
     expect(broadcastCalls.some((c) => c.type === "assistant_text_delta")).toBe(
       true,
     );
+  });
+
+  test("processing → timeout: injects anyway with warning after poll timeout", async () => {
+    const messages: unknown[] = [];
+    // Conversation stays processing permanently — never becomes idle
+    const conv: MockConversation = {
+      processing: true,
+      messages,
+      getMessages: () => messages,
+    };
+    mockConversations.set("conv-inject-3", conv);
+
+    // Mock Date.now() to simulate time past the 60s timeout.
+    // First call sets `start`, second call must exceed IDLE_TIMEOUT_MS (60_000).
+    const realDateNow = Date.now;
+    let dateNowCallCount = 0;
+    const baseTime = 1_000_000;
+    Date.now = () => {
+      dateNowCallCount++;
+      // First call: start = baseTime
+      // Second call onward: past the timeout
+      if (dateNowCallCount <= 1) return baseTime;
+      return baseTime + 60_001;
+    };
+
+    try {
+      await injectAuxAssistantMessage({
+        conversationId: "conv-inject-3",
+        text: "Timeout message",
+        broadcastMessage: mockBroadcast,
+      });
+    } finally {
+      Date.now = realDateNow;
+    }
+
+    // Message was still persisted despite timeout
+    expect(addMessageCalls).toHaveLength(1);
+    expect(addMessageCalls[0].conversationId).toBe("conv-inject-3");
+
+    // Warning log was emitted about the timeout
+    expect(logWarnCalls.length).toBeGreaterThanOrEqual(1);
+    const warnMsg = logWarnCalls.find((c) =>
+      c.args.some(
+        (arg) => typeof arg === "string" && arg.includes("Timed out"),
+      ),
+    );
+    expect(warnMsg).toBeDefined();
+
+    // Since conversation is still processing, no delta/complete broadcasts
+    expect(
+      broadcastCalls.filter((c) => c.type === "assistant_text_delta"),
+    ).toHaveLength(0);
+    expect(
+      broadcastCalls.filter((c) => c.type === "message_complete"),
+    ).toHaveLength(0);
+
+    // But list_invalidated IS sent (always sent regardless of processing state)
+    expect(
+      broadcastCalls.filter((c) => c.type === "conversation_list_invalidated"),
+    ).toHaveLength(1);
   });
 
   test("inactive/unloaded conversation: persists + list_invalidated only", async () => {

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -45,6 +45,7 @@ export async function runProactiveArtifactJob(params: {
   assistantMessageId: string | undefined;
   broadcastMessage: BroadcastFn;
 }): Promise<void> {
+  let buildSucceeded = false;
   try {
     // ── Collect transcript (bounded) ────────────────────────────────
     const rows = rawAll<{ role: string; content: string }>(
@@ -126,6 +127,7 @@ export async function runProactiveArtifactJob(params: {
         transcript,
       });
     }
+    buildSucceeded = true;
 
     // ── Post-build message copy ─────────────────────────────────────
     let messageCopy: string;
@@ -190,6 +192,9 @@ export async function runProactiveArtifactJob(params: {
       { err, conversationId: params.conversationId },
       "Proactive artifact job failed",
     );
+    if (!buildSucceeded) {
+      releaseProactiveArtifactClaim();
+    }
   }
 }
 

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -1,0 +1,291 @@
+/**
+ * Proactive artifact background job orchestrator.
+ *
+ * Runs a multi-phase pipeline:
+ *   1. Collect bounded transcript from the conversation
+ *   2. Phase 1 — Decision: ask the LLM whether to build an artifact
+ *   3. Phase 2 — Build: create the artifact (app or document)
+ *   4. Post-build message copy: generate a user-facing message
+ *   5. Message injection: deliver the message to the conversation
+ *   6. Notification: emit a notification signal
+ *
+ * Build failure = total silence (no message, no notification).
+ * Provider unavailable = silent return.
+ */
+
+import { v4 as uuid } from "uuid";
+
+import { processMessage } from "../daemon/process-message.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
+import { saveDocument } from "../documents/document-store.js";
+import { listApps } from "../memory/app-store.js";
+import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
+import { rawAll } from "../memory/raw-query.js";
+import type { BroadcastFn } from "../notifications/adapters/macos.js";
+import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import {
+  extractText,
+  getConfiguredProvider,
+} from "../providers/provider-send-message.js";
+import { getLogger } from "../util/logger.js";
+import { injectAuxAssistantMessage } from "./aux-message-injector.js";
+import {
+  buildDecisionPrompt,
+  formatTranscript,
+  parseDecisionOutput,
+} from "./decision.js";
+import { buildMessageCopyPrompt, parseMessageCopy } from "./message-copy.js";
+
+const log = getLogger("proactive-artifact-job");
+
+export async function runProactiveArtifactJob(params: {
+  conversationId: string;
+  userMessageCutoff: number;
+  assistantMessageId: string | undefined;
+  broadcastMessage: BroadcastFn;
+}): Promise<void> {
+  try {
+    // ── Collect transcript (bounded) ────────────────────────────────
+    const rows = rawAll<{ role: string; content: string }>(
+      `SELECT m.role, m.content FROM messages m
+       JOIN conversations c ON m.conversation_id = c.id
+       WHERE c.conversation_type = 'standard'
+         AND (m.created_at <= ? OR m.id = ?)
+       ORDER BY m.created_at ASC`,
+      params.userMessageCutoff,
+      params.assistantMessageId ?? "",
+    );
+
+    if (rows.length === 0) {
+      log.info(
+        { conversationId: params.conversationId },
+        "No messages found for proactive artifact transcript",
+      );
+      return;
+    }
+
+    const transcript = formatTranscript(rows);
+
+    // ── Phase 1 — Decision ──────────────────────────────────────────
+    const decisionProvider = await getConfiguredProvider(
+      "proactiveArtifactDecision",
+    );
+    if (!decisionProvider) {
+      log.info("Decision provider unavailable; skipping proactive artifact");
+      return;
+    }
+
+    const decisionResponse = await decisionProvider.sendMessage([
+      {
+        role: "user",
+        content: [{ type: "text", text: buildDecisionPrompt(transcript) }],
+      },
+    ]);
+    const decisionText = extractText(decisionResponse);
+    const decision = parseDecisionOutput(decisionText);
+
+    if (!decision) {
+      log.warn(
+        { conversationId: params.conversationId },
+        "Malformed decision output from proactive artifact LLM",
+      );
+      return;
+    }
+
+    if (!decision.shouldBuild) {
+      log.info(
+        {
+          conversationId: params.conversationId,
+          skipReason: decision.skipReason,
+        },
+        "Proactive artifact decision: skip",
+      );
+      return;
+    }
+
+    // ── Phase 2 — Build ─────────────────────────────────────────────
+    const { artifactType, artifactTitle, artifactDescription } = decision;
+    let artifactId: string;
+
+    if (artifactType === "app") {
+      artifactId = await buildApp({
+        artifactTitle,
+        artifactDescription,
+      });
+    } else {
+      artifactId = await buildDocument({
+        artifactTitle,
+        artifactDescription,
+        conversationId: params.conversationId,
+        transcript,
+      });
+    }
+
+    // ── Post-build message copy ─────────────────────────────────────
+    let messageCopy: string;
+    const fallbackMessage = `I made something for you — ${artifactTitle}. Take a look when you get a chance.`;
+
+    try {
+      const copyProvider = await getConfiguredProvider(
+        "proactiveArtifactBuild",
+      );
+      if (!copyProvider) {
+        messageCopy = fallbackMessage;
+      } else {
+        const copyResponse = await copyProvider.sendMessage([
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: buildMessageCopyPrompt({
+                  artifactType,
+                  artifactTitle,
+                  artifactId,
+                  transcript,
+                }),
+              },
+            ],
+          },
+        ]);
+        const copyText = extractText(copyResponse);
+        messageCopy = parseMessageCopy(copyText) ?? fallbackMessage;
+      }
+    } catch (err) {
+      log.warn({ err }, "Message copy generation failed; using fallback");
+      messageCopy = fallbackMessage;
+    }
+
+    // ── Message injection ───────────────────────────────────────────
+    await injectAuxAssistantMessage({
+      conversationId: params.conversationId,
+      text: messageCopy,
+      broadcastMessage: params.broadcastMessage,
+    });
+
+    // ── Notification ────────────────────────────────────────────────
+    await emitNotificationSignal({
+      sourceEventName: "activity.complete",
+      sourceChannel: "vellum",
+      sourceContextId: params.conversationId,
+      attentionHints: {
+        urgency: "medium",
+        requiresAction: false,
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        summary: `${artifactTitle} is ready`,
+      },
+      dedupeKey: "proactive-artifact",
+    });
+  } catch (err) {
+    log.error(
+      { err, conversationId: params.conversationId },
+      "Proactive artifact job failed",
+    );
+  }
+}
+
+// ── App build ─────────────────────────────────────────────────────────
+
+async function buildApp(params: {
+  artifactTitle: string;
+  artifactDescription: string;
+}): Promise<string> {
+  const conversation = bootstrapConversation({
+    conversationType: "background",
+    source: "proactive_artifact",
+    groupId: "system:background",
+    origin: "heartbeat",
+    systemHint: "Proactive artifact build",
+  });
+
+  const buildStartedAt = Date.now();
+
+  const prompt = `Load the app-builder skill, then create an app with the following details:
+- Title: ${params.artifactTitle}
+- Description: ${params.artifactDescription}
+- auto_open: false
+
+Write the source code following the skill instructions, then compile via app_refresh.`;
+
+  await processMessage(conversation.id, prompt, undefined, {
+    callSite: "proactiveArtifactBuild",
+    trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  });
+
+  // Query app store for newly created app
+  const apps = listApps();
+  const match = apps.find(
+    (app) =>
+      app.createdAt >= buildStartedAt &&
+      app.name.includes(params.artifactTitle),
+  );
+
+  if (!match) {
+    throw new Error(
+      `App build completed but no matching app found (title: ${params.artifactTitle})`,
+    );
+  }
+
+  return match.id;
+}
+
+// ── Document build ────────────────────────────────────────────────────
+
+async function buildDocument(params: {
+  artifactTitle: string;
+  artifactDescription: string;
+  conversationId: string;
+  transcript: string;
+}): Promise<string> {
+  const buildProvider = await getConfiguredProvider("proactiveArtifactBuild");
+  if (!buildProvider) {
+    throw new Error("Build provider unavailable for document generation");
+  }
+
+  const buildResponse = await buildProvider.sendMessage([
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: `Generate a well-structured markdown document based on the following specification.
+
+Title: ${params.artifactTitle}
+Description: ${params.artifactDescription}
+
+Original conversation for context:
+${params.transcript}
+
+Write the complete markdown content. Make it specific, actionable, and tailored to the user's situation.`,
+        },
+      ],
+    },
+  ]);
+
+  const generatedMarkdown = extractText(buildResponse);
+  if (!generatedMarkdown) {
+    throw new Error("Build provider returned empty content for document");
+  }
+
+  const surfaceId = `doc-${uuid()}`;
+  const wordCount = generatedMarkdown
+    .split(/\s+/)
+    .filter((w) => w.length > 0).length;
+
+  const result = saveDocument({
+    surfaceId,
+    conversationId: params.conversationId,
+    title: params.artifactTitle,
+    content: generatedMarkdown,
+    wordCount,
+  });
+
+  if (!result.success) {
+    throw new Error(`Failed to save document: ${result.error}`);
+  }
+
+  return surfaceId;
+}

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -220,7 +220,10 @@ Write the source code following the skill instructions, then compile via app_ref
   const match = apps.find(
     (app) =>
       app.createdAt >= buildStartedAt &&
-      app.name.includes(params.artifactTitle),
+      app.name
+        .trim()
+        .toLowerCase()
+        .includes(params.artifactTitle.trim().toLowerCase()),
   );
 
   if (!match) {

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -18,7 +18,7 @@ import { v4 as uuid } from "uuid";
 import { processMessage } from "../daemon/process-message.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { saveDocument } from "../documents/document-store.js";
-import { listApps } from "../memory/app-store.js";
+import { addAppConversationId, listApps } from "../memory/app-store.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { rawAll } from "../memory/raw-query.js";
 import type { BroadcastFn } from "../notifications/adapters/macos.js";
@@ -35,6 +35,7 @@ import {
   parseDecisionOutput,
 } from "./decision.js";
 import { buildMessageCopyPrompt, parseMessageCopy } from "./message-copy.js";
+import { releaseProactiveArtifactClaim } from "./trigger-state.js";
 
 const log = getLogger("proactive-artifact-job");
 
@@ -61,6 +62,7 @@ export async function runProactiveArtifactJob(params: {
         { conversationId: params.conversationId },
         "No messages found for proactive artifact transcript",
       );
+      releaseProactiveArtifactClaim();
       return;
     }
 
@@ -72,6 +74,7 @@ export async function runProactiveArtifactJob(params: {
     );
     if (!decisionProvider) {
       log.info("Decision provider unavailable; skipping proactive artifact");
+      releaseProactiveArtifactClaim();
       return;
     }
 
@@ -89,6 +92,7 @@ export async function runProactiveArtifactJob(params: {
         { conversationId: params.conversationId },
         "Malformed decision output from proactive artifact LLM",
       );
+      releaseProactiveArtifactClaim();
       return;
     }
 
@@ -100,6 +104,7 @@ export async function runProactiveArtifactJob(params: {
         },
         "Proactive artifact decision: skip",
       );
+      releaseProactiveArtifactClaim();
       return;
     }
 
@@ -111,6 +116,7 @@ export async function runProactiveArtifactJob(params: {
       artifactId = await buildApp({
         artifactTitle,
         artifactDescription,
+        conversationId: params.conversationId,
       });
     } else {
       artifactId = await buildDocument({
@@ -192,6 +198,7 @@ export async function runProactiveArtifactJob(params: {
 async function buildApp(params: {
   artifactTitle: string;
   artifactDescription: string;
+  conversationId: string;
 }): Promise<string> {
   const conversation = bootstrapConversation({
     conversationType: "background",
@@ -207,6 +214,8 @@ async function buildApp(params: {
 - Title: ${params.artifactTitle}
 - Description: ${params.artifactDescription}
 - auto_open: false
+
+For apps, keep scope tight — single file or 2-3 files max, under ~300 lines. Simple and immediately useful beats impressive and slow. This runs as a background job with limited credits — scope accordingly.
 
 Write the source code following the skill instructions, then compile via app_refresh.`;
 
@@ -231,6 +240,8 @@ Write the source code following the skill instructions, then compile via app_ref
       `App build completed but no matching app found (title: ${params.artifactTitle})`,
     );
   }
+
+  addAppConversationId(match.id, params.conversationId);
 
   return match.id;
 }

--- a/assistant/src/proactive-artifact/message-copy.ts
+++ b/assistant/src/proactive-artifact/message-copy.ts
@@ -1,0 +1,41 @@
+/**
+ * Post-build message copy generation for proactive artifacts.
+ *
+ * After building an artifact, we ask the LLM to write a short,
+ * conversational message explaining what was built and why.
+ */
+
+export function buildMessageCopyPrompt(params: {
+  artifactType: "app" | "document";
+  artifactTitle: string;
+  artifactId: string;
+  transcript: string;
+}): string {
+  return `You just built a personalized ${params.artifactType} for the user based on their conversation.
+
+Artifact details:
+- Type: ${params.artifactType}
+- Title: ${params.artifactTitle}
+- ID: ${params.artifactId}
+
+Original conversation:
+${params.transcript}
+
+Write a short message (2-3 sentences) to the user explaining:
+1. What you built
+2. Why you built it (reference something specific from the conversation)
+3. Where to find it
+
+Keep it warm and natural — not robotic. This should feel like a thoughtful gift, not a system notification.
+
+Respond in EXACTLY this format (no extra text before or after):
+
+MESSAGE: <your message>`;
+}
+
+export function parseMessageCopy(text: string): string | null {
+  const match = text.match(/^MESSAGE:\s*(.+)/ms);
+  if (!match) return null;
+  const value = match[1].trim();
+  return value.length > 0 ? value : null;
+}

--- a/assistant/src/proactive-artifact/trigger-state.test.ts
+++ b/assistant/src/proactive-artifact/trigger-state.test.ts
@@ -18,6 +18,7 @@ import {
   backfillGuardIfNeeded,
   getUserMessageCountUpTo,
   hasProactiveArtifactCompleted,
+  releaseProactiveArtifactClaim,
   tryClaimProactiveArtifactTrigger,
 } from "./trigger-state.js";
 
@@ -122,11 +123,11 @@ describe("trigger-state", () => {
       expect(getUserMessageCountUpTo(350)).toBe(3);
     });
 
-    test("caps at 5 due to LIMIT", () => {
-      for (let i = 1; i <= 10; i++) {
+    test("caps at 11 due to LIMIT", () => {
+      for (let i = 1; i <= 15; i++) {
         seedUserMessage(i * 100);
       }
-      expect(getUserMessageCountUpTo(Date.now())).toBe(5);
+      expect(getUserMessageCountUpTo(Date.now())).toBe(11);
     });
   });
 
@@ -145,50 +146,43 @@ describe("trigger-state", () => {
       expect(existsSync(guardPath())).toBe(false);
     });
 
-    test("returns true at count exactly 4 and writes guard", () => {
-      seedUserMessage(100);
-      seedUserMessage(200);
-      seedUserMessage(300);
-      seedUserMessage(400);
+    test("returns true at count 4 (start of window) and writes guard", () => {
+      for (let i = 1; i <= 4; i++) seedUserMessage(i * 100);
 
       expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
       expect(existsSync(guardPath())).toBe(true);
     });
 
-    test("returns false on second call at count 4 (EEXIST from wx)", () => {
-      seedUserMessage(100);
-      seedUserMessage(200);
-      seedUserMessage(300);
-      seedUserMessage(400);
+    test("returns true at count 10 (end of window) and writes guard", () => {
+      for (let i = 1; i <= 10; i++) seedUserMessage(i * 100);
+
+      expect(tryClaimProactiveArtifactTrigger(1000)).toBe(true);
+      expect(existsSync(guardPath())).toBe(true);
+    });
+
+    test("returns true at count 7 (mid-window) and writes guard", () => {
+      for (let i = 1; i <= 7; i++) seedUserMessage(i * 100);
+
+      expect(tryClaimProactiveArtifactTrigger(700)).toBe(true);
+      expect(existsSync(guardPath())).toBe(true);
+    });
+
+    test("returns false on second call (EEXIST from wx)", () => {
+      for (let i = 1; i <= 4; i++) seedUserMessage(i * 100);
 
       expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
       expect(tryClaimProactiveArtifactTrigger(400)).toBe(false);
     });
 
-    test("returns false at count 5+ and does NOT write guard", () => {
-      for (let i = 1; i <= 6; i++) {
-        seedUserMessage(i * 100);
-      }
+    test("returns false at count > 10 and writes guard permanently", () => {
+      for (let i = 1; i <= 11; i++) seedUserMessage(i * 100);
 
-      expect(tryClaimProactiveArtifactTrigger(600)).toBe(false);
-      expect(existsSync(guardPath())).toBe(false);
-    });
-
-    test("count > 4 does not write guard — preserves 4th-turn trigger window", () => {
-      for (let i = 1; i <= 5; i++) {
-        seedUserMessage(i * 100);
-      }
-
-      // Query at timestamp that sees all 5
-      expect(tryClaimProactiveArtifactTrigger(500)).toBe(false);
-      expect(existsSync(guardPath())).toBe(false);
+      expect(tryClaimProactiveArtifactTrigger(1100)).toBe(false);
+      expect(existsSync(guardPath())).toBe(true);
     });
 
     test("concurrent calls: only one returns true", () => {
-      seedUserMessage(100);
-      seedUserMessage(200);
-      seedUserMessage(300);
-      seedUserMessage(400);
+      for (let i = 1; i <= 4; i++) seedUserMessage(i * 100);
 
       const results = [
         tryClaimProactiveArtifactTrigger(400),
@@ -200,18 +194,32 @@ describe("trigger-state", () => {
       expect(results.filter((r) => r === false)).toHaveLength(2);
     });
 
-    test("rapid 5th-message race: 4th message trigger still fires correctly", () => {
-      // Messages 1-4 exist at timestamps 100-400
-      seedUserMessage(100);
-      seedUserMessage(200);
-      seedUserMessage(300);
-      seedUserMessage(400);
-      // 5th message arrives at 500 (processed first due to race)
-      seedUserMessage(500);
+    test("rapid next-message race: in-window trigger still fires", () => {
+      for (let i = 1; i <= 5; i++) seedUserMessage(i * 100);
 
-      // The 4th message's turn uses its own created_at (400)
-      // At that timestamp, count is 4, so it should trigger
       expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+    });
+  });
+
+  describe("releaseProactiveArtifactClaim", () => {
+    test("removes guard file so next turn can retry", () => {
+      for (let i = 1; i <= 4; i++) seedUserMessage(i * 100);
+
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+      expect(existsSync(guardPath())).toBe(true);
+
+      releaseProactiveArtifactClaim();
+      expect(existsSync(guardPath())).toBe(false);
+
+      seedUserMessage(500);
+      expect(tryClaimProactiveArtifactTrigger(500)).toBe(true);
+      expect(existsSync(guardPath())).toBe(true);
+    });
+
+    test("is no-op when guard does not exist", () => {
+      expect(existsSync(guardPath())).toBe(false);
+      releaseProactiveArtifactClaim();
+      expect(existsSync(guardPath())).toBe(false);
     });
   });
 
@@ -228,8 +236,8 @@ describe("trigger-state", () => {
   });
 
   describe("backfillGuardIfNeeded", () => {
-    test("creates guard when count >= 5", () => {
-      for (let i = 1; i <= 6; i++) {
+    test("creates guard when count > 10", () => {
+      for (let i = 1; i <= 11; i++) {
         seedUserMessage(i * 100);
       }
 
@@ -237,7 +245,16 @@ describe("trigger-state", () => {
       expect(existsSync(guardPath())).toBe(true);
     });
 
-    test("is no-op when count < 5", () => {
+    test("is no-op when count is within window (4-10)", () => {
+      for (let i = 1; i <= 7; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      backfillGuardIfNeeded();
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("is no-op when count < 4", () => {
       seedUserMessage(100);
       seedUserMessage(200);
       seedUserMessage(300);
@@ -247,14 +264,13 @@ describe("trigger-state", () => {
     });
 
     test("is no-op when guard already exists", () => {
-      for (let i = 1; i <= 6; i++) {
+      for (let i = 1; i <= 11; i++) {
         seedUserMessage(i * 100);
       }
 
       mkdirSync(join(getDataDir()), { recursive: true });
       writeFileSync(guardPath(), "already-exists");
       backfillGuardIfNeeded();
-      // File content should not have changed
       expect(readFileSync(guardPath(), "utf-8")).toBe("already-exists");
     });
   });

--- a/assistant/src/proactive-artifact/trigger-state.test.ts
+++ b/assistant/src/proactive-artifact/trigger-state.test.ts
@@ -1,0 +1,261 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { initializeDb } from "../memory/db-init.js";
+import { rawRun } from "../memory/raw-query.js";
+import { getDataDir } from "../util/platform.js";
+
+initializeDb();
+
+import {
+  backfillGuardIfNeeded,
+  getUserMessageCountUpTo,
+  hasProactiveArtifactCompleted,
+  tryClaimProactiveArtifactTrigger,
+} from "./trigger-state.js";
+
+let seedId = 0;
+
+function guardPath(): string {
+  return join(getDataDir(), ".proactive-artifact-completed");
+}
+
+function seedUserMessage(createdAt: number): void {
+  const id = ++seedId;
+  const convId = `test-conv-${id}`;
+  rawRun(
+    `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, source)
+     VALUES (?, ?, ?, ?, 'standard', 'user')`,
+    convId,
+    `Test ${id}`,
+    createdAt,
+    createdAt,
+  );
+  rawRun(
+    `INSERT INTO messages (id, conversation_id, role, content, created_at)
+     VALUES (?, ?, 'user', 'hello', ?)`,
+    `test-msg-${id}`,
+    convId,
+    createdAt,
+  );
+}
+
+function removeGuard(): void {
+  try {
+    rmSync(guardPath(), { force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+describe("trigger-state", () => {
+  beforeEach(() => {
+    rawRun("DELETE FROM messages");
+    rawRun("DELETE FROM conversations");
+    removeGuard();
+    seedId = 0;
+  });
+
+  describe("getUserMessageCountUpTo", () => {
+    test("returns 0 when no messages exist", () => {
+      expect(getUserMessageCountUpTo(Date.now())).toBe(0);
+    });
+
+    test("counts only user messages in standard conversations", () => {
+      const now = 1000;
+      seedUserMessage(now);
+      seedUserMessage(now + 1);
+
+      // Insert a non-user message
+      const convId = "non-user-conv";
+      rawRun(
+        `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, source)
+         VALUES (?, ?, ?, ?, 'standard', 'user')`,
+        convId,
+        "Non-user",
+        now + 2,
+        now + 2,
+      );
+      rawRun(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at)
+         VALUES (?, ?, 'assistant', 'hi', ?)`,
+        "assistant-msg",
+        convId,
+        now + 2,
+      );
+
+      // Insert a user message in a non-standard conversation
+      const bgConvId = "bg-conv";
+      rawRun(
+        `INSERT INTO conversations (id, title, created_at, updated_at, conversation_type, source)
+         VALUES (?, ?, ?, ?, 'background', 'user')`,
+        bgConvId,
+        "Background",
+        now + 3,
+        now + 3,
+      );
+      rawRun(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at)
+         VALUES (?, ?, 'user', 'hello', ?)`,
+        "bg-msg",
+        bgConvId,
+        now + 3,
+      );
+
+      expect(getUserMessageCountUpTo(now + 10)).toBe(2);
+    });
+
+    test("respects beforeOrAt filter", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+
+      expect(getUserMessageCountUpTo(150)).toBe(1);
+      expect(getUserMessageCountUpTo(250)).toBe(2);
+      expect(getUserMessageCountUpTo(350)).toBe(3);
+    });
+
+    test("caps at 5 due to LIMIT", () => {
+      for (let i = 1; i <= 10; i++) {
+        seedUserMessage(i * 100);
+      }
+      expect(getUserMessageCountUpTo(Date.now())).toBe(5);
+    });
+  });
+
+  describe("tryClaimProactiveArtifactTrigger", () => {
+    test("returns false at count 1, 2, 3 and does NOT write guard", () => {
+      seedUserMessage(100);
+      expect(tryClaimProactiveArtifactTrigger(100)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+
+      seedUserMessage(200);
+      expect(tryClaimProactiveArtifactTrigger(200)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+
+      seedUserMessage(300);
+      expect(tryClaimProactiveArtifactTrigger(300)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("returns true at count exactly 4 and writes guard", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+      expect(existsSync(guardPath())).toBe(true);
+    });
+
+    test("returns false on second call at count 4 (EEXIST from wx)", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(false);
+    });
+
+    test("returns false at count 5+ and does NOT write guard", () => {
+      for (let i = 1; i <= 6; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      expect(tryClaimProactiveArtifactTrigger(600)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("count > 4 does not write guard — preserves 4th-turn trigger window", () => {
+      for (let i = 1; i <= 5; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      // Query at timestamp that sees all 5
+      expect(tryClaimProactiveArtifactTrigger(500)).toBe(false);
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("concurrent calls: only one returns true", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+
+      const results = [
+        tryClaimProactiveArtifactTrigger(400),
+        tryClaimProactiveArtifactTrigger(400),
+        tryClaimProactiveArtifactTrigger(400),
+      ];
+
+      expect(results.filter((r) => r === true)).toHaveLength(1);
+      expect(results.filter((r) => r === false)).toHaveLength(2);
+    });
+
+    test("rapid 5th-message race: 4th message trigger still fires correctly", () => {
+      // Messages 1-4 exist at timestamps 100-400
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+      seedUserMessage(400);
+      // 5th message arrives at 500 (processed first due to race)
+      seedUserMessage(500);
+
+      // The 4th message's turn uses its own created_at (400)
+      // At that timestamp, count is 4, so it should trigger
+      expect(tryClaimProactiveArtifactTrigger(400)).toBe(true);
+    });
+  });
+
+  describe("hasProactiveArtifactCompleted", () => {
+    test("returns false when guard does not exist", () => {
+      expect(hasProactiveArtifactCompleted()).toBe(false);
+    });
+
+    test("returns true when guard exists", () => {
+      mkdirSync(join(getDataDir()), { recursive: true });
+      writeFileSync(guardPath(), new Date().toISOString());
+      expect(hasProactiveArtifactCompleted()).toBe(true);
+    });
+  });
+
+  describe("backfillGuardIfNeeded", () => {
+    test("creates guard when count >= 5", () => {
+      for (let i = 1; i <= 6; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      backfillGuardIfNeeded();
+      expect(existsSync(guardPath())).toBe(true);
+    });
+
+    test("is no-op when count < 5", () => {
+      seedUserMessage(100);
+      seedUserMessage(200);
+      seedUserMessage(300);
+
+      backfillGuardIfNeeded();
+      expect(existsSync(guardPath())).toBe(false);
+    });
+
+    test("is no-op when guard already exists", () => {
+      for (let i = 1; i <= 6; i++) {
+        seedUserMessage(i * 100);
+      }
+
+      mkdirSync(join(getDataDir()), { recursive: true });
+      writeFileSync(guardPath(), "already-exists");
+      backfillGuardIfNeeded();
+      // File content should not have changed
+      expect(readFileSync(guardPath(), "utf-8")).toBe("already-exists");
+    });
+  });
+});

--- a/assistant/src/proactive-artifact/trigger-state.ts
+++ b/assistant/src/proactive-artifact/trigger-state.ts
@@ -1,0 +1,99 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { rawGet } from "../memory/raw-query.js";
+import { getLogger } from "../util/logger.js";
+import { getDataDir } from "../util/platform.js";
+
+const log = getLogger("proactive-artifact-trigger");
+
+function guardPath(): string {
+  return join(getDataDir(), ".proactive-artifact-completed");
+}
+
+/**
+ * Count user messages in standard conversations with created_at <= beforeOrAt.
+ * LIMIT 5 caps scan cost since we only care about the threshold around 4.
+ */
+export function getUserMessageCountUpTo(beforeOrAt: number): number {
+  const row = rawGet<{ c: number }>(
+    `SELECT COUNT(*) AS c FROM (
+      SELECT 1 FROM messages m
+      JOIN conversations c ON m.conversation_id = c.id
+      WHERE m.role = 'user'
+        AND c.conversation_type = 'standard'
+        AND m.created_at <= ?
+      LIMIT 5
+    ) sub`,
+    beforeOrAt,
+  );
+  return row?.c ?? 0;
+}
+
+/**
+ * Fast-path check to avoid the COUNT query on every turn.
+ * Returns true if the proactive artifact trigger has already fired.
+ */
+export function hasProactiveArtifactCompleted(): boolean {
+  return existsSync(guardPath());
+}
+
+/**
+ * Atomic check-and-claim with correct count-first ordering.
+ *
+ * Returns true if this call successfully claimed the trigger (count === 4
+ * and exclusive file create succeeded). Returns false in all other cases.
+ *
+ * Count > 4 returns false WITHOUT writing the guard — this preserves the
+ * 4th-turn trigger window when the 5th message races ahead.
+ */
+export function tryClaimProactiveArtifactTrigger(
+  userMessageCreatedAt: number,
+): boolean {
+  const count = getUserMessageCountUpTo(userMessageCreatedAt);
+
+  if (count < 4) {
+    return false;
+  }
+
+  if (count > 4) {
+    return false;
+  }
+
+  // count === 4 — attempt exclusive guard write
+  try {
+    mkdirSync(dirname(guardPath()), { recursive: true });
+    writeFileSync(guardPath(), new Date().toISOString(), { flag: "wx" });
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && err.code === "EEXIST") {
+      return false;
+    }
+    log.warn({ err }, "Failed to write proactive artifact guard file");
+    return false;
+  }
+}
+
+/**
+ * Called at daemon startup. If the guard file does not exist and the user
+ * already has >= 5 messages, write the guard. This handles existing users
+ * who had >4 messages before the feature existed.
+ */
+export function backfillGuardIfNeeded(): void {
+  if (hasProactiveArtifactCompleted()) {
+    return;
+  }
+
+  const count = getUserMessageCountUpTo(Date.now());
+  if (count >= 5) {
+    try {
+      mkdirSync(dirname(guardPath()), { recursive: true });
+      writeFileSync(guardPath(), new Date().toISOString(), { flag: "wx" });
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && err.code === "EEXIST") {
+        return;
+      }
+      log.warn({ err }, "Failed to backfill proactive artifact guard file");
+    }
+  }
+}

--- a/assistant/src/proactive-artifact/trigger-state.ts
+++ b/assistant/src/proactive-artifact/trigger-state.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { rawGet } from "../memory/raw-query.js";
@@ -7,13 +7,16 @@ import { getDataDir } from "../util/platform.js";
 
 const log = getLogger("proactive-artifact-trigger");
 
+const TRIGGER_MIN = 4;
+const TRIGGER_MAX = 10;
+
 function guardPath(): string {
   return join(getDataDir(), ".proactive-artifact-completed");
 }
 
 /**
  * Count user messages in standard conversations with created_at <= beforeOrAt.
- * LIMIT 5 caps scan cost since we only care about the threshold around 4.
+ * LIMIT caps scan cost since we only care about thresholds up to TRIGGER_MAX.
  */
 export function getUserMessageCountUpTo(beforeOrAt: number): number {
   const row = rawGet<{ c: number }>(
@@ -23,7 +26,7 @@ export function getUserMessageCountUpTo(beforeOrAt: number): number {
       WHERE m.role = 'user'
         AND c.conversation_type = 'standard'
         AND m.created_at <= ?
-      LIMIT 5
+      LIMIT ${TRIGGER_MAX + 1}
     ) sub`,
     beforeOrAt,
   );
@@ -39,28 +42,33 @@ export function hasProactiveArtifactCompleted(): boolean {
 }
 
 /**
- * Atomic check-and-claim with correct count-first ordering.
+ * Atomic check-and-claim with count-first ordering.
  *
- * Returns true if this call successfully claimed the trigger (count === 4
- * and exclusive file create succeeded). Returns false in all other cases.
- *
- * Count > 4 returns false WITHOUT writing the guard — this preserves the
- * 4th-turn trigger window when the 5th message races ahead.
+ * Trigger window: messages TRIGGER_MIN–TRIGGER_MAX (4–10). Returns true if
+ * count is in-window and exclusive file create succeeded. The guard acts as
+ * an in-flight lock — the job releases it on decision-skip so the next turn
+ * can retry. Past the window, the guard is written permanently.
  */
 export function tryClaimProactiveArtifactTrigger(
   userMessageCreatedAt: number,
 ): boolean {
   const count = getUserMessageCountUpTo(userMessageCreatedAt);
 
-  if (count < 4) {
+  if (count < TRIGGER_MIN) {
     return false;
   }
 
-  if (count > 4) {
+  if (count > TRIGGER_MAX) {
+    try {
+      mkdirSync(dirname(guardPath()), { recursive: true });
+      writeFileSync(guardPath(), new Date().toISOString(), { flag: "wx" });
+    } catch {
+      // Already written or fs error — either way, window is closed
+    }
     return false;
   }
 
-  // count === 4 — attempt exclusive guard write
+  // count in [TRIGGER_MIN, TRIGGER_MAX] — attempt exclusive guard write
   try {
     mkdirSync(dirname(guardPath()), { recursive: true });
     writeFileSync(guardPath(), new Date().toISOString(), { flag: "wx" });
@@ -75,9 +83,21 @@ export function tryClaimProactiveArtifactTrigger(
 }
 
 /**
+ * Release the in-flight claim so the next turn can retry.
+ * Called when the decision phase skips (no build committed).
+ */
+export function releaseProactiveArtifactClaim(): void {
+  try {
+    rmSync(guardPath(), { force: true });
+  } catch {
+    // Best-effort — if removal fails, the next turn just won't retry
+  }
+}
+
+/**
  * Called at daemon startup. If the guard file does not exist and the user
- * already has >= 5 messages, write the guard. This handles existing users
- * who had >4 messages before the feature existed.
+ * already has messages past the trigger window, write the guard. This
+ * handles existing users who had many messages before the feature existed.
  */
 export function backfillGuardIfNeeded(): void {
   if (hasProactiveArtifactCompleted()) {
@@ -85,7 +105,7 @@ export function backfillGuardIfNeeded(): void {
   }
 
   const count = getUserMessageCountUpTo(Date.now());
-  if (count >= 5) {
+  if (count > TRIGGER_MAX) {
     try {
       mkdirSync(dirname(guardPath()), { recursive: true });
       writeFileSync(guardPath(), new Date().toISOString(), { flag: "wx" });

--- a/assistant/src/runtime/routes/documents-routes.ts
+++ b/assistant/src/runtime/routes/documents-routes.ts
@@ -6,7 +6,8 @@
  */
 import { z } from "zod";
 
-import { rawAll, rawGet, rawRun } from "../../memory/raw-query.js";
+import { saveDocument } from "../../documents/document-store.js";
+import { rawAll, rawGet } from "../../memory/raw-query.js";
 import { getLogger } from "../../util/logger.js";
 import { renderMarkdownToPDF } from "./document-pdf-renderer.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
@@ -26,80 +27,6 @@ interface DocumentRow {
 }
 
 type DocumentListRow = Omit<DocumentRow, "content">;
-
-// ---------------------------------------------------------------------------
-// Junction table helper
-// ---------------------------------------------------------------------------
-
-/** Insert a document–conversation association (idempotent via INSERT OR IGNORE). */
-function addDocumentConversation(
-  surfaceId: string,
-  conversationId: string,
-): void {
-  rawRun(
-    /*sql*/ `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
-    surfaceId,
-    conversationId,
-    Date.now(),
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Shared business logic (used by both message handlers and HTTP routes)
-// ---------------------------------------------------------------------------
-
-function saveDocument(params: {
-  surfaceId: string;
-  conversationId: string;
-  title: string;
-  content: string;
-  wordCount: number;
-}): { success: true; surfaceId: string } | { success: false; error: string } {
-  try {
-    const now = Date.now();
-    rawRun(
-      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(surface_id) DO UPDATE SET
-         title = excluded.title,
-         content = excluded.content,
-         word_count = excluded.word_count,
-         updated_at = excluded.updated_at`,
-      params.surfaceId,
-      params.conversationId,
-      params.title,
-      params.content,
-      params.wordCount,
-      now,
-      now,
-    );
-    log.info(
-      { surfaceId: params.surfaceId, title: params.title },
-      "Saved document",
-    );
-
-    // Best-effort: associate the document with the conversation.
-    // Failures (e.g. migration not yet applied, table missing) must not
-    // cause the save response to report failure — the document itself is
-    // already persisted at this point.
-    try {
-      addDocumentConversation(params.surfaceId, params.conversationId);
-    } catch (err) {
-      log.warn(
-        { err, surfaceId: params.surfaceId },
-        "Failed to record document–conversation association",
-      );
-    }
-
-    return { success: true, surfaceId: params.surfaceId };
-  } catch (error) {
-    log.error({ err: error, surfaceId: params.surfaceId }, "Save error");
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error",
-    };
-  }
-}
 
 function loadDocument(surfaceId: string):
   | {


### PR DESCRIPTION
## Summary
After a new user's 4th message (lifetime count across all conversations), trigger a background job that uses an LLM to decide what personalized artifact to build (app or document), builds it via the existing skill infrastructure, injects a message into the original conversation, and sends a native + in-app notification. Fires once per workspace, never repeats.

## Self-review result
GAPS FOUND — 2 gaps fixed across 2 fix PRs (timeout test, case-insensitive title match)

## PRs merged into feature branch
- #29531: feat(proactive-artifact): register LLM call sites and catalog entries
- #29532: refactor(documents): extract saveDocument into shared service
- #29533: feat(proactive-artifact): add count-first atomic trigger claim and startup backfill
- #29534: feat(proactive-artifact): add decision prompt with explicit build/skip gate
- #29538: feat(proactive-artifact): implement background job with artifact-aware delivery
- #29540: feat(proactive-artifact): wire trigger post-turn with correct timing and broadcast access

### Fix PRs
- #29544: fix: use case-insensitive trimmed title match for app ID capture
- #29545: fix: add missing timeout injection test case

Part of plan: proactive-artifact.md
Closes JARVIS-698
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->