### PR TITLE
feat(memory/v2): add concept-frequency debug route

### DIFF
--- a/assistant/src/memory/__tests__/memory-v2-concept-frequency.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-concept-frequency.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+  }),
+}));
+
+let listPagesImpl: (workspaceDir: string) => Promise<string[]> = async () => [];
+
+mock.module("../v2/page-store.js", () => ({
+  listPages: (workspaceDir: string) => listPagesImpl(workspaceDir),
+}));
+
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import {
+  type MemoryV2ConceptRowRecord,
+  type MemoryV2SkillRowRecord,
+  recordMemoryV2ActivationLog,
+} from "../memory-v2-activation-log-store.js";
+import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
+import { memoryV2ActivationLogs } from "../schema.js";
+import { sampleConfig } from "./fixtures/memory-v2-activation-fixtures.js";
+
+initializeDb();
+
+const WORKSPACE = "/tmp/memory-v2-concept-frequency-test";
+const NO_SKILLS: MemoryV2SkillRowRecord[] = [];
+
+function makeConcept(
+  slug: string,
+  status: MemoryV2ConceptRowRecord["status"],
+): MemoryV2ConceptRowRecord {
+  return {
+    slug,
+    finalActivation: 0.5,
+    ownActivation: 0.4,
+    priorActivation: 0.1,
+    simUser: 0.3,
+    simAssistant: 0.2,
+    simNow: 0.1,
+    simUserRerankBoost: 0,
+    simAssistantRerankBoost: 0,
+    spreadContribution: 0.1,
+    source: "ann_top50",
+    status,
+  };
+}
+
+function resetTables(): void {
+  getDb().delete(memoryV2ActivationLogs).run();
+}
+
+describe("memory-v2-concept-frequency", () => {
+  beforeEach(() => {
+    resetTables();
+    listPagesImpl = async () => [];
+  });
+
+  test("aggregates per-status counts across multiple turns", async () => {
+    const conv = "conv-1";
+    recordMemoryV2ActivationLog({
+      conversationId: conv,
+      turn: 1,
+      mode: "context-load",
+      concepts: [
+        makeConcept("alice", "injected"),
+        makeConcept("bob", "not_injected"),
+      ],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+    recordMemoryV2ActivationLog({
+      conversationId: conv,
+      turn: 2,
+      mode: "per-turn",
+      concepts: [
+        makeConcept("alice", "in_context"),
+        makeConcept("bob", "injected"),
+      ],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+    recordMemoryV2ActivationLog({
+      conversationId: conv,
+      turn: 3,
+      mode: "per-turn",
+      concepts: [
+        makeConcept("alice", "injected"),
+        makeConcept("charlie", "page_missing"),
+      ],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+
+    listPagesImpl = async () => ["alice", "bob", "delta"];
+
+    const result = await getConceptFrequencySummary(WORKSPACE, {});
+
+    expect(result.totals.logCount).toBe(3);
+    expect(result.totals.conceptOccurrences).toBe(6);
+    expect(result.filters).toEqual({ conversationId: null, sinceMs: null });
+
+    const bySlug = new Map(result.concepts.map((c) => [c.slug, c]));
+
+    expect(bySlug.get("alice")!.counts).toEqual({
+      injected: 2,
+      in_context: 1,
+      not_injected: 0,
+      page_missing: 0,
+    });
+    expect(bySlug.get("alice")!.totalEvaluations).toBe(3);
+    expect(bySlug.get("alice")!.onDisk).toBe(true);
+    expect(bySlug.get("alice")!.lastInjectedAt).not.toBeNull();
+
+    expect(bySlug.get("bob")!.counts).toEqual({
+      injected: 1,
+      in_context: 0,
+      not_injected: 1,
+      page_missing: 0,
+    });
+    expect(bySlug.get("bob")!.totalEvaluations).toBe(2);
+    expect(bySlug.get("bob")!.onDisk).toBe(true);
+
+    expect(bySlug.get("charlie")!.counts).toEqual({
+      injected: 0,
+      in_context: 0,
+      not_injected: 0,
+      page_missing: 1,
+    });
+    expect(bySlug.get("charlie")!.onDisk).toBe(false);
+    expect(bySlug.get("charlie")!.lastInjectedAt).toBeNull();
+
+    // Sorted by totalEvaluations desc — alice (3) before bob (2) before charlie (1).
+    expect(result.concepts.map((c) => c.slug)).toEqual([
+      "alice",
+      "bob",
+      "charlie",
+    ]);
+
+    // delta is on disk but never appeared in any log row.
+    expect(result.neverEvaluatedSlugs).toEqual(["delta"]);
+  });
+
+  test("conversationId filter narrows aggregation", async () => {
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-a",
+      turn: 1,
+      mode: "per-turn",
+      concepts: [makeConcept("alice", "injected")],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-b",
+      turn: 1,
+      mode: "per-turn",
+      concepts: [
+        makeConcept("alice", "injected"),
+        makeConcept("alice", "injected"),
+      ],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+
+    listPagesImpl = async () => ["alice"];
+
+    const all = await getConceptFrequencySummary(WORKSPACE, {});
+    expect(all.totals.logCount).toBe(2);
+    expect(all.concepts[0]!.counts.injected).toBe(3);
+    expect(all.filters.conversationId).toBeNull();
+
+    const onlyA = await getConceptFrequencySummary(WORKSPACE, {
+      conversationId: "conv-a",
+    });
+    expect(onlyA.totals.logCount).toBe(1);
+    expect(onlyA.concepts[0]!.counts.injected).toBe(1);
+    expect(onlyA.filters.conversationId).toBe("conv-a");
+
+    const onlyB = await getConceptFrequencySummary(WORKSPACE, {
+      conversationId: "conv-b",
+    });
+    expect(onlyB.totals.logCount).toBe(1);
+    expect(onlyB.concepts[0]!.counts.injected).toBe(2);
+  });
+
+  test("sinceMs filter excludes older log rows", async () => {
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-1",
+      turn: 1,
+      mode: "per-turn",
+      concepts: [makeConcept("alice", "injected")],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+    // Backdate the just-written row — recordMemoryV2ActivationLog uses Date.now().
+    getDb().update(memoryV2ActivationLogs).set({ createdAt: 1_000 }).run();
+
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-1",
+      turn: 2,
+      mode: "per-turn",
+      concepts: [makeConcept("alice", "injected")],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+
+    listPagesImpl = async () => ["alice"];
+
+    const all = await getConceptFrequencySummary(WORKSPACE, {});
+    expect(all.totals.logCount).toBe(2);
+    expect(all.concepts[0]!.counts.injected).toBe(2);
+
+    const recent = await getConceptFrequencySummary(WORKSPACE, {
+      sinceMs: 10_000,
+    });
+    expect(recent.totals.logCount).toBe(1);
+    expect(recent.concepts[0]!.counts.injected).toBe(1);
+    expect(recent.filters.sinceMs).toBe(10_000);
+  });
+
+  test("never-evaluated list excludes slugs that appeared in any status", async () => {
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-1",
+      turn: 1,
+      mode: "per-turn",
+      concepts: [
+        makeConcept("alice", "injected"),
+        makeConcept("bob", "not_injected"),
+        makeConcept("charlie", "page_missing"),
+      ],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+
+    listPagesImpl = async () => ["alice", "bob", "delta", "echo"];
+
+    const result = await getConceptFrequencySummary(WORKSPACE, {});
+    // bob was scored but rejected — still excluded from neverEvaluated.
+    expect(result.neverEvaluatedSlugs).toEqual(["delta", "echo"]);
+  });
+
+  test("returns empty result when no logs exist", async () => {
+    listPagesImpl = async () => ["alice", "bob"];
+
+    const result = await getConceptFrequencySummary(WORKSPACE, {});
+    expect(result.totals).toEqual({ logCount: 0, conceptOccurrences: 0 });
+    expect(result.concepts).toEqual([]);
+    expect(result.neverEvaluatedSlugs).toEqual(["alice", "bob"]);
+  });
+
+  test("flags slugs that appear in logs but no longer have a page on disk", async () => {
+    recordMemoryV2ActivationLog({
+      conversationId: "conv-1",
+      turn: 1,
+      mode: "per-turn",
+      concepts: [makeConcept("ghost", "injected")],
+      skills: NO_SKILLS,
+      config: sampleConfig,
+    });
+
+    listPagesImpl = async () => ["alice"];
+
+    const result = await getConceptFrequencySummary(WORKSPACE, {});
+    const ghost = result.concepts.find((c) => c.slug === "ghost")!;
+    expect(ghost.onDisk).toBe(false);
+    expect(ghost.counts.injected).toBe(1);
+  });
+});

--- a/assistant/src/memory/memory-v2-concept-frequency.ts
+++ b/assistant/src/memory/memory-v2-concept-frequency.ts
@@ -1,0 +1,169 @@
+import type { MemoryV2ConceptRowRecord } from "./memory-v2-activation-log-store.js";
+import { rawAll, rawGet } from "./raw-query.js";
+import { listPages } from "./v2/page-store.js";
+
+type ConceptStatus = MemoryV2ConceptRowRecord["status"];
+
+export type ConceptFrequencyCounts = Record<ConceptStatus, number>;
+
+export interface ConceptFrequencyRow {
+  slug: string;
+  counts: ConceptFrequencyCounts;
+  totalEvaluations: number;
+  lastInjectedAt: number | null;
+  /** Whether the slug currently has a markdown page on disk. */
+  onDisk: boolean;
+}
+
+export interface ConceptFrequencyResponse {
+  filters: {
+    conversationId: string | null;
+    sinceMs: number | null;
+  };
+  totals: {
+    /** Activation log rows scanned (turns of evaluation in the window). */
+    logCount: number;
+    /** Sum of per-row concept evaluations across all log rows in the window. */
+    conceptOccurrences: number;
+  };
+  /** Per-slug aggregates, sorted by `totalEvaluations` desc, then slug asc. */
+  concepts: ConceptFrequencyRow[];
+  /**
+   * Slugs present on disk that never appeared in any activation log row in
+   * the window — i.e. retrieval never even scored them as a candidate.
+   */
+  neverEvaluatedSlugs: string[];
+}
+
+export interface GetConceptFrequencyFilters {
+  conversationId?: string;
+  sinceMs?: number;
+}
+
+interface AggRow {
+  slug: string | null;
+  status: ConceptStatus | string | null;
+  count: number;
+  last_seen: number;
+}
+
+const ZERO_COUNTS: ConceptFrequencyCounts = {
+  injected: 0,
+  in_context: 0,
+  not_injected: 0,
+  page_missing: 0,
+};
+
+interface CountRow {
+  count: number;
+}
+
+export async function getConceptFrequencySummary(
+  workspaceDir: string,
+  filters: GetConceptFrequencyFilters = {},
+): Promise<ConceptFrequencyResponse> {
+  const conversationId = filters.conversationId ?? null;
+  const sinceMs = filters.sinceMs ?? null;
+
+  // Kick off the on-disk page walk in parallel with the (synchronous) SQL
+  // queries below — listPages does fs.readdir, rawAll/rawGet are sync.
+  const onDiskSlugsPromise = listPages(workspaceDir);
+
+  const aggRows = rawAll<AggRow>(
+    `SELECT
+       json_extract(c.value, '$.slug')   AS slug,
+       json_extract(c.value, '$.status') AS status,
+       COUNT(*)                          AS count,
+       MAX(l.created_at)                 AS last_seen
+     FROM memory_v2_activation_logs l, json_each(l.concepts_json) c
+     WHERE (? IS NULL OR l.conversation_id = ?)
+       AND (? IS NULL OR l.created_at >= ?)
+     GROUP BY slug, status`,
+    conversationId,
+    conversationId,
+    sinceMs,
+    sinceMs,
+  );
+
+  const logCountRow = rawGet<CountRow>(
+    `SELECT COUNT(*) AS count
+       FROM memory_v2_activation_logs
+       WHERE (? IS NULL OR conversation_id = ?)
+         AND (? IS NULL OR created_at >= ?)`,
+    conversationId,
+    conversationId,
+    sinceMs,
+    sinceMs,
+  );
+
+  const bySlug = new Map<string, ConceptFrequencyRow>();
+  let conceptOccurrences = 0;
+
+  for (const row of aggRows) {
+    if (!row.slug) continue;
+    let entry = bySlug.get(row.slug);
+    if (!entry) {
+      entry = {
+        slug: row.slug,
+        counts: { ...ZERO_COUNTS },
+        totalEvaluations: 0,
+        lastInjectedAt: null,
+        onDisk: false,
+      };
+      bySlug.set(row.slug, entry);
+    }
+
+    switch (row.status) {
+      case "injected":
+        entry.counts.injected += row.count;
+        entry.lastInjectedAt =
+          entry.lastInjectedAt === null
+            ? row.last_seen
+            : Math.max(entry.lastInjectedAt, row.last_seen);
+        break;
+      case "in_context":
+        entry.counts.in_context += row.count;
+        break;
+      case "not_injected":
+        entry.counts.not_injected += row.count;
+        break;
+      case "page_missing":
+        entry.counts.page_missing += row.count;
+        break;
+      default:
+        // Forward-compat: unknown status values are ignored, not summed into
+        // totalEvaluations. The activation pipeline produces a closed enum.
+        continue;
+    }
+    entry.totalEvaluations += row.count;
+    conceptOccurrences += row.count;
+  }
+
+  const onDiskSlugs = new Set(await onDiskSlugsPromise);
+  for (const entry of bySlug.values()) {
+    entry.onDisk = onDiskSlugs.has(entry.slug);
+  }
+
+  const neverEvaluatedSlugs: string[] = [];
+  for (const slug of onDiskSlugs) {
+    if (!bySlug.has(slug)) neverEvaluatedSlugs.push(slug);
+  }
+  neverEvaluatedSlugs.sort();
+
+  const concepts = [...bySlug.values()].sort((a, b) => {
+    if (b.totalEvaluations !== a.totalEvaluations) {
+      return b.totalEvaluations - a.totalEvaluations;
+    }
+    return a.slug.localeCompare(b.slug);
+  });
+
+  return {
+    filters: { conversationId, sinceMs },
+    totals: {
+      logCount: logCountRow?.count ?? 0,
+      conceptOccurrences,
+    },
+    concepts,
+    neverEvaluatedSlugs,
+  };
+}

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -23,6 +23,10 @@ import {
   type MemoryJobType,
 } from "../../memory/jobs-store.js";
 import {
+  type ConceptFrequencyResponse,
+  getConceptFrequencySummary,
+} from "../../memory/memory-v2-concept-frequency.js";
+import {
   getEdgeIndex,
   totalEdgeCount,
   validateEdgeTargets,
@@ -459,6 +463,24 @@ async function handleExplainSimilarity({
   };
 }
 
+// ── Concept injection frequency (debug-only) ────────────────────────────
+
+const MemoryV2ConceptFrequencyParams = z
+  .object({
+    conversationId: z.string().min(1).optional(),
+    sinceMs: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+async function handleConceptFrequency({
+  body = {},
+}: RouteHandlerArgs): Promise<ConceptFrequencyResponse> {
+  const { conversationId, sinceMs } =
+    MemoryV2ConceptFrequencyParams.parse(body);
+  const workspaceDir = getWorkspaceDir();
+  return getConceptFrequencySummary(workspaceDir, { conversationId, sinceMs });
+}
+
 // ── Fit anisotropy calibration ──────────────────────────────────────────
 
 const MemoryV2FitAnisotropyParams = z
@@ -613,6 +635,17 @@ export const ROUTES: RouteDefinition[] = [
       "Walks every concept page on disk, recomputes the document-frequency table and average document length used by the BM25 sparse channel, and atomically swaps the in-memory stats. Run after bulk content imports or to recover from a rebuild that errored at startup. Does not reembed individual page sparse vectors — pair with `assistant memory v2 reembed` when document-side weights need refreshing.",
     tags: ["memory"],
     requestBody: MemoryV2RebuildCorpusStatsParams,
+  },
+  {
+    operationId: "memory_v2_concept_frequency",
+    method: "POST",
+    endpoint: "memory/v2/concept-frequency",
+    handler: handleConceptFrequency,
+    summary: "Aggregate per-concept injection frequency from activation logs",
+    description:
+      "Debug-only. Aggregates the existing memory_v2_activation_logs table by (slug, status) and cross-references on-disk concept pages so an operator can see which concepts get injected often, which get scored but rejected, and which on-disk pages never even surface as candidates. Optional filters: conversationId narrows to a single conversation; sinceMs restricts to logs created at-or-after the given epoch ms timestamp.",
+    tags: ["memory"],
+    requestBody: MemoryV2ConceptFrequencyParams,
   },
   {
     operationId: "memory_v2_fit_anisotropy",


### PR DESCRIPTION
## Summary
- New `POST memory/v2/concept-frequency` debug route. Aggregates the existing `memory_v2_activation_logs` table by `(slug, status)` using SQLite `json_each` and cross-references `listPages()` for the on-disk concept universe.
- Returns per-slug counts (`injected` / `in_context` / `not_injected` / `page_missing`), `lastInjectedAt`, an `onDisk` flag, and a `neverEvaluatedSlugs` array. Optional filters: `conversationId`, `sinceMs`.
- Pure derived view from existing logs — no new schema, no dual-write counter, no migration.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->