### PR TITLE
Replace raw JSON onboarding block with compact markdown in system prompt

### DIFF
--- a/assistant/src/__tests__/prechat-onboarding-contract.test.ts
+++ b/assistant/src/__tests__/prechat-onboarding-contract.test.ts
@@ -153,25 +153,18 @@ describe("pre-chat onboarding contract", () => {
       const result = buildSystemPrompt({ onboardingContext: context });
       const dynamic = dynamicBlock(result);
 
-      expect(dynamic).toContain("## Pre-chat Onboarding Context");
+      expect(dynamic).toContain("## First-Run User Context");
       expect(dynamic).toContain(
-        "The user completed the native pre-chat onboarding.",
+        "The user completed setup before this conversation.",
       );
-      expect(dynamic).toContain('"tools"');
-      expect(dynamic).toContain('"slack"');
-      expect(dynamic).toContain('"linear"');
-      expect(dynamic).toContain('"tasks"');
-      expect(dynamic).toContain('"code-building"');
-      expect(dynamic).toContain('"tone": "warm"');
-      expect(dynamic).toContain('"userName": "Alex"');
-      expect(dynamic).toContain('"assistantName": "Nova"');
-      expect(dynamic).toContain("```json");
-      expect(dynamic).toContain(
-        "Use this to personalize your opener and skip redundant discovery.",
-      );
-      expect(dynamic).toContain(
-        "If `assistantName` is present, it is the name the user chose for you; preserve it in IDENTITY.md.",
-      );
+      expect(dynamic).toContain("- Daily tools: Slack, Linear");
+      expect(dynamic).toContain("- Common work: builds code, apps, or tools");
+      expect(dynamic).toContain("- Name: Alex");
+      expect(dynamic).toContain("- Chosen assistant name: Nova");
+      expect(dynamic).toContain("Apply this context quietly.");
+
+      // Raw JSON must NOT be present
+      expect(dynamic).not.toContain("```json");
     });
 
     test("does NOT inject onboarding context when BOOTSTRAP.md does not exist", () => {
@@ -186,9 +179,9 @@ describe("pre-chat onboarding contract", () => {
       const result = buildSystemPrompt({ onboardingContext: context });
       const dynamic = dynamicBlock(result);
 
-      expect(dynamic).not.toContain("## Pre-chat Onboarding Context");
-      expect(dynamic).not.toContain("pre-chat onboarding");
-      expect(dynamic).not.toContain('"tools"');
+      expect(dynamic).not.toContain("## First-Run User Context");
+      expect(dynamic).not.toContain("First-Run User Context");
+      expect(dynamic).not.toContain("- Daily tools:");
     });
 
     test("does NOT inject onboarding context when excludeBootstrap is true", () => {
@@ -209,7 +202,7 @@ describe("pre-chat onboarding contract", () => {
       });
       const dynamic = dynamicBlock(result);
 
-      expect(dynamic).not.toContain("## Pre-chat Onboarding Context");
+      expect(dynamic).not.toContain("## First-Run User Context");
       expect(dynamic).not.toContain("First-Run Ritual");
     });
 
@@ -225,7 +218,7 @@ describe("pre-chat onboarding contract", () => {
       // Bootstrap should still be present
       expect(dynamic).toContain("First-Run Ritual");
       // But no onboarding context section
-      expect(dynamic).not.toContain("## Pre-chat Onboarding Context");
+      expect(dynamic).not.toContain("## First-Run User Context");
     });
 
     test("accepts all four personality tones", () => {
@@ -247,12 +240,12 @@ describe("pre-chat onboarding contract", () => {
         const result = buildSystemPrompt({ onboardingContext: context });
         const dynamic = dynamicBlock(result);
 
-        expect(dynamic).toContain("## Pre-chat Onboarding Context");
-        expect(dynamic).toContain(`"tone": "${tone}"`);
+        expect(dynamic).toContain("## First-Run User Context");
+        expect(dynamic).toContain(`- Preferred initial voice: ${tone}`);
       }
     });
 
-    test("serializes onboarding context as pretty-printed JSON", () => {
+    test("renders compact markdown, not JSON", () => {
       writeFileSync(
         join(TEST_DIR, "BOOTSTRAP.md"),
         "# Bootstrap\n\nOnboarding.",
@@ -269,9 +262,65 @@ describe("pre-chat onboarding contract", () => {
       const result = buildSystemPrompt({ onboardingContext: context });
       const dynamic = dynamicBlock(result);
 
-      // Verify it contains the pretty-printed JSON (indented with 2 spaces)
+      // Should contain compact markdown lines
+      expect(dynamic).toContain("## First-Run User Context");
+      expect(dynamic).toContain("- Name: Jane");
+      expect(dynamic).toContain("- Common work: plans and coordinates work");
+      expect(dynamic).toContain("- Daily tools: Notion");
+      expect(dynamic).toContain("- Chosen assistant name: Kit");
+      expect(dynamic).toContain("- Preferred initial voice: warm");
+
+      // Must NOT contain JSON output
+      expect(dynamic).not.toContain("```json");
       const expectedJson = JSON.stringify(context, null, 2);
-      expect(dynamic).toContain(expectedJson);
+      expect(dynamic).not.toContain(expectedJson);
+    });
+
+    test("empty tools/tasks arrays result in no Daily tools / Common work lines", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nOnboarding.",
+      );
+
+      const context: OnboardingContext = {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        userName: "Alex",
+      };
+
+      const result = buildSystemPrompt({ onboardingContext: context });
+      const dynamic = dynamicBlock(result);
+
+      expect(dynamic).toContain("## First-Run User Context");
+      expect(dynamic).toContain("- Name: Alex");
+      expect(dynamic).not.toContain("- Daily tools:");
+      expect(dynamic).not.toContain("- Common work:");
+    });
+
+    test("absent userName results in no Name line", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nOnboarding.",
+      );
+
+      const context: OnboardingContext = {
+        tools: ["slack"],
+        tasks: ["writing"],
+        tone: "warm",
+      };
+
+      const result = buildSystemPrompt({ onboardingContext: context });
+      const dynamic = dynamicBlock(result);
+
+      expect(dynamic).toContain("## First-Run User Context");
+      expect(dynamic).not.toContain("- Name:");
+      // Other fields should still be present
+      expect(dynamic).toContain("- Daily tools: Slack");
+      expect(dynamic).toContain(
+        "- Common work: writes docs, emails, or content",
+      );
+      expect(dynamic).toContain("- Preferred initial voice: warm");
     });
   });
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -21,6 +21,7 @@ import {
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { cleanupBootstrapFiles } from "./bootstrap-cleanup.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
+import { normalizeOnboardingContext } from "./normalize-onboarding.js";
 
 export { SYSTEM_PROMPT_CACHE_BOUNDARY };
 
@@ -322,14 +323,27 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
     );
 
     if (options?.onboardingContext) {
-      dynamicParts.push(
-        "## Pre-chat Onboarding Context\n\n" +
-          "The user completed the native pre-chat onboarding. Here is their context:\n\n" +
-          "```json\n" +
-          JSON.stringify(options.onboardingContext, null, 2) +
-          "\n```\n\n" +
-          "Use this to personalize your opener and skip redundant discovery. If `assistantName` is present, it is the name the user chose for you; preserve it in IDENTITY.md.",
+      const n = normalizeOnboardingContext(options.onboardingContext);
+      const lines: string[] = [
+        "## First-Run User Context",
+        "",
+        "The user completed setup before this conversation.",
+        "",
+        "Known context:",
+      ];
+      if (n.preferredName) lines.push(`- Name: ${n.preferredName}`);
+      if (n.commonWork.length)
+        lines.push(`- Common work: ${n.commonWork.join("; ")}`);
+      if (n.dailyTools.length)
+        lines.push(`- Daily tools: ${n.dailyTools.join(", ")}`);
+      if (n.assistantName)
+        lines.push(`- Chosen assistant name: ${n.assistantName}`);
+      if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
+      lines.push(
+        "",
+        "Apply this context quietly. Do not recap it as a list unless the user asks.",
       );
+      dynamicParts.push(lines.join("\n"));
     }
   }
   // Configuration section removed — workspace files are self-describing,


### PR DESCRIPTION
## Summary
- Replace JSON.stringify onboarding injection with compact First-Run User Context markdown
- Normalize tool/task IDs to human-readable labels in the system prompt
- Update all prechat-onboarding-contract tests to verify new format

Part of JARVIS-701 plan: use-pre-chat-info.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->