### PR TITLE
feat(macos): reverse teleport — platform → local

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -69,7 +69,7 @@ struct SettingsGeneralTab: View {
             }
             if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
                let assistant = currentAssistant,
-               !assistant.isManaged && (!assistant.isRemote || assistant.isDocker) {
+               !assistant.isRemote || assistant.isDocker || assistant.isManaged {
                 TeleportSection(assistant: assistant, onClose: onClose)
             }
             SettingsAppearanceTab(store: store)

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -10,6 +10,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Telep
 private enum TeleportDestination {
     case docker
     case platform
+    case local
 
     var displayLabel: String {
         switch self {
@@ -17,6 +18,8 @@ private enum TeleportDestination {
             return "Move to Docker"
         case .platform:
             return "Move to Cloud (Platform)"
+        case .local:
+            return "Move to Local"
         }
     }
 
@@ -26,6 +29,8 @@ private enum TeleportDestination {
             return "Run your assistant in a Docker container on this Mac."
         case .platform:
             return "Run your assistant in the cloud, managed by the Vellum platform."
+        case .local:
+            return "Run your assistant locally on this Mac."
         }
     }
 }
@@ -46,6 +51,7 @@ private enum TeleportError: LocalizedError {
     case notSignedIn
     case exportFailed(statusCode: Int)
     case exportTimedOut
+    case exportJobFailed(message: String)
     case importFailed(message: String)
     case managedEntryNotFound
     case localAssistantNotFound
@@ -53,6 +59,7 @@ private enum TeleportError: LocalizedError {
     case noOrganizations
     case multipleOrganizations
     case existingPlatformAssistant(id: String)
+    case versionMismatch(message: String)
 
     var errorDescription: String? {
         switch self {
@@ -64,6 +71,8 @@ private enum TeleportError: LocalizedError {
             return "Export failed (HTTP \(statusCode))"
         case .exportTimedOut:
             return "Export timed out"
+        case .exportJobFailed(let message):
+            return "Export failed: \(message)"
         case .importFailed(let message):
             return "Import failed: \(message)"
         case .managedEntryNotFound:
@@ -78,6 +87,8 @@ private enum TeleportError: LocalizedError {
             return "Multiple organizations found — please select one in account settings first"
         case .existingPlatformAssistant(let id):
             return "You already have a platform assistant '\(id)'. Retire it first, then retry the teleport."
+        case .versionMismatch(let message):
+            return message
         }
     }
 }
@@ -104,7 +115,9 @@ struct TeleportSection: View {
 
     var body: some View {
         Group {
-            if assistant.isManaged || (assistant.isRemote && !assistant.isDocker) {
+            if assistant.isRemote && !assistant.isDocker && !assistant.isManaged {
+                // Out of scope: remote-but-not-docker-not-managed assistants
+                // (e.g. apple-container) — leave teleport hidden for now.
                 EmptyView()
             } else {
                 teleportContent
@@ -172,7 +185,9 @@ struct TeleportSection: View {
 
     @ViewBuilder
     private var destinationPicker: some View {
-        if assistant.cloud.lowercased() == "local" || assistant.isDocker {
+        if assistant.isManaged {
+            destinationButton(for: .local)
+        } else if assistant.cloud.lowercased() == "local" || assistant.isDocker {
             destinationButton(for: .platform)
         }
     }
@@ -334,6 +349,8 @@ struct TeleportSection: View {
                 try await teleportLocalToDocker()
             case (true, .platform):
                 try await teleportDockerToPlatform()
+            case (_, .local) where assistant.isManaged:
+                try await teleportPlatformToLocal()
             default:
                 throw TeleportError.invalidURL
             }
@@ -614,6 +631,175 @@ struct TeleportSection: View {
 
         // Step 7 — Verification phase (do NOT retire or switch yet)
         phase = .verifying
+    }
+
+    // MARK: - Platform -> Local
+
+    private func teleportPlatformToLocal() async throws {
+        // Step 1 — Request a signed upload URL so the platform runtime
+        // has a GCS slot to stream the export bundle into.
+        phase = .transferring(step: "Preparing export...")
+        let uploadInfo = try await PlatformMigrationClient.requestSignedUploadUrl()
+
+        // Step 2 — Tell the platform runtime to export to that signed URL.
+        // The export is async — runtime returns 202 + job_id, then uploads
+        // the bundle to GCS in the background.
+        phase = .transferring(step: "Exporting cloud data...")
+        let exportResponse = try await GatewayHTTPClient.withAssistant(assistant.assistantId) {
+            try await GatewayHTTPClient.post(
+                path: "migrations/export-to-gcs",
+                json: ["upload_url": uploadInfo.uploadUrl],
+                timeout: 3600,
+                unprefixed: true
+            )
+        }
+        guard exportResponse.isSuccess || exportResponse.statusCode == 202 else {
+            throw TeleportError.exportFailed(statusCode: exportResponse.statusCode)
+        }
+        guard let exportJson = (try? JSONSerialization.jsonObject(with: exportResponse.data)) as? [String: Any],
+              let exportJobId = exportJson["job_id"] as? String else {
+            throw TeleportError.exportFailed(statusCode: exportResponse.statusCode)
+        }
+
+        // Step 3 — Poll the platform job-status endpoint until the export
+        // job completes.
+        try await pollExportJob(jobId: exportJobId)
+
+        // Step 4 — Resolve the target local runtime version for the
+        // version-compat gate. Use the bundled app's short version string;
+        // on macOS the local runtime is bundled with the app, so the app
+        // version is the runtime version that will perform the import.
+        let targetRuntimeVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+
+        // Step 5 — Request a signed download URL from the platform. The
+        // platform validates the bundle's compat range against the target
+        // runtime version and rejects with 422 + version_mismatch if there's
+        // no overlap.
+        phase = .transferring(step: "Preparing import...")
+        let downloadUrl: String
+        do {
+            downloadUrl = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: uploadInfo.bundleKey,
+                targetRuntimeVersion: targetRuntimeVersion
+            )
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .versionMismatch = error {
+                throw TeleportError.versionMismatch(message: error.localizedDescription)
+            }
+            throw error
+        }
+
+        // Step 6 — Download the bundle bytes from GCS.
+        phase = .transferring(step: "Downloading data...")
+        let bundleData = try await PlatformMigrationClient.downloadFromSignedUrl(
+            downloadUrl,
+            onProgress: { self.transferProgress = $0 }
+        )
+        transferProgress = nil
+
+        // Step 7 — Resolve or hatch a local assistant.
+        phase = .transferring(step: "Preparing local assistant...")
+        var localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
+        if localAssistant == nil {
+            let config = VellumCli.RemoteHatchConfig(remote: "local")
+            try await AppDelegate.shared?.vellumCli.runRemoteHatch(config: config) { _ in }
+            localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
+        } else {
+            // Wake existing local assistant in case it's sleeping
+            try await AppDelegate.shared?.vellumCli.wake(name: localAssistant!.assistantId)
+        }
+        guard let resolvedLocal = localAssistant else {
+            throw TeleportError.localAssistantNotFound
+        }
+
+        // Step 8 — Wait for the local gateway to be reachable (up to 30s).
+        phase = .transferring(step: "Waiting for local assistant...")
+        for i in 0..<30 {
+            if await HealthCheckClient.isReachable(for: resolvedLocal, timeout: 1) {
+                break
+            }
+            if i == 29 {
+                throw TeleportError.localAssistantNotFound
+            }
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+
+        // Step 9 — Bootstrap an actor token against the local gateway and
+        // swap it in for the import. Save and restore the original so the
+        // managed assistant keeps working during the verification phase.
+        phase = .transferring(step: "Authenticating with local assistant...")
+        let originalActorToken = ActorTokenManager.getToken()
+        let actorToken = try await bootstrapActorToken(targetAssistantId: resolvedLocal.assistantId)
+        ActorTokenManager.setToken(actorToken)
+        defer {
+            if let originalActorToken {
+                ActorTokenManager.setToken(originalActorToken)
+            } else {
+                ActorTokenManager.deleteToken()
+            }
+        }
+
+        // Step 10 — Import the bundle bytes to the local assistant.
+        phase = .transferring(step: "Importing data...")
+        let importResponse = try await GatewayHTTPClient.withAssistant(resolvedLocal.assistantId) {
+            try await GatewayHTTPClient.post(
+                path: "migrations/import",
+                body: bundleData,
+                contentType: "application/octet-stream",
+                timeout: 3600,
+                unprefixed: true
+            )
+        }
+        guard importResponse.isSuccess else {
+            throw TeleportError.importFailed(message: "HTTP \(importResponse.statusCode)")
+        }
+        if let importJson = try? JSONSerialization.jsonObject(with: importResponse.data) as? [String: Any],
+           let success = importJson["success"] as? Bool, !success {
+            let errorMsg = (importJson["error"] as? String) ?? "Import reported failure"
+            throw TeleportError.importFailed(message: errorMsg)
+        }
+
+        // Step 11 — Hand off to the verification banner. `confirmAndSwitch`
+        // already retires the managed assistant via the existing
+        // `original.isManaged` branch, so no new retire logic here.
+        targetAssistant = resolvedLocal
+        transferTask = nil
+        phase = .verifying
+    }
+
+    /// Polls the platform's job-status endpoint for an export job until it
+    /// reports `complete` or `failed`. Mirrors the polling block in
+    /// `importBundleToManaged` (5s interval, 60min timeout, 5xx-only retry).
+    private func pollExportJob(jobId: String) async throws {
+        let pollInterval: UInt64 = 5_000_000_000
+        let timeout: TimeInterval = 3600
+        let start = Date()
+
+        while Date().timeIntervalSince(start) < timeout {
+            try await Task.sleep(nanoseconds: pollInterval)
+
+            let status: PlatformMigrationClient.JobStatus
+            do {
+                status = try await PlatformMigrationClient.pollJobStatus(jobId: jobId)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch let error as PlatformMigrationClient.PlatformMigrationError {
+                if case .requestFailed(let statusCode, _) = error, (500..<600).contains(statusCode) {
+                    continue
+                }
+                throw error
+            } catch {
+                continue
+            }
+
+            if status.status == "complete" {
+                return
+            }
+            if status.status == "failed" {
+                throw TeleportError.exportJobFailed(message: status.error ?? "Export job failed")
+            }
+        }
+        throw TeleportError.exportTimedOut
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -697,16 +697,15 @@ struct TeleportSection: View {
         transferProgress = nil
 
         // Step 7 — Resolve or hatch a local assistant.
+        // `LockfileAssistant.loadAll()` already sorts newest-first by hatchedAt,
+        // so `first(where:)` picks the most recently hatched local — the one
+        // the user is most likely to consider "their" local assistant.
         phase = .transferring(step: "Preparing local assistant...")
-        var localAssistant = LockfileAssistant.loadAll()
-            .filter { !$0.isRemote }
-            .min(by: { $0.assistantId < $1.assistantId })
+        var localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
         if localAssistant == nil {
             let config = VellumCli.RemoteHatchConfig(remote: "local")
             try await AppDelegate.shared?.vellumCli.runRemoteHatch(config: config) { _ in }
-            localAssistant = LockfileAssistant.loadAll()
-                .filter { !$0.isRemote }
-                .min(by: { $0.assistantId < $1.assistantId })
+            localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
         } else {
             // Wake existing local assistant in case it's sleeping
             try await AppDelegate.shared?.vellumCli.wake(name: localAssistant!.assistantId)

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -649,8 +649,7 @@ struct TeleportSection: View {
             try await GatewayHTTPClient.post(
                 path: "migrations/export-to-gcs",
                 json: ["upload_url": uploadInfo.uploadUrl],
-                timeout: 3600,
-                unprefixed: true
+                timeout: 3600
             )
         }
         guard exportResponse.isSuccess || exportResponse.statusCode == 202 else {

--- a/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TeleportSection.swift
@@ -698,11 +698,15 @@ struct TeleportSection: View {
 
         // Step 7 — Resolve or hatch a local assistant.
         phase = .transferring(step: "Preparing local assistant...")
-        var localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
+        var localAssistant = LockfileAssistant.loadAll()
+            .filter { !$0.isRemote }
+            .min(by: { $0.assistantId < $1.assistantId })
         if localAssistant == nil {
             let config = VellumCli.RemoteHatchConfig(remote: "local")
             try await AppDelegate.shared?.vellumCli.runRemoteHatch(config: config) { _ in }
-            localAssistant = LockfileAssistant.loadAll().first(where: { !$0.isRemote })
+            localAssistant = LockfileAssistant.loadAll()
+                .filter { !$0.isRemote }
+                .min(by: { $0.assistantId < $1.assistantId })
         } else {
             // Wake existing local assistant in case it's sleeping
             try await AppDelegate.shared?.vellumCli.wake(name: localAssistant!.assistantId)

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -43,6 +43,7 @@ public enum PlatformMigrationClient {
         case signedUrlsNotAvailable
         case requestFailed(statusCode: Int, detail: String)
         case uploadFailed(statusCode: Int)
+        case versionMismatch(minVersion: String, maxVersion: String?, targetVersion: String)
 
         public var errorDescription: String? {
             switch self {
@@ -54,6 +55,14 @@ public enum PlatformMigrationClient {
                 return "Migration request failed (HTTP \(statusCode)): \(detail)"
             case .uploadFailed(let statusCode):
                 return "Bundle upload failed (HTTP \(statusCode))."
+            case .versionMismatch(let minVersion, let maxVersion, let targetVersion):
+                let range: String
+                if let maxVersion {
+                    range = "\(minVersion)–\(maxVersion)"
+                } else {
+                    range = "\(minVersion)+"
+                }
+                return "Cannot import: bundle requires runtime \(range), but this local runtime is \(targetVersion). Update your local runtime before importing."
             }
         }
     }
@@ -100,6 +109,80 @@ public enum PlatformMigrationClient {
 
         let decoder = JSONDecoder()
         return try decoder.decode(SignedUrlResponse.self, from: data)
+    }
+
+    /// Requests a signed download URL from the platform's unified signed-URL endpoint.
+    ///
+    /// POSTs to `/v1/migrations/signed-url/` with
+    /// `{"operation": "download", "bundle_key": ..., "target_runtime_version": ...}`.
+    /// The platform validates the bundle's runtime-compat range against the
+    /// target runtime version and rejects with HTTP 422 + `reason: "version_mismatch"`
+    /// when there is no overlap.
+    ///
+    /// - Parameters:
+    ///   - bundleKey: The bundle key returned by `requestSignedUploadUrl()` (and
+    ///     filled by a prior `migrations/export-to-gcs` runtime export).
+    ///   - targetRuntimeVersion: The runtime version that will perform the import.
+    ///     Used by the platform to enforce the bundle's compat range.
+    /// - Returns: The signed download URL string.
+    /// - Throws: `PlatformMigrationError.versionMismatch` on 422 `version_mismatch`,
+    ///   or `PlatformMigrationError.requestFailed` on other non-2xx responses.
+    public static func requestSignedDownloadUrl(
+        bundleKey: String,
+        targetRuntimeVersion: String
+    ) async throws -> String {
+        let (baseURL, token, orgId) = try resolveAuthContext()
+
+        guard let url = URL(string: "\(baseURL)/v1/migrations/signed-url/") else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "operation": "download",
+            "bundle_key": bundleKey,
+            "target_runtime_version": targetRuntimeVersion,
+        ])
+
+        // 422 is a permanent semantic signal (version_mismatch), not a transient
+        // server error — mark it non-retryable so executeWithRetry doesn't burn
+        // attempts retrying a deterministic rejection.
+        let (data, statusCode) = try await executeWithRetry(
+            request: request,
+            label: "signed-url-download",
+            nonRetryableStatusCodes: [422]
+        )
+
+        if statusCode == 422 {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               (json["reason"] as? String) == "version_mismatch",
+               let compat = json["bundle_compat"] as? [String: Any],
+               let minVersion = compat["min_runtime_version"] as? String,
+               let targetVersion = json["target_runtime_version"] as? String {
+                let maxVersion = compat["max_runtime_version"] as? String
+                throw PlatformMigrationError.versionMismatch(
+                    minVersion: minVersion,
+                    maxVersion: maxVersion,
+                    targetVersion: targetVersion
+                )
+            }
+        }
+
+        guard statusCode == 200 || statusCode == 201 else {
+            let detail = String(data: data, encoding: .utf8) ?? "No response body"
+            throw PlatformMigrationError.requestFailed(statusCode: statusCode, detail: detail)
+        }
+
+        struct DownloadUrlResponse: Decodable {
+            let url: String
+        }
+        return try JSONDecoder().decode(DownloadUrlResponse.self, from: data).url
     }
 
     /// Uploads binary bundle data to a GCS signed URL.

--- a/clients/shared/Network/PlatformMigrationClient.swift
+++ b/clients/shared/Network/PlatformMigrationClient.swift
@@ -266,6 +266,84 @@ public enum PlatformMigrationClient {
         throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Unexpected retry loop exit")
     }
 
+    /// Downloads bundle data from a GCS signed URL.
+    ///
+    /// Mirrors `uploadToSignedUrl(_:bundleData:onProgress:)` in reverse: the
+    /// caller passes a signed download URL (from `requestSignedDownloadUrl`)
+    /// and gets back the raw bundle bytes suitable for piping into
+    /// `migrations/import` on a local runtime.
+    ///
+    /// Retries on transient 5xx server errors (500/502/503/504) with the same
+    /// 1s/2s/4s exponential backoff used elsewhere in this client.
+    ///
+    /// - Parameters:
+    ///   - url: The signed download URL.
+    ///   - onProgress: Optional closure called on the main actor with values
+    ///     from 0.0 to 1.0 representing the fraction of bytes received.
+    /// - Returns: The full bundle data.
+    /// - Throws: `PlatformMigrationError.requestFailed` on a non-2xx status,
+    ///   or any error thrown by `URLSession`.
+    public static func downloadFromSignedUrl(
+        _ url: String,
+        onProgress: (@MainActor (Double) -> Void)? = nil
+    ) async throws -> Data {
+        guard let downloadURL = URL(string: url) else {
+            throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Invalid URL")
+        }
+
+        var request = URLRequest(url: downloadURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 3600
+
+        let delegate: DownloadProgressDelegate?
+        let session: URLSession
+        if let onProgress {
+            let d = DownloadProgressDelegate(onProgress: onProgress)
+            delegate = d
+            session = URLSession(configuration: .default, delegate: d, delegateQueue: nil)
+        } else {
+            delegate = nil
+            session = URLSession.shared
+        }
+        defer {
+            delegate?.reset()
+            if delegate != nil {
+                session.finishTasksAndInvalidate()
+            }
+        }
+
+        let urlPath = logPath(from: downloadURL)
+
+        for attempt in 0...maxRetries {
+            log.info("GET \(urlPath, privacy: .public)\(attempt > 0 ? " (retry \(attempt)/\(maxRetries))" : "")")
+            let (data, response) = try await session.data(for: request, delegate: delegate)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            log.info("GET \(urlPath, privacy: .public) → \(statusCode)")
+
+            if attempt < maxRetries && retryableStatusCodes.contains(statusCode) {
+                let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
+                log.warning("Transient server error (\(statusCode)) — retrying in \(1 << attempt)s")
+                try await Task.sleep(nanoseconds: delay)
+                delegate?.reset()
+                await onProgress?(0)
+                continue
+            }
+
+            guard (200..<300).contains(statusCode) else {
+                throw PlatformMigrationError.requestFailed(
+                    statusCode: statusCode,
+                    detail: "Bundle download failed"
+                )
+            }
+            // Ensure the progress reaches 1.0 even if the delegate's last
+            // didReceive event was throttled out by the 0.01-step gate.
+            await onProgress?(1.0)
+            return data
+        }
+
+        throw PlatformMigrationError.requestFailed(statusCode: 0, detail: "Unexpected retry loop exit")
+    }
+
     /// Triggers a GCS-based import on the platform after the bundle has been uploaded.
     ///
     /// - Parameter bundleKey: The bundle key returned by `requestSignedUploadUrl()`.
@@ -426,6 +504,46 @@ public enum PlatformMigrationClient {
         /// in-flight callbacks from the previous attempt are discarded.
         func reset() {
             lastReportedFraction = 0.0
+            generation += 1
+        }
+    }
+
+    /// Tracks download progress and dispatches throttled updates to the main actor.
+    /// Mirrors `UploadProgressDelegate` but for response data instead of request body.
+    private class DownloadProgressDelegate: NSObject, URLSessionDataDelegate {
+        private let onProgress: @MainActor (Double) -> Void
+        private var lastReportedFraction: Double = 0.0
+        private var generation: Int = 0
+        private var bytesReceived: Int64 = 0
+
+        init(onProgress: @escaping @MainActor (Double) -> Void) {
+            self.onProgress = onProgress
+        }
+
+        func urlSession(
+            _ session: URLSession,
+            dataTask: URLSessionDataTask,
+            didReceive data: Data
+        ) {
+            bytesReceived += Int64(data.count)
+            let total = dataTask.countOfBytesExpectedToReceive
+            guard total > 0 else { return }
+            let progress = Double(bytesReceived) / Double(total)
+            guard progress - lastReportedFraction >= 0.01 || progress >= 1.0 else { return }
+            lastReportedFraction = progress
+            let callback = self.onProgress
+            let gen = self.generation
+            Task { [weak self] in
+                guard self?.generation == gen else { return }
+                await callback(progress)
+            }
+        }
+
+        /// Resets throttle and increments the generation counter so any
+        /// in-flight callbacks from the previous attempt are discarded.
+        func reset() {
+            lastReportedFraction = 0.0
+            bytesReceived = 0
             generation += 1
         }
     }

--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -283,3 +283,233 @@ final class PlatformMigrationClientSignedUploadUrlTests: XCTestCase {
         return data
     }
 }
+
+@MainActor
+final class PlatformMigrationClientSignedDownloadUrlTests: XCTestCase {
+    private var previousToken: String?
+
+    override func setUp() {
+        super.setUp()
+        JobStatusURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(JobStatusURLProtocol.self)
+        previousToken = SessionTokenManager.getToken()
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(JobStatusURLProtocol.self)
+        JobStatusURLProtocol.requestHandler = nil
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+        super.tearDown()
+    }
+
+    func testRequestSignedDownloadUrlPostsOperationDownloadWithBundleKeyAndTargetVersion() async throws {
+        let observed = ObservedRequest()
+        JobStatusURLProtocol.requestHandler = { request in
+            observed.url = request.url
+            observed.method = request.httpMethod
+            observed.sessionTokenHeader = request.value(forHTTPHeaderField: "X-Session-Token")
+            if let stream = request.httpBodyStream {
+                observed.body = Self.readAll(from: stream)
+            } else {
+                observed.body = request.httpBody
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 201,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"url":"https://storage.example/dl","bundle_key":"bundles/dl-v.tar.gz","expires_at":"2026-05-01T00:00:00Z"}"#
+            return (response, Data(body.utf8))
+        }
+
+        let url = try await PlatformMigrationClient.requestSignedDownloadUrl(
+            bundleKey: "bundles/dl-v.tar.gz",
+            targetRuntimeVersion: "2.0.0"
+        )
+
+        let observedURL = try XCTUnwrap(observed.url)
+        XCTAssertTrue(
+            observedURL.absoluteString.hasSuffix("/v1/migrations/signed-url/"),
+            "Expected URL to end with unified signed-url path; got \(observedURL.absoluteString)"
+        )
+        XCTAssertEqual(observed.method, "POST")
+        XCTAssertEqual(observed.sessionTokenHeader, "test-session-token")
+
+        let bodyData = try XCTUnwrap(observed.body)
+        let bodyJson = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+        )
+        XCTAssertEqual(bodyJson["operation"] as? String, "download")
+        XCTAssertEqual(bodyJson["bundle_key"] as? String, "bundles/dl-v.tar.gz")
+        XCTAssertEqual(bodyJson["target_runtime_version"] as? String, "2.0.0")
+
+        XCTAssertEqual(url, "https://storage.example/dl")
+    }
+
+    func testRequestSignedDownloadUrlAcceptsStatus200() async throws {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"url":"https://storage.example/dl","bundle_key":"bundles/dl-v.tar.gz","expires_at":"2026-05-01T00:00:00Z"}"#
+            return (response, Data(body.utf8))
+        }
+
+        let url = try await PlatformMigrationClient.requestSignedDownloadUrl(
+            bundleKey: "bundles/dl-v.tar.gz",
+            targetRuntimeVersion: "2.0.0"
+        )
+        XCTAssertEqual(url, "https://storage.example/dl")
+    }
+
+    func testRequestSignedDownloadUrlThrowsVersionMismatchOn422() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"reason":"version_mismatch","bundle_compat":{"min_runtime_version":"2.0.0","max_runtime_version":"2.5.0"},"target_runtime_version":"1.9.0"}"#
+            return (response, Data(body.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "1.9.0"
+            )
+            XCTFail("Expected versionMismatch to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .versionMismatch(let minVersion, let maxVersion, let targetVersion) = error {
+                XCTAssertEqual(minVersion, "2.0.0")
+                XCTAssertEqual(maxVersion, "2.5.0")
+                XCTAssertEqual(targetVersion, "1.9.0")
+                XCTAssertEqual(
+                    error.errorDescription,
+                    "Cannot import: bundle requires runtime 2.0.0–2.5.0, but this local runtime is 1.9.0. Update your local runtime before importing."
+                )
+            } else {
+                XCTFail("Expected .versionMismatch, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRequestSignedDownloadUrlVersionMismatchWithNullMaxUsesPlusSuffix() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = #"{"reason":"version_mismatch","bundle_compat":{"min_runtime_version":"3.0.0","max_runtime_version":null},"target_runtime_version":"2.9.0"}"#
+            return (response, Data(body.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "2.9.0"
+            )
+            XCTFail("Expected versionMismatch to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .versionMismatch(let minVersion, let maxVersion, let targetVersion) = error {
+                XCTAssertEqual(minVersion, "3.0.0")
+                XCTAssertNil(maxVersion)
+                XCTAssertEqual(targetVersion, "2.9.0")
+                let description = error.errorDescription ?? ""
+                XCTAssertTrue(
+                    description.hasSuffix("requires runtime 3.0.0+, but this local runtime is 2.9.0. Update your local runtime before importing."),
+                    "Unexpected description: \(description)"
+                )
+            } else {
+                XCTFail("Expected .versionMismatch, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRequestSignedDownloadUrl422WithoutVersionMismatchPayloadFallsThroughToRequestFailed() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"validation failed"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "2.0.0"
+            )
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 422)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRequestSignedDownloadUrlThrowsRequestFailedOnNon200() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"server error"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.requestSignedDownloadUrl(
+                bundleKey: "bundles/dl-v.tar.gz",
+                targetRuntimeVersion: "2.0.0"
+            )
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 500)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    private static func readAll(from stream: InputStream) -> Data {
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4096)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: 4096)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/clients/shared/Tests/PlatformMigrationClientTests.swift
+++ b/clients/shared/Tests/PlatformMigrationClientTests.swift
@@ -513,3 +513,123 @@ final class PlatformMigrationClientSignedDownloadUrlTests: XCTestCase {
         return data
     }
 }
+
+@MainActor
+final class PlatformMigrationClientDownloadFromSignedUrlTests: XCTestCase {
+    private var previousToken: String?
+
+    override func setUp() {
+        super.setUp()
+        JobStatusURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(JobStatusURLProtocol.self)
+        previousToken = SessionTokenManager.getToken()
+        SessionTokenManager.setToken("test-session-token")
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(JobStatusURLProtocol.self)
+        JobStatusURLProtocol.requestHandler = nil
+        if let token = previousToken {
+            SessionTokenManager.setToken(token)
+        } else {
+            SessionTokenManager.deleteToken()
+        }
+        previousToken = nil
+        super.tearDown()
+    }
+
+    func testDownloadFromSignedUrlGetsAndReturnsBytes() async throws {
+        let observed = ObservedRequest()
+        let stubBytes = Data([0xAA, 0xBB, 0xCC])
+        JobStatusURLProtocol.requestHandler = { request in
+            observed.url = request.url
+            observed.method = request.httpMethod
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, stubBytes)
+        }
+
+        let data = try await PlatformMigrationClient.downloadFromSignedUrl("https://storage.example/dl")
+
+        XCTAssertEqual(data, stubBytes)
+        XCTAssertEqual(observed.method, "GET")
+    }
+
+    func testDownloadFromSignedUrlReportsProgressTo1Point0OnSuccess() async throws {
+        let stubBytes = Data([0xAA, 0xBB, 0xCC])
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, stubBytes)
+        }
+
+        let holder = ProgressHolder()
+        _ = try await PlatformMigrationClient.downloadFromSignedUrl(
+            "https://storage.example/dl",
+            onProgress: { value in
+                holder.update(value)
+            }
+        )
+
+        let highest = await holder.highest
+        XCTAssertEqual(highest, 1.0, accuracy: 0.0001)
+    }
+
+    func testDownloadFromSignedUrlThrowsRequestFailedOnNon2xx() async {
+        JobStatusURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"detail":"not found"}"#.utf8))
+        }
+
+        do {
+            _ = try await PlatformMigrationClient.downloadFromSignedUrl("https://storage.example/dl")
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 404)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testDownloadFromSignedUrlInvalidUrlThrowsRequestFailed() async {
+        do {
+            _ = try await PlatformMigrationClient.downloadFromSignedUrl("")
+            XCTFail("Expected requestFailed to be thrown")
+        } catch let error as PlatformMigrationClient.PlatformMigrationError {
+            if case .requestFailed(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 0)
+            } else {
+                XCTFail("Expected .requestFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}
+
+/// Captures the highest progress fraction observed across `onProgress` callbacks.
+@MainActor
+private final class ProgressHolder {
+    private(set) var highest: Double = 0.0
+
+    func update(_ value: Double) {
+        if value > highest { highest = value }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a "Move to Local" button in macOS Settings → General → Teleport so a managed (platform) assistant can be teleported back to a local assistant on the same Mac. Mirrors the existing local→platform flow in reverse (signed-URL upload slot → runtime export to GCS → poll → version-compat-gated signed-URL download → bundle download → hatch/wake local → import → verifying banner). Existing teleport directions (local→platform, local→docker, docker→platform) are unchanged.

## Self-review result
GAPS FOUND — 1 critical gap fixed across 1 fix PR. Re-review passed.

## PRs merged into feature branch
- #29527: feat(macos): add `PlatformMigrationClient.requestSignedDownloadUrl`
- #29526: feat(macos): add `PlatformMigrationClient.downloadFromSignedUrl`
- #29529: feat(macos): platform → local teleport in Settings General tab

### Fix PRs
- #29539: fix(macos): route managed `migrations/export-to-gcs` through `assistants/{id}/` proxy

Part of plan: teleport-platform-to-local.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->