### PR TITLE
Add disk pressure turn policy classifier

### DIFF
--- a/assistant/src/__tests__/disk-pressure-policy.test.ts
+++ b/assistant/src/__tests__/disk-pressure-policy.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+
+import type { DiskPressureStatus } from "../daemon/disk-pressure-guard.js";
+import {
+  classifyDiskPressureTurnPolicy,
+  type DiskPressureTurnMetadata,
+  type DiskPressureTurnPolicyDecision,
+} from "../daemon/disk-pressure-policy.js";
+
+const LOCKED_STATUS = {
+  enabled: true,
+  state: "critical",
+  locked: true,
+  acknowledged: true,
+  overrideActive: false,
+  effectivelyLocked: true,
+  lockId: "disk-pressure-test",
+  usagePercent: 98,
+  thresholdPercent: 95,
+  path: "/",
+  lastCheckedAt: "2026-05-05T00:00:00.000Z",
+  blockedCapabilities: ["agent-turns", "background-work", "remote-ingress"],
+  error: null,
+} satisfies DiskPressureStatus;
+
+function status(
+  overrides: Partial<DiskPressureStatus> = {},
+): DiskPressureStatus {
+  return {
+    ...LOCKED_STATUS,
+    ...overrides,
+    blockedCapabilities:
+      overrides.blockedCapabilities ?? LOCKED_STATUS.blockedCapabilities,
+  };
+}
+
+const localOwnerTurn = {
+  conversationType: "standard",
+  callSite: "mainAgent",
+  isInteractive: true,
+  sourceChannel: "vellum",
+  sourceInterface: "macos",
+} satisfies DiskPressureTurnMetadata;
+
+const guardianTurn = {
+  ...localOwnerTurn,
+  sourceChannel: "telegram",
+  sourceInterface: "telegram",
+  trustContext: {
+    sourceChannel: "telegram",
+    trustClass: "guardian",
+  },
+} satisfies DiskPressureTurnMetadata;
+
+describe("classifyDiskPressureTurnPolicy", () => {
+  test.each([
+    {
+      name: "flag disabled allows normal turns",
+      status: status({
+        enabled: false,
+        state: "disabled",
+        locked: false,
+        effectivelyLocked: false,
+        blockedCapabilities: [],
+      }),
+      metadata: guardianTurn,
+      expected: { action: "allow-normal" },
+    },
+    {
+      name: "unlocked allows normal turns",
+      status: status({ locked: false, effectivelyLocked: false }),
+      metadata: guardianTurn,
+      expected: { action: "allow-normal" },
+    },
+    {
+      name: "override active allows normal turns",
+      status: status({ overrideActive: true, effectivelyLocked: false }),
+      metadata: guardianTurn,
+      expected: { action: "allow-normal" },
+    },
+    {
+      name: "locked acknowledged local owner without trust enters cleanup mode",
+      status: status({ acknowledged: true }),
+      metadata: localOwnerTurn,
+      expected: { action: "allow-cleanup-mode", reason: "local-owner" },
+    },
+    {
+      name: "locked unacknowledged local owner without trust enters cleanup mode",
+      status: status({ acknowledged: false }),
+      metadata: localOwnerTurn,
+      expected: { action: "allow-cleanup-mode", reason: "local-owner" },
+    },
+    {
+      name: "locked guardian enters cleanup mode",
+      status: status(),
+      metadata: guardianTurn,
+      expected: { action: "allow-cleanup-mode", reason: "guardian" },
+    },
+    {
+      name: "trusted contact is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        trustContext: {
+          sourceChannel: "telegram",
+          trustClass: "trusted_contact",
+        },
+      },
+      expected: { action: "block", reason: "trusted-contact" },
+    },
+    {
+      name: "non-guardian contact is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        trustContext: {
+          sourceChannel: "telegram",
+          trustClass: "non_guardian",
+        },
+      },
+      expected: { action: "block", reason: "non-guardian" },
+    },
+    {
+      name: "future non-guardian trust class is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        trustContext: {
+          sourceChannel: "telegram",
+          trustClass: "member",
+        },
+      },
+      expected: { action: "block", reason: "non-guardian" },
+    },
+    {
+      name: "unknown remote sender is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        trustContext: {
+          sourceChannel: "telegram",
+          trustClass: "unknown",
+        },
+      },
+      expected: { action: "block", reason: "unknown-remote" },
+    },
+    {
+      name: "remote turn without trust context is blocked",
+      status: status(),
+      metadata: {
+        conversationType: "standard",
+        callSite: "mainAgent",
+        isInteractive: true,
+        sourceChannel: "telegram",
+        sourceInterface: "telegram",
+      },
+      expected: { action: "block", reason: "unknown-remote" },
+    },
+    {
+      name: "background conversation is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        conversationType: "background",
+      },
+      expected: { action: "block", reason: "background" },
+    },
+    {
+      name: "scheduled background group is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        conversationGroupId: "system:scheduled",
+      },
+      expected: { action: "block", reason: "background" },
+    },
+    {
+      name: "background source is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        conversationSource: "heartbeat",
+      },
+      expected: { action: "block", reason: "background" },
+    },
+    {
+      name: "non-main call site is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        callSite: "memoryConsolidation",
+      },
+      expected: { action: "block", reason: "background" },
+    },
+    {
+      name: "direct wake metadata is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        isDirectWake: true,
+      },
+      expected: { action: "block", reason: "background" },
+    },
+    {
+      name: "direct wake source is blocked",
+      status: status(),
+      metadata: {
+        ...guardianTurn,
+        conversationSource: "direct",
+      },
+      expected: { action: "block", reason: "background" },
+    },
+  ] satisfies Array<{
+    name: string;
+    status: DiskPressureStatus;
+    metadata: DiskPressureTurnMetadata;
+    expected: DiskPressureTurnPolicyDecision;
+  }>)("$name", ({ status, metadata, expected }) => {
+    expect(classifyDiskPressureTurnPolicy(status, metadata)).toEqual(expected);
+  });
+});

