### PR TITLE
Remove legacy USER.md name seeding — onboarding section covers this

### DIFF
--- a/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
+++ b/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
@@ -88,10 +88,8 @@ describe("persistOnboardingArtifacts", () => {
   });
 
   afterEach(() => {
-    for (const name of ["IDENTITY.md", "USER.md"]) {
-      const p = workspacePath(name);
-      if (existsSync(p)) rmSync(p, { force: true });
-    }
+    const p = workspacePath("IDENTITY.md");
+    if (existsSync(p)) rmSync(p, { force: true });
   });
 
   test("seeds IDENTITY.md with assistant name when file does not exist", () => {
@@ -106,19 +104,7 @@ describe("persistOnboardingArtifacts", () => {
     expect(content).toBe("# Identity\n\n- **Name:** Nova\n");
   });
 
-  test("seeds USER.md with user name when file does not exist", () => {
-    persistOnboardingArtifacts({
-      tools: ["slack"],
-      tasks: ["email"],
-      tone: "balanced",
-      userName: "Alex",
-    });
-
-    const content = readFileSync(workspacePath("USER.md"), "utf-8");
-    expect(content).toBe("# User\n\n- **Name:** Alex\n");
-  });
-
-  test("seeds both IDENTITY.md and USER.md when both names are provided", () => {
+  test("seeds IDENTITY.md when both names are provided", () => {
     persistOnboardingArtifacts({
       tools: [],
       tasks: [],
@@ -129,9 +115,6 @@ describe("persistOnboardingArtifacts", () => {
 
     expect(readFileSync(workspacePath("IDENTITY.md"), "utf-8")).toBe(
       "# Identity\n\n- **Name:** Pax\n",
-    );
-    expect(readFileSync(workspacePath("USER.md"), "utf-8")).toBe(
-      "# User\n\n- **Name:** Alex\n",
     );
   });
 
@@ -152,23 +135,6 @@ describe("persistOnboardingArtifacts", () => {
     expect(content).toBe(
       "# Identity\n\n- **Name:** NewName\n- **Role:** _(not yet established)_\n",
     );
-  });
-
-  test("updates Name field in existing USER.md template", () => {
-    writeFileSync(
-      workspacePath("USER.md"),
-      "# User\n\n- **Name:** _(not yet chosen)_\n",
-    );
-
-    persistOnboardingArtifacts({
-      tools: [],
-      tasks: [],
-      tone: "casual",
-      userName: "NewUser",
-    });
-
-    const content = readFileSync(workspacePath("USER.md"), "utf-8");
-    expect(content).toBe("# User\n\n- **Name:** NewUser\n");
   });
 
   test("updates old-format Name field in existing IDENTITY.md", () => {
@@ -216,17 +182,6 @@ describe("persistOnboardingArtifacts", () => {
     expect(existsSync(workspacePath("IDENTITY.md"))).toBe(false);
   });
 
-  test("skips USER.md when userName is missing", () => {
-    persistOnboardingArtifacts({
-      tools: ["notion"],
-      tasks: ["project-management"],
-      tone: "balanced",
-      assistantName: "Nova",
-    });
-
-    expect(existsSync(workspacePath("USER.md"))).toBe(false);
-  });
-
   test("skips IDENTITY.md when assistantName is whitespace-only", () => {
     persistOnboardingArtifacts({
       tools: [],
@@ -238,31 +193,16 @@ describe("persistOnboardingArtifacts", () => {
     expect(existsSync(workspacePath("IDENTITY.md"))).toBe(false);
   });
 
-  test("skips USER.md when userName is whitespace-only", () => {
+  test("trims whitespace from assistantName before writing", () => {
     persistOnboardingArtifacts({
       tools: [],
       tasks: [],
       tone: "balanced",
-      userName: "  ",
-    });
-
-    expect(existsSync(workspacePath("USER.md"))).toBe(false);
-  });
-
-  test("trims whitespace from names before writing", () => {
-    persistOnboardingArtifacts({
-      tools: [],
-      tasks: [],
-      tone: "balanced",
-      userName: "  Alex  ",
       assistantName: "  Nova  ",
     });
 
     expect(readFileSync(workspacePath("IDENTITY.md"), "utf-8")).toBe(
       "# Identity\n\n- **Name:** Nova\n",
-    );
-    expect(readFileSync(workspacePath("USER.md"), "utf-8")).toBe(
-      "# User\n\n- **Name:** Alex\n",
     );
   });
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1001,7 +1001,7 @@ function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
 /**
  * Persist the pre-chat onboarding payload to disk.
  *
- * Runs only on the very first message of a fresh conversation. Three
+ * Runs only on the very first message of a fresh conversation. Four
  * artifacts are produced:
  *
  *   1. `data/onboarding-context.json` — sidecar read by the
@@ -1009,12 +1009,15 @@ function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
  *      the pure-recomputation write cycle (every turn boundary rebuilds
  *      facts from markdown; the sidecar is the durable source for the
  *      tool/task/tone chips).
- *   2. `IDENTITY.md` / `USER.md` — persona seed files, only written
- *      when missing so we never clobber existing content. These feed
- *      the system prompt and the relationship-state writer's
- *      `parseIdentity` / `parseUserName` helpers after a daemon
- *      restart when the in-memory onboarding context is gone.
- *   3. `data/relationship-state.json` — kicked off fire-and-forget so
+ *   2. `IDENTITY.md` — assistant persona seed file, only written when
+ *      missing so we never clobber existing content. Feeds the system
+ *      prompt and the relationship-state writer's `parseIdentity`
+ *      helper after a daemon restart when the in-memory onboarding
+ *      context is gone.
+ *   3. Onboarding section in the guardian persona file — written via
+ *      `writeOnboardingSection`, which handles the user's preferred
+ *      name (with fallback to root `USER.md`).
+ *   4. `data/relationship-state.json` — kicked off fire-and-forget so
  *      the Home page can populate immediately on first visit instead
  *      of waiting for the first agent-turn boundary.
  *
@@ -1056,27 +1059,6 @@ export function persistOnboardingArtifacts(onboarding: {
         { err, identityPath },
         "Failed to seed IDENTITY.md from onboarding",
       );
-    }
-  }
-
-  const userName = onboarding.userName?.trim();
-  if (userName) {
-    const userPath = getWorkspacePromptPath("USER.md");
-    try {
-      if (existsSync(userPath)) {
-        const content = readFileSync(userPath, "utf-8");
-        const updated = content.replace(
-          /^- (?:\*\*)?Name:(?:\*\*)?\s*.*$/m,
-          () => `- **Name:** ${userName}`,
-        );
-        if (updated !== content) {
-          writeFileSync(userPath, updated, "utf-8");
-        }
-      } else {
-        writeFileSync(userPath, `# User\n\n- **Name:** ${userName}\n`, "utf-8");
-      }
-    } catch (err) {
-      log.warn({ err, userPath }, "Failed to seed USER.md from onboarding");
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove userName → USER.md name seeding from persistOnboardingArtifacts (writeOnboardingSection handles this now)
- Remove 5 tests that asserted legacy USER.md name behavior
- Update remaining tests to only verify IDENTITY.md name seeding

Part of JARVIS-701 plan: use-pre-chat-info.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->