### PR TITLE
feat(oauth): wire Todoist/Dropbox/Discord/Airtable/HubSpot for platform-managed mode

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -74,6 +74,11 @@ function getDeploymentContextDefaults(): Record<string, unknown> {
       "github-oauth": managed,
       "notion-oauth": managed,
       "asana-oauth": managed,
+      "todoist-oauth": managed,
+      "dropbox-oauth": managed,
+      "discord-oauth": managed,
+      "airtable-oauth": managed,
+      "hubspot-oauth": managed,
     },
   };
 }

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -76,6 +76,26 @@ const AsanaOAuthServiceSchema = BaseServiceSchema.extend({
   mode: ServiceModeSchema.default("your-own"),
 });
 
+const TodoistOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+
+const DropboxOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+
+const DiscordOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+
+const AirtableOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+
+const HubspotOAuthServiceSchema = BaseServiceSchema.extend({
+  mode: ServiceModeSchema.default("your-own"),
+});
+
 /**
  * `services.meet.host.*` — daemon-side knobs for the externalized meet-join
  * skill process. Kept narrow: only the values the daemon reads before the
@@ -146,6 +166,21 @@ export const ServicesSchema = z.object({
   ),
   "asana-oauth": AsanaOAuthServiceSchema.default(
     AsanaOAuthServiceSchema.parse({}),
+  ),
+  "todoist-oauth": TodoistOAuthServiceSchema.default(
+    TodoistOAuthServiceSchema.parse({}),
+  ),
+  "dropbox-oauth": DropboxOAuthServiceSchema.default(
+    DropboxOAuthServiceSchema.parse({}),
+  ),
+  "discord-oauth": DiscordOAuthServiceSchema.default(
+    DiscordOAuthServiceSchema.parse({}),
+  ),
+  "airtable-oauth": AirtableOAuthServiceSchema.default(
+    AirtableOAuthServiceSchema.parse({}),
+  ),
+  "hubspot-oauth": HubspotOAuthServiceSchema.default(
+    HubspotOAuthServiceSchema.parse({}),
   ),
   meet: MeetDaemonServiceSchema.default(MeetDaemonServiceSchema.parse({})),
 });

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -393,6 +393,7 @@ export const PROVIDER_SEED_DATA: Record<
       { scope: "project:delete", description: "Delete entire projects" },
     ],
     loopbackPort: 17325,
+    managedServiceConfigKey: "todoist-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.todoist.com",
@@ -429,6 +430,7 @@ export const PROVIDER_SEED_DATA: Record<
     availableScopes:
       "https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes",
     loopbackPort: 17326,
+    managedServiceConfigKey: "discord-oauth",
     injectionTemplates: [
       {
         hostPattern: "discord.com",
@@ -463,6 +465,7 @@ export const PROVIDER_SEED_DATA: Record<
     availableScopes: "https://developers.dropbox.com/oauth-guide",
     authorizeParams: { token_access_type: "offline" },
     loopbackPort: 17327,
+    managedServiceConfigKey: "dropbox-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.dropboxapi.com",
@@ -530,6 +533,7 @@ export const PROVIDER_SEED_DATA: Record<
     availableScopes: "https://airtable.com/developers/web/api/scopes",
     tokenEndpointAuthMethod: "client_secret_basic",
     loopbackPort: 17329,
+    managedServiceConfigKey: "airtable-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.airtable.com",
@@ -564,6 +568,7 @@ export const PROVIDER_SEED_DATA: Record<
     availableScopes:
       "https://developers.hubspot.com/docs/guides/apps/authentication/scopes",
     loopbackPort: 17330,
+    managedServiceConfigKey: "hubspot-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.hubapi.com",


### PR DESCRIPTION
## Summary
- Adds \`managedServiceConfigKey\` to the existing seed entries for **Todoist** (\`todoist-oauth\`), **Dropbox** (\`dropbox-oauth\`), **Discord** (\`discord-oauth\`), **Airtable** (\`airtable-oauth\`), and **HubSpot** (\`hubspot-oauth\`).
- Adds matching \`*OAuthServiceSchema\` declarations and \`*-oauth\` keys to \`ServicesSchema\` so \`connection-resolver.ts\` can route managed/BYO based on config.
- Adds five new entries to \`getDeploymentContextDefaults()\` in \`loader.ts\` so platform-hosted assistants (\`IS_PLATFORM=true\`) default each new provider to managed mode at first launch — same pattern as Google/Outlook/Linear/GitHub/Notion/Asana.

## Cross-repo dependency
Companion changes in \`vellum-assistant-platform\`:
- vellum-ai/vellum-assistant-platform#5798 — Terraform: 5 new GCP secrets (+ Asana staging backfill)
- vellum-ai/vellum-assistant-platform#5799 — provider_registry.json + helm + identity verifier extension + AGENTS.md doc fix

Merge order: terraform → platform app code → this PR. This PR alone is harmless: until the platform side ships, each provider stays in BYO mode (\`connection-resolver.ts\` falls back when it can't find a matching managed catalog entry).

## Test plan
- [x] \`bunx tsc --noEmit\` — clean
- [x] \`bun test src/oauth/__tests__/seed-providers-managed.test.ts\` — cross-repo invariant passes
- [x] \`bun test src/oauth/connection-resolver.test.ts src/cli/commands/oauth/__tests__/mode.test.ts\` — passes
- [ ] Post-deploy: a fresh platform-hosted assistant has \`services.{todoist,dropbox,discord,airtable,hubspot}-oauth.mode === \"managed\"\` in its initial config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->