### PR TITLE
feat(oauth): wire Asana for platform-managed mode

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -73,6 +73,7 @@ function getDeploymentContextDefaults(): Record<string, unknown> {
       "linear-oauth": managed,
       "github-oauth": managed,
       "notion-oauth": managed,
+      "asana-oauth": managed,
     },
   };
 }

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -72,6 +72,10 @@ const TwitterOAuthServiceSchema = BaseServiceSchema.extend({
   mode: ServiceModeSchema.default("your-own"),
 });
 
+const AsanaOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+
 /**
  * `services.meet.host.*` — daemon-side knobs for the externalized meet-join
  * skill process. Kept narrow: only the values the daemon reads before the
@@ -139,6 +143,9 @@ export const ServicesSchema = z.object({
   ),
   "twitter-oauth": TwitterOAuthServiceSchema.default(
     TwitterOAuthServiceSchema.parse({}),
+  ),
+  "asana-oauth": AsanaOAuthServiceSchema.default(
+    AsanaOAuthServiceSchema.parse({}),
   ),
   meet: MeetDaemonServiceSchema.default(MeetDaemonServiceSchema.parse({})),
 });

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -497,6 +497,7 @@ export const PROVIDER_SEED_DATA: Record<
     defaultScopes: ["default"],
     availableScopes: "https://developers.asana.com/docs/oauth-scopes",
     loopbackPort: 17328,
+    managedServiceConfigKey: "asana-oauth",
     injectionTemplates: [
       {
         hostPattern: "app.asana.com",


### PR DESCRIPTION
## Summary
- Adds `managedServiceConfigKey: "asana-oauth"` to the existing `asana` seed entry in `seed-providers.ts`.
- Adds the matching `AsanaOAuthServiceSchema` and `"asana-oauth"` key to `ServicesSchema` so `connection-resolver.ts` can route managed/BYO based on config.
- Adds `"asana-oauth": managed` to `getDeploymentContextDefaults()` in `loader.ts` so platform-hosted assistants (`IS_PLATFORM=true`) default Asana to managed mode at first launch — same pattern used for Google/Outlook/Linear/GitHub/Notion.

## Cross-repo dependency
This is the sibling change to the platform-side provider registry addition:
- vellum-ai/vellum-assistant-platform#5790 — provider_registry.json + helm + generated OpenAPI
- vellum-ai/vellum-assistant-platform#5789 — Terraform for the new GCP secret

Both must land (in that merge order: terraform → platform app code → this PR) for managed mode to be visible end-to-end. This PR alone is harmless: until the platform side ships, asana stays in BYO mode (`connection-resolver.ts` falls back to BYO if it can't find a matching managed catalog entry).

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/oauth/__tests__/seed-providers-managed.test.ts` — cross-repo invariant passes (every `managedServiceConfigKey` resolves to a `ServicesSchema` key)
- [x] `bun test src/oauth/connection-resolver.test.ts src/cli/commands/oauth/__tests__/mode.test.ts` — passes
- [ ] Post-deploy: a fresh platform-hosted assistant has `services.asana-oauth.mode === "managed"` in its initial config
- [ ] Post-deploy: existing assistants are unaffected (deployment defaults only apply on fresh config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->