### PR TITLE
Expose disk pressure status and acknowledgement APIs

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4439,6 +4439,275 @@ paths:
                 - transcription
                 - context
               additionalProperties: false
+  /v1/disk-pressure/acknowledge:
+    post:
+      operationId: diskpressure_acknowledge_post
+      summary: Acknowledge disk pressure
+      description: Acknowledge the current disk pressure lock and enter cleanup mode without overriding assistant protections.
+      tags:
+        - disk-pressure
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      state:
+                        type: string
+                        enum:
+                          - disabled
+                          - ok
+                          - critical
+                          - unknown
+                      locked:
+                        type: boolean
+                      acknowledged:
+                        type: boolean
+                      overrideActive:
+                        type: boolean
+                      effectivelyLocked:
+                        type: boolean
+                      lockId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      usagePercent:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      thresholdPercent:
+                        type: number
+                      path:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      lastCheckedAt:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      blockedCapabilities:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - agent-turns
+                            - background-work
+                            - remote-ingress
+                      error:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                    required:
+                      - enabled
+                      - state
+                      - locked
+                      - acknowledged
+                      - overrideActive
+                      - effectivelyLocked
+                      - lockId
+                      - usagePercent
+                      - thresholdPercent
+                      - path
+                      - lastCheckedAt
+                      - blockedCapabilities
+                      - error
+                    additionalProperties: false
+                required:
+                  - status
+                additionalProperties: false
+        "409":
+          description: No active lock or lock already acknowledged.
+  /v1/disk-pressure/override:
+    post:
+      operationId: diskpressure_override_post
+      summary: Override disk pressure
+      description: Override the current disk pressure lock only after confirming "I understand the risks".
+      tags:
+        - disk-pressure
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      state:
+                        type: string
+                        enum:
+                          - disabled
+                          - ok
+                          - critical
+                          - unknown
+                      locked:
+                        type: boolean
+                      acknowledged:
+                        type: boolean
+                      overrideActive:
+                        type: boolean
+                      effectivelyLocked:
+                        type: boolean
+                      lockId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      usagePercent:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      thresholdPercent:
+                        type: number
+                      path:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      lastCheckedAt:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      blockedCapabilities:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - agent-turns
+                            - background-work
+                            - remote-ingress
+                      error:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                    required:
+                      - enabled
+                      - state
+                      - locked
+                      - acknowledged
+                      - overrideActive
+                      - effectivelyLocked
+                      - lockId
+                      - usagePercent
+                      - thresholdPercent
+                      - path
+                      - lastCheckedAt
+                      - blockedCapabilities
+                      - error
+                    additionalProperties: false
+                required:
+                  - status
+                additionalProperties: false
+        "400":
+          description: Confirmation phrase is invalid.
+        "409":
+          description: No active lock or lock already overridden.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                confirmation:
+                  type: string
+              required:
+                - confirmation
+              additionalProperties: false
+  /v1/disk-pressure/status:
+    get:
+      operationId: diskpressure_status_get
+      summary: Get disk pressure status
+      description:
+        Return the current disk pressure status snapshot. When safe storage limits are disabled, returns a disabled
+        status.
+      tags:
+        - disk-pressure
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                      state:
+                        type: string
+                        enum:
+                          - disabled
+                          - ok
+                          - critical
+                          - unknown
+                      locked:
+                        type: boolean
+                      acknowledged:
+                        type: boolean
+                      overrideActive:
+                        type: boolean
+                      effectivelyLocked:
+                        type: boolean
+                      lockId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      usagePercent:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      thresholdPercent:
+                        type: number
+                      path:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      lastCheckedAt:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      blockedCapabilities:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - agent-turns
+                            - background-work
+                            - remote-ingress
+                      error:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                    required:
+                      - enabled
+                      - state
+                      - locked
+                      - acknowledged
+                      - overrideActive
+                      - effectivelyLocked
+                      - lockId
+                      - usagePercent
+                      - thresholdPercent
+                      - path
+                      - lastCheckedAt
+                      - blockedCapabilities
+                      - error
+                    additionalProperties: false
+                required:
+                  - status
+                additionalProperties: false
   /v1/documents:
     get:
       operationId: documents_get

--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -19,6 +19,25 @@ mock.module("../util/disk-usage.js", () => ({
   },
 }));
 
