### PR TITLE
ci(release): make publish steps idempotent on retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,16 +330,30 @@ jobs:
           CLIENT_ID: ${{ vars.CWS_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
           # CWS API requires a zip — it handles signing server-side
           UPLOAD_FILE=$(ls /tmp/chrome-extension/*.zip)
           echo "Uploading: $UPLOAD_FILE"
-          chrome-webstore-upload upload \
+          set +e
+          OUTPUT=$(chrome-webstore-upload upload \
             --source "$UPLOAD_FILE" \
             --extension-id "$EXTENSION_ID" \
             --client-id "$CLIENT_ID" \
             --client-secret "$CLIENT_SECRET" \
-            --refresh-token "$REFRESH_TOKEN"
+            --refresh-token "$REFRESH_TOKEN" 2>&1)
+          EXIT=$?
+          set -e
+          echo "$OUTPUT"
+          if [ $EXIT -ne 0 ] && echo "$OUTPUT" | grep -q "ITEM_NOT_UPDATABLE"; then
+            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
+              echo "::error::CWS rejected upload with ITEM_NOT_UPDATABLE — this version was likely already pushed. e2e tests are gating this release; failing to surface divergence."
+              exit 1
+            fi
+            echo "::notice::CWS already has this version pending/published — skipping upload (e2e is non-blocking, treating as retry)."
+            exit 0
+          fi
+          exit $EXIT
 
       - name: Publish to Chrome Web Store
         env:
@@ -1275,6 +1289,9 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
           PACKAGE="${{ matrix.package }}"
           cd "$PACKAGE"
@@ -1284,9 +1301,17 @@ jobs:
             rm -rf node_modules
             bun install
           fi
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
+              echo "::error::$PKG_NAME@$PKG_VERSION is already published, but e2e tests are gating this release. Bump the version — refusing to silently retry."
+              exit 1
+            fi
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (e2e is non-blocking, treating as retry)."
+            exit 0
+          fi
           npm publish --access public --no-provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ── Staging: pack CLI tarball and dispatch QA to platform repo ──────
   pack-cli:
@@ -1364,11 +1389,22 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish meta-package
-        run: |
-          cd meta
-          npm publish --access public --no-provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
+        run: |
+          cd meta
+          PKG_NAME=$(node -p "require('./package.json').name")
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
+              echo "::error::$PKG_NAME@$PKG_VERSION is already published, but e2e tests are gating this release. Bump the version — refusing to silently retry."
+              exit 1
+            fi
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (e2e is non-blocking, treating as retry)."
+            exit 0
+          fi
+          npm publish --access public --no-provenance
 
   # arm64 macOS build — builds Swift + Bun binaries in a single job,
   # creates DMG, notarizes, staples, and generates the Sparkle appcast.


### PR DESCRIPTION
## Summary
- Skip already-published npm versions in `publish-npm` and `publish-meta` instead of erroring with E403, so re-running after a flaky e2e cleanly no-ops the shards that already shipped.
- Catch `ITEM_NOT_UPDATABLE` in the Chrome Web Store upload step and treat it as a retry skip.
- When `playwright_blocks_release == true`, an "already published" result fails loudly instead — that signals real version divergence (someone forgot to bump), and the e2e gate is our cue to surface it.

## Original prompt
How can we be more resilient to build failures at this step? https://github.com/vellum-ai/vellum-assistant/actions/runs/25354281054/job/74347120100

For context, I had run this workflow once before and the playwright tests step failed. So I re-reran that step, and then this downstream step failed the second go aroudn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->