### PR TITLE
fix(host-file): require source actor to match target client's actor for cross-client routing

### DIFF
--- a/assistant/src/__tests__/host-file-proxy-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-proxy-targeted.test.ts
@@ -14,11 +14,24 @@ const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
 const resolvedInteractionIds: string[] = [];
 let mockHasClient = false;
-let mockCapableClients: Array<{ clientId: string; capabilities: string[] }> = [];
-let mockClientRegistry: Map<string, { clientId: string; capabilities: string[] }> = new Map();
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockCapableClients: Array<MockClient> = [];
+let mockClientRegistry: Map<string, MockClient> = new Map();
+
+// Pre-existing Phase 2 routing tests use a single user identity. The same-user
+// check added in PR 3 is exercised separately in `host-file-proxy.test.ts`.
+const TEST_PRINCIPAL = "test-user";
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown, _conversationId?: string, options?: unknown) => {
+  broadcastMessage: (
+    msg: unknown,
+    _conversationId?: string,
+    options?: unknown,
+  ) => {
     sentMessages.push(msg);
     sentMessageOptions.push(options);
   },
@@ -27,6 +40,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_file" && mockHasClient ? { id: "mock-client" } : null,
     listClientsByCapability: (_cap: string) => mockCapableClients,
     getClientById: (clientId: string) => mockClientRegistry.get(clientId),
+    getActorPrincipalIdForClient: (clientId: string) =>
+      mockClientRegistry.get(clientId)?.actorPrincipalId,
   },
 }));
 
@@ -42,9 +57,10 @@ mock.module("../runtime/pending-interactions.js", () => ({
     return interaction;
   },
   get: (requestId: string) => pendingInteractionMap.get(requestId),
-  getByKind: (_kind: string) => Array.from(pendingInteractionMap.entries())
-    .filter(([, v]) => v.kind === _kind)
-    .map(([requestId, v]) => ({ requestId, ...v })),
+  getByKind: (_kind: string) =>
+    Array.from(pendingInteractionMap.entries())
+      .filter(([, v]) => v.kind === _kind)
+      .map(([requestId, v]) => ({ requestId, ...v })),
   getByConversation: () => [],
   removeByConversation: () => {},
 }));
@@ -66,7 +82,11 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
   }
 
   function setupSingleClient(clientId = "client-1") {
-    const entry = { clientId, capabilities: ["host_file"] };
+    const entry: MockClient = {
+      clientId,
+      capabilities: ["host_file"],
+      actorPrincipalId: TEST_PRINCIPAL,
+    };
     mockCapableClients = [entry];
     mockClientRegistry.set(clientId, entry);
   }
@@ -75,6 +95,7 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
     mockCapableClients = clientIds.map((id) => ({
       clientId: id,
       capabilities: ["host_file"],
+      actorPrincipalId: TEST_PRINCIPAL,
     }));
     for (const entry of mockCapableClients) {
       mockClientRegistry.set(entry.clientId, entry);
@@ -104,6 +125,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
           targetClientId: "client-mac",
         },
         "session-1",
+        undefined,
+        undefined,
+        TEST_PRINCIPAL,
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -140,7 +164,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("client-unknown");
-      expect(result.content).toContain("assistant clients list --capability host_file");
+      expect(result.content).toContain(
+        "assistant clients list --capability host_file",
+      );
       // No pending entry should have been created
       expect(sentMessages).toHaveLength(0);
     });
@@ -200,6 +226,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
       const resultPromise = proxy.request(
         { operation: "read", path: "/tmp/file.txt" },
         "session-1",
+        undefined,
+        undefined,
+        TEST_PRINCIPAL,
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -257,6 +286,8 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
         { operation: "read", path: "/tmp/file.txt" },
         "session-1",
         controller.signal,
+        undefined,
+        TEST_PRINCIPAL,
       );
 
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -273,7 +304,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
       expect(cancelMsg.requestId).toBe(requestId);
       expect(cancelMsg.targetClientId).toBe("client-abc");
 
-      const cancelOpts = sentMessageOptions[1] as Record<string, unknown> | undefined;
+      const cancelOpts = sentMessageOptions[1] as
+        | Record<string, unknown>
+        | undefined;
       expect(cancelOpts?.targetClientId).toBe("client-abc");
     });
   });
