### PR TITLE
[codex] Bump heartbeat cadence and alert surfacing

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -810,6 +810,9 @@ describe("HeartbeatService", () => {
     expect(emittedNotificationSignals[0].contextPayload.messageId).toBe(
       "assistant-alert-1",
     );
+    expect(
+      emittedNotificationSignals[0].contextPayload.sourceInterface,
+    ).toBeUndefined();
   });
 
   test("HEARTBEAT_OK stays silent", async () => {
@@ -850,6 +853,48 @@ describe("HeartbeatService", () => {
       },
     );
     expect(successFeedCalls).toHaveLength(0);
+  });
+
+  test("HEARTBEAT_OK stays silent when earlier content mentions HEARTBEAT_ALERT", async () => {
+    const conversationCreatedCalls: Array<{
+      conversationId: string;
+      title: string;
+    }> = [];
+    const service = createService({
+      onConversationCreated: (info) => conversationCreatedCalls.push(info),
+      processMessage: async (...args: unknown[]) => {
+        const conversationId = args[0] as string;
+        mockStoredMessages.push({
+          id: "assistant-ok-2",
+          conversationId,
+          role: "assistant",
+          content: JSON.stringify([
+            {
+              type: "thinking",
+              thinking:
+                "I should decide between HEARTBEAT_ALERT and HEARTBEAT_OK.",
+            },
+            {
+              type: "tool_result",
+              content: "Tool output mentions HEARTBEAT_ALERT.",
+            },
+            {
+              type: "text",
+              text: "I considered HEARTBEAT_ALERT, but there is nothing useful to surface.\nHEARTBEAT_OK",
+            },
+          ]),
+          createdAt: Date.now(),
+          metadata: null,
+        });
+        return { messageId: "user-heartbeat-1" };
+      },
+    });
+
+    await service.runOnce();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(conversationCreatedCalls).toHaveLength(0);
+    expect(emittedNotificationSignals).toHaveLength(0);
   });
 
   test("end-to-end: llm.callSites.heartbeatAgent.speed resolves to 'fast'", async () => {

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -20,6 +20,7 @@ const mockSkipHeartbeatRun = mock(() => true);
 const mockSupersedePendingRun = mock(() => true);
 const mockMarkStaleRunsAsMissed = mock(() => 0);
 const mockMarkStaleRunningAsError = mock(() => 0);
+const mockListHeartbeatRuns = mock(() => []);
 mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   insertPendingHeartbeatRun: mockInsertPendingHeartbeatRun,
   startHeartbeatRun: mockStartHeartbeatRun,
@@ -28,6 +29,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   supersedePendingRun: mockSupersedePendingRun,
   markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
   markStaleRunningAsError: mockMarkStaleRunningAsError,
+  listHeartbeatRuns: mockListHeartbeatRuns,
 }));
 
 // ── Feed event mock ───────────────────────────────────────────────
