### PR TITLE
fix(host-proxy): translate dev-bypass actor on host-result routes

### DIFF
--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
+import { isHttpAuthDisabled } from "../config/env.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
@@ -52,6 +53,41 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
  */
 export function findLocalGuardianPrincipalId(): string | undefined {
   return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
+}
+
+/**
+ * Translate the synthetic dev-bypass actor principal to the real local
+ * guardian's principalId when running in `DISABLE_HTTP_AUTH=true` mode.
+ *
+ * The dev-bypass `AuthContext` (`runtime/auth/middleware.ts`) injects
+ * `"dev-bypass"` as the actor principal id for every request, but tool-side
+ * trust resolution (`resolveLocalTrustContext`) and SSE registration both
+ * carry the real local guardian principalId. Without this translation, every
+ * targeted host_bash/host_file/host_cu/host_transfer result POST mismatches
+ * the same-user check and is rejected with 403, and conversation/surface/
+ * guardian-action routes resolve trust against the wrong principal.
+ *
+ * Returns the input unchanged when:
+ *   - HTTP auth is enabled (production / non-dev-bypass deployments), OR
+ *   - the input is not literally `"dev-bypass"` (e.g. service tokens).
+ *
+ * Returns the local guardian principalId when both gates are true. Returns
+ * `undefined` when dev-bypass is set but no guardian binding has been created
+ * yet (e.g. fresh install before bootstrap); callers must treat this the
+ * same as a missing principal.
+ */
+export function resolveActorPrincipalIdForLocalGuardian(
+  rawHeader: string | undefined,
+): string | undefined {
+  if (rawHeader !== "dev-bypass" || !isHttpAuthDisabled()) return rawHeader;
+
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) return guardianPrincipalId;
+
+  log.warn(
+    "dev-bypass actor principal received but no vellum guardian binding found; returning undefined",
+  );
+  return undefined;
 }
 
 /**

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -22,7 +22,6 @@ import { z } from "zod";
 
 import type { HostProxyCapability } from "../../channels/types.js";
 import { parseInterfaceId, supportsHostProxy } from "../../channels/types.js";
-import { isHttpAuthDisabled } from "../../config/env.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
@@ -36,7 +35,7 @@ import {
   AssistantEventHub,
   assistantEventHub,
 } from "../assistant-event-hub.js";
-import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -44,28 +43,6 @@ const log = getLogger("events-routes");
 
 /** Keep-alive comment sent to idle clients every 7 s by default. */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
-
-/**
- * Translate the synthetic dev-bypass actor principal to the real local
- * guardian's principalId when running in `DISABLE_HTTP_AUTH=true` mode.
- *
- * The dev-bypass `AuthContext` (`runtime/auth/middleware.ts`) injects
- * `"dev-bypass"` for every request, but tool-side trust resolution
- * (`resolveLocalTrustContext`) returns the real guardian principalId. Without
- * translation, every targeted host_bash/host_file/host_cu request mismatches
- * the same-user check and is rejected. Mirrors `resolveLocalAuthContext`.
- */
-function resolveActorPrincipalId(raw: string | undefined): string | undefined {
-  if (raw !== "dev-bypass" || !isHttpAuthDisabled()) return raw;
-
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
-  if (guardianPrincipalId) return guardianPrincipalId;
-
-  log.warn(
-    "dev-bypass actor principal received but no vellum guardian binding found; registering client without actorPrincipalId",
-  );
-  return undefined;
-}
 
 /**
  * Stream assistant events as Server-Sent Events.
@@ -114,7 +91,7 @@ export function handleSubscribeAssistantEvents(
   // bearer token's AuthContext. May be absent for legacy / service-token
   // connections that have no principal. See `resolveActorPrincipalId` for the
   // dev-bypass translation rationale.
-  const actorPrincipalId = resolveActorPrincipalId(
+  const actorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
     rawActorPrincipalId?.trim() || undefined,
   );
 

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -12,6 +12,7 @@ import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
 } from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -44,8 +45,9 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
 
   const submittingClientId =
     headers?.["x-vellum-client-id"]?.trim() || undefined;
-  const submittingActorPrincipalId =
-    headers?.["x-vellum-actor-principal-id"]?.trim() || undefined;
+  const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+    headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
+  );
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -12,6 +12,7 @@ import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
 } from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -94,8 +95,9 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     enforceSameActorOrThrow({
       hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -12,6 +12,7 @@ import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
 } from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -72,8 +73,9 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user somehow obtains the
     // target client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     enforceSameActorOrThrow({
       hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import { HostTransferProxy } from "../../daemon/host-transfer-proxy.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -66,8 +67,9 @@ function handleTransferContentGet({
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user obtains the target
     // client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     const targetActorPrincipalId =
       assistantEventHub.getActorPrincipalIdForClient(targetClientId);
     if (
@@ -153,8 +155,9 @@ async function handleTransferContentPut({
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user obtains the target
     // client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     const targetActorPrincipalId =
       assistantEventHub.getActorPrincipalIdForClient(targetClientId);
     if (
@@ -232,8 +235,9 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. Blocks
     // cross-user submissions even if a different user obtains the target
     // client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     const targetActorPrincipalId =
       assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
     if (


### PR DESCRIPTION
Hoists dev-bypass -> local-guardian translation into a shared helper and applies it on all four host-result routes (bash/cu/file/transfer) so targeted result POSTs work in DISABLE_HTTP_AUTH=true mode. Round-2 fix for plan host-proxy-same-user.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->