### PR TITLE
feat(trace-events): index created_at for prune scans

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -165,6 +165,7 @@ import {
   migrateStripPlaceholderSentinelsFromMessages,
   migrateStripThinkingFromConsolidated,
   migrateToolInvocationsMatchedRuleId,
+  migrateTraceEventsCreatedAtIndex,
   migrateUsageDashboardIndexes,
   migrateUsageLlmCallCount,
   migrateVoiceInviteColumns,
@@ -408,6 +409,7 @@ export function initializeDb(): void {
       backfillAppConversationIds();
     },
     migrateScheduleRetryPolicy,
+    migrateTraceEventsCreatedAtIndex,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/239-trace-events-created-at-index.ts
+++ b/assistant/src/memory/migrations/239-trace-events-created-at-index.ts
@@ -1,0 +1,18 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_trace_events_created_at_index_v1";
+
+/**
+ * Add an index on `trace_events.created_at` so the periodic prune job
+ * can locate expired rows without a full table scan.
+ */
+export function migrateTraceEventsCreatedAtIndex(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(
+      `CREATE INDEX IF NOT EXISTS idx_trace_events_created_at ON trace_events(created_at)`,
+    );
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -200,6 +200,7 @@ export {
   migrateHeartbeatRuns,
 } from "./237-heartbeat-runs.js";
 export { migrateScheduleRetryPolicy } from "./238-schedule-retry-policy.js";
+export { migrateTraceEventsCreatedAtIndex } from "./239-trace-events-created-at-index.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Adds `idx_trace_events_created_at` via migration 239, mirroring migration 212 (`idx_llm_request_logs_created_at`).
- Independent of #29567: the existing daemon-startup `deleteOldTraceEvents(N)` already filters by `created_at`, so this index also benefits the current shipping code path.
- Once #29567 lands, the new `prune_old_trace_events` job will also benefit — it batches `DELETE … WHERE created_at < ? LIMIT 1000` and re-enqueues itself, so without the index each batch was a full scan.

## Notes
- Pure DDL (`CREATE INDEX IF NOT EXISTS`) wrapped in `withCrashRecovery`, same shape as migration 212.
- Registered in `migrations/index.ts` and appended to the ordered `migrationSteps` list in `db-init.ts`.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint` on touched files
- [x] `bun test src/__tests__/db-conversation-fork-lineage-migration.test.ts` — confirmed the new `migration_trace_events_created_at_index_v1` checkpoint registers cleanly during `initializeDb`
- [ ] Manual: open `assistant.db` post-upgrade, confirm `idx_trace_events_created_at` exists via `.indexes trace_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->