### PR TITLE
fix(host-proxy): close cross-user broadcast leak in auto-resolve and CU dispatch

### DIFF
--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -655,6 +655,47 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       );
       expect(sentMessages).toHaveLength(0);
     });
+
+    test("auto-resolves to the unique same-user CU client when cross-user clients are present", async () => {
+      // Regression: previously the dispatch counted only same-user clients
+      // for the multi-client guard, so 1 same-user + 1 cross-user passed the
+      // guard with no targetClientId — and the proxy then broadcast to ALL
+      // host_cu subscribers, including the cross-user one.
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "cu-mine",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        {
+          clientId: "cu-other",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-other",
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, DEFAULT_PRINCIPAL);
+
+      const resultPromise = surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+        // Intentionally no target_client_id — exercises auto-resolve.
+      });
+
+      // Broadcast happens, but with the same-user clientId set so only
+      // that client receives it.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("cu-mine");
+
+      // Manually resolve to clean up the pending promise.
+      proxy.resolve(sent.requestId as string, {
+        executionResult: "ok",
+      });
+      await resultPromise;
+    });
   });
 
   describe("step limit enforcement through resolver", () => {

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -691,7 +691,7 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       expect(sent.targetClientId).toBe("cu-mine");
 
       // Manually resolve to clean up the pending promise.
-      proxy.resolve(sent.requestId as string, {
+      proxy.processObservation(sent.requestId as string, {
         executionResult: "ok",
       });
       await resultPromise;

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -679,38 +679,23 @@ describe("HostBashProxy", () => {
       expect(sentMessages).toHaveLength(0);
     });
 
-    test("falls through to untargeted broadcast when multiple capable clients are connected and no targetClientId", async () => {
+    test("rejects ambiguously when multiple same-user capable clients are connected and no targetClientId", async () => {
+      // Regression: previously fell through to untargeted broadcast, fanning
+      // a single targeted-style request out across every same-user machine.
       setup();
       setupMultipleClients(["client-1", "client-2", "client-3"]);
 
-      const resultPromise = proxy.request(
+      const result = await proxy.request(
         { command: "echo hello" },
         "session-1",
         undefined,
         "user-A",
       );
 
-      // Should broadcast without an early error return
-      expect(sentMessages).toHaveLength(1);
-      const sent = sentMessages[0] as Record<string, unknown>;
-      expect(sent.type).toBe("host_bash_request");
-      // No target client resolved — untargeted broadcast
-      expect(sent.targetClientId).toBeUndefined();
-
-      const opts = sentMessageOptions[0] as Record<string, unknown> | undefined;
-      expect(opts?.targetClientId).toBeUndefined();
-
-      // Manually resolve to clean up
-      const requestId = sent.requestId as string;
-      proxy.resolveResult(requestId, {
-        stdout: "hello\n",
-        stderr: "",
-        exitCode: 0,
-        timedOut: false,
-      });
-
-      const result = await resultPromise;
-      expect(result.isError).toBe(false);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("target_client_id");
+      // No broadcast happened
+      expect(sentMessages).toHaveLength(0);
     });
 
     test("falls through to broadcast when zero capable clients (existing timeout path)", async () => {

--- a/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
@@ -709,7 +709,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -738,7 +738,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -767,7 +767,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -863,7 +863,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1930,7 +1930,7 @@ export async function surfaceProxyResolver(
     // Record the action and proxy to the connected desktop client
     const reasoning =
       typeof input.reasoning === "string" ? input.reasoning : undefined;
-    const targetClientId =
+    let targetClientId: string | undefined =
       typeof input.target_client_id === "string" &&
       input.target_client_id !== ""
         ? input.target_client_id
@@ -1985,14 +1985,24 @@ export async function surfaceProxyResolver(
     // host_cu-capable transport for which auto-routing-to-self would be
     // appropriate. We therefore fire whenever there is genuine ambiguity.
     if (targetClientId == null) {
-      const cuClients = assistantEventHub
-        .listClientsByCapability("host_cu")
-        .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
-      if (cuClients.length > 1) {
+      const allCuClients = assistantEventHub.listClientsByCapability("host_cu");
+      const sameUserCuClients = allCuClients.filter(
+        (c) => c.actorPrincipalId === sourceActorPrincipalId,
+      );
+      if (sameUserCuClients.length > 1) {
         return {
           content: `Error: multiple clients support host_cu. Specify which client to target with \`target_client_id\`. Run \`assistant clients list --capability host_cu\` to see client IDs and labels.`,
           isError: true,
         };
+      }
+      // When cross-user host_cu clients are connected, we MUST auto-resolve
+      // to the unique same-user client (or fail explicitly) — otherwise the
+      // proxy would broadcast untargeted and the CU action would reach the
+      // cross-user client too. Setting targetClientId here forces the proxy
+      // to deliver only to that client, with the same-user check below as
+      // belt-and-suspenders.
+      if (sameUserCuClients.length === 1 && allCuClients.length > 1) {
+        targetClientId = sameUserCuClients[0].clientId;
       }
     }
 

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -6,6 +6,7 @@ import {
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
 import {
+  ambiguousSameUserError,
   enforceSameActorOrErrorResult,
   pickSameUserAutoResolve,
 } from "../runtime/auth/same-actor.js";
@@ -85,16 +86,21 @@ export class HostBashProxy {
       }
       resolvedTargetClientId = input.targetClientId;
     } else {
-      // Auto-resolve only to a same-user capable client; falls through to
-      // the untargeted broadcast path when zero or multiple same-user
-      // clients are connected. The zero-client / multi-client cases are
-      // handled by the existing timeout/error path and the tool-executor
-      // layer respectively.
-      resolvedTargetClientId = pickSameUserAutoResolve({
+      // Auto-resolve to the unique same-user client. Reject (rather than
+      // broadcast) when multiple same-user clients are connected so that
+      // a single targeted-style request cannot fan out across every one
+      // of the user's machines. Zero same-user matches falls through to
+      // the existing untargeted code path.
+      const resolved = pickSameUserAutoResolve({
         hub: assistantEventHub,
         capability: "host_bash",
         sourceActorPrincipalId,
       });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_bash"));
+      }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
     // Targeted requests must be bound to the same authenticated user as the

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -5,6 +5,7 @@ import {
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
 import {
+  ambiguousSameUserError,
   enforceSameActorOrErrorResult,
   pickSameUserAutoResolve,
 } from "../runtime/auth/same-actor.js";
@@ -99,11 +100,19 @@ export class HostFileProxy {
         });
       }
     } else {
-      resolvedTargetClientId = pickSameUserAutoResolve({
+      // Auto-resolve to the unique same-user client. Reject ambiguous
+      // (multi-machine) cases so a single targeted-style request cannot
+      // fan out across the user's machines.
+      const resolved = pickSameUserAutoResolve({
         hub: assistantEventHub,
         capability: "host_file",
         sourceActorPrincipalId,
       });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_file"));
+      }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
     // Same-user check: targeted host_file requests must be bound to the same

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -9,6 +9,11 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import {
+  ambiguousSameUserError,
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -147,47 +152,29 @@ export class HostTransferProxy {
         });
       }
     } else {
-      // Auto-resolve only to a capable client whose actorPrincipalId matches
-      // the source caller's. Skips auto-resolve when the caller has no
-      // identity, since same-user binding cannot be enforced.
-      if (sourceActorPrincipalId != null) {
-        const capable = assistantEventHub.listClientsByCapability("host_file");
-        const sameUser = capable.filter(
-          (c) => c.actorPrincipalId === sourceActorPrincipalId,
-        );
-        if (sameUser.length === 1) {
-          resolvedTargetClientId = sameUser[0].clientId;
-        }
+      // Auto-resolve to the unique same-user client; reject ambiguous
+      // (multi-machine) cases so a single targeted-style transfer cannot
+      // fan out across the user's machines.
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_file",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_file"));
       }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
-    // Same-user check: targeted host_transfer requests must be bound to the
-    // same authenticated user identity that opened the target client's SSE
-    // stream. Prevents cross-user routing through actor token mis-targeting.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_transfer",
-            direction: "to_host",
-          },
-          "Rejected cross-user targeted host_transfer request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_transfer",
+      });
+      if (rejection != null) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();
@@ -355,47 +342,29 @@ export class HostTransferProxy {
         });
       }
     } else {
-      // Auto-resolve only to a capable client whose actorPrincipalId matches
-      // the source caller's. Skips auto-resolve when the caller has no
-      // identity, since same-user binding cannot be enforced.
-      if (sourceActorPrincipalId != null) {
-        const capable = assistantEventHub.listClientsByCapability("host_file");
-        const sameUser = capable.filter(
-          (c) => c.actorPrincipalId === sourceActorPrincipalId,
-        );
-        if (sameUser.length === 1) {
-          resolvedTargetClientId = sameUser[0].clientId;
-        }
+      // Auto-resolve to the unique same-user client; reject ambiguous
+      // (multi-machine) cases so a single targeted-style transfer cannot
+      // fan out across the user's machines.
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_file",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_file"));
       }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
-    // Same-user check: targeted host_transfer requests must be bound to the
-    // same authenticated user identity that opened the target client's SSE
-    // stream. Prevents cross-user routing through actor token mis-targeting.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_transfer",
-            direction: "to_sandbox",
-          },
-          "Rejected cross-user targeted host_transfer request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_transfer",
+      });
+      if (rejection != null) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -41,7 +41,11 @@ export const SAME_ACTOR_FORBIDDEN_DESCRIPTION =
   "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.";
 
 /** Per-capability scope for the structured warn log entry. */
-export type SameActorOp = "host_bash" | "host_file" | "host_cu";
+export type SameActorOp =
+  | "host_bash"
+  | "host_file"
+  | "host_cu"
+  | "host_transfer";
 
 export interface SameActorArgs {
   hub: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
@@ -109,24 +113,66 @@ export function enforceSameActorOrErrorResult(
 }
 
 /**
+ * Result of attempting to auto-resolve a single same-user target client.
+ *
+ * - `match`: exactly one same-user client supports the capability. Use the
+ *   returned clientId.
+ * - `none`: no same-user client supports the capability. Caller's choice
+ *   how to handle (typically: fall through to no-target, which broadcasts
+ *   to nobody when no clients are connected).
+ * - `ambiguous`: more than one same-user client supports the capability.
+ *   Caller MUST refuse to silently broadcast across them; instead surface
+ *   an error asking the caller to specify `target_client_id`.
+ */
+export type AutoResolveResult =
+  | { kind: "match"; clientId: string }
+  | { kind: "none" }
+  | { kind: "ambiguous" };
+
+/**
  * Filter capable clients by `actorPrincipalId === sourcePrincipalId` and
- * return the single match's clientId, or `undefined` when zero or more
- * than one same-user client supports the capability.
+ * report whether exactly one matched, zero matched, or more than one
+ * matched.
  *
  * Used by host proxies to auto-resolve a target client when the caller
  * did not specify one. Skipping when the caller has no principal keeps
- * the same-user binding closed: an unauthenticated caller cannot piggyback
- * on a connected user's session.
+ * the same-user binding closed: an unauthenticated caller cannot
+ * piggyback on a connected user's session.
+ *
+ * Why three outcomes (vs. just `string | undefined`)? Earlier revisions
+ * collapsed `none` and `ambiguous` into `undefined`, which caused the
+ * proxy to fall through to an untargeted broadcast — fanning a single
+ * targeted-style request out across every same-user machine. Surfacing
+ * `ambiguous` separately lets the proxy reject with a clear "specify
+ * target_client_id" error instead.
  */
 export function pickSameUserAutoResolve(args: {
   hub: Pick<AssistantEventHub, "listClientsByCapability">;
   capability: HostProxyCapability;
   sourceActorPrincipalId: string | undefined;
-}): string | undefined {
+}): AutoResolveResult {
   const { hub, capability, sourceActorPrincipalId } = args;
-  if (sourceActorPrincipalId == null) return undefined;
+  if (sourceActorPrincipalId == null) return { kind: "none" };
   const sameUser = hub
     .listClientsByCapability(capability)
     .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
-  return sameUser.length === 1 ? sameUser[0].clientId : undefined;
+  if (sameUser.length === 0) return { kind: "none" };
+  if (sameUser.length === 1) {
+    return { kind: "match", clientId: sameUser[0].clientId };
+  }
+  return { kind: "ambiguous" };
+}
+
+/**
+ * Standard error result for proxies when {@link pickSameUserAutoResolve}
+ * returns `ambiguous`. Asks the caller to specify `target_client_id`.
+ */
+export function ambiguousSameUserError(capability: HostProxyCapability): {
+  content: string;
+  isError: true;
+} {
+  return {
+    content: `Multiple ${capability} clients are connected for this user. Specify target_client_id to disambiguate. Run \`assistant clients list --capability ${capability}\` to see client IDs.`,
+    isError: true,
+  };
 }


### PR DESCRIPTION
## Summary
- pickSameUserAutoResolve returns typed result (match | none | ambiguous); 2+ same-user clients now error instead of silently fanning out.
- CU dispatch auto-resolves to the unique same-user client when cross-user clients are present.
- host-transfer-proxy refactored to use shared helpers.
- New regression tests for both broadcast paths.

Round-2 fix for plan host-proxy-same-user.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->