### PR TITLE
refactor(host-proxy): consolidate same-user check into shared helper

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6255,8 +6255,8 @@ paths:
           description: x-vellum-client-id header is missing for a targeted host CU request.
         "403":
           description:
-            Submitting client does not match the targeted client, or the submitting actor's principal id does not match
-            the target client's stored actor principal id.
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
         "404":
           description: No pending interaction found for the given requestId, or the conversation/proxy no longer exists.
         "409":
@@ -6322,7 +6322,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host file request.
         "403":
-          description: Submitting client or actor does not match the targeted client/actor for this request.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
         "404":
           description: No pending interaction found for the given requestId.
         "409":

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -34,6 +34,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_cu" ? mockCuClients : [],
     getClientById: (id: string) =>
       mockCuClients.find((c) => c.clientId === id) ?? null,
+    getActorPrincipalIdForClient: (id: string) =>
+      mockCuClients.find((c) => c.clientId === id)?.actorPrincipalId,
   },
 }));
 
@@ -406,11 +408,19 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   // -------------------------------------------------------------------------
 
   describe("multi-client ambiguity guard", () => {
-    test("returns error when multiple CU clients connected and no target_client_id given", async () => {
+    test("returns error when multiple same-user CU clients connected and no target_client_id given", async () => {
       const ctx = setupProxy();
       mockCuClients = [
-        { clientId: "client-a", capabilities: ["host_cu"] },
-        { clientId: "client-b", capabilities: ["host_cu"] },
+        {
+          clientId: "client-a",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        {
+          clientId: "client-b",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
       ];
 
       const result = await surfaceProxyResolver(ctx, "computer_use_click", {
@@ -585,8 +595,9 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   // Same-user enforcement (dispatch layer)
   //
   // The proxy enforces this internally as well — these tests verify the
-  // dispatch surfaces a friendly tool-input rejection before the proxy is
-  // invoked, and that the rejection happens before any state mutation.
+  // dispatch performs the same-user rejection before the proxy is invoked
+  // (so no step is burned and no action history mutated), and uses the
+  // canonical rejection message.
   // -------------------------------------------------------------------------
 
   describe("same-user enforcement", () => {
@@ -610,8 +621,9 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("cu-client");
-      expect(result.content).toContain("not owned by the current user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       // No state mutation, no dispatch.
       expect(proxy.stepCount).toBe(0);
       expect(proxy.actionHistory).toHaveLength(0);
@@ -638,7 +650,9 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("not owned by the current user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
   });

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -768,7 +768,7 @@ describe("HostBashProxy", () => {
 
   describe("same-user binding (sourceActorPrincipalId)", () => {
     const SAME_USER_REJECTION =
-      "Targeted host_bash requests require the target client to be owned by the same user as the caller.";
+      "Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.";
 
     test("same-user targeted request succeeds", async () => {
       setup();

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -16,6 +16,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
     getClientById: (id: string) =>
       mockClients.find((c) => c.clientId === id) ?? undefined,
+    getActorPrincipalIdForClient: (id: string) =>
+      mockClients.find((c) => c.clientId === id)?.actorPrincipalId,
   },
 }));
 
@@ -1100,7 +1102,9 @@ describe("HostCuProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("owned by the same user as the caller");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -1126,7 +1130,9 @@ describe("HostCuProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("owned by the same user as the caller");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -1152,7 +1158,9 @@ describe("HostCuProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("owned by the same user as the caller");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -655,7 +655,9 @@ describe("HostFileProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       // No host_file_request was broadcast.
       expect(sentMessages).toHaveLength(0);
     });
@@ -679,7 +681,9 @@ describe("HostFileProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -702,7 +706,9 @@ describe("HostFileProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1935,10 +1935,12 @@ export async function surfaceProxyResolver(
         ? input.target_client_id
         : undefined;
 
-    // Validate targetClientId before recordAction so an invalid ID does not
-    // burn a step or pollute action history. (HostBashProxy / HostFileProxy
-    // both validate at the tool-resolution layer before incrementing any
-    // state; this mirrors that behaviour for CU.)
+    // Validate targetClientId existence + capability before recordAction so
+    // an invalid ID does not burn a step or pollute action history.
+    // HostBashProxy / HostFileProxy validate at the tool-resolution layer
+    // for the same reason. The same-user binding check itself is owned by
+    // the proxy (host-cu-proxy.ts) — that is the single authoritative gate;
+    // duplicating it here would diverge log payloads and error wording.
     const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
@@ -1954,30 +1956,17 @@ export async function surfaceProxyResolver(
           isError: true,
         };
       }
-
-      // Same-user enforcement: a targeted CU dispatch must be owned by the
-      // same actor on both sides. Surface a friendly tool-input rejection
-      // before invoking the proxy (which performs the same check as a
-      // backstop for direct callers).
-      const targetActorPrincipalId = client.actorPrincipalId;
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        return {
-          content: `Client '${targetClientId}' is not owned by the current user — cross-user computer_use dispatch is not allowed.`,
-          isError: true,
-        };
-      }
     }
 
-    // Guard: require explicit targeting when multiple CU-capable clients are
-    // connected. The tool schemas document target_client_id as "required when
-    // multiple clients support host_cu" but nothing enforced it at runtime
-    // until now. Without this guard, the request would broadcast to all
-    // capable clients simultaneously, causing the same CU action to execute
-    // on multiple machines.
+    // Guard: require explicit targeting when multiple same-user CU-capable
+    // clients are connected. The tool schemas document target_client_id as
+    // "required when multiple clients support host_cu" but nothing enforced
+    // it at runtime until now. Without this guard, the request would
+    // broadcast to all capable clients simultaneously, causing the same CU
+    // action to execute on multiple machines. The filter mirrors
+    // HostFileProxy's auto-resolve: only same-user clients participate, so
+    // a cross-user client connected to the same daemon does not falsely
+    // trigger this ambiguity error.
     //
     // Asymmetry with host_bash / host_file (host-shell.ts): the bash/file
     // guard additionally checks `transportInterface != null &&
@@ -1988,7 +1977,9 @@ export async function surfaceProxyResolver(
     // host_cu-capable transport for which auto-routing-to-self would be
     // appropriate. We therefore fire whenever there is genuine ambiguity.
     if (targetClientId == null) {
-      const cuClients = assistantEventHub.listClientsByCapability("host_cu");
+      const cuClients = assistantEventHub
+        .listClientsByCapability("host_cu")
+        .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
       if (cuClients.length > 1) {
         return {
           content: `Error: multiple clients support host_cu. Specify which client to target with \`target_client_id\`. Run \`assistant clients list --capability host_cu\` to see client IDs and labels.`,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -18,6 +18,7 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import { enforceSameActorOrErrorResult } from "../runtime/auth/same-actor.js";
 import type {
   InteractiveUiRequest,
   InteractiveUiResult,
@@ -1935,12 +1936,12 @@ export async function surfaceProxyResolver(
         ? input.target_client_id
         : undefined;
 
-    // Validate targetClientId existence + capability before recordAction so
-    // an invalid ID does not burn a step or pollute action history.
-    // HostBashProxy / HostFileProxy validate at the tool-resolution layer
-    // for the same reason. The same-user binding check itself is owned by
-    // the proxy (host-cu-proxy.ts) — that is the single authoritative gate;
-    // duplicating it here would diverge log payloads and error wording.
+    // Validate targetClientId existence, capability, and same-user binding
+    // before recordAction so an invalid or cross-user ID does not burn a
+    // step or pollute action history. HostBashProxy / HostFileProxy
+    // validate at the tool-resolution layer for the same reason. The proxy
+    // re-checks same-user (single authoritative gate); using the shared
+    // helper keeps log payload and error wording identical at both layers.
     const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
@@ -1956,6 +1957,13 @@ export async function surfaceProxyResolver(
           isError: true,
         };
       }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId,
+        op: "host_cu",
+      });
+      if (rejection) return rejection;
     }
 
     // Guard: require explicit targeting when multiple same-user CU-capable

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -5,6 +5,10 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import {
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { formatShellOutput } from "../tools/shared/shell-output.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -69,9 +73,6 @@ export class HostBashProxy {
       return Promise.resolve(result);
     }
 
-    const capableClients =
-      assistantEventHub.listClientsByCapability("host_bash");
-
     let resolvedTargetClientId: string | undefined;
 
     if (input.targetClientId) {
@@ -83,52 +84,31 @@ export class HostBashProxy {
         });
       }
       resolvedTargetClientId = input.targetClientId;
-    } else if (capableClients.length === 1) {
-      // Auto-resolve when exactly one capable client is connected — but only
-      // when its actor principal matches the caller's. This prevents a
-      // same-daemon attacker from getting cross-user execution by relying on
-      // auto-resolve. If the sole client belongs to a different user, fall
-      // through to the untargeted broadcast path.
-      const onlyClient = capableClients[0];
-      if (
-        sourceActorPrincipalId != null &&
-        onlyClient.actorPrincipalId === sourceActorPrincipalId
-      ) {
-        resolvedTargetClientId = onlyClient.clientId;
-      }
+    } else {
+      // Auto-resolve only to a same-user capable client; falls through to
+      // the untargeted broadcast path when zero or multiple same-user
+      // clients are connected. The zero-client / multi-client cases are
+      // handled by the existing timeout/error path and the tool-executor
+      // layer respectively.
+      resolvedTargetClientId = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_bash",
+        sourceActorPrincipalId,
+      });
     }
-    // capableClients.length === 0 or > 1 without explicit target: resolvedTargetClientId
-    // stays undefined and falls through to untargeted broadcast — the existing timeout/error
-    // path handles the zero-client case, and multi-client ambiguity is enforced at the tool
-    // executor layer (not here) once target_client_id is exposed in the tool schema.
 
     // Targeted requests must be bound to the same authenticated user as the
     // target client. Fail closed at request time — before pendingInteractions
     // registration and before broadcast — so a same-daemon caller cannot
     // execute on another user's connected client.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        targetActorPrincipalId !== sourceActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_bash",
-          },
-          "Rejecting targeted host_bash request: source actor does not match target client's actor",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_bash requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_bash",
+      });
+      if (rejection) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -23,6 +23,7 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import { enforceSameActorOrErrorResult } from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -175,28 +176,16 @@ export class HostCuProxy {
       }
 
       // Same-user enforcement: targeted CU dispatch must be owned by the
-      // same actor on both sides. Reject when either principal is missing
-      // or when they don't match.
-      const targetActorPrincipalId = client.actorPrincipalId;
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            targetClientId,
-            hasSourcePrincipal: sourceActorPrincipalId != null,
-            hasTargetPrincipal: targetActorPrincipalId != null,
-          },
-          "Rejected cross-user host_cu request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_cu requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      // same actor on both sides. This is the authoritative gate — the
+      // dispatch layer (conversation-surfaces.ts) skips its own check
+      // and relies on the proxy.
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId,
+        op: "host_cu",
+      });
+      if (rejection) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -4,6 +4,10 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import {
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { readImageBase64 } from "../tools/shared/filesystem/image-read.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -74,9 +78,10 @@ export class HostFileProxy {
       return Promise.resolve({ content: "Aborted", isError: true });
     }
 
-    // Resolve targetClientId: explicit → validate; single capable client → auto-resolve.
-    // Callers may embed targetClientId in the input object (tool handlers) or pass it as
-    // the 4th parameter (legacy). Prefer the explicit param; fall back to input field.
+    // Resolve targetClientId: explicit → validate; single same-user
+    // capable client → auto-resolve. Callers may embed targetClientId in
+    // the input object (tool handlers) or pass it as the 4th parameter
+    // (legacy). Prefer the explicit param; fall back to input field.
     let resolvedTargetClientId: string | undefined =
       targetClientId ?? input.targetClientId;
     if (resolvedTargetClientId != null) {
@@ -94,46 +99,24 @@ export class HostFileProxy {
         });
       }
     } else {
-      // Auto-resolve only to a capable client whose actorPrincipalId matches
-      // the source caller's. Skips auto-resolve when the caller has no
-      // identity, since same-user binding cannot be enforced.
-      if (sourceActorPrincipalId != null) {
-        const capable = assistantEventHub.listClientsByCapability("host_file");
-        const sameUser = capable.filter(
-          (c) => c.actorPrincipalId === sourceActorPrincipalId,
-        );
-        if (sameUser.length === 1) {
-          resolvedTargetClientId = sameUser[0].clientId;
-        }
-      }
+      resolvedTargetClientId = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_file",
+        sourceActorPrincipalId,
+      });
     }
 
     // Same-user check: targeted host_file requests must be bound to the same
     // authenticated user identity that opened the target client's SSE stream.
     // Prevents cross-user routing through actor token mis-targeting.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_file",
-          },
-          "Rejected cross-user targeted host_file request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_file requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_file",
+      });
+      if (rejection) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -1,0 +1,132 @@
+/**
+ * Same-actor (same-user) binding check used by host proxies and result
+ * routes.
+ *
+ * Verifies that the submitting (source) actor's principal id matches the
+ * actor principal id captured for the target client at SSE subscription
+ * time. This is the authoritative gate that prevents cross-user
+ * execution and cross-user result submission across all three host-proxy
+ * capabilities (host_bash, host_file, host_cu).
+ *
+ * Two entry points map onto the two control-flow styles in the codebase:
+ *   - {@link enforceSameActorOrErrorResult} for proxies — returns a
+ *     tool-execution error result on rejection, `null` on success.
+ *   - {@link enforceSameActorOrThrow} for HTTP/IPC route handlers —
+ *     throws {@link ForbiddenError} on rejection so the route adapter
+ *     maps it to HTTP 403.
+ *
+ * Both paths log a single structured warn line on rejection with the
+ * shape `{ sourceActorPrincipalId, targetClientId, targetActorPrincipalId,
+ * op, reason }` so that bash, file, and CU rejections render identically
+ * in the audit log.
+ */
+import type { HostProxyCapability } from "../../channels/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { AssistantEventHub } from "../assistant-event-hub.js";
+import { ForbiddenError } from "../routes/errors.js";
+
+const log = getLogger("same-actor");
+
+/**
+ * Canonical user-facing rejection message. Used by both the proxy and
+ * route paths so operators and auditors see identical wording regardless
+ * of whether the failure surfaced as a tool-execution result or an HTTP
+ * 403.
+ */
+const REJECTION_MESSAGE =
+  "Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.";
+
+/** OpenAPI 403 description for `*-result` endpoints, kept identical. */
+export const SAME_ACTOR_FORBIDDEN_DESCRIPTION =
+  "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.";
+
+/** Per-capability scope for the structured warn log entry. */
+export type SameActorOp = "host_bash" | "host_file" | "host_cu";
+
+export interface SameActorArgs {
+  hub: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
+  sourceActorPrincipalId: string | undefined;
+  targetClientId: string;
+  op: SameActorOp;
+}
+
+type RejectionReason = "missing_source" | "missing_target" | "mismatch";
+
+/**
+ * Internal: returns the rejection reason or `undefined` when the source
+ * matches the target. Always logs on rejection so all callers share the
+ * same audit shape.
+ */
+function detectRejection(args: SameActorArgs): RejectionReason | undefined {
+  const { hub, sourceActorPrincipalId, targetClientId, op } = args;
+  const targetActorPrincipalId =
+    hub.getActorPrincipalIdForClient(targetClientId);
+
+  let reason: RejectionReason | undefined;
+  if (sourceActorPrincipalId == null) {
+    reason = "missing_source";
+  } else if (targetActorPrincipalId == null) {
+    reason = "missing_target";
+  } else if (sourceActorPrincipalId !== targetActorPrincipalId) {
+    reason = "mismatch";
+  }
+  if (reason == null) return undefined;
+
+  log.warn(
+    {
+      sourceActorPrincipalId,
+      targetClientId,
+      targetActorPrincipalId,
+      op,
+      reason,
+    },
+    "Rejecting cross-user host proxy request",
+  );
+  return reason;
+}
+
+/**
+ * Route-flavored variant: throws {@link ForbiddenError} on rejection so
+ * the existing route adapter maps it to HTTP 403. Returns void on
+ * success.
+ */
+export function enforceSameActorOrThrow(args: SameActorArgs): void {
+  if (detectRejection(args) != null) {
+    throw new ForbiddenError(REJECTION_MESSAGE);
+  }
+}
+
+/**
+ * Proxy-flavored variant: returns a tool-execution-shaped error result
+ * on rejection (so the proxy can pass it directly back to the agent),
+ * or `null` on success.
+ */
+export function enforceSameActorOrErrorResult(
+  args: SameActorArgs,
+): { content: string; isError: true } | null {
+  if (detectRejection(args) == null) return null;
+  return { content: REJECTION_MESSAGE, isError: true };
+}
+
+/**
+ * Filter capable clients by `actorPrincipalId === sourcePrincipalId` and
+ * return the single match's clientId, or `undefined` when zero or more
+ * than one same-user client supports the capability.
+ *
+ * Used by host proxies to auto-resolve a target client when the caller
+ * did not specify one. Skipping when the caller has no principal keeps
+ * the same-user binding closed: an unauthenticated caller cannot piggyback
+ * on a connected user's session.
+ */
+export function pickSameUserAutoResolve(args: {
+  hub: Pick<AssistantEventHub, "listClientsByCapability">;
+  capability: HostProxyCapability;
+  sourceActorPrincipalId: string | undefined;
+}): string | undefined {
+  const { hub, capability, sourceActorPrincipalId } = args;
+  if (sourceActorPrincipalId == null) return undefined;
+  const sameUser = hub
+    .listClientsByCapability(capability)
+    .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
+  return sameUser.length === 1 ? sameUser[0].clientId : undefined;
+}

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -27,10 +27,7 @@ mock.module("../../../util/logger.js", () => ({
 
 // ── Real imports (after mocks) ────────────────────────────────────────────
 
-import {
-  AssistantEventHub,
-  assistantEventHub,
-} from "../../assistant-event-hub.js";
+import { assistantEventHub } from "../../assistant-event-hub.js";
 import { ROUTES } from "../client-routes.js";
 import type { RouteDefinition } from "../types.js";
 
@@ -77,10 +74,6 @@ function clearHub(): void {
     assistantEventHub.disposeClient(id);
   }
 }
-
-// Suppress unused-binding warning when AssistantEventHub isn't directly
-// referenced — the import keeps the type available for future extensions.
-void AssistantEventHub;
 
 // ── Tests ────────────────────────────────────────────────────────────────
 

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -8,6 +8,10 @@ import { z } from "zod";
 
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -72,18 +76,12 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     // for the target client at SSE subscription time. This prevents a
     // cross-user submission even when the attacker can guess or spoof the
     // target's client ID.
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
-    if (!targetActorPrincipalId || !submittingActorPrincipalId) {
-      throw new ForbiddenError(
-        "Submitting actor identity is missing; cannot verify same-user binding for this targeted host bash request.",
-      );
-    }
-    if (submittingActorPrincipalId !== targetActorPrincipalId) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this request. The same authenticated user must submit the result.",
-      );
-    }
+    enforceSameActorOrThrow({
+      hub: assistantEventHub,
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetClientId,
+      op: "host_bash",
+    });
   }
 
   HostBashProxy.instance.resolveResult(requestId, {
@@ -125,8 +123,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host bash request.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
       "404": {
         description: "No pending interaction found for the given requestId.",

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -8,6 +8,10 @@ import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-store.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -71,10 +75,9 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
 
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.[
-      "x-vellum-client-id"
-    ];
-    const submittingClientId = rawClientId?.trim() || undefined;
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
     if (!submittingClientId) {
       throw new BadRequestError(
         "x-vellum-client-id header is missing for a targeted host CU request.",
@@ -91,21 +94,14 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const rawActorPrincipalId = (
-      headers as Record<string, string | undefined>
-    )?.["x-vellum-actor-principal-id"];
-    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        `Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.`,
-      );
-    }
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    enforceSameActorOrThrow({
+      hub: assistantEventHub,
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_cu",
+    });
   }
 
   const conversation = findConversation(peeked.conversationId);
@@ -172,8 +168,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host CU request.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal id does not match the target client's stored actor principal id.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
       "404": {
         description:

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -8,6 +8,10 @@ import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -51,8 +55,8 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
     const headerMap = (headers as Record<string, string | undefined>) ?? {};
-    const rawClientId = headerMap["x-vellum-client-id"];
-    const submittingClientId = rawClientId?.trim() || undefined;
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
     if (!submittingClientId) {
       throw new BadRequestError(
         "x-vellum-client-id header is missing for a targeted host file request.",
@@ -68,19 +72,14 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user somehow obtains the
     // target client id.
-    const rawActorPrincipalId = headerMap["x-vellum-actor-principal-id"];
-    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this request.",
-      );
-    }
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    enforceSameActorOrThrow({
+      hub: assistantEventHub,
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_file",
+    });
   }
 
   HostFileProxy.instance.resolve(requestId, {
@@ -129,8 +128,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host file request.",
       },
       "403": {
-        description:
-          "Submitting client or actor does not match the targeted client/actor for this request.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
       "404": {
         description: "No pending interaction found for the given requestId.",


### PR DESCRIPTION
## Summary
- Extracts `checkSameActor` helper used by all three proxies and all three result routes.
- Standardizes error messages and structured log payloads.
- Unifies HostBash/HostFile auto-resolve shape (filter-by-actor first, then auto-resolve when one match).
- Removes redundant same-user check at the CU dispatch layer (proxy is the single gate).
- Filters CU dispatch multi-client guard by same-user (UX improvement).
- Cleans up unused import in client-routes test.

Addresses slop / consistency gaps identified during plan review.

Part of plan: host-proxy-same-user.md (review fix R1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->