### PR TITLE
fix(client-routes): filter `assistant clients list` to same-user clients

### DIFF
--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -67,8 +67,7 @@ function registerClient(args: {
     interfaceId: "macos",
     capabilities: ["host_bash", "host_file", "host_cu"],
     actorPrincipalId: args.actorPrincipalId,
-    onEvent: () => {},
-    onClose: () => {},
+    callback: () => {},
   });
 }
 

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the GET /v1/clients (list_clients) route.
+ *
+ * Validates the same-user filter applied to client listings:
+ * - Caller sees only clients owned by their `actorPrincipalId`.
+ * - Clients with no stored `actorPrincipalId` are filtered out (fail-closed).
+ * - Dev-bypass mode (`isHttpAuthDisabled()`) returns all clients.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must be set up before importing the route) ──────────────
+
+let fakeHttpAuthDisabled = false;
+
+mock.module("../../../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────
+
+import {
+  AssistantEventHub,
+  assistantEventHub,
+} from "../../assistant-event-hub.js";
+import { ROUTES } from "../client-routes.js";
+import type { RouteDefinition } from "../types.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+type ListClientsResponse = {
+  clients: Array<{
+    clientId: string;
+    interfaceId: string;
+    capabilities: string[];
+    machineName?: string;
+    connectedAt: string;
+    lastActiveAt: string;
+  }>;
+};
+
+function registerClient(args: {
+  clientId: string;
+  actorPrincipalId?: string;
+}): void {
+  const ac = new AbortController();
+  assistantEventHub.subscribe(
+    {
+      type: "client",
+      clientId: args.clientId,
+      interfaceId: "macos",
+      capabilities: ["host_bash", "host_file", "host_cu"],
+      actorPrincipalId: args.actorPrincipalId,
+      onEvent: () => {},
+      onClose: () => {},
+    },
+    ac.signal,
+  );
+}
+
+function clearHub(): void {
+  const ids = assistantEventHub.listClients().map((c) => c.clientId);
+  for (const id of ids) {
+    assistantEventHub.disposeClient(id);
+  }
+}
+
+// Suppress unused-binding warning when AssistantEventHub isn't directly
+// referenced — the import keeps the type available for future extensions.
+void AssistantEventHub;
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("list_clients route — same-user filter", () => {
+  beforeEach(() => {
+    fakeHttpAuthDisabled = false;
+    clearHub();
+  });
+
+  test("returns only clients owned by the calling actor", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-A2", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-B1", actorPrincipalId: "user-B" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-A" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-A1", "client-A2"]);
+  });
+
+  test("filters out cross-user clients when listing as a different user", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-B1", actorPrincipalId: "user-B" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-B" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId);
+    expect(ids).toEqual(["client-B1"]);
+  });
+
+  test("filters out clients with no stored actorPrincipalId (fail-closed)", () => {
+    registerClient({
+      clientId: "client-noprincipal",
+      actorPrincipalId: undefined,
+    });
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-A" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId);
+    expect(ids).toEqual(["client-A1"]);
+  });
+
+  test("filters out all clients when caller has no actorPrincipalId header (fail-closed)", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({}) as ListClientsResponse;
+
+    expect(result.clients).toEqual([]);
+  });
+
+  test("dev-bypass mode returns all clients regardless of actor", () => {
+    fakeHttpAuthDisabled = true;
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-B1", actorPrincipalId: "user-B" });
+    registerClient({
+      clientId: "client-noprincipal",
+      actorPrincipalId: undefined,
+    });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-A" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-A1", "client-B1", "client-noprincipal"]);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -61,19 +61,15 @@ function registerClient(args: {
   clientId: string;
   actorPrincipalId?: string;
 }): void {
-  const ac = new AbortController();
-  assistantEventHub.subscribe(
-    {
-      type: "client",
-      clientId: args.clientId,
-      interfaceId: "macos",
-      capabilities: ["host_bash", "host_file", "host_cu"],
-      actorPrincipalId: args.actorPrincipalId,
-      onEvent: () => {},
-      onClose: () => {},
-    },
-    ac.signal,
-  );
+  assistantEventHub.subscribe({
+    type: "client",
+    clientId: args.clientId,
+    interfaceId: "macos",
+    capabilities: ["host_bash", "host_file", "host_cu"],
+    actorPrincipalId: args.actorPrincipalId,
+    onEvent: () => {},
+    onClose: () => {},
+  });
 }
 
 function clearHub(): void {

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 
 import type { HostProxyCapability } from "../../channels/types.js";
+import { isHttpAuthDisabled } from "../../config/env.js";
 import { datesToISO } from "../../util/json.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { NotFoundError } from "./errors.js";
@@ -33,7 +34,7 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       clients: z.array(z.object({}).passthrough()),
     }),
-    handler: ({ queryParams }) => {
+    handler: ({ queryParams, headers }) => {
       const capability = queryParams?.capability as
         | HostProxyCapability
         | undefined;
@@ -42,8 +43,25 @@ export const ROUTES: RouteDefinition[] = [
         ? assistantEventHub.listClientsByCapability(capability)
         : assistantEventHub.listClients();
 
+      // Defense-in-depth: filter the listing to clients owned by the calling
+      // actor so users cannot enumerate other users' connected client IDs.
+      // Clients with no stored `actorPrincipalId` (legacy SSE subscribers from
+      // before host-proxy-same-user, service-gateway tokens) are filtered out
+      // — fail-closed is the right default for this security boundary.
+      // Dev-bypass mode (DISABLE_HTTP_AUTH=true, mirroring
+      // require-bound-guardian.ts) preserves the previous "return all" behavior
+      // for platform-managed deployments where the platform handles auth.
+      const callerPrincipalId = headers?.["x-vellum-actor-principal-id"];
+      const filtered = isHttpAuthDisabled()
+        ? clients
+        : clients.filter(
+            (c) =>
+              c.actorPrincipalId !== undefined &&
+              c.actorPrincipalId === callerPrincipalId,
+          );
+
       return {
-        clients: clients.map((c) =>
+        clients: filtered.map((c) =>
           datesToISO({
             clientId: c.clientId,
             interfaceId: c.interfaceId,


### PR DESCRIPTION
## Summary
- Filters `GET /v1/clients` to clients whose stored `actorPrincipalId` matches the calling actor.
- Clients with no stored `actorPrincipalId` are filtered out (fail-closed).
- Dev-bypass mode preserves the previous behavior of returning all clients.

Defense-in-depth for Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923).

Part of plan: host-proxy-same-user.md (PR 8 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->