### PR TITLE
fix(app-control): bind session lock to (conversationId, app)

### DIFF
--- a/assistant/src/__tests__/app-control-flow.test.ts
+++ b/assistant/src/__tests__/app-control-flow.test.ts
@@ -13,8 +13,9 @@
  * differs in two notable ways:
  *  1. Result payloads carry `pngBase64` (not screenshots-as-strings) and
  *     surface as image content blocks with `media_type: "image/png"`.
- *  2. A module-level singleton lock guards `app_control_start` — only one
- *     conversation may hold an active session at a time.
+ *  2. A module-level session lock binds `(conversationId, app)` — only
+ *     one conversation may hold an active session at a time, and non-start
+ *     tools must target the same `app` the user approved at start time.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -87,8 +88,9 @@ mock.module("../runtime/pending-interactions.js", () => ({
 
 const {
   HostAppControlProxy,
-  _getActiveAppControlConversationId,
-  _resetActiveAppControlConversationId,
+  _getActiveAppControlSession,
+  _resetActiveAppControlSession,
+  _setActiveAppControlSession,
 } = await import("../daemon/host-app-control-proxy.js");
 const { ROUTES } = await import("../runtime/routes/host-app-control-routes.js");
 const { surfaceProxyResolver } =
@@ -176,11 +178,11 @@ describe("app-control end-to-end flow", () => {
     pending.clear();
     clearConversations();
     mockHasClient = true;
-    _resetActiveAppControlConversationId();
+    _resetActiveAppControlSession();
   });
 
   afterEach(() => {
-    _resetActiveAppControlConversationId();
+    _resetActiveAppControlSession();
     clearConversations();
   });
 
@@ -238,8 +240,10 @@ describe("app-control end-to-end flow", () => {
       },
     });
 
-    // Singleton lock is held by this conversation now.
-    expect(_getActiveAppControlConversationId()).toBe(conversationId);
+    // Session lock is held by this conversation now, bound to the started app.
+    const session = _getActiveAppControlSession();
+    expect(session?.conversationId).toBe(conversationId);
+    expect(session?.app).toBe("com.example.app");
 
     proxy.dispose();
   });
