### PR TITLE
feat(memory): enable memory v2 by default

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -7,7 +7,7 @@ describe("MemoryV2ConfigSchema", () => {
   test("parses an empty object to documented defaults", () => {
     const parsed = MemoryV2ConfigSchema.parse({});
     expect(parsed).toEqual({
-      enabled: false,
+      enabled: true,
       sweep_enabled: false,
       d: 0.3,
       c_user: 0.3,
@@ -155,7 +155,7 @@ describe("MemoryConfigSchema integration with v2 block", () => {
   test("parses an empty memory config and includes a v2 block with defaults", () => {
     const parsed = MemoryConfigSchema.parse({});
     expect(parsed.v2).toBeDefined();
-    expect(parsed.v2.enabled).toBe(false);
+    expect(parsed.v2.enabled).toBe(true);
     expect(parsed.v2.sweep_enabled).toBe(false);
     expect(parsed.v2.d).toBe(0.3);
     expect(parsed.v2.dense_weight).toBe(0.85);

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -21,7 +21,7 @@ export const MemoryV2ConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "memory.v2.enabled must be a boolean" })
-      .default(false)
+      .default(true)
       .describe(
         "Whether the v2 memory subsystem (concept-page activation model) is enabled. Independent of the memory-v2-enabled feature flag — both must be true for v2 to run.",
       ),

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -247,7 +247,7 @@
       "key": "memory-v2-enabled",
       "label": "Memory v2 (concept-page activation model)",
       "description": "Enables the v2 memory subsystem: prose concept pages with bidirectional edges, activation-based retrieval, and hourly LLM-driven consolidation. v1 graph + PKB stays write-active until cutover.",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "account-deletion",


### PR DESCRIPTION
## Summary
- Flip \`memory-v2-enabled\` registry default and \`memory.v2.enabled\` schema default from \`false\` to \`true\` so v2 runs out of the box on new assistants (and existing ones without an override).
- Update the two empty-config default assertions in \`memory-v2.test.ts\`. Tests that explicitly pass \`enabled: false\` to exercise v1 paths are unaffected.
- Both gates stay in place — an LD push or per-workspace config still flips v2 off without a code change.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->