### PR TITLE
fix(ipc): forward synthetic actor-principal-id header to shared routes

### DIFF
--- a/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
@@ -1,0 +1,169 @@
+/**
+ * End-to-end test for `assistant clients list` over IPC.
+ *
+ * Regression test for the gap where the same-user filter on
+ * `GET /v1/clients` (which reads `headers["x-vellum-actor-principal-id"]`)
+ * silently returned an empty list over IPC because the IPC adapter did
+ * not inject the synthetic actor-principal header that the HTTP adapter
+ * populates from the verified `AuthContext`.
+ *
+ * Asserts that in non-dev-bypass mode (`isHttpAuthDisabled() === false`),
+ * the CLI sees same-user clients via the IPC path because the IPC server
+ * fills in the header from the local guardian principal.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { runAssistantCommandFull } from "../../cli/__tests__/run-assistant-command.js";
+import { AssistantIpcServer } from "../assistant-server.js";
+
+// ── Module mocks (must be set up before importing the route) ──────────────
+
+let fakeHttpAuthDisabled = false;
+let fakeLocalPrincipalId: string | undefined = "guardian-local";
+
+mock.module("../../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../../runtime/local-actor-identity.js", () => ({
+  resolveLocalActorPrincipalId: () => fakeLocalPrincipalId,
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────
+
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+let server: AssistantIpcServer | null = null;
+
+function registerClient(args: {
+  clientId: string;
+  actorPrincipalId?: string;
+}): void {
+  assistantEventHub.subscribe({
+    type: "client",
+    clientId: args.clientId,
+    interfaceId: "macos",
+    capabilities: ["host_bash", "host_file", "host_cu"],
+    actorPrincipalId: args.actorPrincipalId,
+    callback: () => {},
+  });
+}
+
+function clearHub(): void {
+  const ids = assistantEventHub.listClients().map((c) => c.clientId);
+  for (const id of ids) {
+    assistantEventHub.disposeClient(id);
+  }
+}
+
+async function startServer(): Promise<void> {
+  server = new AssistantIpcServer();
+  await server.start();
+  // Allow the listener to be ready before the CLI tries to connect.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+beforeEach(() => {
+  fakeHttpAuthDisabled = false;
+  fakeLocalPrincipalId = "guardian-local";
+  clearHub();
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("assistant clients list over IPC — same-user filter", () => {
+  test("returns same-user clients in non-dev-bypass mode", async () => {
+    registerClient({
+      clientId: "client-self-1",
+      actorPrincipalId: "guardian-local",
+    });
+    registerClient({
+      clientId: "client-self-2",
+      actorPrincipalId: "guardian-local",
+    });
+    registerClient({
+      clientId: "client-other",
+      actorPrincipalId: "other-user",
+    });
+
+    await startServer();
+
+    const { stdout } = await runAssistantCommandFull(
+      "clients",
+      "list",
+      "--json",
+    );
+
+    const parsed = JSON.parse(stdout.trim()) as {
+      clients: Array<{ clientId: string }>;
+    };
+    const ids = parsed.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-self-1", "client-self-2"]);
+  });
+
+  test("returns empty when no local guardian principal is bound (fail-closed)", async () => {
+    fakeLocalPrincipalId = undefined;
+    registerClient({
+      clientId: "client-self",
+      actorPrincipalId: "guardian-local",
+    });
+
+    await startServer();
+
+    const { stdout } = await runAssistantCommandFull(
+      "clients",
+      "list",
+      "--json",
+    );
+    const parsed = JSON.parse(stdout.trim()) as {
+      clients: Array<{ clientId: string }>;
+    };
+    expect(parsed.clients).toEqual([]);
+  });
+
+  test("dev-bypass mode returns all clients regardless of principal", async () => {
+    fakeHttpAuthDisabled = true;
+    registerClient({
+      clientId: "client-self",
+      actorPrincipalId: "guardian-local",
+    });
+    registerClient({
+      clientId: "client-other",
+      actorPrincipalId: "other-user",
+    });
+
+    await startServer();
+
+    const { stdout } = await runAssistantCommandFull(
+      "clients",
+      "list",
+      "--json",
+    );
+    const parsed = JSON.parse(stdout.trim()) as {
+      clients: Array<{ clientId: string }>;
+    };
+    const ids = parsed.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-other", "client-self"]);
+  });
+});

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -32,9 +32,13 @@ import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 
+import { resolveLocalActorPrincipalId } from "../runtime/local-actor-identity.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/index.js";
-import type { RouteDefinition } from "../runtime/routes/types.js";
+import type {
+  RouteDefinition,
+  RouteHandlerArgs,
+} from "../runtime/routes/types.js";
 import { getLogger } from "../util/logger.js";
 import {
   type IpcEnvelope,
@@ -150,7 +154,6 @@ export class AssistantIpcServer {
     this.methods.set("db_proxy", (params) =>
       handleDbProxy(params as unknown as DbProxyParams),
     );
-
   }
 
   /** Start listening on the Unix domain socket. */