@@ -253,6 +257,12 @@ describe("app-control end-to-end flow", () => {
     const proxy = new HostAppControlProxy(conversationId);
     const ctx = buildContext(proxy, conversationId);
     registerConversation(conversationId, proxy);
+    // Prime a session so observe passes the auth gate. This test exercises
+    // the result-formatting path, not the start flow.
+    _setActiveAppControlSession({
+      conversationId,
+      app: "com.example.app",
+    });
 
     const resultPromise = surfaceProxyResolver(ctx, "app_control_observe", {
       tool: "observe",
@@ -306,7 +316,7 @@ describe("app-control end-to-end flow", () => {
     });
     await postResult({ state: "running", pngBase64: TINY_PNG_B64 });
     await startPromise;
-    expect(_getActiveAppControlConversationId()).toBe(conversationId);
+    expect(_getActiveAppControlSession()?.conversationId).toBe(conversationId);
 
     // Wrap dispose to verify it was called by the resolver.
     let disposeCalls = 0;
@@ -328,7 +338,7 @@ describe("app-control end-to-end flow", () => {
     expect(sentMessages).toHaveLength(0);
     expect(disposeCalls).toBe(1);
     // Lock released.
-    expect(_getActiveAppControlConversationId()).toBeUndefined();
+    expect(_getActiveAppControlSession()).toBeUndefined();
   });
 
   // -------------------------------------------------------------------------
@@ -347,7 +357,7 @@ describe("app-control end-to-end flow", () => {
     await postResult({ state: "running", pngBase64: TINY_PNG_B64 });
     const resultA = await startA;
     expect(resultA.isError).toBe(false);
-    expect(_getActiveAppControlConversationId()).toBe("conv-a");
+    expect(_getActiveAppControlSession()?.conversationId).toBe("conv-a");
 
     // Second conversation tries to start while conv-a holds the lock.
     sentMessages.length = 0;

--- a/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-app-control.test.ts
@@ -33,8 +33,11 @@ mock.module("../runtime/pending-interactions.js", () => ({
 
 const { surfaceProxyResolver } =
   await import("../daemon/conversation-surfaces.js");
-const { HostAppControlProxy, _resetActiveAppControlConversationId } =
-  await import("../daemon/host-app-control-proxy.js");
+const {
+  HostAppControlProxy,
+  _resetActiveAppControlSession,
+  _setActiveAppControlSession,
+} = await import("../daemon/host-app-control-proxy.js");
 type SurfaceConversationContext =
   import("../daemon/conversation-surfaces.js").SurfaceConversationContext;
 
@@ -83,11 +86,11 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
   beforeEach(() => {
     sentMessages.length = 0;
     mockHasClient = true;
-    _resetActiveAppControlConversationId();
+    _resetActiveAppControlSession();
   });
 
   afterEach(() => {
-    _resetActiveAppControlConversationId();
+    _resetActiveAppControlSession();
   });
 
   // -------------------------------------------------------------------------
@@ -148,6 +151,10 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
     test("app_control_observe routes through proxy and returns observation", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctx = buildMockContext(proxy, "conv-1");
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
 
       const resultPromise = surfaceProxyResolver(ctx, "app_control_observe", {
         tool: "observe",
@@ -254,6 +261,10 @@ describe("surfaceProxyResolver — app-control tool routing", () => {
     test("injects `tool` derived from toolName when the agent input omits it", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctx = buildMockContext(proxy, "conv-1");
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
 
       // Agent inputs do not carry the discriminator — the resolver has to
       // synthesize it from `toolName` ("app_control_observe" → "observe")

--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -28,8 +28,9 @@ mock.module("../runtime/pending-interactions.js", () => ({
 
 const {
   HostAppControlProxy,
-  _getActiveAppControlConversationId,
-  _resetActiveAppControlConversationId,
+  _getActiveAppControlSession,
+  _resetActiveAppControlSession,
+  _setActiveAppControlSession,
 } = await import("../daemon/host-app-control-proxy.js");
 
 import type { HostAppControlResultPayload } from "../daemon/message-types/host-app-control.js";
@@ -58,11 +59,11 @@ describe("HostAppControlProxy", () => {
     sentMessages.length = 0;
     resolvedInteractionIds.length = 0;
     mockHasClient = false;
-    _resetActiveAppControlConversationId();
+    _resetActiveAppControlSession();
   });
 
   afterEach(() => {
-    _resetActiveAppControlConversationId();
+    _resetActiveAppControlSession();
   });
 
   // -------------------------------------------------------------------------
@@ -120,8 +121,10 @@ describe("HostAppControlProxy", () => {
         },
       });
 
-      // Singleton lock acquired by this conversation.
-      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+      // Session lock acquired by this conversation, bound to the started app.
+      const session = _getActiveAppControlSession();
+      expect(session?.conversationId).toBe("conv-1");
+      expect(session?.app).toBe("com.example.editor");
 
       proxy.dispose();
     });
@@ -129,6 +132,22 @@ describe("HostAppControlProxy", () => {
     test("formats execution error with isError=true", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const controller = new AbortController();
+
+      // Acquire a session first so the click below passes the auth gate
+      // and reaches dispatch.
+      const startCtrl = new AbortController();
+      const startPromise = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        startCtrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await startPromise;
+      sentMessages.length = 0;
 
       const resultPromise = proxy.request(
         "app_control_click",
@@ -157,10 +176,10 @@ describe("HostAppControlProxy", () => {
   });
 
   // -------------------------------------------------------------------------
-  // (b) Singleton lock
+  // (b) Session lock
   // -------------------------------------------------------------------------
 
-  describe("singleton lock", () => {
+  describe("session lock", () => {
     test("second conversation's start returns isError naming the holder", async () => {
       const proxy1 = new HostAppControlProxy("conv-1");
       const ctrl1 = new AbortController();
@@ -175,7 +194,7 @@ describe("HostAppControlProxy", () => {
       proxy1.resolve(sent1.requestId as string, payload({ pngBase64: PNG_A }));
       await p1;
 
-      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+      expect(_getActiveAppControlSession()?.conversationId).toBe("conv-1");
 
       // Second conversation tries to start — should be rejected without
       // sending any envelope.
@@ -235,14 +254,33 @@ describe("HostAppControlProxy", () => {
       proxy.dispose();
     });
 
-    test("non-start tools are not gated by the lock", async () => {
-      const proxy = new HostAppControlProxy("conv-2");
+    test("non-start tool with no active session is rejected before dispatch", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();
 
-      // Pretend another conversation already owns the session by manually
-      // priming the lock via a successful start in conv-1.
+      const result = await proxy.request(
+        "app_control_type",
+        {
+          tool: "type",
+          app: "com.example.editor",
+          text: "rm -rf ~",
+        },
+        "conv-1",
+        ctrl.signal,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("No app-control session is active");
+      expect(result.content).toContain("app_control_start");
+      expect(sentMessages).toHaveLength(0); // No envelope dispatched
+
+      proxy.dispose();
+    });
+
+    test("non-start tool from non-owning conversation is rejected", async () => {
       const proxyOwner = new HostAppControlProxy("conv-1");
       const startCtrl = new AbortController();
+
       const pStart = proxyOwner.request(
         "app_control_start",
         { tool: "start", app: "com.example.editor" },
@@ -254,15 +292,128 @@ describe("HostAppControlProxy", () => {
         payload({ pngBase64: PNG_A }),
       );
       await pStart;
-
       sentMessages.length = 0;
 
-      // conv-2 issues a non-start tool — proxy must NOT short-circuit on
-      // the lock; the dispatch goes through.
-      const observePromise = proxy.request(
+      // conv-2 tries to observe the app conv-1 owns — must be rejected
+      // before any host dispatch.
+      const proxyOther = new HostAppControlProxy("conv-2");
+      const ctrl = new AbortController();
+      const result = await proxyOther.request(
         "app_control_observe",
         { tool: "observe", app: "com.example.editor" },
         "conv-2",
+        ctrl.signal,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("conv-1");
+      expect(result.content).toContain("currently");
+      expect(sentMessages).toHaveLength(0);
+
+      proxyOwner.dispose();
+      proxyOther.dispose();
+    });
+
+    test("non-start tool with mismatched app is rejected (cross-app bypass)", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const startCtrl = new AbortController();
+
+      // User approves control of the editor.
+      const pStart = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        startCtrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await pStart;
+      sentMessages.length = 0;
+
+      // The model attempts to type into a different app — must be
+      // rejected with an informative error.
+      const ctrl = new AbortController();
+      const result = await proxy.request(
+        "app_control_type",
+        {
+          tool: "type",
+          app: "com.apple.Terminal",
+          text: "rm -rf ~",
+        },
+        "conv-1",
+        ctrl.signal,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("com.example.editor");
+      expect(result.content).toContain("com.apple.Terminal");
+      expect(result.content).toContain("app_control_stop");
+      expect(sentMessages).toHaveLength(0);
+
+      proxy.dispose();
+    });
+
+    test("non-start tool with case-different but otherwise matching app is allowed", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const startCtrl = new AbortController();
+
+      const pStart = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.apple.Safari" },
+        "conv-1",
+        startCtrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await pStart;
+      sentMessages.length = 0;
+
+      // Different casing of the same bundle ID — bundle IDs are
+      // case-insensitive on macOS, so this should pass the gate.
+      const ctrl = new AbortController();
+      const obsPromise = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "COM.APPLE.SAFARI" },
+        "conv-1",
+        ctrl.signal,
+      );
+      expect(sentMessages).toHaveLength(1);
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_B }),
+      );
+      const result = await obsPromise;
+      expect(result.isError).toBe(false);
+
+      proxy.dispose();
+    });
+
+    test("non-start tool from owning conversation with matching app dispatches", async () => {
+      const proxy = new HostAppControlProxy("conv-1");
+      const startCtrl = new AbortController();
+
+      const pStart = proxy.request(
+        "app_control_start",
+        { tool: "start", app: "com.example.editor" },
+        "conv-1",
+        startCtrl.signal,
+      );
+      proxy.resolve(
+        (sentMessages[0] as Record<string, unknown>).requestId as string,
+        payload({ pngBase64: PNG_A }),
+      );
+      await pStart;
+      sentMessages.length = 0;
+
+      const ctrl = new AbortController();
+      const obsPromise = proxy.request(
+        "app_control_observe",
+        { tool: "observe", app: "com.example.editor" },
+        "conv-1",
         ctrl.signal,
       );
       expect(sentMessages).toHaveLength(1);
@@ -270,11 +421,10 @@ describe("HostAppControlProxy", () => {
       expect(sent.toolName).toBe("app_control_observe");
 
       proxy.resolve(sent.requestId as string, payload({ pngBase64: PNG_B }));
-      const result = await observePromise;
+      const result = await obsPromise;
       expect(result.isError).toBe(false);
 
       proxy.dispose();
-      proxyOwner.dispose();
     });
   });
 
@@ -286,6 +436,10 @@ describe("HostAppControlProxy", () => {
     test("attaches stuck warning after 5 identical observations", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
 
       // First observation establishes the baseline (count = 0).
       const p0 = proxy.request(
@@ -341,6 +495,10 @@ describe("HostAppControlProxy", () => {
     test("resets repeat count when the screenshot hash differs", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
 
       // Establish baseline at PNG_A.
       const p1 = proxy.request(
@@ -391,6 +549,10 @@ describe("HostAppControlProxy", () => {
     test("non-running states do not feed the loop guard", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
 
       // Several observations with state != running (and identical PNGs)
       // should not increment the repeat count.
@@ -435,10 +597,10 @@ describe("HostAppControlProxy", () => {
         payload({ pngBase64: PNG_A }),
       );
       await p1;
-      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+      expect(_getActiveAppControlSession()?.conversationId).toBe("conv-1");
 
       proxy1.dispose();
-      expect(_getActiveAppControlConversationId()).toBeUndefined();
+      expect(_getActiveAppControlSession()).toBeUndefined();
 
       // Now a new conversation can acquire the lock.
       sentMessages.length = 0;
@@ -458,7 +620,7 @@ describe("HostAppControlProxy", () => {
       );
       const result = await p2;
       expect(result.isError).toBe(false);
-      expect(_getActiveAppControlConversationId()).toBe("conv-2");
+      expect(_getActiveAppControlSession()?.conversationId).toBe("conv-2");
 
       proxy2.dispose();
     });
@@ -478,16 +640,16 @@ describe("HostAppControlProxy", () => {
         payload({ pngBase64: PNG_A }),
       );
       await pStart;
-      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+      expect(_getActiveAppControlSession()?.conversationId).toBe("conv-1");
 
       // A different conversation's proxy disposes — the lock should remain
       // with conv-1.
       const proxyOther = new HostAppControlProxy("conv-2");
       proxyOther.dispose();
-      expect(_getActiveAppControlConversationId()).toBe("conv-1");
+      expect(_getActiveAppControlSession()?.conversationId).toBe("conv-1");
 
       proxyOwner.dispose();
-      expect(_getActiveAppControlConversationId()).toBeUndefined();
+      expect(_getActiveAppControlSession()).toBeUndefined();
     });
   });
 
@@ -499,6 +661,10 @@ describe("HostAppControlProxy", () => {
     test("propagates abort and emits cancel envelope", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const controller = new AbortController();
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
 
       const resultPromise = proxy.request(
         "app_control_observe",
@@ -557,6 +723,10 @@ describe("HostAppControlProxy", () => {
     test("100 sequential requests dispatch without an artificial limit", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();
+      _setActiveAppControlSession({
+        conversationId: "conv-1",
+        app: "com.example.editor",
+      });
 
       for (let i = 0; i < 100; i++) {
         const p = proxy.request(

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -2023,7 +2023,7 @@ export async function surfaceProxyResolver(
     // union on `tool` ("start" | "observe" | "press" | …). The agent's raw
     // tool input only carries the action-specific payload (app, x/y, text,
     // …) — the discriminator is implied by `toolName` (`app_control_<tool>`).
-    // Inject it here so the proxy's singleton-lock guard (`input.tool ===
+    // Inject it here so the proxy's session-lock guard (`input.tool ===
     // "start"`) and the Swift client's discriminated-union decoder both see
     // the field they require.
     const tool = toolName.slice("app_control_".length);

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -11,13 +11,22 @@
  * (PNG-hash loop guard) and the result-payload → ToolExecutionResult
  * translation on top.
  *
- * **Singleton lock.** Only one conversation may hold an active app-control
- * session at a time. The lock is module-level (`activeAppControlConversationId`)
- * because a session targets the user's actual desktop application, which
- * is a host-wide resource. The lock is acquired on a successful
- * `app_control_start` and released when the owning proxy's `dispose()`
- * fires. A second conversation that calls `start` while the lock is held
- * receives an `isError: true` tool result naming the holding conversation.
+ * **Session lock.** Only one conversation may hold an active app-control
+ * session at a time, and that session is bound to a specific target app.
+ * The lock is module-level (`activeAppControlSession`) because the session
+ * targets the user's actual desktop application, which is a host-wide
+ * resource. It is acquired on a successful `app_control_start` (storing
+ * `(conversationId, app)`) and released when the owning proxy's
+ * `dispose()` fires.
+ *
+ * `app_control_start` is the only tool that can acquire the lock — the
+ * user's medium-risk approval at start time is the consent boundary. All
+ * other tools (observe / press / combo / sequence / type / click / drag)
+ * require the calling conversation to own an active session targeting the
+ * same `app`; otherwise the call is rejected before any host dispatch.
+ * This prevents prompt-injected tool calls from sending raw input to
+ * arbitrary apps without the user having approved control of that
+ * specific app.
  *
  * **No step cap.** Unlike {@link HostCuProxy} which enforces a per-session
  * step ceiling via `loadConfig().maxStepsPerSession`, app-control sessions
@@ -51,36 +60,111 @@ const REQUEST_TIMEOUT_MS = 60 * 1000;
 const STUCK_REPEAT_THRESHOLD = 4;
 
 // ---------------------------------------------------------------------------
-// Tool name constants
-// ---------------------------------------------------------------------------
-//
-// Kept here (rather than imported from PR 5's tool registrations) so the
-// proxy is independently testable. PR 5 must use these same string values.
-
-const TOOL_START = "app_control_start";
-
-// ---------------------------------------------------------------------------
-// Module-level singleton lock
+// Module-level session lock
 // ---------------------------------------------------------------------------
 
 /**
- * Conversation id that currently owns the active app-control session, or
- * `undefined` if no session is active. Set on a successful
- * `app_control_start`; cleared by the owning proxy's `dispose()`.
+ * Active app-control session: the conversation that owns the lock and the
+ * `app` it was approved against. Set on a successful `app_control_start`;
+ * cleared by the owning proxy's `dispose()`.
+ */
+export interface ActiveAppControlSession {
+  conversationId: string;
+  /**
+   * The exact `app` string the user approved at start time (bundle ID or
+   * process name — preserved as-is). Compared case-insensitively against
+   * the `app` of subsequent non-start tool calls.
+   */
+  app: string;
+}
+
+/**
+ * Currently active session, or `undefined` when no session is held.
  *
  * Exported for test inspection only. Production code paths must not read
  * or mutate this directly — use the proxy methods.
  */
-let activeAppControlConversationId: string | undefined;
+let activeAppControlSession: ActiveAppControlSession | undefined;
 
-/** Test-only helper: read current lock owner. */
-export function _getActiveAppControlConversationId(): string | undefined {
-  return activeAppControlConversationId;
+/** Test-only helper: read current session. */
+export function _getActiveAppControlSession():
+  | ActiveAppControlSession
+  | undefined {
+  return activeAppControlSession;
 }
 
-/** Test-only helper: clear lock between test cases. */
-export function _resetActiveAppControlConversationId(): void {
-  activeAppControlConversationId = undefined;
+/** Test-only helper: clear session between test cases. */
+export function _resetActiveAppControlSession(): void {
+  activeAppControlSession = undefined;
+}
+
+/**
+ * Test-only helper: prime the active session without a full `start` round-trip.
+ * Useful for tests that exercise non-start tool paths and don't need to
+ * verify the start flow itself.
+ */
+export function _setActiveAppControlSession(
+  session: ActiveAppControlSession,
+): void {
+  activeAppControlSession = session;
+}
+
+/**
+ * Validate a non-start tool call against the active session. Returns a
+ * `ToolExecutionResult` (with `isError: true`) when the call should be
+ * rejected; returns `null` when the call is authorized to dispatch.
+ *
+ * `app` matching is case-insensitive (macOS bundle IDs are
+ * case-insensitive in practice) but strict on form: `"Safari"` and
+ * `"com.apple.Safari"` do not match — the user approved a specific string
+ * and substituting a different form requires a new approval.
+ */
+function checkNonStartAuthorization(
+  input: HostAppControlInput,
+  conversationId: string,
+): ToolExecutionResult | null {
+  if (activeAppControlSession == null) {
+    return {
+      content:
+        "No app-control session is active. Call app_control_start to request " +
+        "user approval to control the target app, then retry.",
+      isError: true,
+    };
+  }
+  if (activeAppControlSession.conversationId !== conversationId) {
+    return {
+      content:
+        `Another conversation (${activeAppControlSession.conversationId}) currently ` +
+        `holds the app-control session. Wait for it to finish, or call ` +
+        `app_control_stop from that conversation first.`,
+      isError: true,
+    };
+  }
+  // `app` is required on every non-start variant of HostAppControlInput
+  // except `stop`, and `stop` short-circuits in conversation-surfaces and
+  // does not reach this method in production. A stop reaching here would
+  // be a defensive bug — surface it explicitly rather than dispatch.
+  const requestedApp = (input as { app?: string }).app;
+  if (requestedApp == null) {
+    return {
+      content:
+        "Tool input missing required 'app' field; cannot validate against " +
+        "the active app-control session.",
+      isError: true,
+    };
+  }
+  if (
+    requestedApp.toLowerCase() !== activeAppControlSession.app.toLowerCase()
+  ) {
+    return {
+      content:
+        `Active app-control session targets ${activeAppControlSession.app}; ` +
+        `cannot send actions to ${requestedApp}. Call app_control_stop and ` +
+        `app_control_start to switch apps.`,
+      isError: true,
+    };
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,7 +175,7 @@ export class HostAppControlProxy extends HostProxyBase<
   HostAppControlInput,
   HostAppControlResultPayload
 > {
-  /** Conversation that owns this proxy instance. Used by `dispose()` to release the singleton lock only when this proxy is the holder. */
+  /** Conversation that owns this proxy instance. Used by `dispose()` to release the session lock only when this proxy is the holder. */
   private readonly conversationId: string;
 
   /** sha256 hex of the most recent observation's `pngBase64`, or undefined. */
@@ -143,20 +227,28 @@ export class HostAppControlProxy extends HostProxyBase<
       return { content: "Aborted", isError: true };
     }
 
-    // Singleton-lock guard for `start`. Other tools assume a session
-    // already exists and are not gated here.
-    if (toolName === TOOL_START) {
+    // Authorization gate. `start` acquires the session lock (the user's
+    // medium-risk approval is the consent boundary); all other tools must
+    // belong to the active session and target the same `app`. Without this
+    // gate, prompt-injected calls would bypass the start-time approval and
+    // send raw input to arbitrary apps.
+    if (input.tool === "start") {
       if (
-        activeAppControlConversationId != null &&
-        activeAppControlConversationId !== conversationId
+        activeAppControlSession != null &&
+        activeAppControlSession.conversationId !== conversationId
       ) {
         return {
           content:
-            `Another conversation (${activeAppControlConversationId}) currently holds the ` +
+            `Another conversation (${activeAppControlSession.conversationId}) currently holds the ` +
             `app-control session. Wait for it to finish, or call app_control_stop ` +
             `from that conversation first.`,
           isError: true,
         };
+      }
+    } else {
+      const sessionError = checkNonStartAuthorization(input, conversationId);
+      if (sessionError != null) {
+        return sessionError;
       }
     }
 
@@ -167,7 +259,7 @@ export class HostAppControlProxy extends HostProxyBase<
         conversationId,
         signal,
       );
-      return this.handleSuccess(toolName, payload);
+      return this.handleSuccess(input, payload);
     } catch (err) {
       if (err instanceof HostProxyRequestError) {
         if (err.reason === "timeout") {
@@ -192,7 +284,7 @@ export class HostAppControlProxy extends HostProxyBase<
   // ---------------------------------------------------------------------------
 
   private handleSuccess(
-    toolName: string,
+    input: HostAppControlInput,
     payload: HostAppControlResultPayload,
   ): ToolExecutionResult {
     // Update PNG-hash loop tracking only for the "running" state — other
@@ -212,9 +304,13 @@ export class HostAppControlProxy extends HostProxyBase<
       }
     }
 
-    // Acquire the singleton lock on a successful `start`.
-    if (toolName === TOOL_START && payload.state === "running") {
-      activeAppControlConversationId = this.conversationId;
+    // Store the exact `app` form for validation against subsequent
+    // non-start tool calls.
+    if (input.tool === "start" && payload.state === "running") {
+      activeAppControlSession = {
+        conversationId: this.conversationId,
+        app: input.app,
+      };
     }
 
     return this.formatResult(payload, stuck);
@@ -281,13 +377,13 @@ export class HostAppControlProxy extends HostProxyBase<
   // ---------------------------------------------------------------------------
 
   /**
-   * Reject pending requests via the base, then release the singleton lock
+   * Reject pending requests via the base, then release the session lock
    * if this proxy is the holder. Idempotent: safe to call multiple times.
    */
   override dispose(): void {
     super.dispose();
-    if (activeAppControlConversationId === this.conversationId) {
-      activeAppControlConversationId = undefined;
+    if (activeAppControlSession?.conversationId === this.conversationId) {
+      activeAppControlSession = undefined;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bind the app-control session lock to `(conversationId, app)` and gate non-start tools against it. Previously only `app_control_start` was gated; the other tools (observe, press, combo, sequence, type, click, drag) dispatched without verifying an active session or matching app.
- Closes a bypass where a prompt-injected model could call `app_control_type({app: "com.apple.Terminal", text: "…"})` directly — no `start`, no approval — and the desktop client would activate Terminal and type.
- App matching is case-insensitive (macOS bundle IDs are case-insensitive in practice) but strict on form: `Safari` and `com.apple.Safari` do not match. The user approved a specific string; substituting a different form requires a fresh approval.
- Test coverage: replaced the test that asserted the bug ("non-start tools are not gated by the lock") with positive and negative gate cases — no session, non-owning conversation, mismatched app, case-different match, full owning-conversation flow.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->