### PR TITLE
fix(macos): silence unused-result warning on TrustRuleClient.createRule

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -453,7 +453,7 @@ struct ChatBubble: View, Equatable {
                 onSave: { rule in
                     Task {
                         do {
-                            try await TrustRuleClient().createRule(
+                            _ = try await TrustRuleClient().createRule(
                                 tool: rule.toolName,
                                 pattern: rule.pattern,
                                 risk: rule.riskLevel,


### PR DESCRIPTION
## Summary
- Discard the `TrustRule` return value from `TrustRuleClient().createRule(...)` in `ChatBubble.swift` with `_ =` to silence the `#no-usage` build warning.
- Matches the existing pattern used by every other call site (`AssistantProgressView`, `ChatViewModel`, `ToolPermissionTesterModel`).

## Original prompt
Fix: ~v/clients/macos (main) ❯❯❯ VELLUM_NO_WATCH=1 ./build.sh run
VELLUM_ENVIRONMENT=dev
BUNDLE_ID=com.vellum.vellum-assistant-dev
BUNDLE_DISPLAY_NAME=Velissa
Building (debug)...
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift:456:57: warning: result of call to 'createRule(tool:pattern:risk:description:scope:)' is unused [#no-usage]
 454 |                     Task {
 455 |                         do {
 456 |                             try await TrustRuleClient().createRule(
     |                                                         \`- warning: result of call to 'createRule(tool:pattern:risk:description:scope:)' is unused [#no-usage]
 457 |                                 tool: rule.toolName,
 458 |                                 pattern: rule.pattern,
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->