### PR TITLE
Add feature-flagged disk pressure state machine

### DIFF
--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { DiskPressureTransitionResult } from "../daemon/disk-pressure-guard.js";
+import type { DiskUsageInfo } from "../util/disk-usage.js";
+
+let diskSample: DiskUsageInfo | null = null;
+let diskSampleError: unknown = null;
+let diskSampleCalls = 0;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+mock.module("../util/disk-usage.js", () => ({
+  getDiskUsageInfo: () => {
+    diskSampleCalls += 1;
+    if (diskSampleError) throw diskSampleError;
+    return diskSample;
+  },
+}));
+
+const { _setOverridesForTesting } =
+  await import("../config/assistant-feature-flags.js");
+const {
+  DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+  DISK_PRESSURE_THRESHOLD_PERCENT,
+  __getDiskPressureGuardTimerForTests,
+  __resetDiskPressureGuardForTests,
+  acknowledgeDiskPressureLock,
+  evaluateDiskPressureNow,
+  getDiskPressureStatus,
+  overrideDiskPressureLock,
+  startDiskPressureGuard,
+  stopDiskPressureGuard,
+} = await import("../daemon/disk-pressure-guard.js");
+
+function setFeatureFlag(enabled: boolean): void {
+  _setOverridesForTesting({ "safe-storage-limits": enabled });
+}
+
+function setDiskUsage(usedMb: number, totalMb = 100): void {
+  diskSample = {
+    path: "/workspace",
+    totalMb,
+    usedMb,
+    freeMb: Math.max(0, totalMb - usedMb),
+  };
+  diskSampleError = null;
+}
+
+function expectRejected(
+  result: DiskPressureTransitionResult,
+  reason: Exclude<DiskPressureTransitionResult, { ok: true }>["reason"],
+): asserts result is Exclude<DiskPressureTransitionResult, { ok: true }> {
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("Expected disk pressure transition to be rejected");
+  }
+  expect(result.reason).toBe(reason);
+}
+
+beforeEach(() => {
+  __resetDiskPressureGuardForTests();
+  setFeatureFlag(true);
+  setDiskUsage(10);
+  diskSampleCalls = 0;
+});
+
+afterEach(() => {
+  __resetDiskPressureGuardForTests();
+  _setOverridesForTesting({});
+  diskSample = null;
+  diskSampleError = null;
+  diskSampleCalls = 0;
+});
+
+describe("disk pressure guard", () => {
+  test("returns a stable disabled status without sampling when the flag is disabled", () => {
+    setDiskUsage(99);
+    setFeatureFlag(false);
+
+    const status = evaluateDiskPressureNow();
+
+    expect(status.enabled).toBe(false);
+    expect(status.state).toBe("disabled");
+    expect(status.locked).toBe(false);
+    expect(status.effectivelyLocked).toBe(false);
+    expect(status.usagePercent).toBeNull();
+    expect(diskSampleCalls).toBe(0);
+    expect(getDiskPressureStatus()).toEqual(status);
+  });
+
+  test("locks when sampled usage reaches the threshold", () => {
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT);
+
+    const status = evaluateDiskPressureNow();
+
+    expect(status.enabled).toBe(true);
+    expect(status.state).toBe("critical");
+    expect(status.locked).toBe(true);
+    expect(status.acknowledged).toBe(false);
+    expect(status.overrideActive).toBe(false);
+    expect(status.effectivelyLocked).toBe(true);
+    expect(status.lockId).toBeTruthy();
+    expect(status.usagePercent).toBe(DISK_PRESSURE_THRESHOLD_PERCENT);
+    expect(status.thresholdPercent).toBe(DISK_PRESSURE_THRESHOLD_PERCENT);
+    expect(status.path).toBe("/workspace");
+    expect(status.lastCheckedAt).toBeTruthy();
+    expect(status.blockedCapabilities.length).toBeGreaterThan(0);
+  });
+
+  test("acknowledges an active lock without overriding it", () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+
+    const result = acknowledgeDiskPressureLock();
+
+    expect(result.ok).toBe(true);
+    expect(result.status.acknowledged).toBe(true);
+    expect(result.status.overrideActive).toBe(false);
+    expect(result.status.effectivelyLocked).toBe(true);
+  });
+
+  test("unlocks and clears acknowledgement and override when usage falls below threshold", () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+    acknowledgeDiskPressureLock();
+    overrideDiskPressureLock(DISK_PRESSURE_OVERRIDE_CONFIRMATION);
+
+    setDiskUsage(20);
+    const status = evaluateDiskPressureNow();
+
+    expect(status.state).toBe("ok");
+    expect(status.locked).toBe(false);
+    expect(status.acknowledged).toBe(false);
+    expect(status.overrideActive).toBe(false);
+    expect(status.effectivelyLocked).toBe(false);
+    expect(status.lockId).toBeNull();
+    expect(status.blockedCapabilities).toEqual([]);
+  });
+
+  test("overrides an active lock only with the exact confirmation after trimming whitespace", () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+
+    const invalid = overrideDiskPressureLock("I accept the risks");
+    expectRejected(invalid, "invalid_confirmation");
+    expect(invalid.status.effectivelyLocked).toBe(true);
+
+    const valid = overrideDiskPressureLock(
+      `  ${DISK_PRESSURE_OVERRIDE_CONFIRMATION}  `,
+    );
+
+    expect(valid.ok).toBe(true);
+    expect(valid.status.locked).toBe(true);
+    expect(valid.status.overrideActive).toBe(true);
+    expect(valid.status.effectivelyLocked).toBe(false);
+  });
+
+  test("rejects acknowledgement when no lock is active", () => {
+    setDiskUsage(10);
+    evaluateDiskPressureNow();
+
+    const result = acknowledgeDiskPressureLock();
+
+    expectRejected(result, "not_locked");
+    expect(result.status.locked).toBe(false);
+  });
+
+  test("rejects override when no lock is active", () => {
+    setDiskUsage(10);
+    evaluateDiskPressureNow();
+
+    const result = overrideDiskPressureLock(
+      DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+    );
+
+    expectRejected(result, "not_locked");
+    expect(result.status.locked).toBe(false);
+  });
+
+  test("rejects repeated override while preserving the existing override", () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+    const first = overrideDiskPressureLock(DISK_PRESSURE_OVERRIDE_CONFIRMATION);
+    expect(first.ok).toBe(true);
+
+    const second = overrideDiskPressureLock(
+      DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+    );
+
+    expectRejected(second, "already_overridden");
+    expect(second.status.overrideActive).toBe(true);
+    expect(second.status.effectivelyLocked).toBe(false);
+  });
+
+  test("sample failures degrade open and do not preserve a prior lock", () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+    expect(getDiskPressureStatus().locked).toBe(true);
+
+    diskSampleError = new Error("sample failed");
+    const status = evaluateDiskPressureNow();
+
+    expect(status.enabled).toBe(true);
+    expect(status.state).toBe("unknown");
+    expect(status.locked).toBe(false);
+    expect(status.effectivelyLocked).toBe(false);
+    expect(status.error).toBe("sample failed");
+    expect(status.lastCheckedAt).toBeTruthy();
+  });
+
+  test("timer start and stop are idempotent", () => {
+    expect(__getDiskPressureGuardTimerForTests()).toBeNull();
+
+    startDiskPressureGuard();
+    const firstTimer = __getDiskPressureGuardTimerForTests();
+    expect(firstTimer).toBeTruthy();
+
+    startDiskPressureGuard();
+    expect(__getDiskPressureGuardTimerForTests()).toBe(firstTimer);
+
+    stopDiskPressureGuard();
+    expect(__getDiskPressureGuardTimerForTests()).toBeNull();
+
+    stopDiskPressureGuard();
+    expect(__getDiskPressureGuardTimerForTests()).toBeNull();
+  });
+
+  test("disabling the flag clears an active timer and lock", () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+    startDiskPressureGuard();
+    expect(__getDiskPressureGuardTimerForTests()).toBeTruthy();
+
+    setFeatureFlag(false);
+    const status = getDiskPressureStatus();
+
+    expect(status.enabled).toBe(false);
+    expect(status.locked).toBe(false);
+    expect(__getDiskPressureGuardTimerForTests()).toBeNull();
+  });
+});

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -1,0 +1,281 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import { getDiskUsageInfo } from "../util/disk-usage.js";
+
+export const DISK_PRESSURE_THRESHOLD_PERCENT = 95;
+export const DISK_PRESSURE_CHECK_INTERVAL_MS = 60_000;
+export const DISK_PRESSURE_OVERRIDE_CONFIRMATION = "I understand the risks";
+export const DISK_PRESSURE_BLOCKED_CAPABILITIES = [
+  "agent-turns",
+  "background-work",
+  "remote-ingress",
+] as const;
+
+export type DiskPressureState = "disabled" | "ok" | "critical" | "unknown";
+
+export type DiskPressureBlockedCapability =
+  (typeof DISK_PRESSURE_BLOCKED_CAPABILITIES)[number];
+
+export interface DiskPressureStatus {
+  enabled: boolean;
+  state: DiskPressureState;
+  locked: boolean;
+  acknowledged: boolean;
+  overrideActive: boolean;
+  effectivelyLocked: boolean;
+  lockId: string | null;
+  usagePercent: number | null;
+  thresholdPercent: number;
+  path: string | null;
+  lastCheckedAt: string | null;
+  blockedCapabilities: DiskPressureBlockedCapability[];
+  error: string | null;
+}
+
+export type DiskPressureTransitionResult =
+  | { ok: true; status: DiskPressureStatus }
+  | {
+      ok: false;
+      reason: "not_locked" | "already_overridden" | "invalid_confirmation";
+      message: string;
+      status: DiskPressureStatus;
+    };
+
+interface DiskPressureGuardState {
+  timer: ReturnType<typeof setInterval> | null;
+  status: DiskPressureStatus;
+}
+
+const DISABLED_STATUS: DiskPressureStatus = {
+  enabled: false,
+  state: "disabled",
+  locked: false,
+  acknowledged: false,
+  overrideActive: false,
+  effectivelyLocked: false,
+  lockId: null,
+  usagePercent: null,
+  thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
+  path: null,
+  lastCheckedAt: null,
+  blockedCapabilities: [],
+  error: null,
+};
+
+const OPEN_STATUS: DiskPressureStatus = {
+  ...DISABLED_STATUS,
+  enabled: true,
+  state: "ok",
+  thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
+};
+
+const state: DiskPressureGuardState = {
+  timer: null,
+  status: cloneStatus(DISABLED_STATUS),
+};
+
+function cloneStatus(status: DiskPressureStatus): DiskPressureStatus {
+  return {
+    ...status,
+    blockedCapabilities: [...status.blockedCapabilities],
+  };
+}
+
+function isEnabled(): boolean {
+  return isAssistantFeatureFlagEnabled("safe-storage-limits", getConfig());
+}
+
+function resetToDisabled(): DiskPressureStatus {
+  stopDiskPressureGuard();
+  state.status = cloneStatus(DISABLED_STATUS);
+  return cloneStatus(state.status);
+}
+
+function ensureEnabledStatus(): DiskPressureStatus | null {
+  if (!isEnabled()) return resetToDisabled();
+  if (!state.status.enabled) {
+    state.status = cloneStatus(OPEN_STATUS);
+  }
+  return null;
+}
+
+function nextLockId(): string {
+  return `disk-pressure-${Date.now()}`;
+}
+
+function roundPercent(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sampleFailureStatus(error: unknown): DiskPressureStatus {
+  const now = new Date().toISOString();
+  return {
+    ...state.status,
+    enabled: true,
+    state: "unknown",
+    locked: false,
+    acknowledged: false,
+    overrideActive: false,
+    effectivelyLocked: false,
+    lockId: null,
+    usagePercent: null,
+    thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
+    path: null,
+    lastCheckedAt: now,
+    blockedCapabilities: [],
+    error: formatError(error),
+  };
+}
+
+function rejectTransition(
+  reason: Exclude<DiskPressureTransitionResult, { ok: true }>["reason"],
+  message: string,
+  status: DiskPressureStatus,
+): DiskPressureTransitionResult {
+  return { ok: false, reason, message, status };
+}
+
+export function startDiskPressureGuard(): DiskPressureStatus {
+  const disabledStatus = ensureEnabledStatus();
+  if (disabledStatus) return disabledStatus;
+
+  if (!state.timer) {
+    state.timer = setInterval(() => {
+      void evaluateDiskPressureNow();
+    }, DISK_PRESSURE_CHECK_INTERVAL_MS);
+    (state.timer as { unref?: () => void }).unref?.();
+  }
+
+  return cloneStatus(state.status);
+}
+
+export function stopDiskPressureGuard(): void {
+  if (!state.timer) return;
+  clearInterval(state.timer);
+  state.timer = null;
+}
+
+export function evaluateDiskPressureNow(): DiskPressureStatus {
+  const disabledStatus = ensureEnabledStatus();
+  if (disabledStatus) return disabledStatus;
+
+  let usageInfo: ReturnType<typeof getDiskUsageInfo>;
+  try {
+    usageInfo = getDiskUsageInfo();
+  } catch (error) {
+    state.status = sampleFailureStatus(error);
+    return cloneStatus(state.status);
+  }
+
+  if (!usageInfo || usageInfo.totalMb <= 0) {
+    state.status = sampleFailureStatus("Disk usage sample unavailable");
+    return cloneStatus(state.status);
+  }
+
+  const usagePercent = roundPercent(
+    (usageInfo.usedMb / usageInfo.totalMb) * 100,
+  );
+  const isCritical = usagePercent >= DISK_PRESSURE_THRESHOLD_PERCENT;
+  const lastCheckedAt = new Date().toISOString();
+
+  if (!isCritical) {
+    state.status = {
+      ...OPEN_STATUS,
+      usagePercent,
+      path: usageInfo.path,
+      lastCheckedAt,
+    };
+    return cloneStatus(state.status);
+  }
+
+  const lockId = state.status.locked ? state.status.lockId : nextLockId();
+  state.status = {
+    enabled: true,
+    state: "critical",
+    locked: true,
+    acknowledged: state.status.locked ? state.status.acknowledged : false,
+    overrideActive: state.status.locked ? state.status.overrideActive : false,
+    effectivelyLocked: state.status.locked
+      ? !state.status.overrideActive
+      : true,
+    lockId,
+    usagePercent,
+    thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
+    path: usageInfo.path,
+    lastCheckedAt,
+    blockedCapabilities: [...DISK_PRESSURE_BLOCKED_CAPABILITIES],
+    error: null,
+  };
+
+  return cloneStatus(state.status);
+}
+
+export function getDiskPressureStatus(): DiskPressureStatus {
+  const disabledStatus = ensureEnabledStatus();
+  if (disabledStatus) return disabledStatus;
+  return cloneStatus(state.status);
+}
+
+export function acknowledgeDiskPressureLock(): DiskPressureTransitionResult {
+  const disabledStatus = ensureEnabledStatus();
+  const status = disabledStatus ?? cloneStatus(state.status);
+  if (!status.locked) {
+    return rejectTransition(
+      "not_locked",
+      "No disk pressure lock is active for this assistant.",
+      status,
+    );
+  }
+
+  state.status.acknowledged = true;
+  return { ok: true, status: cloneStatus(state.status) };
+}
+
+export function overrideDiskPressureLock(
+  confirmation: string,
+): DiskPressureTransitionResult {
+  const disabledStatus = ensureEnabledStatus();
+  const status = disabledStatus ?? cloneStatus(state.status);
+  if (!status.locked) {
+    return rejectTransition(
+      "not_locked",
+      "No disk pressure lock is active for this assistant.",
+      status,
+    );
+  }
+
+  if (status.overrideActive) {
+    return rejectTransition(
+      "already_overridden",
+      "The disk pressure lock has already been overridden.",
+      status,
+    );
+  }
+
+  if (confirmation.trim() !== DISK_PRESSURE_OVERRIDE_CONFIRMATION) {
+    return rejectTransition(
+      "invalid_confirmation",
+      `Type "${DISK_PRESSURE_OVERRIDE_CONFIRMATION}" to resume normal assistant behavior.`,
+      status,
+    );
+  }
+
+  state.status.overrideActive = true;
+  state.status.effectivelyLocked = false;
+  return { ok: true, status: cloneStatus(state.status) };
+}
+
+export function __resetDiskPressureGuardForTests(): void {
+  stopDiskPressureGuard();
+  state.status = cloneStatus(DISABLED_STATUS);
+}
+
+export function __getDiskPressureGuardTimerForTests(): ReturnType<
+  typeof setInterval
+> | null {
+  return state.timer;
+}


### PR DESCRIPTION
## Summary
- Add a feature-flagged disk pressure guard state machine.
- Track lock, acknowledgement, override, and effective lock status from shared disk usage samples.
- Add focused state-machine coverage for lock lifecycle and invalid transitions.

Part of plan: disk-pressure-protection.md (PR 3 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->