### PR TITLE
fix(host-proxy): correct same-user check in dev-bypass mode

### DIFF
--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression tests for the SSE registration dev-bypass actor principal
+ * translation.
+ *
+ * In `DISABLE_HTTP_AUTH=true` (platform-managed) deployments the synthetic
+ * dev-bypass `AuthContext` injects `actorPrincipalId="dev-bypass"` for every
+ * request. Tool-side trust resolution still resolves to the real local
+ * guardian's principalId via `resolveLocalTrustContext`. Without translation,
+ * `ClientEntry.actorPrincipalId === "dev-bypass"` and
+ * `ToolContext.sourceActorPrincipalId === "<real-guardian>"` mismatch, so the
+ * same-user check in HostBashProxy / HostFileProxy / HostCuProxy /
+ * conversation-surfaces rejects every targeted host proxy invocation and the
+ * auto-resolve path silently falls through to untargeted broadcast.
+ *
+ * The events-routes handler translates `"dev-bypass"` to the real guardian's
+ * principalId at registration time so both sides agree. This keeps targeted
+ * host proxy execution working on Docker / platform-managed deployments.
+ */
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must be set up before importing the route) ──────────────
+
+let fakeHttpAuthDisabled = false;
+let fakeGuardianPrincipalId: string | undefined = undefined;
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../runtime/local-actor-identity.js", () => ({
+  findLocalGuardianPrincipalId: () => fakeGuardianPrincipalId,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────
+
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { handleSubscribeAssistantEvents } from "../runtime/routes/events-routes.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("events SSE registration — dev-bypass actor translation", () => {
+  test("translates 'dev-bypass' to the real guardian principalId when auth is disabled", () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = "guardian-real-id";
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "devbypass-client-001",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("devbypass-client-001");
+    expect(entry?.actorPrincipalId).toBe("guardian-real-id");
+    expect(hub.getActorPrincipalIdForClient("devbypass-client-001")).toBe(
+      "guardian-real-id",
+    );
+
+    ac.abort();
+  });
+
+  test("registers without principalId when dev-bypass is set but no guardian is bound", () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = undefined;
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "devbypass-client-002",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("devbypass-client-002");
+    expect(entry).toBeDefined();
+    expect(entry?.actorPrincipalId).toBeUndefined();
+
+    ac.abort();
+  });
+
+  test("does NOT translate when auth is enabled (production mode)", () => {
+    // Defense in depth: make sure we never silently rewrite a real
+    // principalId that legitimately happens to be the literal "dev-bypass"
+    // string in a non-dev-bypass deployment. The translation is gated on
+    // isHttpAuthDisabled() === true.
+    fakeHttpAuthDisabled = false;
+    fakeGuardianPrincipalId = "guardian-real-id";
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "prod-client-003",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("prod-client-003");
+    expect(entry?.actorPrincipalId).toBe("dev-bypass");
+
+    ac.abort();
+  });
+
+  test("passes through non-dev-bypass principalId verbatim in dev-bypass mode", () => {
+    // Edge case: a service-token connection that happens to be made while
+    // the daemon runs in DISABLE_HTTP_AUTH=true mode should still register
+    // with its own principalId, not the guardian's.
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = "guardian-real-id";
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "service-client-004",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "service-account-A",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("service-client-004");
+    expect(entry?.actorPrincipalId).toBe("service-account-A");
+
+    ac.abort();
+  });
+});

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -44,6 +44,17 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
 }
 
 /**
+ * Look up the local vellum guardian's principalId from the contacts table.
+ *
+ * Returns `undefined` when no vellum guardian binding exists (e.g. fresh
+ * install before bootstrap). Callers should treat that case as
+ * "not yet available" and either fall back or proceed without a principalId.
+ */
+export function findLocalGuardianPrincipalId(): string | undefined {
+  return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
+}
+
+/**
  * Resolve the guardian runtime context for a local connection.
  *
  * Looks up the vellum guardian binding to obtain the `guardianPrincipalId`,
@@ -60,10 +71,8 @@ export function resolveLocalTrustContext(
 ): TrustContext {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
 
-  // Try contacts-first for the vellum guardian channel
-  const guardianResult = findGuardianForChannel("vellum");
-  if (guardianResult && guardianResult.contact.principalId) {
-    const guardianPrincipalId = guardianResult.contact.principalId;
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) {
     const trustCtx = resolveTrustContext({
       assistantId,
       sourceChannel: "vellum",
@@ -97,13 +106,9 @@ export function resolveLocalTrustContext(
 export function resolveLocalAuthContext(conversationId: string): AuthContext {
   const authContext = buildLocalAuthContext(conversationId);
 
-  // Enrich with the guardian principal ID from contacts-first path
-  const guardianResult = findGuardianForChannel("vellum");
-  if (guardianResult && guardianResult.contact.principalId) {
-    return {
-      ...authContext,
-      actorPrincipalId: guardianResult.contact.principalId,
-    };
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) {
+    return { ...authContext, actorPrincipalId: guardianPrincipalId };
   }
 
   log.warn(

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 
 import type { HostProxyCapability } from "../../channels/types.js";
 import { parseInterfaceId, supportsHostProxy } from "../../channels/types.js";
+import { isHttpAuthDisabled } from "../../config/env.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
@@ -35,6 +36,7 @@ import {
   AssistantEventHub,
   assistantEventHub,
 } from "../assistant-event-hub.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -42,6 +44,28 @@ const log = getLogger("events-routes");
 
 /** Keep-alive comment sent to idle clients every 7 s by default. */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
