### PR TITLE
Refresh config cache after external writes

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -327,6 +327,21 @@ describe("loadConfig startup behavior", () => {
     expect(config.memory.v2.bm25_b).toBe(0.4);
   });
 
+  test("reloads cached config when config.json is updated externally", () => {
+    // Models a CLI subprocess writing twilio.accountSid while the assistant
+    // process already has an effective config cached in memory.
+    writeConfig({ twilio: { accountSid: "AC_cached_before" } });
+    expect(loadConfig().twilio.accountSid).toBe("AC_cached_before");
+
+    writeConfig({
+      twilio: { accountSid: "AC_fresh_after_external_write" },
+    });
+
+    expect(loadConfig().twilio.accountSid).toBe(
+      "AC_fresh_after_external_write",
+    );
+  });
+
   test("still strips deprecated fields and rewrites", () => {
     // `warnAndStripDeprecatedFields` is a legitimate self-healing path:
     // it removes fields the schema no longer recognizes and persists the

--- a/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
+++ b/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
@@ -128,11 +128,9 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (v: string) => v,
 }));
 
-// Simulate a config-cache layer: `diskConfig` is the on-disk value,
-// `cachedConfig` is what getConfig() returns until invalidateConfigCache()
-// is called. This matches the production behavior where getConfig() returns
-// a memoized value that only refreshes after explicit invalidation. Tests
-// mutate `diskConfig` to simulate a user writing a new config.json.
+// Simulate a config-cache layer: `diskConfig` is the on-disk value and
+// `cachedConfig` is the in-memory value returned by getConfig() when present.
+// Tests mutate `diskConfig` to simulate a user writing a new config.json.
 interface TestConfig {
   memory: {
     enabled: boolean;
@@ -246,6 +244,20 @@ describe("ConfigWatcher.refreshConfigFromSources cleanup throttle reset", () => 
     diskConfig = makeConfig({
       llmRequestLogRetentionMs: 7 * 24 * 60 * 60 * 1000,
     });
+
+    const changed = await watcher.refreshConfigFromSources();
+    expect(changed).toBe(true);
+    expect(resetCleanupScheduleThrottleCalls).toBe(1);
+  });
+
+  test("resets throttle when the loader cache has already observed the disk change", async () => {
+    const watcher = new ConfigWatcher();
+    watcher.initFingerprint(diskConfig as never);
+
+    diskConfig = makeConfig({
+      llmRequestLogRetentionMs: 7 * 24 * 60 * 60 * 1000,
+    });
+    cachedConfig = null;
 
     const changed = await watcher.refreshConfigFromSources();
     expect(changed).toBe(true);

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -7,6 +7,7 @@ import {
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
+import { safeStatSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";
 import {
   ensureDataDir,
@@ -22,7 +23,21 @@ export { API_KEY_PROVIDERS } from "../providers/provider-secret-catalog.js";
 const log = getLogger("config");
 
 let cached: AssistantConfig | null = null;
+let cachedFileSignature: ConfigFileSignature | null = null;
 let loading = false;
+
+type ConfigFileSignature =
+  | {
+      path: string;
+      exists: true;
+      size: number;
+      mtimeMs: number;
+      ctimeMs: number;
+    }
+  | {
+      path: string;
+      exists: false;
+    };
 
 function getConfigPath(): string {
   return getWorkspaceConfigPath();
@@ -30,6 +45,48 @@ function getConfigPath(): string {
 
 function ensureMigratedDataDir(): void {
   ensureDataDir();
+}
+
+function readConfigFileSignature(configPath: string): ConfigFileSignature {
+  const stats = safeStatSync(configPath);
+  if (!stats) {
+    return {
+      path: configPath,
+      exists: false,
+    };
+  }
+
+  return {
+    path: configPath,
+    exists: true,
+    size: stats.size,
+    mtimeMs: stats.mtimeMs,
+    ctimeMs: stats.ctimeMs,
+  };
+}
+
+function configFileSignaturesEqual(
+  a: ConfigFileSignature,
+  b: ConfigFileSignature,
+): boolean {
+  if (a.path !== b.path || a.exists !== b.exists) return false;
+  if (!a.exists || !b.exists) return true;
+  return (
+    a.size === b.size && a.mtimeMs === b.mtimeMs && a.ctimeMs === b.ctimeMs
+  );
+}
+
+function getCachedConfigIfFresh(): AssistantConfig | null {
+  if (!cached || !cachedFileSignature) return null;
+
+  const currentSignature = readConfigFileSignature(getConfigPath());
+  if (configFileSignaturesEqual(cachedFileSignature, currentSignature)) {
+    return cached;
+  }
+
+  cached = null;
+  cachedFileSignature = null;
+  return null;
 }
 
 /**
@@ -462,6 +519,7 @@ export function mergeDefaultWorkspaceConfig(): void {
     mkdirSync(dir, { recursive: true });
   }
   writeFileSync(configPath, JSON.stringify(existing, null, 2) + "\n");
+  invalidateConfigCache();
 
   // Move the temp file into the workspace directory as a permanent record.
   // This prevents re-application on daemon restart (the env var still points
@@ -480,7 +538,8 @@ export function mergeDefaultWorkspaceConfig(): void {
 }
 
 export function loadConfig(): AssistantConfig {
-  if (cached) return cached;
+  const freshCached = getCachedConfigIfFresh();
+  if (freshCached) return freshCached;
 
   // Re-entrancy guard: log calls during loading (e.g. file-mode warning)
   // can trigger loadConfig again. Return defaults to break the cycle
@@ -599,12 +658,14 @@ export function loadConfig(): AssistantConfig {
     }
 
     cached = config;
+    cachedFileSignature = readConfigFileSignature(configPath);
 
     loading = false;
     return config;
   } catch (err) {
     // Loading failed — clear cached so the next call retries
     cached = null;
+    cachedFileSignature = null;
     loading = false;
     throw err;
   }
@@ -638,7 +699,8 @@ export function getConfig(): AssistantConfig {
  * workspace-existence check runs.
  */
 export function getConfigReadOnly(): AssistantConfig {
-  if (cached) return cached;
+  const freshCached = getCachedConfigIfFresh();
+  if (freshCached) return freshCached;
 
   const configPath = getConfigPath();
   let fileConfig: Record<string, unknown> = {};
@@ -655,6 +717,7 @@ export function getConfigReadOnly(): AssistantConfig {
 
 export function invalidateConfigCache(): void {
   cached = null;
+  cachedFileSignature = null;
   loading = false;
 }
 
@@ -692,6 +755,7 @@ export function saveRawConfig(config: Record<string, unknown>): void {
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 
   cached = null; // invalidate cache
+  cachedFileSignature = null;
 }
 
 export function getNestedValue(

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -56,6 +56,7 @@ export class ConfigWatcher {
   });
   private suppressReload = false;
   lastFingerprint = "";
+  private lastConfig: ReturnType<typeof getConfig> | null = null;
   private lastRefreshTime = 0;
 
   static readonly REFRESH_INTERVAL_MS = 30_000;
@@ -88,12 +89,15 @@ export class ConfigWatcher {
 
   /** Initialize the config fingerprint (call after first config load). */
   initFingerprint(config: ReturnType<typeof getConfig>): void {
+    this.lastConfig = config;
     this.lastFingerprint = this.configFingerprint(config);
   }
 
   /** Update the fingerprint to match the current config. */
   updateFingerprint(): void {
-    this.lastFingerprint = this.configFingerprint(getConfig());
+    const config = getConfig();
+    this.lastConfig = config;
+    this.lastFingerprint = this.configFingerprint(config);
     this.lastRefreshTime = Date.now();
   }
 
@@ -103,7 +107,7 @@ export class ConfigWatcher {
    * Returns true if config actually changed.
    */
   async refreshConfigFromSources(): Promise<boolean> {
-    const prevCleanup = safeGetCleanupConfig();
+    const prevCleanup = this.lastConfig?.memory?.cleanup;
     invalidateConfigCache();
     const config = getConfig();
     const fingerprint = this.configFingerprint(config);
@@ -120,6 +124,7 @@ export class ConfigWatcher {
     }
     const isFirstInit = this.lastFingerprint === "";
     await initializeProviders(config);
+    this.lastConfig = config;
     this.lastFingerprint = fingerprint;
     return !isFirstInit;
   }
@@ -142,13 +147,12 @@ export class ConfigWatcher {
       "config.json": async () => {
         if (this.suppressReload) return;
         try {
-          const prevConfig = getConfig();
-          const prevMcpFingerprint = JSON.stringify(prevConfig.mcp ?? {});
+          const prevMcpFingerprint = JSON.stringify(this.lastConfig?.mcp ?? {});
           const changed = await this.refreshConfigFromSources();
           if (changed) {
             onConversationEvict();
             onConfigChanged?.();
-            const newConfig = getConfig();
+            const newConfig = this.lastConfig ?? getConfig();
             const newMcpFingerprint = JSON.stringify(newConfig.mcp ?? {});
             if (newMcpFingerprint !== prevMcpFingerprint) {
               reloadMcpServers().catch((err: unknown) => {
@@ -483,20 +487,6 @@ export class ConfigWatcher {
       { dir: skillsDir },
       "Watching skills directory with non-recursive fallback",
     );
-  }
-}
-
-/**
- * Snapshot the current cleanup config so we can compare it against the
- * post-reload value. Tolerant of config-load failures — if the config can't
- * be read (e.g. first-load), returns undefined so the comparison below
- * treats it as "no previous value".
- */
-function safeGetCleanupConfig(): MemoryCleanupConfig | undefined {
-  try {
-    return getConfig().memory?.cleanup;
-  } catch {
-    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary
- Refresh the assistant config cache when config.json changes on disk, so subprocess CLI writes are visible immediately.
- Add regression coverage for externally updating twilio.accountSid after config was cached.

## Original prompt
The assistant itself says this when I had an issue loading assistant credentials while trying to use twilio yo

The bug was the daemon's in-memory config cache. loadConfig() had cached a version from before twilio.accountSid was written, so getTwilioConfig() was getting an empty accountSid. The CLI writes to disk, but the daemon's cache never got the fresh value. Bypassing the cache by patching config through the daemon's own HTTP API forced a proper cache invalidation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->