@@ -288,6 +321,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
       const p = proxy.request(
         { operation: "read", path: "/tmp/file.txt" },
         "session-1",
+        undefined,
+        undefined,
+        TEST_PRINCIPAL,
       );
       p.catch(() => {}); // expected rejection on dispose
 
@@ -320,6 +356,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
         const resultPromise = proxy.request(
           { operation: "read", path: "/tmp/slow.txt" },
           "session-1",
+          undefined,
+          undefined,
+          TEST_PRINCIPAL,
         );
 
         const sent = sentMessages[0] as Record<string, unknown>;

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -3,16 +3,36 @@ import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 const sentMessages: unknown[] = [];
 let mockHasClient = false;
 
+interface MockClient {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+}
+
+let mockClients: MockClient[] = [];
+
 mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: (msg: unknown) => sentMessages.push(msg),
   assistantEventHub: {
-    getMostRecentClientByCapability: (cap: string) =>
-      cap === "host_file" && mockHasClient ? { id: "mock-client" } : null,
-    listClientsByCapability: (cap: string) =>
-      cap === "host_file" && mockHasClient
+    getMostRecentClientByCapability: (cap: string) => {
+      if (mockClients.length > 0) {
+        return mockClients.find((c) => c.capabilities.includes(cap));
+      }
+      return cap === "host_file" && mockHasClient
+        ? { id: "mock-client" }
+        : null;
+    },
+    listClientsByCapability: (cap: string) => {
+      if (mockClients.length > 0) {
+        return mockClients.filter((c) => c.capabilities.includes(cap));
+      }
+      return cap === "host_file" && mockHasClient
         ? [{ clientId: "mock-client", capabilities: ["host_file"] }]
-        : [],
-    getClientById: (_id: string) => undefined,
+        : [];
+    },
+    getClientById: (id: string) => mockClients.find((c) => c.clientId === id),
+    getActorPrincipalIdForClient: (id: string) =>
+      mockClients.find((c) => c.clientId === id)?.actorPrincipalId,
   },
 }));
 
