### PR TITLE
Persist normalized onboarding context to guardian persona file

### DIFF
--- a/assistant/src/__tests__/onboarding-persona-write.test.ts
+++ b/assistant/src/__tests__/onboarding-persona-write.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for `writeOnboardingSection` in persona-resolver.
+ *
+ * The function writes a managed `## Onboarding Context` section to the
+ * guardian persona file (with a fallback chain). These tests stub
+ * `util/platform.js` and `contacts/contact-store.js` to control the
+ * write target and verify idempotency, fallback, and field omission.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ── Mock state ────────────────────────────────────────────────────
+
+let mockWorkspaceDir: string = "";
+let mockVellumGuardian: {
+  contact: { userFile: string | null };
+  channel: Record<string, unknown>;
+} | null = null;
+
+// ── Mock modules (must precede imports from the module under test) ──
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) =>
+        prop === "child"
+          ? () =>
+              new Proxy({} as Record<string, unknown>, { get: () => () => {} })
+          : () => {},
+    }),
+  getCliLogger: () => ({}),
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+  getWorkspacePromptPath: (file: string) => join(mockWorkspaceDir, file),
+}));
+
+mock.module("../contacts/contact-store.js", () => ({
+  findContactByChannelExternalId: () => null,
+  findGuardianForChannel: (channelType: string) =>
+    channelType === "vellum" ? mockVellumGuardian : null,
+  listGuardianChannels: () => null,
+}));
+
+// Import AFTER mocks so the module under test binds to the stubbed
+// implementations.
+import { writeOnboardingSection } from "../prompts/persona-resolver.js";
+
+// ── Temp workspace scaffold ───────────────────────────────────────
+
+let testRoot: string;
+
+function workspacePath(file: string): string {
+  return join(mockWorkspaceDir, file);
+}
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "onboarding-persona-write-test-"));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  mockWorkspaceDir = mkdtempSync(join(testRoot, "ws-"));
+  mockVellumGuardian = null;
+});
+
+afterEach(() => {
+  rmSync(mockWorkspaceDir, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("writeOnboardingSection", () => {
+  test("writes section to guardian persona file when it exists", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "alice.md" },
+      channel: {},
+    };
+    const guardianPath = workspacePath("users/alice.md");
+    mkdirSync(workspacePath("users"), { recursive: true });
+    writeFileSync(guardianPath, "# User Profile\n\n- **Name:** Alice\n");
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools", "plans and coordinates work"],
+      dailyTools: ["GitHub", "Linear", "Slack"],
+    });
+
+    const content = readFileSync(guardianPath, "utf-8");
+    expect(content).toContain("- **Name:** Alice");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+    expect(content).toContain(
+      "- **Common work:** builds code, apps, or tools; plans and coordinates work",
+    );
+    expect(content).toContain("- **Daily tools:** GitHub, Linear, Slack");
+  });
+
+  test("falls back to users/default.md when guardian path is null", () => {
+    mockVellumGuardian = null;
+    mkdirSync(workspacePath("users"), { recursive: true });
+    writeFileSync(
+      workspacePath("users/default.md"),
+      "# User Profile\n\n- **Name:** Default User\n",
+    );
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: [],
+      dailyTools: ["Slack"],
+    });
+
+    const content = readFileSync(workspacePath("users/default.md"), "utf-8");
+    expect(content).toContain("- **Name:** Default User");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+    expect(content).toContain("- **Daily tools:** Slack");
+
+    // USER.md should not be created
+    expect(existsSync(workspacePath("USER.md"))).toBe(false);
+  });
+
+  test("falls back to USER.md when no users/ files exist", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: [],
+      dailyTools: [],
+    });
+
+    expect(existsSync(workspacePath("USER.md"))).toBe(true);
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+  });
+
+  test("creates file with header + section when target doesn't exist", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub", "Linear", "Slack"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("# User Profile");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+    expect(content).toContain("- **Common work:** builds code, apps, or tools");
+    expect(content).toContain("- **Daily tools:** GitHub, Linear, Slack");
+  });
+
+  test("idempotent: calling twice produces the same file content", () => {
+    mockVellumGuardian = null;
+    const normalized = {
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub", "Linear"],
+    };
+
+    writeOnboardingSection(normalized);
+    const first = readFileSync(workspacePath("USER.md"), "utf-8");
+
+    writeOnboardingSection(normalized);
+    const second = readFileSync(workspacePath("USER.md"), "utf-8");
+
+    expect(first).toBe(second);
+  });
+
+  test("replaces existing onboarding section with updated data", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub"],
+    });
+
+    writeOnboardingSection({
+      preferredName: "Bob",
+      commonWork: ["writes docs, emails, or content"],
+      dailyTools: ["Notion", "Slack"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("- **Preferred name:** Bob");
+    expect(content).toContain(
+      "- **Common work:** writes docs, emails, or content",
+    );
+    expect(content).toContain("- **Daily tools:** Notion, Slack");
+    // Old values should be gone
+    expect(content).not.toContain("**Preferred name:** Alice");
+    expect(content).not.toContain("GitHub");
+  });
+
+  test("preserves content outside the managed section", () => {
+    mockVellumGuardian = null;
+    writeFileSync(
+      workspacePath("USER.md"),
+      "# User Profile\n\n- **Name:** Alice\n- **Role:** Engineer\n",
+    );
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: [],
+      dailyTools: ["GitHub"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("- **Name:** Alice");
+    expect(content).toContain("- **Role:** Engineer");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Daily tools:** GitHub");
+  });
+
+  test("omits empty fields", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      commonWork: [],
+      dailyTools: [],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).not.toContain("Preferred name");
+    expect(content).not.toContain("Common work");
+    expect(content).not.toContain("Daily tools");
+  });
+
+  test("omits preferredName when undefined", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: undefined,
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).not.toContain("Preferred name");
+    expect(content).toContain("- **Common work:** builds code, apps, or tools");
+    expect(content).toContain("- **Daily tools:** GitHub");
+  });
+
+  test("preserves content after onboarding section when followed by another heading", () => {
+    mockVellumGuardian = null;
+    writeFileSync(
+      workspacePath("USER.md"),
+      [
+        "# User Profile",
+        "",
+        "- **Name:** Alice",
+        "",
+        "## Onboarding Context",
+        "",
+        "- **Preferred name:** Alice",
+        "",
+        "## Preferences",
+        "",
+        "- Likes dark mode",
+        "",
+      ].join("\n"),
+    );
+
+    writeOnboardingSection({
+      preferredName: "Bob",
+      commonWork: [],
+      dailyTools: ["Slack"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("- **Preferred name:** Bob");
+    expect(content).toContain("- **Daily tools:** Slack");
+    expect(content).toContain("## Preferences");
+    expect(content).toContain("- Likes dark mode");
+    // Old preferred name should be gone from the onboarding section
+    expect(content).not.toContain("**Preferred name:** Alice");
+  });
+});

--- a/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
+++ b/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
@@ -27,6 +27,31 @@ mock.module("../util/logger.js", () => ({
 
 let writeRelationshipStateCalled = false;
 let sidecarPayload: unknown = null;
+let writeOnboardingSectionPayload: unknown = null;
+
+mock.module("../prompts/normalize-onboarding.js", () => ({
+  normalizeOnboardingContext: (ctx: unknown) => ctx,
+}));
+
+mock.module("../prompts/persona-resolver.js", () => ({
+  writeOnboardingSection: (payload: unknown) => {
+    writeOnboardingSectionPayload = payload;
+  },
+  resolveGuardianPersonaPath: () => join(TEST_DIR, "users", "guardian.md"),
+  resolveGuardianPersona: () => null,
+  resolveGuardianPersonaStrict: () => null,
+  resolveUserPersona: () => null,
+  resolveChannelPersona: () => null,
+  resolvePersonaContext: () => ({
+    userPersona: null,
+    userSlug: null,
+    channelPersona: null,
+  }),
+  resolveUserSlug: () => null,
+  ensureGuardianPersonaFile: () => {},
+  isGuardianPersonaCustomized: () => false,
+  GUARDIAN_PERSONA_TEMPLATE: "",
+}));
 
 mock.module("../home/relationship-state-writer.js", () => ({
   RELATIONSHIP_STATE_FILENAME: "relationship-state.json",
@@ -59,6 +84,7 @@ describe("persistOnboardingArtifacts", () => {
     mkdirSync(TEST_DIR, { recursive: true });
     writeRelationshipStateCalled = false;
     sidecarPayload = null;
+    writeOnboardingSectionPayload = null;
   });
 
   afterEach(() => {
@@ -262,5 +288,19 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     expect(writeRelationshipStateCalled).toBe(true);
+  });
+
+  test("calls writeOnboardingSection with normalized data", () => {
+    const payload = {
+      tools: ["slack", "linear"],
+      tasks: ["code-building", "writing"],
+      tone: "professional",
+      userName: "Alex",
+      assistantName: "Nova",
+    };
+
+    persistOnboardingArtifacts(payload);
+
+    expect(writeOnboardingSectionPayload).toEqual(payload);
   });
 });

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -1,9 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 import {
@@ -14,8 +9,9 @@ import {
 import type { ChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
+import type { NormalizedOnboarding } from "./normalize-onboarding.js";
 
 const log = getLogger("persona-resolver");
 
@@ -110,7 +106,11 @@ function resolveUserFilename(
 
   // Validate basename to prevent path traversal
   if (filename) {
-    if (basename(filename) !== filename || filename === ".." || filename === ".") {
+    if (
+      basename(filename) !== filename ||
+      filename === ".." ||
+      filename === "."
+    ) {
       log.warn(
         { userFile: filename },
         "Contact userFile contains path traversal; ignoring",
@@ -268,7 +268,11 @@ export function resolveGuardianPersonaStrict(): string | null {
  * Creates the parent `users/` directory if missing.
  */
 export function ensureGuardianPersonaFile(userFile: string): void {
-  if (basename(userFile) !== userFile || userFile === ".." || userFile === ".") {
+  if (
+    basename(userFile) !== userFile ||
+    userFile === ".." ||
+    userFile === "."
+  ) {
     log.warn(
       { userFile },
       "Guardian persona userFile contains path traversal; refusing to write",
@@ -313,4 +317,92 @@ export function isGuardianPersonaCustomized(filePath: string): boolean {
 
   const templateStripped = stripCommentLines(GUARDIAN_PERSONA_TEMPLATE);
   return stripped !== templateStripped;
+}
+
+// ── Onboarding section writer ────────────────────────────────────
+
+const ONBOARDING_HEADING = "## Onboarding Context";
+
+/**
+ * Build the markdown section content for the onboarding context.
+ * Omits bullet lines where the value is empty/absent.
+ */
+function buildOnboardingSection(normalized: NormalizedOnboarding): string {
+  const lines: string[] = [ONBOARDING_HEADING, ""];
+
+  if (normalized.preferredName) {
+    lines.push(`- **Preferred name:** ${normalized.preferredName}`);
+  }
+  if (normalized.commonWork.length > 0) {
+    lines.push(`- **Common work:** ${normalized.commonWork.join("; ")}`);
+  }
+  if (normalized.dailyTools.length > 0) {
+    lines.push(`- **Daily tools:** ${normalized.dailyTools.join(", ")}`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Resolve the write target for the onboarding section using the
+ * fallback chain: guardian persona → `users/default.md` → `USER.md`.
+ */
+function resolveOnboardingWriteTarget(): string {
+  const guardianPath = resolveGuardianPersonaPath();
+  if (guardianPath) return guardianPath;
+
+  const defaultUserPath = join(getWorkspaceDir(), "users", "default.md");
+  if (existsSync(defaultUserPath)) return defaultUserPath;
+
+  return getWorkspacePromptPath("USER.md");
+}
+
+/**
+ * Write a managed `## Onboarding Context` section to the guardian persona
+ * file (or fallback target). Idempotent: replaces the section in-place if
+ * it already exists, appends if not, and creates the file when missing.
+ *
+ * Never throws — logs a warning on failure (fire-and-forget pattern).
+ */
+export function writeOnboardingSection(normalized: NormalizedOnboarding): void {
+  try {
+    const targetPath = resolveOnboardingWriteTarget();
+    const section = buildOnboardingSection(normalized);
+
+    let content: string;
+    if (existsSync(targetPath)) {
+      content = readFileSync(targetPath, "utf-8");
+    } else {
+      // Create parent directories and start with a header
+      mkdirSync(dirname(targetPath), { recursive: true });
+      content = "# User Profile\n\n";
+    }
+
+    // Replace existing section or append
+    const headingIndex = content.indexOf(ONBOARDING_HEADING);
+    if (headingIndex !== -1) {
+      // Find the end of the section: next `## ` heading or EOF
+      const afterHeading = content.indexOf("\n", headingIndex);
+      const rest = afterHeading !== -1 ? content.slice(afterHeading + 1) : "";
+      const nextHeadingMatch = rest.match(/^## /m);
+      const before = content.slice(0, headingIndex);
+      const after = nextHeadingMatch ? rest.slice(nextHeadingMatch.index!) : "";
+      content = before + section + after;
+    } else {
+      // Append after a blank line (ensure trailing newline first)
+      if (!content.endsWith("\n")) {
+        content += "\n";
+      }
+      if (!content.endsWith("\n\n")) {
+        content += "\n";
+      }
+      content += section;
+    }
+
+    writeFileSync(targetPath, content, "utf-8");
+    log.debug({ path: targetPath }, "Wrote onboarding section to persona file");
+  } catch (err) {
+    log.warn({ err }, "Failed to write onboarding section to persona file");
+  }
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1031,9 +1031,6 @@ export function persistOnboardingArtifacts(onboarding: {
 }): void {
   writeOnboardingSidecar(onboarding);
 
-  const normalized = normalizeOnboardingContext(onboarding);
-  writeOnboardingSection(normalized);
-
   const assistantName = onboarding.assistantName?.trim();
   if (assistantName) {
     const identityPath = getWorkspacePromptPath("IDENTITY.md");
@@ -1082,6 +1079,9 @@ export function persistOnboardingArtifacts(onboarding: {
       log.warn({ err, userPath }, "Failed to seed USER.md from onboarding");
     }
   }
+
+  const normalized = normalizeOnboardingContext(onboarding);
+  writeOnboardingSection(normalized);
 
   void writeRelationshipState().catch((err) => {
     log.warn(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -86,6 +86,8 @@ import {
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { searchConversations } from "../../memory/conversation-queries.js";
+import { normalizeOnboardingContext } from "../../prompts/normalize-onboarding.js";
+import { writeOnboardingSection } from "../../prompts/persona-resolver.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
@@ -1028,6 +1030,9 @@ export function persistOnboardingArtifacts(onboarding: {
   assistantName?: string;
 }): void {
   writeOnboardingSidecar(onboarding);
+
+  const normalized = normalizeOnboardingContext(onboarding);
+  writeOnboardingSection(normalized);
 
   const assistantName = onboarding.assistantName?.trim();
   if (assistantName) {


### PR DESCRIPTION
## Summary
- Add writeOnboardingSection() to persona-resolver that writes a managed Onboarding Context section to the guardian persona file
- Idempotent updates with fallback chain: guardian persona → users/default.md → USER.md
- Wire into persistOnboardingArtifacts() to normalize and persist on first message
- Add comprehensive tests for write behavior, fallbacks, and idempotency

Part of JARVIS-701 plan: use-pre-chat-info.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->