### PR TITLE
fix(host-transfer): bind targeted transfer execution to same authenticated user

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6372,7 +6372,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host transfer request.
         "403":
-          description: Submitting client does not match the targeted client for this transfer.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
       requestBody:
         required: true
         content:
@@ -11418,7 +11420,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted transfer.
         "403":
-          description: Submitting client does not match the targeted client for this transfer.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
       parameters:
         - name: transferId
           in: path
@@ -11437,7 +11441,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted transfer.
         "403":
-          description: Submitting client does not match the targeted client for this transfer.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
       parameters:
         - name: transferId
           in: path

--- a/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
@@ -20,11 +20,24 @@ const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
 const resolvedInteractionIds: string[] = [];
 let mockHasClient = false;
-let mockCapableClients: Array<{ clientId: string; capabilities: string[] }> = [];
-let mockClientRegistry: Map<string, { clientId: string; capabilities: string[] }> = new Map();
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockCapableClients: Array<MockClient> = [];
+let mockClientRegistry: Map<string, MockClient> = new Map();
+
+// Pre-existing Phase 1 routing tests use a single user identity. The same-user
+// check added in the host_transfer fix is exercised separately below.
+const TEST_PRINCIPAL = "test-user";
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown, _conversationId?: string, options?: unknown) => {
+  broadcastMessage: (
+    msg: unknown,
+    _conversationId?: string,
+    options?: unknown,
+  ) => {
     sentMessages.push(msg);
     sentMessageOptions.push(options);
   },
@@ -33,6 +46,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_file" && mockHasClient ? { id: "mock-client" } : null,
     listClientsByCapability: (_cap: string) => mockCapableClients,
     getClientById: (clientId: string) => mockClientRegistry.get(clientId),
+    getActorPrincipalIdForClient: (clientId: string) =>
+      mockClientRegistry.get(clientId)?.actorPrincipalId,
   },
 }));
 
@@ -95,7 +110,11 @@ describe("HostTransferProxy — targetClientId", () => {
   }
 
   function setupSingleClient(clientId = "client-1") {
-    const entry = { clientId, capabilities: ["host_file"] };
+    const entry: MockClient = {
+      clientId,
+      capabilities: ["host_file"],
+      actorPrincipalId: TEST_PRINCIPAL,
+    };
     mockCapableClients = [entry];
     mockClientRegistry.set(clientId, entry);
   }
@@ -117,13 +136,17 @@ describe("HostTransferProxy — targetClientId", () => {
       const srcPath = `/tmp/htp-targeted-${Date.now()}.txt`;
       await globalThis.Bun.write(srcPath, fileContent);
 
-      const resultPromise = proxy.requestToHost({
-        sourcePath: srcPath,
-        destPath: "/host/dest.txt",
-        overwrite: false,
-        conversationId: "conv-1",
-        targetClientId: "client-mac",
-      });
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-1",
+          targetClientId: "client-mac",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       await waitForMessages(sentMessages, 1);
 
@@ -135,7 +158,10 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(opts?.targetClientId).toBe("client-mac");
 
       const requestId = sent.requestId as string;
-      proxy.resolveTransferResult(requestId, { isError: false, bytesWritten: 5 });
+      proxy.resolveTransferResult(requestId, {
+        isError: false,
+        bytesWritten: 5,
+      });
 
       const result = await resultPromise;
       expect(result.isError).toBe(false);
@@ -152,12 +178,16 @@ describe("HostTransferProxy — targetClientId", () => {
       const srcPath = `/tmp/htp-targeted-solo-${Date.now()}.txt`;
       await globalThis.Bun.write(srcPath, "content");
 
-      const resultPromise = proxy.requestToHost({
-        sourcePath: srcPath,
-        destPath: "/host/dest.txt",
-        overwrite: false,
-        conversationId: "conv-2",
-      });
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-2",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       await waitForMessages(sentMessages, 1);
 
@@ -191,7 +221,9 @@ describe("HostTransferProxy — targetClientId", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("client-ghost");
-      expect(result.content).toContain("assistant clients list --capability host_file");
+      expect(result.content).toContain(
+        "assistant clients list --capability host_file",
+      );
       expect(sentMessages).toHaveLength(0);
     });
   });
@@ -228,12 +260,16 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-mac");
 
-      const resultPromise = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-5",
-        targetClientId: "client-mac",
-      });
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-5",
+          targetClientId: "client-mac",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       expect(sentMessages).toHaveLength(1);
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -256,11 +292,15 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-solo");
 
