### PR TITLE
fix(security): bound consolidation prompt override to regular files under 1 MiB

### DIFF
--- a/assistant/src/memory/v2/__tests__/prompts-consolidation.test.ts
+++ b/assistant/src/memory/v2/__tests__/prompts-consolidation.test.ts
@@ -4,7 +4,14 @@
  * file-based override and falls back to the bundled prompt when the
  * override is missing/empty/unreadable.
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -67,7 +74,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  for (const entry of ["custom-prompt.md", "empty.md", "no-placeholder.md"]) {
+  for (const entry of [
+    "custom-prompt.md",
+    "empty.md",
+    "no-placeholder.md",
+    "huge.md",
+    "link.md",
+    "fifo",
+  ]) {
     rmSync(join(tmpWorkspace, entry), { force: true });
   }
 });
@@ -177,5 +191,50 @@ describe("resolveConsolidationPrompt — failure modes", () => {
     expect(warnCalls).toHaveLength(1);
     const data = warnCalls[0].data as Record<string, unknown>;
     expect(data.reason).toBe("empty_override");
+  });
+
+  test("falls back to bundled prompt when the override exceeds the size limit", () => {
+    const path = join(tmpWorkspace, "huge.md");
+    // 1 MiB + 1 byte — just over the cap so we don't waste test memory.
+    writeFileSync(path, Buffer.alloc(1 * 1024 * 1024 + 1, 0x61));
+
+    const result = resolveConsolidationPrompt(path, CUTOFF);
+
+    expect(result).toBe(bundledPrompt());
+    expect(warnCalls).toHaveLength(1);
+    const data = warnCalls[0].data as Record<string, unknown>;
+    expect(data.reason).toBe("oversized_override");
+    expect(data.size).toBe(1 * 1024 * 1024 + 1);
+  });
+
+  test("falls back to bundled prompt when the override is a symlink", () => {
+    const target = join(tmpWorkspace, "custom-prompt.md");
+    writeFileSync(target, "real prompt body\n");
+    const link = join(tmpWorkspace, "link.md");
+    symlinkSync(target, link);
+
+    const result = resolveConsolidationPrompt(link, CUTOFF);
+
+    expect(result).toBe(bundledPrompt());
+    expect(warnCalls).toHaveLength(1);
+    const data = warnCalls[0].data as Record<string, unknown>;
+    expect(data.reason).toBe("not_regular_file");
+  });
+
+  test("falls back to bundled prompt when the override is a FIFO", () => {
+    const fifoPath = join(tmpWorkspace, "fifo");
+    try {
+      execFileSync("mkfifo", [fifoPath]);
+    } catch {
+      // mkfifo unavailable on this platform — skip without failing.
+      return;
+    }
+
+    const result = resolveConsolidationPrompt(fifoPath, CUTOFF);
+
+    expect(result).toBe(bundledPrompt());
+    expect(warnCalls).toHaveLength(1);
+    const data = warnCalls[0].data as Record<string, unknown>;
+    expect(data.reason).toBe("not_regular_file");
   });
 });

--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -16,7 +16,7 @@
  * the convention established for the sweep prompt.
  */
 
-import { readFileSync } from "node:fs";
+import { lstatSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
@@ -27,6 +27,14 @@ const log = getLogger("memory-v2-consolidate-prompt");
 
 /** Sentinel substituted with the cutoff timestamp at runtime. */
 export const CUTOFF_PLACEHOLDER = "{{CUTOFF}}";
+
+/**
+ * Upper bound for the override file. Real consolidation prompts are kilobytes;
+ * 1 MiB is generous headroom while preventing a `settings.write` principal from
+ * pointing the field at a multi-gigabyte file (or `/dev/zero`-like stream that
+ * `lstat` can't size cap on its own) and exfiltrating it through the wake hint.
+ */
+const MAX_PROMPT_BYTES = 1 * 1024 * 1024;
 
 /**
  * Consolidation prompt — live-mode only. The agent runs as itself (full
@@ -447,6 +455,33 @@ export function resolveConsolidationPrompt(
   const resolvedPath = resolveOverridePath(overridePath);
   let contents: string;
   try {
+    const stat = lstatSync(resolvedPath);
+    if (!stat.isFile()) {
+      log.warn(
+        {
+          configuredPath: overridePath,
+          resolvedPath,
+          reason: "not_regular_file",
+          fallback: "bundled",
+        },
+        "consolidation prompt override is not a regular file; using bundled prompt",
+      );
+      return renderConsolidationPrompt(cutoff);
+    }
+    if (stat.size > MAX_PROMPT_BYTES) {
+      log.warn(
+        {
+          configuredPath: overridePath,
+          resolvedPath,
+          size: stat.size,
+          limit: MAX_PROMPT_BYTES,
+          reason: "oversized_override",
+          fallback: "bundled",
+        },
+        "consolidation prompt override exceeds size limit; using bundled prompt",
+      );
+      return renderConsolidationPrompt(cutoff);
+    }
     contents = readFileSync(resolvedPath, "utf-8");
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;


### PR DESCRIPTION
## Summary
- Reject non-regular files (FIFOs, devices, sockets, symlinks) and files larger than 1 MiB before reading the `memory.v2.consolidation_prompt_path` override, falling back to the bundled prompt with a structured warning. Closes the arbitrary-file-read and FIFO/`/dev/zero` DoS vectors against the consolidation wake hint introduced in 7ee11e5.
- Adds regression tests for the oversize, symlink, and FIFO failure modes alongside the existing missing/empty/whitespace cases.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->