### PR TITLE
Revert #29553; fix v1 tests broken by memory-v2 default flip

### DIFF
--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type {
   ContentBlock,
   Message,
   ProviderResponse,
 } from "../providers/types.js";
+
+// This test exercises v1 conversation routing. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -12,7 +12,13 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
+
+// This test exercises v1 conversation routing. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 // Use an object wrapper so TypeScript doesn't narrow the captured type to
 // `undefined` based on the initial assignment in the test setup.

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { UserMessageAttachment } from "../daemon/message-protocol.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
 import { ProviderError } from "../util/errors.js";
+
+// This test exercises v1 conversation routing. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
+
+// This test exercises v1 conversation routing. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
+
 // PKB search is mocked so the reminder-hints tests can assert behavior
 // without standing up Qdrant. The mock returns whatever is staged in
 // `pkbSearchResults` / `pkbSearchThrows` for the enclosing test.

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -5,8 +5,14 @@ import type {
   CheckpointDecision,
   CheckpointInfo,
 } from "../agent/loop.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
+
+// This test exercises v1 conversation routing. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 // ---------------------------------------------------------------------------
 // Mocks — must precede the Conversation import so Bun applies them at load time.

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
+
+// This test exercises v1 conversation routing. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 // ---------------------------------------------------------------------------
 // Track agent loop calls

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { AgentEvent } from "../agent/loop.js";
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import type { Message, ProviderResponse } from "../providers/types.js";
+
+// This test exercises v1 conversation routing. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 // ---------------------------------------------------------------------------
 // Configurable agent loop behavior

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -25,6 +25,7 @@
 
 import { beforeEach, describe, expect, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../config/assistant-feature-flags.js";
 import {
   applyRuntimeInjections,
   composeInjectorChain,
@@ -33,6 +34,11 @@ import {
   DEFAULT_INJECTOR_ORDER,
   defaultInjectorsPlugin,
 } from "../plugins/defaults/injectors.js";
+
+// This test exercises v1 PKB injection. The `memory-v2-enabled` flag
+// (registry default `true`) makes the PKB injector go silent — disable it
+// here so the v1 injection chain assertions stay meaningful.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 import {
   getInjectors,
   registerPlugin,

--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -55,7 +55,7 @@ import type {
 export function isMemoryV2ReadActive(config: AssistantConfig): boolean {
   return (
     isAssistantFeatureFlagEnabled("memory-v2-enabled", config) &&
-    config.memory?.v2?.enabled === true
+    config.memory.v2.enabled
   );
 }
 

--- a/assistant/src/memory/graph/graph-search.test.ts
+++ b/assistant/src/memory/graph/graph-search.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+import { _setOverridesForTesting } from "../../config/assistant-feature-flags.js";
+
+// This test exercises the v1 graph search path. The `memory-v2-enabled` flag
+// (registry default `true`) makes graph-search short-circuit to keep traffic
+// off the legacy collection — disable it so the v1 path stays under test.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),

--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -71,6 +71,7 @@ mock.module("../../providers/provider-send-message.js", () => ({
   extractToolUse: () => null,
 }));
 
+import { _setOverridesForTesting } from "../../config/assistant-feature-flags.js";
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { resetDb } from "../db-connection.js";
@@ -80,6 +81,11 @@ import { InContextTracker } from "./injection.js";
 import { loadContextMemory, retrieveForTurn } from "./retriever.js";
 import { createNode } from "./store.js";
 import type { NewNode } from "./types.js";
+
+// These tests exercise v1 retrieval. v2 takeover (both `memory-v2-enabled`
+// flag *and* `memory.v2.enabled` schema field) makes `loadContextMemory`
+// short-circuit, so disable the flag here to keep the v1 path under test.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 const TEST_CONFIG: AssistantConfig = { ...DEFAULT_CONFIG };
 

--- a/assistant/src/memory/pkb/pkb-search.test.ts
+++ b/assistant/src/memory/pkb/pkb-search.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "../../__tests__/helpers/mock-logger.js";
+import { _setOverridesForTesting } from "../../config/assistant-feature-flags.js";
+
+// This test exercises the v1 PKB search path. The `memory-v2-enabled` flag
+// (registry default `true`) makes pkb-search short-circuit to keep traffic
+// off the legacy collection — disable it so the v1 path stays under test.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 mock.module("../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),

--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -6,6 +6,13 @@
  */
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { _setOverridesForTesting } from "../../config/assistant-feature-flags.js";
+
+// This test exercises v1 memory CRUD routes. The `memory-v2-enabled` flag
+// (registry default `true`) flips memory routing to v2 — disable it here so
+// the v1 paths under test stay active.
+_setOverridesForTesting({ "memory-v2-enabled": false });
+
 mock.module("../../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
@@ -68,11 +75,7 @@ import { eq } from "drizzle-orm";
 import { getDb } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import { memoryGraphNodes, memoryJobs } from "../../memory/schema.js";
-import {
-  BadRequestError,
-  ConflictError,
-  NotFoundError,
-} from "./errors.js";
+import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
 import { ROUTES } from "./memory-item-routes.js";
 import type { RouteDefinition } from "./types.js";
 
@@ -269,7 +272,9 @@ describe("Memory Item Routes", () => {
         content: "s2\nst2",
       });
 
-      const res = await callHandler(route, { queryParams: { kind: "semantic" } });
+      const res = await callHandler(route, {
+        queryParams: { kind: "semantic" },
+      });
       const body = (await res.json()) as {
         items: Array<{ id: string }>;
         total: number;
@@ -319,7 +324,9 @@ describe("Memory Item Routes", () => {
         lastAccessed: 3000,
       });
 
-      const res = await callHandler(route, { queryParams: { limit: "1", offset: "1" } });
+      const res = await callHandler(route, {
+        queryParams: { limit: "1", offset: "1" },
+      });
       const body = (await res.json()) as {
         items: Array<{ id: string }>;
         total: number;
@@ -344,7 +351,9 @@ describe("Memory Item Routes", () => {
         created: 1000,
       });
 
-      const res = await callHandler(route, { queryParams: { sort: "firstSeenAt", order: "asc" } });
+      const res = await callHandler(route, {
+        queryParams: { sort: "firstSeenAt", order: "asc" },
+      });
       const body = (await res.json()) as {
         items: Array<{ id: string }>;
       };
@@ -366,7 +375,9 @@ describe("Memory Item Routes", () => {
         significance: 0.9,
       });
 
-      const res = await callHandler(route, { queryParams: { sort: "importance", order: "desc" } });
+      const res = await callHandler(route, {
+        queryParams: { sort: "importance", order: "desc" },
+      });
       const body = (await res.json()) as {
         items: Array<{ id: string }>;
       };
@@ -418,7 +429,9 @@ describe("Memory Item Routes", () => {
         },
       ];
 
-      const res = await callHandler(route, { queryParams: { search: "alice" } });
+      const res = await callHandler(route, {
+        queryParams: { search: "alice" },
+      });
       const body = (await res.json()) as {
         items: Array<{ id: string }>;
         total: number;
@@ -503,7 +516,9 @@ describe("Memory Item Routes", () => {
       ];
 
       // Request page 2 (offset=1, limit=1)
-      const res = await callHandler(route, { queryParams: { search: "item", limit: "1", offset: "1" } });
+      const res = await callHandler(route, {
+        queryParams: { search: "item", limit: "1", offset: "1" },
+      });
       const body = (await res.json()) as {
         items: Array<{ id: string }>;
         total: number;
@@ -563,7 +578,10 @@ describe("Memory Item Routes", () => {
         content: "dark mode\nPrefers dark mode",
       });
 
-      const res = await callHandler(route, { queryParams: {}, pathParams: { id: "i1" } });
+      const res = await callHandler(route, {
+        queryParams: {},
+        pathParams: { id: "i1" },
+      });
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
         item: { id: string; subject: string };
@@ -573,7 +591,10 @@ describe("Memory Item Routes", () => {
     });
 
     test("returns 404 for non-existent item", async () => {
-      const res = await callHandler(route, { queryParams: {}, pathParams: { id: "nonexistent" } });
+      const res = await callHandler(route, {
+        queryParams: {},
+        pathParams: { id: "nonexistent" },
+      });
       expect(res.status).toBe(404);
     });
 
@@ -584,7 +605,10 @@ describe("Memory Item Routes", () => {
         content: "some content\nsome statement",
       });
 
-      const res = await callHandler(route, { queryParams: {}, pathParams: { id: "i1" } });
+      const res = await callHandler(route, {
+        queryParams: {},
+        pathParams: { id: "i1" },
+      });
       const body = (await res.json()) as {
         item: { supersedes: unknown; supersededBy: unknown };
       };
@@ -862,7 +886,9 @@ describe("Memory Item Routes", () => {
     });
 
     test("returns 404 for non-existent item", async () => {
-      const res = await callHandler(route, { pathParams: { id: "nonexistent" } });
+      const res = await callHandler(route, {
+        pathParams: { id: "nonexistent" },
+      });
       expect(res.status).toBe(404);
     });
 

--- a/assistant/src/tools/memory/register.test.ts
+++ b/assistant/src/tools/memory/register.test.ts
@@ -11,8 +11,14 @@ import {
   test,
 } from "bun:test";
 
+import { _setOverridesForTesting } from "../../config/assistant-feature-flags.js";
 import { PKB_WORKSPACE_SCOPE } from "../../memory/pkb/types.js";
 import type { ToolContext } from "../types.js";
+
+// This test exercises v1 PKB re-index enqueue. The `memory-v2-enabled` flag
+// (registry default `true`) makes the enqueue path skipped — disable it so
+// the v1 PKB index path stays under test.
+_setOverridesForTesting({ "memory-v2-enabled": false });
 
 let tmpWorkspace: string;
 let previousWorkspaceEnv: string | undefined;

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -247,7 +247,7 @@
       "key": "memory-v2-enabled",
       "label": "Memory v2 (concept-page activation model)",
       "description": "Enables the v2 memory subsystem: prose concept pages with bidirectional edges, activation-based retrieval, and hourly LLM-driven consolidation. v1 graph + PKB stays write-active until cutover.",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "account-deletion",


### PR DESCRIPTION
## Summary
- Revert PR #29553 (`fix(memory): restore CI by guarding v2 read check and reverting default flag`). Restores the strict `config.memory.v2.enabled` access in `isMemoryV2ReadActive` and the `memory-v2-enabled` registry default of \`true\` from PR #29551.
- Disable the \`memory-v2-enabled\` flag explicitly in the 12 v1-targeted test files that exercise the v1 retrieval / injection / conversation paths so they keep asserting v1 behavior instead of being short-circuited by the v2 takeover.

## Original prompt
Revert 83a3959847 and fix tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->