### PR TITLE
fix(auth): add route policy for memory/v2/concept-frequency

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -435,6 +435,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     endpoint: "memory/v2/rebuild-corpus-stats:POST",
     scopes: ["settings.write"],
   },
+  { endpoint: "memory/v2/concept-frequency:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/fit-anisotropy:POST", scopes: ["settings.write"] },
 
   // Trust rule listing
@@ -587,7 +588,7 @@ const INTERNAL_ENDPOINTS = [
   "internal/oauth/callback",
   "internal/mcp/auth/start",
   "internal/mcp/auth/status",
-  "internal/mcp/reload",  // ← new
+  "internal/mcp/reload", // ← new
 ];
 for (const endpoint of INTERNAL_ENDPOINTS) {
   registerPolicy(endpoint, {


### PR DESCRIPTION
## Summary
- Add missing `memory/v2/concept-frequency:POST` entry to `route-policy.ts` with `settings.read` scope (matches sibling read-only debug routes).
- Fixes `guard-tests.test.ts` failure: "Endpoints dispatched in http-server.ts have no route policy in route-policy.ts: memory/v2/concept-frequency".

## Original prompt
--yolo Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/25363413453/job/74368127577
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->