-      const resultPromise = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-6",
-      });
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-6",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       expect(sentMessages).toHaveLength(1);
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -333,6 +373,7 @@ describe("HostTransferProxy — targetClientId", () => {
           targetClientId: "client-abc",
         },
         controller.signal,
+        TEST_PRINCIPAL,
       );
 
       await waitForMessages(sentMessages, 1);
@@ -350,7 +391,9 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(cancelMsg.type).toBe("host_transfer_cancel");
       expect(cancelMsg.targetClientId).toBe("client-abc");
 
-      const cancelOpts = sentMessageOptions[1] as Record<string, unknown> | undefined;
+      const cancelOpts = sentMessageOptions[1] as
+        | Record<string, unknown>
+        | undefined;
       expect(cancelOpts?.targetClientId).toBe("client-abc");
     });
   });
@@ -362,12 +405,16 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-xyz");
 
-      const resultPromise = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-10",
-        targetClientId: "client-xyz",
-      });
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-10",
+          targetClientId: "client-xyz",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       const sent = sentMessages[0] as Record<string, unknown>;
       const requestId = sent.requestId as string;
@@ -384,7 +431,9 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(cancelMsg.type).toBe("host_transfer_cancel");
       expect(cancelMsg.targetClientId).toBe("client-xyz");
 
-      const cancelOpts = sentMessageOptions[1] as Record<string, unknown> | undefined;
+      const cancelOpts = sentMessageOptions[1] as
+        | Record<string, unknown>
+        | undefined;
       expect(cancelOpts?.targetClientId).toBe("client-xyz");
     });
   });
@@ -396,12 +445,16 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-dispose");
 
