### PR TITLE
fix(host-file-result): require submitting actor to match target client's actor

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6318,7 +6318,7 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host file request.
         "403":
-          description: Submitting client does not match the targeted client for this request.
+          description: Submitting client or actor does not match the targeted client/actor for this request.
         "404":
           description: No pending interaction found for the given requestId.
         "409":

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -1,11 +1,14 @@
 /**
- * Tests for the host-file-result route 403 guard introduced in Phase 2.
+ * Tests for the host-file-result route 403 guard.
  *
  * Covers:
- *  1. Targeted + correct x-vellum-client-id header → 200 accepted
- *  2. Targeted + missing header → 400 BadRequestError
- *  3. Targeted + wrong header → 403 ForbiddenError, interaction NOT consumed
+ *  1. Targeted + correct x-vellum-client-id header (and matching actor) → 200
+ *  2. Targeted + missing client-id header → 400 BadRequestError
+ *  3. Targeted + wrong client-id header → 403 ForbiddenError, interaction NOT consumed
  *  4. Untargeted (no targetClientId, no header) → 200 accepted (regression)
+ *  5. Targeted + matching client-id but mismatched actor principal → 403, NOT consumed
+ *  6. Targeted + matching client-id but missing actor principal header → 403, NOT consumed
+ *  7. Targeted + matching client-id but target client has no stored actor → 403, NOT consumed
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -61,12 +64,20 @@ mock.module("../daemon/host-file-proxy.js", () => ({
   },
 }));
 
+// Stub event hub so tests control what actorPrincipalId is associated with
+// each connected client.
+const clientActors = new Map<string, string>();
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getActorPrincipalIdForClient: (clientId: string) =>
+      clientActors.get(clientId),
+  },
+}));
+
 // ── Real imports (after mocks) ──────────────────────────────────────────────
 
-import {
-  BadRequestError,
-  ForbiddenError,
-} from "../runtime/routes/errors.js";
+import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/host-file-routes.js";
 
 afterAll(() => {
@@ -100,23 +111,28 @@ function fileBody(requestId: string): Record<string, unknown> {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
+describe("handleHostFileResult — targetClientId guard", () => {
   beforeEach(() => {
     pendingStore.clear();
     resolvedIds.length = 0;
     resolveSpy.length = 0;
+    clientActors.clear();
   });
 
-  // ── 1. Targeted + correct header → 200 ────────────────────────────────────
+  // ── 1. Targeted + correct headers (client + actor) → 200 ──────────────────
 
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-file-targeted-match";
       registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -128,26 +144,30 @@ describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-file-targeted-trim";
       registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
     });
   });
 
-  // ── 2. Targeted + missing header → 400 ────────────────────────────────────
+  // ── 2. Targeted + missing client-id header → 400 ──────────────────────────
 
   describe("targeted + missing x-vellum-client-id header", () => {
     test("throws BadRequestError (400) when header is absent", () => {
       const requestId = "req-file-targeted-no-header";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      expect(() =>
-        handleHostFileResult({ body: fileBody(requestId) }),
-      ).toThrow(BadRequestError);
+      expect(() => handleHostFileResult({ body: fileBody(requestId) })).toThrow(
+        BadRequestError,
+      );
     });
 
     test("throws BadRequestError (400) when header is empty string", () => {
@@ -177,7 +197,7 @@ describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
     });
   });
 
-  // ── 3. Targeted + wrong header → 403 ──────────────────────────────────────
+  // ── 3. Targeted + wrong client-id header → 403 ────────────────────────────
 
   describe("targeted + wrong x-vellum-client-id header", () => {
     test("throws ForbiddenError (403) when client ID does not match", () => {
@@ -257,6 +277,138 @@ describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
 
       expect(result).toEqual({ accepted: true });
       expect(resolveSpy).toHaveLength(1);
+    });
+  });
+
+  // ── 5. Targeted + matching client but mismatched actor → 403 ──────────────
+
+  describe("targeted + actor principal mismatch", () => {
+    test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
+      const requestId = "req-file-actor-mismatch";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-2",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT consumed on actor-mismatch 403", () => {
+      const requestId = "req-file-actor-mismatch-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      try {
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-2",
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+  });
+
+  // ── 6. Targeted + matching client but missing actor header → 403 ──────────
+
+  describe("targeted + missing x-vellum-actor-principal-id header", () => {
+    test("throws ForbiddenError (403) when submitting actor header is absent", () => {
+      const requestId = "req-file-actor-missing";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor header is empty string", () => {
+      const requestId = "req-file-actor-empty";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "   ",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT consumed when submitting actor is missing", () => {
+      const requestId = "req-file-actor-missing-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      try {
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: { "x-vellum-client-id": "client-A" },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+  });
+
+  // ── 7. Targeted + target client has no stored actor → 403 ─────────────────
+
+  describe("targeted + target client has no stored actor", () => {
+    test("throws ForbiddenError (403) when target client has no actorPrincipalId on record", () => {
+      const requestId = "req-file-target-no-actor";
+      registerPending(requestId, { targetClientId: "client-A" });
+      // intentionally do not set clientActors entry for client-A
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT consumed when target client has no stored actor", () => {
+      const requestId = "req-file-target-no-actor-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+
+      try {
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
     });
   });
 });

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -7,8 +7,14 @@
 import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -44,14 +50,35 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
 
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.["x-vellum-client-id"];
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const rawClientId = headerMap["x-vellum-client-id"];
     const submittingClientId = rawClientId?.trim() || undefined;
     if (!submittingClientId) {
-      throw new BadRequestError("x-vellum-client-id header is missing for a targeted host file request.");
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host file request.",
+      );
     }
     if (submittingClientId !== peeked.targetClientId) {
       throw new ForbiddenError(
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. This blocks
+    // cross-user submissions even if a different user somehow obtains the
+    // target client id.
+    const rawActorPrincipalId = headerMap["x-vellum-actor-principal-id"];
+    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this request.",
       );
     }
   }
@@ -103,7 +130,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this request.",
+          "Submitting client or actor does not match the targeted client/actor for this request.",
       },
       "404": {
         description: "No pending interaction found for the given requestId.",


### PR DESCRIPTION
## Summary
- Adds same-user check on `POST /v1/host-file-result`: when the pending interaction was targeted, the submitting actor must match the target client's stored `actorPrincipalId`.
- Cross-user submissions return 403; pending interaction left in place.
- Untargeted submissions unchanged.

Defense-in-depth for Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923).

Part of plan: host-proxy-same-user.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->