### PR TITLE
fix(host-cu): validate target client and require same actor for cross-client routing

### DIFF
--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -9,8 +9,20 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
 let mockHasClient = true; // Default to true for CU unified flow tests
-let mockCuClients: Array<{ clientId: string; capabilities: string[] }> = [
-  { clientId: "mock-client-1", capabilities: ["host_cu"] },
+// Default principal id used for both ctx.trustContext and clients in the
+// existing single-user tests. Tests that exercise cross-user behaviour
+// override this on individual clients and on the SurfaceConversationContext.
+const DEFAULT_PRINCIPAL = "user-1";
+let mockCuClients: Array<{
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+}> = [
+  {
+    clientId: "mock-client-1",
+    capabilities: ["host_cu"],
+    actorPrincipalId: DEFAULT_PRINCIPAL,
+  },
 ];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
@@ -38,12 +50,25 @@ type SurfaceConversationContext =
 /**
  * Build a minimal SurfaceConversationContext with optional hostCuProxy.
  * Only the fields required by the CU routing path are populated.
+ *
+ * `trustContext` defaults to a guardian context owned by `DEFAULT_PRINCIPAL`.
+ * Pass `null` to omit the field entirely (used to verify same-user
+ * enforcement when the conversation has no source actor principal).
  */
 function buildMockContext(
   hostCuProxy?: InstanceType<typeof HostCuProxy>,
+  trustGuardianPrincipalId: string | null = DEFAULT_PRINCIPAL,
 ): SurfaceConversationContext {
   return {
     conversationId: "test-session",
+    trustContext:
+      trustGuardianPrincipalId != null
+        ? {
+            sourceChannel: "vellum",
+            trustClass: "guardian",
+            guardianPrincipalId: trustGuardianPrincipalId,
+          }
+        : undefined,
     traceEmitter: { emit: () => {} },
     sendToClient: () => {},
     pendingSurfaceActions: new Map(),
@@ -72,7 +97,13 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   function setupProxy(maxSteps?: number): SurfaceConversationContext {
     sentMessages.length = 0;
     mockHasClient = true;
-    mockCuClients = [{ clientId: "mock-client-1", capabilities: ["host_cu"] }];
+    mockCuClients = [
+      {
+        clientId: "mock-client-1",
+        capabilities: ["host_cu"],
+        actorPrincipalId: DEFAULT_PRINCIPAL,
+      },
+    ];
     proxy = new HostCuProxy(maxSteps);
     return buildMockContext(proxy);
   }
@@ -397,8 +428,16 @@ describe("surfaceProxyResolver — CU tool routing", () => {
     test("proceeds when multiple clients connected and target_client_id is given", async () => {
       const ctx = setupProxy();
       mockCuClients = [
-        { clientId: "client-a", capabilities: ["host_cu"] },
-        { clientId: "client-b", capabilities: ["host_cu"] },
+        {
+          clientId: "client-a",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        {
+          clientId: "client-b",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
       ];
 
       const resultPromise = surfaceProxyResolver(ctx, "computer_use_click", {
@@ -508,8 +547,18 @@ describe("surfaceProxyResolver — CU tool routing", () => {
     test("dispatches and records action when targetClientId is valid", async () => {
       const ctx = setupProxy();
       mockCuClients = [
-        { clientId: "cu-client", capabilities: ["host_cu"] },
-        { clientId: "client-b", capabilities: ["host_cu"] }, // would otherwise trip ambiguity guard
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        // Second client present to ensure target_client_id resolves
+        // unambiguously and would otherwise trip the ambiguity guard.
+        {
+          clientId: "client-b",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
       ];
 
       const resultPromise = surfaceProxyResolver(ctx, "computer_use_click", {
@@ -529,6 +578,68 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       proxy.processObservation(sent.requestId as string, { axTree: "ok" });
       const result = await resultPromise;
       expect(result.isError).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Same-user enforcement (dispatch layer)
+  //
+  // The proxy enforces this internally as well — these tests verify the
+  // dispatch surfaces a friendly tool-input rejection before the proxy is
+  // invoked, and that the rejection happens before any state mutation.
+  // -------------------------------------------------------------------------
+
+  describe("same-user enforcement", () => {
+    test("rejects targeted CU dispatch from a different actor principal", async () => {
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-other",
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, DEFAULT_PRINCIPAL);
+
+      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+        target_client_id: "cu-client",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("cu-client");
+      expect(result.content).toContain("not owned by the current user");
+      // No state mutation, no dispatch.
+      expect(proxy.stepCount).toBe(0);
+      expect(proxy.actionHistory).toHaveLength(0);
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when the conversation has no source actor principal", async () => {
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, null);
+
+      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+        target_client_id: "cu-client",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not owned by the current user");
+      expect(sentMessages).toHaveLength(0);
     });
   });
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -2,12 +2,20 @@ import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
 let mockHasClient = false;
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: (msg: unknown) => sentMessages.push(msg),
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
+    getClientById: (id: string) =>
+      mockClients.find((c) => c.clientId === id) ?? undefined,
   },
 }));
 
@@ -21,6 +29,7 @@ describe("HostCuProxy", () => {
   function setup(maxSteps?: number) {
     sentMessages.length = 0;
     mockHasClient = false;
+    mockClients = [];
     pendingInteractions.clear();
     proxy = new HostCuProxy(maxSteps);
   }
@@ -974,7 +983,197 @@ describe("HostCuProxy", () => {
     });
   });
 
-  // targetClientId validation lives at the surfaceProxyResolver layer (so an
-  // invalid ID does not burn a step or pollute action history before being
-  // rejected). See cu-unified-flow.test.ts for those tests.
+  // -------------------------------------------------------------------------
+  // targetClientId validation
+  //
+  // The surfaceProxyResolver layer validates first (so an invalid ID does
+  // not burn a step or pollute action history — see cu-unified-flow.test.ts
+  // for those tests). The proxy ALSO validates internally because it is
+  // exposed as a separately-callable API; these tests exercise that
+  // backstop along with the same-user enforcement.
+  // -------------------------------------------------------------------------
+
+  describe("targetClientId validation", () => {
+    test("rejects when targetClientId does not match any connected client", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "real-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "ghost-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("ghost-client");
+      expect(result.content).toContain("host_cu");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when target client lacks host_cu capability", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "no-cu-client",
+          capabilities: ["host_bash"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "no-cu-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("does not support host_cu");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("succeeds when caller and target share the same actor principal", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        "user-1",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_cu_request");
+      expect(sent.targetClientId).toBe("cu-client");
+
+      proxy.processObservation(sent.requestId as string, { axTree: "ok" });
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+    });
+
+    test("rejects cross-user targeted request", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-2",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("owned by the same user as the caller");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when source actor principal is missing", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        // sourceActorPrincipalId omitted
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("owned by the same user as the caller");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when target actor principal is missing", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          // actorPrincipalId omitted
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("owned by the same user as the caller");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("untargeted request bypasses same-user check", async () => {
+      setup();
+      // No targetClientId, no sourceActorPrincipalId — flow proceeds.
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_cu_request");
+      expect(sent.targetClientId).toBeUndefined();
+
+      proxy.processObservation(sent.requestId as string, { axTree: "ok" });
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+    });
+  });
 });

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1939,6 +1939,7 @@ export async function surfaceProxyResolver(
     // burn a step or pollute action history. (HostBashProxy / HostFileProxy
     // both validate at the tool-resolution layer before incrementing any
     // state; this mirrors that behaviour for CU.)
+    const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
       if (!client) {
@@ -1950,6 +1951,22 @@ export async function surfaceProxyResolver(
       if (!client.capabilities.includes("host_cu")) {
         return {
           content: `Client '${targetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          isError: true,
+        };
+      }
+
+      // Same-user enforcement: a targeted CU dispatch must be owned by the
+      // same actor on both sides. Surface a friendly tool-input rejection
+      // before invoking the proxy (which performs the same check as a
+      // backstop for direct callers).
+      const targetActorPrincipalId = client.actorPrincipalId;
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        return {
+          content: `Client '${targetClientId}' is not owned by the current user — cross-user computer_use dispatch is not allowed.`,
           isError: true,
         };
       }
@@ -1989,6 +2006,7 @@ export async function surfaceProxyResolver(
       reasoning,
       signal,
       targetClientId,
+      sourceActorPrincipalId,
     );
   }
 

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -121,6 +121,16 @@ export class HostCuProxy {
   // Request / resolve lifecycle
   // ---------------------------------------------------------------------------
 
+  /**
+   * Send a CU request to the connected desktop client.
+   *
+   * When `targetClientId` is supplied, the proxy validates that the target
+   * exists and advertises the `host_cu` capability, mirroring HostFileProxy's
+   * resolver-side checks so that the proxy is safe to call as a standalone
+   * API. It additionally enforces that the caller (`sourceActorPrincipalId`)
+   * and the target client share the same actor principal — cross-user
+   * targeted dispatch is rejected.
+   */
   request(
     toolName: string,
     input: Record<string, unknown>,
@@ -129,6 +139,7 @@ export class HostCuProxy {
     reasoning?: string,
     signal?: AbortSignal,
     targetClientId?: string,
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({
@@ -142,6 +153,50 @@ export class HostCuProxy {
         content: `Step limit (${this._maxSteps}) exceeded. Call computer_use_done to finish.`,
         isError: true,
       });
+    }
+
+    // Existence + capability validation for explicit targets. Mirrors
+    // HostFileProxy's resolver-side guard so that the proxy is safe even
+    // when called outside the conversation-surfaces dispatch (which has
+    // its own validation layer).
+    if (targetClientId != null) {
+      const client = assistantEventHub.getClientById(targetClientId);
+      if (!client) {
+        return Promise.resolve({
+          content: `No connected client with id '${targetClientId}' supports host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          isError: true,
+        });
+      }
+      if (!client.capabilities.includes("host_cu")) {
+        return Promise.resolve({
+          content: `Client '${targetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          isError: true,
+        });
+      }
+
+      // Same-user enforcement: targeted CU dispatch must be owned by the
+      // same actor on both sides. Reject when either principal is missing
+      // or when they don't match.
+      const targetActorPrincipalId = client.actorPrincipalId;
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            targetClientId,
+            hasSourcePrincipal: sourceActorPrincipalId != null,
+            hasTargetPrincipal: targetActorPrincipalId != null,
+          },
+          "Rejected cross-user host_cu request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_cu requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
     }
 
     const requestId = uuid();
@@ -170,9 +225,7 @@ export class HostCuProxy {
                   type: "host_cu_cancel",
                   requestId,
                   conversationId,
-                  ...(targetClientId != null
-                    ? { targetClientId }
-                    : {}),
+                  ...(targetClientId != null ? { targetClientId } : {}),
                 },
                 conversationId,
                 { targetClientId },


### PR DESCRIPTION
## Summary
- Adds missing existence + capability validation in `HostCuProxy.request` (closes prior gap where targeted CU requests were broadcast without validation).
- Adds `sourceActorPrincipalId` parameter to `HostCuProxy.request` and to the CU dispatch in `conversation-surfaces.ts`; rejects cross-user targeted requests.
- Untargeted CU flows are unchanged.

Closes Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923) for host_cu.

Part of plan: host-proxy-same-user.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->