### PR TITLE
fix(memory/security): block v2 static memory injection for remote untrusted actors

### DIFF
--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -73,7 +73,10 @@ import type { ConversationGraphMemory } from "../memory/graph/conversation-graph
 import { recordMemoryRecallLog } from "../memory/memory-recall-log-store.js";
 import { PKB_WORKSPACE_SCOPE } from "../memory/pkb/types.js";
 import type { QdrantSparseVector } from "../memory/qdrant-client.js";
-import { readMemoryV2StaticContent } from "../memory/v2/static-context.js";
+import {
+  readMemoryV2StaticContent,
+  shouldLoadMemoryV2Static,
+} from "../memory/v2/static-context.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import { defaultCompactionTerminal } from "../plugins/defaults/compaction.js";
 import { defaultHistoryRepairTerminal } from "../plugins/defaults/history-repair.js";
@@ -1336,10 +1339,16 @@ export async function runAgentLoopImpl(
     const pkbActive = currentPkbContent !== null;
 
     // V2 static memory block (essentials/threads/recent/buffer). Same
-    // first-turn / post-compaction cadence as PKB — `readMemoryV2StaticContent`
-    // self-gates on the v2 flag + config, returning null when v2 is off.
-    // Skip the file reads entirely on non-injection turns.
-    const currentMemoryV2Static = shouldInjectNowAndPkb
+    // first-turn / post-compaction cadence as PKB. `shouldLoadMemoryV2Static`
+    // also blocks remote-channel non-guardian actors from inducing the
+    // model to recite private memory; `readMemoryV2StaticContent` self-gates
+    // on the v2 flag + config and returns null when v2 is off, so the file
+    // reads are skipped on non-injection turns.
+    const currentMemoryV2Static = shouldLoadMemoryV2Static({
+      shouldInjectNowAndPkb,
+      sourceChannel: ctx.trustContext?.sourceChannel,
+      isTrustedActor,
+    })
       ? readMemoryV2StaticContent()
       : null;
     const memoryV2Static = currentMemoryV2Static;

--- a/assistant/src/memory/v2/__tests__/static-context.test.ts
+++ b/assistant/src/memory/v2/__tests__/static-context.test.ts
@@ -49,7 +49,8 @@ mock.module("../../../config/loader.js", () => ({
 
 const { _setOverridesForTesting } =
   await import("../../../config/assistant-feature-flags.js");
-const { readMemoryV2StaticContent } = await import("../static-context.js");
+const { readMemoryV2StaticContent, shouldLoadMemoryV2Static } =
+  await import("../static-context.js");
 
 const MEMORY_FILES = [
   "essentials.md",
@@ -148,5 +149,79 @@ describe("readMemoryV2StaticContent", () => {
   test("returns null when memory directory is missing entirely", () => {
     cleanupMemoryDir();
     expect(readMemoryV2StaticContent()).toBeNull();
+  });
+});
+
+describe("shouldLoadMemoryV2Static", () => {
+  test("blocks all turns until the cadence gate fires", () => {
+    expect(
+      shouldLoadMemoryV2Static({
+        shouldInjectNowAndPkb: false,
+        sourceChannel: "vellum",
+        isTrustedActor: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("allows guardian-trusted local conversations", () => {
+    expect(
+      shouldLoadMemoryV2Static({
+        shouldInjectNowAndPkb: true,
+        sourceChannel: "vellum",
+        isTrustedActor: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("allows local-channel conversations even when trust class is unknown (analyze runs, dev)", () => {
+    expect(
+      shouldLoadMemoryV2Static({
+        shouldInjectNowAndPkb: true,
+        sourceChannel: "vellum",
+        isTrustedActor: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("allows turns with no trust context (work-item task runs, internal background)", () => {
+    expect(
+      shouldLoadMemoryV2Static({
+        shouldInjectNowAndPkb: true,
+        sourceChannel: undefined,
+        isTrustedActor: false,
+      }),
+    ).toBe(true);
+  });
+
+  const REMOTE_CHANNELS = [
+    "phone",
+    "slack",
+    "telegram",
+    "whatsapp",
+    "email",
+  ] as const;
+
+  test("allows guardian-trusted remote channels (user's own phone/Slack)", () => {
+    for (const channel of REMOTE_CHANNELS) {
+      expect(
+        shouldLoadMemoryV2Static({
+          shouldInjectNowAndPkb: true,
+          sourceChannel: channel,
+          isTrustedActor: true,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("blocks non-guardian remote-channel actors (the leak this gate exists to prevent)", () => {
+    for (const channel of REMOTE_CHANNELS) {
+      expect(
+        shouldLoadMemoryV2Static({
+          shouldInjectNowAndPkb: true,
+          sourceChannel: channel,
+          isTrustedActor: false,
+        }),
+      ).toBe(false);
+    }
   });
 });

--- a/assistant/src/memory/v2/static-context.ts
+++ b/assistant/src/memory/v2/static-context.ts
@@ -17,6 +17,7 @@
 // content through when `mode === "full"` (first turn / post-compaction),
 // matching the existing PKB auto-inject pattern.
 
+import type { ChannelId } from "../../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { loadConfig } from "../../config/loader.js";
 import { readPromptFile } from "../../prompts/system-prompt.js";
@@ -60,4 +61,25 @@ export function readMemoryV2StaticContent(): string | null {
     sections.push(`${heading}\n\n${content}`);
   }
   return sections.length > 0 ? sections.join("\n\n") : null;
+}
+
+/**
+ * Static memory holds the user's aggregate personal pages
+ * (essentials/threads/recent/buffer). Block injection when a non-guardian
+ * actor reaches the assistant over a remote channel — otherwise the model
+ * can be prompt-injected into reciting private memory. Internal flows
+ * (`sourceChannel: "vellum"`) and turns with no trust context pass through
+ * unchanged; this gate exists only to keep remote untrusted actors out.
+ */
+export function shouldLoadMemoryV2Static(args: {
+  shouldInjectNowAndPkb: boolean;
+  sourceChannel: ChannelId | undefined;
+  isTrustedActor: boolean;
+}): boolean {
+  if (!args.shouldInjectNowAndPkb) return false;
+  const isRemoteUntrustedActor =
+    args.sourceChannel !== undefined &&
+    args.sourceChannel !== "vellum" &&
+    !args.isTrustedActor;
+  return !isRemoteUntrustedActor;
 }


### PR DESCRIPTION
## Summary

- PR #28767 (commit a8e8ef2) added the `memory-v2-static` runtime injector that splices the user's aggregate personal memory (essentials/threads/recent/buffer) onto the user message, gated only on `memory-v2-enabled` + `config.memory.v2.enabled` — the trust class was never checked. A non-guardian actor arriving over a remote channel could prompt-inject the model into reciting private memory contents.
- Add `shouldLoadMemoryV2Static` in `assistant/src/memory/v2/static-context.ts` and route the agent-loop call site through it. Blocks injection only when `sourceChannel` is a real remote channel AND the actor is not the guardian.
- Internal flows (`sourceChannel: "vellum"` for local desktop/web/macOS/iOS, `INTERNAL_GUARDIAN_TRUST_CONTEXT` for scheduler/consolidation/update-bulletin, analyze-conversation) and turns with no trust context pass through unchanged, so background jobs and analyze runs keep getting memory regardless of trust class.
- Mirrors the guardian-only gate on `runDefaultMemoryRetrieval` (`assistant/src/plugins/defaults/memory-retrieval.ts:114`) for the graph-memory pipeline against the same threat model.

## Original prompt

it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->