### PR TITLE
Suppress v1 graph pipeline when memory-v2-enabled is on

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -390,7 +390,12 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
   const originalAnalysisBatch = TEST_CONFIG.analysis.batchSize;
 
   beforeEach(() => {
-    _setOverridesForTesting({ "auto-analyze": true });
+    // memory-v2-enabled gates v1 graph_extract enqueue; force off so
+    // these cadence tests can observe the v1 path.
+    _setOverridesForTesting({
+      "auto-analyze": true,
+      "memory-v2-enabled": false,
+    });
     TEST_CONFIG.memory.extraction.batchSize = 2;
     TEST_CONFIG.analysis.batchSize = 5;
   });
@@ -535,5 +540,61 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
     const row = graphRows[0]!;
     expect(row.runAfter).toBeGreaterThanOrEqual(before - 1_000);
     expect(row.runAfter).toBeLessThanOrEqual(after + 1_000);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// Indexer v1/v2 mutual exclusion: when memory-v2-enabled is on AND
+// memory.v2.enabled is on, the v1 graph_extract enqueue is suppressed
+// (v2 reads from buffer.md, so v1 graph data is unread). When either
+// gate is off, v1 graph_extract fires.
+// ─────────────────────────────────────────────────────────────────
+
+describe("indexer v1/v2 mutual exclusion for graph_extract", () => {
+  // Force the v1 batch trigger so any enqueued row is observable.
+  const originalExtractionBatch = TEST_CONFIG.memory.extraction.batchSize;
+  const originalV2Enabled = TEST_CONFIG.memory.v2.enabled;
+
+  beforeEach(() => {
+    TEST_CONFIG.memory.extraction.batchSize = 1;
+  });
+
+  afterEach(() => {
+    TEST_CONFIG.memory.extraction.batchSize = originalExtractionBatch;
+    TEST_CONFIG.memory.v2.enabled = originalV2Enabled;
+  });
+
+  test("v2 active (flag on + config on) → graph_extract not enqueued", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    TEST_CONFIG.memory.v2.enabled = true;
+
+    const source = createConversation("v2-active");
+    await indexMessages(source.id, 2);
+
+    expect(countJobsOfType("graph_extract", source.id)).toBe(0);
+  });
+
+  test("flag off → graph_extract enqueued", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    TEST_CONFIG.memory.v2.enabled = true;
+
+    const source = createConversation("v2-flag-off");
+    await indexMessages(source.id, 2);
+
+    expect(countJobsOfType("graph_extract", source.id)).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  test("config gate off (flag on) → graph_extract enqueued", async () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    TEST_CONFIG.memory.v2.enabled = false;
+
+    const source = createConversation("v2-config-off");
+    await indexMessages(source.id, 2);
+
+    expect(countJobsOfType("graph_extract", source.id)).toBeGreaterThanOrEqual(
+      1,
+    );
   });
 });

--- a/assistant/src/cli/commands/memory-v2.ts
+++ b/assistant/src/cli/commands/memory-v2.ts
@@ -25,9 +25,9 @@
  *     violation lists). Does not mutate the workspace.
  *
  * Lives alongside the existing v1 `memory` command rather than replacing it
- * because v1 graph + PKB stays write-active until the cutover PR. Until the
- * `memory-v2-enabled` feature flag flips on, the workspace keeps both v1 and
- * v2 state side-by-side.
+ * so flipping `memory-v2-enabled` back to off fully re-engages the v1
+ * pipeline. While the flag is on, v1 graph extraction/maintenance and PKB
+ * filing are suppressed; v1 data stays in place but stops being updated.
  */
 
 import type { Command } from "commander";

