### PR TITLE
chore(clients): scan tracked files only in check-design-tokens

### DIFF
--- a/clients/scripts/check-design-tokens.sh
+++ b/clients/scripts/check-design-tokens.sh
@@ -22,53 +22,54 @@ if [[ "$MODE" != "ratchet" && "$MODE" != "strict" ]]; then
   exit 1
 fi
 
-# Run grep from CLIENTS_DIR so paths are relative (e.g., macos/foo/bar.swift:42:...)
+# git grep restricts the scan to tracked files (skips .build/, Pods/, and other
+# checkouts). cd into clients/ so output paths are e.g. macos/foo.swift, not
+# clients/macos/foo.swift.
 cd "$CLIENTS_DIR"
 
-# Scope: macOS + shared only (exclude ios/)
-SCOPE="--include=*.swift"
-SCOPE_DIRS="./macos ./shared"
+# Scope: macOS + shared only (exclude ios/). :(glob) enables `**` recursion.
+SCOPE_PATHSPECS=(":(glob)macos/**/*.swift" ":(glob)shared/**/*.swift")
 
 VIOLATIONS=""
 
 # Rule A: Color(hex:) outside token files
-RULE_A=$(grep -rn 'Color(hex:' $SCOPE_DIRS $SCOPE | grep -v 'shared/DesignSystem/Tokens/' | sed 's|^\./||' || true)
+RULE_A=$(git grep -n 'Color(hex:' -- "${SCOPE_PATHSPECS[@]}" | grep -v 'shared/DesignSystem/Tokens/' || true)
 if [[ -n "$RULE_A" ]]; then
   VIOLATIONS="${VIOLATIONS}${RULE_A}"$'\n'
 fi
 
 # Rule B: adaptiveColor( outside token files
-RULE_B=$(grep -rn 'adaptiveColor(' $SCOPE_DIRS $SCOPE | grep -v 'shared/DesignSystem/Tokens/' | sed 's|^\./||' || true)
+RULE_B=$(git grep -n 'adaptiveColor(' -- "${SCOPE_PATHSPECS[@]}" | grep -v 'shared/DesignSystem/Tokens/' || true)
 if [[ -n "$RULE_B" ]]; then
   VIOLATIONS="${VIOLATIONS}${RULE_B}"$'\n'
 fi
 
 # Rule C: Legacy CSS variable names without --v- prefix
-RULE_C=$(grep -rn -E '\-\-(bg|bg-subtle|text|text-secondary|border|accent|accent-text):' $SCOPE_DIRS $SCOPE | sed 's|^\./||' || true)
+RULE_C=$(git grep -n -E '\-\-(bg|bg-subtle|text|text-secondary|border|accent|accent-text):' -- "${SCOPE_PATHSPECS[@]}" || true)
 if [[ -n "$RULE_C" ]]; then
   VIOLATIONS="${VIOLATIONS}${RULE_C}"$'\n'
 fi
 
 # Rule D: Legacy systemDanger* references (renamed to systemNegative*)
-RULE_D=$(grep -rn 'systemDanger' $SCOPE_DIRS $SCOPE | sed 's|^\./||' || true)
+RULE_D=$(git grep -n 'systemDanger' -- "${SCOPE_PATHSPECS[@]}" || true)
 if [[ -n "$RULE_D" ]]; then
   VIOLATIONS="${VIOLATIONS}${RULE_D}"$'\n'
 fi
 
 # Rule E: Raw palette enum usage outside token files
-RULE_E=$(grep -rn -E '\b(Emerald|Danger|Amber|Stone|Slate|Moss|Forest|Sage)\._[0-9]' $SCOPE_DIRS $SCOPE | grep -v 'shared/DesignSystem/Tokens/' | sed 's|^\./||' || true)
+RULE_E=$(git grep -n -E '\b(Emerald|Danger|Amber|Stone|Slate|Moss|Forest|Sage)\._[0-9]' -- "${SCOPE_PATHSPECS[@]}" | grep -v 'shared/DesignSystem/Tokens/' || true)
 if [[ -n "$RULE_E" ]]; then
   VIOLATIONS="${VIOLATIONS}${RULE_E}"$'\n'
 fi
 
 # Rule F: Direct non-semantic color literals outside token files and allowlist
 # Matches: .white, .black, .red, .orange, .yellow, .green, .blue, .gray (but not .clear)
-RULE_F=$(grep -rn -E '\.(white|black|red|orange|yellow|green|blue|gray)\b' $SCOPE_DIRS $SCOPE \
+RULE_F=$(git grep -n -E '\.(white|black|red|orange|yellow|green|blue|gray)\b' -- "${SCOPE_PATHSPECS[@]}" \
   | grep -v 'shared/DesignSystem/Tokens/' \
   | grep -v 'Tests/' \
   | grep -v 'VellumQLThumbnail/' \
   | grep -v '// color-literal-ok' \
-  | sed 's|^\./||' || true)
+  || true)
 if [[ -n "$RULE_F" ]]; then
   VIOLATIONS="${VIOLATIONS}${RULE_F}"$'\n'
 fi


### PR DESCRIPTION
## Summary
- Migrate the design-token guardrail (`clients/scripts/check-design-tokens.sh`) from `grep -r` to `git grep`, restricting the scan to files tracked in git.
- Drops the need to walk third-party SwiftPM checkouts under `.build/`, `Pods/`, and any other untracked source under `clients/macos` and `clients/shared`.
- Replaces `--include` + dir args with `:(glob)` pathspecs so `**` recursion works with `git grep`.
- Tightens the comment block — the `cd "$CLIENTS_DIR"` is now only about output-path shaping (drop the `clients/` prefix), since `git grep` itself does the tracked-files filtering.

## Test plan
- [x] `bash clients/scripts/check-design-tokens.sh --mode=strict` exits 0 with `No design token violations found.`
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->