### PR TITLE
fix(host-bash): require source actor to match target client's actor for cross-client routing

### DIFF
--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -17,11 +17,20 @@ mock.module("../config/loader.js", () => ({
 const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
 let mockHasClient = false;
-let mockCapableClients: Array<{ clientId: string; capabilities: string[] }> = [];
-let mockClientRegistry: Map<string, { clientId: string; capabilities: string[] }> = new Map();
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockCapableClients: Array<MockClient> = [];
+let mockClientRegistry: Map<string, MockClient> = new Map();
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown, _conversationId?: string, options?: unknown) => {
+  broadcastMessage: (
+    msg: unknown,
+    _conversationId?: string,
+    options?: unknown,
+  ) => {
     sentMessages.push(msg);
     sentMessageOptions.push(options);
   },
@@ -30,6 +39,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_bash" && mockHasClient ? { id: "mock-client" } : null,
     listClientsByCapability: (_cap: string) => mockCapableClients,
     getClientById: (clientId: string) => mockClientRegistry.get(clientId),
+    getActorPrincipalIdForClient: (clientId: string) =>
+      mockClientRegistry.get(clientId)?.actorPrincipalId,
   },
 }));
 
@@ -50,8 +61,15 @@ describe("HostBashProxy", () => {
     proxy = new (HostBashProxy as any)();
   }
 
-  function setupSingleClient(clientId = "client-1") {
-    const entry = { clientId, capabilities: ["host_bash"] };
+  function setupSingleClient(
+    clientId: string = "client-1",
+    actorPrincipalId: string = "user-A",
+  ) {
+    const entry: MockClient = {
+      clientId,
+      capabilities: ["host_bash"],
+      actorPrincipalId,
+    };
     mockCapableClients = [entry];
     mockClientRegistry.set(clientId, entry);
   }
@@ -60,6 +78,7 @@ describe("HostBashProxy", () => {
     mockCapableClients = clientIds.map((id) => ({
       clientId: id,
       capabilities: ["host_bash"],
+      actorPrincipalId: "user-A",
     }));
     for (const entry of mockCapableClients) {
       mockClientRegistry.set(entry.clientId, entry);
@@ -551,11 +570,13 @@ describe("HostBashProxy", () => {
   describe("target client routing", () => {
     test("auto-resolves when exactly one capable client is connected", async () => {
       setup();
-      setupSingleClient("client-abc");
+      setupSingleClient("client-abc", "user-A");
 
       const resultPromise = proxy.request(
         { command: "echo hello" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -580,15 +601,21 @@ describe("HostBashProxy", () => {
 
     test("uses explicit targetClientId when it is valid", async () => {
       setup();
-      setupSingleClient("client-abc");
+      setupSingleClient("client-abc", "user-A");
       // Also register a second client so we're sure explicit targeting works
-      const entry2 = { clientId: "client-xyz", capabilities: ["host_bash"] };
+      const entry2: MockClient = {
+        clientId: "client-xyz",
+        capabilities: ["host_bash"],
+        actorPrincipalId: "user-A",
+      };
       mockCapableClients.push(entry2);
       mockClientRegistry.set("client-xyz", entry2);
 
       const resultPromise = proxy.request(
         { command: "echo hello", targetClientId: "client-abc" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -612,17 +639,21 @@ describe("HostBashProxy", () => {
 
     test("returns error for explicit targetClientId that is not connected", async () => {
       setup();
-      setupSingleClient("client-abc");
+      setupSingleClient("client-abc", "user-A");
 
       const result = await proxy.request(
         { command: "echo hello", targetClientId: "client-unknown" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       // Should return error without broadcasting
       expect(result.isError).toBe(true);
       expect(result.content).toContain("client-unknown");
-      expect(result.content).toContain("assistant clients list --capability host_bash");
+      expect(result.content).toContain(
+        "assistant clients list --capability host_bash",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -632,11 +663,14 @@ describe("HostBashProxy", () => {
       mockClientRegistry.set("client-no-bash", {
         clientId: "client-no-bash",
         capabilities: [],
+        actorPrincipalId: "user-A",
       });
 
       const result = await proxy.request(
         { command: "echo hello", targetClientId: "client-no-bash" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       expect(result.isError).toBe(true);
@@ -652,6 +686,8 @@ describe("HostBashProxy", () => {
       const resultPromise = proxy.request(
         { command: "echo hello" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       // Should broadcast without an early error return
@@ -707,13 +743,15 @@ describe("HostBashProxy", () => {
 
     test("includes targetClientId in timeout error message when client was resolved", async () => {
       setup();
-      setupSingleClient("client-mac");
+      setupSingleClient("client-mac", "user-A");
 
       jest.useFakeTimers();
       try {
         const resultPromise = proxy.request(
           { command: "echo slow", timeout_seconds: 30 },
           "session-1",
+          undefined,
+          "user-A",
         );
 
         // Proxy timeout = 33s; advance past it
@@ -725,6 +763,176 @@ describe("HostBashProxy", () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe("same-user binding (sourceActorPrincipalId)", () => {
+    const SAME_USER_REJECTION =
+      "Targeted host_bash requests require the target client to be owned by the same user as the caller.";
+
+    test("same-user targeted request succeeds", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const resultPromise = proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_bash_request");
+      expect(sent.targetClientId).toBe("client-abc");
+      const requestId = sent.requestId as string;
+      expect(pendingInteractions.get(requestId)).toBeDefined();
+
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
+    });
+
+    test("cross-user targeted request rejected", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const result = await proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(SAME_USER_REJECTION);
+      // No broadcast and no pending registration
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("target client missing actorPrincipalId rejected", async () => {
+      setup();
+      // Register a client without an actorPrincipalId (legacy/service-token).
+      const entry: MockClient = {
+        clientId: "client-abc",
+        capabilities: ["host_bash"],
+      };
+      mockCapableClients = [entry];
+      mockClientRegistry.set("client-abc", entry);
+
+      const result = await proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(SAME_USER_REJECTION);
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("source missing actorPrincipalId rejected when targeting", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const result = await proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        undefined,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(SAME_USER_REJECTION);
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("untargeted local flow unchanged when no auto-resolve match", async () => {
+      setup();
+      // No capable clients connected — untargeted path runs.
+
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_bash_request");
+      expect(sent.targetClientId).toBeUndefined();
+
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
+    });
+
+    test("auto-resolve to same-user client succeeds", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-abc");
+
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
+    });
+
+    test("auto-resolve to different-user client falls through to untargeted", async () => {
+      setup();
+      // Single capable client owned by user-B; caller is user-A.
+      setupSingleClient("client-abc", "user-B");
+
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      // Auto-resolve must NOT pick the cross-user client; the untargeted
+      // broadcast path runs instead.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_bash_request");
+      expect(sent.targetClientId).toBeUndefined();
+
+      const opts = sentMessageOptions[0] as Record<string, unknown> | undefined;
+      expect(opts?.targetClientId).toBeUndefined();
+
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
     });
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -135,6 +135,7 @@ export function createToolExecutor(
       taskRunId: ctx.taskRunId,
       trustClass: resolveTrustClass(ctx.trustContext),
       executionChannel: ctx.trustContext?.sourceChannel,
+      sourceActorPrincipalId: ctx.trustContext?.guardianPrincipalId,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:
         ctx.surfaceActionRequestIds?.has(ctx.currentRequestId ?? "") ?? false,

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -13,7 +13,6 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("host-bash-proxy");
 
-
 export class HostBashProxy {
   private static _instance: HostBashProxy | null = null;
 
@@ -62,13 +61,16 @@ export class HostBashProxy {
     },
     conversationId: string,
     signal?: AbortSignal,
+    // Principal ID of the actor on whose behalf this request is initiated.
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       const result = formatShellOutput("", "Aborted", null, false, 0);
       return Promise.resolve(result);
     }
 
-    const capableClients = assistantEventHub.listClientsByCapability("host_bash");
+    const capableClients =
+      assistantEventHub.listClientsByCapability("host_bash");
 
     let resolvedTargetClientId: string | undefined;
 
@@ -82,13 +84,52 @@ export class HostBashProxy {
       }
       resolvedTargetClientId = input.targetClientId;
     } else if (capableClients.length === 1) {
-      // Auto-resolve when exactly one capable client is connected.
-      resolvedTargetClientId = capableClients[0].clientId;
+      // Auto-resolve when exactly one capable client is connected — but only
+      // when its actor principal matches the caller's. This prevents a
+      // same-daemon attacker from getting cross-user execution by relying on
+      // auto-resolve. If the sole client belongs to a different user, fall
+      // through to the untargeted broadcast path.
+      const onlyClient = capableClients[0];
+      if (
+        sourceActorPrincipalId != null &&
+        onlyClient.actorPrincipalId === sourceActorPrincipalId
+      ) {
+        resolvedTargetClientId = onlyClient.clientId;
+      }
     }
     // capableClients.length === 0 or > 1 without explicit target: resolvedTargetClientId
     // stays undefined and falls through to untargeted broadcast — the existing timeout/error
     // path handles the zero-client case, and multi-client ambiguity is enforced at the tool
     // executor layer (not here) once target_client_id is exposed in the tool schema.
+
+    // Targeted requests must be bound to the same authenticated user as the
+    // target client. Fail closed at request time — before pendingInteractions
+    // registration and before broadcast — so a same-daemon caller cannot
+    // execute on another user's connected client.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        targetActorPrincipalId !== sourceActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_bash",
+          },
+          "Rejecting targeted host_bash request: source actor does not match target client's actor",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_bash requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
+    }
 
     const requestId = uuid();
 
@@ -108,15 +149,7 @@ export class HostBashProxy {
         const timeoutMessage = resolvedTargetClientId
           ? `Host bash proxy timed out waiting for response from client ${resolvedTargetClientId}`
           : "Host bash proxy timed out waiting for client response";
-        resolve(
-          formatShellOutput(
-            "",
-            timeoutMessage,
-            null,
-            true,
-            timeoutSec,
-          ),
-        );
+        resolve(formatShellOutput("", timeoutMessage, null, true, timeoutSec));
       }, proxyTimeoutSec * 1000);
 
       if (signal) {
@@ -166,8 +199,8 @@ export class HostBashProxy {
             timeout_seconds: input.timeout_seconds,
             targetClientId: resolvedTargetClientId,
             ...(input.env && Object.keys(input.env).length > 0
-                ? { env: input.env }
-                : {}),
+              ? { env: input.env }
+              : {}),
           },
           conversationId,
           { targetClientId: resolvedTargetClientId },

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -181,7 +181,8 @@ class HostShellTool implements Tool {
     const background = input.background === true;
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -236,10 +237,7 @@ class HostShellTool implements Tool {
     // guard both targetClientId != null guards above are bypassed, and the
     // code falls through to local daemon execution — silently running commands
     // inside the Docker container instead of on the intended host machine.
-    if (
-      targetClientId != null &&
-      !HostBashProxy.instance.isAvailable()
-    ) {
+    if (targetClientId != null && !HostBashProxy.instance.isAvailable()) {
       return {
         content: `Error: target client "${targetClientId}" is no longer connected. The specified client may have disconnected since the tool was called. Run \`assistant clients list --capability host_bash\` to see currently connected clients.`,
         isError: true,
@@ -287,6 +285,7 @@ class HostShellTool implements Tool {
           },
           context.conversationId,
           abortController.signal,
+          context.sourceActorPrincipalId,
         );
 
         proxyPromise
@@ -334,6 +333,7 @@ class HostShellTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -268,6 +268,14 @@ export interface ToolContext {
    * `executeSubagentSpawn` in tools/subagent/spawn.ts.
    */
   overrideProfile?: string;
+  /**
+   * Canonical principal ID of the actor on whose behalf this tool invocation
+   * is running. Sourced from `conversation.trustContext.guardianPrincipalId`.
+   * Used by host proxies to bind cross-client targeted execution to the same
+   * authenticated user identity. May be undefined for legacy/internal flows
+   * with no resolved actor identity.
+   */
+  sourceActorPrincipalId?: string;
 }
 
 export interface Tool {


### PR DESCRIPTION
## Summary
- Adds `sourceActorPrincipalId` parameter to `HostBashProxy.request`; rejects targeted requests when the source caller's principal does not match the target client's stored `actorPrincipalId`.
- Auto-resolve respects the same-user constraint.
- Untargeted host_bash flows are unchanged.

Closes Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923) for host_bash.

Part of plan: host-proxy-same-user.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->