### PR TITLE
Add safe-storage-limits assistant feature flag

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 const DECLARED_FLAG_ID = "email-channel";
 const DECLARED_FLAG_KEY = DECLARED_FLAG_ID;
+const SAFE_STORAGE_LIMITS_FLAG = "safe-storage-limits";
 
 const { isAssistantFeatureFlagEnabled, _setOverridesForTesting } =
   await import("../config/assistant-feature-flags.js");
@@ -60,6 +61,23 @@ describe("isAssistantFeatureFlagEnabled", () => {
     expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
       false,
     );
+  });
+
+  test("safe-storage-limits defaults to disabled", () => {
+    const config = {} as any;
+
+    expect(
+      isAssistantFeatureFlagEnabled(SAFE_STORAGE_LIMITS_FLAG, config),
+    ).toBe(false);
+  });
+
+  test("safe-storage-limits respects explicit override", () => {
+    _setOverridesForTesting({ [SAFE_STORAGE_LIMITS_FLAG]: true });
+    const config = {} as any;
+
+    expect(
+      isAssistantFeatureFlagEnabled(SAFE_STORAGE_LIMITS_FLAG, config),
+    ).toBe(true);
   });
 
   test("unknown flag defaults to true when no persisted override", () => {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -242,6 +242,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "safe-storage-limits",
+      "scope": "assistant",
+      "key": "safe-storage-limits",
+      "label": "Safe Storage Limits",
+      "description": "Enable disk pressure protection flows that block background work and remote actors while storage is critically low.",
+      "defaultEnabled": false
+    },
+    {
       "id": "memory-v2-enabled",
       "scope": "assistant",
       "key": "memory-v2-enabled",


### PR DESCRIPTION
## Summary
- Add the safe-storage-limits assistant feature flag.
- Sync bundled feature flag registries.
- Cover default resolution in assistant feature flag tests.

Part of plan: disk-pressure-protection.md (PR 1 of 13)

Note: companion platform Terraform must provision the same safe-storage-limits LaunchDarkly flag before rollout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->