+mock.module("../runtime/assistant-event.js", () => ({
+  buildAssistantEvent: (message: unknown, conversationId?: string) => ({
+    id: "event-test",
+    type: "message",
+    timestamp: new Date().toISOString(),
+    conversationId,
+    message,
+  }),
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  AssistantEventHub: class {},
+  broadcastMessage: () => {},
+  capabilityForMessageType: () => undefined,
+  assistantEventHub: {
+    publish: async () => {},
+  },
+}));
+
 const { _setOverridesForTesting } =
   await import("../config/assistant-feature-flags.js");
 const {

--- a/assistant/src/__tests__/disk-pressure-guard.test.ts
+++ b/assistant/src/__tests__/disk-pressure-guard.test.ts
@@ -253,7 +253,7 @@ describe("disk pressure guard", () => {
     expect(__getDiskPressureGuardTimerForTests()).toBeTruthy();
 
     setFeatureFlag(false);
-    const status = getDiskPressureStatus();
+    const status = evaluateDiskPressureNow();
 
     expect(status.enabled).toBe(false);
     expect(status.locked).toBe(false);

--- a/assistant/src/__tests__/disk-pressure-lifecycle.test.ts
+++ b/assistant/src/__tests__/disk-pressure-lifecycle.test.ts
@@ -7,6 +7,24 @@ let stopCalls = 0;
 let evaluateCalls = 0;
 let evaluateError: string | null = null;
 
+function makeOpenStatus() {
+  return {
+    enabled: true,
+    state: "ok",
+    locked: false,
+    acknowledged: false,
+    overrideActive: false,
+    effectivelyLocked: false,
+    lockId: null,
+    usagePercent: 10,
+    thresholdPercent: 95,
+    path: "/workspace",
+    lastCheckedAt: new Date().toISOString(),
+    blockedCapabilities: [],
+    error: null,
+  };
+}
+
 mock.module("../daemon/disk-pressure-guard.js", () => ({
   startDiskPressureGuard: () => {
     startCalls += 1;
@@ -47,6 +65,20 @@ mock.module("../daemon/disk-pressure-guard.js", () => ({
       error: evaluateError,
     };
   },
+  getDiskPressureStatus: () => makeOpenStatus(),
+  acknowledgeDiskPressureLock: () => ({
+    ok: false,
+    reason: "not_locked",
+    message: "No disk pressure lock is active for this assistant.",
+    status: makeOpenStatus(),
+  }),
+  overrideDiskPressureLock: () => ({
+    ok: false,
+    reason: "not_locked",
+    message: "No disk pressure lock is active for this assistant.",
+    status: makeOpenStatus(),
+  }),
+  DISK_PRESSURE_OVERRIDE_CONFIRMATION: "I understand the risks",
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/disk-pressure-routes.test.ts
+++ b/assistant/src/__tests__/disk-pressure-routes.test.ts
@@ -191,7 +191,6 @@ describe("disk pressure routes", () => {
 
   test("returns the full status shape for an active lock", async () => {
     setDiskUsage(99);
-    evaluateDiskPressureNow();
 
     const result = await callRoute("disk-pressure/status", "GET");
 
@@ -214,6 +213,32 @@ describe("disk pressure routes", () => {
       "remote-ingress",
     ]);
     expect(result.status.error).toBeNull();
+  });
+
+  test("refreshes status from disk without emitting a read-path status event", async () => {
+    const events: unknown[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        if (event.message.type === "disk_pressure_status_changed") {
+          events.push(event.message);
+        }
+      },
+    });
+
+    try {
+      setDiskUsage(99);
+
+      const result = await callRoute("disk-pressure/status", "GET");
+      await flushPublishedEvents();
+
+      expect(result.status.state).toBe("critical");
+      expect(result.status.locked).toBe(true);
+      expect(result.status.usagePercent).toBe(99);
+      expect(events).toEqual([]);
+    } finally {
+      subscription.dispose();
+    }
   });
 
   test("acknowledges an active lock without overriding it", async () => {
@@ -335,7 +360,6 @@ describe("disk pressure routes", () => {
         (message as { status: DiskPressureRouteResult["status"] }).status,
     );
     expect(statuses.map((status) => status.state)).toEqual([
-      "ok",
       "critical",
       "critical",
       "critical",
@@ -343,12 +367,12 @@ describe("disk pressure routes", () => {
       "ok",
     ]);
     expect(statuses[0].enabled).toBe(true);
-    expect(statuses[2].acknowledged).toBe(true);
-    expect(statuses[2].overrideActive).toBe(false);
-    expect(statuses[3].overrideActive).toBe(true);
-    expect(statuses[3].effectivelyLocked).toBe(false);
-    expect(statuses[4].usagePercent).toBe(98);
-    expect(statuses[5].locked).toBe(false);
-    expect(statuses[5].lockId).toBeNull();
+    expect(statuses[1].acknowledged).toBe(true);
+    expect(statuses[1].overrideActive).toBe(false);
+    expect(statuses[2].overrideActive).toBe(true);
+    expect(statuses[2].effectivelyLocked).toBe(false);
+    expect(statuses[3].usagePercent).toBe(98);
+    expect(statuses[4].locked).toBe(false);
+    expect(statuses[4].lockId).toBeNull();
   });
 });

--- a/assistant/src/__tests__/disk-pressure-routes.test.ts
+++ b/assistant/src/__tests__/disk-pressure-routes.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { DiskUsageInfo } from "../util/disk-usage.js";
+
+let diskSample: DiskUsageInfo | null = null;
+const eventSubscribers = new Set<(event: unknown) => void>();
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+}));
+
+mock.module("../util/disk-usage.js", () => ({
+  getDiskUsageInfo: () => diskSample,
+}));
+
+mock.module("../runtime/assistant-event.js", () => ({
+  buildAssistantEvent: (message: unknown, conversationId?: string) => ({
+    id: "event-test",
+    type: "message",
+    timestamp: new Date().toISOString(),
+    conversationId,
+    message,
+  }),
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  AssistantEventHub: class {},
+  broadcastMessage: () => {},
+  capabilityForMessageType: () => undefined,
+  assistantEventHub: {
+    publish: async (event: unknown) => {
+      for (const callback of eventSubscribers) callback(event);
+    },
+    subscribe: ({ callback }: { callback: (event: unknown) => void }) => {
+      eventSubscribers.add(callback);
+      return {
+        dispose: () => {
+          eventSubscribers.delete(callback);
+        },
+      };
+    },
+  },
+}));
+
+const { _setOverridesForTesting } =
+  await import("../config/assistant-feature-flags.js");
+const {
+  DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+  DISK_PRESSURE_THRESHOLD_PERCENT,
+  __resetDiskPressureGuardForTests,
+  evaluateDiskPressureNow,
+} = await import("../daemon/disk-pressure-guard.js");
+const { assistantEventHub } = await import("../runtime/assistant-event-hub.js");
+const { getPolicy } = await import("../runtime/auth/route-policy.js");
+const { RouteError } = await import("../runtime/routes/errors.js");
+const { ROUTES } = await import("../runtime/routes/disk-pressure-routes.js");
+
+type DiskPressureRouteResult = {
+  status: {
+    enabled: boolean;
+    state: string;
+    locked: boolean;
+    acknowledged: boolean;
+    overrideActive: boolean;
+    effectivelyLocked: boolean;
+    lockId: string | null;
+    usagePercent: number | null;
+    thresholdPercent: number;
+    path: string | null;
+    lastCheckedAt: string | null;
+    blockedCapabilities: string[];
+    error: string | null;
+  };
+};
+
+function setFeatureFlag(enabled: boolean): void {
+  _setOverridesForTesting({ "safe-storage-limits": enabled });
+}
+
+function setDiskUsage(usedMb: number, totalMb = 100): void {
+  diskSample = {
+    path: "/workspace",
+    totalMb,
+    usedMb,
+    freeMb: Math.max(0, totalMb - usedMb),
+  };
+}
+
+function getRoute(endpoint: string, method: string) {
+  const route = ROUTES.find(
+    (r) => r.endpoint === endpoint && r.method === method,
+  );
+  if (!route) throw new Error(`${method} ${endpoint} route not registered`);
+  return route;
+}
+
+async function callRoute(
+  endpoint: string,
+  method: string,
+  body?: Record<string, unknown>,
+): Promise<DiskPressureRouteResult> {
+  return (await getRoute(endpoint, method).handler({
+    body,
+  })) as DiskPressureRouteResult;
+}
+
+function expectRouteError(
+  error: unknown,
+  code: string,
+  statusCode: number,
+): void {
+  expect(error).toBeInstanceOf(RouteError);
+  const routeError = error as RouteError;
+  expect(routeError.code).toBe(code);
+  expect(routeError.statusCode).toBe(statusCode);
+}
+
+async function expectRouteRejects(
+  endpoint: string,
+  method: string,
+  body: Record<string, unknown> | undefined,
+  code: string,
+  statusCode: number,
+): Promise<void> {
+  try {
+    await callRoute(endpoint, method, body);
+    throw new Error("Expected route to reject");
+  } catch (error) {
+    expectRouteError(error, code, statusCode);
+  }
+}
+
+async function flushPublishedEvents(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  __resetDiskPressureGuardForTests();
+  setFeatureFlag(true);
+  setDiskUsage(10);
+});
+
+afterEach(() => {
+  __resetDiskPressureGuardForTests();
+  _setOverridesForTesting({});
+  diskSample = null;
+  eventSubscribers.clear();
+});
+
+describe("disk pressure routes", () => {
+  test("registers routes and route auth policies", () => {
+    for (const [endpoint, method] of [
+      ["disk-pressure/status", "GET"],
+      ["disk-pressure/acknowledge", "POST"],
+      ["disk-pressure/override", "POST"],
+    ] as const) {
+      expect(
+        ROUTES.some(
+          (route) => route.endpoint === endpoint && route.method === method,
+        ),
+      ).toBe(true);
+      expect(getPolicy(endpoint)).toBeDefined();
+    }
+  });
+
+  test("returns disabled status without error when the feature flag is off", async () => {
+    setFeatureFlag(false);
+    setDiskUsage(99);
+
+    const result = await callRoute("disk-pressure/status", "GET");
+
+    expect(result.status).toMatchObject({
+      enabled: false,
+      state: "disabled",
+      locked: false,
+      acknowledged: false,
+      overrideActive: false,
+      effectivelyLocked: false,
+      lockId: null,
+      usagePercent: null,
+      path: null,
+      lastCheckedAt: null,
+      blockedCapabilities: [],
+      error: null,
+    });
+    expect(result.status.thresholdPercent).toBe(
+      DISK_PRESSURE_THRESHOLD_PERCENT,
+    );
+  });
+
+  test("returns the full status shape for an active lock", async () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+
+    const result = await callRoute("disk-pressure/status", "GET");
+
+    expect(result.status.enabled).toBe(true);
+    expect(result.status.state).toBe("critical");
+    expect(result.status.locked).toBe(true);
+    expect(result.status.acknowledged).toBe(false);
+    expect(result.status.overrideActive).toBe(false);
+    expect(result.status.effectivelyLocked).toBe(true);
+    expect(result.status.lockId).toBeTruthy();
+    expect(result.status.usagePercent).toBe(99);
+    expect(result.status.thresholdPercent).toBe(
+      DISK_PRESSURE_THRESHOLD_PERCENT,
+    );
+    expect(result.status.path).toBe("/workspace");
+    expect(result.status.lastCheckedAt).toBeTruthy();
+    expect(result.status.blockedCapabilities).toEqual([
+      "agent-turns",
+      "background-work",
+      "remote-ingress",
+    ]);
+    expect(result.status.error).toBeNull();
+  });
+
+  test("acknowledges an active lock without overriding it", async () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+
+    const result = await callRoute("disk-pressure/acknowledge", "POST");
+
+    expect(result.status.acknowledged).toBe(true);
+    expect(result.status.overrideActive).toBe(false);
+    expect(result.status.effectivelyLocked).toBe(true);
+  });
+
+  test("overrides an active lock only after the confirmation phrase", async () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+
+    const result = await callRoute("disk-pressure/override", "POST", {
+      confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+    });
+
+    expect(result.status.locked).toBe(true);
+    expect(result.status.overrideActive).toBe(true);
+    expect(result.status.effectivelyLocked).toBe(false);
+  });
+
+  test("rejects an invalid override phrase with INVALID_CONFIRMATION", async () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+
+    await expectRouteRejects(
+      "disk-pressure/override",
+      "POST",
+      { confirmation: "I accept the risks" },
+      "INVALID_CONFIRMATION",
+      400,
+    );
+  });
+
+  test("rejects acknowledgement and override when no lock is active", async () => {
+    setDiskUsage(10);
+    evaluateDiskPressureNow();
+
+    await expectRouteRejects(
+      "disk-pressure/acknowledge",
+      "POST",
+      undefined,
+      "NOT_LOCKED",
+      409,
+    );
+    await expectRouteRejects(
+      "disk-pressure/override",
+      "POST",
+      { confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION },
+      "NOT_LOCKED",
+      409,
+    );
+  });
+
+  test("rejects repeated acknowledgement", async () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+    await callRoute("disk-pressure/acknowledge", "POST");
+
+    await expectRouteRejects(
+      "disk-pressure/acknowledge",
+      "POST",
+      undefined,
+      "ALREADY_ACKNOWLEDGED",
+      409,
+    );
+  });
+
+  test("rejects repeated override", async () => {
+    setDiskUsage(99);
+    evaluateDiskPressureNow();
+    await callRoute("disk-pressure/override", "POST", {
+      confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+    });
+
+    await expectRouteRejects(
+      "disk-pressure/override",
+      "POST",
+      { confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION },
+      "ALREADY_OVERRIDDEN",
+      409,
+    );
+  });
+
+  test("emits typed status-change events for lock, acknowledgement, override, usage, and unlock changes", async () => {
+    const events: unknown[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        if (event.message.type === "disk_pressure_status_changed") {
+          events.push(event.message);
+        }
+      },
+    });
+
+    try {
+      setDiskUsage(99);
+      evaluateDiskPressureNow();
+      await callRoute("disk-pressure/acknowledge", "POST");
+      await callRoute("disk-pressure/override", "POST", {
+        confirmation: DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+      });
+      setDiskUsage(98);
+      evaluateDiskPressureNow();
+      setDiskUsage(10);
+      evaluateDiskPressureNow();
+      await flushPublishedEvents();
+    } finally {
+      subscription.dispose();
+    }
+
+    const statuses = events.map(
+      (message) =>
+        (message as { status: DiskPressureRouteResult["status"] }).status,
+    );
+    expect(statuses.map((status) => status.state)).toEqual([
+      "ok",
+      "critical",
+      "critical",
+      "critical",
+      "critical",
+      "ok",
+    ]);
+    expect(statuses[0].enabled).toBe(true);
+    expect(statuses[2].acknowledged).toBe(true);
+    expect(statuses[2].overrideActive).toBe(false);
+    expect(statuses[3].overrideActive).toBe(true);
+    expect(statuses[3].effectivelyLocked).toBe(false);
+    expect(statuses[4].usagePercent).toBe(98);
+    expect(statuses[5].locked).toBe(false);
+    expect(statuses[5].lockId).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/disk-pressure-routes.test.ts
+++ b/assistant/src/__tests__/disk-pressure-routes.test.ts
@@ -191,6 +191,7 @@ describe("disk pressure routes", () => {
 
   test("returns the full status shape for an active lock", async () => {
     setDiskUsage(99);
+    evaluateDiskPressureNow();
 
     const result = await callRoute("disk-pressure/status", "GET");
 
@@ -215,7 +216,7 @@ describe("disk pressure routes", () => {
     expect(result.status.error).toBeNull();
   });
 
-  test("refreshes status from disk without emitting a read-path status event", async () => {
+  test("returns cached status without sampling or emitting a read-path status event", async () => {
     const events: unknown[] = [];
     const subscription = assistantEventHub.subscribe({
       type: "process",
@@ -232,9 +233,9 @@ describe("disk pressure routes", () => {
       const result = await callRoute("disk-pressure/status", "GET");
       await flushPublishedEvents();
 
-      expect(result.status.state).toBe("critical");
-      expect(result.status.locked).toBe(true);
-      expect(result.status.usagePercent).toBe(99);
+      expect(result.status.state).toBe("ok");
+      expect(result.status.locked).toBe(false);
+      expect(result.status.usagePercent).toBeNull();
       expect(events).toEqual([]);
     } finally {
       subscription.dispose();

--- a/assistant/src/__tests__/disk-pressure-routes.test.ts
+++ b/assistant/src/__tests__/disk-pressure-routes.test.ts
@@ -110,7 +110,7 @@ function expectRouteError(
   statusCode: number,
 ): void {
   expect(error).toBeInstanceOf(RouteError);
-  const routeError = error as RouteError;
+  const routeError = error as { code: string; statusCode: number };
   expect(routeError.code).toBe(code);
   expect(routeError.statusCode).toBe(statusCode);
 }

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -3,6 +3,7 @@ import { getConfig } from "../config/loader.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { getDiskUsageInfo } from "../util/disk-usage.js";
+import { getLogger } from "../util/logger.js";
 
 export const DISK_PRESSURE_THRESHOLD_PERCENT = 95;
 export const DISK_PRESSURE_CHECK_INTERVAL_MS = 60_000;
@@ -52,6 +53,12 @@ interface DiskPressureGuardState {
   status: DiskPressureStatus;
 }
 
+interface StatusChangeOptions {
+  emitStatusChanged?: boolean;
+}
+
+const log = getLogger("disk-pressure-guard");
+
 const DISABLED_STATUS: DiskPressureStatus = {
   enabled: false,
   state: "disabled",
@@ -88,24 +95,34 @@ function cloneStatus(status: DiskPressureStatus): DiskPressureStatus {
 }
 
 function statusFingerprint(status: DiskPressureStatus): string {
-  return JSON.stringify(status);
+  const { lastCheckedAt: _lastCheckedAt, ...substantiveStatus } = status;
+  return JSON.stringify(substantiveStatus);
 }
 
 function publishStatusChangedIfNeeded(previous: DiskPressureStatus): void {
   if (statusFingerprint(previous) === statusFingerprint(state.status)) return;
   const status = cloneStatus(state.status);
-  void assistantEventHub.publish(
-    buildAssistantEvent({
-      type: "disk_pressure_status_changed",
-      status,
-    }),
-  );
+  assistantEventHub
+    .publish(
+      buildAssistantEvent({
+        type: "disk_pressure_status_changed",
+        status,
+      }),
+    )
+    .catch((err) => {
+      log.warn({ err }, "Failed to publish disk pressure status change");
+    });
 }
 
-function replaceStatus(next: DiskPressureStatus): DiskPressureStatus {
+function replaceStatus(
+  next: DiskPressureStatus,
+  options: StatusChangeOptions = {},
+): DiskPressureStatus {
   const previous = cloneStatus(state.status);
   state.status = cloneStatus(next);
-  publishStatusChangedIfNeeded(previous);
+  if (options.emitStatusChanged !== false) {
+    publishStatusChangedIfNeeded(previous);
+  }
   return cloneStatus(state.status);
 }
 
@@ -113,18 +130,24 @@ function isEnabled(): boolean {
   return isAssistantFeatureFlagEnabled("safe-storage-limits", getConfig());
 }
 
-function resetToDisabled(): DiskPressureStatus {
+function resetToDisabled(
+  options: StatusChangeOptions = {},
+): DiskPressureStatus {
   const previous = cloneStatus(state.status);
   stopDiskPressureGuard();
   state.status = cloneStatus(DISABLED_STATUS);
-  publishStatusChangedIfNeeded(previous);
+  if (options.emitStatusChanged !== false) {
+    publishStatusChangedIfNeeded(previous);
+  }
   return cloneStatus(state.status);
 }
 
-function ensureEnabledStatus(): DiskPressureStatus | null {
-  if (!isEnabled()) return resetToDisabled();
+function ensureEnabledStatus(
+  options: StatusChangeOptions = {},
+): DiskPressureStatus | null {
+  if (!isEnabled()) return resetToDisabled(options);
   if (!state.status.enabled) {
-    replaceStatus(OPEN_STATUS);
+    state.status = cloneStatus(OPEN_STATUS);
   }
   return null;
 }
@@ -189,19 +212,24 @@ export function stopDiskPressureGuard(): void {
   state.timer = null;
 }
 
-export function evaluateDiskPressureNow(): DiskPressureStatus {
-  const disabledStatus = ensureEnabledStatus();
+export function evaluateDiskPressureNow(
+  options: StatusChangeOptions = {},
+): DiskPressureStatus {
+  const disabledStatus = ensureEnabledStatus(options);
   if (disabledStatus) return disabledStatus;
 
   let usageInfo: ReturnType<typeof getDiskUsageInfo>;
   try {
     usageInfo = getDiskUsageInfo();
   } catch (error) {
-    return replaceStatus(sampleFailureStatus(error));
+    return replaceStatus(sampleFailureStatus(error), options);
   }
 
   if (!usageInfo || usageInfo.totalMb <= 0) {
-    return replaceStatus(sampleFailureStatus("Disk usage sample unavailable"));
+    return replaceStatus(
+      sampleFailureStatus("Disk usage sample unavailable"),
+      options,
+    );
   }
 
   const usagePercent = roundPercent(
@@ -211,36 +239,42 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
   const lastCheckedAt = new Date().toISOString();
 
   if (!isCritical) {
-    return replaceStatus({
-      ...OPEN_STATUS,
-      usagePercent,
-      path: usageInfo.path,
-      lastCheckedAt,
-    });
+    return replaceStatus(
+      {
+        ...OPEN_STATUS,
+        usagePercent,
+        path: usageInfo.path,
+        lastCheckedAt,
+      },
+      options,
+    );
   }
 
   const lockId = state.status.locked ? state.status.lockId : nextLockId();
-  return replaceStatus({
-    enabled: true,
-    state: "critical",
-    locked: true,
-    acknowledged: state.status.locked ? state.status.acknowledged : false,
-    overrideActive: state.status.locked ? state.status.overrideActive : false,
-    effectivelyLocked: state.status.locked
-      ? !state.status.overrideActive
-      : true,
-    lockId,
-    usagePercent,
-    thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
-    path: usageInfo.path,
-    lastCheckedAt,
-    blockedCapabilities: [...DISK_PRESSURE_BLOCKED_CAPABILITIES],
-    error: null,
-  });
+  return replaceStatus(
+    {
+      enabled: true,
+      state: "critical",
+      locked: true,
+      acknowledged: state.status.locked ? state.status.acknowledged : false,
+      overrideActive: state.status.locked ? state.status.overrideActive : false,
+      effectivelyLocked: state.status.locked
+        ? !state.status.overrideActive
+        : true,
+      lockId,
+      usagePercent,
+      thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
+      path: usageInfo.path,
+      lastCheckedAt,
+      blockedCapabilities: [...DISK_PRESSURE_BLOCKED_CAPABILITIES],
+      error: null,
+    },
+    options,
+  );
 }
 
 export function getDiskPressureStatus(): DiskPressureStatus {
-  const disabledStatus = ensureEnabledStatus();
+  const disabledStatus = ensureEnabledStatus({ emitStatusChanged: false });
   if (disabledStatus) return disabledStatus;
   return cloneStatus(state.status);
 }

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -1,5 +1,7 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { getDiskUsageInfo } from "../util/disk-usage.js";
 
 export const DISK_PRESSURE_THRESHOLD_PERCENT = 95;
@@ -36,7 +38,11 @@ export type DiskPressureTransitionResult =
   | { ok: true; status: DiskPressureStatus }
   | {
       ok: false;
-      reason: "not_locked" | "already_overridden" | "invalid_confirmation";
+      reason:
+        | "not_locked"
+        | "already_acknowledged"
+        | "already_overridden"
+        | "invalid_confirmation";
       message: string;
       status: DiskPressureStatus;
     };
@@ -81,20 +87,44 @@ function cloneStatus(status: DiskPressureStatus): DiskPressureStatus {
   };
 }
 
+function statusFingerprint(status: DiskPressureStatus): string {
+  return JSON.stringify(status);
+}
+
+function publishStatusChangedIfNeeded(previous: DiskPressureStatus): void {
+  if (statusFingerprint(previous) === statusFingerprint(state.status)) return;
+  const status = cloneStatus(state.status);
+  void assistantEventHub.publish(
+    buildAssistantEvent({
+      type: "disk_pressure_status_changed",
+      status,
+    }),
+  );
+}
+
+function replaceStatus(next: DiskPressureStatus): DiskPressureStatus {
+  const previous = cloneStatus(state.status);
+  state.status = cloneStatus(next);
+  publishStatusChangedIfNeeded(previous);
+  return cloneStatus(state.status);
+}
+
 function isEnabled(): boolean {
   return isAssistantFeatureFlagEnabled("safe-storage-limits", getConfig());
 }
 
 function resetToDisabled(): DiskPressureStatus {
+  const previous = cloneStatus(state.status);
   stopDiskPressureGuard();
   state.status = cloneStatus(DISABLED_STATUS);
+  publishStatusChangedIfNeeded(previous);
   return cloneStatus(state.status);
 }
 
 function ensureEnabledStatus(): DiskPressureStatus | null {
   if (!isEnabled()) return resetToDisabled();
   if (!state.status.enabled) {
-    state.status = cloneStatus(OPEN_STATUS);
+    replaceStatus(OPEN_STATUS);
   }
   return null;
 }
@@ -167,13 +197,11 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
   try {
     usageInfo = getDiskUsageInfo();
   } catch (error) {
-    state.status = sampleFailureStatus(error);
-    return cloneStatus(state.status);
+    return replaceStatus(sampleFailureStatus(error));
   }
 
   if (!usageInfo || usageInfo.totalMb <= 0) {
-    state.status = sampleFailureStatus("Disk usage sample unavailable");
-    return cloneStatus(state.status);
+    return replaceStatus(sampleFailureStatus("Disk usage sample unavailable"));
   }
 
   const usagePercent = roundPercent(
@@ -183,17 +211,16 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
   const lastCheckedAt = new Date().toISOString();
 
   if (!isCritical) {
-    state.status = {
+    return replaceStatus({
       ...OPEN_STATUS,
       usagePercent,
       path: usageInfo.path,
       lastCheckedAt,
-    };
-    return cloneStatus(state.status);
+    });
   }
 
   const lockId = state.status.locked ? state.status.lockId : nextLockId();
-  state.status = {
+  return replaceStatus({
     enabled: true,
     state: "critical",
     locked: true,
@@ -209,9 +236,7 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
     lastCheckedAt,
     blockedCapabilities: [...DISK_PRESSURE_BLOCKED_CAPABILITIES],
     error: null,
-  };
-
-  return cloneStatus(state.status);
+  });
 }
 
 export function getDiskPressureStatus(): DiskPressureStatus {
@@ -231,7 +256,17 @@ export function acknowledgeDiskPressureLock(): DiskPressureTransitionResult {
     );
   }
 
+  if (status.acknowledged) {
+    return rejectTransition(
+      "already_acknowledged",
+      "The disk pressure lock has already been acknowledged.",
+      status,
+    );
+  }
+
+  const previous = cloneStatus(state.status);
   state.status.acknowledged = true;
+  publishStatusChangedIfNeeded(previous);
   return { ok: true, status: cloneStatus(state.status) };
 }
 
@@ -264,8 +299,10 @@ export function overrideDiskPressureLock(
     );
   }
 
+  const previous = cloneStatus(state.status);
   state.status.overrideActive = true;
   state.status.effectivelyLocked = false;
+  publishStatusChangedIfNeeded(previous);
   return { ok: true, status: cloneStatus(state.status) };
 }
 

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -53,10 +53,6 @@ interface DiskPressureGuardState {
   status: DiskPressureStatus;
 }
 
-interface StatusChangeOptions {
-  emitStatusChanged?: boolean;
-}
-
 const log = getLogger("disk-pressure-guard");
 
 const DISABLED_STATUS: DiskPressureStatus = {
@@ -114,15 +110,10 @@ function publishStatusChangedIfNeeded(previous: DiskPressureStatus): void {
     });
 }
 
-function replaceStatus(
-  next: DiskPressureStatus,
-  options: StatusChangeOptions = {},
-): DiskPressureStatus {
+function replaceStatus(next: DiskPressureStatus): DiskPressureStatus {
   const previous = cloneStatus(state.status);
   state.status = cloneStatus(next);
-  if (options.emitStatusChanged !== false) {
-    publishStatusChangedIfNeeded(previous);
-  }
+  publishStatusChangedIfNeeded(previous);
   return cloneStatus(state.status);
 }
 
@@ -130,22 +121,16 @@ function isEnabled(): boolean {
   return isAssistantFeatureFlagEnabled("safe-storage-limits", getConfig());
 }
 
-function resetToDisabled(
-  options: StatusChangeOptions = {},
-): DiskPressureStatus {
+function resetToDisabled(): DiskPressureStatus {
   const previous = cloneStatus(state.status);
   stopDiskPressureGuard();
   state.status = cloneStatus(DISABLED_STATUS);
-  if (options.emitStatusChanged !== false) {
-    publishStatusChangedIfNeeded(previous);
-  }
+  publishStatusChangedIfNeeded(previous);
   return cloneStatus(state.status);
 }
 
-function ensureEnabledStatus(
-  options: StatusChangeOptions = {},
-): DiskPressureStatus | null {
-  if (!isEnabled()) return resetToDisabled(options);
+function ensureEnabledStatus(): DiskPressureStatus | null {
+  if (!isEnabled()) return resetToDisabled();
   if (!state.status.enabled) {
     state.status = cloneStatus(OPEN_STATUS);
   }
@@ -212,24 +197,19 @@ export function stopDiskPressureGuard(): void {
   state.timer = null;
 }
 
-export function evaluateDiskPressureNow(
-  options: StatusChangeOptions = {},
-): DiskPressureStatus {
-  const disabledStatus = ensureEnabledStatus(options);
+export function evaluateDiskPressureNow(): DiskPressureStatus {
+  const disabledStatus = ensureEnabledStatus();
   if (disabledStatus) return disabledStatus;
 
   let usageInfo: ReturnType<typeof getDiskUsageInfo>;
   try {
     usageInfo = getDiskUsageInfo();
   } catch (error) {
-    return replaceStatus(sampleFailureStatus(error), options);
+    return replaceStatus(sampleFailureStatus(error));
   }
 
   if (!usageInfo || usageInfo.totalMb <= 0) {
-    return replaceStatus(
-      sampleFailureStatus("Disk usage sample unavailable"),
-      options,
-    );
+    return replaceStatus(sampleFailureStatus("Disk usage sample unavailable"));
   }
 
   const usagePercent = roundPercent(
@@ -239,43 +219,37 @@ export function evaluateDiskPressureNow(
   const lastCheckedAt = new Date().toISOString();
 
   if (!isCritical) {
-    return replaceStatus(
-      {
-        ...OPEN_STATUS,
-        usagePercent,
-        path: usageInfo.path,
-        lastCheckedAt,
-      },
-      options,
-    );
+    return replaceStatus({
+      ...OPEN_STATUS,
+      usagePercent,
+      path: usageInfo.path,
+      lastCheckedAt,
+    });
   }
 
   const lockId = state.status.locked ? state.status.lockId : nextLockId();
-  return replaceStatus(
-    {
-      enabled: true,
-      state: "critical",
-      locked: true,
-      acknowledged: state.status.locked ? state.status.acknowledged : false,
-      overrideActive: state.status.locked ? state.status.overrideActive : false,
-      effectivelyLocked: state.status.locked
-        ? !state.status.overrideActive
-        : true,
-      lockId,
-      usagePercent,
-      thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
-      path: usageInfo.path,
-      lastCheckedAt,
-      blockedCapabilities: [...DISK_PRESSURE_BLOCKED_CAPABILITIES],
-      error: null,
-    },
-    options,
-  );
+  return replaceStatus({
+    enabled: true,
+    state: "critical",
+    locked: true,
+    acknowledged: state.status.locked ? state.status.acknowledged : false,
+    overrideActive: state.status.locked ? state.status.overrideActive : false,
+    effectivelyLocked: state.status.locked
+      ? !state.status.overrideActive
+      : true,
+    lockId,
+    usagePercent,
+    thresholdPercent: DISK_PRESSURE_THRESHOLD_PERCENT,
+    path: usageInfo.path,
+    lastCheckedAt,
+    blockedCapabilities: [...DISK_PRESSURE_BLOCKED_CAPABILITIES],
+    error: null,
+  });
 }
 
 export function getDiskPressureStatus(): DiskPressureStatus {
-  const disabledStatus = ensureEnabledStatus({ emitStatusChanged: false });
-  if (disabledStatus) return disabledStatus;
+  if (!isEnabled()) return cloneStatus(DISABLED_STATUS);
+  if (!state.status.enabled) return cloneStatus(OPEN_STATUS);
   return cloneStatus(state.status);
 }
 

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -20,6 +20,7 @@ export * from "./message-types/computer-use.js";
 export * from "./message-types/contacts.js";
 export * from "./message-types/conversations.js";
 export * from "./message-types/diagnostics.js";
+export * from "./message-types/disk-pressure.js";
 export * from "./message-types/documents.js";
 export * from "./message-types/guardian-actions.js";
 export * from "./message-types/home.js";
@@ -71,6 +72,7 @@ import type {
   _DiagnosticsClientMessages,
   _DiagnosticsServerMessages,
 } from "./message-types/diagnostics.js";
+import type { _DiskPressureServerMessages } from "./message-types/disk-pressure.js";
 import type {
   _DocumentsClientMessages,
   _DocumentsServerMessages,
@@ -203,6 +205,7 @@ export type ServerMessage =
   | _NotificationsServerMessages
   | _UpgradesServerMessages
   | _AcpServerMessages
+  | _DiskPressureServerMessages
   | SubagentEvent;
 
 // === Contract schema ===

--- a/assistant/src/daemon/message-types/disk-pressure.ts
+++ b/assistant/src/daemon/message-types/disk-pressure.ts
@@ -1,0 +1,9 @@
+import type { DiskPressureStatus } from "../disk-pressure-guard.js";
+
+/** Server push when the disk pressure status snapshot changes. */
+export interface DiskPressureStatusChanged {
+  type: "disk_pressure_status_changed";
+  status: DiskPressureStatus;
+}
+
+export type _DiskPressureServerMessages = DiskPressureStatusChanged;

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -186,6 +186,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "calls/instruction", scopes: ["calls.write"] },
 
   // Settings / integrations / identity
+  { endpoint: "disk-pressure/status", scopes: ["settings.read"] },
+  { endpoint: "disk-pressure/acknowledge", scopes: ["settings.write"] },
+  { endpoint: "disk-pressure/override", scopes: ["settings.write"] },
   { endpoint: "ps", scopes: ["settings.read"] },
   { endpoint: "identity", scopes: ["settings.read"] },
   { endpoint: "identity/intro", scopes: ["settings.read"] },
@@ -587,7 +590,7 @@ const INTERNAL_ENDPOINTS = [
   "internal/oauth/callback",
   "internal/mcp/auth/start",
   "internal/mcp/auth/status",
-  "internal/mcp/reload",  // ← new
+  "internal/mcp/reload", // ← new
 ];
 for (const endpoint of INTERNAL_ENDPOINTS) {
   registerPolicy(endpoint, {

--- a/assistant/src/runtime/routes/disk-pressure-routes.ts
+++ b/assistant/src/runtime/routes/disk-pressure-routes.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+
+import {
+  acknowledgeDiskPressureLock,
+  DISK_PRESSURE_OVERRIDE_CONFIRMATION,
+  getDiskPressureStatus,
+  overrideDiskPressureLock,
+} from "../../daemon/disk-pressure-guard.js";
+import { RouteError } from "./errors.js";
+import type { RouteDefinition } from "./types.js";
+
+const DiskPressureStatusSchema = z.object({
+  enabled: z.boolean(),
+  state: z.enum(["disabled", "ok", "critical", "unknown"]),
+  locked: z.boolean(),
+  acknowledged: z.boolean(),
+  overrideActive: z.boolean(),
+  effectivelyLocked: z.boolean(),
+  lockId: z.string().nullable(),
+  usagePercent: z.number().nullable(),
+  thresholdPercent: z.number(),
+  path: z.string().nullable(),
+  lastCheckedAt: z.string().nullable(),
+  blockedCapabilities: z.array(
+    z.enum(["agent-turns", "background-work", "remote-ingress"]),
+  ),
+  error: z.string().nullable(),
+});
+
+const DiskPressureActionResponseSchema = z.object({
+  status: DiskPressureStatusSchema,
+});
+
+const OverrideRequestSchema = z.object({
+  confirmation: z.string(),
+});
+
+function statusResponse() {
+  return { status: getDiskPressureStatus() };
+}
+
+function transitionErrorCode(
+  reason: "not_locked" | "already_acknowledged" | "already_overridden",
+): string {
+  if (reason === "not_locked") return "NOT_LOCKED";
+  if (reason === "already_acknowledged") return "ALREADY_ACKNOWLEDGED";
+  return "ALREADY_OVERRIDDEN";
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "getDiskPressureStatus",
+    endpoint: "disk-pressure/status",
+    method: "GET",
+    policyKey: "disk-pressure/status",
+    requirePolicyEnforcement: true,
+    summary: "Get disk pressure status",
+    description:
+      "Return the current disk pressure status snapshot. When safe storage limits are disabled, returns a disabled status.",
+    tags: ["disk-pressure"],
+    responseBody: DiskPressureActionResponseSchema,
+    handler: () => statusResponse(),
+  },
+  {
+    operationId: "acknowledgeDiskPressure",
+    endpoint: "disk-pressure/acknowledge",
+    method: "POST",
+    policyKey: "disk-pressure/acknowledge",
+    requirePolicyEnforcement: true,
+    summary: "Acknowledge disk pressure",
+    description:
+      "Acknowledge the current disk pressure lock and enter cleanup mode without overriding assistant protections.",
+    tags: ["disk-pressure"],
+    responseBody: DiskPressureActionResponseSchema,
+    additionalResponses: {
+      "409": { description: "No active lock or lock already acknowledged." },
+    },
+    handler: () => {
+      const result = acknowledgeDiskPressureLock();
+      if (result.ok) return { status: result.status };
+      if (result.reason === "invalid_confirmation") {
+        throw new RouteError(result.message, "INVALID_CONFIRMATION", 400);
+      }
+      throw new RouteError(
+        result.message,
+        transitionErrorCode(result.reason),
+        409,
+      );
+    },
+  },
+  {
+    operationId: "overrideDiskPressure",
+    endpoint: "disk-pressure/override",
+    method: "POST",
+    policyKey: "disk-pressure/override",
+    requirePolicyEnforcement: true,
+    summary: "Override disk pressure",
+    description: `Override the current disk pressure lock only after confirming "${DISK_PRESSURE_OVERRIDE_CONFIRMATION}".`,
+    tags: ["disk-pressure"],
+    requestBody: OverrideRequestSchema,
+    responseBody: DiskPressureActionResponseSchema,
+    additionalResponses: {
+      "400": { description: "Confirmation phrase is invalid." },
+      "409": { description: "No active lock or lock already overridden." },
+    },
+    handler: ({ body }) => {
+      const parsed = OverrideRequestSchema.safeParse(body);
+      const confirmation = parsed.success ? parsed.data.confirmation : "";
+      const result = overrideDiskPressureLock(confirmation);
+      if (result.ok) return { status: result.status };
+      if (result.reason === "invalid_confirmation") {
+        throw new RouteError(result.message, "INVALID_CONFIRMATION", 400);
+      }
+      throw new RouteError(
+        result.message,
+        transitionErrorCode(result.reason),
+        409,
+      );
+    },
+  },
+];

--- a/assistant/src/runtime/routes/disk-pressure-routes.ts
+++ b/assistant/src/runtime/routes/disk-pressure-routes.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import {
   acknowledgeDiskPressureLock,
   DISK_PRESSURE_OVERRIDE_CONFIRMATION,
-  getDiskPressureStatus,
+  evaluateDiskPressureNow,
   overrideDiskPressureLock,
 } from "../../daemon/disk-pressure-guard.js";
 import { RouteError } from "./errors.js";
@@ -36,7 +36,9 @@ const OverrideRequestSchema = z.object({
 });
 
 function statusResponse() {
-  return { status: getDiskPressureStatus() };
+  return {
+    status: evaluateDiskPressureNow({ emitStatusChanged: false }),
+  };
 }
 
 function transitionErrorCode(

--- a/assistant/src/runtime/routes/disk-pressure-routes.ts
+++ b/assistant/src/runtime/routes/disk-pressure-routes.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import {
   acknowledgeDiskPressureLock,
   DISK_PRESSURE_OVERRIDE_CONFIRMATION,
-  evaluateDiskPressureNow,
+  getDiskPressureStatus,
   overrideDiskPressureLock,
 } from "../../daemon/disk-pressure-guard.js";
 import { RouteError } from "./errors.js";
@@ -36,9 +36,7 @@ const OverrideRequestSchema = z.object({
 });
 
 function statusResponse() {
-  return {
-    status: evaluateDiskPressureNow({ emitStatusChanged: false }),
-  };
+  return { status: getDiskPressureStatus() };
 }
 
 function transitionErrorCode(

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -40,6 +40,7 @@ import { ROUTES as CREDENTIAL_PROMPT_ROUTES } from "./credential-prompt-routes.j
 import { ROUTES as DEBUG_ROUTES } from "./debug-routes.js";
 import { ROUTES as DEFER_ROUTES } from "./defer-routes.js";
 import { ROUTES as DIAGNOSTICS_ROUTES } from "./diagnostics-routes.js";
+import { ROUTES as DISK_PRESSURE_ROUTES } from "./disk-pressure-routes.js";
 import { ROUTES as DOCUMENT_ROUTES } from "./documents-routes.js";
 import { ROUTES as EVENTS_ROUTES } from "./events-routes.js";
 import { ROUTES as FILING_ROUTES } from "./filing-routes.js";
@@ -139,6 +140,7 @@ export const ROUTES: RouteDefinition[] = [
   ...CONVERSATION_STARTER_ROUTES,
   ...DEBUG_ROUTES,
   ...DIAGNOSTICS_ROUTES,
+  ...DISK_PRESSURE_ROUTES,
   ...DOCUMENT_ROUTES,
   ...EVENTS_ROUTES,
   ...FILING_ROUTES,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1307,6 +1307,48 @@ public struct DictationResponse: Codable, Sendable {
     }
 }
 
+public struct DiskPressureStatus: Codable, Sendable {
+    public let enabled: Bool
+    public let state: String
+    public let locked: Bool
+    public let acknowledged: Bool
+    public let overrideActive: Bool
+    public let effectivelyLocked: Bool
+    public let lockId: String?
+    public let usagePercent: Double?
+    public let thresholdPercent: Double
+    public let path: String?
+    public let lastCheckedAt: String?
+    public let blockedCapabilities: [String]
+    public let error: String?
+
+    public init(enabled: Bool, state: String, locked: Bool, acknowledged: Bool, overrideActive: Bool, effectivelyLocked: Bool, lockId: String? = nil, usagePercent: Double? = nil, thresholdPercent: Double, path: String? = nil, lastCheckedAt: String? = nil, blockedCapabilities: [String], error: String? = nil) {
+        self.enabled = enabled
+        self.state = state
+        self.locked = locked
+        self.acknowledged = acknowledged
+        self.overrideActive = overrideActive
+        self.effectivelyLocked = effectivelyLocked
+        self.lockId = lockId
+        self.usagePercent = usagePercent
+        self.thresholdPercent = thresholdPercent
+        self.path = path
+        self.lastCheckedAt = lastCheckedAt
+        self.blockedCapabilities = blockedCapabilities
+        self.error = error
+    }
+}
+
+public struct DiskPressureStatusChanged: Codable, Sendable {
+    public let type: String
+    public let status: DiskPressureStatus
+
+    public init(type: String, status: DiskPressureStatus) {
+        self.type = type
+        self.status = status
+    }
+}
+
 public struct DocumentEditorShow: Codable, Sendable {
     public let type: String
     public let conversationId: String

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2821,6 +2821,7 @@ public enum ServerMessage: Decodable, Sendable {
     case memoryStatus(MemoryStatusMessage)
     case memoryRecalled(MemoryRecalledMessage)
     case dictationResponse(DictationResponseMessage)
+    case diskPressureStatusChanged(DiskPressureStatusChanged)
     case error(ErrorMessage)
     case uiSurfaceShow(UiSurfaceShowMessage)
     case uiSurfaceUpdate(UiSurfaceUpdateMessage)
@@ -3048,6 +3049,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "dictation_response":
             let message = try DictationResponseMessage(from: decoder)
             self = .dictationResponse(message)
+        case "disk_pressure_status_changed":
+            let message = try DiskPressureStatusChanged(from: decoder)
+            self = .diskPressureStatusChanged(message)
         case "error":
             let message = try ErrorMessage(from: decoder)
             self = .error(message)


### PR DESCRIPTION
## Summary
- Add disk pressure status, acknowledge, and override runtime routes.
- Publish typed disk pressure status-change events for SSE clients.
- Register route auth/OpenAPI contract and add focused route/event coverage.

Part of plan: disk-pressure-protection.md (PR 4 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->