### PR TITLE
Pause background execution under disk pressure

### DIFF
--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -244,6 +244,18 @@ describe("background workers disk pressure gate", () => {
     expect(mockProcessMessage).not.toHaveBeenCalled();
   });
 
+  test("filing service allows forced user-initiated runs while locked", async () => {
+    const service = new FilingService();
+
+    const ran = await service.runOnce({ force: true });
+    const compacted = await service.runCompactionOnce({ force: true });
+
+    expect(ran).toBe(true);
+    expect(compacted).toBe(true);
+    expect(createdConversations).toHaveLength(2);
+    expect(mockProcessMessage).toHaveBeenCalledTimes(2);
+  });
+
   test("workspace heartbeat skips auto-commit checks while locked", async () => {
     const getServices = mock(() => new Map());
     const heartbeat = new WorkspaceHeartbeatService({ getServices });

--- a/assistant/src/__tests__/background-workers-disk-pressure.test.ts
+++ b/assistant/src/__tests__/background-workers-disk-pressure.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    filing: {
+      enabled: true,
+      intervalMs: 60_000,
+      compactionEnabled: true,
+      compactionIntervalMs: 60_000,
+      activeHoursStart: null,
+      activeHoursEnd: null,
+    },
+    memory: {
+      enabled: true,
+      jobs: {
+        stalledJobTimeoutMs: 60_000,
+        slowLlmConcurrency: 1,
+        fastConcurrency: 1,
+        embedConcurrency: 1,
+      },
+      cleanup: {
+        enabled: true,
+        enqueueIntervalMs: 60_000,
+        conversationRetentionDays: 30,
+        llmRequestLogRetentionMs: 60_000,
+        traceEventRetentionDays: 30,
+      },
+      v2: {
+        enabled: false,
+        consolidation_interval_hours: 4,
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getConfigReadOnly: () => ({}),
+  applyNestedDefaults: (config: unknown) => config,
+  deepMergeOverwrite: (base: unknown) => base,
+  mergeDefaultWorkspaceConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
+  _appendQuarantineBulletin: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../daemon/disk-pressure-background-gate.js", () => ({
+  checkDiskPressureBackgroundGate: () => ({
+    action: "skip",
+    reason: "disk_pressure",
+    blockedCapability: "background-work",
+    status: {
+      enabled: true,
+      state: "critical",
+      locked: true,
+      acknowledged: true,
+      overrideActive: false,
+      effectivelyLocked: true,
+      lockId: "disk-pressure-test",
+      usagePercent: 98,
+      thresholdPercent: 95,
+      path: "/",
+      lastCheckedAt: "2026-05-05T00:00:00.000Z",
+      blockedCapabilities: ["agent-turns", "background-work", "remote-ingress"],
+      error: null,
+    },
+  }),
+  diskPressureBackgroundSkipLogFields: () => ({
+    reason: "disk_pressure",
+    thresholdPercent: 95,
+    usagePercent: 98,
+    blockedCapability: "background-work",
+    lockId: "disk-pressure-test",
+    path: "/",
+  }),
+  shouldLogDiskPressureBackgroundSkip: () => true,
+}));
+
+const mockProcessMessage = mock(() => Promise.resolve({ messageId: "msg-1" }));
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: mockProcessMessage,
+  processMessageInBackground: mock(() =>
+    Promise.resolve({ messageId: "msg-bg" }),
+  ),
+  resolveTurnChannel: () => "vellum",
+  resolveTurnInterface: () => "vellum",
+}));
+
+const createdConversations: Array<{ conversationType: string }> = [];
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: mock(() => ({ id: "msg-1" })),
+  archiveConversation: mock(() => true),
+  batchSetDisplayOrders: mock(() => {}),
+  clearStrippedInjectionMetadataForConversation: mock(() => {}),
+  createConversation: (opts: { conversationType: string }) => {
+    createdConversations.push(opts);
+    return { id: "conv-1", ...opts };
+  },
+  countConversationsByScheduleJobId: mock(() => 0),
+  deleteMessageById: mock(() => {}),
+  clearAll: mock(() => ({ conversations: 0, messages: 0 })),
+  deleteConversation: mock(() => ({ memoryIds: [] })),
+  deleteLastExchange: mock(() => 0),
+  findAnalysisConversationFor: mock(() => null),
+  forkConversation: mock(() => ({ id: "conv-fork" })),
+  getConversationOverrideProfile: () => undefined,
+  getConversationOverrideProfileFromRow: () => undefined,
+  getConversationMemoryScopeId: () => "default",
+  getConversationOriginChannel: () => null,
+  getConversationOriginInterface: () => null,
+  getConversationRecentProvenanceTrustClass: () => null,
+  getConversationSource: () => null,
+  getAssistantMessageIdsInTurn: () => [],
+  getDisplayMetaForConversations: () => new Map(),
+  getLastAssistantTimestampBefore: () => null,
+  getLastUserTimestampBefore: () => null,
+  getMessageById: () => null,
+  getMessages: () => [],
+  getMessagesPaginated: () => ({ messages: [], hasMore: false }),
+  getTurnTimeBounds: () => null,
+  getConversation: () => null,
+  hasMessages: () => false,
+  messageMetadataSchema: { parse: (value: unknown) => value },
+  parseConversation: (row: unknown) => row,
+  provenanceFromTrustContext: () => ({ source: "user" }),
+  relinkAttachments: mock(() => {}),
+  selectSlackMetaCandidateMetadata: () => null,
+  setConversationOriginChannelIfUnset: mock(() => {}),
+  setConversationOriginInterfaceIfUnset: mock(() => {}),
+  setConversationInferenceProfile: mock(() => {}),
+  unarchiveConversation: mock(() => true),
+  updateMessageContent: mock(() => {}),
+  updateMessageContentAndMetadata: mock(() => {}),
+  updateMessageMetadata: mock(() => {}),
+  updateConversationContextWindow: mock(() => {}),
+  updateConversationSlackContextWatermark: mock(() => {}),
+  updateConversationTitle: mock(() => {}),
+  updateConversationUsage: mock(() => {}),
+  wipeConversation: mock(() => ({ memoryIds: [] })),
+}));
+
+mock.module("../memory/conversation-title-service.js", () => ({
+  GENERATING_TITLE: "Generating title...",
+  isReplaceableTitle: () => true,
+  queueGenerateConversationTitle: () => {},
+  queueRegenerateConversationTitle: () => {},
+}));
+
+const mockFailStalledJobs = mock(() => 0);
+const mockClaimMemoryJobs = mock(() => []);
+mock.module("../memory/jobs-store.js", () => ({
+  claimMemoryJobs: mockClaimMemoryJobs,
+  completeMemoryJob: mock(() => {}),
+  deferMemoryJob: mock(() => "deferred"),
+  EMBED_JOB_TYPES: [],
+  enqueueMemoryJob: mock(() => "job-1"),
+  enqueuePruneOldConversationsJob: mock(() => "job-prune-conv"),
+  enqueuePruneOldLlmRequestLogsJob: mock(() => "job-prune-llm"),
+  enqueuePruneOldTraceEventsJob: mock(() => "job-prune-trace"),
+  failMemoryJob: mock(() => {}),
+  failStalledJobs: mockFailStalledJobs,
+  getMemoryJobCounts: mock(() => ({})),
+  hasActiveJobOfType: mock(() => false),
+  resetRunningJobsToPending: mock(() => 0),
+  SLOW_LLM_JOB_TYPES: [],
+  upsertAutoAnalysisJob: mock(() => "job-auto-analysis"),
+  upsertDebouncedJob: mock(() => "job-debounced"),
+}));
+
+const mockMaybeRunDbMaintenance = mock(() => {});
+mock.module("../memory/db-maintenance.js", () => ({
+  maybeRunDbMaintenance: mockMaybeRunDbMaintenance,
+}));
+
+mock.module("../memory/cleanup-schedule-state.js", () => ({
+  getLastScheduledCleanupEnqueueMs: () => 0,
+  markScheduledCleanupEnqueued: mock(() => {}),
+}));
+
+const { startFeedScheduler } = await import("../home/feed-scheduler.js");
+const { runMemoryJobsOnce } = await import("../memory/jobs-worker.js");
+const { FilingService } = await import("../filing/filing-service.js");
+const { WorkspaceHeartbeatService } =
+  await import("../workspace/heartbeat-service.js");
+
+describe("background workers disk pressure gate", () => {
+  beforeEach(() => {
+    mockProcessMessage.mockClear();
+    createdConversations.length = 0;
+    mockFailStalledJobs.mockClear();
+    mockClaimMemoryJobs.mockClear();
+    mockMaybeRunDbMaintenance.mockClear();
+  });
+
+  test("home feed scheduler skips producers while locked", async () => {
+    const gmailDigestRunner = mock(async () => null);
+    const rollupRunner = mock(async () => ({
+      wroteCount: 1,
+      skippedReason: "empty_items" as const,
+    }));
+    const handle = startFeedScheduler({
+      runOnStart: false,
+      gmailCountSource: async () => 0,
+      gmailDigestRunner,
+      rollupRunner,
+    });
+
+    const summary = await handle.runOnce(new Date("2026-05-05T12:00:00.000Z"));
+    handle.stop();
+
+    expect(summary).toEqual({ gmailDigestRan: false, rollupRan: false });
+    expect(gmailDigestRunner).not.toHaveBeenCalled();
+    expect(rollupRunner).not.toHaveBeenCalled();
+  });
+
+  test("memory jobs worker skips before claiming or maintenance writes", async () => {
+    const processed = await runMemoryJobsOnce({ enableScheduledCleanup: true });
+
+    expect(processed).toBe(0);
+    expect(mockFailStalledJobs).not.toHaveBeenCalled();
+    expect(mockClaimMemoryJobs).not.toHaveBeenCalled();
+    expect(mockMaybeRunDbMaintenance).not.toHaveBeenCalled();
+  });
+
+  test("filing service skips background LLM work while locked", async () => {
+    const service = new FilingService();
+
+    const ran = await service.runOnce();
+    const compacted = await service.runCompactionOnce();
+
+    expect(ran).toBe(false);
+    expect(compacted).toBe(false);
+    expect(createdConversations).toHaveLength(0);
+    expect(mockProcessMessage).not.toHaveBeenCalled();
+  });
+
+  test("workspace heartbeat skips auto-commit checks while locked", async () => {
+    const getServices = mock(() => new Map());
+    const heartbeat = new WorkspaceHeartbeatService({ getServices });
+
+    const result = await heartbeat.check();
+
+    expect(result).toEqual({ checked: 0, committed: 0, skipped: 0, failed: 0 });
+    expect(getServices).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/__tests__/disk-pressure-policy.test.ts
+++ b/assistant/src/__tests__/disk-pressure-policy.test.ts
@@ -211,6 +211,16 @@ describe("classifyDiskPressureTurnPolicy", () => {
       expected: { action: "block", reason: "background" },
     },
     {
+      name: "local-owner background turn without direct wake is blocked",
+      status: status(),
+      metadata: {
+        ...localOwnerTurn,
+        conversationType: "background",
+        conversationSource: "heartbeat",
+      },
+      expected: { action: "block", reason: "background" },
+    },
+    {
       name: "explicit local-owner direct wake can enter cleanup mode",
       status: status(),
       metadata: {

--- a/assistant/src/__tests__/disk-pressure-policy.test.ts
+++ b/assistant/src/__tests__/disk-pressure-policy.test.ts
@@ -210,6 +210,16 @@ describe("classifyDiskPressureTurnPolicy", () => {
       },
       expected: { action: "block", reason: "background" },
     },
+    {
+      name: "explicit local-owner direct wake can enter cleanup mode",
+      status: status(),
+      metadata: {
+        ...localOwnerTurn,
+        conversationSource: "local-cleanup",
+        isDirectWake: true,
+      },
+      expected: { action: "allow-cleanup-mode", reason: "local-owner" },
+    },
   ] satisfies Array<{
     name: string;
     status: DiskPressureStatus;

--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    heartbeat: {
+      enabled: true,
+      intervalMs: 60_000,
+      cronExpression: null,
+      timezone: null,
+      activeHoursStart: undefined,
+      activeHoursEnd: undefined,
+    },
+  }),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getConfigReadOnly: () => ({}),
+  applyNestedDefaults: (config: unknown) => config,
+  deepMergeOverwrite: (base: unknown) => base,
+  mergeDefaultWorkspaceConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
+  _appendQuarantineBulletin: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+const mockInsertPendingHeartbeatRun = mock(() => "run-1");
+const mockStartHeartbeatRun = mock(() => true);
+const mockCompleteHeartbeatRun = mock(() => true);
+const mockSkipHeartbeatRun = mock(() => true);
+const mockMarkStaleRunsAsMissed = mock(() => 0);
+const mockMarkStaleRunningAsError = mock(() => 0);
+mock.module("../heartbeat/heartbeat-run-store.js", () => ({
+  insertPendingHeartbeatRun: mockInsertPendingHeartbeatRun,
+  startHeartbeatRun: mockStartHeartbeatRun,
+  completeHeartbeatRun: mockCompleteHeartbeatRun,
+  skipHeartbeatRun: mockSkipHeartbeatRun,
+  supersedePendingRun: mock(() => true),
+  markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
+  markStaleRunningAsError: mockMarkStaleRunningAsError,
+}));
+
+mock.module("../schedule/recurrence-engine.js", () => ({
+  computeNextRunAt: () => Date.now() + 60_000,
+}));
+
+const createdConversations: Array<{ conversationType: string }> = [];
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversation: () => null,
+  getMessages: () => [],
+  createConversation: (opts: { conversationType: string }) => {
+    createdConversations.push(opts);
+    return { id: "conv-1", ...opts };
+  },
+}));
+
+const mockProcessMessage = mock(() => Promise.resolve({ messageId: "msg-1" }));
+mock.module("../daemon/process-message.js", () => ({
+  processMessage: mockProcessMessage,
+}));
+
+const mockEmitFeedEvent = mock(() => Promise.resolve());
+mock.module("../home/emit-feed-event.js", () => ({
+  emitFeedEvent: mockEmitFeedEvent,
+}));
+
+mock.module("../prompts/persona-resolver.js", () => ({
+  GUARDIAN_PERSONA_TEMPLATE: "# User Profile\n",
+  resolveGuardianPersona: () => "# User Profile\n",
+}));
+
+mock.module("../memory/conversation-title-service.js", () => ({
+  GENERATING_TITLE: "Generating title...",
+  queueGenerateConversationTitle: () => {},
+}));
+
+mock.module("../daemon/disk-pressure-background-gate.js", () => ({
+  checkDiskPressureBackgroundGate: () => ({
+    action: "skip",
+    reason: "disk_pressure",
+    blockedCapability: "background-work",
+    status: {
+      enabled: true,
+      state: "critical",
+      locked: true,
+      acknowledged: true,
+      overrideActive: false,
+      effectivelyLocked: true,
+      lockId: "disk-pressure-test",
+      usagePercent: 98,
+      thresholdPercent: 95,
+      path: "/",
+      lastCheckedAt: "2026-05-05T00:00:00.000Z",
+      blockedCapabilities: ["agent-turns", "background-work", "remote-ingress"],
+      error: null,
+    },
+  }),
+  diskPressureBackgroundSkipLogFields: () => ({
+    reason: "disk_pressure",
+    thresholdPercent: 95,
+    usagePercent: 98,
+    blockedCapability: "background-work",
+    lockId: "disk-pressure-test",
+    path: "/",
+  }),
+  shouldLogDiskPressureBackgroundSkip: () => true,
+}));
+
+const { HeartbeatService } = await import("../heartbeat/heartbeat-service.js");
+
+describe("HeartbeatService disk pressure gate", () => {
+  beforeEach(() => {
+    createdConversations.length = 0;
+    mockInsertPendingHeartbeatRun.mockClear();
+    mockStartHeartbeatRun.mockClear();
+    mockCompleteHeartbeatRun.mockClear();
+    mockSkipHeartbeatRun.mockClear();
+    mockMarkStaleRunsAsMissed.mockClear();
+    mockMarkStaleRunsAsMissed.mockImplementation(() => 0);
+    mockMarkStaleRunningAsError.mockClear();
+    mockMarkStaleRunningAsError.mockImplementation(() => 0);
+    mockProcessMessage.mockClear();
+    mockEmitFeedEvent.mockClear();
+  });
+
+  test("skips without creating heartbeat rows, conversations, or feed events", async () => {
+    const service = new HeartbeatService({
+      alerter: () => {},
+    });
+
+    const ran = await service.runOnce();
+
+    expect(ran).toBe(false);
+    expect(mockInsertPendingHeartbeatRun).not.toHaveBeenCalled();
+    expect(mockStartHeartbeatRun).not.toHaveBeenCalled();
+    expect(mockCompleteHeartbeatRun).not.toHaveBeenCalled();
+    expect(mockSkipHeartbeatRun).not.toHaveBeenCalled();
+    expect(createdConversations).toHaveLength(0);
+    expect(mockProcessMessage).not.toHaveBeenCalled();
+    expect(mockEmitFeedEvent).not.toHaveBeenCalled();
+  });
+
+  test("start recovery skips missed-run feed events while locked", async () => {
+    mockMarkStaleRunsAsMissed.mockImplementationOnce(() => 1);
+    const service = new HeartbeatService({
+      alerter: () => {},
+    });
+
+    service.start();
+    await service.stop();
+
+    expect(mockMarkStaleRunsAsMissed).toHaveBeenCalledTimes(1);
+    expect(mockEmitFeedEvent).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -150,6 +150,23 @@ describe("HeartbeatService disk pressure gate", () => {
     expect(mockEmitFeedEvent).not.toHaveBeenCalled();
   });
 
+  test("allows forced user-initiated heartbeat runs while locked", async () => {
+    const service = new HeartbeatService({
+      alerter: () => {},
+    });
+
+    const ran = await service.runOnce({ force: true });
+
+    expect(ran).toBe(true);
+    expect(mockStartHeartbeatRun).toHaveBeenCalled();
+    expect(mockCompleteHeartbeatRun).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ status: "ok" }),
+    );
+    expect(createdConversations).toHaveLength(1);
+    expect(mockProcessMessage).toHaveBeenCalledTimes(1);
+  });
+
   test("start recovery skips missed-run feed events while locked", async () => {
     mockMarkStaleRunsAsMissed.mockImplementationOnce(() => 1);
     const service = new HeartbeatService({

--- a/assistant/src/__tests__/scheduler-disk-pressure.test.ts
+++ b/assistant/src/__tests__/scheduler-disk-pressure.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+  truncateForLog: (value: string) => value,
+}));
+
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: mock(() =>
+    Promise.resolve({ invoked: true, producedToolCalls: false }),
+  ),
+}));
+
+mock.module("../home/emit-feed-event.js", () => ({
+  emitFeedEvent: mock(() => Promise.resolve()),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  loadConfig: () => ({}),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getConfigReadOnly: () => ({}),
+  applyNestedDefaults: (config: unknown) => config,
+  deepMergeOverwrite: (base: unknown) => base,
+  mergeDefaultWorkspaceConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
+  _appendQuarantineBulletin: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+let locked = true;
+mock.module("../daemon/disk-pressure-background-gate.js", () => ({
+  checkDiskPressureBackgroundGate: () =>
+    locked
+      ? {
+          action: "skip",
+          reason: "disk_pressure",
+          blockedCapability: "background-work",
+          status: {
+            enabled: true,
+            state: "critical",
+            locked: true,
+            acknowledged: true,
+            overrideActive: false,
+            effectivelyLocked: true,
+            lockId: "disk-pressure-test",
+            usagePercent: 98,
+            thresholdPercent: 95,
+            path: "/",
+            lastCheckedAt: "2026-05-05T00:00:00.000Z",
+            blockedCapabilities: [
+              "agent-turns",
+              "background-work",
+              "remote-ingress",
+            ],
+            error: null,
+          },
+        }
+      : {
+          action: "allow",
+          status: {
+            enabled: false,
+            state: "disabled",
+            locked: false,
+            acknowledged: false,
+            overrideActive: false,
+            effectivelyLocked: false,
+            lockId: null,
+            usagePercent: null,
+            thresholdPercent: 95,
+            path: null,
+            lastCheckedAt: null,
+            blockedCapabilities: [],
+            error: null,
+          },
+        },
+  diskPressureBackgroundSkipLogFields: () => ({
+    reason: "disk_pressure",
+    thresholdPercent: 95,
+    usagePercent: 98,
+    blockedCapability: "background-work",
+    lockId: "disk-pressure-test",
+    path: "/",
+  }),
+  shouldLogDiskPressureBackgroundSkip: () => true,
+}));
+
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { createSchedule } from "../schedule/schedule-store.js";
+import { runScheduleOnce } from "../schedule/scheduler.js";
+
+initializeDb();
+
+function rawDb(): import("bun:sqlite").Database {
+  return (getDb() as unknown as { $client: import("bun:sqlite").Database })
+    .$client;
+}
+
+describe("scheduler disk pressure gate", () => {
+  beforeEach(() => {
+    locked = true;
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+    db.run("DELETE FROM task_runs");
+    db.run("DELETE FROM tasks");
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+  });
+
+  test("skips before claiming due schedules while disk pressure is locked", async () => {
+    const dueAt = Date.now() - 10_000;
+    const schedule = createSchedule({
+      name: "Due reminder",
+      message: "Do not fire while locked",
+      mode: "notify",
+      nextRunAt: dueAt,
+    });
+
+    const processMessage = mock(() => Promise.resolve());
+    const notify = mock(() => Promise.resolve());
+
+    const processed = await runScheduleOnce(processMessage, notify);
+
+    expect(processed).toBe(0);
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+
+    const row = rawDb()
+      .query("SELECT status, next_run_at FROM cron_jobs WHERE id = ?")
+      .get(schedule.id) as { status: string; next_run_at: number } | null;
+    expect(row).toEqual({ status: "active", next_run_at: dueAt });
+
+    const runCount = rawDb()
+      .query("SELECT COUNT(*) AS count FROM cron_runs")
+      .get() as { count: number };
+    expect(runCount.count).toBe(0);
+  });
+});

--- a/assistant/src/daemon/disk-pressure-background-gate.ts
+++ b/assistant/src/daemon/disk-pressure-background-gate.ts
@@ -1,0 +1,73 @@
+import {
+  type DiskPressureBlockedCapability,
+  type DiskPressureStatus,
+  getDiskPressureStatus,
+} from "./disk-pressure-guard.js";
+
+export type DiskPressureBackgroundGateDecision =
+  | { action: "allow"; status: DiskPressureStatus }
+  | {
+      action: "skip";
+      reason: "disk_pressure";
+      status: DiskPressureStatus;
+      blockedCapability: DiskPressureBlockedCapability;
+    };
+
+export const DISK_PRESSURE_BACKGROUND_LOG_THROTTLE_MS = 60_000;
+
+const lastSkipLogAtByKey = new Map<string, number>();
+
+export function checkDiskPressureBackgroundGate(
+  blockedCapability: DiskPressureBlockedCapability = "background-work",
+): DiskPressureBackgroundGateDecision {
+  const status = getDiskPressureStatus();
+  if (!status.enabled || !status.locked || status.overrideActive) {
+    return { action: "allow", status };
+  }
+  if (!status.effectivelyLocked) {
+    return { action: "allow", status };
+  }
+  return {
+    action: "skip",
+    reason: "disk_pressure",
+    status,
+    blockedCapability,
+  };
+}
+
+export function shouldLogDiskPressureBackgroundSkip(
+  key: string,
+  nowMs = Date.now(),
+): boolean {
+  const lastLoggedAt = lastSkipLogAtByKey.get(key) ?? 0;
+  if (nowMs - lastLoggedAt < DISK_PRESSURE_BACKGROUND_LOG_THROTTLE_MS) {
+    return false;
+  }
+  lastSkipLogAtByKey.set(key, nowMs);
+  return true;
+}
+
+export function diskPressureBackgroundSkipLogFields(
+  decision: Extract<DiskPressureBackgroundGateDecision, { action: "skip" }>,
+): {
+  reason: "disk_pressure";
+  thresholdPercent: number;
+  usagePercent: number | null;
+  blockedCapability: DiskPressureBlockedCapability;
+  lockId: string | null;
+  path: string | null;
+} {
+  return {
+    reason: decision.reason,
+    thresholdPercent: decision.status.thresholdPercent,
+    usagePercent: decision.status.usagePercent,
+    blockedCapability: decision.blockedCapability,
+    lockId: decision.status.lockId,
+    path: decision.status.path,
+  };
+}
+
+/** @internal */
+export function __resetDiskPressureBackgroundGateForTests(): void {
+  lastSkipLogAtByKey.clear();
+}

--- a/assistant/src/daemon/disk-pressure-policy.ts
+++ b/assistant/src/daemon/disk-pressure-policy.ts
@@ -147,6 +147,7 @@ function isLocalOwnerTurnWithoutTrust(
 function isExplicitLocalOwnerCleanupTurn(
   metadata: DiskPressureTurnMetadata,
 ): boolean {
+  if (metadata.isDirectWake !== true) return false;
   const sourceInterface = metadata.sourceInterface;
   if (
     metadata.sourceChannel !== "vellum" ||

--- a/assistant/src/daemon/disk-pressure-policy.ts
+++ b/assistant/src/daemon/disk-pressure-policy.ts
@@ -104,6 +104,7 @@ export function classifyDiskPressureTurnPolicy(
 }
 
 function isBackgroundTurn(metadata: DiskPressureTurnMetadata): boolean {
+  if (isExplicitLocalOwnerCleanupTurn(metadata)) return false;
   if (metadata.isDirectWake) return true;
   if (metadata.callSite != null && metadata.callSite !== "mainAgent") {
     return true;
@@ -141,4 +142,21 @@ function isLocalOwnerTurnWithoutTrust(
   const sourceInterface = metadata.sourceInterface;
   if (channel !== "vellum" || sourceInterface == null) return false;
   return LOCAL_OWNER_INTERFACES.has(sourceInterface);
+}
+
+function isExplicitLocalOwnerCleanupTurn(
+  metadata: DiskPressureTurnMetadata,
+): boolean {
+  const sourceInterface = metadata.sourceInterface;
+  if (
+    metadata.sourceChannel !== "vellum" ||
+    sourceInterface == null ||
+    !LOCAL_OWNER_INTERFACES.has(sourceInterface)
+  ) {
+    return false;
+  }
+  return (
+    metadata.trustContext == null ||
+    metadata.trustContext.trustClass === "guardian"
+  );
 }

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -197,7 +197,7 @@ export class FilingService {
     const config = getConfig().filing;
     if (!force && !config.enabled) return false;
 
-    if (this.shouldSkipForDiskPressure("filing")) {
+    if (!force && this.shouldSkipForDiskPressure("filing")) {
       return false;
     }
 
@@ -251,7 +251,7 @@ export class FilingService {
     const config = getConfig().filing;
     if (!force && !config.compactionEnabled) return false;
 
-    if (this.shouldSkipForDiskPressure("compaction")) {
+    if (!force && this.shouldSkipForDiskPressure("compaction")) {
       return false;
     }
 

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -4,6 +4,11 @@ import { join } from "node:path";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import {
+  checkDiskPressureBackgroundGate,
+  diskPressureBackgroundSkipLogFields,
+  shouldLogDiskPressureBackgroundSkip,
+} from "../daemon/disk-pressure-background-gate.js";
 import { processMessage } from "../daemon/process-message.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getLogger } from "../util/logger.js";
@@ -192,6 +197,10 @@ export class FilingService {
     const config = getConfig().filing;
     if (!force && !config.enabled) return false;
 
+    if (this.shouldSkipForDiskPressure("filing")) {
+      return false;
+    }
+
     if (
       !force &&
       !this.isWithinActiveHoursNow(
@@ -241,6 +250,10 @@ export class FilingService {
   }: { force?: boolean } = {}): Promise<boolean> {
     const config = getConfig().filing;
     if (!force && !config.compactionEnabled) return false;
+
+    if (this.shouldSkipForDiskPressure("compaction")) {
+      return false;
+    }
 
     if (
       !force &&
@@ -294,6 +307,21 @@ export class FilingService {
 
   private scheduleNextCompactionRun(intervalMs: number): void {
     this._nextCompactionAt = Date.now() + intervalMs;
+  }
+
+  private shouldSkipForDiskPressure(source: "filing" | "compaction"): boolean {
+    const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
+    if (diskPressureGate.action === "allow") return false;
+    if (shouldLogDiskPressureBackgroundSkip(`filing-service:${source}`)) {
+      log.warn(
+        {
+          source,
+          ...diskPressureBackgroundSkipLogFields(diskPressureGate),
+        },
+        "Filing service skipped during disk pressure cleanup mode",
+      );
+    }
+    return true;
   }
 
   private hasBufferContent(): boolean {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -403,7 +403,7 @@ export class HeartbeatService {
   async runOnce({ force = false }: { force?: boolean } = {}): Promise<boolean> {
     const config = getConfig().heartbeat;
 
-    if (isDiskPressureBackgroundLocked("heartbeat")) {
+    if (!force && isDiskPressureBackgroundLocked("heartbeat")) {
       return false;
     }
 

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -3,6 +3,11 @@ import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
 import type { HeartbeatConfig } from "../config/schemas/heartbeat.js";
+import {
+  checkDiskPressureBackgroundGate,
+  diskPressureBackgroundSkipLogFields,
+  shouldLogDiskPressureBackgroundSkip,
+} from "../daemon/disk-pressure-background-gate.js";
 import type { HeartbeatAlert } from "../daemon/message-protocol.js";
 import { processMessage } from "../daemon/process-message.js";
 import { emitFeedEvent } from "../home/emit-feed-event.js";
@@ -234,18 +239,22 @@ export class HeartbeatService {
           "Recovered stale heartbeat runs on startup",
         );
 
-        const total = this._startupMissedCount + this._startupCrashedCount;
-        const today = new Date().toISOString().split("T")[0];
-        void emitFeedEvent({
-          source: "assistant",
-          title: "Heartbeat Runs Missed",
-          summary: `${total} heartbeat run${total > 1 ? "s were" : " was"} missed while the assistant was offline.`,
-          dedupKey: `heartbeat:missed:${today}`,
-          priority: 55,
-          urgency: "high",
-        }).catch((err) => {
-          log.warn({ err }, "Failed to emit missed heartbeat feed event");
-        });
+        if (!isDiskPressureBackgroundLocked("heartbeat-startup")) {
+          const total = this._startupMissedCount + this._startupCrashedCount;
+          const today = new Date().toISOString().split("T")[0];
+          void emitFeedEvent({
+            source: "assistant",
+            title: "Heartbeat Runs Missed",
+            summary: `${total} heartbeat run${
+              total > 1 ? "s were" : " was"
+            } missed while the assistant was offline.`,
+            dedupKey: `heartbeat:missed:${today}`,
+            priority: 55,
+            urgency: "high",
+          }).catch((err) => {
+            log.warn({ err }, "Failed to emit missed heartbeat feed event");
+          });
+        }
       }
     }
 
@@ -393,6 +402,10 @@ export class HeartbeatService {
    *  When `force` is true (e.g. manual "Run Now"), skip enabled & active-hours guards. */
   async runOnce({ force = false }: { force?: boolean } = {}): Promise<boolean> {
     const config = getConfig().heartbeat;
+
+    if (isDiskPressureBackgroundLocked("heartbeat")) {
+      return false;
+    }
 
     let runId: string | null;
     let scheduledFor: number;
@@ -878,6 +891,21 @@ After completing your review, end your response with one of:
 
     return { prompt, includedReengagement };
   }
+}
+
+function isDiskPressureBackgroundLocked(logKey: string): boolean {
+  const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
+  if (diskPressureGate.action === "allow") return false;
+  if (shouldLogDiskPressureBackgroundSkip(logKey)) {
+    log.warn(
+      {
+        source: "heartbeat",
+        ...diskPressureBackgroundSkipLogFields(diskPressureGate),
+      },
+      "Heartbeat skipped during disk pressure cleanup mode",
+    );
+  }
+  return true;
 }
 
 /**

--- a/assistant/src/home/feed-scheduler.ts
+++ b/assistant/src/home/feed-scheduler.ts
@@ -28,6 +28,11 @@
  *     scheduler needing to touch the event hub.
  */
 
+import {
+  checkDiskPressureBackgroundGate,
+  diskPressureBackgroundSkipLogFields,
+  shouldLogDiskPressureBackgroundSkip,
+} from "../daemon/disk-pressure-background-gate.js";
 import { getLogger } from "../util/logger.js";
 import type { FeedItem } from "./feed-types.js";
 import {
@@ -119,6 +124,19 @@ export function startFeedScheduler(
       rollupRan: false,
     };
     if (stopped || tickRunning) return summary;
+    const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
+    if (diskPressureGate.action === "skip") {
+      if (shouldLogDiskPressureBackgroundSkip("home-feed-scheduler")) {
+        log.warn(
+          {
+            source: "feed-scheduler",
+            ...diskPressureBackgroundSkipLogFields(diskPressureGate),
+          },
+          "Home feed scheduler skipped during disk pressure cleanup mode",
+        );
+      }
+      return summary;
+    }
     tickRunning = true;
     const nowMs = now.getTime();
     try {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -1,6 +1,11 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
+import {
+  checkDiskPressureBackgroundGate,
+  diskPressureBackgroundSkipLogFields,
+  shouldLogDiskPressureBackgroundSkip,
+} from "../daemon/disk-pressure-background-gate.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
 import {
@@ -168,6 +173,20 @@ export async function runMemoryJobsOnce(
   const config = getConfig();
   if (!config.memory.enabled) return 0;
   const enableScheduledCleanup = options.enableScheduledCleanup === true;
+
+  const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
+  if (diskPressureGate.action === "skip") {
+    if (shouldLogDiskPressureBackgroundSkip("memory-jobs-worker")) {
+      log.warn(
+        {
+          source: "memory",
+          ...diskPressureBackgroundSkipLogFields(diskPressureGate),
+        },
+        "Memory jobs worker skipped during disk pressure cleanup mode",
+      );
+    }
+    return 0;
+  }
 
   // Fail jobs that have been running longer than the configured timeout
   const timedOut = failStalledJobs(config.memory.jobs.stalledJobTimeoutMs);

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -17,11 +17,55 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { DiskPressureStatus } from "../../daemon/disk-pressure-guard.js";
+
 // Stub the DB-backed override-profile read so unit tests don't need a
 // real SQLite database. The wake helper calls this on every invocation
 // to honor the conversation's pinned inference profile.
 mock.module("../../memory/conversation-crud.js", () => ({
   getConversationOverrideProfile: () => undefined,
+}));
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ llm: {} }),
+  loadConfig: () => ({ llm: {} }),
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getConfigReadOnly: () => ({ llm: {} }),
+  applyNestedDefaults: (config: unknown) => config,
+  deepMergeOverwrite: (base: unknown) => base,
+  mergeDefaultWorkspaceConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+  API_KEY_PROVIDERS: [],
+  _appendQuarantineBulletin: () => {},
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../../config/llm-context-resolution.js", () => ({
+  resolveEffectiveContextWindow: () => ({
+    maxInputTokens: 200_000,
+  }),
+}));
+
+let mockDiskPressureStatus: DiskPressureStatus = {
+  enabled: false,
+  state: "disabled",
+  locked: false,
+  acknowledged: false,
+  overrideActive: false,
+  effectivelyLocked: false,
+  lockId: null,
+  usagePercent: null,
+  thresholdPercent: 95,
+  path: null,
+  lastCheckedAt: null,
+  blockedCapabilities: [],
+  error: null,
+};
+
+mock.module("../../daemon/disk-pressure-guard.js", () => ({
+  getDiskPressureStatus: () => mockDiskPressureStatus,
 }));
 
 import type { AgentEvent } from "../../agent/loop.js";
@@ -37,7 +81,11 @@ import {
 interface MockTarget extends WakeTarget {
   emittedEvents: AgentEvent[];
   pushedMessages: Message[];
-  runCalls: Array<{ input: Message[]; requestId?: string }>;
+  runCalls: Array<{
+    input: Message[];
+    requestId?: string;
+    turnContext?: unknown;
+  }>;
   processingToggles: boolean[];
   /** Tail messages handed to `persistTailMessage`, in call order. */
   persistedTailCalls: Message[];
@@ -70,7 +118,11 @@ function makeTarget(options: {
 }): MockTarget {
   const emittedEvents: AgentEvent[] = [];
   const pushedMessages: Message[] = [];
-  const runCalls: Array<{ input: Message[]; requestId?: string }> = [];
+  const runCalls: Array<{
+    input: Message[];
+    requestId?: string;
+    turnContext?: unknown;
+  }> = [];
   const processingToggles: boolean[] = [];
   const persistedTailCalls: Message[] = [];
   const callSequence: string[] = [];
@@ -97,8 +149,11 @@ function makeTarget(options: {
         onEvent: (event: AgentEvent) => void | Promise<void>,
         _signal?: AbortSignal,
         requestId?: string,
+        _onCheckpoint?: unknown,
+        _callSite?: unknown,
+        turnContext?: unknown,
       ) => {
-        runCalls.push({ input: [...input], requestId });
+        runCalls.push({ input: [...input], requestId, turnContext });
         // Emit any scripted events the test wanted us to produce.
         for (const ev of options.scriptedEvents ?? []) {
           await onEvent(ev);
@@ -165,11 +220,163 @@ function makeTarget(options: {
 
 beforeEach(() => {
   __resetWakeChainForTests();
+  mockDiskPressureStatus = {
+    enabled: false,
+    state: "disabled",
+    locked: false,
+    acknowledged: false,
+    overrideActive: false,
+    effectivelyLocked: false,
+    lockId: null,
+    usagePercent: null,
+    thresholdPercent: 95,
+    path: null,
+    lastCheckedAt: null,
+    blockedCapabilities: [],
+    error: null,
+  };
 });
 
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("wakeAgentForOpportunity", () => {
+  test("disabled disk pressure flag allows background wakes to pass through", async () => {
+    const target = makeTarget({
+      scriptedAssistant: null,
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "background completion",
+        source: "background-tool",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(target.runCalls).toHaveLength(1);
+  });
+
+  test("blocks background wakes during disk pressure before marking processing", async () => {
+    mockDiskPressureStatus = {
+      enabled: true,
+      state: "critical",
+      locked: true,
+      acknowledged: true,
+      overrideActive: false,
+      effectivelyLocked: true,
+      lockId: "disk-pressure-test",
+      usagePercent: 98,
+      thresholdPercent: 95,
+      path: "/",
+      lastCheckedAt: "2026-05-05T00:00:00.000Z",
+      blockedCapabilities: ["agent-turns", "background-work", "remote-ingress"],
+      error: null,
+    };
+    const target = makeTarget({
+      isProcessing: true,
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "should not run" }],
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "background shell completed",
+        source: "background-tool",
+        trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({
+      invoked: false,
+      producedToolCalls: false,
+      reason: "disk_pressure",
+    });
+    expect(target.runCalls).toHaveLength(0);
+    expect(target.processingToggles).toEqual([]);
+    expect(target.drainQueueCalls).toBe(0);
+    expect(target.isProcessing()).toBe(true);
+  });
+
+  test("blocks trusted-contact direct wakes during disk pressure", async () => {
+    mockDiskPressureStatus = {
+      enabled: true,
+      state: "critical",
+      locked: true,
+      acknowledged: true,
+      overrideActive: false,
+      effectivelyLocked: true,
+      lockId: "disk-pressure-test",
+      usagePercent: 98,
+      thresholdPercent: 95,
+      path: "/",
+      lastCheckedAt: "2026-05-05T00:00:00.000Z",
+      blockedCapabilities: ["agent-turns", "background-work", "remote-ingress"],
+      error: null,
+    };
+    const target = makeTarget({ scriptedAssistant: null });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "notify the guardian",
+        source: "notification",
+        trustContext: {
+          sourceChannel: "slack",
+          trustClass: "trusted_contact",
+        },
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result.reason).toBe("disk_pressure");
+    expect(target.runCalls).toHaveLength(0);
+  });
+
+  test("threads cleanup-mode injection context for explicit local-owner wakes", async () => {
+    mockDiskPressureStatus = {
+      enabled: true,
+      state: "critical",
+      locked: true,
+      acknowledged: true,
+      overrideActive: false,
+      effectivelyLocked: true,
+      lockId: "disk-pressure-test",
+      usagePercent: 98,
+      thresholdPercent: 95,
+      path: "/",
+      lastCheckedAt: "2026-05-05T00:00:00.000Z",
+      blockedCapabilities: ["agent-turns", "background-work", "remote-ingress"],
+      error: null,
+    };
+    const target = makeTarget({ scriptedAssistant: null });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "clean storage",
+        source: "local-cleanup",
+        sourceChannel: "vellum",
+        sourceInterface: "macos",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(target.runCalls).toHaveLength(1);
+    expect(target.runCalls[0]!.turnContext).toMatchObject({
+      conversationId: target.conversationId,
+      injectionInputs: {
+        diskPressureContext: { cleanupModeActive: true },
+      },
+    });
+  });
+
   test("silent no-op when agent produces no tool calls and no text", async () => {
     const target = makeTarget({
       baseline: [

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -41,10 +41,17 @@
  */
 
 import type { AgentEvent, AgentLoop } from "../agent/loop.js";
+import type { InterfaceId } from "../channels/types.js";
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { getConfig } from "../config/loader.js";
+import { getDiskPressureStatus } from "../daemon/disk-pressure-guard.js";
+import {
+  classifyDiskPressureTurnPolicy,
+  type DiskPressureTurnPolicyDecision,
+} from "../daemon/disk-pressure-policy.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getConversationOverrideProfile } from "../memory/conversation-crud.js";
+import type { TurnContext } from "../plugins/types.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
@@ -164,6 +171,13 @@ export interface WakeOptions {
    * assistant-self-maintenance jobs.
    */
   trustContext?: TrustContext;
+  /**
+   * Explicit local-owner metadata for rare direct wakes that are allowed to run
+   * in cleanup mode. Omit for background jobs; they are paused under disk
+   * pressure even when they otherwise carry internal guardian trust.
+   */
+  sourceChannel?: TrustContext["sourceChannel"];
+  sourceInterface?: InterfaceId | "vellum";
 }
 
 /**
@@ -176,7 +190,8 @@ export type WakeSkipReason =
   | "not_found"
   | "archived"
   | "timeout"
-  | "no_resolver";
+  | "no_resolver"
+  | "disk_pressure";
 
 export interface WakeResult {
   invoked: boolean;
@@ -294,6 +309,48 @@ async function waitUntilIdle(
   return !target.isProcessing();
 }
 
+function classifyWakeDiskPressurePolicy(opts: WakeOptions): {
+  decision: DiskPressureTurnPolicyDecision;
+  status: ReturnType<typeof getDiskPressureStatus>;
+} {
+  const status = getDiskPressureStatus();
+  const decision = classifyDiskPressureTurnPolicy(status, {
+    conversationSource: opts.source,
+    callSite: "mainAgent",
+    isDirectWake: true,
+    sourceChannel: opts.sourceChannel ?? opts.trustContext?.sourceChannel,
+    sourceInterface: opts.sourceInterface,
+    trustContext: opts.trustContext
+      ? {
+          sourceChannel: opts.trustContext.sourceChannel,
+          trustClass: opts.trustContext.trustClass,
+        }
+      : null,
+  });
+  return { decision, status };
+}
+
+function buildWakeTurnContext(
+  opts: WakeOptions,
+  decision: DiskPressureTurnPolicyDecision,
+): TurnContext | undefined {
+  if (decision.action !== "allow-cleanup-mode") return undefined;
+  return {
+    requestId: `wake:${opts.source}`,
+    conversationId: opts.conversationId,
+    turnIndex: 0,
+    trust:
+      opts.trustContext ??
+      ({
+        sourceChannel: opts.sourceChannel ?? "vellum",
+        trustClass: "guardian",
+      } satisfies TrustContext),
+    injectionInputs: {
+      diskPressureContext: { cleanupModeActive: true },
+    },
+  };
+}
+
 /**
  * Inspect the post-run history slice to decide whether the wake produced
  * output worth persisting/emitting, and collect any tool-use names from
@@ -382,6 +439,30 @@ export async function wakeAgentForOpportunity(
     }
     const target = resolved;
 
+    const { decision: diskPressureDecision, status: diskPressureStatus } =
+      classifyWakeDiskPressurePolicy(opts);
+    if (diskPressureDecision.action === "block") {
+      log.warn(
+        {
+          conversationId,
+          source,
+          reason: "disk_pressure",
+          diskPressureReason: diskPressureDecision.reason,
+          thresholdPercent: diskPressureStatus.thresholdPercent,
+          usagePercent: diskPressureStatus.usagePercent,
+          blockedCapability: "background-work",
+          lockId: diskPressureStatus.lockId,
+          path: diskPressureStatus.path,
+        },
+        "agent-wake: blocked by disk pressure cleanup mode",
+      );
+      return {
+        invoked: false,
+        producedToolCalls: false,
+        reason: "disk_pressure" as const,
+      };
+    }
+
     const idle = await waitUntilIdle(target, nowFn);
     if (!idle) {
       log.warn(
@@ -399,6 +480,7 @@ export async function wakeAgentForOpportunity(
     }
 
     const baseline = target.getMessages();
+    const wakeTurnContext = buildWakeTurnContext(opts, diskPressureDecision);
     const hintContent = `[opportunity:${source}] ${hint}`;
     // Sandwich the hint as an assistant message between two hardcoded
     // user messages. The assistant role prevents prompt injection — LLMs
@@ -476,7 +558,7 @@ export async function wakeAgentForOpportunity(
           // short-circuit and silently drop both `llm.callSites.mainAgent`
           // config and the pinned `overrideProfile` below.
           "mainAgent",
-          undefined, // turnContext
+          wakeTurnContext,
           overrideProfile,
           effectiveContextWindow.maxInputTokens,
         );

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,3 +1,8 @@
+import {
+  checkDiskPressureBackgroundGate,
+  diskPressureBackgroundSkipLogFields,
+  shouldLogDiskPressureBackgroundSkip,
+} from "../daemon/disk-pressure-background-gate.js";
 import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation } from "../memory/conversation-crud.js";
@@ -129,7 +134,7 @@ export function startScheduler(
   };
 }
 
-async function runScheduleOnce(
+export async function runScheduleOnce(
   processMessage: ScheduleMessageProcessor,
   notifyScheduleOneShot: ScheduleNotifyModeNotifier,
   watcherNotifier?: WatcherNotifier,
@@ -138,6 +143,20 @@ async function runScheduleOnce(
 ): Promise<number> {
   const now = Date.now();
   let processed = 0;
+
+  const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
+  if (diskPressureGate.action === "skip") {
+    if (shouldLogDiskPressureBackgroundSkip("scheduler")) {
+      log.warn(
+        {
+          source: "schedule",
+          ...diskPressureBackgroundSkipLogFields(diskPressureGate),
+        },
+        "Schedule tick skipped during disk pressure cleanup mode",
+      );
+    }
+    return 0;
+  }
 
   // ── Schedules (recurring cron/RRULE + one-shot) ─────────────────────
   const jobs = claimDueSchedules(now);

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -1,3 +1,8 @@
+import {
+  checkDiskPressureBackgroundGate,
+  diskPressureBackgroundSkipLogFields,
+  shouldLogDiskPressureBackgroundSkip,
+} from "../daemon/disk-pressure-background-gate.js";
 import { getLogger } from "../util/logger.js";
 import { getEnrichmentService } from "./commit-message-enrichment-service.js";
 import {
@@ -134,6 +139,20 @@ export class WorkspaceHeartbeatService {
   async check(): Promise<HeartbeatCheckResult> {
     // Guard: skip if a previous check is still running
     if (this.activeCheck) {
+      return { checked: 0, committed: 0, skipped: 0, failed: 0 };
+    }
+
+    const diskPressureGate = checkDiskPressureBackgroundGate("background-work");
+    if (diskPressureGate.action === "skip") {
+      if (shouldLogDiskPressureBackgroundSkip("workspace-heartbeat")) {
+        log.warn(
+          {
+            source: "workspace-heartbeat",
+            ...diskPressureBackgroundSkipLogFields(diskPressureGate),
+          },
+          "Workspace heartbeat skipped during disk pressure cleanup mode",
+        );
+      }
       return { checked: 0, committed: 0, skipped: 0, failed: 0 };
     }
 


### PR DESCRIPTION
## Summary
- Add a shared disk-pressure background gate for wakes and schedulers.
- Skip heartbeat, feed, memory, filing, and workspace-heartbeat background work while locked.
- Cover blocked wakes and scheduler/worker skip behavior with focused tests.

Part of plan: disk-pressure-protection.md (PR 9 of 13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->