@@ -32,6 +52,7 @@ describe("HostFileProxy", () => {
   function setup() {
     sentMessages.length = 0;
     mockHasClient = false;
+    mockClients = [];
     pendingInteractions.clear();
     proxy = new (HostFileProxy as any)();
   }
@@ -582,6 +603,241 @@ describe("HostFileProxy", () => {
 
       await resultPromise;
       expect(pendingInteractions.get(requestId)).toBeUndefined();
+    });
+  });
+
+  describe("same-user binding (sourceActorPrincipalId)", () => {
+    test("targeted request from same user reaches pendingInteractions", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        "user-A",
+      );
+
+      // Request was registered (made it past the same-user gate).
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(pendingInteractions.get(requestId)).toBeDefined();
+
+      // Drain to avoid leaks.
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("targeted request from a different user is rejected", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const result = await proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      // No host_file_request was broadcast.
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("targeted request to a client with no actor principal is rejected", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          // actorPrincipalId omitted (legacy/service-token client).
+        },
+      ];
+
+      const result = await proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        "user-A",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("targeted request without source principal is rejected", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const result = await proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        undefined,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("untargeted request with no auto-resolve match still broadcasts (legacy path unchanged)", async () => {
+      setup();
+      // No matching same-user clients available.
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        undefined,
+        "user-B", // No same-user match → no auto-resolve, broadcast untargeted.
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBeUndefined();
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("auto-resolve picks the same-user client when there's exactly one", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+        {
+          clientId: "client-B",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-B",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        undefined,
+        "user-A",
+      );
+
+      // Auto-resolved to client-A and broadcast targeted at it.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("auto-resolve falls through when no client matches the source user", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        undefined,
+        "user-C",
+      );
+
+      // No same-user client → no auto-resolve, broadcast untargeted.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBeUndefined();
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("legacy embedded targetClientId in input still goes through the same-user gate", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      // Same-user via embedded input.targetClientId — should succeed.
+      const okPromise = proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/ok.txt",
+          targetClientId: "client-A",
+        },
+        "session-1",
+        undefined,
+        undefined,
+        "user-A",
+      );
+      expect(sentMessages).toHaveLength(1);
+      const okRequestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(okRequestId, { content: "ok", isError: false });
+      await okPromise;
+
+      // Cross-user via embedded input.targetClientId — should be rejected.
+      sentMessages.length = 0;
+      const rejectResult = await proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/bad.txt",
+          targetClientId: "client-A",
+        },
+        "session-1",
+        undefined,
+        undefined,
+        "user-B",
+      );
+      expect(rejectResult.isError).toBe(true);
+      expect(sentMessages).toHaveLength(0);
     });
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -135,6 +135,7 @@ export function createToolExecutor(
       taskRunId: ctx.taskRunId,
       trustClass: resolveTrustClass(ctx.trustContext),
       executionChannel: ctx.trustContext?.sourceChannel,
+      sourceActorPrincipalId: ctx.trustContext?.guardianPrincipalId,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:
         ctx.surfaceActionRequestIds?.has(ctx.currentRequestId ?? "") ?? false,

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -68,6 +68,7 @@ export class HostFileProxy {
     conversationId: string,
     signal?: AbortSignal,
     targetClientId?: string,
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({ content: "Aborted", isError: true });
@@ -76,7 +77,8 @@ export class HostFileProxy {
     // Resolve targetClientId: explicit → validate; single capable client → auto-resolve.
     // Callers may embed targetClientId in the input object (tool handlers) or pass it as
     // the 4th parameter (legacy). Prefer the explicit param; fall back to input field.
-    let resolvedTargetClientId: string | undefined = targetClientId ?? input.targetClientId;
+    let resolvedTargetClientId: string | undefined =
+      targetClientId ?? input.targetClientId;
     if (resolvedTargetClientId != null) {
       const client = assistantEventHub.getClientById(resolvedTargetClientId);
       if (!client) {
@@ -92,9 +94,45 @@ export class HostFileProxy {
         });
       }
     } else {
-      const capable = assistantEventHub.listClientsByCapability("host_file");
-      if (capable.length === 1) {
-        resolvedTargetClientId = capable[0].clientId;
+      // Auto-resolve only to a capable client whose actorPrincipalId matches
+      // the source caller's. Skips auto-resolve when the caller has no
+      // identity, since same-user binding cannot be enforced.
+      if (sourceActorPrincipalId != null) {
+        const capable = assistantEventHub.listClientsByCapability("host_file");
+        const sameUser = capable.filter(
+          (c) => c.actorPrincipalId === sourceActorPrincipalId,
+        );
+        if (sameUser.length === 1) {
+          resolvedTargetClientId = sameUser[0].clientId;
+        }
+      }
+    }
+
+    // Same-user check: targeted host_file requests must be bound to the same
+    // authenticated user identity that opened the target client's SSE stream.
+    // Prevents cross-user routing through actor token mis-targeting.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_file",
+          },
+          "Rejected cross-user targeted host_file request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_file requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
       }
     }
 

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -1,4 +1,5 @@
 import { supportsHostProxy } from "../../channels/types.js";
