### PR TITLE
fix(security): add IPC policy entries for daemon MCP OAuth routes

### DIFF
--- a/gateway/src/__tests__/ipc-route-policy.test.ts
+++ b/gateway/src/__tests__/ipc-route-policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test";
+
+import { getIpcRoutePolicy } from "../auth/ipc-route-policy.js";
+
+describe("ipc-route-policy: gateway-only daemon routes", () => {
+  // The gateway IPC proxy default-allows operationIds with no policy entry.
+  // Routes that the daemon's HTTP route policy marks as gateway-only
+  // (internal.write + svc_gateway) MUST also have a matching IPC policy
+  // entry — otherwise an authenticated edge JWT can reach them by setting
+  // X-Vellum-Proxy-Server: ipc, bypassing the daemon HTTP router entirely.
+  test.each([
+    "admin_rollbackmigrations_post",
+    "internal_mcp_auth_start",
+    "internal_mcp_auth_status",
+    "internal_mcp_reload",
+  ])("%s requires internal.write and svc_gateway", (operationId) => {
+    const policy = getIpcRoutePolicy(operationId);
+    expect(policy).toBeDefined();
+    expect(policy!.requiredScopes).toEqual(["internal.write"]);
+    expect(policy!.allowedPrincipalTypes).toEqual(["svc_gateway"]);
+  });
+});

--- a/gateway/src/auth/ipc-route-policy.ts
+++ b/gateway/src/auth/ipc-route-policy.ts
@@ -49,6 +49,9 @@ type PolicyEntry =
 const POLICY_TABLE: PolicyEntry[] = [
   // Admin / internal
   ["admin_rollbackmigrations_post", ["internal.write"], ["svc_gateway"]],
+  ["internal_mcp_auth_start", ["internal.write"], ["svc_gateway"]],
+  ["internal_mcp_auth_status", ["internal.write"], ["svc_gateway"]],
+  ["internal_mcp_reload", ["internal.write"], ["svc_gateway"]],
 
   // Calls
   ["calls_answer", ["calls.write"]],


### PR DESCRIPTION
## Summary

- The gateway IPC proxy default-allows operationIds with no policy entry. The MCP OAuth routes added in #29455 / #29484 — `internal_mcp_auth_start`, `internal_mcp_auth_status`, `internal_mcp_reload` — are marked gateway-only (`internal.write` + `svc_gateway`) on the daemon HTTP path, but the gateway IPC policy table was never updated to match. An authenticated edge JWT could therefore reach these daemon-owned routes by sending `X-Vellum-Proxy-Server: ipc` to `/v1/internal/mcp/auth/...`, bypassing the daemon HTTP router entirely. The bypass lets a low-privileged actor start daemon-owned MCP OAuth flows, retrieve pending auth URLs/status, invalidate client/discovery credentials, and potentially overwrite the assistant's MCP OAuth tokens.
- Adds the three missing operationIds to `POLICY_TABLE` in `gateway/src/auth/ipc-route-policy.ts`, mirroring the daemon HTTP `INTERNAL_ENDPOINTS` registration.
- Adds a focused unit test against the real `getIpcRoutePolicy` registry to verify these entries exist (the existing `ipc-runtime-proxy.test.ts` mocks the policy lookup, so it would not catch new gaps).

## Codex finding

https://chatgpt.com/codex/cloud/security/findings/07276d5c43d881918966109e720c8e03?sev=critical%2Chigh&q=mcp

The original Codex patch only covered `internal_mcp_auth_start` and `internal_mcp_auth_status`. This PR additionally fixes `internal_mcp_reload`, which was added in #29484 with the same vulnerability shape (registered as gateway-only on the daemon HTTP path at `assistant/src/runtime/auth/route-policy.ts:582-597` but absent from the gateway IPC policy table).

## Follow-up

Triage flagged that several other gateway-only daemon routes have the same pre-existing IPC policy gap (not introduced by the MCP commit, so out of scope for this PR):

- `internal_oauth_callback`
- `internal_twilio_voice_webhook`
- `internal_twilio_status`
- `internal_twilio_connect_action`
- `upgrade_broadcast`
- `workspace_commit`
- `emit_event`
- `channel_inbound`

These should be triaged separately. A guard test that asserts every `svc_gateway`-restricted daemon HTTP policy has a matching IPC policy entry would prevent the same class of bug from recurring.

## Test plan

- [x] `bun test src/__tests__/ipc-route-policy.test.ts` (new)
- [x] `bun test src/http/routes/ipc-runtime-proxy.test.ts` (existing, no regressions)
- [ ] Manual: with the fix in place, a public IPC request `POST /v1/internal/mcp/auth/start` from an `actor`-principal JWT now returns 403 instead of triggering the daemon flow.

## Original prompt

Fix a high-severity authorization bypass in the gateway IPC proxy: the gateway IPC policy table at `gateway/src/auth/ipc-route-policy.ts` does not register the daemon-owned MCP OAuth routes, and `enforceRoutePolicy` default-allows missing policies, so any authenticated gateway actor can hit these intended-gateway-only daemon routes by adding `X-Vellum-Proxy-Server: ipc` to a `/v1/internal/mcp/auth/...` request.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->