--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -1,23 +1,23 @@
 /**
- * Tests for the v2 consolidation entry in `maybeEnqueueGraphMaintenanceJobs`.
+ * Tests for v1/v2 mutual exclusion in `maybeEnqueueGraphMaintenanceJobs`.
  *
- * Coverage matrix (from PR 24 acceptance criteria):
- *   - Flag off → no `memory_v2_consolidate` row enqueued, even after the
- *     interval has elapsed.
- *   - Flag on + config off → still no row enqueued (both gates required).
- *   - Flag on + config on, no prior checkpoint → row enqueued, checkpoint
- *     stamped to `nowMs`.
- *   - Flag on + config on, recent checkpoint → no row enqueued (interval
- *     not yet elapsed).
- *   - Flag on + config on, stale checkpoint → row enqueued, checkpoint
+ * The schedule is now mutually exclusive: when both the `memory-v2-enabled`
+ * flag and `memory.v2.enabled` config are on, only `memory_v2_consolidate`
+ * is scheduled; otherwise the four v1 entries (decay, consolidate,
+ * pattern_scan, narrative) fire and the v2 entry does not.
+ *
+ * Coverage:
+ *   - Flag off → only v1 entries fire (no `memory_v2_consolidate`).
+ *   - Flag on + config off → only v1 entries fire.
+ *   - Flag on + config on, no prior checkpoint → only the v2 entry fires.
+ *   - Flag on + config on, recent checkpoint → no v2 row (interval not
+ *     yet elapsed).
+ *   - Flag on + config on, stale checkpoint → v2 row enqueued, checkpoint
  *     refreshed.
- *   - The v1 maintenance entries (decay, consolidate, pattern_scan,
- *     narrative) still fire under the v2 path — adding the v2 entry must
- *     not regress v1 scheduling.
  *
- * The sweep job is intentionally NOT scheduled here: PR 24 wires it into
- * the `graph_extract` debounce in `indexer.ts`. Those triggers are covered
- * by the separate trigger-path tests; this file owns only the cron entries.
+ * The sweep job is intentionally NOT scheduled here: it is wired into the
+ * `graph_extract` debounce in `indexer.ts`. Those triggers are covered by
+ * the separate trigger-path tests; this file owns only the cron entries.
  *
  * Tests use a temp workspace pinned via `VELLUM_WORKSPACE_DIR` so the DB
  * lives under `tmpdir()` and `~/.vellum/` is never touched.
@@ -145,6 +145,11 @@ describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
     maybeEnqueueGraphMaintenanceJobs(config, Date.now());
 
     expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+    // v1 entries are suppressed when v2 is active.
+    expect(countPendingJobs("graph_decay")).toBe(0);
+    expect(countPendingJobs("graph_consolidate")).toBe(0);
+    expect(countPendingJobs("graph_pattern_scan")).toBe(0);
+    expect(countPendingJobs("graph_narrative_refine")).toBe(0);
   });
 
   test("does not enqueue consolidate before the interval has elapsed", () => {
@@ -200,11 +205,30 @@ describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
     expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
   });
 
-  test("v1 graph maintenance entries still fire alongside the v2 entry", () => {
+  test("v1 maintenance entries are suppressed when v2 is active", () => {
     _setOverridesForTesting({ "memory-v2-enabled": true });
     const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
 
-    // No checkpoints set — every entry should be due.
+    // No checkpoints set — every entry would be due if it were scheduled.
+    deleteMemoryCheckpoint("graph_maintenance:decay:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:consolidate:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:pattern_scan:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:narrative:last_run");
+    deleteMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY);
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("graph_decay")).toBe(0);
+    expect(countPendingJobs("graph_consolidate")).toBe(0);
+    expect(countPendingJobs("graph_pattern_scan")).toBe(0);
+    expect(countPendingJobs("graph_narrative_refine")).toBe(0);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+  });
+
+  test("flag-off path fires v1 entries and does not enqueue v2", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": false });
+    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+
     deleteMemoryCheckpoint("graph_maintenance:decay:last_run");
     deleteMemoryCheckpoint("graph_maintenance:consolidate:last_run");
     deleteMemoryCheckpoint("graph_maintenance:pattern_scan:last_run");
@@ -217,19 +241,25 @@ describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
     expect(countPendingJobs("graph_consolidate")).toBe(1);
     expect(countPendingJobs("graph_pattern_scan")).toBe(1);
     expect(countPendingJobs("graph_narrative_refine")).toBe(1);
-    expect(countPendingJobs("memory_v2_consolidate")).toBe(1);
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
   });
 
-  test("flag-off path does not enqueue v2 but still fires the v1 entries", () => {
-    _setOverridesForTesting({ "memory-v2-enabled": false });
-    const config = buildConfig({ v2Enabled: true, intervalHours: 1 });
+  test("config-gate-off path fires v1 entries and does not enqueue v2", () => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+    const config = buildConfig({ v2Enabled: false, intervalHours: 1 });
 
     deleteMemoryCheckpoint("graph_maintenance:decay:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:consolidate:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:pattern_scan:last_run");
+    deleteMemoryCheckpoint("graph_maintenance:narrative:last_run");
     deleteMemoryCheckpoint(CONSOLIDATE_CHECKPOINT_KEY);
 
     maybeEnqueueGraphMaintenanceJobs(config, Date.now());
 
     expect(countPendingJobs("graph_decay")).toBe(1);
+    expect(countPendingJobs("graph_consolidate")).toBe(1);
+    expect(countPendingJobs("graph_pattern_scan")).toBe(1);
+    expect(countPendingJobs("graph_narrative_refine")).toBe(1);
     expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
   });
 });

--- a/assistant/src/memory/context-search/sources/memory-v2.ts
+++ b/assistant/src/memory/context-search/sources/memory-v2.ts
@@ -47,10 +47,11 @@ import type {
 } from "../types.js";
 
 /**
- * True when both v2 gates are on. Single source of truth shared by the recall
- * `memory` source (which delegates to v2), the `pkb` source (which
- * short-circuits because v2 absorbs PKB as a read source), and the per-turn
- * PKB injectors (which go silent so v2 owns the read path end-to-end).
+ * True when both v2 gates are on. Single source of truth for whether v2 is
+ * the active memory subsystem — used by recall sources (`memory`, `pkb`),
+ * per-turn injectors, the indexer's v1 graph_extract suppression, and the
+ * v1/v2 maintenance scheduler. The historical name retains "Read" but the
+ * predicate now gates both read and write paths.
  */
 export function isMemoryV2ReadActive(config: AssistantConfig): boolean {
   return (

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -9,6 +9,7 @@ import { getLogger } from "../util/logger.js";
 import { enqueueAutoAnalysisIfEnabled } from "./auto-analysis-enqueue.js";
 import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
+import { isMemoryV2ReadActive } from "./context-search/sources/memory-v2.js";
 import { getDb } from "./db-connection.js";
 import { selectedBackendSupportsMultimodal } from "./embedding-backend.js";
 import { enqueueMemoryJob, upsertDebouncedJob } from "./jobs-store.js";
@@ -175,39 +176,9 @@ export async function indexMessageNow(
     // Summaries still run — they feed the graph retrieval pipeline and
     // are not recursion-prone.
     if (!isAutoAnalysisSource) {
-      // ── Graph extraction ────────────────────────────────────────────
-      const graphPendingKey = `graph_extract:${input.conversationId}:pending_count`;
-      const graphCurrentVal = getMemoryCheckpoint(graphPendingKey);
-      const graphPendingCount =
-        (graphCurrentVal ? parseInt(graphCurrentVal, 10) : 0) + 1;
-      setMemoryCheckpoint(graphPendingKey, String(graphPendingCount));
-
-      const graphBatchFired = graphPendingCount >= batchSize;
-      if (graphBatchFired) {
-        setMemoryCheckpoint(graphPendingKey, "0");
-      }
-
-      // Single pending `graph_extract` row per conversation. If the
-      // batch threshold just fired, pull `runAfter` back to now so the
-      // job runs immediately; otherwise debounce by the idle timeout.
-      // Routing both paths through `upsertDebouncedJob` ensures the
-      // row's `runAfter` reflects whichever trigger ran last, so a
-      // batch crossing always takes effect immediately.
-      const extractRunAfter = graphBatchFired
-        ? Date.now()
-        : Date.now() + idleTimeoutMs;
-      upsertDebouncedJob(
-        "graph_extract",
-        {
-          conversationId: input.conversationId,
-          scopeId: input.scopeId ?? "default",
-        },
-        extractRunAfter,
-      );
-
-      // Reading config here is best-effort: feature-gated triggers below
-      // (memory v2 sweep, auto-analyze batch) skip when it fails — the
-      // idle-debounced enqueues above are unaffected.
+      // Reading config here is best-effort: when it fails we treat v2 as
+      // inactive (failing-open to v1) so a config error never silently
+      // drops both extraction paths.
       let triggerConfig: ReturnType<typeof getConfig> | null = null;
       try {
         triggerConfig = getConfig();
@@ -218,20 +189,58 @@ export async function indexMessageNow(
         );
       }
 
-      // Memory v2 sweep mirrors graph_extract's debounce: when the v2
-      // flag + config are on AND `sweep_enabled` is set, every extraction
-      // trigger also enqueues a sweep. The sweep itself reads recent
-      // messages globally, so the `conversationId` here is just the dedup
-      // key — one pending row per active conversation. All three gates
-      // (feature flag, v2 master toggle, sweep_enabled) must be true.
+      const v2Config =
+        triggerConfig != null && isMemoryV2ReadActive(triggerConfig)
+          ? triggerConfig
+          : null;
+
+      // ── Graph extraction (v1) ───────────────────────────────────────
+      // Suppressed when v2 is active — v2 reads memory from buffer.md
+      // and concept pages, so the v1 graph would be stale data nobody
+      // consumes. Pending-count tracking is suppressed too; otherwise a
+      // flag flip back to v1 would fire an immediate batch from counts
+      // accumulated during the v2 window.
+      let extractRunAfter: number;
+      if (v2Config == null) {
+        const graphPendingKey = `graph_extract:${input.conversationId}:pending_count`;
+        const graphCurrentVal = getMemoryCheckpoint(graphPendingKey);
+        const graphPendingCount =
+          (graphCurrentVal ? parseInt(graphCurrentVal, 10) : 0) + 1;
+        setMemoryCheckpoint(graphPendingKey, String(graphPendingCount));
+
+        const graphBatchFired = graphPendingCount >= batchSize;
+        if (graphBatchFired) {
+          setMemoryCheckpoint(graphPendingKey, "0");
+        }
+
+        // Single pending `graph_extract` row per conversation. If the
+        // batch threshold just fired, pull `runAfter` back to now so the
+        // job runs immediately; otherwise debounce by the idle timeout.
+        // Routing both paths through `upsertDebouncedJob` ensures the
+        // row's `runAfter` reflects whichever trigger ran last, so a
+        // batch crossing always takes effect immediately.
+        extractRunAfter = graphBatchFired
+          ? Date.now()
+          : Date.now() + idleTimeoutMs;
+        upsertDebouncedJob(
+          "graph_extract",
+          {
+            conversationId: input.conversationId,
+            scopeId: input.scopeId ?? "default",
+          },
+          extractRunAfter,
+        );
+      } else {
+        extractRunAfter = Date.now() + idleTimeoutMs;
+      }
+
+      // Memory v2 sweep: when v2 is on AND `sweep_enabled` is set, every
+      // extraction trigger also enqueues a sweep. The sweep itself reads
+      // recent messages globally, so the `conversationId` here is just
+      // the dedup key — one pending row per active conversation.
       // `sweep_enabled` defaults to false because `remember()` is the
       // primary capture path; the sweep is opt-in.
-      if (
-        triggerConfig != null &&
-        isAssistantFeatureFlagEnabled("memory-v2-enabled", triggerConfig) &&
-        triggerConfig.memory.v2.enabled &&
-        triggerConfig.memory.v2.sweep_enabled
-      ) {
+      if (v2Config != null && v2Config.memory.v2.sweep_enabled) {
         upsertDebouncedJob(
           "memory_v2_sweep",
           { conversationId: input.conversationId },

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,4 +1,3 @@
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getLogger } from "../util/logger.js";
@@ -7,6 +6,7 @@ import {
   getLastScheduledCleanupEnqueueMs,
   markScheduledCleanupEnqueued,
 } from "./cleanup-schedule-state.js";
+import { isMemoryV2ReadActive } from "./context-search/sources/memory-v2.js";
 import { conversationAnalyzeJob } from "./conversation-analyze-job.js";
 import { maybeRunDbMaintenance } from "./db-maintenance.js";
 import { bootstrapFromHistory } from "./graph/bootstrap.js";
@@ -601,58 +601,66 @@ export const GRAPH_MAINTENANCE_CHECKPOINTS = {
 } as const;
 
 /**
- * Enqueue periodic graph maintenance jobs (decay, consolidation, pattern scan, narrative).
- * Uses durable checkpoints so intervals survive daemon restarts — jobs only fire
- * when the actual elapsed time since last run exceeds the interval.
+ * Enqueue periodic graph maintenance jobs.
  *
- * The v2 consolidation entry is gated on both the `memory-v2-enabled` feature
- * flag and the `memory.v2.enabled` config — both must be true for the cron
- * to fire. Sweep is intentionally not on this schedule: it is debounced from
- * the live `graph_extract` trigger path (see `indexMessageNow` in
- * `indexer.ts`) so it runs on the same idle/message-count cadence.
+ * Mutually exclusive between v1 and v2:
+ *   - v2 active (both `memory-v2-enabled` flag and `memory.v2.enabled`
+ *     config on) → only `memory_v2_consolidate` is scheduled.
+ *   - v2 inactive → the four v1 entries (decay, consolidate, pattern_scan,
+ *     narrative) are scheduled instead.
+ *
+ * Read/write paths route to v2 when the flag is on, so v1 graph data goes
+ * unread; running v1 maintenance alongside v2 is wasted compute and LLM
+ * spend. The v1 code path remains live so flipping the flag back to off
+ * fully re-engages v1.
+ *
+ * Uses durable checkpoints so intervals survive daemon restarts — jobs only
+ * fire when the actual elapsed time since last run exceeds the interval.
+ * Sweep is intentionally not on this schedule: it is debounced from the
+ * live `graph_extract` trigger path (see `indexMessageNow` in `indexer.ts`)
+ * so it runs on the same idle/message-count cadence.
  */
 export function maybeEnqueueGraphMaintenanceJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
 ): void {
+  const v2Active = isMemoryV2ReadActive(config);
+
   const schedule: Array<{
     key: string;
     intervalMs: number;
     jobType: MemoryJobType;
-  }> = [
-    {
-      key: GRAPH_MAINTENANCE_CHECKPOINTS.decay,
-      intervalMs: GRAPH_DECAY_INTERVAL_MS,
-      jobType: "graph_decay",
-    },
-    {
-      key: GRAPH_MAINTENANCE_CHECKPOINTS.consolidate,
-      intervalMs: GRAPH_CONSOLIDATE_INTERVAL_MS,
-      jobType: "graph_consolidate",
-    },
-    {
-      key: GRAPH_MAINTENANCE_CHECKPOINTS.patternScan,
-      intervalMs: GRAPH_PATTERN_SCAN_INTERVAL_MS,
-      jobType: "graph_pattern_scan",
-    },
-    {
-      key: GRAPH_MAINTENANCE_CHECKPOINTS.narrative,
-      intervalMs: GRAPH_NARRATIVE_INTERVAL_MS,
-      jobType: "graph_narrative_refine",
-    },
-  ];
-
-  if (
-    isAssistantFeatureFlagEnabled("memory-v2-enabled", config) &&
-    config.memory.v2.enabled
-  ) {
-    schedule.push({
-      key: GRAPH_MAINTENANCE_CHECKPOINTS.memoryV2Consolidate,
-      intervalMs:
-        config.memory.v2.consolidation_interval_hours * 60 * 60 * 1000,
-      jobType: "memory_v2_consolidate",
-    });
-  }
+  }> = v2Active
+    ? [
+        {
+          key: GRAPH_MAINTENANCE_CHECKPOINTS.memoryV2Consolidate,
+          intervalMs:
+            config.memory.v2.consolidation_interval_hours * 60 * 60 * 1000,
+          jobType: "memory_v2_consolidate",
+        },
+      ]
+    : [
+        {
+          key: GRAPH_MAINTENANCE_CHECKPOINTS.decay,
+          intervalMs: GRAPH_DECAY_INTERVAL_MS,
+          jobType: "graph_decay",
+        },
+        {
+          key: GRAPH_MAINTENANCE_CHECKPOINTS.consolidate,
+          intervalMs: GRAPH_CONSOLIDATE_INTERVAL_MS,
+          jobType: "graph_consolidate",
+        },
+        {
+          key: GRAPH_MAINTENANCE_CHECKPOINTS.patternScan,
+          intervalMs: GRAPH_PATTERN_SCAN_INTERVAL_MS,
+          jobType: "graph_pattern_scan",
+        },
+        {
+          key: GRAPH_MAINTENANCE_CHECKPOINTS.narrative,
+          intervalMs: GRAPH_NARRATIVE_INTERVAL_MS,
+          jobType: "graph_narrative_refine",
+        },
+      ];
 
   for (const { key, intervalMs, jobType } of schedule) {
     const lastRun = parseInt(getMemoryCheckpoint(key) ?? "0", 10);

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -246,7 +246,7 @@
       "scope": "assistant",
       "key": "memory-v2-enabled",
       "label": "Memory v2 (concept-page activation model)",
-      "description": "Enables the v2 memory subsystem: prose concept pages with bidirectional edges, activation-based retrieval, and hourly LLM-driven consolidation. v1 graph + PKB stays write-active until cutover.",
+      "description": "Enables the v2 memory subsystem: prose concept pages with bidirectional edges, activation-based retrieval, and hourly LLM-driven consolidation. When on, v1 graph extraction/maintenance and PKB filing are suppressed; flipping the flag back off re-engages the full v1 pipeline.",
       "defaultEnabled": true
     },
     {


### PR DESCRIPTION
## Summary
- Make `maybeEnqueueGraphMaintenanceJobs` mutually exclusive: when v2 is active, only `memory_v2_consolidate` is scheduled; otherwise the four v1 entries (decay, consolidate, pattern_scan, narrative) fire and the v2 entry does not.
- Gate the indexer's per-message `graph_extract` enqueue (and its pending-count tracking) on `v2Config == null`, so v1 extraction stops cold while v2 is on.
- Reuse the existing `isMemoryV2ReadActive` helper instead of duplicating the dual-gate predicate; update its docstring to reflect the broader use.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->