@@ -119,6 +121,14 @@ mock.module("../prompts/persona-resolver.js", () => ({
 const createdConversations: Array<{ title: string; conversationType: string }> =
   [];
 let conversationIdCounter = 0;
+const mockStoredMessages: Array<{
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  createdAt: number;
+  metadata: string | null;
+}> = [];
 
 mock.module("../memory/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
@@ -127,7 +137,7 @@ mock.module("../memory/conversation-crud.js", () => ({
   updateConversationTitle: () => {},
   updateConversationUsage: () => {},
   addMessage: () => ({ id: "mock-msg-id" }),
-  getMessages: () => [],
+  getMessages: () => mockStoredMessages,
   getConversation: () => ({
     id: "conv-1",
     contextSummary: null,
@@ -199,21 +209,36 @@ mock.module("../credential-health/credential-health-service.js", () => ({
 // `notifyUnhealthyCredentials` dynamically imports `emitNotificationSignal`.
 // Track calls so tests can assert which credentials were notified about.
 const emittedNotificationSignals: Array<{
+  sourceEventName?: string;
+  sourceChannel?: string;
   sourceContextId: string;
   dedupeKey: string;
+  attentionHints?: Record<string, unknown>;
   contextPayload: Record<string, unknown>;
+  conversationAffinityHint?: Record<string, string>;
+  conversationMetadata?: Record<string, unknown>;
 }> = [];
 
 mock.module("../notifications/emit-signal.js", () => ({
   emitNotificationSignal: async (opts: {
+    sourceEventName?: string;
+    sourceChannel?: string;
     sourceContextId: string;
     dedupeKey: string;
+    attentionHints?: Record<string, unknown>;
     contextPayload: Record<string, unknown>;
+    conversationAffinityHint?: Record<string, string>;
+    conversationMetadata?: Record<string, unknown>;
   }) => {
     emittedNotificationSignals.push({
+      sourceEventName: opts.sourceEventName,
+      sourceChannel: opts.sourceChannel,
       sourceContextId: opts.sourceContextId,
       dedupeKey: opts.dedupeKey,
+      attentionHints: opts.attentionHints,
       contextPayload: opts.contextPayload,
+      conversationAffinityHint: opts.conversationAffinityHint,
+      conversationMetadata: opts.conversationMetadata,
     });
   },
 }));
@@ -318,6 +343,7 @@ describe("HeartbeatService", () => {
     alerterCalls = [];
     createdConversations.length = 0;
     conversationIdCounter = 0;
+    mockStoredMessages.length = 0;
     mockGuardianPersona = null;
     mockCredentialHealthReport = null;
     mockCheckAllCredentialsFail = false;
@@ -351,6 +377,8 @@ describe("HeartbeatService", () => {
     mockMarkStaleRunsAsMissed.mockImplementation(() => 0);
     mockMarkStaleRunningAsError.mockClear();
     mockMarkStaleRunningAsError.mockImplementation(() => 0);
+    mockListHeartbeatRuns.mockClear();
+    mockListHeartbeatRuns.mockImplementation(() => []);
     mockEmitFeedEvent.mockClear();
     mockEmitFeedEvent.mockImplementation(() => Promise.resolve());
 
@@ -369,6 +397,10 @@ describe("HeartbeatService", () => {
   function createService(overrides?: {
     processMessage?: (...args: unknown[]) => Promise<{ messageId: string }>;
     getCurrentHour?: () => number;
+    onConversationCreated?: (info: {
+      conversationId: string;
+      title: string;
+    }) => void;
   }) {
     if (overrides?.processMessage) {
       setTestProcessMessage(overrides.processMessage);
@@ -377,6 +409,7 @@ describe("HeartbeatService", () => {
       alerter: (alert: { type: string; title: string; body: string }) => {
         alerterCalls.push(alert);
       },
+      onConversationCreated: overrides?.onConversationCreated,
       getCurrentHour: overrides?.getCurrentHour,
     });
   }
@@ -719,6 +752,104 @@ describe("HeartbeatService", () => {
       callSite: "heartbeatAgent",
       trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
     });
+  });
+
+  test("HEARTBEAT_ALERT emits a notification signal and surfaces the conversation", async () => {
+    const conversationCreatedCalls: Array<{
+      conversationId: string;
+      title: string;
+    }> = [];
+    const service = createService({
+      onConversationCreated: (info) => conversationCreatedCalls.push(info),
+      processMessage: async (...args: unknown[]) => {
+        const conversationId = args[0] as string;
+        mockStoredMessages.push({
+          id: "assistant-alert-1",
+          conversationId,
+          role: "assistant",
+          content: JSON.stringify([
+            {
+              type: "text",
+              text: "The first heartbeat found a concrete follow-up for the guardian.\nHEARTBEAT_ALERT",
+            },
+          ]),
+          createdAt: Date.now(),
+          metadata: null,
+        });
+        return { messageId: "user-heartbeat-1" };
+      },
+    });
+
+    await service.runOnce();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(conversationCreatedCalls).toEqual([
+      { conversationId: "conv-1", title: "Heartbeat" },
+    ]);
+    expect(emittedNotificationSignals).toHaveLength(1);
+    expect(emittedNotificationSignals[0]).toMatchObject({
+      sourceEventName: "heartbeat.alert",
+      sourceChannel: "watcher",
+      sourceContextId: "mock-run-id",
+      dedupeKey: "heartbeat:alert:mock-run-id",
+      attentionHints: {
+        requiresAction: true,
+        urgency: "medium",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+      conversationAffinityHint: { vellum: "conv-1" },
+      conversationMetadata: {
+        source: "heartbeat",
+        groupId: "system:background",
+      },
+    });
+    expect(emittedNotificationSignals[0].contextPayload.summary).toBe(
+      "The first heartbeat found a concrete follow-up for the guardian.",
+    );
+    expect(emittedNotificationSignals[0].contextPayload.messageId).toBe(
+      "assistant-alert-1",
+    );
+  });
+
+  test("HEARTBEAT_OK stays silent", async () => {
+    const conversationCreatedCalls: Array<{
+      conversationId: string;
+      title: string;
+    }> = [];
+    const service = createService({
+      onConversationCreated: (info) => conversationCreatedCalls.push(info),
+      processMessage: async (...args: unknown[]) => {
+        const conversationId = args[0] as string;
+        mockStoredMessages.push({
+          id: "assistant-ok-1",
+          conversationId,
+          role: "assistant",
+          content: JSON.stringify([
+            {
+              type: "text",
+              text: "Everything looks good.\nHEARTBEAT_OK",
+            },
+          ]),
+          createdAt: Date.now(),
+          metadata: null,
+        });
+        return { messageId: "user-heartbeat-1" };
+      },
+    });
+
+    await service.runOnce();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(conversationCreatedCalls).toHaveLength(0);
+    expect(emittedNotificationSignals).toHaveLength(0);
+    const successFeedCalls = mockEmitFeedEvent.mock.calls.filter(
+      (call: unknown[]) => {
+        const opts = call[0] as { dedupKey?: string };
+        return opts.dedupKey?.startsWith("heartbeat:ok:");
+      },
+    );
+    expect(successFeedCalls).toHaveLength(0);
   });
 
   test("end-to-end: llm.callSites.heartbeatAgent.speed resolves to 'fast'", async () => {
@@ -1354,20 +1485,38 @@ describe("HeartbeatService", () => {
       });
     });
 
-    test("CAS false suppresses success feed event", async () => {
+    test("CAS false suppresses success surfacing", async () => {
       mockCompleteHeartbeatRun.mockImplementation(() => false);
 
-      const service = createService();
-      await service.runOnce();
-
-      // completeHeartbeatRun returned false, so no feed event should be emitted for success
-      const successCalls = mockEmitFeedEvent.mock.calls.filter(
-        (call: unknown[]) => {
-          const opts = call[0] as { dedupKey?: string };
-          return opts.dedupKey?.startsWith("heartbeat:ok:");
+      const conversationCreatedCalls: Array<{
+        conversationId: string;
+        title: string;
+      }> = [];
+      const service = createService({
+        onConversationCreated: (info) => conversationCreatedCalls.push(info),
+        processMessage: async (...args: unknown[]) => {
+          const conversationId = args[0] as string;
+          mockStoredMessages.push({
+            id: "assistant-alert-1",
+            conversationId,
+            role: "assistant",
+            content: JSON.stringify([
+              {
+                type: "text",
+                text: "Something worth surfacing.\nHEARTBEAT_ALERT",
+              },
+            ]),
+            createdAt: Date.now(),
+            metadata: null,
+          });
+          return { messageId: "msg-1" };
         },
-      );
-      expect(successCalls).toHaveLength(0);
+      });
+      await service.runOnce();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(conversationCreatedCalls).toHaveLength(0);
+      expect(emittedNotificationSignals).toHaveLength(0);
     });
 
     test("CAS false suppresses failure alerter and feed event", async () => {

--- a/assistant/src/__tests__/workspace-migration-065-bump-stale-heartbeat-interval.test.ts
+++ b/assistant/src/__tests__/workspace-migration-065-bump-stale-heartbeat-interval.test.ts
@@ -1,0 +1,122 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { bumpStaleHeartbeatIntervalMigration } from "../workspace/migrations/065-bump-stale-heartbeat-interval.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-065-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(configPath(), JSON.stringify(data, null, 2) + "\n");
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath(), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("065-bump-stale-heartbeat-interval migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(bumpStaleHeartbeatIntervalMigration.id).toBe(
+      "065-bump-stale-heartbeat-interval",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "065-bump-stale-heartbeat-interval",
+    );
+  });
+
+  test("bumps stale baked 6-hour default to 30 minutes", () => {
+    writeConfig({
+      heartbeat: {
+        enabled: true,
+        intervalMs: 6 * 60 * 60 * 1000,
+        activeHoursStart: 8,
+        activeHoursEnd: 22,
+      },
+    });
+
+    bumpStaleHeartbeatIntervalMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual({
+      heartbeat: {
+        enabled: true,
+        intervalMs: THIRTY_MINUTES_MS,
+        activeHoursStart: 8,
+        activeHoursEnd: 22,
+      },
+    });
+  });
+
+  test("bumps stale baked 3-hour default to 30 minutes", () => {
+    writeConfig({
+      heartbeat: {
+        intervalMs: 3 * 60 * 60 * 1000,
+      },
+    });
+
+    bumpStaleHeartbeatIntervalMigration.run(workspaceDir);
+
+    expect((readConfig().heartbeat as Record<string, unknown>).intervalMs).toBe(
+      THIRTY_MINUTES_MS,
+    );
+  });
+
+  test("preserves custom heartbeat intervals", () => {
+    writeConfig({
+      heartbeat: {
+        intervalMs: 60 * 60 * 1000,
+      },
+    });
+
+    bumpStaleHeartbeatIntervalMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual({
+      heartbeat: {
+        intervalMs: 60 * 60 * 1000,
+      },
+    });
+  });
+
+  test("is a no-op when config or heartbeat interval is absent", () => {
+    bumpStaleHeartbeatIntervalMigration.run(workspaceDir);
+    expect(existsSync(configPath())).toBe(false);
+
+    writeConfig({ heartbeat: { enabled: true }, other: "value" });
+    bumpStaleHeartbeatIntervalMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({
+      heartbeat: { enabled: true },
+      other: "value",
+    });
+  });
+});

--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -11,7 +11,7 @@ export const HeartbeatConfigSchema = z
       .number({ error: "heartbeat.intervalMs must be a number" })
       .int("heartbeat.intervalMs must be an integer")
       .positive("heartbeat.intervalMs must be a positive integer")
-      .default(6 * 3_600_000)
+      .default(30 * 60_000)
       .describe("Time between heartbeat checks in milliseconds"),
     cronExpression: z
       .string()

--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -146,6 +146,7 @@ interface OnDiskItem {
 }
 
 function readFeedItems(): OnDiskItem[] {
+  if (!existsSync(getHomeFeedPath())) return [];
   const raw = JSON.parse(readFileSync(getHomeFeedPath(), "utf-8"));
   return raw.items as OnDiskItem[];
 }
@@ -174,7 +175,7 @@ afterEach(() => {
 });
 
 describe("heartbeat feed events", () => {
-  test("successful heartbeat emits feed event with priority 30 and no urgency", async () => {
+  test("successful heartbeat without an alert does not emit a feed event", async () => {
     _testProcessMessage = async () => ({ messageId: "msg-1" });
     const service = new HeartbeatService({
       alerter: () => {},
@@ -182,18 +183,12 @@ describe("heartbeat feed events", () => {
 
     await service.runOnce({ force: true });
 
-    // Give the fire-and-forget emitFeedEvent time to flush.
+    // Give any fire-and-forget surfacing work time to flush.
     await new Promise((r) => setTimeout(r, 100));
 
     const items = readFeedItems();
     const heartbeatItem = items.find((i) => i.title === "Heartbeat");
-    expect(heartbeatItem).toBeDefined();
-    expect(heartbeatItem!.summary).toBe(
-      "Periodic check completed. Tap to see details.",
-    );
-    expect(heartbeatItem!.priority).toBe(30);
-    expect(heartbeatItem!.urgency).toBeUndefined();
-    expect(heartbeatItem!.source).toBe("assistant");
+    expect(heartbeatItem).toBeUndefined();
   });
 
   test("failed heartbeat emits feed event with priority 55 and urgency medium", async () => {
@@ -218,13 +213,13 @@ describe("heartbeat feed events", () => {
     expect(heartbeatItem!.source).toBe("assistant");
   });
 
-  test("dedupKey uses date for daily dedup", async () => {
+  test("repeated successful heartbeats without alerts stay silent", async () => {
     _testProcessMessage = async () => ({ messageId: "msg-1" });
     const service = new HeartbeatService({
       alerter: () => {},
     });
 
-    // Run twice — same day should dedup to one item.
+    // Run twice — neither should create a generic success item.
     await service.runOnce({ force: true });
     await new Promise((r) => setTimeout(r, 100));
     await service.runOnce({ force: true });
@@ -232,9 +227,6 @@ describe("heartbeat feed events", () => {
 
     const items = readFeedItems();
     const heartbeatItems = items.filter((i) => i.title === "Heartbeat");
-    expect(heartbeatItems).toHaveLength(1);
-
-    const today = new Date().toISOString().split("T")[0];
-    expect(heartbeatItems[0]!.id).toBe(`emit:assistant:heartbeat:ok:${today}`);
+    expect(heartbeatItems).toHaveLength(0);
   });
 });

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -7,8 +7,9 @@ import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { processMessage } from "../daemon/process-message.js";
 import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
-import { getConversation } from "../memory/conversation-crud.js";
+import { getConversation, getMessages } from "../memory/conversation-crud.js";
 import { GENERATING_TITLE } from "../memory/conversation-title-service.js";
+import { extractTextFromStoredMessageContent } from "../memory/message-content.js";
 import {
   GUARDIAN_PERSONA_TEMPLATE,
   resolveGuardianPersona,
@@ -40,6 +41,9 @@ const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still ac
 
 const REENGAGEMENT_COOLDOWN_MS = 18 * 60 * 60 * 1000; // 18 hours
 const HEARTBEAT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const HEARTBEAT_ALERT_MARKER = "HEARTBEAT_ALERT";
+const HEARTBEAT_OK_MARKER = "HEARTBEAT_OK";
+const HEARTBEAT_ALERT_SUMMARY_MAX_CHARS = 700;
 
 // Stripped-comment form of the guardian persona scaffold. Computed
 // once at module load because stripping comment lines is deterministic
@@ -90,6 +94,35 @@ function recordReengagementTimestamp(): void {
   } catch {
     // Best-effort; don't block the heartbeat.
   }
+}
+
+type HeartbeatDisposition = "alert" | "ok" | "unknown";
+
+function parseHeartbeatDisposition(text: string | null): HeartbeatDisposition {
+  if (!text) return "unknown";
+  if (new RegExp(`\\b${HEARTBEAT_ALERT_MARKER}\\b`).test(text)) return "alert";
+  if (new RegExp(`\\b${HEARTBEAT_OK_MARKER}\\b`).test(text)) return "ok";
+  return "unknown";
+}
+
+function stripHeartbeatDispositionMarkers(text: string): string {
+  return text
+    .replace(new RegExp(`\\b${HEARTBEAT_ALERT_MARKER}\\b`, "g"), "")
+    .replace(new RegExp(`\\b${HEARTBEAT_OK_MARKER}\\b`, "g"), "")
+    .trim();
+}
+
+function truncateSummary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function buildHeartbeatAlertSummary(text: string | null): string {
+  const summary = text ? stripHeartbeatDispositionMarkers(text) : "";
+  return truncateSummary(
+    summary || "Your assistant found something worth your attention.",
+    HEARTBEAT_ALERT_SUMMARY_MAX_CHARS,
+  );
 }
 
 export interface HeartbeatDeps {
@@ -579,6 +612,66 @@ export class HeartbeatService {
     }
   }
 
+  private getLatestAssistantMessage(
+    conversationId: string,
+  ): { id: string; text: string } | null {
+    try {
+      const messages = getMessages(conversationId);
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i]!;
+        if (message.role !== "assistant") continue;
+        return {
+          id: message.id,
+          text: extractTextFromStoredMessageContent(message.content),
+        };
+      }
+    } catch (err) {
+      log.warn(
+        { err, conversationId },
+        "Failed to read heartbeat assistant message",
+      );
+    }
+    return null;
+  }
+
+  private async emitHeartbeatAlertNotification(params: {
+    runId: string;
+    conversationId: string;
+    messageId?: string;
+    conversationTitle: string;
+    summary: string;
+  }): Promise<void> {
+    const { emitNotificationSignal } =
+      await import("../notifications/emit-signal.js");
+
+    await emitNotificationSignal({
+      sourceEventName: "heartbeat.alert",
+      sourceChannel: "watcher",
+      sourceContextId: params.runId,
+      dedupeKey: `heartbeat:alert:${params.runId}`,
+      attentionHints: {
+        requiresAction: true,
+        urgency: "medium",
+        isAsyncBackground: true,
+        visibleInSourceNow: false,
+      },
+      contextPayload: {
+        title: "Heartbeat Alert",
+        summary: params.summary,
+        conversationTitle: params.conversationTitle,
+        conversationId: params.conversationId,
+        messageId: params.messageId,
+        sourceInterface: "macos",
+      },
+      routingIntent: "single_channel",
+      conversationAffinityHint: { vellum: params.conversationId },
+      conversationMetadata: {
+        source: "heartbeat",
+        groupId: "system:background",
+      },
+    });
+  }
+
   private async executeRun(runId: string, scheduledFor: number): Promise<void> {
     log.info("Running heartbeat");
 
@@ -608,11 +701,6 @@ export class HeartbeatService {
         systemHint: "Heartbeat",
       });
       conversationId = conversation.id;
-
-      this.deps.onConversationCreated?.({
-        conversationId: conversation.id,
-        title: "Heartbeat",
-      });
 
       await processMessage(conversation.id, prompt, undefined, {
         trustContext: {
@@ -644,20 +732,32 @@ export class HeartbeatService {
           // Best-effort; fall back to generic title.
         }
 
-        const today = new Date().toISOString().split("T")[0];
-        void emitFeedEvent({
-          source: "assistant",
-          title,
-          summary: "Periodic check completed. Tap to see details.",
-          dedupKey: `heartbeat:ok:${today}`,
-          priority: 30,
-        }).catch((err) => {
-          log.warn(
-            { err, conversationId: conversation.id },
-            "Failed to emit heartbeat feed event",
-          );
-        });
+        const assistantMessage = this.getLatestAssistantMessage(
+          conversation.id,
+        );
+        const disposition = parseHeartbeatDisposition(
+          assistantMessage?.text ?? null,
+        );
+        if (disposition === "alert") {
+          this.deps.onConversationCreated?.({
+            conversationId: conversation.id,
+            title,
+          });
+          void this.emitHeartbeatAlertNotification({
+            runId,
+            conversationId: conversation.id,
+            messageId: assistantMessage?.id,
+            conversationTitle: title,
+            summary: buildHeartbeatAlertSummary(assistantMessage?.text ?? null),
+          }).catch((err) => {
+            log.warn(
+              { err, conversationId: conversation.id },
+              "Failed to emit heartbeat alert notification",
+            );
+          });
+        }
 
+        const today = new Date().toISOString().split("T")[0];
         if (latenessMs > LATE_THRESHOLD_MS) {
           const lateMinutes = Math.round(latenessMs / 60_000);
           void emitFeedEvent({
@@ -730,6 +830,9 @@ Do NOT attempt to use tools for these providers — they will fail. Skip any che
     }
 
     prompt += `\n\n<heartbeat-disposition>
+This heartbeat runs frequently. Do not manufacture a report just because it ran.
+If there is nothing genuinely useful, actionable, or interesting to surface, keep the response brief and end with HEARTBEAT_OK.
+If there is something worth interrupting the guardian for, write a concise guardian-facing note first: what happened, why it matters, and the recommended next step. Then end with HEARTBEAT_ALERT. That note may be used as notification copy.
 After completing your review, end your response with one of:
 - HEARTBEAT_OK — if everything looks good, no action needed
 - HEARTBEAT_ALERT — if you found issues that need attention (describe them before this marker)

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -9,7 +9,6 @@ import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation, getMessages } from "../memory/conversation-crud.js";
 import { GENERATING_TITLE } from "../memory/conversation-title-service.js";
-import { extractTextFromStoredMessageContent } from "../memory/message-content.js";
 import {
   GUARDIAN_PERSONA_TEMPLATE,
   resolveGuardianPersona,
@@ -100,15 +99,25 @@ type HeartbeatDisposition = "alert" | "ok" | "unknown";
 
 function parseHeartbeatDisposition(text: string | null): HeartbeatDisposition {
   if (!text) return "unknown";
-  if (new RegExp(`\\b${HEARTBEAT_ALERT_MARKER}\\b`).test(text)) return "alert";
-  if (new RegExp(`\\b${HEARTBEAT_OK_MARKER}\\b`).test(text)) return "ok";
+  const lines = text
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const lastLine = lines.at(-1);
+  if (lastLine === HEARTBEAT_ALERT_MARKER) return "alert";
+  if (lastLine === HEARTBEAT_OK_MARKER) return "ok";
   return "unknown";
 }
 
 function stripHeartbeatDispositionMarkers(text: string): string {
   return text
-    .replace(new RegExp(`\\b${HEARTBEAT_ALERT_MARKER}\\b`, "g"), "")
-    .replace(new RegExp(`\\b${HEARTBEAT_OK_MARKER}\\b`, "g"), "")
+    .replace(
+      new RegExp(
+        `(?:\\r?\\n)?\\s*(?:${HEARTBEAT_ALERT_MARKER}|${HEARTBEAT_OK_MARKER})\\s*$`,
+      ),
+      "",
+    )
     .trim();
 }
 
@@ -123,6 +132,30 @@ function buildHeartbeatAlertSummary(text: string | null): string {
     summary || "Your assistant found something worth your attention.",
     HEARTBEAT_ALERT_SUMMARY_MAX_CHARS,
   );
+}
+
+function extractVisibleTextFromStoredMessageContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === "string") return parsed;
+    if (!Array.isArray(parsed)) return "";
+    const texts: string[] = [];
+    for (const block of parsed) {
+      if (
+        block != null &&
+        typeof block === "object" &&
+        "type" in block &&
+        block.type === "text" &&
+        "text" in block &&
+        typeof block.text === "string"
+      ) {
+        texts.push(block.text);
+      }
+    }
+    return texts.join("\n").trim();
+  } catch {
+    return raw;
+  }
 }
 
 export interface HeartbeatDeps {
@@ -622,7 +655,7 @@ export class HeartbeatService {
         if (message.role !== "assistant") continue;
         return {
           id: message.id,
-          text: extractTextFromStoredMessageContent(message.content),
+          text: extractVisibleTextFromStoredMessageContent(message.content),
         };
       }
     } catch (err) {
@@ -661,7 +694,6 @@ export class HeartbeatService {
         conversationTitle: params.conversationTitle,
         conversationId: params.conversationId,
         messageId: params.messageId,
-        sourceInterface: "macos",
       },
       routingIntent: "single_channel",
       conversationAffinityHint: { vellum: params.conversationId },

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -505,6 +505,19 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     body: str(payload.body, "A watcher event requires your attention"),
   }),
 
+  "heartbeat.alert": (payload) => {
+    const body = str(
+      payload.summary,
+      str(payload.body, "Your assistant found something worth your attention."),
+    );
+    return {
+      title: str(payload.title, "Heartbeat Alert"),
+      body,
+      conversationTitle: str(payload.conversationTitle, "Heartbeat"),
+      conversationSeedMessage: body,
+    };
+  },
+
   "tool_confirmation.required_action": (payload) => ({
     title: "Tool Confirmation",
     body: str(payload.toolName, "A tool") + " requires your confirmation",

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -101,6 +101,10 @@ export const NOTIFICATION_SOURCE_EVENT_NAMES = [
     description:
       "OAuth credential health issue detected (expired, revoked, missing scopes)",
   },
+  {
+    id: "heartbeat.alert",
+    description: "Heartbeat found something worth surfacing to the guardian",
+  },
 ] as const;
 
 export type NotificationSourceEventName =

--- a/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
@@ -90,7 +90,7 @@ describe("setHeartbeatConfig handler", () => {
     // invalidation + getConfig() read picked up the new on-disk state.
     expect(result.success).toBe(true);
     expect(result.enabled).toBe(true);
-    expect(result.intervalMs).toBe(6 * 3_600_000);
+    expect(result.intervalMs).toBe(30 * 60_000);
     expect(result.activeHoursStart).toBe(8);
     expect(result.activeHoursEnd).toBe(22);
   });

--- a/assistant/src/workspace/migrations/065-bump-stale-heartbeat-interval.ts
+++ b/assistant/src/workspace/migrations/065-bump-stale-heartbeat-interval.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+const LEGACY_DEFAULT_INTERVALS_MS = new Set([
+  3 * 60 * 60 * 1000,
+  6 * 60 * 60 * 1000,
+]);
+
+/**
+ * Bump stale baked heartbeat defaults to 30 minutes.
+ *
+ * Older first-launch config files materialized the then-current heartbeat
+ * default into `config.json`, so changing the schema default alone would not
+ * affect existing default users.
+ */
+export const bumpStaleHeartbeatIntervalMigration: WorkspaceMigration = {
+  id: "065-bump-stale-heartbeat-interval",
+  description:
+    "Bump legacy heartbeat.intervalMs defaults of 3h/6h to the current 30-minute default",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const heartbeat = config.heartbeat;
+    if (!heartbeat || typeof heartbeat !== "object" || Array.isArray(heartbeat))
+      return;
+
+    const heartbeatConfig = heartbeat as Record<string, unknown>;
+    const intervalMs = heartbeatConfig.intervalMs;
+    if (
+      typeof intervalMs !== "number" ||
+      !LEGACY_DEFAULT_INTERVALS_MS.has(intervalMs)
+    ) {
+      return;
+    }
+
+    heartbeatConfig.intervalMs = THIRTY_MINUTES_MS;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: the stale value may have been a schema-default artifact,
+    // while 30 minutes may also have been explicitly configured later. Without
+    // per-workspace state we cannot safely distinguish those cases.
+  },
+};

--- a/assistant/src/workspace/migrations/065-bump-stale-heartbeat-interval.ts
+++ b/assistant/src/workspace/migrations/065-bump-stale-heartbeat-interval.ts
@@ -14,7 +14,10 @@ const LEGACY_DEFAULT_INTERVALS_MS = new Set([
  *
  * Older first-launch config files materialized the then-current heartbeat
  * default into `config.json`, so changing the schema default alone would not
- * affect existing default users.
+ * affect existing default users. A workspace could have intentionally selected
+ * one of these exact intervals; product intent is still to move legacy 3h/6h
+ * heartbeat schedules to the 30-minute default, and those users can reset the
+ * interval after upgrade.
  */
 export const bumpStaleHeartbeatIntervalMigration: WorkspaceMigration = {
   id: "065-bump-stale-heartbeat-interval",

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -62,6 +62,7 @@ import { moveBackupKeyToWorkspaceMigration } from "./061-move-backup-key-to-work
 import { dropMemoryV2EdgesJsonMigration } from "./062-drop-memory-v2-edges-json.js";
 import { releaseNotesDynamicModelContextMigration } from "./063-release-notes-dynamic-model-context.js";
 import { unwindMainAgentOpusSeedMigration } from "./064-unwind-main-agent-opus-seed.js";
+import { bumpStaleHeartbeatIntervalMigration } from "./065-bump-stale-heartbeat-interval.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -135,4 +136,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   dropMemoryV2EdgesJsonMigration,
   releaseNotesDynamicModelContextMigration,
   unwindMainAgentOpusSeedMigration,
+  bumpStaleHeartbeatIntervalMigration,
 ];


### PR DESCRIPTION
## Summary

- Change the default heartbeat interval to 30 minutes.
- Add a workspace migration that bumps stale baked 3-hour and 6-hour heartbeat defaults to 30 minutes for existing workspaces.
- Gate heartbeat surfacing on the assistant's `HEARTBEAT_ALERT` / `HEARTBEAT_OK` disposition instead of surfacing every successful heartbeat.
- Emit `heartbeat.alert` notification signals for actionable heartbeat reports and keep OK heartbeats quiet.

## Root Cause

Successful heartbeat runs were always surfaced: the service broadcast the background conversation before the model response was known and emitted a generic success feed item regardless of the `HEARTBEAT_OK` / `HEARTBEAT_ALERT` marker. Also, first-launch configs can materialize old interval defaults into `config.json`, so changing the schema default alone would not update existing default users.

## Validation

- `bunx tsc --noEmit`
- `bun test src/__tests__/heartbeat-service.test.ts`
- `bun test src/heartbeat/__tests__/heartbeat-feed-event.test.ts`
- `bun test src/runtime/routes/__tests__/heartbeat-routes.test.ts`
- `bun test src/__tests__/workspace-migration-065-bump-stale-heartbeat-interval.test.ts`
- Commit hook: formatting, lint, typecheck
- Pre-push hook: lint, typecheck
