### PR TITLE
Pre-chat onboarding: normalize IDs, persist to persona, compact system prompt

### DIFF
--- a/assistant/src/__tests__/normalize-onboarding.test.ts
+++ b/assistant/src/__tests__/normalize-onboarding.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  normalizeOnboardingContext,
+  normalizeTasks,
+  normalizeTools,
+  TASK_DISPLAY_LABELS,
+  TOOL_DISPLAY_NAMES,
+} from "../prompts/normalize-onboarding.js";
+import type { OnboardingContext } from "../types/onboarding-context.js";
+
+describe("normalizeTools", () => {
+  test("known tool IDs produce display labels", () => {
+    expect(normalizeTools(["github"])).toEqual(["GitHub"]);
+    expect(normalizeTools(["google-calendar"])).toEqual(["Google Calendar"]);
+    expect(normalizeTools(["slack"])).toEqual(["Slack"]);
+    expect(normalizeTools(["notion"])).toEqual(["Notion"]);
+    expect(normalizeTools(["linear"])).toEqual(["Linear"]);
+    expect(normalizeTools(["gmail"])).toEqual(["Gmail"]);
+    expect(normalizeTools(["google-drive"])).toEqual(["Google Drive"]);
+    expect(normalizeTools(["figma"])).toEqual(["Figma"]);
+    expect(normalizeTools(["jira"])).toEqual(["Jira"]);
+    expect(normalizeTools(["outlook"])).toEqual(["Outlook"]);
+    expect(normalizeTools(["excel"])).toEqual(["Excel"]);
+    expect(normalizeTools(["apple-notes"])).toEqual(["Apple Notes"]);
+  });
+
+  test("all known tool IDs from the client onboarding UI are mapped", () => {
+    const clientToolIds = [
+      "gmail",
+      "outlook",
+      "google-calendar",
+      "slack",
+      "notion",
+      "linear",
+      "jira",
+      "github",
+      "figma",
+      "google-drive",
+      "excel",
+      "apple-notes",
+    ];
+    expect(Object.keys(TOOL_DISPLAY_NAMES)).toEqual(
+      expect.arrayContaining(clientToolIds),
+    );
+    expect(Object.keys(TOOL_DISPLAY_NAMES)).toHaveLength(clientToolIds.length);
+  });
+
+  test("unknown/custom tool IDs pass through with first-letter capitalization", () => {
+    expect(normalizeTools(["trello"])).toEqual(["Trello"]);
+    expect(normalizeTools(["asana"])).toEqual(["Asana"]);
+  });
+
+  test("mixed known and unknown IDs normalize correctly", () => {
+    expect(normalizeTools(["github", "trello", "slack"])).toEqual([
+      "GitHub",
+      "Trello",
+      "Slack",
+    ]);
+  });
+
+  test("empty array produces empty array", () => {
+    expect(normalizeTools([])).toEqual([]);
+  });
+});
+
+describe("normalizeTasks", () => {
+  test("known task IDs produce plain-language labels", () => {
+    expect(normalizeTasks(["code-building"])).toEqual([
+      "builds code, apps, or tools",
+    ]);
+    expect(normalizeTasks(["writing"])).toEqual([
+      "writes docs, emails, or content",
+    ]);
+    expect(normalizeTasks(["research"])).toEqual([
+      "does research and analysis",
+    ]);
+    expect(normalizeTasks(["project-management"])).toEqual([
+      "plans and coordinates work",
+    ]);
+    expect(normalizeTasks(["scheduling"])).toEqual([
+      "handles meetings, calendar, and logistics",
+    ]);
+    expect(normalizeTasks(["personal"])).toEqual(["handles life admin"]);
+  });
+
+  test("all six known task IDs are mapped", () => {
+    const knownIds = [
+      "code-building",
+      "writing",
+      "research",
+      "project-management",
+      "scheduling",
+      "personal",
+    ];
+    expect(Object.keys(TASK_DISPLAY_LABELS)).toEqual(
+      expect.arrayContaining(knownIds),
+    );
+    expect(Object.keys(TASK_DISPLAY_LABELS)).toHaveLength(knownIds.length);
+  });
+
+  test("unknown/custom task IDs pass through unchanged", () => {
+    expect(normalizeTasks(["data-entry"])).toEqual(["data-entry"]);
+    expect(normalizeTasks(["custom-workflow"])).toEqual(["custom-workflow"]);
+  });
+
+  test("mixed known and unknown IDs normalize correctly", () => {
+    expect(normalizeTasks(["writing", "data-entry", "research"])).toEqual([
+      "writes docs, emails, or content",
+      "data-entry",
+      "does research and analysis",
+    ]);
+  });
+
+  test("empty array produces empty array", () => {
+    expect(normalizeTasks([])).toEqual([]);
+  });
+});
+
+describe("normalizeOnboardingContext", () => {
+  test("maps userName to preferredName", () => {
+    const ctx: OnboardingContext = {
+      tools: [],
+      tasks: [],
+      tone: "friendly",
+      userName: "Alice",
+    };
+    const result = normalizeOnboardingContext(ctx);
+    expect(result.preferredName).toBe("Alice");
+  });
+
+  test("absent userName yields undefined preferredName", () => {
+    const ctx: OnboardingContext = {
+      tools: [],
+      tasks: [],
+      tone: "professional",
+    };
+    const result = normalizeOnboardingContext(ctx);
+    expect(result.preferredName).toBeUndefined();
+  });
+
+  test("tone passes through", () => {
+    const ctx: OnboardingContext = {
+      tools: [],
+      tasks: [],
+      tone: "casual",
+    };
+    const result = normalizeOnboardingContext(ctx);
+    expect(result.tone).toBe("casual");
+  });
+
+  test("assistantName passes through", () => {
+    const ctx: OnboardingContext = {
+      tools: [],
+      tasks: [],
+      tone: "friendly",
+      assistantName: "Jarvis",
+    };
+    const result = normalizeOnboardingContext(ctx);
+    expect(result.assistantName).toBe("Jarvis");
+  });
+
+  test("normalizes tools and tasks together", () => {
+    const ctx: OnboardingContext = {
+      tools: ["github", "trello"],
+      tasks: ["code-building", "data-entry"],
+      tone: "professional",
+      userName: "Bob",
+      assistantName: "Friday",
+    };
+    const result = normalizeOnboardingContext(ctx);
+    expect(result).toEqual({
+      preferredName: "Bob",
+      commonWork: ["builds code, apps, or tools", "data-entry"],
+      dailyTools: ["GitHub", "Trello"],
+      tone: "professional",
+      assistantName: "Friday",
+    });
+  });
+});

