### PR TITLE
feat(trace-events): wire pruning into scheduled memory cleanup jobs

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -358,6 +358,7 @@ describe("AssistantConfigSchema", () => {
       supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
       conversationRetentionDays: 0,
       llmRequestLogRetentionMs: 1 * 60 * 60 * 1000,
+      traceEventRetentionDays: 3,
     });
   });
 

--- a/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
+++ b/assistant/src/__tests__/config-watcher-cleanup-throttle.test.ts
@@ -37,6 +37,7 @@ describe("cleanupSettingsChanged", () => {
     supersededItemRetentionMs: 30 * 24 * 60 * 60 * 1000,
     conversationRetentionDays: 0,
     llmRequestLogRetentionMs: 1 * 24 * 60 * 60 * 1000,
+    traceEventRetentionDays: 3,
   };
 
   test("returns false when either side is undefined", () => {

--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -149,6 +149,19 @@ export const MemoryCleanupConfigSchema = z
       .describe(
         "Retention period for LLM request/response logs in milliseconds (null keeps forever, 0 prunes immediately)",
       ),
+    traceEventRetentionDays: z
+      .number({
+        error: "memory.cleanup.traceEventRetentionDays must be a number",
+      })
+      .int("memory.cleanup.traceEventRetentionDays must be an integer")
+      .nonnegative(
+        "memory.cleanup.traceEventRetentionDays must be non-negative",
+      )
+      .max(365, "memory.cleanup.traceEventRetentionDays must be <= 365 days")
+      .default(3)
+      .describe(
+        "Number of days to retain trace events before cleanup (0 disables pruning)",
+      ),
   })
   .describe("Automatic memory cleanup and garbage collection settings");
 

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -530,6 +530,7 @@ export function cleanupSettingsChanged(
   return (
     prev.llmRequestLogRetentionMs !== next.llmRequestLogRetentionMs ||
     prev.conversationRetentionDays !== next.conversationRetentionDays ||
+    prev.traceEventRetentionDays !== next.traceEventRetentionDays ||
     prev.enabled !== next.enabled
   );
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -54,7 +54,6 @@ import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient, resolveQdrantUrl } from "../memory/qdrant-client.js";
 import { QdrantManager } from "../memory/qdrant-manager.js";
 import { rotateToolInvocations } from "../memory/tool-usage-store.js";
-import { deleteOldTraceEvents } from "../memory/trace-event-store.js";
 import {
   emitNotificationSignal,
   registerBroadcastFn,
@@ -1197,22 +1196,6 @@ export async function runDaemon(): Promise<void> {
         log.warn({ err }, "Audit log rotation failed");
       }
     }
-
-    // Prune trace events older than 7 days to keep the database lean.
-    // Deferred so synchronous cleanup doesn't block the startup path.
-    setTimeout(() => {
-      try {
-        const deletedTraceEvents = deleteOldTraceEvents(7);
-        if (deletedTraceEvents > 0) {
-          log.debug(
-            { deletedTraceEvents },
-            `Pruned ${deletedTraceEvents} trace event(s) older than 7 days`,
-          );
-        }
-      } catch (err) {
-        log.warn({ err }, "Trace event cleanup failed");
-      }
-    }, 0);
 
     const workspaceHeartbeat = new WorkspaceHeartbeatService();
     workspaceHeartbeat.start();

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -55,6 +55,49 @@ export function pruneOldLlmRequestLogsJob(
 }
 
 /**
+ * Delete trace events older than the configured retention period.
+ * Processes in batches to avoid long DB locks and excessive WAL growth.
+ * Re-enqueues itself if more rows remain.
+ */
+export function pruneOldTraceEventsJob(
+  job: MemoryJob,
+  config: AssistantConfig,
+): void {
+  const rawRetention = job.payload.retentionDays;
+  const retentionDays =
+    typeof rawRetention === "number" &&
+    Number.isFinite(rawRetention) &&
+    rawRetention >= 0
+      ? rawRetention
+      : config.memory.cleanup.traceEventRetentionDays;
+
+  // 0 means disabled
+  if (retentionDays === 0) return;
+
+  const cutoffMs = Date.now() - retentionDays * 86_400_000;
+
+  rawRun(
+    `DELETE FROM trace_events WHERE rowid IN (SELECT rowid FROM trace_events WHERE created_at < ? LIMIT ?)`,
+    cutoffMs,
+    PRUNE_LOG_BATCH_LIMIT,
+  );
+  const deleted = rawChanges();
+
+  if (deleted >= PRUNE_LOG_BATCH_LIMIT) {
+    enqueueMemoryJob("prune_old_trace_events", { retentionDays });
+  }
+
+  log.info(
+    {
+      deleted,
+      retentionDays,
+      cutoffMs,
+    },
+    "Pruned old trace events",
+  );
+}
+
+/**
  * Delete conversations that have had no activity (updatedAt) for longer than
  * the configured retention period. Processes in batches so a single job doesn't
  * hold the DB lock for too long.

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -18,6 +18,7 @@ export type MemoryJobType =
   | "embed_summary"
   | "prune_old_conversations"
   | "prune_old_llm_request_logs"
+  | "prune_old_trace_events"
   | "build_conversation_summary"
   | "conversation_analyze"
   | "backfill"
@@ -364,6 +365,53 @@ export function enqueuePruneOldConversationsJob(
       ? { retentionDays }
       : {};
   return enqueueMemoryJob("prune_old_conversations", payload);
+}
+
+export function enqueuePruneOldTraceEventsJob(retentionDays?: number): string {
+  const db = getDb();
+  const existing = db
+    .select()
+    .from(memoryJobs)
+    .where(
+      and(
+        eq(memoryJobs.type, "prune_old_trace_events"),
+        inArray(memoryJobs.status, ["pending", "running"]),
+      ),
+    )
+    .orderBy(asc(memoryJobs.createdAt))
+    .get();
+  if (existing) {
+    if (
+      existing.status === "pending" &&
+      typeof retentionDays === "number" &&
+      Number.isFinite(retentionDays) &&
+      retentionDays >= 0
+    ) {
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = JSON.parse(existing.payload) as Record<string, unknown>;
+      } catch {
+        payload = {};
+      }
+      if (payload.retentionDays !== retentionDays) {
+        db.update(memoryJobs)
+          .set({
+            payload: JSON.stringify({ ...payload, retentionDays }),
+            updatedAt: Date.now(),
+          })
+          .where(eq(memoryJobs.id, existing.id))
+          .run();
+      }
+    }
+    return existing.id;
+  }
+  const payload =
+    typeof retentionDays === "number" &&
+    Number.isFinite(retentionDays) &&
+    retentionDays >= 0
+      ? { retentionDays }
+      : {};
+  return enqueueMemoryJob("prune_old_trace_events", payload);
 }
 
 export interface LaneBudgets {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -23,6 +23,7 @@ import { backfillJob } from "./job-handlers/backfill.js";
 import {
   pruneOldConversationsJob,
   pruneOldLlmRequestLogsJob,
+  pruneOldTraceEventsJob,
 } from "./job-handlers/cleanup.js";
 import { generateConversationStartersJob } from "./job-handlers/conversation-starters.js";
 // ── Per-job-type handlers ──────────────────────────────────────────
@@ -54,6 +55,7 @@ import {
   enqueueMemoryJob,
   enqueuePruneOldConversationsJob,
   enqueuePruneOldLlmRequestLogsJob,
+  enqueuePruneOldTraceEventsJob,
   failMemoryJob,
   failStalledJobs,
   type MemoryJob,
@@ -455,6 +457,9 @@ async function processJob(
     case "prune_old_llm_request_logs":
       pruneOldLlmRequestLogsJob(job, config);
       return;
+    case "prune_old_trace_events":
+      pruneOldTraceEventsJob(job, config);
+      return;
     case "build_conversation_summary":
       await buildConversationSummaryJob(job, config);
       return;
@@ -560,14 +565,20 @@ function maybeEnqueueScheduledCleanupJobs(
     cleanup.llmRequestLogRetentionMs !== null
       ? enqueuePruneOldLlmRequestLogsJob(cleanup.llmRequestLogRetentionMs)
       : null;
+  const pruneTraceEventsJobId =
+    cleanup.traceEventRetentionDays > 0
+      ? enqueuePruneOldTraceEventsJob(cleanup.traceEventRetentionDays)
+      : null;
   markScheduledCleanupEnqueued(nowMs);
   log.debug(
     {
       pruneConversationsJobId,
       pruneLlmRequestLogsJobId,
+      pruneTraceEventsJobId,
       enqueueIntervalMs: cleanup.enqueueIntervalMs,
       conversationRetentionDays: cleanup.conversationRetentionDays,
       llmRequestLogRetentionMs: cleanup.llmRequestLogRetentionMs,
+      traceEventRetentionDays: cleanup.traceEventRetentionDays,
     },
     "Enqueued scheduled memory cleanup jobs",
   );

--- a/assistant/src/memory/trace-event-store.ts
+++ b/assistant/src/memory/trace-event-store.ts
@@ -1,11 +1,10 @@
-import { and, asc, eq, gt, lt, sql } from "drizzle-orm";
+import { and, asc, eq, gt, sql } from "drizzle-orm";
 
 import type {
   TraceEvent,
   TraceEventKind,
 } from "../daemon/message-types/messages.js";
 import { getDb } from "./db-connection.js";
-import { rawChanges } from "./raw-query.js";
 import { traceEvents } from "./schema.js";
 
 // ---------------------------------------------------------------------------
@@ -113,21 +112,6 @@ export function getTraceEvents(
     .all();
 
   return rows.map(rowToTraceEventRow);
-}
-
-// ---------------------------------------------------------------------------
-// Cleanup
-// ---------------------------------------------------------------------------
-
-/**
- * Delete trace events older than `maxAgeDays` based on `created_at`.
- * Returns the count of deleted rows.
- */
-export function deleteOldTraceEvents(maxAgeDays: number): number {
-  const db = getDb();
-  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
-  db.delete(traceEvents).where(lt(traceEvents.createdAt, cutoff)).run();
-  return rawChanges();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Moves trace-event pruning off the once-per-startup `setTimeout` and onto the same periodic memory-jobs-worker mechanism that already prunes `llm_request_logs`. New default retention is 3 days (down from the previous hardcoded 7).
- Adds `memory.cleanup.traceEventRetentionDays` (default 3, max 365, `0` disables) so the retention window can be configured per workspace and re-applied without a daemon restart.
- New `prune_old_trace_events` job: batched `DELETE ... LIMIT 1000` with self re-enqueue when more rows remain — same shape as `pruneOldLlmRequestLogsJob`.
- Hooked into `maybeEnqueueScheduledCleanupJobs` (deduped by `enqueuePruneOldTraceEventsJob`) and into `cleanupSettingsChanged` so live retention edits reset the cleanup-scheduler throttle.

## Notes
- Removes the daemon-startup `setTimeout` that was the only caller of `deleteOldTraceEvents`, and drops that helper. The scheduled cleanup state starts at `0` on each daemon launch, so the first worker tick will enqueue a prune job — the cadence is preserved.
- No gateway/macOS surface change: trace-event retention is daemon-internal (no privacy-config picker).

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/__tests__/config-schema.test.ts src/__tests__/config-watcher-cleanup-throttle.test.ts` (170/170 pass; default fixture updated to include `traceEventRetentionDays: 3`)
- [x] `bun test src/__tests__/memory-jobs-worker-{backoff,lanes}.test.ts src/__tests__/jobs-store-upsert-debounced.test.ts` (8/8 pass)
- [ ] Manual: start daemon, confirm `Enqueued scheduled memory cleanup jobs` log includes `pruneTraceEventsJobId`, and `Pruned old trace events` fires shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)