-      const p = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-11",
-        targetClientId: "client-dispose",
-      });
+      const p = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-11",
+          targetClientId: "client-dispose",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
       p.catch(() => {}); // expected rejection on dispose
 
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -431,20 +484,26 @@ describe("HostTransferProxy — targetClientId", () => {
       const srcPath = `/tmp/htp-targeted-peek-${Date.now()}.txt`;
       await globalThis.Bun.write(srcPath, "content");
 
-      const resultPromise = proxy.requestToHost({
-        sourcePath: srcPath,
-        destPath: "/host/dest.txt",
-        overwrite: false,
-        conversationId: "conv-12",
-        targetClientId: "client-peek",
-      });
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-12",
+          targetClientId: "client-peek",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       await waitForMessages(sentMessages, 1);
 
       const sent = sentMessages[0] as Record<string, unknown>;
       const transferId = sent.transferId as string;
 
-      expect(proxy.getTargetClientIdForTransfer(transferId)).toBe("client-peek");
+      expect(proxy.getTargetClientIdForTransfer(transferId)).toBe(
+        "client-peek",
+      );
 
       // Clean up
       const requestId = sent.requestId as string;
@@ -493,12 +552,16 @@ describe("HostTransferProxy — targetClientId", () => {
 
       jest.useFakeTimers();
       try {
-        const resultPromise = proxy.requestToSandbox({
-          sourcePath: "/host/source.txt",
-          destPath: "/sandbox/dest.txt",
-          conversationId: "conv-14",
-          targetClientId: "client-timeout",
-        });
+        const resultPromise = proxy.requestToSandbox(
+          {
+            sourcePath: "/host/source.txt",
+            destPath: "/sandbox/dest.txt",
+            conversationId: "conv-14",
+            targetClientId: "client-timeout",
+          },
+          undefined,
+          TEST_PRINCIPAL,
+        );
 
         const sent = sentMessages[0] as Record<string, unknown>;
         expect(sent.targetClientId).toBe("client-timeout");
@@ -546,7 +609,10 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(opts?.targetClientId).toBeUndefined();
 
       const requestId = sent.requestId as string;
-      proxy.resolveTransferResult(requestId, { isError: false, bytesWritten: 18 });
+      proxy.resolveTransferResult(requestId, {
+        isError: false,
+        bytesWritten: 18,
+      });
 
       const result = await resultPromise;
       expect(result.isError).toBe(false);
@@ -578,6 +644,289 @@ describe("HostTransferProxy — targetClientId", () => {
       const result = await resultPromise;
       expect(result.isError).toBe(true);
       expect(result.content).toBe("Transfer cancelled");
+    });
+  });
+
+  // ── Same-user binding (sourceActorPrincipalId) ───────────────────────
+
+  describe("same-user binding (sourceActorPrincipalId)", () => {
+    test("requestToHost: targeted request from same user reaches pendingInteractions", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-same-user-ok-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "ok");
+
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-1",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-A",
+      );
+
+      await waitForMessages(sentMessages, 1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_transfer_request");
+      expect(sent.targetClientId).toBe("client-A");
+
+      const requestId = sent.requestId as string;
+      proxy.resolveTransferResult(requestId, { isError: false });
+      await resultPromise;
+    });
+
+    test("requestToHost: targeted request from a different user is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-cross-user-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const result = await proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-2",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToHost: targeted request without source principal is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-no-principal-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const result = await proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-3",
+          targetClientId: "client-A",
+        },
+        undefined,
+        undefined,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToHost: targeted request to a client with no actor principal is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        // actorPrincipalId omitted (legacy/service-token client).
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-target-no-principal-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const result = await proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-4",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-A",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToHost: auto-resolve picks the same-user client when there's exactly one", async () => {
+      setup();
+      const a: MockClient = {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      };
+      const b: MockClient = {
+        clientId: "client-B",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-B",
+      };
+      mockCapableClients = [a, b];
+      mockClientRegistry.set("client-A", a);
+      mockClientRegistry.set("client-B", b);
+
+      const srcPath = `/tmp/htp-auto-same-user-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-5",
+        },
+        undefined,
+        "user-A",
+      );
+
+      await waitForMessages(sentMessages, 1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+
+      const requestId = sent.requestId as string;
+      proxy.resolveTransferResult(requestId, { isError: false });
+      await resultPromise;
+    });
+
+    test("requestToHost: auto-resolve falls through when no client matches the source user", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-auto-no-match-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-6",
+        },
+        undefined,
+        "user-C",
+      );
+
+      await waitForMessages(sentMessages, 1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBeUndefined();
+
+      const requestId = sent.requestId as string;
+      proxy.resolveTransferResult(requestId, { isError: false });
+      await resultPromise;
+    });
+
+    test("requestToSandbox: targeted request from a different user is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const result = await proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-same-7",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToSandbox: targeted request from same user proceeds", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-same-8",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+
+      proxy.cancel(sent.requestId as string);
+      await resultPromise;
+    });
+
+    test("requestToSandbox: auto-resolve picks the same-user client when there's exactly one", async () => {
+      setup();
+      const a: MockClient = {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      };
+      const b: MockClient = {
+        clientId: "client-B",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-B",
+      };
+      mockCapableClients = [a, b];
+      mockClientRegistry.set("client-A", a);
+      mockClientRegistry.set("client-B", b);
+
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-same-9",
+        },
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+
+      proxy.cancel(sent.requestId as string);
+      await resultPromise;
     });
   });
 });

--- a/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
@@ -49,9 +49,17 @@ mock.module("../daemon/host-transfer-proxy.js", () => ({
         },
         getTransferContent(transferId: string) {
           getTransferContentCalls.push(transferId);
-          return { buffer: Buffer.from("data"), sizeBytes: 4, sha256: "abc123" };
+          return {
+            buffer: Buffer.from("data"),
+            sizeBytes: 4,
+            sha256: "abc123",
+          };
         },
-        async receiveTransferContent(transferId: string, _data: Buffer, _sha256: string) {
+        async receiveTransferContent(
+          transferId: string,
+          _data: Buffer,
+          _sha256: string,
+        ) {
           receiveTransferContentCalls.push(transferId);
           return { accepted: true };
         },
@@ -63,12 +71,20 @@ mock.module("../daemon/host-transfer-proxy.js", () => ({
   },
 }));
 
+// Stub event hub so tests control what actorPrincipalId is associated with
+// each connected client.
+const clientActors = new Map<string, string>();
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getActorPrincipalIdForClient: (clientId: string) =>
+      clientActors.get(clientId),
+  },
+}));
+
 // ── Real imports (after mocks) ──────────────────────────────────────────────
 
-import {
-  BadRequestError,
-  ForbiddenError,
-} from "../runtime/routes/errors.js";
+import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/host-transfer-routes.js";
 
 afterAll(() => {
@@ -107,6 +123,7 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
     pendingStore.clear();
     stubTargetClientId = null;
     getTransferContentCalls.length = 0;
+    clientActors.clear();
   });
 
   // ── 1. Targeted + correct header → success ────────────────────────────────
@@ -114,9 +131,13 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns Uint8Array and calls getTransferContent", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentGet({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
       });
 
       expect(result).toBeInstanceOf(Uint8Array);
@@ -125,9 +146,13 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentGet({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+        },
       });
 
       expect(result).toBeInstanceOf(Uint8Array);
@@ -199,6 +224,52 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
       expect(getTransferContentCalls).toContain(TEST_TRANSFER_ID);
     });
   });
+
+  // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
+
+  describe("targeted + actor principal binding", () => {
+    test("throws ForbiddenError when submitting actor does not match target client's actor", () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferContentGet({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-attacker",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(getTransferContentCalls).toHaveLength(0);
+    });
+
+    test("throws ForbiddenError when actor principal header is missing", () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferContentGet({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(getTransferContentCalls).toHaveLength(0);
+    });
+
+    test("throws ForbiddenError when target client has no stored actor", () => {
+      stubTargetClientId = "client-A";
+      // No entry in clientActors for "client-A"
+      expect(() =>
+        handleTransferContentGet({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(getTransferContentCalls).toHaveLength(0);
+    });
+  });
 });
 
 describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
@@ -206,6 +277,7 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
     pendingStore.clear();
     stubTargetClientId = null;
     receiveTransferContentCalls.length = 0;
+    clientActors.clear();
   });
 
   // ── 1. Targeted + correct header → success ────────────────────────────────
@@ -213,9 +285,14 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and calls receiveTransferContent", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentPut({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "client-A", "x-transfer-sha256": "abc" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+          "x-transfer-sha256": "abc",
+        },
         rawBody: new Uint8Array(Buffer.from("data")),
       });
 
@@ -225,9 +302,14 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentPut({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "  client-A  ", "x-transfer-sha256": "abc" },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+          "x-transfer-sha256": "abc",
+        },
         rawBody: new Uint8Array(Buffer.from("data")),
       });
 
@@ -272,7 +354,10 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
       await expect(
         handleTransferContentPut({
           pathParams: { transferId: TEST_TRANSFER_ID },
-          headers: { "x-vellum-client-id": "client-B", "x-transfer-sha256": "abc" },
+          headers: {
+            "x-vellum-client-id": "client-B",
+            "x-transfer-sha256": "abc",
+          },
           rawBody: new Uint8Array(Buffer.from("data")),
         }),
       ).rejects.toBeInstanceOf(ForbiddenError);
@@ -283,7 +368,10 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
       try {
         await handleTransferContentPut({
           pathParams: { transferId: TEST_TRANSFER_ID },
-          headers: { "x-vellum-client-id": "client-B", "x-transfer-sha256": "abc" },
+          headers: {
+            "x-vellum-client-id": "client-B",
+            "x-transfer-sha256": "abc",
+          },
           rawBody: new Uint8Array(Buffer.from("data")),
         });
       } catch {
@@ -308,6 +396,60 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
       expect(receiveTransferContentCalls).toContain(TEST_TRANSFER_ID);
     });
   });
+
+  // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
+
+  describe("targeted + actor principal binding", () => {
+    test("rejects when submitting actor does not match target client's actor", async () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      await expect(
+        handleTransferContentPut({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-attacker",
+            "x-transfer-sha256": "abc",
+          },
+          rawBody: new Uint8Array(Buffer.from("data")),
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      expect(receiveTransferContentCalls).toHaveLength(0);
+    });
+
+    test("rejects when actor principal header is missing", async () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      await expect(
+        handleTransferContentPut({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-transfer-sha256": "abc",
+          },
+          rawBody: new Uint8Array(Buffer.from("data")),
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      expect(receiveTransferContentCalls).toHaveLength(0);
+    });
+
+    test("rejects when target client has no stored actor", async () => {
+      stubTargetClientId = "client-A";
+      // No entry in clientActors for "client-A"
+      await expect(
+        handleTransferContentPut({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+            "x-transfer-sha256": "abc",
+          },
+          rawBody: new Uint8Array(Buffer.from("data")),
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      expect(receiveTransferContentCalls).toHaveLength(0);
+    });
+  });
 });
 
 describe("handleTransferResult — Phase 3 targetClientId guard", () => {
@@ -315,6 +457,7 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
     pendingStore.clear();
     stubTargetClientId = null;
     resolveTransferResultCalls.length = 0;
+    clientActors.clear();
   });
 
   function registerHostTransferPending(targetClientId?: string): void {
@@ -330,9 +473,13 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and calls resolveTransferResult", async () => {
       registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferResult({
         body: resultBody(),
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -341,9 +488,13 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferResult({
         body: resultBody(),
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -355,9 +506,9 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
   describe("targeted + missing x-vellum-client-id header", () => {
     test("throws BadRequestError when header is absent", () => {
       registerHostTransferPending("client-A");
-      expect(() =>
-        handleTransferResult({ body: resultBody() }),
-      ).toThrow(BadRequestError);
+      expect(() => handleTransferResult({ body: resultBody() })).toThrow(
+        BadRequestError,
+      );
     });
 
     test("resolveTransferResult NOT called on 400", () => {
@@ -442,6 +593,56 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
       });
 
       expect(result).toEqual({ accepted: true });
+    });
+  });
+
+  // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
+
+  describe("targeted + actor principal binding", () => {
+    test("throws ForbiddenError when submitting actor does not match target client's actor", () => {
+      registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferResult({
+          body: resultBody(),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-attacker",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(resolveTransferResultCalls).toHaveLength(0);
+      // Pending interaction should still be present (not consumed on 403).
+      expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
+    });
+
+    test("throws ForbiddenError when actor principal header is missing", () => {
+      registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferResult({
+          body: resultBody(),
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(resolveTransferResultCalls).toHaveLength(0);
+      expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
+    });
+
+    test("throws ForbiddenError when target client has no stored actor", () => {
+      registerHostTransferPending("client-A");
+      // No entry in clientActors for "client-A"
+      expect(() =>
+        handleTransferResult({
+          body: resultBody(),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(resolveTransferResultCalls).toHaveLength(0);
+      expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
     });
   });
 });

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -124,6 +124,8 @@ export class HostTransferProxy {
       targetClientId?: string;
     },
     signal?: AbortSignal,
+    // Principal ID of the actor on whose behalf this request is initiated.
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({ content: "Aborted", isError: true });
@@ -145,8 +147,47 @@ export class HostTransferProxy {
         });
       }
     } else {
-      const capable = assistantEventHub.listClientsByCapability("host_file");
-      if (capable.length === 1) resolvedTargetClientId = capable[0].clientId;
+      // Auto-resolve only to a capable client whose actorPrincipalId matches
+      // the source caller's. Skips auto-resolve when the caller has no
+      // identity, since same-user binding cannot be enforced.
+      if (sourceActorPrincipalId != null) {
+        const capable = assistantEventHub.listClientsByCapability("host_file");
+        const sameUser = capable.filter(
+          (c) => c.actorPrincipalId === sourceActorPrincipalId,
+        );
+        if (sameUser.length === 1) {
+          resolvedTargetClientId = sameUser[0].clientId;
+        }
+      }
+    }
+
+    // Same-user check: targeted host_transfer requests must be bound to the
+    // same authenticated user identity that opened the target client's SSE
+    // stream. Prevents cross-user routing through actor token mis-targeting.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_transfer",
+            direction: "to_host",
+          },
+          "Rejected cross-user targeted host_transfer request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
     }
 
     const requestId = uuid();
@@ -291,6 +332,8 @@ export class HostTransferProxy {
       targetClientId?: string;
     },
     signal?: AbortSignal,
+    // Principal ID of the actor on whose behalf this request is initiated.
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({ content: "Aborted", isError: true });
@@ -312,8 +355,47 @@ export class HostTransferProxy {
         });
       }
     } else {
-      const capable = assistantEventHub.listClientsByCapability("host_file");
-      if (capable.length === 1) resolvedTargetClientId = capable[0].clientId;
+      // Auto-resolve only to a capable client whose actorPrincipalId matches
+      // the source caller's. Skips auto-resolve when the caller has no
+      // identity, since same-user binding cannot be enforced.
+      if (sourceActorPrincipalId != null) {
+        const capable = assistantEventHub.listClientsByCapability("host_file");
+        const sameUser = capable.filter(
+          (c) => c.actorPrincipalId === sourceActorPrincipalId,
+        );
+        if (sameUser.length === 1) {
+          resolvedTargetClientId = sameUser[0].clientId;
+        }
+      }
+    }
+
+    // Same-user check: targeted host_transfer requests must be bound to the
+    // same authenticated user identity that opened the target client's SSE
+    // stream. Prevents cross-user routing through actor token mis-targeting.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_transfer",
+            direction: "to_sandbox",
+          },
+          "Rejected cross-user targeted host_transfer request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
     }
 
     const requestId = uuid();

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -8,8 +8,14 @@
 import { z } from "zod";
 
 import { HostTransferProxy } from "../../daemon/host-transfer-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 /**
@@ -44,9 +50,35 @@ function handleTransferContentGet({
 
   const targetClientId = match.proxy.getTargetClientIdForTransfer(transferId);
   if (targetClientId != null) {
-    const submittingClientId = (headers as Record<string, string>)["x-vellum-client-id"]?.trim() || undefined;
-    if (!submittingClientId) throw new BadRequestError("x-vellum-client-id header required for targeted transfer");
-    if (submittingClientId !== targetClientId) throw new ForbiddenError(`Client "${submittingClientId}" is not the owner of this transfer`);
+    const headerMap = headers as Record<string, string | undefined>;
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    if (!submittingClientId)
+      throw new BadRequestError(
+        "x-vellum-client-id header required for targeted transfer",
+      );
+    if (submittingClientId !== targetClientId)
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the owner of this transfer`,
+      );
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. This blocks
+    // cross-user submissions even if a different user obtains the target
+    // client id.
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this transfer.",
+      );
+    }
   }
 
   const content = match.proxy.getTransferContent(transferId);
