### PR TITLE
chore(trace-events): lower TTL from 7 to 3 days

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1198,15 +1198,15 @@ export async function runDaemon(): Promise<void> {
       }
     }
 
-    // Prune trace events older than 7 days to keep the database lean.
+    // Prune trace events older than 3 days to keep the database lean.
     // Deferred so synchronous cleanup doesn't block the startup path.
     setTimeout(() => {
       try {
-        const deletedTraceEvents = deleteOldTraceEvents(7);
+        const deletedTraceEvents = deleteOldTraceEvents(3);
         if (deletedTraceEvents > 0) {
           log.debug(
             { deletedTraceEvents },
-            `Pruned ${deletedTraceEvents} trace event(s) older than 7 days`,
+            `Pruned ${deletedTraceEvents} trace event(s) older than 3 days`,
           );
         }
       } catch (err) {


### PR DESCRIPTION
This is a stop-gap since pruning only runs at startup. We'll set up a cron to prune this periodically similar to LLM logs.

## Summary
- Lowers the trace events retention from 7 days to 3 days in the daemon startup cleanup path (`assistant/src/daemon/lifecycle.ts`).
- Trace events accumulate quickly; 3 days covers the recent debugging window while keeping the local SQLite database lean.

## Notes
- Cleanup currently runs once per daemon start via the existing `deleteOldTraceEvents` helper. A follow-up will wire this into the same scheduled jobs mechanism that prunes `llm_request_logs`, so trace pruning runs on the periodic cadence rather than only at startup.

## Test plan
- [ ] Daemon starts cleanly and trace cleanup log line shows the new 3-day phrasing.
- [ ] Existing trace event functionality (recording / reading recent events) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->