@@ -257,7 +260,8 @@ export class AssistantIpcServer {
     void binary;
 
     try {
-      const result = handler(req.params ?? {});
+      const handlerArgs = injectLocalActorHeader(req.params);
+      const result = handler(handlerArgs);
 
       if (result instanceof Promise) {
         result
@@ -455,3 +459,52 @@ export class AssistantIpcServer {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Inject a synthetic `x-vellum-actor-principal-id` header from the local
+ * guardian principal when the caller hasn't already provided one.
+ *
+ * Local IPC is intra-process and owned by the same user as the daemon, so
+ * routes that consume `headers["x-vellum-actor-principal-id"]` (e.g. the
+ * same-user filter on `GET /v1/clients`) need an actor identity to function
+ * over IPC. The HTTP adapter does this from the verified `AuthContext`
+ * (`http-adapter.ts`); this helper mirrors that convention for IPC.
+ *
+ * Existing headers from the caller (e.g. the gateway's IPC runtime proxy,
+ * which forwards real `x-vellum-*` headers from the authenticated HTTP
+ * request) are preserved — we only fill in the gap for direct CLI/local
+ * IPC callers.
+ */
+function injectLocalActorHeader(
+  params: Record<string, unknown> | undefined,
+): RouteHandlerArgs {
+  const args = (params ?? {}) as RouteHandlerArgs;
+  const existingHeaders = args.headers;
+  if (existingHeaders?.["x-vellum-actor-principal-id"]) {
+    return args;
+  }
+
+  // Defensive: the guardian lookup queries the contacts table, which may
+  // not yet exist on a very early boot path or in test fixtures that don't
+  // initialize the DB. A failure here must not block IPC dispatch — routes
+  // that require the header will fail-closed on their own.
+  let localActor: string | undefined;
+  try {
+    localActor = resolveLocalActorPrincipalId();
+  } catch (err) {
+    log.debug(
+      { err },
+      "failed to resolve local actor principal for IPC header injection",
+    );
+    return args;
+  }
+  if (!localActor) return args;
+
+  return {
+    ...args,
+    headers: {
+      ...existingHeaders,
+      "x-vellum-actor-principal-id": localActor,
+    },
+  };
+}

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -86,6 +86,22 @@ export function resolveLocalTrustContext(
 }
 
 /**
+ * Resolve the local guardian's `actorPrincipalId` from the vellum channel
+ * binding, when available.
+ *
+ * Returns `undefined` when no vellum guardian binding exists (e.g. fresh
+ * install before bootstrap). Callers that need an `AuthContext` shape
+ * should use `resolveLocalAuthContext`; callers that only need the
+ * principal id (e.g. the IPC adapter populating the
+ * `x-vellum-actor-principal-id` header for shared route handlers) can
+ * use this directly.
+ */
+export function resolveLocalActorPrincipalId(): string | undefined {
+  const guardianResult = findGuardianForChannel("vellum");
+  return guardianResult?.contact.principalId ?? undefined;
+}
+
+/**
  * Build an AuthContext for a local connection.
  *
  * Produces the same AuthContext shape that HTTP routes receive from JWT
@@ -97,13 +113,9 @@ export function resolveLocalTrustContext(
 export function resolveLocalAuthContext(conversationId: string): AuthContext {
   const authContext = buildLocalAuthContext(conversationId);
 
-  // Enrich with the guardian principal ID from contacts-first path
-  const guardianResult = findGuardianForChannel("vellum");
-  if (guardianResult && guardianResult.contact.principalId) {
-    return {
-      ...authContext,
-      actorPrincipalId: guardianResult.contact.principalId,
-    };
+  const actorPrincipalId = resolveLocalActorPrincipalId();
+  if (actorPrincipalId) {
+    return { ...authContext, actorPrincipalId };
   }
 
   log.warn(


### PR DESCRIPTION
## Summary
Fixes `assistant clients list` returning empty in non-dev-bypass mode. The IPC adapter now injects an `x-vellum-actor-principal-id` header from the local guardian principal so shared routes that consume that header (e.g. the new same-user filter) work over both HTTP and IPC.

**Gap:** `list_clients` filter broken over IPC
**What was expected:** Same-user filter on `/v1/clients` works over both HTTP and IPC transports
**What was found:** IPC adapter discards headers; filter saw `undefined` caller and dropped all clients

Part of plan: host-proxy-same-user.md (review fix R1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->