--- a/assistant/src/daemon/disk-pressure-policy.ts
+++ b/assistant/src/daemon/disk-pressure-policy.ts
@@ -1,0 +1,144 @@
+import type { InterfaceId } from "../channels/types.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
+import type { DiskPressureStatus } from "./disk-pressure-guard.js";
+import type { ConversationType } from "./message-types/shared.js";
+import type { TrustContext } from "./trust-context.js";
+
+export type DiskPressureCleanupReason = "local-owner" | "guardian";
+
+export type DiskPressureBlockReason =
+  | "background"
+  | "trusted-contact"
+  | "non-guardian"
+  | "unknown-remote";
+
+export type DiskPressureTurnPolicyDecision =
+  | { action: "allow-normal" }
+  | { action: "allow-cleanup-mode"; reason: DiskPressureCleanupReason }
+  | { action: "block"; reason: DiskPressureBlockReason };
+
+export type DiskPressureTurnTrustClass =
+  | TrustContext["trustClass"]
+  | "non_guardian"
+  | "non-guardian"
+  | (string & {});
+
+export interface DiskPressureTurnTrustContext {
+  sourceChannel?: TrustContext["sourceChannel"] | (string & {});
+  trustClass?: DiskPressureTurnTrustClass;
+}
+
+export interface DiskPressureTurnMetadata {
+  conversationType?: ConversationType | (string & {}) | null;
+  conversationGroupId?: string | null;
+  conversationSource?: string | null;
+  callSite?: LLMCallSite | (string & {}) | null;
+  isInteractive?: boolean | null;
+  sourceChannel?: TrustContext["sourceChannel"] | (string & {}) | null;
+  sourceInterface?: InterfaceId | "vellum" | (string & {}) | null;
+  trustContext?: DiskPressureTurnTrustContext | null;
+  isDirectWake?: boolean | null;
+}
+
+const BACKGROUND_CONVERSATION_TYPES = new Set(["background", "scheduled"]);
+const BACKGROUND_GROUP_IDS = new Set(["system:background", "system:scheduled"]);
+const BACKGROUND_SOURCES = new Set([
+  "auto-analysis",
+  "background",
+  "compaction",
+  "direct",
+  "filing",
+  "heartbeat",
+  "memory",
+  "notification",
+  "proactive-artifact",
+  "reminder",
+  "schedule",
+  "task",
+  "update-bulletin",
+]);
+const LOCAL_OWNER_INTERFACES = new Set(["macos", "web", "vellum", "cli"]);
+
+export function classifyDiskPressureTurnPolicy(
+  status: DiskPressureStatus,
+  metadata: DiskPressureTurnMetadata,
+): DiskPressureTurnPolicyDecision {
+  if (!status.enabled || !status.locked || status.overrideActive) {
+    return { action: "allow-normal" };
+  }
+
+  if (!status.effectivelyLocked) {
+    return { action: "allow-normal" };
+  }
+
+  if (isBackgroundTurn(metadata)) {
+    return { action: "block", reason: "background" };
+  }
+
+  const trustClass = metadata.trustContext?.trustClass;
+  if (trustClass === "guardian") {
+    return { action: "allow-cleanup-mode", reason: "guardian" };
+  }
+
+  if (trustClass === "trusted_contact") {
+    return { action: "block", reason: "trusted-contact" };
+  }
+
+  if (isNonGuardianTrustClass(trustClass)) {
+    return { action: "block", reason: "non-guardian" };
+  }
+
+  if (trustClass === "unknown") {
+    return { action: "block", reason: "unknown-remote" };
+  }
+
+  if (trustClass !== undefined) {
+    return { action: "block", reason: "non-guardian" };
+  }
+
+  if (isLocalOwnerTurnWithoutTrust(metadata)) {
+    return { action: "allow-cleanup-mode", reason: "local-owner" };
+  }
+
+  return { action: "block", reason: "unknown-remote" };
+}
+
+function isBackgroundTurn(metadata: DiskPressureTurnMetadata): boolean {
+  if (metadata.isDirectWake) return true;
+  if (metadata.callSite != null && metadata.callSite !== "mainAgent") {
+    return true;
+  }
+  if (
+    metadata.conversationType != null &&
+    BACKGROUND_CONVERSATION_TYPES.has(metadata.conversationType)
+  ) {
+    return true;
+  }
+  if (
+    metadata.conversationGroupId != null &&
+    BACKGROUND_GROUP_IDS.has(metadata.conversationGroupId)
+  ) {
+    return true;
+  }
+  return (
+    metadata.conversationSource != null &&
+    BACKGROUND_SOURCES.has(metadata.conversationSource)
+  );
+}
+
+function isNonGuardianTrustClass(
+  trustClass: DiskPressureTurnTrustClass | undefined,
+): boolean {
+  return trustClass === "non_guardian" || trustClass === "non-guardian";
+}
+
+function isLocalOwnerTurnWithoutTrust(
+  metadata: DiskPressureTurnMetadata,
+): boolean {
+  if (metadata.trustContext != null) return false;
+
+  const channel = metadata.sourceChannel;
+  const sourceInterface = metadata.sourceInterface;
+  if (channel !== "vellum" || sourceInterface == null) return false;
+  return LOCAL_OWNER_INTERFACES.has(sourceInterface);
+}


### PR DESCRIPTION
## Summary
- Add a pure disk pressure turn-policy classifier.
- Distinguish cleanup-eligible local/guardian turns from blocked background and remote turns.
- Cover trusted-contact, unknown-remote, direct-wake, and missing-trust local cases.

Part of plan: disk-pressure-protection.md (PR 6 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->