+
+/**
+ * Translate the synthetic dev-bypass actor principal to the real local
+ * guardian's principalId when running in `DISABLE_HTTP_AUTH=true` mode.
+ *
+ * The dev-bypass `AuthContext` (`runtime/auth/middleware.ts`) injects
+ * `"dev-bypass"` for every request, but tool-side trust resolution
+ * (`resolveLocalTrustContext`) returns the real guardian principalId. Without
+ * translation, every targeted host_bash/host_file/host_cu request mismatches
+ * the same-user check and is rejected. Mirrors `resolveLocalAuthContext`.
+ */
+function resolveActorPrincipalId(raw: string | undefined): string | undefined {
+  if (raw !== "dev-bypass" || !isHttpAuthDisabled()) return raw;
+
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) return guardianPrincipalId;
+
+  log.warn(
+    "dev-bypass actor principal received but no vellum guardian binding found; registering client without actorPrincipalId",
+  );
+  return undefined;
+}
 
 /**
  * Stream assistant events as Server-Sent Events.
@@ -88,8 +112,11 @@ export function handleSubscribeAssistantEvents(
     : null;
   // Verified by RuntimeHttpServer and forwarded by the http-adapter from the
   // bearer token's AuthContext. May be absent for legacy / service-token
-  // connections that have no principal.
-  const actorPrincipalId = rawActorPrincipalId?.trim() || undefined;
+  // connections that have no principal. See `resolveActorPrincipalId` for the
+  // dev-bypass translation rationale.
+  const actorPrincipalId = resolveActorPrincipalId(
+    rawActorPrincipalId?.trim() || undefined,
+  );
 
   if (clientId && !interfaceId) {
     log.error(


### PR DESCRIPTION
## Summary
Targeted host proxy execution was silently broken in `DISABLE_HTTP_AUTH=true` (platform-managed) deployments. SSE clients were registering with `actorPrincipalId='dev-bypass'` while the tool side resolved the real local guardian principalId, so every targeted request mismatched and was rejected.

**Gap:** `DISABLE_HTTP_AUTH=true` deployments breaks targeted execution
**Fix:** translate the dev-bypass actor principal to the real local guardian principalId at SSE registration (`events-routes.ts`), mirroring `resolveLocalAuthContext`. One translation point, no scattered bypasses in the proxy check sites.

Also extracts `findLocalGuardianPrincipalId()` in `local-actor-identity.ts` so the three call sites (events-routes, `resolveLocalAuthContext`, `resolveLocalTrustContext`) share the lookup.

Part of plan: host-proxy-same-user.md (review fix R1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->