### PR TITLE
fix(macos): silence unused-result warning on trust rule mutations

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1001,13 +1001,13 @@ struct ToolCallStepDetailRow: View {
                     Task {
                         do {
                             if let existingRule {
-                                try await Self.trustRuleClient.updateRule(
+                                _ = try await Self.trustRuleClient.updateRule(
                                     id: existingRule.id,
                                     risk: rule.riskLevel,
                                     description: nil
                                 )
                             } else {
-                                try await Self.trustRuleClient.createRule(
+                                _ = try await Self.trustRuleClient.createRule(
                                     tool: rule.toolName,
                                     pattern: rule.pattern,
                                     risk: rule.riskLevel,
@@ -1026,7 +1026,7 @@ struct ToolCallStepDetailRow: View {
                 onSaveAsNew: { rule in
                     Task {
                         do {
-                            try await Self.trustRuleClient.createRule(
+                            _ = try await Self.trustRuleClient.createRule(
                                 tool: rule.toolName,
                                 pattern: rule.pattern,
                                 risk: rule.riskLevel,


### PR DESCRIPTION
## Summary
- Discard the `TrustRule` return value from `updateRule`/`createRule` in `AssistantProgressView.swift` rule editor save handlers using `_ =`, matching the convention already used in `ChatViewModel.swift`, `TrustRulesView.swift`, and `ToolPermissionTesterModel.swift`.
- Silences the Swift `[#no-usage]` warning surfaced during `./build.sh run`.

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift:1004:64: warning: result of call to 'updateRule(id:risk:description:)' is unused [#no-usage]
1002 |                         do {
1003 |                             if let existingRule {
1004 |                                 try await Self.trustRuleClient.updateRule(
     |                                                                `- warning: result of call to 'updateRule(id:risk:description:)' is unused [#no-usage]
1005 |                                     id: existingRule.id,
1006 |                                     risk: rule.riskLevel,
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->