+import { findConversation } from "../../daemon/conversation-store.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -92,7 +93,8 @@ class HostFileEditTool implements Tool {
     const replaceAll = input.replace_all === true;
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -112,6 +114,9 @@ class HostFileEditTool implements Tool {
     // Proxy to connected client for execution on the user's machine
     // when a capable client is available (managed/cloud-hosted mode).
     if (HostFileProxy.instance.isAvailable()) {
+      const sourceActorPrincipalId =
+        findConversation(context.conversationId)?.trustContext
+          ?.guardianPrincipalId ?? undefined;
       return HostFileProxy.instance.request(
         {
           operation: "edit",
@@ -123,6 +128,8 @@ class HostFileEditTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        targetClientId,
+        sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -1,5 +1,4 @@
 import { supportsHostProxy } from "../../channels/types.js";
-import { findConversation } from "../../daemon/conversation-store.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -114,9 +113,6 @@ class HostFileEditTool implements Tool {
     // Proxy to connected client for execution on the user's machine
     // when a capable client is available (managed/cloud-hosted mode).
     if (HostFileProxy.instance.isAvailable()) {
-      const sourceActorPrincipalId =
-        findConversation(context.conversationId)?.trustContext
-          ?.guardianPrincipalId ?? undefined;
       return HostFileProxy.instance.request(
         {
           operation: "edit",
@@ -129,7 +125,7 @@ class HostFileEditTool implements Tool {
         context.conversationId,
         context.signal,
         targetClientId,
-        sourceActorPrincipalId,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -1,7 +1,6 @@
 import { extname } from "node:path";
 
 import { supportsHostProxy } from "../../channels/types.js";
-import { findConversation } from "../../daemon/conversation-store.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -86,9 +85,6 @@ class HostFileReadTool implements Tool {
     // when a capable client is available (managed/cloud-hosted mode),
     // including image reads that need the host filesystem view.
     if (HostFileProxy.instance.isAvailable()) {
-      const sourceActorPrincipalId =
-        findConversation(context.conversationId)?.trustContext
-          ?.guardianPrincipalId ?? undefined;
       return HostFileProxy.instance.request(
         {
           operation: "read",
@@ -100,7 +96,7 @@ class HostFileReadTool implements Tool {
         context.conversationId,
         context.signal,
         targetClientId,
-        sourceActorPrincipalId,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -1,6 +1,7 @@
 import { extname } from "node:path";
 
 import { supportsHostProxy } from "../../channels/types.js";
+import { findConversation } from "../../daemon/conversation-store.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -63,7 +64,8 @@ class HostFileReadTool implements Tool {
     }
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -84,6 +86,9 @@ class HostFileReadTool implements Tool {
     // when a capable client is available (managed/cloud-hosted mode),
     // including image reads that need the host filesystem view.
     if (HostFileProxy.instance.isAvailable()) {
+      const sourceActorPrincipalId =
+        findConversation(context.conversationId)?.trustContext
+          ?.guardianPrincipalId ?? undefined;
       return HostFileProxy.instance.request(
         {
           operation: "read",
@@ -94,6 +99,8 @@ class HostFileReadTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        targetClientId,
+        sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -1,5 +1,4 @@
 import { supportsHostProxy } from "../../channels/types.js";
-import { findConversation } from "../../daemon/conversation-store.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -84,9 +83,6 @@ class HostFileWriteTool implements Tool {
     // Proxy to connected client for execution on the user's machine
     // when a capable client is available (managed/cloud-hosted mode).
     if (HostFileProxy.instance.isAvailable()) {
-      const sourceActorPrincipalId =
-        findConversation(context.conversationId)?.trustContext
-          ?.guardianPrincipalId ?? undefined;
       return HostFileProxy.instance.request(
         {
           operation: "write",
@@ -97,7 +93,7 @@ class HostFileWriteTool implements Tool {
         context.conversationId,
         context.signal,
         targetClientId,
-        sourceActorPrincipalId,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -1,4 +1,5 @@
 import { supportsHostProxy } from "../../channels/types.js";
+import { findConversation } from "../../daemon/conversation-store.js";
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
@@ -62,7 +63,8 @@ class HostFileWriteTool implements Tool {
     }
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -82,6 +84,9 @@ class HostFileWriteTool implements Tool {
     // Proxy to connected client for execution on the user's machine
     // when a capable client is available (managed/cloud-hosted mode).
     if (HostFileProxy.instance.isAvailable()) {
+      const sourceActorPrincipalId =
+        findConversation(context.conversationId)?.trustContext
+          ?.guardianPrincipalId ?? undefined;
       return HostFileProxy.instance.request(
         {
           operation: "write",
@@ -91,6 +96,8 @@ class HostFileWriteTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        targetClientId,
+        sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -268,6 +268,14 @@ export interface ToolContext {
    * `executeSubagentSpawn` in tools/subagent/spawn.ts.
    */
   overrideProfile?: string;
+  /**
+   * Canonical principal ID of the actor on whose behalf this tool invocation
+   * is running. Sourced from `conversation.trustContext.guardianPrincipalId`.
+   * Used by host proxies to bind cross-client targeted execution to the same
+   * authenticated user identity. May be undefined for legacy/internal flows
+   * with no resolved actor identity.
+   */
+  sourceActorPrincipalId?: string;
 }
 
 export interface Tool {


### PR DESCRIPTION
## Summary
- Adds `sourceActorPrincipalId` parameter to `HostFileProxy.request`; rejects cross-user targeted requests at request time.
- Auto-resolve respects the same-user constraint.
- Untargeted host_file flows are unchanged.

Closes Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923) for host_file.

Part of plan: host-proxy-same-user.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->