### PR TITLE
Revert "ci(build-chrome-extension): add ref input to build any branch from main"

### DIFF
--- a/.github/workflows/build-chrome-extension.yaml
+++ b/.github/workflows/build-chrome-extension.yaml
@@ -1,23 +1,13 @@
 name: Build Chrome Extension
 
-# Manually triggered build of the Chrome extension against a target ref.
+# Manually triggered build of the Chrome extension against a target branch.
 # Mirrors the build-chrome-extension job in release.yml and produces the same
 # two artifacts (chrome-extension-crx, chrome-extension-zip) for download from
 # the workflow run page.
-#
-# Always dispatch this workflow from `main` (the "Use workflow from" dropdown).
-# Specify the branch / tag / SHA you actually want to build via the `ref`
-# input. Dispatching directly from an older branch only works if that branch
-# already contains this workflow file — which most don't.
 
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Branch, tag, or SHA to build (defaults to the dispatch ref, typically main)'
-        required: false
-        type: string
-        default: ''
       environment:
         description: 'VELLUM_ENVIRONMENT to bake into the bundle'
         required: false
@@ -29,13 +19,13 @@ on:
           - dev
           - local
       version:
-        description: 'Version to stamp in manifest.json (defaults to the value already in manifest.json on the target ref)'
+        description: 'Version to stamp in manifest.json (defaults to the value already in manifest.json on the target branch)'
         required: false
         type: string
         default: ''
 
 concurrency:
-  group: build-chrome-extension-${{ inputs.ref || github.ref }}
+  group: build-chrome-extension-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -44,8 +34,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
## Summary
- Revert #29546. We'll cherry-pick the workflow file onto target branches instead of carrying a `ref` input.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->