### PR TITLE
fix(gateway): overwrite x-vellum-actor-principal-id from verified JWT claims on IPC fast-path

### DIFF
--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -118,6 +118,24 @@ export async function tryIpcProxy(
     }
   });
 
+  // Override caller-supplied identity headers with values derived from the
+  // verified JWT claims. The daemon's IPC adapter (`injectLocalActorHeader`)
+  // preserves any inbound `x-vellum-actor-principal-id`, so without this
+  // step a malicious client could spoof another user's principal id by
+  // setting the header explicitly. Mirrors the HTTP adapter's behavior in
+  // `assistant/src/runtime/routes/http-adapter.ts`.
+  delete headers["x-vellum-actor-principal-id"];
+  delete headers["x-vellum-principal-type"];
+  if (claims) {
+    const sub = parseSub(claims.sub);
+    if (sub.ok) {
+      headers["x-vellum-principal-type"] = sub.principalType;
+      if (sub.actorPrincipalId) {
+        headers["x-vellum-actor-principal-id"] = sub.actorPrincipalId;
+      }
+    }
+  }
+
   let body: Record<string, unknown> | undefined;
   if (req.method !== "GET" && req.method !== "HEAD") {
     const contentType = req.headers.get("content-type") ?? "";


### PR DESCRIPTION
## Summary
- Gateway IPC proxy now derives x-vellum-actor-principal-id from verified claims.sub and overwrites the client-supplied value (mirroring the daemon's HTTP adapter).
- Closes a header-spoofing path identified during plan review (round 2).

Round-2 fix for plan host-proxy-same-user.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->