### PR TITLE
fix(security): block SSRF in PDF export by disabling JS and aborting subresource requests

### DIFF
--- a/assistant/src/runtime/routes/document-pdf-renderer.ts
+++ b/assistant/src/runtime/routes/document-pdf-renderer.ts
@@ -162,7 +162,6 @@ export async function renderMarkdownToPDF(
       },
       printBackground: true,
     });
-    await context.close();
     return Buffer.from(pdfBuffer);
   } finally {
     await browser.close();

--- a/assistant/src/runtime/routes/document-pdf-renderer.ts
+++ b/assistant/src/runtime/routes/document-pdf-renderer.ts
@@ -146,8 +146,12 @@ export async function renderMarkdownToPDF(
   const pw = await importPlaywright();
   const browser = await pw.chromium.launch({ headless: true });
   try {
-    const page = await browser.newPage();
-    await page.setContent(fullHtml, { waitUntil: "networkidle" });
+    const context = await browser.newContext({
+      javaScriptEnabled: false,
+    });
+    const page = await context.newPage();
+    await page.route("**/*", (route) => route.abort());
+    await page.setContent(fullHtml, { waitUntil: "domcontentloaded" });
     const pdfBuffer = await page.pdf({
       format: "A4",
       margin: {
@@ -158,6 +162,7 @@ export async function renderMarkdownToPDF(
       },
       printBackground: true,
     });
+    await context.close();
     return Buffer.from(pdfBuffer);
   } finally {
     await browser.close();


### PR DESCRIPTION
## Summary
- Block server-side request forgery in the document PDF export by disabling JavaScript on the Playwright context, intercepting all subresource requests with \`page.route(\"**/*\", route.abort)\`, and switching \`setContent\` to \`waitUntil: \"domcontentloaded\"\` so the renderer doesn't wait on aborted network activity.
- Close the browser context explicitly before \`browser.close()\` to release resources cleanly.

## Why
The PDF export endpoint (\`GET /v1/documents/:id/pdf\`) loads attacker-influenceable saved document content and renders it through \`marked.parse()\` (raw HTML allowed by default) into a default headless Chromium page. With no request interception, JavaScript disabling, URL allowlist, or sanitizer, document content containing \`<iframe>\`, \`<img>\`, \`<link rel=\"stylesheet\">\`, \`@import\`, etc. could trigger requests from the runtime host to localhost, RFC1918 addresses, link-local cloud metadata endpoints, or other internal services — and where those resources render into the PDF, expose internal content to the exporting caller. The route is authenticated (\`settings.read\`), but in managed/cloud deployments the SSRF impact is meaningful.

The fix mirrors the safest available control for a renderer that doesn't need network: disable JS so script-driven exfiltration is impossible, and abort every subresource request so iframes, images, fonts, and CSS imports never leave the host. Existing browser-tool SSRF protections (\`tools/browser/browser-execution.ts\`) take a different shape because that surface intentionally allows public-network access; PDF rendering does not, so an outright block is both stricter and simpler.

## Trade-off
Remote images referenced in markdown (\`![alt](https://example.com/image.png)\`) will no longer render in the exported PDF. PDF export is a recently added feature (#29179) and image rendering wasn't a documented requirement. A future change can add a sanitizer + URL allowlist if image support is required.

## Codex finding
https://chatgpt.com/codex/cloud/security/findings/fe5eb287ebf0819180a6c9b1ac9f7fb8

## Test plan
- [ ] Export a markdown document containing only text/headings/lists/code → PDF renders correctly
- [ ] Export a markdown document containing \`![image](https://...)\` → image is omitted but PDF still renders
- [ ] Export a markdown document containing \`<iframe src=\"http://169.254.169.254/...\">\` or \`<img src=\"http://localhost:.../\">\` → no network request leaves the host (verified via runtime logs / network observation)

## Original prompt
Fix SSRF and unsanitized markdown rendering in PDF export. Replace default Playwright browser usage in \`assistant/src/runtime/routes/document-pdf-renderer.ts\` (\`renderMarkdownToPDF\`) with a context that disables JavaScript, aborts all subresource requests via \`page.route\`, and uses \`waitUntil: \"domcontentloaded\"\`. Close the context before browser close. The known trade-off is that remote images won't render; that's acceptable for a new feature and can be revisited with a sanitizer + URL allowlist if needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->