### PR TITLE
fix(calls): Distinguish CES-unreachable from missing Twilio credentials

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -11,6 +11,10 @@ const platformConnectedProviders = new Set<string>();
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (account: string) => secureKeyValues.get(account),
+  getSecureKeyResultAsync: async (account: string) => ({
+    value: secureKeyValues.get(account) ?? undefined,
+    unreachable: false,
+  }),
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mockSecureKeys: Record<string, string | null> = {};
 let mockLoadConfigResult: Record<string, unknown> = {};
+let mockCredentialStoreUnreachable = false;
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -14,6 +15,10 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
+  getSecureKeyResultAsync: async (key: string) => ({
+    value: mockSecureKeys[key] ?? undefined,
+    unreachable: mockCredentialStoreUnreachable,
+  }),
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -34,6 +39,7 @@ describe("twilio-config", () => {
         phoneNumber: "+15550123",
       },
     };
+    mockCredentialStoreUnreachable = false;
   });
 
   test("returns config when credentials and phone number are set", async () => {
@@ -83,6 +89,23 @@ describe("twilio-config", () => {
     mockLoadConfigResult = {};
     expect(getTwilioConfig()).rejects.toThrow(
       /Twilio Account SID not configured/,
+    );
+  });
+
+  test("throws credential-store-unreachable error when auth token lookup fails due to CES", async () => {
+    mockSecureKeys = {};
+    mockCredentialStoreUnreachable = true;
+    expect(getTwilioConfig()).rejects.toThrow(
+      /credential store is unreachable/,
+    );
+  });
+
+  test("throws credential-store-unreachable error when both missing and CES is down", async () => {
+    mockLoadConfigResult = {};
+    mockSecureKeys = {};
+    mockCredentialStoreUnreachable = true;
+    expect(getTwilioConfig()).rejects.toThrow(
+      /credential store is unreachable/,
     );
   });
 });

--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -48,14 +48,14 @@ describe("twilio-config", () => {
       twilio: { accountSid: "", phoneNumber: "+15550123" },
     };
     expect(getTwilioConfig()).rejects.toThrow(
-      /Twilio credentials not configured/,
+      /Twilio Account SID not configured/,
     );
   });
 
   test("throws ConfigError when auth token is missing", async () => {
     mockSecureKeys = {};
     expect(getTwilioConfig()).rejects.toThrow(
-      /Twilio credentials not configured/,
+      /Twilio Auth Token not configured/,
     );
   });
 
@@ -71,10 +71,18 @@ describe("twilio-config", () => {
     );
   });
 
