### PR TITLE
fix(memory): gate v1 filing on memory-v2 flag alone

### DIFF
--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -342,16 +342,15 @@ describe("FilingService", () => {
       expect(service.nextCompactionAt).toBeNull();
     });
 
-    test("start() schedules timers when only the flag is on", () => {
+    test("start() does not schedule timers when only the flag is on", () => {
       _setOverridesForTesting({ "memory-v2-enabled": true });
       mockConfig.memory.v2.enabled = false;
 
       const service = createService();
       service.start();
 
-      expect(service.nextRunAt).not.toBeNull();
-      expect(service.nextCompactionAt).not.toBeNull();
-      service.stop();
+      expect(service.nextRunAt).toBeNull();
+      expect(service.nextCompactionAt).toBeNull();
     });
 
     test("start() schedules timers when only the config is on", () => {

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -110,11 +110,8 @@ export class FilingService {
 
   start(): void {
     const fullConfig = getConfig();
-    if (
-      isAssistantFeatureFlagEnabled("memory-v2-enabled", fullConfig) &&
-      fullConfig.memory.v2.enabled
-    ) {
-      log.info("Filing service disabled — memory v2 is active");
+    if (isAssistantFeatureFlagEnabled("memory-v2-enabled", fullConfig)) {
+      log.info("Filing service disabled — memory v2 flag is set");
       this._nextRunAt = null;
       this._nextCompactionAt = null;
       return;


### PR DESCRIPTION
## Summary
- `FilingService.start()` now skips v1 filing and compaction timers whenever the `memory-v2-enabled` LD flag is on, instead of requiring both the flag and `config.memory.v2.enabled`.
- Aligns with `filing-routes.ts:isFilingAvailable()` and `consolidation-routes.ts:isConsolidationAvailable()`, which already gate on the flag alone. Fixes the inconsistency where flag-only state left the timer running but the run-now button greyed out.
- `isMemoryV2ReadActive()` keeps its dual-gate semantics — it governs whether the v2 read path is wired, which is intentionally distinct from "v2 owns filing."

## Original prompt
The memory v1 filing jobs shouldn't run if the memory v2 feature flag is set
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->