### PR TITLE
fix(memory-v2): take over stale consolidation lock via PID liveness probe

### DIFF
--- a/assistant/src/backup/snapshot-lock.ts
+++ b/assistant/src/backup/snapshot-lock.ts
@@ -32,10 +32,10 @@ import {
   writeSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
-import { kill } from "node:process";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import { getLogger } from "../util/logger.js";
+import { isProcessAlive } from "../util/process-liveness.js";
 import { getLocalBackupsDir } from "./paths.js";
 
 const log = getLogger("snapshot-lock");
@@ -86,29 +86,6 @@ const EMPTY_FILE_MAX_RETRIES = 3;
  */
 export function getSnapshotLockPath(): string {
   return join(dirname(getLocalBackupsDir()), ".snapshot.lock");
-}
-
-/**
- * Check whether a PID refers to a live process. Uses `kill(pid, 0)`, which
- * does not send any signal — it just probes for existence and permission.
- *
- * Returns `false` for obviously invalid PIDs (<= 0) and for any error that
- * indicates the process is gone. Returns `true` for ESRCH-negative results
- * (meaning a process exists) and for EPERM (process exists but is owned by
- * another user — still a live process, still should not be taken over).
- */
-function isProcessAlive(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    kill(pid, 0);
-    return true;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    // EPERM means the PID exists but we cannot signal it — treat as alive so
-    // we don't accidentally take over another user's lock.
-    if (code === "EPERM") return true;
-    return false;
-  }
 }
 
 /**
@@ -348,9 +325,7 @@ export async function acquireSnapshotLock(
     }
 
     if (isProcessAlive(holder.pid)) {
-      throw new Error(
-        `snapshot in progress (locked by pid ${holder.pid})`,
-      );
+      throw new Error(`snapshot in progress (locked by pid ${holder.pid})`);
     }
 
     // --- Step 3: stale takeover via rename-aside ---

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -372,25 +372,57 @@ describe("memoryV2ConsolidateJob — concurrent invocations", () => {
     writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
   });
 
-  test("a stale lock file blocks a second concurrent invocation", async () => {
-    // Pre-seed a lock file as if a prior run was still in flight. The
-    // simple wx-based lock has no liveness probe, so this also covers
-    // stale-lock-on-disk behavior — operators clear stale locks manually.
+  test("a live lock holder blocks a second concurrent invocation", async () => {
+    // Pre-seed a lock file with the current process's PID so the liveness
+    // probe sees a running holder and the second invocation correctly
+    // reports `locked` rather than taking over.
     mkdirSync(join(memoryDir(), ".v2-state"), { recursive: true });
-    writeFileSync(lockPath(), "9999 1700000000000\n");
+    writeFileSync(lockPath(), `${process.pid} 1700000000000\n`);
 
     const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
 
     expect(result.kind).toBe("locked");
     if (result.kind === "locked") {
-      expect(result.holder).toContain("9999");
+      expect(result.holder).toContain(`${process.pid}`);
     }
     expect(bootstrapCalls).toBe(0);
     expect(wakeCalls).toBe(0);
     expect(enqueuedJobs).toHaveLength(0);
-    // The pre-seeded lock must NOT be removed by a contender — only the
-    // owner releases it.
+    // The live holder's lock must NOT be removed by a contender.
     expect(existsSync(lockPath())).toBe(true);
+  });
+
+  test("a stale lock from a non-running PID is taken over and consolidation proceeds", async () => {
+    // PID 999999 is well outside the typical kernel max_pid range on macOS
+    // and Linux, so kill(pid, 0) reliably returns ESRCH. The takeover path
+    // must unlink the stale file, retry the wx create, and bootstrap the
+    // background conversation as if the lock had been free all along.
+    mkdirSync(join(memoryDir(), ".v2-state"), { recursive: true });
+    writeFileSync(lockPath(), "999999 1700000000000\n");
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    expect(bootstrapCalls).toBe(1);
+    expect(wakeCalls).toBe(1);
+    // Lock is released in the finally block after a successful run.
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  test("an empty / corrupted lock file is treated as stale and taken over", async () => {
+    // A zero-byte file simulates a prior holder that crashed between the
+    // O_EXCL create and the PID write. With only one writer ever, an
+    // unparseable payload is unambiguously corruption, not a live
+    // mid-write — take it over.
+    mkdirSync(join(memoryDir(), ".v2-state"), { recursive: true });
+    writeFileSync(lockPath(), "");
+
+    const result = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(result.kind).toBe("invoked");
+    expect(bootstrapCalls).toBe(1);
+    expect(wakeCalls).toBe(1);
+    expect(existsSync(lockPath())).toBe(false);
   });
 });
 

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -59,6 +59,7 @@ import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { isProcessAlive } from "../../util/process-liveness.js";
 import { bootstrapConversation } from "../conversation-bootstrap.js";
 import { deleteConversation } from "../conversation-crud.js";
 import {
@@ -240,14 +241,20 @@ function readBufferContent(bufferPath: string): string {
 /**
  * Atomically create the lock file with `wx` (O_CREAT | O_EXCL) flags. Returns
  * `null` on success, or the current holder string (file contents, typically
- * `pid timestamp`) when the file already exists — the holder is surfaced for
- * log diagnostics so operators can identify a stuck lock without re-reading.
+ * `pid timestamp`) when the file already exists and the holder is still alive.
  *
- * Crash recovery: if the prior daemon died with the lock held, the file will
- * still be on disk on the next start. PR 20 keeps the lock simple per the
- * plan instructions; a future iteration can probe liveness via `kill(pid, 0)`
- * the way `snapshot-lock.ts` does. Until then, an operator can clear a
- * stale lock by removing the file.
+ * Stale-lock takeover: if the file exists but its holder PID is not running,
+ * unlink the stale file and retry the create exactly once. This recovers
+ * automatically from a crashed daemon that died with the lock held —
+ * otherwise every subsequent scheduled consolidation would skip with `locked`
+ * indefinitely until an operator manually removed the file.
+ *
+ * The simple takeover-then-retry is safe here (unlike `snapshot-lock.ts`'s
+ * full rename-aside dance) because only the assistant's jobs worker calls
+ * this lock, and at most one assistant process runs per workspace at any
+ * time. A holder with an unparseable / empty payload is treated as stale —
+ * the only writers ever produce a `<pid> <timestamp>` line, so an
+ * unparseable file is corruption from a partial write that crashed.
  */
 function tryAcquireLock(lockPath: string): string | null {
   // The workspace migration seeds `memory/.v2-state/`, but tests and
@@ -255,9 +262,40 @@ function tryAcquireLock(lockPath: string): string | null {
   // is idempotent, so the call is cheap when the dir already exists.
   mkdirSync(dirname(lockPath), { recursive: true });
 
+  const firstHolder = tryCreate(lockPath);
+  if (firstHolder === null) return null;
+  if (!isHolderStale(firstHolder)) return firstHolder;
+
+  log.info(
+    { lockPath, holder: firstHolder },
+    "consolidation: taking over stale lock (holder not running)",
+  );
+  try {
+    unlinkSync(lockPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      log.warn(
+        { err, lockPath },
+        "consolidation: failed to unlink stale lock; reporting as locked",
+      );
+      return firstHolder;
+    }
+  }
+  // After unlink, the next `wx` create should succeed. If a third party
+  // raced in and re-acquired (vanishingly unlikely with one writer per
+  // workspace), surface their holder string rather than overwriting.
+  return tryCreate(lockPath);
+}
+
+/**
+ * Atomically create the lock file. Returns `null` on success, or the holder
+ * string read from the file when it already exists (`"unknown"` if the read
+ * itself fails). Rethrows any non-EEXIST errno from `openSync`.
+ */
+function tryCreate(lockPath: string): string | null {
   let fd: number;
   try {
-    // `wx` = create-if-not-exists, fail with EEXIST if it does.
     fd = openSync(lockPath, "wx");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
@@ -267,13 +305,10 @@ function tryAcquireLock(lockPath: string): string | null {
       return "unknown";
     }
   }
-
-  // Best-effort PID + timestamp payload so a stale lock can be diagnosed.
-  // The worker only cares that the file exists; the contents are advisory.
   try {
     writeSync(fd, `${process.pid} ${Date.now()}\n`);
   } catch {
-    // best-effort
+    // best-effort — payload is advisory, the file's existence is the lock
   } finally {
     try {
       closeSync(fd);
@@ -282,6 +317,21 @@ function tryAcquireLock(lockPath: string): string | null {
     }
   }
   return null;
+}
+
+/**
+ * A holder string is stale when its PID parses to a non-running process.
+ * The payload format is `<pid> <timestamp>` (see `tryCreate`'s write), but
+ * an unparseable / empty / `"unknown"` payload is also treated as stale:
+ * the only writer is `tryCreate` itself, so corruption indicates a partial
+ * write from a crashed prior holder rather than a live writer mid-flush.
+ */
+function isHolderStale(holder: string): boolean {
+  const match = /^\d+/.exec(holder);
+  if (!match) return true;
+  const pid = Number.parseInt(match[0], 10);
+  if (!Number.isFinite(pid) || pid <= 0) return true;
+  return !isProcessAlive(pid);
 }
 
 /**

--- a/assistant/src/util/process-liveness.ts
+++ b/assistant/src/util/process-liveness.ts
@@ -1,0 +1,26 @@
+/**
+ * Cross-process liveness probe shared by file-locking helpers.
+ *
+ * Uses `kill(pid, 0)`, which sends no signal but probes the OS for whether a
+ * process exists and whether the caller has permission to signal it. Returns
+ * `false` for obviously invalid PIDs and for any error indicating the process
+ * is gone (most commonly ESRCH). Returns `true` for ESRCH-negative results
+ * (process exists) and for EPERM (process exists but is owned by another user
+ * — still alive, still must not be taken over).
+ */
+
+import { kill } from "node:process";
+
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the PID exists but we cannot signal it — treat as alive so
+    // we don't accidentally take over another user's lock.
+    if (code === "EPERM") return true;
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Fix: `tryAcquireLock` in `assistant/src/memory/v2/consolidation-job.ts` now probes the holder PID with `kill(pid, 0)` and takes over the lock when the holder is dead, instead of skipping every subsequent run with `kind: \"locked\"` until an operator manually removes the file. A daemon crash mid-consolidation could otherwise strand the pipeline indefinitely — observed in the wild as a 132 KB \`buffer.md\` with no \`memory_v2_consolidation\` conversations appearing under the sidebar's Background section.
- Refactor: extract the `kill(pid, 0)` liveness helper from `snapshot-lock.ts` into a shared `assistant/src/util/process-liveness.ts` so both file-locking helpers use the same implementation.
- Tests: replace the existing \"stale lock blocks\" test (which relied on the absence of a liveness probe) with a \"live lock holder blocks\" test that pins `process.pid` so the holder is genuinely alive, plus two new takeover cases: dead-PID takeover and empty/corrupted-file takeover.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->