--- a/assistant/src/__tests__/onboarding-persona-write.test.ts
+++ b/assistant/src/__tests__/onboarding-persona-write.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for `writeOnboardingSection` in persona-resolver.
+ *
+ * The function writes a managed `## Onboarding Context` section to the
+ * guardian persona file (with a fallback chain). These tests stub
+ * `util/platform.js` and `contacts/contact-store.js` to control the
+ * write target and verify idempotency, fallback, and field omission.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+// ── Mock state ────────────────────────────────────────────────────
+
+let mockWorkspaceDir: string = "";
+let mockVellumGuardian: {
+  contact: { userFile: string | null };
+  channel: Record<string, unknown>;
+} | null = null;
+
+// ── Mock modules (must precede imports from the module under test) ──
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) =>
+        prop === "child"
+          ? () =>
+              new Proxy({} as Record<string, unknown>, { get: () => () => {} })
+          : () => {},
+    }),
+  getCliLogger: () => ({}),
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+  getWorkspacePromptPath: (file: string) => join(mockWorkspaceDir, file),
+}));
+
+mock.module("../contacts/contact-store.js", () => ({
+  findContactByChannelExternalId: () => null,
+  findGuardianForChannel: (channelType: string) =>
+    channelType === "vellum" ? mockVellumGuardian : null,
+  listGuardianChannels: () => null,
+}));
+
+// Import AFTER mocks so the module under test binds to the stubbed
+// implementations.
+import { writeOnboardingSection } from "../prompts/persona-resolver.js";
+
+// ── Temp workspace scaffold ───────────────────────────────────────
+
+let testRoot: string;
+
+function workspacePath(file: string): string {
+  return join(mockWorkspaceDir, file);
+}
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "onboarding-persona-write-test-"));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  mockWorkspaceDir = mkdtempSync(join(testRoot, "ws-"));
+  mockVellumGuardian = null;
+});
+
+afterEach(() => {
+  rmSync(mockWorkspaceDir, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe("writeOnboardingSection", () => {
+  test("writes section to guardian persona file when it exists", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "alice.md" },
+      channel: {},
+    };
+    const guardianPath = workspacePath("users/alice.md");
+    mkdirSync(workspacePath("users"), { recursive: true });
+    writeFileSync(guardianPath, "# User Profile\n\n- **Name:** Alice\n");
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools", "plans and coordinates work"],
+      dailyTools: ["GitHub", "Linear", "Slack"],
+    });
+
+    const content = readFileSync(guardianPath, "utf-8");
+    expect(content).toContain("- **Name:** Alice");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+    expect(content).toContain(
+      "- **Common work:** builds code, apps, or tools; plans and coordinates work",
+    );
+    expect(content).toContain("- **Daily tools:** GitHub, Linear, Slack");
+  });
+
+  test("falls back to users/default.md when guardian path is null", () => {
+    mockVellumGuardian = null;
+    mkdirSync(workspacePath("users"), { recursive: true });
+    writeFileSync(
+      workspacePath("users/default.md"),
+      "# User Profile\n\n- **Name:** Default User\n",
+    );
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: [],
+      dailyTools: ["Slack"],
+    });
+
+    const content = readFileSync(workspacePath("users/default.md"), "utf-8");
+    expect(content).toContain("- **Name:** Default User");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+    expect(content).toContain("- **Daily tools:** Slack");
+
+    // USER.md should not be created
+    expect(existsSync(workspacePath("USER.md"))).toBe(false);
+  });
+
+  test("falls back to USER.md when no users/ files exist", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: [],
+      dailyTools: [],
+    });
+
+    expect(existsSync(workspacePath("USER.md"))).toBe(true);
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+  });
+
+  test("creates file with header + section when target doesn't exist", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub", "Linear", "Slack"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("# User Profile");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Preferred name:** Alice");
+    expect(content).toContain("- **Common work:** builds code, apps, or tools");
+    expect(content).toContain("- **Daily tools:** GitHub, Linear, Slack");
+  });
+
+  test("idempotent: calling twice produces the same file content", () => {
+    mockVellumGuardian = null;
+    const normalized = {
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub", "Linear"],
+    };
+
+    writeOnboardingSection(normalized);
+    const first = readFileSync(workspacePath("USER.md"), "utf-8");
+
+    writeOnboardingSection(normalized);
+    const second = readFileSync(workspacePath("USER.md"), "utf-8");
+
+    expect(first).toBe(second);
+  });
+
+  test("replaces existing onboarding section with updated data", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub"],
+    });
+
+    writeOnboardingSection({
+      preferredName: "Bob",
+      commonWork: ["writes docs, emails, or content"],
+      dailyTools: ["Notion", "Slack"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("- **Preferred name:** Bob");
+    expect(content).toContain(
+      "- **Common work:** writes docs, emails, or content",
+    );
+    expect(content).toContain("- **Daily tools:** Notion, Slack");
+    // Old values should be gone
+    expect(content).not.toContain("**Preferred name:** Alice");
+    expect(content).not.toContain("GitHub");
+  });
+
+  test("preserves content outside the managed section", () => {
+    mockVellumGuardian = null;
+    writeFileSync(
+      workspacePath("USER.md"),
+      "# User Profile\n\n- **Name:** Alice\n- **Role:** Engineer\n",
+    );
+
+    writeOnboardingSection({
+      preferredName: "Alice",
+      commonWork: [],
+      dailyTools: ["GitHub"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("- **Name:** Alice");
+    expect(content).toContain("- **Role:** Engineer");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).toContain("- **Daily tools:** GitHub");
+  });
+
+  test("omits empty fields", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      commonWork: [],
+      dailyTools: [],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("## Onboarding Context");
+    expect(content).not.toContain("Preferred name");
+    expect(content).not.toContain("Common work");
+    expect(content).not.toContain("Daily tools");
+  });
+
+  test("omits preferredName when undefined", () => {
+    mockVellumGuardian = null;
+
+    writeOnboardingSection({
+      preferredName: undefined,
+      commonWork: ["builds code, apps, or tools"],
+      dailyTools: ["GitHub"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).not.toContain("Preferred name");
+    expect(content).toContain("- **Common work:** builds code, apps, or tools");
+    expect(content).toContain("- **Daily tools:** GitHub");
+  });
+
+  test("preserves content after onboarding section when followed by another heading", () => {
+    mockVellumGuardian = null;
+    writeFileSync(
+      workspacePath("USER.md"),
+      [
+        "# User Profile",
+        "",
+        "- **Name:** Alice",
+        "",
+        "## Onboarding Context",
+        "",
+        "- **Preferred name:** Alice",
+        "",
+        "## Preferences",
+        "",
+        "- Likes dark mode",
+        "",
+      ].join("\n"),
+    );
+
+    writeOnboardingSection({
+      preferredName: "Bob",
+      commonWork: [],
+      dailyTools: ["Slack"],
+    });
+
+    const content = readFileSync(workspacePath("USER.md"), "utf-8");
+    expect(content).toContain("- **Preferred name:** Bob");
+    expect(content).toContain("- **Daily tools:** Slack");
+    expect(content).toContain("## Preferences");
+    expect(content).toContain("- Likes dark mode");
+    // Old preferred name should be gone from the onboarding section
+    expect(content).not.toContain("**Preferred name:** Alice");
+  });
+});

--- a/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
+++ b/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
@@ -88,10 +88,8 @@ describe("persistOnboardingArtifacts", () => {
   });
 
   afterEach(() => {
-    for (const name of ["IDENTITY.md", "USER.md"]) {
-      const p = workspacePath(name);
-      if (existsSync(p)) rmSync(p, { force: true });
-    }
+    const p = workspacePath("IDENTITY.md");
+    if (existsSync(p)) rmSync(p, { force: true });
   });
 
   test("seeds IDENTITY.md with assistant name when file does not exist", () => {
@@ -106,19 +104,7 @@ describe("persistOnboardingArtifacts", () => {
     expect(content).toBe("# Identity\n\n- **Name:** Nova\n");
   });
 
-  test("seeds USER.md with user name when file does not exist", () => {
-    persistOnboardingArtifacts({
-      tools: ["slack"],
-      tasks: ["email"],
-      tone: "balanced",
-      userName: "Alex",
-    });
-
-    const content = readFileSync(workspacePath("USER.md"), "utf-8");
-    expect(content).toBe("# User\n\n- **Name:** Alex\n");
-  });
-
-  test("seeds both IDENTITY.md and USER.md when both names are provided", () => {
+  test("seeds IDENTITY.md when both names are provided", () => {
     persistOnboardingArtifacts({
       tools: [],
       tasks: [],
@@ -129,9 +115,6 @@ describe("persistOnboardingArtifacts", () => {
 
     expect(readFileSync(workspacePath("IDENTITY.md"), "utf-8")).toBe(
       "# Identity\n\n- **Name:** Pax\n",
-    );
-    expect(readFileSync(workspacePath("USER.md"), "utf-8")).toBe(
-      "# User\n\n- **Name:** Alex\n",
     );
   });
 
@@ -152,23 +135,6 @@ describe("persistOnboardingArtifacts", () => {
     expect(content).toBe(
       "# Identity\n\n- **Name:** NewName\n- **Role:** _(not yet established)_\n",
     );
-  });
-
-  test("updates Name field in existing USER.md template", () => {
-    writeFileSync(
-      workspacePath("USER.md"),
-      "# User\n\n- **Name:** _(not yet chosen)_\n",
-    );
-
-    persistOnboardingArtifacts({
-      tools: [],
-      tasks: [],
-      tone: "casual",
-      userName: "NewUser",
-    });
-
-    const content = readFileSync(workspacePath("USER.md"), "utf-8");
-    expect(content).toBe("# User\n\n- **Name:** NewUser\n");
   });
 
   test("updates old-format Name field in existing IDENTITY.md", () => {
@@ -216,17 +182,6 @@ describe("persistOnboardingArtifacts", () => {
     expect(existsSync(workspacePath("IDENTITY.md"))).toBe(false);
   });
 
-  test("skips USER.md when userName is missing", () => {
-    persistOnboardingArtifacts({
-      tools: ["notion"],
-      tasks: ["project-management"],
-      tone: "balanced",
-      assistantName: "Nova",
-    });
-
-    expect(existsSync(workspacePath("USER.md"))).toBe(false);
-  });
-
   test("skips IDENTITY.md when assistantName is whitespace-only", () => {
     persistOnboardingArtifacts({
       tools: [],
@@ -238,31 +193,16 @@ describe("persistOnboardingArtifacts", () => {
     expect(existsSync(workspacePath("IDENTITY.md"))).toBe(false);
   });
 
-  test("skips USER.md when userName is whitespace-only", () => {
+  test("trims whitespace from assistantName before writing", () => {
     persistOnboardingArtifacts({
       tools: [],
       tasks: [],
       tone: "balanced",
-      userName: "  ",
-    });
-
-    expect(existsSync(workspacePath("USER.md"))).toBe(false);
-  });
-
-  test("trims whitespace from names before writing", () => {
-    persistOnboardingArtifacts({
-      tools: [],
-      tasks: [],
-      tone: "balanced",
-      userName: "  Alex  ",
       assistantName: "  Nova  ",
     });
 
     expect(readFileSync(workspacePath("IDENTITY.md"), "utf-8")).toBe(
       "# Identity\n\n- **Name:** Nova\n",
-    );
-    expect(readFileSync(workspacePath("USER.md"), "utf-8")).toBe(
-      "# User\n\n- **Name:** Alex\n",
     );
   });
 

--- a/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
+++ b/assistant/src/__tests__/persist-onboarding-artifacts.test.ts
@@ -27,6 +27,31 @@ mock.module("../util/logger.js", () => ({
 
 let writeRelationshipStateCalled = false;
 let sidecarPayload: unknown = null;
+let writeOnboardingSectionPayload: unknown = null;
+
+mock.module("../prompts/normalize-onboarding.js", () => ({
+  normalizeOnboardingContext: (ctx: unknown) => ctx,
+}));
+
+mock.module("../prompts/persona-resolver.js", () => ({
+  writeOnboardingSection: (payload: unknown) => {
+    writeOnboardingSectionPayload = payload;
+  },
+  resolveGuardianPersonaPath: () => join(TEST_DIR, "users", "guardian.md"),
+  resolveGuardianPersona: () => null,
+  resolveGuardianPersonaStrict: () => null,
+  resolveUserPersona: () => null,
+  resolveChannelPersona: () => null,
+  resolvePersonaContext: () => ({
+    userPersona: null,
+    userSlug: null,
+    channelPersona: null,
+  }),
+  resolveUserSlug: () => null,
+  ensureGuardianPersonaFile: () => {},
+  isGuardianPersonaCustomized: () => false,
+  GUARDIAN_PERSONA_TEMPLATE: "",
+}));
 
 mock.module("../home/relationship-state-writer.js", () => ({
   RELATIONSHIP_STATE_FILENAME: "relationship-state.json",
@@ -59,6 +84,7 @@ describe("persistOnboardingArtifacts", () => {
     mkdirSync(TEST_DIR, { recursive: true });
     writeRelationshipStateCalled = false;
     sidecarPayload = null;
+    writeOnboardingSectionPayload = null;
   });
 
   afterEach(() => {
@@ -262,5 +288,19 @@ describe("persistOnboardingArtifacts", () => {
     });
 
     expect(writeRelationshipStateCalled).toBe(true);
+  });
+
+  test("calls writeOnboardingSection with normalized data", () => {
+    const payload = {
+      tools: ["slack", "linear"],
+      tasks: ["code-building", "writing"],
+      tone: "professional",
+      userName: "Alex",
+      assistantName: "Nova",
+    };
+
+    persistOnboardingArtifacts(payload);
+
+    expect(writeOnboardingSectionPayload).toEqual(payload);
   });
 });

--- a/assistant/src/__tests__/prechat-onboarding-contract.test.ts
+++ b/assistant/src/__tests__/prechat-onboarding-contract.test.ts
@@ -339,4 +339,142 @@ describe("pre-chat onboarding contract", () => {
       expect(true).toBe(true); // structural acknowledgment
     });
   });
+
+  describe("end-to-end onboarding integration", () => {
+    test("with BOOTSTRAP.md present, onboarding context produces compact markdown with normalized labels", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nWelcome to your first conversation.",
+      );
+
+      const context: OnboardingContext = {
+        tools: ["slack", "notion", "linear"],
+        tasks: ["code-building", "writing", "project-management"],
+        tone: "grounded",
+        userName: "Alice",
+        assistantName: "Pax",
+      };
+
+      const result = buildSystemPrompt({ onboardingContext: context });
+      const dynamic = dynamicBlock(result);
+
+      // Heading is present
+      expect(dynamic).toContain("## First-Run User Context");
+
+      // Normalized labels appear (capitalised tool names, human-readable task descriptions)
+      expect(dynamic).toContain("- Daily tools: Slack, Notion, Linear");
+      expect(dynamic).toContain("- Name: Alice");
+      expect(dynamic).toContain("- Chosen assistant name: Pax");
+      expect(dynamic).toContain("- Preferred initial voice: grounded");
+      // Common work descriptions are normalised from task IDs
+      expect(dynamic).toContain("- Common work:");
+
+      // No raw JSON anywhere in the dynamic block
+      expect(dynamic).not.toContain("```json");
+      expect(dynamic).not.toContain('"tools"');
+      expect(dynamic).not.toContain('"tasks"');
+      expect(dynamic).not.toContain('"tone"');
+      expect(dynamic).not.toContain('"userName"');
+      expect(dynamic).not.toContain('"assistantName"');
+    });
+
+    test("without BOOTSTRAP.md, onboarding context does NOT appear in system prompt", () => {
+      // No BOOTSTRAP.md created — simulates a returning user session
+      const context: OnboardingContext = {
+        tools: ["slack", "figma"],
+        tasks: ["design", "writing"],
+        tone: "warm",
+        userName: "Bob",
+        assistantName: "Kit",
+      };
+
+      const result = buildSystemPrompt({ onboardingContext: context });
+      const dynamic = dynamicBlock(result);
+
+      // Onboarding section must be absent
+      expect(dynamic).not.toContain("## First-Run User Context");
+      expect(dynamic).not.toContain("First-Run Ritual");
+      expect(dynamic).not.toContain("- Daily tools:");
+      expect(dynamic).not.toContain("- Name: Bob");
+      expect(dynamic).not.toContain("- Chosen assistant name:");
+      expect(dynamic).not.toContain("Apply this context quietly.");
+    });
+
+    test("excludeBootstrap suppresses both bootstrap and onboarding sections", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nFirst run instructions.",
+      );
+
+      const context: OnboardingContext = {
+        tools: ["linear"],
+        tasks: ["code-building"],
+        tone: "energetic",
+        userName: "Charlie",
+        assistantName: "Nova",
+      };
+
+      const result = buildSystemPrompt({
+        onboardingContext: context,
+        excludeBootstrap: true,
+      });
+      const dynamic = dynamicBlock(result);
+
+      // Both bootstrap and onboarding must be suppressed
+      expect(dynamic).not.toContain("First-Run Ritual");
+      expect(dynamic).not.toContain("## First-Run User Context");
+      expect(dynamic).not.toContain("- Daily tools:");
+      expect(dynamic).not.toContain("- Name: Charlie");
+      expect(dynamic).not.toContain("Apply this context quietly.");
+    });
+
+    test("userPersona is included independently of onboarding context", () => {
+      // No BOOTSTRAP.md — the durable persona path after bootstrap is deleted
+      const personaContent =
+        "# User Persona\n\nPrefers concise answers. Works in fintech.";
+
+      const result = buildSystemPrompt({
+        userPersona: personaContent,
+        // No onboardingContext — simulates post-onboarding conversation
+      });
+      const dynamic = dynamicBlock(result);
+
+      // Persona content appears in prompt even without bootstrap or onboarding
+      expect(dynamic).toContain("# User Persona");
+      expect(dynamic).toContain("Prefers concise answers. Works in fintech.");
+
+      // No onboarding section should be present
+      expect(dynamic).not.toContain("## First-Run User Context");
+      expect(dynamic).not.toContain("First-Run Ritual");
+    });
+
+    test("userPersona appears alongside onboarding context during first run", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nOnboarding flow.",
+      );
+
+      const personaContent =
+        "# User Persona\n\nEarly-stage startup founder. Likes bullet points.";
+      const context: OnboardingContext = {
+        tools: ["slack"],
+        tasks: ["writing"],
+        tone: "warm",
+        userName: "Dana",
+      };
+
+      const result = buildSystemPrompt({
+        userPersona: personaContent,
+        onboardingContext: context,
+      });
+      const dynamic = dynamicBlock(result);
+
+      // Both persona and onboarding context appear
+      expect(dynamic).toContain("# User Persona");
+      expect(dynamic).toContain("Likes bullet points.");
+      expect(dynamic).toContain("## First-Run User Context");
+      expect(dynamic).toContain("- Name: Dana");
+      expect(dynamic).toContain("- Daily tools: Slack");
+    });
+  });
 });

--- a/assistant/src/__tests__/prechat-onboarding-contract.test.ts
+++ b/assistant/src/__tests__/prechat-onboarding-contract.test.ts
@@ -153,25 +153,18 @@ describe("pre-chat onboarding contract", () => {
       const result = buildSystemPrompt({ onboardingContext: context });
       const dynamic = dynamicBlock(result);
 
-      expect(dynamic).toContain("## Pre-chat Onboarding Context");
+      expect(dynamic).toContain("## First-Run User Context");
       expect(dynamic).toContain(
-        "The user completed the native pre-chat onboarding.",
+        "The user completed setup before this conversation.",
       );
-      expect(dynamic).toContain('"tools"');
-      expect(dynamic).toContain('"slack"');
-      expect(dynamic).toContain('"linear"');
-      expect(dynamic).toContain('"tasks"');
-      expect(dynamic).toContain('"code-building"');
-      expect(dynamic).toContain('"tone": "warm"');
-      expect(dynamic).toContain('"userName": "Alex"');
-      expect(dynamic).toContain('"assistantName": "Nova"');
-      expect(dynamic).toContain("```json");
-      expect(dynamic).toContain(
-        "Use this to personalize your opener and skip redundant discovery.",
-      );
-      expect(dynamic).toContain(
-        "If `assistantName` is present, it is the name the user chose for you; preserve it in IDENTITY.md.",
-      );
+      expect(dynamic).toContain("- Daily tools: Slack, Linear");
+      expect(dynamic).toContain("- Common work: builds code, apps, or tools");
+      expect(dynamic).toContain("- Name: Alex");
+      expect(dynamic).toContain("- Chosen assistant name: Nova");
+      expect(dynamic).toContain("Apply this context quietly.");
+
+      // Raw JSON must NOT be present
+      expect(dynamic).not.toContain("```json");
     });
 
     test("does NOT inject onboarding context when BOOTSTRAP.md does not exist", () => {
@@ -186,9 +179,9 @@ describe("pre-chat onboarding contract", () => {
       const result = buildSystemPrompt({ onboardingContext: context });
       const dynamic = dynamicBlock(result);
 
-      expect(dynamic).not.toContain("## Pre-chat Onboarding Context");
-      expect(dynamic).not.toContain("pre-chat onboarding");
-      expect(dynamic).not.toContain('"tools"');
+      expect(dynamic).not.toContain("## First-Run User Context");
+      expect(dynamic).not.toContain("First-Run User Context");
+      expect(dynamic).not.toContain("- Daily tools:");
     });
 
     test("does NOT inject onboarding context when excludeBootstrap is true", () => {
@@ -209,7 +202,7 @@ describe("pre-chat onboarding contract", () => {
       });
       const dynamic = dynamicBlock(result);
 
-      expect(dynamic).not.toContain("## Pre-chat Onboarding Context");
+      expect(dynamic).not.toContain("## First-Run User Context");
       expect(dynamic).not.toContain("First-Run Ritual");
     });
 
@@ -225,7 +218,7 @@ describe("pre-chat onboarding contract", () => {
       // Bootstrap should still be present
       expect(dynamic).toContain("First-Run Ritual");
       // But no onboarding context section
-      expect(dynamic).not.toContain("## Pre-chat Onboarding Context");
+      expect(dynamic).not.toContain("## First-Run User Context");
     });
 
     test("accepts all four personality tones", () => {
@@ -247,12 +240,12 @@ describe("pre-chat onboarding contract", () => {
         const result = buildSystemPrompt({ onboardingContext: context });
         const dynamic = dynamicBlock(result);
 
-        expect(dynamic).toContain("## Pre-chat Onboarding Context");
-        expect(dynamic).toContain(`"tone": "${tone}"`);
+        expect(dynamic).toContain("## First-Run User Context");
+        expect(dynamic).toContain(`- Preferred initial voice: ${tone}`);
       }
     });
 
-    test("serializes onboarding context as pretty-printed JSON", () => {
+    test("renders compact markdown, not JSON", () => {
       writeFileSync(
         join(TEST_DIR, "BOOTSTRAP.md"),
         "# Bootstrap\n\nOnboarding.",
@@ -269,9 +262,65 @@ describe("pre-chat onboarding contract", () => {
       const result = buildSystemPrompt({ onboardingContext: context });
       const dynamic = dynamicBlock(result);
 
-      // Verify it contains the pretty-printed JSON (indented with 2 spaces)
+      // Should contain compact markdown lines
+      expect(dynamic).toContain("## First-Run User Context");
+      expect(dynamic).toContain("- Name: Jane");
+      expect(dynamic).toContain("- Common work: plans and coordinates work");
+      expect(dynamic).toContain("- Daily tools: Notion");
+      expect(dynamic).toContain("- Chosen assistant name: Kit");
+      expect(dynamic).toContain("- Preferred initial voice: warm");
+
+      // Must NOT contain JSON output
+      expect(dynamic).not.toContain("```json");
       const expectedJson = JSON.stringify(context, null, 2);
-      expect(dynamic).toContain(expectedJson);
+      expect(dynamic).not.toContain(expectedJson);
+    });
+
+    test("empty tools/tasks arrays result in no Daily tools / Common work lines", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nOnboarding.",
+      );
+
+      const context: OnboardingContext = {
+        tools: [],
+        tasks: [],
+        tone: "warm",
+        userName: "Alex",
+      };
+
+      const result = buildSystemPrompt({ onboardingContext: context });
+      const dynamic = dynamicBlock(result);
+
+      expect(dynamic).toContain("## First-Run User Context");
+      expect(dynamic).toContain("- Name: Alex");
+      expect(dynamic).not.toContain("- Daily tools:");
+      expect(dynamic).not.toContain("- Common work:");
+    });
+
+    test("absent userName results in no Name line", () => {
+      writeFileSync(
+        join(TEST_DIR, "BOOTSTRAP.md"),
+        "# Bootstrap\n\nOnboarding.",
+      );
+
+      const context: OnboardingContext = {
+        tools: ["slack"],
+        tasks: ["writing"],
+        tone: "warm",
+      };
+
+      const result = buildSystemPrompt({ onboardingContext: context });
+      const dynamic = dynamicBlock(result);
+
+      expect(dynamic).toContain("## First-Run User Context");
+      expect(dynamic).not.toContain("- Name:");
+      // Other fields should still be present
+      expect(dynamic).toContain("- Daily tools: Slack");
+      expect(dynamic).toContain(
+        "- Common work: writes docs, emails, or content",
+      );
+      expect(dynamic).toContain("- Preferred initial voice: warm");
     });
   });
 

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -71,7 +71,7 @@ export function normalizeOnboardingContext(
   ctx: OnboardingContext,
 ): NormalizedOnboarding {
   return {
-    preferredName: ctx.userName,
+    preferredName: ctx.userName?.trim() || undefined,
     commonWork: normalizeTasks(ctx.tasks),
     dailyTools: normalizeTools(ctx.tools),
     tone: ctx.tone,

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -1,0 +1,80 @@
+import type { OnboardingContext } from "../types/onboarding-context.js";
+
+/**
+ * Map of known tool IDs (from the client onboarding UI) to display labels.
+ * Unknown IDs pass through with first-letter capitalization via `normalizeTools`.
+ */
+export const TOOL_DISPLAY_NAMES: Record<string, string> = {
+  gmail: "Gmail",
+  outlook: "Outlook",
+  "google-calendar": "Google Calendar",
+  slack: "Slack",
+  notion: "Notion",
+  linear: "Linear",
+  jira: "Jira",
+  github: "GitHub",
+  figma: "Figma",
+  "google-drive": "Google Drive",
+  excel: "Excel",
+  "apple-notes": "Apple Notes",
+};
+
+/**
+ * Map of known task IDs to plain-language labels describing what the assistant
+ * does for each task category.
+ */
+export const TASK_DISPLAY_LABELS: Record<string, string> = {
+  "code-building": "builds code, apps, or tools",
+  writing: "writes docs, emails, or content",
+  research: "does research and analysis",
+  "project-management": "plans and coordinates work",
+  scheduling: "handles meetings, calendar, and logistics",
+  personal: "handles life admin",
+};
+
+/**
+ * Capitalize the first letter of a string (fallback for unknown IDs).
+ */
+function capitalizeFirst(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Maps each tool ID through `TOOL_DISPLAY_NAMES`, falling back to the raw
+ * string for unknown IDs.
+ */
+export function normalizeTools(tools: string[]): string[] {
+  return tools.map((id) => TOOL_DISPLAY_NAMES[id] ?? capitalizeFirst(id));
+}
+
+/**
+ * Maps each task ID through `TASK_DISPLAY_LABELS`, falling back to the raw
+ * string for unknown IDs.
+ */
+export function normalizeTasks(tasks: string[]): string[] {
+  return tasks.map((id) => TASK_DISPLAY_LABELS[id] ?? id);
+}
+
+export interface NormalizedOnboarding {
+  preferredName?: string;
+  commonWork: string[];
+  dailyTools: string[];
+  tone?: string;
+  assistantName?: string;
+}
+
+/**
+ * Normalizes raw onboarding context from the client into display-ready data.
+ */
+export function normalizeOnboardingContext(
+  ctx: OnboardingContext,
+): NormalizedOnboarding {
+  return {
+    preferredName: ctx.userName,
+    commonWork: normalizeTasks(ctx.tasks),
+    dailyTools: normalizeTools(ctx.tools),
+    tone: ctx.tone,
+    assistantName: ctx.assistantName,
+  };
+}

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -1,9 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 import {
@@ -14,8 +9,9 @@ import {
 import type { ChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
+import type { NormalizedOnboarding } from "./normalize-onboarding.js";
 
 const log = getLogger("persona-resolver");
 
@@ -110,7 +106,11 @@ function resolveUserFilename(
 
   // Validate basename to prevent path traversal
   if (filename) {
-    if (basename(filename) !== filename || filename === ".." || filename === ".") {
+    if (
+      basename(filename) !== filename ||
+      filename === ".." ||
+      filename === "."
+    ) {
       log.warn(
         { userFile: filename },
         "Contact userFile contains path traversal; ignoring",
@@ -268,7 +268,11 @@ export function resolveGuardianPersonaStrict(): string | null {
  * Creates the parent `users/` directory if missing.
  */
 export function ensureGuardianPersonaFile(userFile: string): void {
-  if (basename(userFile) !== userFile || userFile === ".." || userFile === ".") {
+  if (
+    basename(userFile) !== userFile ||
+    userFile === ".." ||
+    userFile === "."
+  ) {
     log.warn(
       { userFile },
       "Guardian persona userFile contains path traversal; refusing to write",
@@ -313,4 +317,92 @@ export function isGuardianPersonaCustomized(filePath: string): boolean {
 
   const templateStripped = stripCommentLines(GUARDIAN_PERSONA_TEMPLATE);
   return stripped !== templateStripped;
+}
+
+// ── Onboarding section writer ────────────────────────────────────
+
+const ONBOARDING_HEADING = "## Onboarding Context";
+
+/**
+ * Build the markdown section content for the onboarding context.
+ * Omits bullet lines where the value is empty/absent.
+ */
+function buildOnboardingSection(normalized: NormalizedOnboarding): string {
+  const lines: string[] = [ONBOARDING_HEADING, ""];
+
+  if (normalized.preferredName) {
+    lines.push(`- **Preferred name:** ${normalized.preferredName}`);
+  }
+  if (normalized.commonWork.length > 0) {
+    lines.push(`- **Common work:** ${normalized.commonWork.join("; ")}`);
+  }
+  if (normalized.dailyTools.length > 0) {
+    lines.push(`- **Daily tools:** ${normalized.dailyTools.join(", ")}`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Resolve the write target for the onboarding section using the
+ * fallback chain: guardian persona → `users/default.md` → `USER.md`.
+ */
+function resolveOnboardingWriteTarget(): string {
+  const guardianPath = resolveGuardianPersonaPath();
+  if (guardianPath) return guardianPath;
+
+  const defaultUserPath = join(getWorkspaceDir(), "users", "default.md");
+  if (existsSync(defaultUserPath)) return defaultUserPath;
+
+  return getWorkspacePromptPath("USER.md");
+}
+
+/**
+ * Write a managed `## Onboarding Context` section to the guardian persona
+ * file (or fallback target). Idempotent: replaces the section in-place if
+ * it already exists, appends if not, and creates the file when missing.
+ *
+ * Never throws — logs a warning on failure (fire-and-forget pattern).
+ */
+export function writeOnboardingSection(normalized: NormalizedOnboarding): void {
+  try {
+    const targetPath = resolveOnboardingWriteTarget();
+    const section = buildOnboardingSection(normalized);
+
+    let content: string;
+    if (existsSync(targetPath)) {
+      content = readFileSync(targetPath, "utf-8");
+    } else {
+      // Create parent directories and start with a header
+      mkdirSync(dirname(targetPath), { recursive: true });
+      content = "# User Profile\n\n";
+    }
+
+    // Replace existing section or append
+    const headingIndex = content.indexOf(ONBOARDING_HEADING);
+    if (headingIndex !== -1) {
+      // Find the end of the section: next `## ` heading or EOF
+      const afterHeading = content.indexOf("\n", headingIndex);
+      const rest = afterHeading !== -1 ? content.slice(afterHeading + 1) : "";
+      const nextHeadingMatch = rest.match(/^## /m);
+      const before = content.slice(0, headingIndex);
+      const after = nextHeadingMatch ? rest.slice(nextHeadingMatch.index!) : "";
+      content = before + section + after;
+    } else {
+      // Append after a blank line (ensure trailing newline first)
+      if (!content.endsWith("\n")) {
+        content += "\n";
+      }
+      if (!content.endsWith("\n\n")) {
+        content += "\n";
+      }
+      content += section;
+    }
+
+    writeFileSync(targetPath, content, "utf-8");
+    log.debug({ path: targetPath }, "Wrote onboarding section to persona file");
+  } catch (err) {
+    log.warn({ err }, "Failed to write onboarding section to persona file");
+  }
 }

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -21,6 +21,7 @@ import {
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import { cleanupBootstrapFiles } from "./bootstrap-cleanup.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "./cache-boundary.js";
+import { normalizeOnboardingContext } from "./normalize-onboarding.js";
 
 export { SYSTEM_PROMPT_CACHE_BOUNDARY };
 
@@ -322,14 +323,27 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
     );
 
     if (options?.onboardingContext) {
-      dynamicParts.push(
-        "## Pre-chat Onboarding Context\n\n" +
-          "The user completed the native pre-chat onboarding. Here is their context:\n\n" +
-          "```json\n" +
-          JSON.stringify(options.onboardingContext, null, 2) +
-          "\n```\n\n" +
-          "Use this to personalize your opener and skip redundant discovery. If `assistantName` is present, it is the name the user chose for you; preserve it in IDENTITY.md.",
+      const n = normalizeOnboardingContext(options.onboardingContext);
+      const lines: string[] = [
+        "## First-Run User Context",
+        "",
+        "The user completed setup before this conversation.",
+        "",
+        "Known context:",
+      ];
+      if (n.preferredName) lines.push(`- Name: ${n.preferredName}`);
+      if (n.commonWork.length)
+        lines.push(`- Common work: ${n.commonWork.join("; ")}`);
+      if (n.dailyTools.length)
+        lines.push(`- Daily tools: ${n.dailyTools.join(", ")}`);
+      if (n.assistantName)
+        lines.push(`- Chosen assistant name: ${n.assistantName}`);
+      if (n.tone) lines.push(`- Preferred initial voice: ${n.tone}`);
+      lines.push(
+        "",
+        "Apply this context quietly. Do not recap it as a list unless the user asks.",
       );
+      dynamicParts.push(lines.join("\n"));
     }
   }
   // Configuration section removed — workspace files are self-describing,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1062,8 +1062,12 @@ export function persistOnboardingArtifacts(onboarding: {
     }
   }
 
-  const normalized = normalizeOnboardingContext(onboarding);
-  writeOnboardingSection(normalized);
+  try {
+    const normalized = normalizeOnboardingContext(onboarding);
+    writeOnboardingSection(normalized);
+  } catch (err) {
+    log.warn({ err }, "Failed to write onboarding section to persona file");
+  }
 
   void writeRelationshipState().catch((err) => {
     log.warn(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1001,7 +1001,7 @@ function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
 /**
  * Persist the pre-chat onboarding payload to disk.
  *
- * Runs only on the very first message of a fresh conversation. Three
+ * Runs only on the very first message of a fresh conversation. Four
  * artifacts are produced:
  *
  *   1. `data/onboarding-context.json` — sidecar read by the
@@ -1009,12 +1009,15 @@ function mergeConsecutiveAssistantMessages(messages: MessageRow[]): {
  *      the pure-recomputation write cycle (every turn boundary rebuilds
  *      facts from markdown; the sidecar is the durable source for the
  *      tool/task/tone chips).
- *   2. `IDENTITY.md` / `USER.md` — persona seed files, only written
- *      when missing so we never clobber existing content. These feed
- *      the system prompt and the relationship-state writer's
- *      `parseIdentity` / `parseUserName` helpers after a daemon
- *      restart when the in-memory onboarding context is gone.
- *   3. `data/relationship-state.json` — kicked off fire-and-forget so
+ *   2. `IDENTITY.md` — assistant persona seed file, only written when
+ *      missing so we never clobber existing content. Feeds the system
+ *      prompt and the relationship-state writer's `parseIdentity`
+ *      helper after a daemon restart when the in-memory onboarding
+ *      context is gone.
+ *   3. Onboarding section in the guardian persona file — written via
+ *      `writeOnboardingSection`, which handles the user's preferred
+ *      name (with fallback to root `USER.md`).
+ *   4. `data/relationship-state.json` — kicked off fire-and-forget so
  *      the Home page can populate immediately on first visit instead
  *      of waiting for the first agent-turn boundary.
  *
@@ -1056,27 +1059,6 @@ export function persistOnboardingArtifacts(onboarding: {
         { err, identityPath },
         "Failed to seed IDENTITY.md from onboarding",
       );
-    }
-  }
-
-  const userName = onboarding.userName?.trim();
-  if (userName) {
-    const userPath = getWorkspacePromptPath("USER.md");
-    try {
-      if (existsSync(userPath)) {
-        const content = readFileSync(userPath, "utf-8");
-        const updated = content.replace(
-          /^- (?:\*\*)?Name:(?:\*\*)?\s*.*$/m,
-          () => `- **Name:** ${userName}`,
-        );
-        if (updated !== content) {
-          writeFileSync(userPath, updated, "utf-8");
-        }
-      } else {
-        writeFileSync(userPath, `# User\n\n- **Name:** ${userName}\n`, "utf-8");
-      }
-    } catch (err) {
-      log.warn({ err, userPath }, "Failed to seed USER.md from onboarding");
     }
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -86,6 +86,8 @@ import {
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { searchConversations } from "../../memory/conversation-queries.js";
+import { normalizeOnboardingContext } from "../../prompts/normalize-onboarding.js";
+import { writeOnboardingSection } from "../../prompts/persona-resolver.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
 import { checkIngressForSecrets } from "../../security/secret-ingress.js";
@@ -1077,6 +1079,9 @@ export function persistOnboardingArtifacts(onboarding: {
       log.warn({ err, userPath }, "Failed to seed USER.md from onboarding");
     }
   }
+
+  const normalized = normalizeOnboardingContext(onboarding);
+  writeOnboardingSection(normalized);
 
   void writeRelationshipState().catch((err) => {
     log.warn(


### PR DESCRIPTION
## Summary
- Normalize onboarding tool/task IDs to human-readable labels (e.g. `github` → `GitHub`, `code-building` → `builds code, apps, or tools`)
- Persist normalized onboarding context as a managed `## Onboarding Context` section in the guardian persona file (with fallback chain: guardian → `users/default.md` → `USER.md`)
- Replace raw JSON onboarding block in system prompt with compact `## First-Run User Context` markdown
- Remove legacy `USER.md` direct name seeding (now handled by the onboarding section)

## Self-review result
PASS — all three review passes (external feedback, plan faithfulness, repo integration) passed with no gaps.

## PRs merged into feature branch
- #29569: Add onboarding context normalizer with tool/task ID maps
- #29574: Persist normalized onboarding context to guardian persona file
- #29572: Replace raw JSON onboarding block with compact markdown in system prompt
- #29579: Remove legacy USER.md name seeding — onboarding section covers this
- #29585: Add integration test verifying full onboarding flow end-to-end

Closes JARVIS-701
Part of plan: use-pre-chat-info.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->