### PR TITLE
fix(host-cu-result): require submitting actor to match target client's actor

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6252,7 +6252,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host CU request.
         "403":
-          description: Submitting client does not match the targeted client for this request.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal id does not match
+            the target client's stored actor principal id.
         "404":
           description: No pending interaction found for the given requestId, or the conversation/proxy no longer exists.
         "409":

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -71,19 +71,30 @@ interface CuResolveCall {
 const cuResolveSpy: CuResolveCall[] = [];
 
 // Controlled conversation map: conversationId → conversation object
-const conversationStore = new Map<string, { hostCuProxy?: { processObservation: (...args: unknown[]) => void } }>();
+const conversationStore = new Map<
+  string,
+  { hostCuProxy?: { processObservation: (...args: unknown[]) => void } }
+>();
 
 mock.module("../daemon/conversation-store.js", () => ({
-  findConversation: (conversationId: string) => conversationStore.get(conversationId),
+  findConversation: (conversationId: string) =>
+    conversationStore.get(conversationId),
+}));
+
+// Controlled actor-principal map: clientId → actorPrincipalId
+const actorPrincipalByClient = new Map<string, string>();
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getActorPrincipalIdForClient: (clientId: string) =>
+      actorPrincipalByClient.get(clientId),
+  },
 }));
 
 // ── Real imports (after mocks) ──────────────────────────────────────────────
 // Use dynamic import to ensure the mocks above are applied before loading.
 
-import {
-  BadRequestError,
-  ForbiddenError,
-} from "../runtime/routes/errors.js";
+import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
 
 const { ROUTES } = await import("../runtime/routes/host-cu-routes.js");
 
@@ -139,6 +150,7 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
   beforeEach(() => {
     pendingStore.clear();
     conversationStore.clear();
+    actorPrincipalByClient.clear();
     resolvedIds.length = 0;
     cuResolveSpy.length = 0;
     // Default: register a conversation with a hostCuProxy
@@ -151,10 +163,14 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-cu-targeted-match";
       registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -166,10 +182,14 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-cu-targeted-trim";
       registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "user-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -183,9 +203,9 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       const requestId = "req-cu-targeted-no-header";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      expect(() =>
-        handleHostCuResult({ body: cuBody(requestId) }),
-      ).toThrow(BadRequestError);
+      expect(() => handleHostCuResult({ body: cuBody(requestId) })).toThrow(
+        BadRequestError,
+      );
     });
 
     test("throws BadRequestError (400) when header is empty string", () => {
@@ -265,6 +285,110 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
+    });
+  });
+
+  // ── 3b. Actor-principal-id (PR 7) — defense-in-depth ──────────────────────
+
+  describe("targeted + actor-principal-id binding", () => {
+    test("accepts when submitting actor matches target client's stored actor", async () => {
+      const requestId = "req-cu-actor-match";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      const result = await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-1",
+        },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(cuResolveSpy).toHaveLength(1);
+      expect(resolvedIds).toContain(requestId);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
+      const requestId = "req-cu-actor-mismatch";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "user-2",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction NOT consumed on 403 actor mismatch", () => {
+      const requestId = "req-cu-actor-mismatch-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      try {
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "user-2",
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor header is missing", () => {
+      const requestId = "req-cu-actor-missing";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("throws ForbiddenError (403) when target client has no stored actor principal id", () => {
+      const requestId = "req-cu-target-no-actor";
+      registerPending(requestId, { targetClientId: "client-A" });
+      // No actorPrincipalByClient entry for client-A.
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "user-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor header is whitespace only", () => {
+      const requestId = "req-cu-actor-whitespace";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "   ",
+          },
+        }),
+      ).toThrow(ForbiddenError);
     });
   });
 

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -7,8 +7,14 @@
 import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-store.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -65,14 +71,39 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
 
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.["x-vellum-client-id"];
+    const rawClientId = (headers as Record<string, string | undefined>)?.[
+      "x-vellum-client-id"
+    ];
     const submittingClientId = rawClientId?.trim() || undefined;
     if (!submittingClientId) {
-      throw new BadRequestError("x-vellum-client-id header is missing for a targeted host CU request.");
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host CU request.",
+      );
     }
     if (submittingClientId !== peeked.targetClientId) {
       throw new ForbiddenError(
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+
+    // Defense-in-depth: require the submitting actor's principal id to match
+    // the actor principal id captured when the target client opened its SSE
+    // stream. This prevents a different authenticated user with knowledge of
+    // both the requestId and target clientId from submitting a result on
+    // behalf of the targeted client.
+    const rawActorPrincipalId = (
+      headers as Record<string, string | undefined>
+    )?.["x-vellum-actor-principal-id"];
+    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        `Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.`,
       );
     }
   }
@@ -142,7 +173,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this request.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal id does not match the target client's stored actor principal id.",
       },
       "404": {
         description:


### PR DESCRIPTION
## Summary
- Adds same-user check on `POST /v1/host-cu-result`: when the pending interaction was targeted, the submitting actor must match the target client's stored `actorPrincipalId`.
- Cross-user submissions return 403; pending interaction left in place.
- Untargeted submissions unchanged.

Defense-in-depth for Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923).

Part of plan: host-proxy-same-user.md (PR 7 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->