@@ -105,9 +137,35 @@ async function handleTransferContentPut({
 
   const targetClientId = match.proxy.getTargetClientIdForTransfer(transferId);
   if (targetClientId != null) {
-    const submittingClientId = (headers as Record<string, string>)["x-vellum-client-id"]?.trim() || undefined;
-    if (!submittingClientId) throw new BadRequestError("x-vellum-client-id header required for targeted transfer");
-    if (submittingClientId !== targetClientId) throw new ForbiddenError(`Client "${submittingClientId}" is not the owner of this transfer`);
+    const headerMap = headers as Record<string, string | undefined>;
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    if (!submittingClientId)
+      throw new BadRequestError(
+        "x-vellum-client-id header required for targeted transfer",
+      );
+    if (submittingClientId !== targetClientId)
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the owner of this transfer`,
+      );
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. This blocks
+    // cross-user submissions even if a different user obtains the target
+    // client id.
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this transfer.",
+      );
+    }
   }
 
   const data = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0);
@@ -158,10 +216,35 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
   }
 
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.["x-vellum-client-id"];
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const rawClientId = headerMap["x-vellum-client-id"];
     const submittingClientId = rawClientId?.trim() || undefined;
-    if (!submittingClientId) throw new BadRequestError("x-vellum-client-id header is missing for a targeted host transfer request.");
-    if (submittingClientId !== peeked.targetClientId) throw new ForbiddenError(`Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}").`);
+    if (!submittingClientId)
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host transfer request.",
+      );
+    if (submittingClientId !== peeked.targetClientId)
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}").`,
+      );
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. Blocks
+    // cross-user submissions even if a different user obtains the target
+    // client id.
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this request.",
+      );
+    }
   }
 
   HostTransferProxy.instance.resolveTransferResult(requestId, {
@@ -196,7 +279,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this transfer.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
       },
     },
     handler: handleTransferContentGet,