-  test("throws ConfigError when twilio config section is absent", async () => {
+  test("throws ConfigError when twilio config section is absent and no auth token", async () => {
     mockLoadConfigResult = {};
+    mockSecureKeys = {};
     expect(getTwilioConfig()).rejects.toThrow(
       /Twilio credentials not configured/,
+    );
+  });
+
+  test("throws ConfigError for missing SID when twilio config section is absent but auth token exists", async () => {
+    mockLoadConfigResult = {};
+    expect(getTwilioConfig()).rejects.toThrow(
+      /Twilio Account SID not configured/,
     );
   });
 });

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -30,6 +30,13 @@ mock.module("../security/secure-keys.js", () => ({
     if (key === credentialKey("twilio", "account_sid")) return mockAccountSid;
     return undefined;
   },
+  getSecureKeyResultAsync: async (key: string) => {
+    let value: string | undefined;
+    if (key === credentialKey("twilio", "auth_token")) value = mockAuthToken;
+    else if (key === credentialKey("twilio", "account_sid"))
+      value = mockAccountSid;
+    return { value, unreachable: false };
+  },
 }));
 
 import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -38,9 +38,19 @@ export async function getTwilioConfig(): Promise<TwilioConfig> {
     (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) || "";
   const phoneNumber = resolveTwilioPhoneNumber();
 
-  if (!accountSid || !authToken) {
+  if (!accountSid && !authToken) {
     throw new ConfigError(
       "Twilio credentials not configured. Set twilio.accountSid via config and store auth token via credential store.",
+    );
+  }
+  if (!accountSid) {
+    throw new ConfigError(
+      "Twilio Account SID not configured. Set twilio.accountSid via config.",
+    );
+  }
+  if (!authToken) {
+    throw new ConfigError(
+      "Twilio Auth Token not configured. Store auth token via credential store.",
     );
   }
   if (!phoneNumber) {

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "../config/loader.js";
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getSecureKeyResultAsync } from "../security/secure-keys.js";
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 
@@ -34,11 +34,18 @@ export function resolveTwilioPhoneNumber(): string {
 
 export async function getTwilioConfig(): Promise<TwilioConfig> {
   const accountSid = loadConfig().twilio?.accountSid || "";
-  const authToken =
-    (await getSecureKeyAsync(credentialKey("twilio", "auth_token"))) || "";
+  const authTokenResult = await getSecureKeyResultAsync(
+    credentialKey("twilio", "auth_token"),
+  );
+  const authToken = authTokenResult.value || "";
   const phoneNumber = resolveTwilioPhoneNumber();
 
   if (!accountSid && !authToken) {
+    if (authTokenResult.unreachable) {
+      throw new ConfigError(
+        "Twilio credentials could not be loaded. Account SID is not configured and the credential store is unreachable (auth token cannot be verified).",
+      );
+    }
     throw new ConfigError(
       "Twilio credentials not configured. Set twilio.accountSid via config and store auth token via credential store.",
     );
@@ -49,6 +56,11 @@ export async function getTwilioConfig(): Promise<TwilioConfig> {
     );
   }
   if (!authToken) {
+    if (authTokenResult.unreachable) {
+      throw new ConfigError(
+        "Twilio Auth Token could not be loaded: credential store is unreachable. The token may be stored but cannot be retrieved right now.",
+      );
+    }
     throw new ConfigError(
       "Twilio Auth Token not configured. Store auth token via credential store.",
     );

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -48,9 +48,19 @@ async function resolveAuthToken(): Promise<string | undefined> {
 export async function getTwilioCredentials(): Promise<TwilioCredentials> {
   const accountSid = resolveAccountSid();
   const authToken = await resolveAuthToken();
-  if (!accountSid || !authToken) {
+  if (!accountSid && !authToken) {
     throw new ConfigError(
       "Twilio credentials not configured. Set twilio.accountSid via config and store auth token via credential store.",
+    );
+  }
+  if (!accountSid) {
+    throw new ConfigError(
+      "Twilio Account SID not configured. Set twilio.accountSid via config.",
+    );
+  }
+  if (!authToken) {
+    throw new ConfigError(
+      "Twilio Auth Token not configured. Store auth token via credential store.",
     );
   }
   return { accountSid, authToken };

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -17,7 +17,10 @@ import {
 
 import { loadConfig } from "../config/loader.js";
 import { credentialKey } from "../security/credential-key.js";
-import { getSecureKeyAsync } from "../security/secure-keys.js";
+import {
+  getSecureKeyAsync,
+  getSecureKeyResultAsync,
+} from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 
 export interface TwilioCredentials {
@@ -47,8 +50,16 @@ async function resolveAuthToken(): Promise<string | undefined> {
 /** Resolve Twilio credentials from config (SID) and credential store (token). Throws if not configured. */
 export async function getTwilioCredentials(): Promise<TwilioCredentials> {
   const accountSid = resolveAccountSid();
-  const authToken = await resolveAuthToken();
+  const authTokenResult = await getSecureKeyResultAsync(
+    credentialKey("twilio", "auth_token"),
+  );
+  const authToken = authTokenResult.value || undefined;
   if (!accountSid && !authToken) {
+    if (authTokenResult.unreachable) {
+      throw new ConfigError(
+        "Twilio credentials could not be loaded. Account SID is not configured and the credential store is unreachable (auth token cannot be verified).",
+      );
+    }
     throw new ConfigError(
       "Twilio credentials not configured. Set twilio.accountSid via config and store auth token via credential store.",
     );
@@ -59,6 +70,11 @@ export async function getTwilioCredentials(): Promise<TwilioCredentials> {
     );
   }
   if (!authToken) {
+    if (authTokenResult.unreachable) {
+      throw new ConfigError(
+        "Twilio Auth Token could not be loaded: credential store is unreachable. The token may be stored but cannot be retrieved right now.",
+      );
+    }
     throw new ConfigError(
       "Twilio Auth Token not configured. Store auth token via credential store.",
     );


### PR DESCRIPTION
When the credential store (CES) is unreachable at call time, `getSecureKeyAsync` returns `undefined` — identical to "credential not stored." This causes a misleading "Twilio credentials not configured" error even when credentials were previously stored successfully. Users see a setup instruction when the real problem is a transient CES connectivity issue.

This switches both `getTwilioConfig()` and `getTwilioCredentials()` to use `getSecureKeyResultAsync`, which exposes the `unreachable` flag from the credential backend. The error messages now distinguish three states: both missing, individual credential missing (SID vs auth token), and credential store unreachable. This is safe because `getSecureKeyResultAsync` is the underlying function that `getSecureKeyAsync` already delegates to — we're just reading the full result instead of discarding the `unreachable` field.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/8937e208cdf84c3e9a4dd3dc7cebe387
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->