### PR TITLE
fix(memory): restore CI by guarding v2 read check and reverting default flag

### DIFF
--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -55,7 +55,7 @@ import type {
 export function isMemoryV2ReadActive(config: AssistantConfig): boolean {
   return (
     isAssistantFeatureFlagEnabled("memory-v2-enabled", config) &&
-    config.memory.v2.enabled
+    config.memory?.v2?.enabled === true
   );
 }
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -247,7 +247,7 @@
       "key": "memory-v2-enabled",
       "label": "Memory v2 (concept-page activation model)",
       "description": "Enables the v2 memory subsystem: prose concept pages with bidirectional edges, activation-based retrieval, and hourly LLM-driven consolidation. v1 graph + PKB stays write-active until cutover.",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "account-deletion",


### PR DESCRIPTION
## Summary
- Make \`isMemoryV2ReadActive\` defensive against test configs missing the \`memory.v2\` block, fixing TypeError crashes in 13 test files.
- Revert the \`memory-v2-enabled\` registry default from \`true\` back to \`false\`. Schema \`memory.v2.enabled\` default stays \`true\` so remote LD activation still works without per-user config changes.

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25351148306/job/74330797767
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->