@@ -218,7 +301,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this transfer.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
       },
     },
     handler: handleTransferContentPut,
@@ -248,7 +331,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this transfer.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
       },
     },
     handler: handleTransferResult,

--- a/assistant/src/tools/host-filesystem/transfer.ts
+++ b/assistant/src/tools/host-filesystem/transfer.ts
@@ -93,7 +93,8 @@ class HostFileTransferTool implements Tool {
     const overwrite = input.overwrite === true;
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -103,7 +104,10 @@ class HostFileTransferTool implements Tool {
       !supportsHostProxy(context.transportInterface) &&
       assistantEventHub.listClientsByCapability("host_file").length > 1
     ) {
-      return { content: `Error: multiple clients support host_file. Specify which client to use with \`target_client_id\`. Run \`assistant clients list --capability host_file\` to see client IDs and labels.`, isError: true };
+      return {
+        content: `Error: multiple clients support host_file. Specify which client to use with \`target_client_id\`. Run \`assistant clients list --capability host_file\` to see client IDs and labels.`,
+        isError: true,
+      };
     }
 
     // Validate that host-side paths are absolute.
@@ -136,7 +140,9 @@ class HostFileTransferTool implements Tool {
 
     let resolvedDestPath = destPath;
     if (direction === "to_sandbox") {
-      const pathCheck = sandboxPolicy(destPath, context.workingDir, { mustExist: false });
+      const pathCheck = sandboxPolicy(destPath, context.workingDir, {
+        mustExist: false,
+      });
       if (!pathCheck.ok) {
         return {
           content: `Invalid destination path: ${pathCheck.error}`,
@@ -158,6 +164,7 @@ class HostFileTransferTool implements Tool {
             targetClientId,
           },
           context.signal,
+          context.sourceActorPrincipalId,
         );
       }
       return HostTransferProxy.instance.requestToSandbox(
@@ -169,6 +176,7 @@ class HostFileTransferTool implements Tool {
           targetClientId,
         },
         context.signal,
+        context.sourceActorPrincipalId,
       );
     }
 


### PR DESCRIPTION
## Summary
- Adds same-user binding to `HostTransferProxy.requestToHost` / `requestToSandbox`.
- Adds same-user check on `POST /v1/host-transfer-*` result routes.
- Mirrors the host_bash / host_file / host_cu pattern.

Closes Codex security finding [0926d57eb6ac819186f065c5c37aa923](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923) for host_transfer (gap identified during self-review).

Part of plan: host-proxy-same-user.md (review fix R1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->