### PR TITLE
feat(event-hub): capture actorPrincipalId on connected client records

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -356,6 +356,54 @@ describe("AssistantEventHub — re-entrancy / snapshot isolation", () => {
   });
 });
 
+// ── ClientEntry actorPrincipalId capture ────────────────────────────────────
+
+describe("AssistantEventHub — actorPrincipalId on ClientEntry", () => {
+  test("stores actorPrincipalId provided at subscribe time", () => {
+    const hub = new AssistantEventHub();
+
+    hub.subscribe({
+      type: "client" as const,
+      clientId: "client-with-principal",
+      interfaceId: "macos",
+      capabilities: ["host_bash"],
+      actorPrincipalId: "user-A",
+      callback: () => {},
+    });
+
+    expect(hub.getClientById("client-with-principal")?.actorPrincipalId).toBe(
+      "user-A",
+    );
+    expect(hub.getActorPrincipalIdForClient("client-with-principal")).toBe(
+      "user-A",
+    );
+  });
+
+  test("actorPrincipalId is undefined when omitted at subscribe time", () => {
+    const hub = new AssistantEventHub();
+
+    hub.subscribe({
+      type: "client" as const,
+      clientId: "client-no-principal",
+      interfaceId: "macos",
+      capabilities: ["host_bash"],
+      callback: () => {},
+    });
+
+    expect(
+      hub.getClientById("client-no-principal")?.actorPrincipalId,
+    ).toBeUndefined();
+    expect(
+      hub.getActorPrincipalIdForClient("client-no-principal"),
+    ).toBeUndefined();
+  });
+
+  test("getActorPrincipalIdForClient returns undefined for unknown clientId", () => {
+    const hub = new AssistantEventHub();
+    expect(hub.getActorPrincipalIdForClient("does-not-exist")).toBeUndefined();
+  });
+});
+
 // ── capabilityForMessageType — host-prefix routing ───────────────────────────
 
 describe("capabilityForMessageType — host-prefix routing", () => {

--- a/assistant/src/__tests__/events-client-registration.test.ts
+++ b/assistant/src/__tests__/events-client-registration.test.ts
@@ -395,6 +395,58 @@ describe("events client registration", () => {
     ac2.abort();
   });
 
+  // ── actorPrincipalId capture ──────────────────────────────────────────────
+
+  test("captures actorPrincipalId from x-vellum-actor-principal-id header", () => {
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "principal-client-001",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "user-A",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("principal-client-001");
+    expect(entry?.actorPrincipalId).toBe("user-A");
+    expect(hub.getActorPrincipalIdForClient("principal-client-001")).toBe(
+      "user-A",
+    );
+
+    ac.abort();
+  });
+
+  test("registers client with undefined actorPrincipalId when header is absent", () => {
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "principal-client-002",
+          "x-vellum-interface-id": "macos",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("principal-client-002");
+    expect(entry).toBeDefined();
+    expect(entry?.actorPrincipalId).toBeUndefined();
+    expect(
+      hub.getActorPrincipalIdForClient("principal-client-002"),
+    ).toBeUndefined();
+
+    ac.abort();
+  });
+
   // ── disposeClient (force disconnect) ──────────────────────────────────────
 
   test("disposeClient removes all subscribers for the clientId", () => {

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -86,6 +86,16 @@ export interface ClientEntry extends BaseSubscriberEntry {
   interfaceId: InterfaceId;
   capabilities: HostProxyCapability[];
   machineName?: string;
+  /**
+   * The verified actor principal id (canonical user identity, parsed from JWT
+   * `sub`) of the user that opened this SSE connection, when available.
+   *
+   * Populated from `AuthContext.actorPrincipalId` at SSE subscription time.
+   * Used by host proxies to gate cross-client targeted execution to the same
+   * authenticated user identity. May be `undefined` for legacy or
+   * service-token connections that have no principal.
+   */
+  actorPrincipalId?: string;
 }
 
 export interface ProcessEntry extends BaseSubscriberEntry {
@@ -255,7 +265,10 @@ export class AssistantEventHub {
    */
   async publish(
     event: AssistantEvent,
-    options?: { targetCapability?: HostProxyCapability; targetClientId?: string },
+    options?: {
+      targetCapability?: HostProxyCapability;
+      targetClientId?: string;
+    },
   ): Promise<void> {
     if (event.conversationId) {
       try {
@@ -323,10 +336,26 @@ export class AssistantEventHub {
    */
   getClientById(clientId: string): ClientEntry | undefined {
     for (const entry of this.subscribers) {
-      if (entry.active && entry.type === "client" && entry.clientId === clientId)
+      if (
+        entry.active &&
+        entry.type === "client" &&
+        entry.clientId === clientId
+      )
         return entry;
     }
     return undefined;
+  }
+
+  /**
+   * Return the verified actor principal id captured at SSE subscription time
+   * for the given client, or `undefined` if the client is unknown or
+   * connected without a principal (e.g. legacy/service tokens).
+   *
+   * Used by host proxies to bind cross-client targeted execution to the same
+   * authenticated user identity that opened the target client's SSE stream.
+   */
+  getActorPrincipalIdForClient(clientId: string): string | undefined {
+    return this.getClientById(clientId)?.actorPrincipalId;
   }
 
   /**

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -81,10 +81,15 @@ export function handleSubscribeAssistantEvents(
   const rawClientId = headers?.["x-vellum-client-id"];
   const rawInterfaceId = headers?.["x-vellum-interface-id"];
   const rawMachineName = headers?.["x-vellum-machine-name"];
+  const rawActorPrincipalId = headers?.["x-vellum-actor-principal-id"];
   const clientId = rawClientId?.trim() || null;
   const interfaceId = clientId
     ? parseInterfaceId(rawInterfaceId?.trim())
     : null;
+  // Verified by RuntimeHttpServer and forwarded by the http-adapter from the
+  // bearer token's AuthContext. May be absent for legacy / service-token
+  // connections that have no principal.
+  const actorPrincipalId = rawActorPrincipalId?.trim() || undefined;
 
   if (clientId && !interfaceId) {
     log.error(
@@ -171,6 +176,7 @@ export function handleSubscribeAssistantEvents(
               supportsHostProxy(interfaceId, cap),
             ),
             machineName: rawMachineName?.trim() || undefined,
+            actorPrincipalId,
           })
         : hub.subscribe({
             ...subscriberBase,


### PR DESCRIPTION
## Summary
- Adds optional `actorPrincipalId` field to `ClientEntry` in `AssistantEventHub`, populated from the verified auth context at SSE subscription time.
- Adds `getActorPrincipalIdForClient(clientId)` accessor for use by host proxies in subsequent PRs.
- Pure scaffolding — no behavior change for existing call sites.

This is the foundation for binding cross-client targeted host proxy routing to the same authenticated user identity, closing Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923).

Part of plan: host-proxy-same-user.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->