### PR TITLE
fix(host-proxy): bind cross-client targeted execution to same authenticated user

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6322,7 +6322,7 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host file request.
         "403":
-          description: Submitting client does not match the targeted client for this request.
+          description: Submitting client or actor does not match the targeted client/actor for this request.
         "404":
           description: No pending interaction found for the given requestId.
         "409":

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6255,8 +6255,8 @@ paths:
           description: x-vellum-client-id header is missing for a targeted host CU request.
         "403":
           description:
-            Submitting client does not match the targeted client, or the submitting actor's principal id does not match
-            the target client's stored actor principal id.
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
         "404":
           description: No pending interaction found for the given requestId, or the conversation/proxy no longer exists.
         "409":
@@ -6322,7 +6322,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host file request.
         "403":
-          description: Submitting client or actor does not match the targeted client/actor for this request.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
         "404":
           description: No pending interaction found for the given requestId.
         "409":

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6254,7 +6254,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host CU request.
         "403":
-          description: Submitting client does not match the targeted client for this request.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal id does not match
+            the target client's stored actor principal id.
         "404":
           description: No pending interaction found for the given requestId, or the conversation/proxy no longer exists.
         "409":

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6094,7 +6094,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host bash request.
         "403":
-          description: Submitting client does not match the targeted client for this request.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
         "404":
           description: No pending interaction found for the given requestId.
         "409":

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6372,7 +6372,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted host transfer request.
         "403":
-          description: Submitting client does not match the targeted client for this transfer.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
       requestBody:
         required: true
         content:
@@ -11418,7 +11420,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted transfer.
         "403":
-          description: Submitting client does not match the targeted client for this transfer.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
       parameters:
         - name: transferId
           in: path
@@ -11437,7 +11441,9 @@ paths:
         "400":
           description: x-vellum-client-id header is missing for a targeted transfer.
         "403":
-          description: Submitting client does not match the targeted client for this transfer.
+          description:
+            Submitting client does not match the targeted client, or the submitting actor's principal does not match
+            the target client's actor.
       parameters:
         - name: transferId
           in: path

--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -356,6 +356,54 @@ describe("AssistantEventHub — re-entrancy / snapshot isolation", () => {
   });
 });
 
+// ── ClientEntry actorPrincipalId capture ────────────────────────────────────
+
+describe("AssistantEventHub — actorPrincipalId on ClientEntry", () => {
+  test("stores actorPrincipalId provided at subscribe time", () => {
+    const hub = new AssistantEventHub();
+
+    hub.subscribe({
+      type: "client" as const,
+      clientId: "client-with-principal",
+      interfaceId: "macos",
+      capabilities: ["host_bash"],
+      actorPrincipalId: "user-A",
+      callback: () => {},
+    });
+
+    expect(hub.getClientById("client-with-principal")?.actorPrincipalId).toBe(
+      "user-A",
+    );
+    expect(hub.getActorPrincipalIdForClient("client-with-principal")).toBe(
+      "user-A",
+    );
+  });
+
+  test("actorPrincipalId is undefined when omitted at subscribe time", () => {
+    const hub = new AssistantEventHub();
+
+    hub.subscribe({
+      type: "client" as const,
+      clientId: "client-no-principal",
+      interfaceId: "macos",
+      capabilities: ["host_bash"],
+      callback: () => {},
+    });
+
+    expect(
+      hub.getClientById("client-no-principal")?.actorPrincipalId,
+    ).toBeUndefined();
+    expect(
+      hub.getActorPrincipalIdForClient("client-no-principal"),
+    ).toBeUndefined();
+  });
+
+  test("getActorPrincipalIdForClient returns undefined for unknown clientId", () => {
+    const hub = new AssistantEventHub();
+    expect(hub.getActorPrincipalIdForClient("does-not-exist")).toBeUndefined();
+  });
+});
+
 // ── capabilityForMessageType — host-prefix routing ───────────────────────────
 
 describe("capabilityForMessageType — host-prefix routing", () => {

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -655,6 +655,47 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       );
       expect(sentMessages).toHaveLength(0);
     });
+
+    test("auto-resolves to the unique same-user CU client when cross-user clients are present", async () => {
+      // Regression: previously the dispatch counted only same-user clients
+      // for the multi-client guard, so 1 same-user + 1 cross-user passed the
+      // guard with no targetClientId — and the proxy then broadcast to ALL
+      // host_cu subscribers, including the cross-user one.
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "cu-mine",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        {
+          clientId: "cu-other",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-other",
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, DEFAULT_PRINCIPAL);
+
+      const resultPromise = surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+        // Intentionally no target_client_id — exercises auto-resolve.
+      });
+
+      // Broadcast happens, but with the same-user clientId set so only
+      // that client receives it.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("cu-mine");
+
+      // Manually resolve to clean up the pending promise.
+      proxy.processObservation(sent.requestId as string, {
+        executionResult: "ok",
+      });
+      await resultPromise;
+    });
   });
 
   describe("step limit enforcement through resolver", () => {

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -9,8 +9,20 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
 let mockHasClient = true; // Default to true for CU unified flow tests
-let mockCuClients: Array<{ clientId: string; capabilities: string[] }> = [
-  { clientId: "mock-client-1", capabilities: ["host_cu"] },
+// Default principal id used for both ctx.trustContext and clients in the
+// existing single-user tests. Tests that exercise cross-user behaviour
+// override this on individual clients and on the SurfaceConversationContext.
+const DEFAULT_PRINCIPAL = "user-1";
+let mockCuClients: Array<{
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+}> = [
+  {
+    clientId: "mock-client-1",
+    capabilities: ["host_cu"],
+    actorPrincipalId: DEFAULT_PRINCIPAL,
+  },
 ];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
@@ -38,12 +50,25 @@ type SurfaceConversationContext =
 /**
  * Build a minimal SurfaceConversationContext with optional hostCuProxy.
  * Only the fields required by the CU routing path are populated.
+ *
+ * `trustContext` defaults to a guardian context owned by `DEFAULT_PRINCIPAL`.
+ * Pass `null` to omit the field entirely (used to verify same-user
+ * enforcement when the conversation has no source actor principal).
  */
 function buildMockContext(
   hostCuProxy?: InstanceType<typeof HostCuProxy>,
+  trustGuardianPrincipalId: string | null = DEFAULT_PRINCIPAL,
 ): SurfaceConversationContext {
   return {
     conversationId: "test-session",
+    trustContext:
+      trustGuardianPrincipalId != null
+        ? {
+            sourceChannel: "vellum",
+            trustClass: "guardian",
+            guardianPrincipalId: trustGuardianPrincipalId,
+          }
+        : undefined,
     traceEmitter: { emit: () => {} },
     sendToClient: () => {},
     pendingSurfaceActions: new Map(),
@@ -72,7 +97,13 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   function setupProxy(maxSteps?: number): SurfaceConversationContext {
     sentMessages.length = 0;
     mockHasClient = true;
-    mockCuClients = [{ clientId: "mock-client-1", capabilities: ["host_cu"] }];
+    mockCuClients = [
+      {
+        clientId: "mock-client-1",
+        capabilities: ["host_cu"],
+        actorPrincipalId: DEFAULT_PRINCIPAL,
+      },
+    ];
     proxy = new HostCuProxy(maxSteps);
     return buildMockContext(proxy);
   }
@@ -397,8 +428,16 @@ describe("surfaceProxyResolver — CU tool routing", () => {
     test("proceeds when multiple clients connected and target_client_id is given", async () => {
       const ctx = setupProxy();
       mockCuClients = [
-        { clientId: "client-a", capabilities: ["host_cu"] },
-        { clientId: "client-b", capabilities: ["host_cu"] },
+        {
+          clientId: "client-a",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        {
+          clientId: "client-b",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
       ];
 
       const resultPromise = surfaceProxyResolver(ctx, "computer_use_click", {
@@ -508,8 +547,18 @@ describe("surfaceProxyResolver — CU tool routing", () => {
     test("dispatches and records action when targetClientId is valid", async () => {
       const ctx = setupProxy();
       mockCuClients = [
-        { clientId: "cu-client", capabilities: ["host_cu"] },
-        { clientId: "client-b", capabilities: ["host_cu"] }, // would otherwise trip ambiguity guard
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        // Second client present to ensure target_client_id resolves
+        // unambiguously and would otherwise trip the ambiguity guard.
+        {
+          clientId: "client-b",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
       ];
 
       const resultPromise = surfaceProxyResolver(ctx, "computer_use_click", {
@@ -529,6 +578,68 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       proxy.processObservation(sent.requestId as string, { axTree: "ok" });
       const result = await resultPromise;
       expect(result.isError).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Same-user enforcement (dispatch layer)
+  //
+  // The proxy enforces this internally as well — these tests verify the
+  // dispatch surfaces a friendly tool-input rejection before the proxy is
+  // invoked, and that the rejection happens before any state mutation.
+  // -------------------------------------------------------------------------
+
+  describe("same-user enforcement", () => {
+    test("rejects targeted CU dispatch from a different actor principal", async () => {
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-other",
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, DEFAULT_PRINCIPAL);
+
+      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+        target_client_id: "cu-client",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("cu-client");
+      expect(result.content).toContain("not owned by the current user");
+      // No state mutation, no dispatch.
+      expect(proxy.stepCount).toBe(0);
+      expect(proxy.actionHistory).toHaveLength(0);
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when the conversation has no source actor principal", async () => {
+      sentMessages.length = 0;
+      mockHasClient = true;
+      mockCuClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+      ];
+      proxy = new HostCuProxy();
+      const ctx = buildMockContext(proxy, null);
+
+      const result = await surfaceProxyResolver(ctx, "computer_use_click", {
+        element_id: 1,
+        reasoning: "click",
+        target_client_id: "cu-client",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not owned by the current user");
+      expect(sentMessages).toHaveLength(0);
     });
   });
 

--- a/assistant/src/__tests__/cu-unified-flow.test.ts
+++ b/assistant/src/__tests__/cu-unified-flow.test.ts
@@ -34,6 +34,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_cu" ? mockCuClients : [],
     getClientById: (id: string) =>
       mockCuClients.find((c) => c.clientId === id) ?? null,
+    getActorPrincipalIdForClient: (id: string) =>
+      mockCuClients.find((c) => c.clientId === id)?.actorPrincipalId,
   },
 }));
 
@@ -406,11 +408,19 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   // -------------------------------------------------------------------------
 
   describe("multi-client ambiguity guard", () => {
-    test("returns error when multiple CU clients connected and no target_client_id given", async () => {
+    test("returns error when multiple same-user CU clients connected and no target_client_id given", async () => {
       const ctx = setupProxy();
       mockCuClients = [
-        { clientId: "client-a", capabilities: ["host_cu"] },
-        { clientId: "client-b", capabilities: ["host_cu"] },
+        {
+          clientId: "client-a",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
+        {
+          clientId: "client-b",
+          capabilities: ["host_cu"],
+          actorPrincipalId: DEFAULT_PRINCIPAL,
+        },
       ];
 
       const result = await surfaceProxyResolver(ctx, "computer_use_click", {
@@ -585,8 +595,9 @@ describe("surfaceProxyResolver — CU tool routing", () => {
   // Same-user enforcement (dispatch layer)
   //
   // The proxy enforces this internally as well — these tests verify the
-  // dispatch surfaces a friendly tool-input rejection before the proxy is
-  // invoked, and that the rejection happens before any state mutation.
+  // dispatch performs the same-user rejection before the proxy is invoked
+  // (so no step is burned and no action history mutated), and uses the
+  // canonical rejection message.
   // -------------------------------------------------------------------------
 
   describe("same-user enforcement", () => {
@@ -610,8 +621,9 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("cu-client");
-      expect(result.content).toContain("not owned by the current user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       // No state mutation, no dispatch.
       expect(proxy.stepCount).toBe(0);
       expect(proxy.actionHistory).toHaveLength(0);
@@ -638,7 +650,9 @@ describe("surfaceProxyResolver — CU tool routing", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("not owned by the current user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
   });

--- a/assistant/src/__tests__/events-client-registration.test.ts
+++ b/assistant/src/__tests__/events-client-registration.test.ts
@@ -395,6 +395,58 @@ describe("events client registration", () => {
     ac2.abort();
   });
 
+  // ── actorPrincipalId capture ──────────────────────────────────────────────
+
+  test("captures actorPrincipalId from x-vellum-actor-principal-id header", () => {
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "principal-client-001",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "user-A",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("principal-client-001");
+    expect(entry?.actorPrincipalId).toBe("user-A");
+    expect(hub.getActorPrincipalIdForClient("principal-client-001")).toBe(
+      "user-A",
+    );
+
+    ac.abort();
+  });
+
+  test("registers client with undefined actorPrincipalId when header is absent", () => {
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "principal-client-002",
+          "x-vellum-interface-id": "macos",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("principal-client-002");
+    expect(entry).toBeDefined();
+    expect(entry?.actorPrincipalId).toBeUndefined();
+    expect(
+      hub.getActorPrincipalIdForClient("principal-client-002"),
+    ).toBeUndefined();
+
+    ac.abort();
+  });
+
   // ── disposeClient (force disconnect) ──────────────────────────────────────
 
   test("disposeClient removes all subscribers for the clientId", () => {

--- a/assistant/src/__tests__/events-dev-bypass-actor.test.ts
+++ b/assistant/src/__tests__/events-dev-bypass-actor.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression tests for the SSE registration dev-bypass actor principal
+ * translation.
+ *
+ * In `DISABLE_HTTP_AUTH=true` (platform-managed) deployments the synthetic
+ * dev-bypass `AuthContext` injects `actorPrincipalId="dev-bypass"` for every
+ * request. Tool-side trust resolution still resolves to the real local
+ * guardian's principalId via `resolveLocalTrustContext`. Without translation,
+ * `ClientEntry.actorPrincipalId === "dev-bypass"` and
+ * `ToolContext.sourceActorPrincipalId === "<real-guardian>"` mismatch, so the
+ * same-user check in HostBashProxy / HostFileProxy / HostCuProxy /
+ * conversation-surfaces rejects every targeted host proxy invocation and the
+ * auto-resolve path silently falls through to untargeted broadcast.
+ *
+ * The events-routes handler translates `"dev-bypass"` to the real guardian's
+ * principalId at registration time so both sides agree. This keeps targeted
+ * host proxy execution working on Docker / platform-managed deployments.
+ */
+import { afterAll, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must be set up before importing the route) ──────────────
+
+let fakeHttpAuthDisabled = false;
+let fakeGuardianPrincipalId: string | undefined = undefined;
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../runtime/local-actor-identity.js", () => ({
+  findLocalGuardianPrincipalId: () => fakeGuardianPrincipalId,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────
+
+import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
+import { handleSubscribeAssistantEvents } from "../runtime/routes/events-routes.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("events SSE registration — dev-bypass actor translation", () => {
+  test("translates 'dev-bypass' to the real guardian principalId when auth is disabled", () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = "guardian-real-id";
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "devbypass-client-001",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("devbypass-client-001");
+    expect(entry?.actorPrincipalId).toBe("guardian-real-id");
+    expect(hub.getActorPrincipalIdForClient("devbypass-client-001")).toBe(
+      "guardian-real-id",
+    );
+
+    ac.abort();
+  });
+
+  test("registers without principalId when dev-bypass is set but no guardian is bound", () => {
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = undefined;
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "devbypass-client-002",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("devbypass-client-002");
+    expect(entry).toBeDefined();
+    expect(entry?.actorPrincipalId).toBeUndefined();
+
+    ac.abort();
+  });
+
+  test("does NOT translate when auth is enabled (production mode)", () => {
+    // Defense in depth: make sure we never silently rewrite a real
+    // principalId that legitimately happens to be the literal "dev-bypass"
+    // string in a non-dev-bypass deployment. The translation is gated on
+    // isHttpAuthDisabled() === true.
+    fakeHttpAuthDisabled = false;
+    fakeGuardianPrincipalId = "guardian-real-id";
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "prod-client-003",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "dev-bypass",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("prod-client-003");
+    expect(entry?.actorPrincipalId).toBe("dev-bypass");
+
+    ac.abort();
+  });
+
+  test("passes through non-dev-bypass principalId verbatim in dev-bypass mode", () => {
+    // Edge case: a service-token connection that happens to be made while
+    // the daemon runs in DISABLE_HTTP_AUTH=true mode should still register
+    // with its own principalId, not the guardian's.
+    fakeHttpAuthDisabled = true;
+    fakeGuardianPrincipalId = "guardian-real-id";
+
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "service-client-004",
+          "x-vellum-interface-id": "macos",
+          "x-vellum-actor-principal-id": "service-account-A",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("service-client-004");
+    expect(entry?.actorPrincipalId).toBe("service-account-A");
+
+    ac.abort();
+  });
+});

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -679,38 +679,23 @@ describe("HostBashProxy", () => {
       expect(sentMessages).toHaveLength(0);
     });
 
-    test("falls through to untargeted broadcast when multiple capable clients are connected and no targetClientId", async () => {
+    test("rejects ambiguously when multiple same-user capable clients are connected and no targetClientId", async () => {
+      // Regression: previously fell through to untargeted broadcast, fanning
+      // a single targeted-style request out across every same-user machine.
       setup();
       setupMultipleClients(["client-1", "client-2", "client-3"]);
 
-      const resultPromise = proxy.request(
+      const result = await proxy.request(
         { command: "echo hello" },
         "session-1",
         undefined,
         "user-A",
       );
 
-      // Should broadcast without an early error return
-      expect(sentMessages).toHaveLength(1);
-      const sent = sentMessages[0] as Record<string, unknown>;
-      expect(sent.type).toBe("host_bash_request");
-      // No target client resolved — untargeted broadcast
-      expect(sent.targetClientId).toBeUndefined();
-
-      const opts = sentMessageOptions[0] as Record<string, unknown> | undefined;
-      expect(opts?.targetClientId).toBeUndefined();
-
-      // Manually resolve to clean up
-      const requestId = sent.requestId as string;
-      proxy.resolveResult(requestId, {
-        stdout: "hello\n",
-        stderr: "",
-        exitCode: 0,
-        timedOut: false,
-      });
-
-      const result = await resultPromise;
-      expect(result.isError).toBe(false);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("target_client_id");
+      // No broadcast happened
+      expect(sentMessages).toHaveLength(0);
     });
 
     test("falls through to broadcast when zero capable clients (existing timeout path)", async () => {

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -768,7 +768,7 @@ describe("HostBashProxy", () => {
 
   describe("same-user binding (sourceActorPrincipalId)", () => {
     const SAME_USER_REJECTION =
-      "Targeted host_bash requests require the target client to be owned by the same user as the caller.";
+      "Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.";
 
     test("same-user targeted request succeeds", async () => {
       setup();

--- a/assistant/src/__tests__/host-bash-proxy.test.ts
+++ b/assistant/src/__tests__/host-bash-proxy.test.ts
@@ -17,11 +17,20 @@ mock.module("../config/loader.js", () => ({
 const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
 let mockHasClient = false;
-let mockCapableClients: Array<{ clientId: string; capabilities: string[] }> = [];
-let mockClientRegistry: Map<string, { clientId: string; capabilities: string[] }> = new Map();
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockCapableClients: Array<MockClient> = [];
+let mockClientRegistry: Map<string, MockClient> = new Map();
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown, _conversationId?: string, options?: unknown) => {
+  broadcastMessage: (
+    msg: unknown,
+    _conversationId?: string,
+    options?: unknown,
+  ) => {
     sentMessages.push(msg);
     sentMessageOptions.push(options);
   },
@@ -30,6 +39,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_bash" && mockHasClient ? { id: "mock-client" } : null,
     listClientsByCapability: (_cap: string) => mockCapableClients,
     getClientById: (clientId: string) => mockClientRegistry.get(clientId),
+    getActorPrincipalIdForClient: (clientId: string) =>
+      mockClientRegistry.get(clientId)?.actorPrincipalId,
   },
 }));
 
@@ -50,8 +61,15 @@ describe("HostBashProxy", () => {
     proxy = new (HostBashProxy as any)();
   }
 
-  function setupSingleClient(clientId = "client-1") {
-    const entry = { clientId, capabilities: ["host_bash"] };
+  function setupSingleClient(
+    clientId: string = "client-1",
+    actorPrincipalId: string = "user-A",
+  ) {
+    const entry: MockClient = {
+      clientId,
+      capabilities: ["host_bash"],
+      actorPrincipalId,
+    };
     mockCapableClients = [entry];
     mockClientRegistry.set(clientId, entry);
   }
@@ -60,6 +78,7 @@ describe("HostBashProxy", () => {
     mockCapableClients = clientIds.map((id) => ({
       clientId: id,
       capabilities: ["host_bash"],
+      actorPrincipalId: "user-A",
     }));
     for (const entry of mockCapableClients) {
       mockClientRegistry.set(entry.clientId, entry);
@@ -551,11 +570,13 @@ describe("HostBashProxy", () => {
   describe("target client routing", () => {
     test("auto-resolves when exactly one capable client is connected", async () => {
       setup();
-      setupSingleClient("client-abc");
+      setupSingleClient("client-abc", "user-A");
 
       const resultPromise = proxy.request(
         { command: "echo hello" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -580,15 +601,21 @@ describe("HostBashProxy", () => {
 
     test("uses explicit targetClientId when it is valid", async () => {
       setup();
-      setupSingleClient("client-abc");
+      setupSingleClient("client-abc", "user-A");
       // Also register a second client so we're sure explicit targeting works
-      const entry2 = { clientId: "client-xyz", capabilities: ["host_bash"] };
+      const entry2: MockClient = {
+        clientId: "client-xyz",
+        capabilities: ["host_bash"],
+        actorPrincipalId: "user-A",
+      };
       mockCapableClients.push(entry2);
       mockClientRegistry.set("client-xyz", entry2);
 
       const resultPromise = proxy.request(
         { command: "echo hello", targetClientId: "client-abc" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -612,17 +639,21 @@ describe("HostBashProxy", () => {
 
     test("returns error for explicit targetClientId that is not connected", async () => {
       setup();
-      setupSingleClient("client-abc");
+      setupSingleClient("client-abc", "user-A");
 
       const result = await proxy.request(
         { command: "echo hello", targetClientId: "client-unknown" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       // Should return error without broadcasting
       expect(result.isError).toBe(true);
       expect(result.content).toContain("client-unknown");
-      expect(result.content).toContain("assistant clients list --capability host_bash");
+      expect(result.content).toContain(
+        "assistant clients list --capability host_bash",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -632,11 +663,14 @@ describe("HostBashProxy", () => {
       mockClientRegistry.set("client-no-bash", {
         clientId: "client-no-bash",
         capabilities: [],
+        actorPrincipalId: "user-A",
       });
 
       const result = await proxy.request(
         { command: "echo hello", targetClientId: "client-no-bash" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       expect(result.isError).toBe(true);
@@ -652,6 +686,8 @@ describe("HostBashProxy", () => {
       const resultPromise = proxy.request(
         { command: "echo hello" },
         "session-1",
+        undefined,
+        "user-A",
       );
 
       // Should broadcast without an early error return
@@ -707,13 +743,15 @@ describe("HostBashProxy", () => {
 
     test("includes targetClientId in timeout error message when client was resolved", async () => {
       setup();
-      setupSingleClient("client-mac");
+      setupSingleClient("client-mac", "user-A");
 
       jest.useFakeTimers();
       try {
         const resultPromise = proxy.request(
           { command: "echo slow", timeout_seconds: 30 },
           "session-1",
+          undefined,
+          "user-A",
         );
 
         // Proxy timeout = 33s; advance past it
@@ -725,6 +763,176 @@ describe("HostBashProxy", () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe("same-user binding (sourceActorPrincipalId)", () => {
+    const SAME_USER_REJECTION =
+      "Targeted host_bash requests require the target client to be owned by the same user as the caller.";
+
+    test("same-user targeted request succeeds", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const resultPromise = proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_bash_request");
+      expect(sent.targetClientId).toBe("client-abc");
+      const requestId = sent.requestId as string;
+      expect(pendingInteractions.get(requestId)).toBeDefined();
+
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
+    });
+
+    test("cross-user targeted request rejected", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const result = await proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(SAME_USER_REJECTION);
+      // No broadcast and no pending registration
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("target client missing actorPrincipalId rejected", async () => {
+      setup();
+      // Register a client without an actorPrincipalId (legacy/service-token).
+      const entry: MockClient = {
+        clientId: "client-abc",
+        capabilities: ["host_bash"],
+      };
+      mockCapableClients = [entry];
+      mockClientRegistry.set("client-abc", entry);
+
+      const result = await proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(SAME_USER_REJECTION);
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("source missing actorPrincipalId rejected when targeting", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const result = await proxy.request(
+        { command: "echo hello", targetClientId: "client-abc" },
+        "session-1",
+        undefined,
+        undefined,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe(SAME_USER_REJECTION);
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("untargeted local flow unchanged when no auto-resolve match", async () => {
+      setup();
+      // No capable clients connected — untargeted path runs.
+
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_bash_request");
+      expect(sent.targetClientId).toBeUndefined();
+
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
+    });
+
+    test("auto-resolve to same-user client succeeds", async () => {
+      setup();
+      setupSingleClient("client-abc", "user-A");
+
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-abc");
+
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
+    });
+
+    test("auto-resolve to different-user client falls through to untargeted", async () => {
+      setup();
+      // Single capable client owned by user-B; caller is user-A.
+      setupSingleClient("client-abc", "user-B");
+
+      const resultPromise = proxy.request(
+        { command: "echo hello" },
+        "session-1",
+        undefined,
+        "user-A",
+      );
+
+      // Auto-resolve must NOT pick the cross-user client; the untargeted
+      // broadcast path runs instead.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_bash_request");
+      expect(sent.targetClientId).toBeUndefined();
+
+      const opts = sentMessageOptions[0] as Record<string, unknown> | undefined;
+      expect(opts?.targetClientId).toBeUndefined();
+
+      const requestId = sent.requestId as string;
+      proxy.resolveResult(requestId, {
+        stdout: "hello\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      });
+      await resultPromise;
     });
   });
 });

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -102,10 +102,19 @@ function registerPending(
   requestId: string,
   overrides: Partial<PendingInteraction> = {},
 ): void {
+  // Mirror the production proxy behavior: capture the target's actor
+  // principal at registration time so the result-route check compares
+  // against the persisted value rather than a live hub lookup.
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? clientActorPrincipals.get(overrides.targetClientId)
+      : undefined);
   pendingStore.set(requestId, {
     conversationId: "conv-1",
     kind: "host_bash",
     ...overrides,
+    targetActorPrincipalId,
   });
 }
 
@@ -163,8 +172,8 @@ describe("handleHostBashResult", () => {
   describe("targeted request (targetClientId set)", () => {
     test("accepts when x-vellum-client-id matches targetClientId", async () => {
       const requestId = "req-targeted-match";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-1");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
@@ -182,8 +191,8 @@ describe("handleHostBashResult", () => {
 
     test("trims whitespace from x-vellum-client-id before comparing", async () => {
       const requestId = "req-targeted-trim";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-1");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
@@ -202,8 +211,8 @@ describe("handleHostBashResult", () => {
   describe("targeted request — actor principal binding", () => {
     test("accepts when submitting actor matches target client's actor", async () => {
       const requestId = "req-actor-match";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-shared");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
@@ -220,8 +229,8 @@ describe("handleHostBashResult", () => {
 
     test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
       const requestId = "req-actor-mismatch";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       expect(() =>
         handleHostBashResult({
@@ -236,8 +245,8 @@ describe("handleHostBashResult", () => {
 
     test("interaction is NOT resolved on cross-actor 403 (still pending)", () => {
       const requestId = "req-actor-mismatch-stays";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       try {
         handleHostBashResult({
@@ -257,8 +266,8 @@ describe("handleHostBashResult", () => {
 
     test("throws ForbiddenError (403) when x-vellum-actor-principal-id header is missing entirely", () => {
       const requestId = "req-actor-missing";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       expect(() =>
         handleHostBashResult({
@@ -270,8 +279,8 @@ describe("handleHostBashResult", () => {
 
     test("interaction is NOT resolved when submitting actor is missing (still pending)", () => {
       const requestId = "req-actor-missing-stays";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       try {
         handleHostBashResult({

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -35,7 +35,12 @@ mock.module("../runtime/pending-interactions.js", () => ({
 
 interface ResolveCall {
   requestId: string;
-  result: { stdout: string; stderr: string; exitCode: number | null; timedOut: boolean };
+  result: {
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+    timedOut: boolean;
+  };
 }
 
 const resolveSpy: ResolveCall[] = [];
@@ -46,7 +51,12 @@ mock.module("../daemon/host-bash-proxy.js", () => ({
       return {
         resolveResult(
           requestId: string,
-          result: { stdout: string; stderr: string; exitCode: number | null; timedOut: boolean },
+          result: {
+            stdout: string;
+            stderr: string;
+            exitCode: number | null;
+            timedOut: boolean;
+          },
         ) {
           // resolveResult() internally calls pendingInteractions.resolve() in the real
           // implementation; simulate that here so resolvedIds assertions still hold.
@@ -55,6 +65,16 @@ mock.module("../daemon/host-bash-proxy.js", () => ({
         },
       };
     },
+  },
+}));
+
+// Stored actor-principal-id keyed by clientId, populated by tests.
+const clientActorPrincipals = new Map<string, string>();
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getActorPrincipalIdForClient: (clientId: string) =>
+      clientActorPrincipals.get(clientId),
   },
 }));
 
@@ -106,6 +126,7 @@ describe("handleHostBashResult", () => {
     pendingStore.clear();
     resolvedIds.length = 0;
     resolveSpy.length = 0;
+    clientActorPrincipals.clear();
   });
 
   // ── Happy paths ────────────────────────────────────────────────────
@@ -143,10 +164,14 @@ describe("handleHostBashResult", () => {
     test("accepts when x-vellum-client-id matches targetClientId", async () => {
       const requestId = "req-targeted-match";
       registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-1");
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
-        headers: { "x-vellum-client-id": "client-abc" },
+        headers: {
+          "x-vellum-client-id": "client-abc",
+          "x-vellum-actor-principal-id": "principal-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -158,13 +183,144 @@ describe("handleHostBashResult", () => {
     test("trims whitespace from x-vellum-client-id before comparing", async () => {
       const requestId = "req-targeted-trim";
       registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-1");
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
-        headers: { "x-vellum-client-id": "  client-abc  " },
+        headers: {
+          "x-vellum-client-id": "  client-abc  ",
+          "x-vellum-actor-principal-id": "principal-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
+    });
+  });
+
+  // ── Same-user actor binding (defense-in-depth) ─────────────────────
+
+  describe("targeted request — actor principal binding", () => {
+    test("accepts when submitting actor matches target client's actor", async () => {
+      const requestId = "req-actor-match";
+      registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-shared");
+
+      const result = await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-abc",
+          "x-vellum-actor-principal-id": "principal-shared",
+        },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(resolveSpy).toHaveLength(1);
+      expect(resolvedIds).toContain(requestId);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
+      const requestId = "req-actor-mismatch";
+      registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-victim");
+
+      expect(() =>
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-abc",
+            "x-vellum-actor-principal-id": "principal-attacker",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT resolved on cross-actor 403 (still pending)", () => {
+      const requestId = "req-actor-mismatch-stays";
+      registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-victim");
+
+      try {
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-abc",
+            "x-vellum-actor-principal-id": "principal-attacker",
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+
+    test("throws ForbiddenError (403) when x-vellum-actor-principal-id header is missing entirely", () => {
+      const requestId = "req-actor-missing";
+      registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-victim");
+
+      expect(() =>
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: { "x-vellum-client-id": "client-abc" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT resolved when submitting actor is missing (still pending)", () => {
+      const requestId = "req-actor-missing-stays";
+      registerPending(requestId, { targetClientId: "client-abc" });
+      clientActorPrincipals.set("client-abc", "principal-victim");
+
+      try {
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: { "x-vellum-client-id": "client-abc" },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+
+    test("throws ForbiddenError (403) when target client has no stored actor principal", () => {
+      // Target client connected without a verified principal (e.g. legacy
+      // service token) — refuse the submission rather than silently allow
+      // any actor through.
+      const requestId = "req-actor-target-missing";
+      registerPending(requestId, { targetClientId: "client-abc" });
+      // Note: no entry in clientActorPrincipals for "client-abc".
+
+      expect(() =>
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-abc",
+            "x-vellum-actor-principal-id": "principal-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+  });
+
+  // ── Untargeted-request behavior (regression for new check) ─────────
+
+  describe("untargeted request — actor principal check is skipped", () => {
+    test("accepts even when submitting actor is absent and no target client is set", async () => {
+      const requestId = "req-untargeted-no-actor";
+      registerPending(requestId);
+
+      const result = await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: {},
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(resolveSpy).toHaveLength(1);
+      expect(resolvedIds).toContain(requestId);
     });
   });
 
@@ -175,9 +331,9 @@ describe("handleHostBashResult", () => {
       const requestId = "req-targeted-no-header";
       registerPending(requestId, { targetClientId: "client-abc" });
 
-      expect(() =>
-        handleHostBashResult({ body: bashBody(requestId) }),
-      ).toThrow(BadRequestError);
+      expect(() => handleHostBashResult({ body: bashBody(requestId) })).toThrow(
+        BadRequestError,
+      );
     });
 
     test("throws BadRequestError (400) when header is empty string", () => {
@@ -267,9 +423,9 @@ describe("handleHostBashResult", () => {
   });
 
   test("throws BadRequestError when requestId is missing", () => {
-    expect(() =>
-      handleHostBashResult({ body: { stdout: "x" } }),
-    ).toThrow(BadRequestError);
+    expect(() => handleHostBashResult({ body: { stdout: "x" } })).toThrow(
+      BadRequestError,
+    );
   });
 
   test("throws NotFoundError for unknown requestId", () => {
@@ -287,8 +443,8 @@ describe("handleHostBashResult", () => {
       kind: "confirmation",
     });
 
-    expect(() =>
-      handleHostBashResult({ body: bashBody(requestId) }),
-    ).toThrow(ConflictError);
+    expect(() => handleHostBashResult({ body: bashBody(requestId) })).toThrow(
+      ConflictError,
+    );
   });
 });

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -2,12 +2,20 @@ import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
 let mockHasClient = false;
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: (msg: unknown) => sentMessages.push(msg),
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
+    getClientById: (id: string) =>
+      mockClients.find((c) => c.clientId === id) ?? undefined,
   },
 }));
 
@@ -21,6 +29,7 @@ describe("HostCuProxy", () => {
   function setup(maxSteps?: number) {
     sentMessages.length = 0;
     mockHasClient = false;
+    mockClients = [];
     pendingInteractions.clear();
     proxy = new HostCuProxy(maxSteps);
   }
@@ -974,7 +983,197 @@ describe("HostCuProxy", () => {
     });
   });
 
-  // targetClientId validation lives at the surfaceProxyResolver layer (so an
-  // invalid ID does not burn a step or pollute action history before being
-  // rejected). See cu-unified-flow.test.ts for those tests.
+  // -------------------------------------------------------------------------
+  // targetClientId validation
+  //
+  // The surfaceProxyResolver layer validates first (so an invalid ID does
+  // not burn a step or pollute action history — see cu-unified-flow.test.ts
+  // for those tests). The proxy ALSO validates internally because it is
+  // exposed as a separately-callable API; these tests exercise that
+  // backstop along with the same-user enforcement.
+  // -------------------------------------------------------------------------
+
+  describe("targetClientId validation", () => {
+    test("rejects when targetClientId does not match any connected client", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "real-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "ghost-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("ghost-client");
+      expect(result.content).toContain("host_cu");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when target client lacks host_cu capability", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "no-cu-client",
+          capabilities: ["host_bash"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "no-cu-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("does not support host_cu");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("succeeds when caller and target share the same actor principal", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        "user-1",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_cu_request");
+      expect(sent.targetClientId).toBe("cu-client");
+
+      proxy.processObservation(sent.requestId as string, { axTree: "ok" });
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+    });
+
+    test("rejects cross-user targeted request", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-2",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("owned by the same user as the caller");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when source actor principal is missing", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          actorPrincipalId: "user-1",
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        // sourceActorPrincipalId omitted
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("owned by the same user as the caller");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("rejects when target actor principal is missing", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "cu-client",
+          capabilities: ["host_cu"],
+          // actorPrincipalId omitted
+        },
+      ];
+
+      const result = await proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        "cu-client",
+        "user-1",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("owned by the same user as the caller");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("untargeted request bypasses same-user check", async () => {
+      setup();
+      // No targetClientId, no sourceActorPrincipalId — flow proceeds.
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 1 },
+        "session-1",
+        1,
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_cu_request");
+      expect(sent.targetClientId).toBeUndefined();
+
+      proxy.processObservation(sent.requestId as string, { axTree: "ok" });
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+    });
+  });
 });

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -16,6 +16,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
     getClientById: (id: string) =>
       mockClients.find((c) => c.clientId === id) ?? undefined,
+    getActorPrincipalIdForClient: (id: string) =>
+      mockClients.find((c) => c.clientId === id)?.actorPrincipalId,
   },
 }));
 
@@ -1100,7 +1102,9 @@ describe("HostCuProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("owned by the same user as the caller");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -1126,7 +1130,9 @@ describe("HostCuProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("owned by the same user as the caller");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -1152,7 +1158,9 @@ describe("HostCuProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("owned by the same user as the caller");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -112,10 +112,16 @@ function registerPending(
   requestId: string,
   overrides: Partial<PendingInteraction> = {},
 ): void {
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? actorPrincipalByClient.get(overrides.targetClientId)
+      : undefined);
   const entry: PendingInteraction = {
     conversationId: "conv-cu-1",
     kind: "host_cu",
     ...overrides,
+    targetActorPrincipalId,
   };
   pendingStore.set(requestId, entry);
 }
@@ -162,8 +168,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-cu-targeted-match";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
@@ -181,8 +187,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-cu-targeted-trim";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
@@ -293,8 +299,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
   describe("targeted + actor-principal-id binding", () => {
     test("accepts when submitting actor matches target client's stored actor", async () => {
       const requestId = "req-cu-actor-match";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
@@ -311,8 +317,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
       const requestId = "req-cu-actor-mismatch";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostCuResult({
@@ -327,8 +333,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("interaction NOT consumed on 403 actor mismatch", () => {
       const requestId = "req-cu-actor-mismatch-stays";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       try {
         handleHostCuResult({
@@ -348,8 +354,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor header is missing", () => {
       const requestId = "req-cu-actor-missing";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostCuResult({
@@ -377,8 +383,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor header is whitespace only", () => {
       const requestId = "req-cu-actor-whitespace";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostCuResult({

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -71,19 +71,30 @@ interface CuResolveCall {
 const cuResolveSpy: CuResolveCall[] = [];
 
 // Controlled conversation map: conversationId → conversation object
-const conversationStore = new Map<string, { hostCuProxy?: { processObservation: (...args: unknown[]) => void } }>();
+const conversationStore = new Map<
+  string,
+  { hostCuProxy?: { processObservation: (...args: unknown[]) => void } }
+>();
 
 mock.module("../daemon/conversation-store.js", () => ({
-  findConversation: (conversationId: string) => conversationStore.get(conversationId),
+  findConversation: (conversationId: string) =>
+    conversationStore.get(conversationId),
+}));
+
+// Controlled actor-principal map: clientId → actorPrincipalId
+const actorPrincipalByClient = new Map<string, string>();
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getActorPrincipalIdForClient: (clientId: string) =>
+      actorPrincipalByClient.get(clientId),
+  },
 }));
 
 // ── Real imports (after mocks) ──────────────────────────────────────────────
 // Use dynamic import to ensure the mocks above are applied before loading.
 
-import {
-  BadRequestError,
-  ForbiddenError,
-} from "../runtime/routes/errors.js";
+import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
 
 const { ROUTES } = await import("../runtime/routes/host-cu-routes.js");
 
@@ -139,6 +150,7 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
   beforeEach(() => {
     pendingStore.clear();
     conversationStore.clear();
+    actorPrincipalByClient.clear();
     resolvedIds.length = 0;
     cuResolveSpy.length = 0;
     // Default: register a conversation with a hostCuProxy
@@ -151,10 +163,14 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-cu-targeted-match";
       registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -166,10 +182,14 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-cu-targeted-trim";
       registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "user-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -183,9 +203,9 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       const requestId = "req-cu-targeted-no-header";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      expect(() =>
-        handleHostCuResult({ body: cuBody(requestId) }),
-      ).toThrow(BadRequestError);
+      expect(() => handleHostCuResult({ body: cuBody(requestId) })).toThrow(
+        BadRequestError,
+      );
     });
 
     test("throws BadRequestError (400) when header is empty string", () => {
@@ -265,6 +285,110 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
       expect(resolvedIds).not.toContain(requestId);
       expect(pendingStore.has(requestId)).toBe(true);
+    });
+  });
+
+  // ── 3b. Actor-principal-id (PR 7) — defense-in-depth ──────────────────────
+
+  describe("targeted + actor-principal-id binding", () => {
+    test("accepts when submitting actor matches target client's stored actor", async () => {
+      const requestId = "req-cu-actor-match";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      const result = await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "user-1",
+        },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(cuResolveSpy).toHaveLength(1);
+      expect(resolvedIds).toContain(requestId);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
+      const requestId = "req-cu-actor-mismatch";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "user-2",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction NOT consumed on 403 actor mismatch", () => {
+      const requestId = "req-cu-actor-mismatch-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      try {
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "user-2",
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor header is missing", () => {
+      const requestId = "req-cu-actor-missing";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("throws ForbiddenError (403) when target client has no stored actor principal id", () => {
+      const requestId = "req-cu-target-no-actor";
+      registerPending(requestId, { targetClientId: "client-A" });
+      // No actorPrincipalByClient entry for client-A.
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "user-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor header is whitespace only", () => {
+      const requestId = "req-cu-actor-whitespace";
+      registerPending(requestId, { targetClientId: "client-A" });
+      actorPrincipalByClient.set("client-A", "user-1");
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "   ",
+          },
+        }),
+      ).toThrow(ForbiddenError);
     });
   });
 

--- a/assistant/src/__tests__/host-file-proxy-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-proxy-targeted.test.ts
@@ -14,11 +14,24 @@ const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
 const resolvedInteractionIds: string[] = [];
 let mockHasClient = false;
-let mockCapableClients: Array<{ clientId: string; capabilities: string[] }> = [];
-let mockClientRegistry: Map<string, { clientId: string; capabilities: string[] }> = new Map();
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockCapableClients: Array<MockClient> = [];
+let mockClientRegistry: Map<string, MockClient> = new Map();
+
+// Pre-existing Phase 2 routing tests use a single user identity. The same-user
+// check added in PR 3 is exercised separately in `host-file-proxy.test.ts`.
+const TEST_PRINCIPAL = "test-user";
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown, _conversationId?: string, options?: unknown) => {
+  broadcastMessage: (
+    msg: unknown,
+    _conversationId?: string,
+    options?: unknown,
+  ) => {
     sentMessages.push(msg);
     sentMessageOptions.push(options);
   },
@@ -27,6 +40,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_file" && mockHasClient ? { id: "mock-client" } : null,
     listClientsByCapability: (_cap: string) => mockCapableClients,
     getClientById: (clientId: string) => mockClientRegistry.get(clientId),
+    getActorPrincipalIdForClient: (clientId: string) =>
+      mockClientRegistry.get(clientId)?.actorPrincipalId,
   },
 }));
 
@@ -42,9 +57,10 @@ mock.module("../runtime/pending-interactions.js", () => ({
     return interaction;
   },
   get: (requestId: string) => pendingInteractionMap.get(requestId),
-  getByKind: (_kind: string) => Array.from(pendingInteractionMap.entries())
-    .filter(([, v]) => v.kind === _kind)
-    .map(([requestId, v]) => ({ requestId, ...v })),
+  getByKind: (_kind: string) =>
+    Array.from(pendingInteractionMap.entries())
+      .filter(([, v]) => v.kind === _kind)
+      .map(([requestId, v]) => ({ requestId, ...v })),
   getByConversation: () => [],
   removeByConversation: () => {},
 }));
@@ -66,7 +82,11 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
   }
 
   function setupSingleClient(clientId = "client-1") {
-    const entry = { clientId, capabilities: ["host_file"] };
+    const entry: MockClient = {
+      clientId,
+      capabilities: ["host_file"],
+      actorPrincipalId: TEST_PRINCIPAL,
+    };
     mockCapableClients = [entry];
     mockClientRegistry.set(clientId, entry);
   }
@@ -75,6 +95,7 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
     mockCapableClients = clientIds.map((id) => ({
       clientId: id,
       capabilities: ["host_file"],
+      actorPrincipalId: TEST_PRINCIPAL,
     }));
     for (const entry of mockCapableClients) {
       mockClientRegistry.set(entry.clientId, entry);
@@ -104,6 +125,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
           targetClientId: "client-mac",
         },
         "session-1",
+        undefined,
+        undefined,
+        TEST_PRINCIPAL,
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -140,7 +164,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("client-unknown");
-      expect(result.content).toContain("assistant clients list --capability host_file");
+      expect(result.content).toContain(
+        "assistant clients list --capability host_file",
+      );
       // No pending entry should have been created
       expect(sentMessages).toHaveLength(0);
     });
@@ -200,6 +226,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
       const resultPromise = proxy.request(
         { operation: "read", path: "/tmp/file.txt" },
         "session-1",
+        undefined,
+        undefined,
+        TEST_PRINCIPAL,
       );
 
       expect(sentMessages).toHaveLength(1);
@@ -257,6 +286,8 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
         { operation: "read", path: "/tmp/file.txt" },
         "session-1",
         controller.signal,
+        undefined,
+        TEST_PRINCIPAL,
       );
 
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -273,7 +304,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
       expect(cancelMsg.requestId).toBe(requestId);
       expect(cancelMsg.targetClientId).toBe("client-abc");
 
-      const cancelOpts = sentMessageOptions[1] as Record<string, unknown> | undefined;
+      const cancelOpts = sentMessageOptions[1] as
+        | Record<string, unknown>
+        | undefined;
       expect(cancelOpts?.targetClientId).toBe("client-abc");
     });
   });
@@ -288,6 +321,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
       const p = proxy.request(
         { operation: "read", path: "/tmp/file.txt" },
         "session-1",
+        undefined,
+        undefined,
+        TEST_PRINCIPAL,
       );
       p.catch(() => {}); // expected rejection on dispose
 
@@ -320,6 +356,9 @@ describe("HostFileProxy — targetClientId (Phase 2)", () => {
         const resultPromise = proxy.request(
           { operation: "read", path: "/tmp/slow.txt" },
           "session-1",
+          undefined,
+          undefined,
+          TEST_PRINCIPAL,
         );
 
         const sent = sentMessages[0] as Record<string, unknown>;

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -655,7 +655,9 @@ describe("HostFileProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       // No host_file_request was broadcast.
       expect(sentMessages).toHaveLength(0);
     });
@@ -679,7 +681,9 @@ describe("HostFileProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -702,7 +706,9 @@ describe("HostFileProxy", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain(
+        "Submitting actor does not match the target client's actor",
+      );
       expect(sentMessages).toHaveLength(0);
     });
 

--- a/assistant/src/__tests__/host-file-proxy.test.ts
+++ b/assistant/src/__tests__/host-file-proxy.test.ts
@@ -3,16 +3,36 @@ import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 const sentMessages: unknown[] = [];
 let mockHasClient = false;
 
+interface MockClient {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+}
+
+let mockClients: MockClient[] = [];
+
 mock.module("../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: (msg: unknown) => sentMessages.push(msg),
   assistantEventHub: {
-    getMostRecentClientByCapability: (cap: string) =>
-      cap === "host_file" && mockHasClient ? { id: "mock-client" } : null,
-    listClientsByCapability: (cap: string) =>
-      cap === "host_file" && mockHasClient
+    getMostRecentClientByCapability: (cap: string) => {
+      if (mockClients.length > 0) {
+        return mockClients.find((c) => c.capabilities.includes(cap));
+      }
+      return cap === "host_file" && mockHasClient
+        ? { id: "mock-client" }
+        : null;
+    },
+    listClientsByCapability: (cap: string) => {
+      if (mockClients.length > 0) {
+        return mockClients.filter((c) => c.capabilities.includes(cap));
+      }
+      return cap === "host_file" && mockHasClient
         ? [{ clientId: "mock-client", capabilities: ["host_file"] }]
-        : [],
-    getClientById: (_id: string) => undefined,
+        : [];
+    },
+    getClientById: (id: string) => mockClients.find((c) => c.clientId === id),
+    getActorPrincipalIdForClient: (id: string) =>
+      mockClients.find((c) => c.clientId === id)?.actorPrincipalId,
   },
 }));
 
@@ -32,6 +52,7 @@ describe("HostFileProxy", () => {
   function setup() {
     sentMessages.length = 0;
     mockHasClient = false;
+    mockClients = [];
     pendingInteractions.clear();
     proxy = new (HostFileProxy as any)();
   }
@@ -582,6 +603,241 @@ describe("HostFileProxy", () => {
 
       await resultPromise;
       expect(pendingInteractions.get(requestId)).toBeUndefined();
+    });
+  });
+
+  describe("same-user binding (sourceActorPrincipalId)", () => {
+    test("targeted request from same user reaches pendingInteractions", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        "user-A",
+      );
+
+      // Request was registered (made it past the same-user gate).
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      const requestId = sent.requestId as string;
+      expect(pendingInteractions.get(requestId)).toBeDefined();
+
+      // Drain to avoid leaks.
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("targeted request from a different user is rejected", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const result = await proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      // No host_file_request was broadcast.
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("targeted request to a client with no actor principal is rejected", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          // actorPrincipalId omitted (legacy/service-token client).
+        },
+      ];
+
+      const result = await proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        "user-A",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("targeted request without source principal is rejected", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const result = await proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        "client-A",
+        undefined,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("untargeted request with no auto-resolve match still broadcasts (legacy path unchanged)", async () => {
+      setup();
+      // No matching same-user clients available.
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        undefined,
+        "user-B", // No same-user match → no auto-resolve, broadcast untargeted.
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBeUndefined();
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("auto-resolve picks the same-user client when there's exactly one", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+        {
+          clientId: "client-B",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-B",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        undefined,
+        "user-A",
+      );
+
+      // Auto-resolved to client-A and broadcast targeted at it.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("auto-resolve falls through when no client matches the source user", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      const resultPromise = proxy.request(
+        { operation: "read", path: "/tmp/test.txt" },
+        "session-1",
+        undefined,
+        undefined,
+        "user-C",
+      );
+
+      // No same-user client → no auto-resolve, broadcast untargeted.
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBeUndefined();
+      const requestId = sent.requestId as string;
+
+      proxy.resolve(requestId, { content: "ok", isError: false });
+      await resultPromise;
+    });
+
+    test("legacy embedded targetClientId in input still goes through the same-user gate", async () => {
+      setup();
+      mockClients = [
+        {
+          clientId: "client-A",
+          capabilities: ["host_file"],
+          actorPrincipalId: "user-A",
+        },
+      ];
+
+      // Same-user via embedded input.targetClientId — should succeed.
+      const okPromise = proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/ok.txt",
+          targetClientId: "client-A",
+        },
+        "session-1",
+        undefined,
+        undefined,
+        "user-A",
+      );
+      expect(sentMessages).toHaveLength(1);
+      const okRequestId = (sentMessages[0] as Record<string, unknown>)
+        .requestId as string;
+      proxy.resolve(okRequestId, { content: "ok", isError: false });
+      await okPromise;
+
+      // Cross-user via embedded input.targetClientId — should be rejected.
+      sentMessages.length = 0;
+      const rejectResult = await proxy.request(
+        {
+          operation: "read",
+          path: "/tmp/bad.txt",
+          targetClientId: "client-A",
+        },
+        "session-1",
+        undefined,
+        undefined,
+        "user-B",
+      );
+      expect(rejectResult.isError).toBe(true);
+      expect(sentMessages).toHaveLength(0);
     });
   });
 });

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -94,10 +94,16 @@ function registerPending(
   requestId: string,
   overrides: Partial<PendingInteraction> = {},
 ): void {
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? clientActors.get(overrides.targetClientId)
+      : undefined);
   pendingStore.set(requestId, {
     conversationId: "conv-1",
     kind: "host_file",
     ...overrides,
+    targetActorPrincipalId,
   });
 }
 
@@ -124,8 +130,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-file-targeted-match";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
@@ -143,8 +149,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-file-targeted-trim";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
@@ -285,8 +291,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
   describe("targeted + actor principal mismatch", () => {
     test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
       const requestId = "req-file-actor-mismatch";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostFileResult({
@@ -301,8 +307,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("interaction is NOT consumed on actor-mismatch 403", () => {
       const requestId = "req-file-actor-mismatch-stays";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       try {
         handleHostFileResult({
@@ -326,8 +332,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
   describe("targeted + missing x-vellum-actor-principal-id header", () => {
     test("throws ForbiddenError (403) when submitting actor header is absent", () => {
       const requestId = "req-file-actor-missing";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostFileResult({
@@ -339,8 +345,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor header is empty string", () => {
       const requestId = "req-file-actor-empty";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostFileResult({
@@ -355,8 +361,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("interaction is NOT consumed when submitting actor is missing", () => {
       const requestId = "req-file-actor-missing-stays";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       try {
         handleHostFileResult({

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -1,11 +1,14 @@
 /**
- * Tests for the host-file-result route 403 guard introduced in Phase 2.
+ * Tests for the host-file-result route 403 guard.
  *
  * Covers:
- *  1. Targeted + correct x-vellum-client-id header → 200 accepted
- *  2. Targeted + missing header → 400 BadRequestError
- *  3. Targeted + wrong header → 403 ForbiddenError, interaction NOT consumed
+ *  1. Targeted + correct x-vellum-client-id header (and matching actor) → 200
+ *  2. Targeted + missing client-id header → 400 BadRequestError
+ *  3. Targeted + wrong client-id header → 403 ForbiddenError, interaction NOT consumed
  *  4. Untargeted (no targetClientId, no header) → 200 accepted (regression)
+ *  5. Targeted + matching client-id but mismatched actor principal → 403, NOT consumed
+ *  6. Targeted + matching client-id but missing actor principal header → 403, NOT consumed
+ *  7. Targeted + matching client-id but target client has no stored actor → 403, NOT consumed
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -61,12 +64,20 @@ mock.module("../daemon/host-file-proxy.js", () => ({
   },
 }));
 
+// Stub event hub so tests control what actorPrincipalId is associated with
+// each connected client.
+const clientActors = new Map<string, string>();
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getActorPrincipalIdForClient: (clientId: string) =>
+      clientActors.get(clientId),
+  },
+}));
+
 // ── Real imports (after mocks) ──────────────────────────────────────────────
 
-import {
-  BadRequestError,
-  ForbiddenError,
-} from "../runtime/routes/errors.js";
+import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/host-file-routes.js";
 
 afterAll(() => {
@@ -100,23 +111,28 @@ function fileBody(requestId: string): Record<string, unknown> {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
+describe("handleHostFileResult — targetClientId guard", () => {
   beforeEach(() => {
     pendingStore.clear();
     resolvedIds.length = 0;
     resolveSpy.length = 0;
+    clientActors.clear();
   });
 
-  // ── 1. Targeted + correct header → 200 ────────────────────────────────────
+  // ── 1. Targeted + correct headers (client + actor) → 200 ──────────────────
 
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-file-targeted-match";
       registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -128,26 +144,30 @@ describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-file-targeted-trim";
       registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
     });
   });
 
-  // ── 2. Targeted + missing header → 400 ────────────────────────────────────
+  // ── 2. Targeted + missing client-id header → 400 ──────────────────────────
 
   describe("targeted + missing x-vellum-client-id header", () => {
     test("throws BadRequestError (400) when header is absent", () => {
       const requestId = "req-file-targeted-no-header";
       registerPending(requestId, { targetClientId: "client-A" });
 
-      expect(() =>
-        handleHostFileResult({ body: fileBody(requestId) }),
-      ).toThrow(BadRequestError);
+      expect(() => handleHostFileResult({ body: fileBody(requestId) })).toThrow(
+        BadRequestError,
+      );
     });
 
     test("throws BadRequestError (400) when header is empty string", () => {
@@ -177,7 +197,7 @@ describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
     });
   });
 
-  // ── 3. Targeted + wrong header → 403 ──────────────────────────────────────
+  // ── 3. Targeted + wrong client-id header → 403 ────────────────────────────
 
   describe("targeted + wrong x-vellum-client-id header", () => {
     test("throws ForbiddenError (403) when client ID does not match", () => {
@@ -257,6 +277,138 @@ describe("handleHostFileResult — Phase 2 targetClientId guard", () => {
 
       expect(result).toEqual({ accepted: true });
       expect(resolveSpy).toHaveLength(1);
+    });
+  });
+
+  // ── 5. Targeted + matching client but mismatched actor → 403 ──────────────
+
+  describe("targeted + actor principal mismatch", () => {
+    test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
+      const requestId = "req-file-actor-mismatch";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-2",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT consumed on actor-mismatch 403", () => {
+      const requestId = "req-file-actor-mismatch-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      try {
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-2",
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+  });
+
+  // ── 6. Targeted + matching client but missing actor header → 403 ──────────
+
+  describe("targeted + missing x-vellum-actor-principal-id header", () => {
+    test("throws ForbiddenError (403) when submitting actor header is absent", () => {
+      const requestId = "req-file-actor-missing";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("throws ForbiddenError (403) when submitting actor header is empty string", () => {
+      const requestId = "req-file-actor-empty";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "   ",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT consumed when submitting actor is missing", () => {
+      const requestId = "req-file-actor-missing-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+      clientActors.set("client-A", "actor-1");
+
+      try {
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: { "x-vellum-client-id": "client-A" },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
+    });
+  });
+
+  // ── 7. Targeted + target client has no stored actor → 403 ─────────────────
+
+  describe("targeted + target client has no stored actor", () => {
+    test("throws ForbiddenError (403) when target client has no actorPrincipalId on record", () => {
+      const requestId = "req-file-target-no-actor";
+      registerPending(requestId, { targetClientId: "client-A" });
+      // intentionally do not set clientActors entry for client-A
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("interaction is NOT consumed when target client has no stored actor", () => {
+      const requestId = "req-file-target-no-actor-stays";
+      registerPending(requestId, { targetClientId: "client-A" });
+
+      try {
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      expect(resolvedIds).not.toContain(requestId);
+      expect(pendingStore.has(requestId)).toBe(true);
     });
   });
 });

--- a/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
@@ -709,7 +709,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -738,7 +738,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -767,7 +767,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 
@@ -863,7 +863,7 @@ describe("HostTransferProxy — targetClientId", () => {
       );
 
       expect(result.isError).toBe(true);
-      expect(result.content).toContain("same user");
+      expect(result.content).toContain("does not match");
       expect(sentMessages).toHaveLength(0);
     });
 

--- a/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-proxy-targeted.test.ts
@@ -20,11 +20,24 @@ const sentMessages: unknown[] = [];
 const sentMessageOptions: unknown[] = [];
 const resolvedInteractionIds: string[] = [];
 let mockHasClient = false;
-let mockCapableClients: Array<{ clientId: string; capabilities: string[] }> = [];
-let mockClientRegistry: Map<string, { clientId: string; capabilities: string[] }> = new Map();
+type MockClient = {
+  clientId: string;
+  capabilities: string[];
+  actorPrincipalId?: string;
+};
+let mockCapableClients: Array<MockClient> = [];
+let mockClientRegistry: Map<string, MockClient> = new Map();
+
+// Pre-existing Phase 1 routing tests use a single user identity. The same-user
+// check added in the host_transfer fix is exercised separately below.
+const TEST_PRINCIPAL = "test-user";
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown, _conversationId?: string, options?: unknown) => {
+  broadcastMessage: (
+    msg: unknown,
+    _conversationId?: string,
+    options?: unknown,
+  ) => {
     sentMessages.push(msg);
     sentMessageOptions.push(options);
   },
@@ -33,6 +46,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       cap === "host_file" && mockHasClient ? { id: "mock-client" } : null,
     listClientsByCapability: (_cap: string) => mockCapableClients,
     getClientById: (clientId: string) => mockClientRegistry.get(clientId),
+    getActorPrincipalIdForClient: (clientId: string) =>
+      mockClientRegistry.get(clientId)?.actorPrincipalId,
   },
 }));
 
@@ -95,7 +110,11 @@ describe("HostTransferProxy — targetClientId", () => {
   }
 
   function setupSingleClient(clientId = "client-1") {
-    const entry = { clientId, capabilities: ["host_file"] };
+    const entry: MockClient = {
+      clientId,
+      capabilities: ["host_file"],
+      actorPrincipalId: TEST_PRINCIPAL,
+    };
     mockCapableClients = [entry];
     mockClientRegistry.set(clientId, entry);
   }
@@ -117,13 +136,17 @@ describe("HostTransferProxy — targetClientId", () => {
       const srcPath = `/tmp/htp-targeted-${Date.now()}.txt`;
       await globalThis.Bun.write(srcPath, fileContent);
 
-      const resultPromise = proxy.requestToHost({
-        sourcePath: srcPath,
-        destPath: "/host/dest.txt",
-        overwrite: false,
-        conversationId: "conv-1",
-        targetClientId: "client-mac",
-      });
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-1",
+          targetClientId: "client-mac",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       await waitForMessages(sentMessages, 1);
 
@@ -135,7 +158,10 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(opts?.targetClientId).toBe("client-mac");
 
       const requestId = sent.requestId as string;
-      proxy.resolveTransferResult(requestId, { isError: false, bytesWritten: 5 });
+      proxy.resolveTransferResult(requestId, {
+        isError: false,
+        bytesWritten: 5,
+      });
 
       const result = await resultPromise;
       expect(result.isError).toBe(false);
@@ -152,12 +178,16 @@ describe("HostTransferProxy — targetClientId", () => {
       const srcPath = `/tmp/htp-targeted-solo-${Date.now()}.txt`;
       await globalThis.Bun.write(srcPath, "content");
 
-      const resultPromise = proxy.requestToHost({
-        sourcePath: srcPath,
-        destPath: "/host/dest.txt",
-        overwrite: false,
-        conversationId: "conv-2",
-      });
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-2",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       await waitForMessages(sentMessages, 1);
 
@@ -191,7 +221,9 @@ describe("HostTransferProxy — targetClientId", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("client-ghost");
-      expect(result.content).toContain("assistant clients list --capability host_file");
+      expect(result.content).toContain(
+        "assistant clients list --capability host_file",
+      );
       expect(sentMessages).toHaveLength(0);
     });
   });
@@ -228,12 +260,16 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-mac");
 
-      const resultPromise = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-5",
-        targetClientId: "client-mac",
-      });
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-5",
+          targetClientId: "client-mac",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       expect(sentMessages).toHaveLength(1);
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -256,11 +292,15 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-solo");
 
-      const resultPromise = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-6",
-      });
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-6",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       expect(sentMessages).toHaveLength(1);
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -333,6 +373,7 @@ describe("HostTransferProxy — targetClientId", () => {
           targetClientId: "client-abc",
         },
         controller.signal,
+        TEST_PRINCIPAL,
       );
 
       await waitForMessages(sentMessages, 1);
@@ -350,7 +391,9 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(cancelMsg.type).toBe("host_transfer_cancel");
       expect(cancelMsg.targetClientId).toBe("client-abc");
 
-      const cancelOpts = sentMessageOptions[1] as Record<string, unknown> | undefined;
+      const cancelOpts = sentMessageOptions[1] as
+        | Record<string, unknown>
+        | undefined;
       expect(cancelOpts?.targetClientId).toBe("client-abc");
     });
   });
@@ -362,12 +405,16 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-xyz");
 
-      const resultPromise = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-10",
-        targetClientId: "client-xyz",
-      });
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-10",
+          targetClientId: "client-xyz",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       const sent = sentMessages[0] as Record<string, unknown>;
       const requestId = sent.requestId as string;
@@ -384,7 +431,9 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(cancelMsg.type).toBe("host_transfer_cancel");
       expect(cancelMsg.targetClientId).toBe("client-xyz");
 
-      const cancelOpts = sentMessageOptions[1] as Record<string, unknown> | undefined;
+      const cancelOpts = sentMessageOptions[1] as
+        | Record<string, unknown>
+        | undefined;
       expect(cancelOpts?.targetClientId).toBe("client-xyz");
     });
   });
@@ -396,12 +445,16 @@ describe("HostTransferProxy — targetClientId", () => {
       setup();
       setupSingleClient("client-dispose");
 
-      const p = proxy.requestToSandbox({
-        sourcePath: "/host/source.txt",
-        destPath: "/sandbox/dest.txt",
-        conversationId: "conv-11",
-        targetClientId: "client-dispose",
-      });
+      const p = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-11",
+          targetClientId: "client-dispose",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
       p.catch(() => {}); // expected rejection on dispose
 
       const sent = sentMessages[0] as Record<string, unknown>;
@@ -431,20 +484,26 @@ describe("HostTransferProxy — targetClientId", () => {
       const srcPath = `/tmp/htp-targeted-peek-${Date.now()}.txt`;
       await globalThis.Bun.write(srcPath, "content");
 
-      const resultPromise = proxy.requestToHost({
-        sourcePath: srcPath,
-        destPath: "/host/dest.txt",
-        overwrite: false,
-        conversationId: "conv-12",
-        targetClientId: "client-peek",
-      });
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-12",
+          targetClientId: "client-peek",
+        },
+        undefined,
+        TEST_PRINCIPAL,
+      );
 
       await waitForMessages(sentMessages, 1);
 
       const sent = sentMessages[0] as Record<string, unknown>;
       const transferId = sent.transferId as string;
 
-      expect(proxy.getTargetClientIdForTransfer(transferId)).toBe("client-peek");
+      expect(proxy.getTargetClientIdForTransfer(transferId)).toBe(
+        "client-peek",
+      );
 
       // Clean up
       const requestId = sent.requestId as string;
@@ -493,12 +552,16 @@ describe("HostTransferProxy — targetClientId", () => {
 
       jest.useFakeTimers();
       try {
-        const resultPromise = proxy.requestToSandbox({
-          sourcePath: "/host/source.txt",
-          destPath: "/sandbox/dest.txt",
-          conversationId: "conv-14",
-          targetClientId: "client-timeout",
-        });
+        const resultPromise = proxy.requestToSandbox(
+          {
+            sourcePath: "/host/source.txt",
+            destPath: "/sandbox/dest.txt",
+            conversationId: "conv-14",
+            targetClientId: "client-timeout",
+          },
+          undefined,
+          TEST_PRINCIPAL,
+        );
 
         const sent = sentMessages[0] as Record<string, unknown>;
         expect(sent.targetClientId).toBe("client-timeout");
@@ -546,7 +609,10 @@ describe("HostTransferProxy — targetClientId", () => {
       expect(opts?.targetClientId).toBeUndefined();
 
       const requestId = sent.requestId as string;
-      proxy.resolveTransferResult(requestId, { isError: false, bytesWritten: 18 });
+      proxy.resolveTransferResult(requestId, {
+        isError: false,
+        bytesWritten: 18,
+      });
 
       const result = await resultPromise;
       expect(result.isError).toBe(false);
@@ -578,6 +644,289 @@ describe("HostTransferProxy — targetClientId", () => {
       const result = await resultPromise;
       expect(result.isError).toBe(true);
       expect(result.content).toBe("Transfer cancelled");
+    });
+  });
+
+  // ── Same-user binding (sourceActorPrincipalId) ───────────────────────
+
+  describe("same-user binding (sourceActorPrincipalId)", () => {
+    test("requestToHost: targeted request from same user reaches pendingInteractions", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-same-user-ok-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "ok");
+
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-1",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-A",
+      );
+
+      await waitForMessages(sentMessages, 1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.type).toBe("host_transfer_request");
+      expect(sent.targetClientId).toBe("client-A");
+
+      const requestId = sent.requestId as string;
+      proxy.resolveTransferResult(requestId, { isError: false });
+      await resultPromise;
+    });
+
+    test("requestToHost: targeted request from a different user is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-cross-user-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const result = await proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-2",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToHost: targeted request without source principal is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-no-principal-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const result = await proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-3",
+          targetClientId: "client-A",
+        },
+        undefined,
+        undefined,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToHost: targeted request to a client with no actor principal is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        // actorPrincipalId omitted (legacy/service-token client).
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-target-no-principal-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const result = await proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-4",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-A",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToHost: auto-resolve picks the same-user client when there's exactly one", async () => {
+      setup();
+      const a: MockClient = {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      };
+      const b: MockClient = {
+        clientId: "client-B",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-B",
+      };
+      mockCapableClients = [a, b];
+      mockClientRegistry.set("client-A", a);
+      mockClientRegistry.set("client-B", b);
+
+      const srcPath = `/tmp/htp-auto-same-user-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-5",
+        },
+        undefined,
+        "user-A",
+      );
+
+      await waitForMessages(sentMessages, 1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+
+      const requestId = sent.requestId as string;
+      proxy.resolveTransferResult(requestId, { isError: false });
+      await resultPromise;
+    });
+
+    test("requestToHost: auto-resolve falls through when no client matches the source user", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const srcPath = `/tmp/htp-auto-no-match-${Date.now()}.txt`;
+      await globalThis.Bun.write(srcPath, "data");
+
+      const resultPromise = proxy.requestToHost(
+        {
+          sourcePath: srcPath,
+          destPath: "/host/dest.txt",
+          overwrite: false,
+          conversationId: "conv-same-6",
+        },
+        undefined,
+        "user-C",
+      );
+
+      await waitForMessages(sentMessages, 1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBeUndefined();
+
+      const requestId = sent.requestId as string;
+      proxy.resolveTransferResult(requestId, { isError: false });
+      await resultPromise;
+    });
+
+    test("requestToSandbox: targeted request from a different user is rejected", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const result = await proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-same-7",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-B",
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("same user");
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    test("requestToSandbox: targeted request from same user proceeds", async () => {
+      setup();
+      mockClientRegistry.set("client-A", {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      });
+      mockCapableClients = [mockClientRegistry.get("client-A")!];
+
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-same-8",
+          targetClientId: "client-A",
+        },
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+
+      proxy.cancel(sent.requestId as string);
+      await resultPromise;
+    });
+
+    test("requestToSandbox: auto-resolve picks the same-user client when there's exactly one", async () => {
+      setup();
+      const a: MockClient = {
+        clientId: "client-A",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-A",
+      };
+      const b: MockClient = {
+        clientId: "client-B",
+        capabilities: ["host_file"],
+        actorPrincipalId: "user-B",
+      };
+      mockCapableClients = [a, b];
+      mockClientRegistry.set("client-A", a);
+      mockClientRegistry.set("client-B", b);
+
+      const resultPromise = proxy.requestToSandbox(
+        {
+          sourcePath: "/host/source.txt",
+          destPath: "/sandbox/dest.txt",
+          conversationId: "conv-same-9",
+        },
+        undefined,
+        "user-A",
+      );
+
+      expect(sentMessages).toHaveLength(1);
+      const sent = sentMessages[0] as Record<string, unknown>;
+      expect(sent.targetClientId).toBe("client-A");
+
+      proxy.cancel(sent.requestId as string);
+      await resultPromise;
     });
   });
 });

--- a/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
@@ -47,6 +47,11 @@ mock.module("../daemon/host-transfer-proxy.js", () => ({
         getTargetClientIdForTransfer(_transferId: string) {
           return stubTargetClientId;
         },
+        getTargetActorPrincipalIdForTransfer(_transferId: string) {
+          return stubTargetClientId
+            ? clientActors.get(stubTargetClientId)
+            : undefined;
+        },
         getTransferContent(transferId: string) {
           getTransferContentCalls.push(transferId);
           return {
@@ -109,10 +114,19 @@ const TEST_TRANSFER_ID = "transfer-abc";
 const TEST_REQUEST_ID = "req-1";
 
 function registerPending(overrides: Partial<PendingInteraction> = {}): void {
+  // Mirror the production proxy: capture the target's actor principal at
+  // registration time so the result-route check compares against a stable
+  // value rather than the live hub.
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? clientActors.get(overrides.targetClientId)
+      : undefined);
   pendingStore.set(TEST_REQUEST_ID, {
     conversationId: "conv-1",
     kind: "host_transfer",
     ...overrides,
+    targetActorPrincipalId,
   });
 }
 
@@ -472,8 +486,8 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
 
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and calls resolveTransferResult", async () => {
-      registerHostTransferPending("client-A");
       clientActors.set("client-A", "actor-1");
+      registerHostTransferPending("client-A");
       const result = await handleTransferResult({
         body: resultBody(),
         headers: {
@@ -487,8 +501,8 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
     });
 
     test("trims whitespace from header before comparing", async () => {
-      registerHostTransferPending("client-A");
       clientActors.set("client-A", "actor-1");
+      registerHostTransferPending("client-A");
       const result = await handleTransferResult({
         body: resultBody(),
         headers: {

--- a/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
@@ -49,9 +49,17 @@ mock.module("../daemon/host-transfer-proxy.js", () => ({
         },
         getTransferContent(transferId: string) {
           getTransferContentCalls.push(transferId);
-          return { buffer: Buffer.from("data"), sizeBytes: 4, sha256: "abc123" };
+          return {
+            buffer: Buffer.from("data"),
+            sizeBytes: 4,
+            sha256: "abc123",
+          };
         },
-        async receiveTransferContent(transferId: string, _data: Buffer, _sha256: string) {
+        async receiveTransferContent(
+          transferId: string,
+          _data: Buffer,
+          _sha256: string,
+        ) {
           receiveTransferContentCalls.push(transferId);
           return { accepted: true };
         },
@@ -63,12 +71,20 @@ mock.module("../daemon/host-transfer-proxy.js", () => ({
   },
 }));
 
+// Stub event hub so tests control what actorPrincipalId is associated with
+// each connected client.
+const clientActors = new Map<string, string>();
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  assistantEventHub: {
+    getActorPrincipalIdForClient: (clientId: string) =>
+      clientActors.get(clientId),
+  },
+}));
+
 // ── Real imports (after mocks) ──────────────────────────────────────────────
 
-import {
-  BadRequestError,
-  ForbiddenError,
-} from "../runtime/routes/errors.js";
+import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/host-transfer-routes.js";
 
 afterAll(() => {
@@ -107,6 +123,7 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
     pendingStore.clear();
     stubTargetClientId = null;
     getTransferContentCalls.length = 0;
+    clientActors.clear();
   });
 
   // ── 1. Targeted + correct header → success ────────────────────────────────
@@ -114,9 +131,13 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns Uint8Array and calls getTransferContent", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentGet({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
       });
 
       expect(result).toBeInstanceOf(Uint8Array);
@@ -125,9 +146,13 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentGet({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+        },
       });
 
       expect(result).toBeInstanceOf(Uint8Array);
@@ -199,6 +224,52 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
       expect(getTransferContentCalls).toContain(TEST_TRANSFER_ID);
     });
   });
+
+  // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
+
+  describe("targeted + actor principal binding", () => {
+    test("throws ForbiddenError when submitting actor does not match target client's actor", () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferContentGet({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-attacker",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(getTransferContentCalls).toHaveLength(0);
+    });
+
+    test("throws ForbiddenError when actor principal header is missing", () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferContentGet({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(getTransferContentCalls).toHaveLength(0);
+    });
+
+    test("throws ForbiddenError when target client has no stored actor", () => {
+      stubTargetClientId = "client-A";
+      // No entry in clientActors for "client-A"
+      expect(() =>
+        handleTransferContentGet({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(getTransferContentCalls).toHaveLength(0);
+    });
+  });
 });
 
 describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
@@ -206,6 +277,7 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
     pendingStore.clear();
     stubTargetClientId = null;
     receiveTransferContentCalls.length = 0;
+    clientActors.clear();
   });
 
   // ── 1. Targeted + correct header → success ────────────────────────────────
@@ -213,9 +285,14 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and calls receiveTransferContent", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentPut({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "client-A", "x-transfer-sha256": "abc" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+          "x-transfer-sha256": "abc",
+        },
         rawBody: new Uint8Array(Buffer.from("data")),
       });
 
@@ -225,9 +302,14 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferContentPut({
         pathParams: { transferId: TEST_TRANSFER_ID },
-        headers: { "x-vellum-client-id": "  client-A  ", "x-transfer-sha256": "abc" },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+          "x-transfer-sha256": "abc",
+        },
         rawBody: new Uint8Array(Buffer.from("data")),
       });
 
@@ -272,7 +354,10 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
       await expect(
         handleTransferContentPut({
           pathParams: { transferId: TEST_TRANSFER_ID },
-          headers: { "x-vellum-client-id": "client-B", "x-transfer-sha256": "abc" },
+          headers: {
+            "x-vellum-client-id": "client-B",
+            "x-transfer-sha256": "abc",
+          },
           rawBody: new Uint8Array(Buffer.from("data")),
         }),
       ).rejects.toBeInstanceOf(ForbiddenError);
@@ -283,7 +368,10 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
       try {
         await handleTransferContentPut({
           pathParams: { transferId: TEST_TRANSFER_ID },
-          headers: { "x-vellum-client-id": "client-B", "x-transfer-sha256": "abc" },
+          headers: {
+            "x-vellum-client-id": "client-B",
+            "x-transfer-sha256": "abc",
+          },
           rawBody: new Uint8Array(Buffer.from("data")),
         });
       } catch {
@@ -308,6 +396,60 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
       expect(receiveTransferContentCalls).toContain(TEST_TRANSFER_ID);
     });
   });
+
+  // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
+
+  describe("targeted + actor principal binding", () => {
+    test("rejects when submitting actor does not match target client's actor", async () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      await expect(
+        handleTransferContentPut({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-attacker",
+            "x-transfer-sha256": "abc",
+          },
+          rawBody: new Uint8Array(Buffer.from("data")),
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      expect(receiveTransferContentCalls).toHaveLength(0);
+    });
+
+    test("rejects when actor principal header is missing", async () => {
+      stubTargetClientId = "client-A";
+      clientActors.set("client-A", "actor-victim");
+      await expect(
+        handleTransferContentPut({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-transfer-sha256": "abc",
+          },
+          rawBody: new Uint8Array(Buffer.from("data")),
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      expect(receiveTransferContentCalls).toHaveLength(0);
+    });
+
+    test("rejects when target client has no stored actor", async () => {
+      stubTargetClientId = "client-A";
+      // No entry in clientActors for "client-A"
+      await expect(
+        handleTransferContentPut({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+            "x-transfer-sha256": "abc",
+          },
+          rawBody: new Uint8Array(Buffer.from("data")),
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      expect(receiveTransferContentCalls).toHaveLength(0);
+    });
+  });
 });
 
 describe("handleTransferResult — Phase 3 targetClientId guard", () => {
@@ -315,6 +457,7 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
     pendingStore.clear();
     stubTargetClientId = null;
     resolveTransferResultCalls.length = 0;
+    clientActors.clear();
   });
 
   function registerHostTransferPending(targetClientId?: string): void {
@@ -330,9 +473,13 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and calls resolveTransferResult", async () => {
       registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferResult({
         body: resultBody(),
-        headers: { "x-vellum-client-id": "client-A" },
+        headers: {
+          "x-vellum-client-id": "client-A",
+          "x-vellum-actor-principal-id": "actor-1",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -341,9 +488,13 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-1");
       const result = await handleTransferResult({
         body: resultBody(),
-        headers: { "x-vellum-client-id": "  client-A  " },
+        headers: {
+          "x-vellum-client-id": "  client-A  ",
+          "x-vellum-actor-principal-id": "  actor-1  ",
+        },
       });
 
       expect(result).toEqual({ accepted: true });
@@ -355,9 +506,9 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
   describe("targeted + missing x-vellum-client-id header", () => {
     test("throws BadRequestError when header is absent", () => {
       registerHostTransferPending("client-A");
-      expect(() =>
-        handleTransferResult({ body: resultBody() }),
-      ).toThrow(BadRequestError);
+      expect(() => handleTransferResult({ body: resultBody() })).toThrow(
+        BadRequestError,
+      );
     });
 
     test("resolveTransferResult NOT called on 400", () => {
@@ -442,6 +593,56 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
       });
 
       expect(result).toEqual({ accepted: true });
+    });
+  });
+
+  // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
+
+  describe("targeted + actor principal binding", () => {
+    test("throws ForbiddenError when submitting actor does not match target client's actor", () => {
+      registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferResult({
+          body: resultBody(),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-attacker",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(resolveTransferResultCalls).toHaveLength(0);
+      // Pending interaction should still be present (not consumed on 403).
+      expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
+    });
+
+    test("throws ForbiddenError when actor principal header is missing", () => {
+      registerHostTransferPending("client-A");
+      clientActors.set("client-A", "actor-victim");
+      expect(() =>
+        handleTransferResult({
+          body: resultBody(),
+          headers: { "x-vellum-client-id": "client-A" },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(resolveTransferResultCalls).toHaveLength(0);
+      expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
+    });
+
+    test("throws ForbiddenError when target client has no stored actor", () => {
+      registerHostTransferPending("client-A");
+      // No entry in clientActors for "client-A"
+      expect(() =>
+        handleTransferResult({
+          body: resultBody(),
+          headers: {
+            "x-vellum-client-id": "client-A",
+            "x-vellum-actor-principal-id": "actor-1",
+          },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(resolveTransferResultCalls).toHaveLength(0);
+      expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
     });
   });
 });

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1930,7 +1930,7 @@ export async function surfaceProxyResolver(
     // Record the action and proxy to the connected desktop client
     const reasoning =
       typeof input.reasoning === "string" ? input.reasoning : undefined;
-    const targetClientId =
+    let targetClientId: string | undefined =
       typeof input.target_client_id === "string" &&
       input.target_client_id !== ""
         ? input.target_client_id
@@ -1985,14 +1985,24 @@ export async function surfaceProxyResolver(
     // host_cu-capable transport for which auto-routing-to-self would be
     // appropriate. We therefore fire whenever there is genuine ambiguity.
     if (targetClientId == null) {
-      const cuClients = assistantEventHub
-        .listClientsByCapability("host_cu")
-        .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
-      if (cuClients.length > 1) {
+      const allCuClients = assistantEventHub.listClientsByCapability("host_cu");
+      const sameUserCuClients = allCuClients.filter(
+        (c) => c.actorPrincipalId === sourceActorPrincipalId,
+      );
+      if (sameUserCuClients.length > 1) {
         return {
           content: `Error: multiple clients support host_cu. Specify which client to target with \`target_client_id\`. Run \`assistant clients list --capability host_cu\` to see client IDs and labels.`,
           isError: true,
         };
+      }
+      // When cross-user host_cu clients are connected, we MUST auto-resolve
+      // to the unique same-user client (or fail explicitly) — otherwise the
+      // proxy would broadcast untargeted and the CU action would reach the
+      // cross-user client too. Setting targetClientId here forces the proxy
+      // to deliver only to that client, with the same-user check below as
+      // belt-and-suspenders.
+      if (sameUserCuClients.length === 1 && allCuClients.length > 1) {
+        targetClientId = sameUserCuClients[0].clientId;
       }
     }
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1939,6 +1939,7 @@ export async function surfaceProxyResolver(
     // burn a step or pollute action history. (HostBashProxy / HostFileProxy
     // both validate at the tool-resolution layer before incrementing any
     // state; this mirrors that behaviour for CU.)
+    const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
       if (!client) {
@@ -1950,6 +1951,22 @@ export async function surfaceProxyResolver(
       if (!client.capabilities.includes("host_cu")) {
         return {
           content: `Client '${targetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          isError: true,
+        };
+      }
+
+      // Same-user enforcement: a targeted CU dispatch must be owned by the
+      // same actor on both sides. Surface a friendly tool-input rejection
+      // before invoking the proxy (which performs the same check as a
+      // backstop for direct callers).
+      const targetActorPrincipalId = client.actorPrincipalId;
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        return {
+          content: `Client '${targetClientId}' is not owned by the current user — cross-user computer_use dispatch is not allowed.`,
           isError: true,
         };
       }
@@ -1989,6 +2006,7 @@ export async function surfaceProxyResolver(
       reasoning,
       signal,
       targetClientId,
+      sourceActorPrincipalId,
     );
   }
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -18,6 +18,7 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import { enforceSameActorOrErrorResult } from "../runtime/auth/same-actor.js";
 import type {
   InteractiveUiRequest,
   InteractiveUiResult,
@@ -1935,10 +1936,12 @@ export async function surfaceProxyResolver(
         ? input.target_client_id
         : undefined;
 
-    // Validate targetClientId before recordAction so an invalid ID does not
-    // burn a step or pollute action history. (HostBashProxy / HostFileProxy
-    // both validate at the tool-resolution layer before incrementing any
-    // state; this mirrors that behaviour for CU.)
+    // Validate targetClientId existence, capability, and same-user binding
+    // before recordAction so an invalid or cross-user ID does not burn a
+    // step or pollute action history. HostBashProxy / HostFileProxy
+    // validate at the tool-resolution layer for the same reason. The proxy
+    // re-checks same-user (single authoritative gate); using the shared
+    // helper keeps log payload and error wording identical at both layers.
     const sourceActorPrincipalId = ctx.trustContext?.guardianPrincipalId;
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
@@ -1954,30 +1957,24 @@ export async function surfaceProxyResolver(
           isError: true,
         };
       }
-
-      // Same-user enforcement: a targeted CU dispatch must be owned by the
-      // same actor on both sides. Surface a friendly tool-input rejection
-      // before invoking the proxy (which performs the same check as a
-      // backstop for direct callers).
-      const targetActorPrincipalId = client.actorPrincipalId;
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        return {
-          content: `Client '${targetClientId}' is not owned by the current user — cross-user computer_use dispatch is not allowed.`,
-          isError: true,
-        };
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId,
+        op: "host_cu",
+      });
+      if (rejection) return rejection;
     }
 
-    // Guard: require explicit targeting when multiple CU-capable clients are
-    // connected. The tool schemas document target_client_id as "required when
-    // multiple clients support host_cu" but nothing enforced it at runtime
-    // until now. Without this guard, the request would broadcast to all
-    // capable clients simultaneously, causing the same CU action to execute
-    // on multiple machines.
+    // Guard: require explicit targeting when multiple same-user CU-capable
+    // clients are connected. The tool schemas document target_client_id as
+    // "required when multiple clients support host_cu" but nothing enforced
+    // it at runtime until now. Without this guard, the request would
+    // broadcast to all capable clients simultaneously, causing the same CU
+    // action to execute on multiple machines. The filter mirrors
+    // HostFileProxy's auto-resolve: only same-user clients participate, so
+    // a cross-user client connected to the same daemon does not falsely
+    // trigger this ambiguity error.
     //
     // Asymmetry with host_bash / host_file (host-shell.ts): the bash/file
     // guard additionally checks `transportInterface != null &&
@@ -1988,7 +1985,9 @@ export async function surfaceProxyResolver(
     // host_cu-capable transport for which auto-routing-to-self would be
     // appropriate. We therefore fire whenever there is genuine ambiguity.
     if (targetClientId == null) {
-      const cuClients = assistantEventHub.listClientsByCapability("host_cu");
+      const cuClients = assistantEventHub
+        .listClientsByCapability("host_cu")
+        .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
       if (cuClients.length > 1) {
         return {
           content: `Error: multiple clients support host_cu. Specify which client to target with \`target_client_id\`. Run \`assistant clients list --capability host_cu\` to see client IDs and labels.`,

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -135,6 +135,7 @@ export function createToolExecutor(
       taskRunId: ctx.taskRunId,
       trustClass: resolveTrustClass(ctx.trustContext),
       executionChannel: ctx.trustContext?.sourceChannel,
+      sourceActorPrincipalId: ctx.trustContext?.guardianPrincipalId,
       callSessionId: ctx.callSessionId,
       triggeredBySurfaceAction:
         ctx.surfaceActionRequestIds?.has(ctx.currentRequestId ?? "") ?? false,

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -6,6 +6,7 @@ import {
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
 import {
+  ambiguousSameUserError,
   enforceSameActorOrErrorResult,
   pickSameUserAutoResolve,
 } from "../runtime/auth/same-actor.js";
@@ -85,16 +86,21 @@ export class HostBashProxy {
       }
       resolvedTargetClientId = input.targetClientId;
     } else {
-      // Auto-resolve only to a same-user capable client; falls through to
-      // the untargeted broadcast path when zero or multiple same-user
-      // clients are connected. The zero-client / multi-client cases are
-      // handled by the existing timeout/error path and the tool-executor
-      // layer respectively.
-      resolvedTargetClientId = pickSameUserAutoResolve({
+      // Auto-resolve to the unique same-user client. Reject (rather than
+      // broadcast) when multiple same-user clients are connected so that
+      // a single targeted-style request cannot fan out across every one
+      // of the user's machines. Zero same-user matches falls through to
+      // the existing untargeted code path.
+      const resolved = pickSameUserAutoResolve({
         hub: assistantEventHub,
         capability: "host_bash",
         sourceActorPrincipalId,
       });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_bash"));
+      }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
     // Targeted requests must be bound to the same authenticated user as the

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -171,6 +171,12 @@ export class HostBashProxy {
         timer,
         detachAbort,
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
         metadata: { timeoutSec },
       });
 

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -5,6 +5,10 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import {
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { formatShellOutput } from "../tools/shared/shell-output.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -69,9 +73,6 @@ export class HostBashProxy {
       return Promise.resolve(result);
     }
 
-    const capableClients =
-      assistantEventHub.listClientsByCapability("host_bash");
-
     let resolvedTargetClientId: string | undefined;
 
     if (input.targetClientId) {
@@ -83,52 +84,31 @@ export class HostBashProxy {
         });
       }
       resolvedTargetClientId = input.targetClientId;
-    } else if (capableClients.length === 1) {
-      // Auto-resolve when exactly one capable client is connected — but only
-      // when its actor principal matches the caller's. This prevents a
-      // same-daemon attacker from getting cross-user execution by relying on
-      // auto-resolve. If the sole client belongs to a different user, fall
-      // through to the untargeted broadcast path.
-      const onlyClient = capableClients[0];
-      if (
-        sourceActorPrincipalId != null &&
-        onlyClient.actorPrincipalId === sourceActorPrincipalId
-      ) {
-        resolvedTargetClientId = onlyClient.clientId;
-      }
+    } else {
+      // Auto-resolve only to a same-user capable client; falls through to
+      // the untargeted broadcast path when zero or multiple same-user
+      // clients are connected. The zero-client / multi-client cases are
+      // handled by the existing timeout/error path and the tool-executor
+      // layer respectively.
+      resolvedTargetClientId = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_bash",
+        sourceActorPrincipalId,
+      });
     }
-    // capableClients.length === 0 or > 1 without explicit target: resolvedTargetClientId
-    // stays undefined and falls through to untargeted broadcast — the existing timeout/error
-    // path handles the zero-client case, and multi-client ambiguity is enforced at the tool
-    // executor layer (not here) once target_client_id is exposed in the tool schema.
 
     // Targeted requests must be bound to the same authenticated user as the
     // target client. Fail closed at request time — before pendingInteractions
     // registration and before broadcast — so a same-daemon caller cannot
     // execute on another user's connected client.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        targetActorPrincipalId !== sourceActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_bash",
-          },
-          "Rejecting targeted host_bash request: source actor does not match target client's actor",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_bash requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_bash",
+      });
+      if (rejection) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -13,7 +13,6 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("host-bash-proxy");
 
-
 export class HostBashProxy {
   private static _instance: HostBashProxy | null = null;
 
@@ -62,13 +61,16 @@ export class HostBashProxy {
     },
     conversationId: string,
     signal?: AbortSignal,
+    // Principal ID of the actor on whose behalf this request is initiated.
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       const result = formatShellOutput("", "Aborted", null, false, 0);
       return Promise.resolve(result);
     }
 
-    const capableClients = assistantEventHub.listClientsByCapability("host_bash");
+    const capableClients =
+      assistantEventHub.listClientsByCapability("host_bash");
 
     let resolvedTargetClientId: string | undefined;
 
@@ -82,13 +84,52 @@ export class HostBashProxy {
       }
       resolvedTargetClientId = input.targetClientId;
     } else if (capableClients.length === 1) {
-      // Auto-resolve when exactly one capable client is connected.
-      resolvedTargetClientId = capableClients[0].clientId;
+      // Auto-resolve when exactly one capable client is connected — but only
+      // when its actor principal matches the caller's. This prevents a
+      // same-daemon attacker from getting cross-user execution by relying on
+      // auto-resolve. If the sole client belongs to a different user, fall
+      // through to the untargeted broadcast path.
+      const onlyClient = capableClients[0];
+      if (
+        sourceActorPrincipalId != null &&
+        onlyClient.actorPrincipalId === sourceActorPrincipalId
+      ) {
+        resolvedTargetClientId = onlyClient.clientId;
+      }
     }
     // capableClients.length === 0 or > 1 without explicit target: resolvedTargetClientId
     // stays undefined and falls through to untargeted broadcast — the existing timeout/error
     // path handles the zero-client case, and multi-client ambiguity is enforced at the tool
     // executor layer (not here) once target_client_id is exposed in the tool schema.
+
+    // Targeted requests must be bound to the same authenticated user as the
+    // target client. Fail closed at request time — before pendingInteractions
+    // registration and before broadcast — so a same-daemon caller cannot
+    // execute on another user's connected client.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        targetActorPrincipalId !== sourceActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_bash",
+          },
+          "Rejecting targeted host_bash request: source actor does not match target client's actor",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_bash requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
+    }
 
     const requestId = uuid();
 
@@ -108,15 +149,7 @@ export class HostBashProxy {
         const timeoutMessage = resolvedTargetClientId
           ? `Host bash proxy timed out waiting for response from client ${resolvedTargetClientId}`
           : "Host bash proxy timed out waiting for client response";
-        resolve(
-          formatShellOutput(
-            "",
-            timeoutMessage,
-            null,
-            true,
-            timeoutSec,
-          ),
-        );
+        resolve(formatShellOutput("", timeoutMessage, null, true, timeoutSec));
       }, proxyTimeoutSec * 1000);
 
       if (signal) {
@@ -166,8 +199,8 @@ export class HostBashProxy {
             timeout_seconds: input.timeout_seconds,
             targetClientId: resolvedTargetClientId,
             ...(input.env && Object.keys(input.env).length > 0
-                ? { env: input.env }
-                : {}),
+              ? { env: input.env }
+              : {}),
           },
           conversationId,
           { targetClientId: resolvedTargetClientId },

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -235,6 +235,10 @@ export class HostCuProxy {
         conversationId,
         kind: "host_cu",
         targetClientId,
+        targetActorPrincipalId:
+          targetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
+            : undefined,
         rpcResolve: resolve,
         rpcReject: reject,
         timer,

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -121,6 +121,16 @@ export class HostCuProxy {
   // Request / resolve lifecycle
   // ---------------------------------------------------------------------------
 
+  /**
+   * Send a CU request to the connected desktop client.
+   *
+   * When `targetClientId` is supplied, the proxy validates that the target
+   * exists and advertises the `host_cu` capability, mirroring HostFileProxy's
+   * resolver-side checks so that the proxy is safe to call as a standalone
+   * API. It additionally enforces that the caller (`sourceActorPrincipalId`)
+   * and the target client share the same actor principal — cross-user
+   * targeted dispatch is rejected.
+   */
   request(
     toolName: string,
     input: Record<string, unknown>,
@@ -129,6 +139,7 @@ export class HostCuProxy {
     reasoning?: string,
     signal?: AbortSignal,
     targetClientId?: string,
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({
@@ -142,6 +153,50 @@ export class HostCuProxy {
         content: `Step limit (${this._maxSteps}) exceeded. Call computer_use_done to finish.`,
         isError: true,
       });
+    }
+
+    // Existence + capability validation for explicit targets. Mirrors
+    // HostFileProxy's resolver-side guard so that the proxy is safe even
+    // when called outside the conversation-surfaces dispatch (which has
+    // its own validation layer).
+    if (targetClientId != null) {
+      const client = assistantEventHub.getClientById(targetClientId);
+      if (!client) {
+        return Promise.resolve({
+          content: `No connected client with id '${targetClientId}' supports host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          isError: true,
+        });
+      }
+      if (!client.capabilities.includes("host_cu")) {
+        return Promise.resolve({
+          content: `Client '${targetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          isError: true,
+        });
+      }
+
+      // Same-user enforcement: targeted CU dispatch must be owned by the
+      // same actor on both sides. Reject when either principal is missing
+      // or when they don't match.
+      const targetActorPrincipalId = client.actorPrincipalId;
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            targetClientId,
+            hasSourcePrincipal: sourceActorPrincipalId != null,
+            hasTargetPrincipal: targetActorPrincipalId != null,
+          },
+          "Rejected cross-user host_cu request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_cu requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
     }
 
     const requestId = uuid();
@@ -170,9 +225,7 @@ export class HostCuProxy {
                   type: "host_cu_cancel",
                   requestId,
                   conversationId,
-                  ...(targetClientId != null
-                    ? { targetClientId }
-                    : {}),
+                  ...(targetClientId != null ? { targetClientId } : {}),
                 },
                 conversationId,
                 { targetClientId },

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -23,6 +23,7 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import { enforceSameActorOrErrorResult } from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -175,28 +176,16 @@ export class HostCuProxy {
       }
 
       // Same-user enforcement: targeted CU dispatch must be owned by the
-      // same actor on both sides. Reject when either principal is missing
-      // or when they don't match.
-      const targetActorPrincipalId = client.actorPrincipalId;
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            targetClientId,
-            hasSourcePrincipal: sourceActorPrincipalId != null,
-            hasTargetPrincipal: targetActorPrincipalId != null,
-          },
-          "Rejected cross-user host_cu request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_cu requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      // same actor on both sides. This is the authoritative gate — the
+      // dispatch layer (conversation-surfaces.ts) skips its own check
+      // and relies on the proxy.
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId,
+        op: "host_cu",
+      });
+      if (rejection) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -180,6 +180,12 @@ export class HostFileProxy {
         conversationId,
         kind: "host_file",
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
         rpcResolve: resolve,
         rpcReject: reject,
         timer,

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -5,6 +5,7 @@ import {
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
 import {
+  ambiguousSameUserError,
   enforceSameActorOrErrorResult,
   pickSameUserAutoResolve,
 } from "../runtime/auth/same-actor.js";
@@ -99,11 +100,19 @@ export class HostFileProxy {
         });
       }
     } else {
-      resolvedTargetClientId = pickSameUserAutoResolve({
+      // Auto-resolve to the unique same-user client. Reject ambiguous
+      // (multi-machine) cases so a single targeted-style request cannot
+      // fan out across the user's machines.
+      const resolved = pickSameUserAutoResolve({
         hub: assistantEventHub,
         capability: "host_file",
         sourceActorPrincipalId,
       });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_file"));
+      }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
     // Same-user check: targeted host_file requests must be bound to the same

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -4,6 +4,10 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import {
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { readImageBase64 } from "../tools/shared/filesystem/image-read.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -74,9 +78,10 @@ export class HostFileProxy {
       return Promise.resolve({ content: "Aborted", isError: true });
     }
 
-    // Resolve targetClientId: explicit → validate; single capable client → auto-resolve.
-    // Callers may embed targetClientId in the input object (tool handlers) or pass it as
-    // the 4th parameter (legacy). Prefer the explicit param; fall back to input field.
+    // Resolve targetClientId: explicit → validate; single same-user
+    // capable client → auto-resolve. Callers may embed targetClientId in
+    // the input object (tool handlers) or pass it as the 4th parameter
+    // (legacy). Prefer the explicit param; fall back to input field.
     let resolvedTargetClientId: string | undefined =
       targetClientId ?? input.targetClientId;
     if (resolvedTargetClientId != null) {
@@ -94,46 +99,24 @@ export class HostFileProxy {
         });
       }
     } else {
-      // Auto-resolve only to a capable client whose actorPrincipalId matches
-      // the source caller's. Skips auto-resolve when the caller has no
-      // identity, since same-user binding cannot be enforced.
-      if (sourceActorPrincipalId != null) {
-        const capable = assistantEventHub.listClientsByCapability("host_file");
-        const sameUser = capable.filter(
-          (c) => c.actorPrincipalId === sourceActorPrincipalId,
-        );
-        if (sameUser.length === 1) {
-          resolvedTargetClientId = sameUser[0].clientId;
-        }
-      }
+      resolvedTargetClientId = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_file",
+        sourceActorPrincipalId,
+      });
     }
 
     // Same-user check: targeted host_file requests must be bound to the same
     // authenticated user identity that opened the target client's SSE stream.
     // Prevents cross-user routing through actor token mis-targeting.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_file",
-          },
-          "Rejected cross-user targeted host_file request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_file requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_file",
+      });
+      if (rejection) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -68,6 +68,7 @@ export class HostFileProxy {
     conversationId: string,
     signal?: AbortSignal,
     targetClientId?: string,
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({ content: "Aborted", isError: true });
@@ -76,7 +77,8 @@ export class HostFileProxy {
     // Resolve targetClientId: explicit → validate; single capable client → auto-resolve.
     // Callers may embed targetClientId in the input object (tool handlers) or pass it as
     // the 4th parameter (legacy). Prefer the explicit param; fall back to input field.
-    let resolvedTargetClientId: string | undefined = targetClientId ?? input.targetClientId;
+    let resolvedTargetClientId: string | undefined =
+      targetClientId ?? input.targetClientId;
     if (resolvedTargetClientId != null) {
       const client = assistantEventHub.getClientById(resolvedTargetClientId);
       if (!client) {
@@ -92,9 +94,45 @@ export class HostFileProxy {
         });
       }
     } else {
-      const capable = assistantEventHub.listClientsByCapability("host_file");
-      if (capable.length === 1) {
-        resolvedTargetClientId = capable[0].clientId;
+      // Auto-resolve only to a capable client whose actorPrincipalId matches
+      // the source caller's. Skips auto-resolve when the caller has no
+      // identity, since same-user binding cannot be enforced.
+      if (sourceActorPrincipalId != null) {
+        const capable = assistantEventHub.listClientsByCapability("host_file");
+        const sameUser = capable.filter(
+          (c) => c.actorPrincipalId === sourceActorPrincipalId,
+        );
+        if (sameUser.length === 1) {
+          resolvedTargetClientId = sameUser[0].clientId;
+        }
+      }
+    }
+
+    // Same-user check: targeted host_file requests must be bound to the same
+    // authenticated user identity that opened the target client's SSE stream.
+    // Prevents cross-user routing through actor token mis-targeting.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_file",
+          },
+          "Rejected cross-user targeted host_file request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_file requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
       }
     }
 

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -36,6 +36,13 @@ interface TransferEntry {
   sha256?: string;
   fileBuffer?: Buffer;
   targetClientId?: string;
+  /**
+   * Snapshot of `targetClientId`'s `actorPrincipalId` taken at registration
+   * time. Persisted so the GET/PUT content routes compare against a stable
+   * value rather than the live hub — the target client's SSE subscription
+   * may briefly disconnect between dispatch and content fetch/upload.
+   */
+  targetActorPrincipalId?: string;
 }
 
 /**
@@ -248,12 +255,24 @@ export class HostTransferProxy {
             sha256,
             fileBuffer,
             targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
           });
 
           pendingInteractions.register(requestId, {
             conversationId: input.conversationId,
             kind: "host_transfer",
             targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
             rpcResolve: resolve,
             rpcReject: reject,
             timer,
@@ -425,12 +444,24 @@ export class HostTransferProxy {
         filePath: input.destPath,
         overwrite: input.overwrite,
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
       });
 
       pendingInteractions.register(requestId, {
         conversationId: input.conversationId,
         kind: "host_transfer",
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
         rpcResolve: resolve,
         rpcReject: reject,
         timer,
@@ -672,6 +703,15 @@ export class HostTransferProxy {
    */
   getTargetClientIdForTransfer(transferId: string): string | null {
     return this.transfers.get(transferId)?.targetClientId ?? null;
+  }
+
+  /**
+   * Look up the persisted `targetActorPrincipalId` for a given transferId
+   * without consuming the entry. Routes call this for the same-actor
+   * binding check so it's stable across brief SSE reconnects.
+   */
+  getTargetActorPrincipalIdForTransfer(transferId: string): string | undefined {
+    return this.transfers.get(transferId)?.targetActorPrincipalId;
   }
 
   dispose(): void {

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -9,6 +9,11 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import {
+  ambiguousSameUserError,
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -147,47 +152,29 @@ export class HostTransferProxy {
         });
       }
     } else {
-      // Auto-resolve only to a capable client whose actorPrincipalId matches
-      // the source caller's. Skips auto-resolve when the caller has no
-      // identity, since same-user binding cannot be enforced.
-      if (sourceActorPrincipalId != null) {
-        const capable = assistantEventHub.listClientsByCapability("host_file");
-        const sameUser = capable.filter(
-          (c) => c.actorPrincipalId === sourceActorPrincipalId,
-        );
-        if (sameUser.length === 1) {
-          resolvedTargetClientId = sameUser[0].clientId;
-        }
+      // Auto-resolve to the unique same-user client; reject ambiguous
+      // (multi-machine) cases so a single targeted-style transfer cannot
+      // fan out across the user's machines.
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_file",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_file"));
       }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
-    // Same-user check: targeted host_transfer requests must be bound to the
-    // same authenticated user identity that opened the target client's SSE
-    // stream. Prevents cross-user routing through actor token mis-targeting.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_transfer",
-            direction: "to_host",
-          },
-          "Rejected cross-user targeted host_transfer request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_transfer",
+      });
+      if (rejection != null) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();
@@ -355,47 +342,29 @@ export class HostTransferProxy {
         });
       }
     } else {
-      // Auto-resolve only to a capable client whose actorPrincipalId matches
-      // the source caller's. Skips auto-resolve when the caller has no
-      // identity, since same-user binding cannot be enforced.
-      if (sourceActorPrincipalId != null) {
-        const capable = assistantEventHub.listClientsByCapability("host_file");
-        const sameUser = capable.filter(
-          (c) => c.actorPrincipalId === sourceActorPrincipalId,
-        );
-        if (sameUser.length === 1) {
-          resolvedTargetClientId = sameUser[0].clientId;
-        }
+      // Auto-resolve to the unique same-user client; reject ambiguous
+      // (multi-machine) cases so a single targeted-style transfer cannot
+      // fan out across the user's machines.
+      const resolved = pickSameUserAutoResolve({
+        hub: assistantEventHub,
+        capability: "host_file",
+        sourceActorPrincipalId,
+      });
+      if (resolved.kind === "ambiguous") {
+        return Promise.resolve(ambiguousSameUserError("host_file"));
       }
+      resolvedTargetClientId =
+        resolved.kind === "match" ? resolved.clientId : undefined;
     }
 
-    // Same-user check: targeted host_transfer requests must be bound to the
-    // same authenticated user identity that opened the target client's SSE
-    // stream. Prevents cross-user routing through actor token mis-targeting.
     if (resolvedTargetClientId != null) {
-      const targetActorPrincipalId =
-        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
-      if (
-        sourceActorPrincipalId == null ||
-        targetActorPrincipalId == null ||
-        sourceActorPrincipalId !== targetActorPrincipalId
-      ) {
-        log.warn(
-          {
-            sourceActorPrincipalId,
-            targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId,
-            op: "host_transfer",
-            direction: "to_sandbox",
-          },
-          "Rejected cross-user targeted host_transfer request",
-        );
-        return Promise.resolve({
-          content:
-            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
-          isError: true,
-        });
-      }
+      const rejection = enforceSameActorOrErrorResult({
+        hub: assistantEventHub,
+        sourceActorPrincipalId,
+        targetClientId: resolvedTargetClientId,
+        op: "host_transfer",
+      });
+      if (rejection != null) return Promise.resolve(rejection);
     }
 
     const requestId = uuid();

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -124,6 +124,8 @@ export class HostTransferProxy {
       targetClientId?: string;
     },
     signal?: AbortSignal,
+    // Principal ID of the actor on whose behalf this request is initiated.
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({ content: "Aborted", isError: true });
@@ -145,8 +147,47 @@ export class HostTransferProxy {
         });
       }
     } else {
-      const capable = assistantEventHub.listClientsByCapability("host_file");
-      if (capable.length === 1) resolvedTargetClientId = capable[0].clientId;
+      // Auto-resolve only to a capable client whose actorPrincipalId matches
+      // the source caller's. Skips auto-resolve when the caller has no
+      // identity, since same-user binding cannot be enforced.
+      if (sourceActorPrincipalId != null) {
+        const capable = assistantEventHub.listClientsByCapability("host_file");
+        const sameUser = capable.filter(
+          (c) => c.actorPrincipalId === sourceActorPrincipalId,
+        );
+        if (sameUser.length === 1) {
+          resolvedTargetClientId = sameUser[0].clientId;
+        }
+      }
+    }
+
+    // Same-user check: targeted host_transfer requests must be bound to the
+    // same authenticated user identity that opened the target client's SSE
+    // stream. Prevents cross-user routing through actor token mis-targeting.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_transfer",
+            direction: "to_host",
+          },
+          "Rejected cross-user targeted host_transfer request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
     }
 
     const requestId = uuid();
@@ -291,6 +332,8 @@ export class HostTransferProxy {
       targetClientId?: string;
     },
     signal?: AbortSignal,
+    // Principal ID of the actor on whose behalf this request is initiated.
+    sourceActorPrincipalId?: string,
   ): Promise<ToolExecutionResult> {
     if (signal?.aborted) {
       return Promise.resolve({ content: "Aborted", isError: true });
@@ -312,8 +355,47 @@ export class HostTransferProxy {
         });
       }
     } else {
-      const capable = assistantEventHub.listClientsByCapability("host_file");
-      if (capable.length === 1) resolvedTargetClientId = capable[0].clientId;
+      // Auto-resolve only to a capable client whose actorPrincipalId matches
+      // the source caller's. Skips auto-resolve when the caller has no
+      // identity, since same-user binding cannot be enforced.
+      if (sourceActorPrincipalId != null) {
+        const capable = assistantEventHub.listClientsByCapability("host_file");
+        const sameUser = capable.filter(
+          (c) => c.actorPrincipalId === sourceActorPrincipalId,
+        );
+        if (sameUser.length === 1) {
+          resolvedTargetClientId = sameUser[0].clientId;
+        }
+      }
+    }
+
+    // Same-user check: targeted host_transfer requests must be bound to the
+    // same authenticated user identity that opened the target client's SSE
+    // stream. Prevents cross-user routing through actor token mis-targeting.
+    if (resolvedTargetClientId != null) {
+      const targetActorPrincipalId =
+        assistantEventHub.getActorPrincipalIdForClient(resolvedTargetClientId);
+      if (
+        sourceActorPrincipalId == null ||
+        targetActorPrincipalId == null ||
+        sourceActorPrincipalId !== targetActorPrincipalId
+      ) {
+        log.warn(
+          {
+            sourceActorPrincipalId,
+            targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId,
+            op: "host_transfer",
+            direction: "to_sandbox",
+          },
+          "Rejected cross-user targeted host_transfer request",
+        );
+        return Promise.resolve({
+          content:
+            "Targeted host_transfer requests require the target client to be owned by the same user as the caller.",
+          isError: true,
+        });
+      }
     }
 
     const requestId = uuid();

--- a/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
@@ -1,0 +1,169 @@
+/**
+ * End-to-end test for `assistant clients list` over IPC.
+ *
+ * Regression test for the gap where the same-user filter on
+ * `GET /v1/clients` (which reads `headers["x-vellum-actor-principal-id"]`)
+ * silently returned an empty list over IPC because the IPC adapter did
+ * not inject the synthetic actor-principal header that the HTTP adapter
+ * populates from the verified `AuthContext`.
+ *
+ * Asserts that in non-dev-bypass mode (`isHttpAuthDisabled() === false`),
+ * the CLI sees same-user clients via the IPC path because the IPC server
+ * fills in the header from the local guardian principal.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { runAssistantCommandFull } from "../../cli/__tests__/run-assistant-command.js";
+import { AssistantIpcServer } from "../assistant-server.js";
+
+// ── Module mocks (must be set up before importing the route) ──────────────
+
+let fakeHttpAuthDisabled = false;
+let fakeLocalPrincipalId: string | undefined = "guardian-local";
+
+mock.module("../../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../../runtime/local-actor-identity.js", () => ({
+  findLocalGuardianPrincipalId: () => fakeLocalPrincipalId,
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────
+
+import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+let server: AssistantIpcServer | null = null;
+
+function registerClient(args: {
+  clientId: string;
+  actorPrincipalId?: string;
+}): void {
+  assistantEventHub.subscribe({
+    type: "client",
+    clientId: args.clientId,
+    interfaceId: "macos",
+    capabilities: ["host_bash", "host_file", "host_cu"],
+    actorPrincipalId: args.actorPrincipalId,
+    callback: () => {},
+  });
+}
+
+function clearHub(): void {
+  const ids = assistantEventHub.listClients().map((c) => c.clientId);
+  for (const id of ids) {
+    assistantEventHub.disposeClient(id);
+  }
+}
+
+async function startServer(): Promise<void> {
+  server = new AssistantIpcServer();
+  await server.start();
+  // Allow the listener to be ready before the CLI tries to connect.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+beforeEach(() => {
+  fakeHttpAuthDisabled = false;
+  fakeLocalPrincipalId = "guardian-local";
+  clearHub();
+});
+
+afterEach(() => {
+  server?.stop();
+  server = null;
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("assistant clients list over IPC — same-user filter", () => {
+  test("returns same-user clients in non-dev-bypass mode", async () => {
+    registerClient({
+      clientId: "client-self-1",
+      actorPrincipalId: "guardian-local",
+    });
+    registerClient({
+      clientId: "client-self-2",
+      actorPrincipalId: "guardian-local",
+    });
+    registerClient({
+      clientId: "client-other",
+      actorPrincipalId: "other-user",
+    });
+
+    await startServer();
+
+    const { stdout } = await runAssistantCommandFull(
+      "clients",
+      "list",
+      "--json",
+    );
+
+    const parsed = JSON.parse(stdout.trim()) as {
+      clients: Array<{ clientId: string }>;
+    };
+    const ids = parsed.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-self-1", "client-self-2"]);
+  });
+
+  test("returns empty when no local guardian principal is bound (fail-closed)", async () => {
+    fakeLocalPrincipalId = undefined;
+    registerClient({
+      clientId: "client-self",
+      actorPrincipalId: "guardian-local",
+    });
+
+    await startServer();
+
+    const { stdout } = await runAssistantCommandFull(
+      "clients",
+      "list",
+      "--json",
+    );
+    const parsed = JSON.parse(stdout.trim()) as {
+      clients: Array<{ clientId: string }>;
+    };
+    expect(parsed.clients).toEqual([]);
+  });
+
+  test("dev-bypass mode returns all clients regardless of principal", async () => {
+    fakeHttpAuthDisabled = true;
+    registerClient({
+      clientId: "client-self",
+      actorPrincipalId: "guardian-local",
+    });
+    registerClient({
+      clientId: "client-other",
+      actorPrincipalId: "other-user",
+    });
+
+    await startServer();
+
+    const { stdout } = await runAssistantCommandFull(
+      "clients",
+      "list",
+      "--json",
+    );
+    const parsed = JSON.parse(stdout.trim()) as {
+      clients: Array<{ clientId: string }>;
+    };
+    const ids = parsed.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-other", "client-self"]);
+  });
+});

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -32,9 +32,13 @@ import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { dirname } from "node:path";
 
+import { findLocalGuardianPrincipalId } from "../runtime/local-actor-identity.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/index.js";
-import type { RouteDefinition } from "../runtime/routes/types.js";
+import type {
+  RouteDefinition,
+  RouteHandlerArgs,
+} from "../runtime/routes/types.js";
 import { getLogger } from "../util/logger.js";
 import {
   type IpcEnvelope,
@@ -150,7 +154,6 @@ export class AssistantIpcServer {
     this.methods.set("db_proxy", (params) =>
       handleDbProxy(params as unknown as DbProxyParams),
     );
-
   }
 
   /** Start listening on the Unix domain socket. */
@@ -257,7 +260,8 @@ export class AssistantIpcServer {
     void binary;
 
     try {
-      const result = handler(req.params ?? {});
+      const handlerArgs = injectLocalActorHeader(req.params);
+      const result = handler(handlerArgs);
 
       if (result instanceof Promise) {
         result
@@ -455,3 +459,52 @@ export class AssistantIpcServer {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Inject a synthetic `x-vellum-actor-principal-id` header from the local
+ * guardian principal when the caller hasn't already provided one.
+ *
+ * Local IPC is intra-process and owned by the same user as the daemon, so
+ * routes that consume `headers["x-vellum-actor-principal-id"]` (e.g. the
+ * same-user filter on `GET /v1/clients`) need an actor identity to function
+ * over IPC. The HTTP adapter does this from the verified `AuthContext`
+ * (`http-adapter.ts`); this helper mirrors that convention for IPC.
+ *
+ * Existing headers from the caller (e.g. the gateway's IPC runtime proxy,
+ * which forwards real `x-vellum-*` headers from the authenticated HTTP
+ * request) are preserved — we only fill in the gap for direct CLI/local
+ * IPC callers.
+ */
+function injectLocalActorHeader(
+  params: Record<string, unknown> | undefined,
+): RouteHandlerArgs {
+  const args = (params ?? {}) as RouteHandlerArgs;
+  const existingHeaders = args.headers;
+  if (existingHeaders?.["x-vellum-actor-principal-id"]) {
+    return args;
+  }
+
+  // Defensive: the guardian lookup queries the contacts table, which may
+  // not yet exist on a very early boot path or in test fixtures that don't
+  // initialize the DB. A failure here must not block IPC dispatch — routes
+  // that require the header will fail-closed on their own.
+  let localActor: string | undefined;
+  try {
+    localActor = findLocalGuardianPrincipalId();
+  } catch (err) {
+    log.debug(
+      { err },
+      "failed to resolve local actor principal for IPC header injection",
+    );
+    return args;
+  }
+  if (!localActor) return args;
+
+  return {
+    ...args,
+    headers: {
+      ...existingHeaders,
+      "x-vellum-actor-principal-id": localActor,
+    },
+  };
+}

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -86,6 +86,16 @@ export interface ClientEntry extends BaseSubscriberEntry {
   interfaceId: InterfaceId;
   capabilities: HostProxyCapability[];
   machineName?: string;
+  /**
+   * The verified actor principal id (canonical user identity, parsed from JWT
+   * `sub`) of the user that opened this SSE connection, when available.
+   *
+   * Populated from `AuthContext.actorPrincipalId` at SSE subscription time.
+   * Used by host proxies to gate cross-client targeted execution to the same
+   * authenticated user identity. May be `undefined` for legacy or
+   * service-token connections that have no principal.
+   */
+  actorPrincipalId?: string;
 }
 
 export interface ProcessEntry extends BaseSubscriberEntry {
@@ -255,7 +265,10 @@ export class AssistantEventHub {
    */
   async publish(
     event: AssistantEvent,
-    options?: { targetCapability?: HostProxyCapability; targetClientId?: string },
+    options?: {
+      targetCapability?: HostProxyCapability;
+      targetClientId?: string;
+    },
   ): Promise<void> {
     if (event.conversationId) {
       try {
@@ -323,10 +336,26 @@ export class AssistantEventHub {
    */
   getClientById(clientId: string): ClientEntry | undefined {
     for (const entry of this.subscribers) {
-      if (entry.active && entry.type === "client" && entry.clientId === clientId)
+      if (
+        entry.active &&
+        entry.type === "client" &&
+        entry.clientId === clientId
+      )
         return entry;
     }
     return undefined;
+  }
+
+  /**
+   * Return the verified actor principal id captured at SSE subscription time
+   * for the given client, or `undefined` if the client is unknown or
+   * connected without a principal (e.g. legacy/service tokens).
+   *
+   * Used by host proxies to bind cross-client targeted execution to the same
+   * authenticated user identity that opened the target client's SSE stream.
+   */
+  getActorPrincipalIdForClient(clientId: string): string | undefined {
+    return this.getClientById(clientId)?.actorPrincipalId;
   }
 
   /**

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -47,24 +47,54 @@ export type SameActorOp =
   | "host_cu"
   | "host_transfer";
 
-export interface SameActorArgs {
+/**
+ * Args for the live-lookup variant: caller supplies the hub + target client
+ * id, and the helper looks up the target's actor principal in real time.
+ * Used at proxy request time (registration), where the SSE subscription is
+ * present by definition.
+ */
+export interface SameActorLiveArgs {
   hub: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
   sourceActorPrincipalId: string | undefined;
   targetClientId: string;
   op: SameActorOp;
 }
 
+/**
+ * Args for the persisted-value variant: caller supplies a target actor
+ * principal id captured at registration time. Used at result-submission
+ * time, where the SSE subscription may have briefly disconnected and the
+ * live hub lookup would falsely 403 a legitimate result.
+ */
+export interface SameActorPersistedArgs {
+  sourceActorPrincipalId: string | undefined;
+  targetActorPrincipalId: string | undefined;
+  targetClientId: string;
+  op: SameActorOp;
+}
+
+export type SameActorArgs = SameActorLiveArgs;
+
 type RejectionReason = "missing_source" | "missing_target" | "mismatch";
+
+function isLive(
+  args: SameActorLiveArgs | SameActorPersistedArgs,
+): args is SameActorLiveArgs {
+  return (args as SameActorLiveArgs).hub != null;
+}
 
 /**
  * Internal: returns the rejection reason or `undefined` when the source
  * matches the target. Always logs on rejection so all callers share the
  * same audit shape.
  */
-function detectRejection(args: SameActorArgs): RejectionReason | undefined {
-  const { hub, sourceActorPrincipalId, targetClientId, op } = args;
-  const targetActorPrincipalId =
-    hub.getActorPrincipalIdForClient(targetClientId);
+function detectRejection(
+  args: SameActorLiveArgs | SameActorPersistedArgs,
+): RejectionReason | undefined {
+  const { sourceActorPrincipalId, targetClientId, op } = args;
+  const targetActorPrincipalId = isLive(args)
+    ? args.hub.getActorPrincipalIdForClient(targetClientId)
+    : args.targetActorPrincipalId;
 
   let reason: RejectionReason | undefined;
   if (sourceActorPrincipalId == null) {
@@ -93,8 +123,15 @@ function detectRejection(args: SameActorArgs): RejectionReason | undefined {
  * Route-flavored variant: throws {@link ForbiddenError} on rejection so
  * the existing route adapter maps it to HTTP 403. Returns void on
  * success.
+ *
+ * Accepts EITHER {@link SameActorLiveArgs} (live hub lookup, used at
+ * proxy registration time) OR {@link SameActorPersistedArgs} (compare
+ * against a value captured earlier, used at result-submission time so a
+ * brief SSE reconnect doesn't 403 a legitimate result).
  */
-export function enforceSameActorOrThrow(args: SameActorArgs): void {
+export function enforceSameActorOrThrow(
+  args: SameActorLiveArgs | SameActorPersistedArgs,
+): void {
   if (detectRejection(args) != null) {
     throw new ForbiddenError(REJECTION_MESSAGE);
   }
@@ -103,10 +140,11 @@ export function enforceSameActorOrThrow(args: SameActorArgs): void {
 /**
  * Proxy-flavored variant: returns a tool-execution-shaped error result
  * on rejection (so the proxy can pass it directly back to the agent),
- * or `null` on success.
+ * or `null` on success. Always uses the live hub lookup — proxy
+ * registration runs while the target SSE subscription is active.
  */
 export function enforceSameActorOrErrorResult(
-  args: SameActorArgs,
+  args: SameActorLiveArgs,
 ): { content: string; isError: true } | null {
   if (detectRejection(args) == null) return null;
   return { content: REJECTION_MESSAGE, isError: true };

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -41,7 +41,11 @@ export const SAME_ACTOR_FORBIDDEN_DESCRIPTION =
   "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.";
 
 /** Per-capability scope for the structured warn log entry. */
-export type SameActorOp = "host_bash" | "host_file" | "host_cu";
+export type SameActorOp =
+  | "host_bash"
+  | "host_file"
+  | "host_cu"
+  | "host_transfer";
 
 export interface SameActorArgs {
   hub: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
@@ -109,24 +113,66 @@ export function enforceSameActorOrErrorResult(
 }
 
 /**
+ * Result of attempting to auto-resolve a single same-user target client.
+ *
+ * - `match`: exactly one same-user client supports the capability. Use the
+ *   returned clientId.
+ * - `none`: no same-user client supports the capability. Caller's choice
+ *   how to handle (typically: fall through to no-target, which broadcasts
+ *   to nobody when no clients are connected).
+ * - `ambiguous`: more than one same-user client supports the capability.
+ *   Caller MUST refuse to silently broadcast across them; instead surface
+ *   an error asking the caller to specify `target_client_id`.
+ */
+export type AutoResolveResult =
+  | { kind: "match"; clientId: string }
+  | { kind: "none" }
+  | { kind: "ambiguous" };
+
+/**
  * Filter capable clients by `actorPrincipalId === sourcePrincipalId` and
- * return the single match's clientId, or `undefined` when zero or more
- * than one same-user client supports the capability.
+ * report whether exactly one matched, zero matched, or more than one
+ * matched.
  *
  * Used by host proxies to auto-resolve a target client when the caller
  * did not specify one. Skipping when the caller has no principal keeps
- * the same-user binding closed: an unauthenticated caller cannot piggyback
- * on a connected user's session.
+ * the same-user binding closed: an unauthenticated caller cannot
+ * piggyback on a connected user's session.
+ *
+ * Why three outcomes (vs. just `string | undefined`)? Earlier revisions
+ * collapsed `none` and `ambiguous` into `undefined`, which caused the
+ * proxy to fall through to an untargeted broadcast — fanning a single
+ * targeted-style request out across every same-user machine. Surfacing
+ * `ambiguous` separately lets the proxy reject with a clear "specify
+ * target_client_id" error instead.
  */
 export function pickSameUserAutoResolve(args: {
   hub: Pick<AssistantEventHub, "listClientsByCapability">;
   capability: HostProxyCapability;
   sourceActorPrincipalId: string | undefined;
-}): string | undefined {
+}): AutoResolveResult {
   const { hub, capability, sourceActorPrincipalId } = args;
-  if (sourceActorPrincipalId == null) return undefined;
+  if (sourceActorPrincipalId == null) return { kind: "none" };
   const sameUser = hub
     .listClientsByCapability(capability)
     .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
-  return sameUser.length === 1 ? sameUser[0].clientId : undefined;
+  if (sameUser.length === 0) return { kind: "none" };
+  if (sameUser.length === 1) {
+    return { kind: "match", clientId: sameUser[0].clientId };
+  }
+  return { kind: "ambiguous" };
+}
+
+/**
+ * Standard error result for proxies when {@link pickSameUserAutoResolve}
+ * returns `ambiguous`. Asks the caller to specify `target_client_id`.
+ */
+export function ambiguousSameUserError(capability: HostProxyCapability): {
+  content: string;
+  isError: true;
+} {
+  return {
+    content: `Multiple ${capability} clients are connected for this user. Specify target_client_id to disambiguate. Run \`assistant clients list --capability ${capability}\` to see client IDs.`,
+    isError: true,
+  };
 }

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -1,0 +1,132 @@
+/**
+ * Same-actor (same-user) binding check used by host proxies and result
+ * routes.
+ *
+ * Verifies that the submitting (source) actor's principal id matches the
+ * actor principal id captured for the target client at SSE subscription
+ * time. This is the authoritative gate that prevents cross-user
+ * execution and cross-user result submission across all three host-proxy
+ * capabilities (host_bash, host_file, host_cu).
+ *
+ * Two entry points map onto the two control-flow styles in the codebase:
+ *   - {@link enforceSameActorOrErrorResult} for proxies — returns a
+ *     tool-execution error result on rejection, `null` on success.
+ *   - {@link enforceSameActorOrThrow} for HTTP/IPC route handlers —
+ *     throws {@link ForbiddenError} on rejection so the route adapter
+ *     maps it to HTTP 403.
+ *
+ * Both paths log a single structured warn line on rejection with the
+ * shape `{ sourceActorPrincipalId, targetClientId, targetActorPrincipalId,
+ * op, reason }` so that bash, file, and CU rejections render identically
+ * in the audit log.
+ */
+import type { HostProxyCapability } from "../../channels/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { AssistantEventHub } from "../assistant-event-hub.js";
+import { ForbiddenError } from "../routes/errors.js";
+
+const log = getLogger("same-actor");
+
+/**
+ * Canonical user-facing rejection message. Used by both the proxy and
+ * route paths so operators and auditors see identical wording regardless
+ * of whether the failure surfaced as a tool-execution result or an HTTP
+ * 403.
+ */
+const REJECTION_MESSAGE =
+  "Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.";
+
+/** OpenAPI 403 description for `*-result` endpoints, kept identical. */
+export const SAME_ACTOR_FORBIDDEN_DESCRIPTION =
+  "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.";
+
+/** Per-capability scope for the structured warn log entry. */
+export type SameActorOp = "host_bash" | "host_file" | "host_cu";
+
+export interface SameActorArgs {
+  hub: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
+  sourceActorPrincipalId: string | undefined;
+  targetClientId: string;
+  op: SameActorOp;
+}
+
+type RejectionReason = "missing_source" | "missing_target" | "mismatch";
+
+/**
+ * Internal: returns the rejection reason or `undefined` when the source
+ * matches the target. Always logs on rejection so all callers share the
+ * same audit shape.
+ */
+function detectRejection(args: SameActorArgs): RejectionReason | undefined {
+  const { hub, sourceActorPrincipalId, targetClientId, op } = args;
+  const targetActorPrincipalId =
+    hub.getActorPrincipalIdForClient(targetClientId);
+
+  let reason: RejectionReason | undefined;
+  if (sourceActorPrincipalId == null) {
+    reason = "missing_source";
+  } else if (targetActorPrincipalId == null) {
+    reason = "missing_target";
+  } else if (sourceActorPrincipalId !== targetActorPrincipalId) {
+    reason = "mismatch";
+  }
+  if (reason == null) return undefined;
+
+  log.warn(
+    {
+      sourceActorPrincipalId,
+      targetClientId,
+      targetActorPrincipalId,
+      op,
+      reason,
+    },
+    "Rejecting cross-user host proxy request",
+  );
+  return reason;
+}
+
+/**
+ * Route-flavored variant: throws {@link ForbiddenError} on rejection so
+ * the existing route adapter maps it to HTTP 403. Returns void on
+ * success.
+ */
+export function enforceSameActorOrThrow(args: SameActorArgs): void {
+  if (detectRejection(args) != null) {
+    throw new ForbiddenError(REJECTION_MESSAGE);
+  }
+}
+
+/**
+ * Proxy-flavored variant: returns a tool-execution-shaped error result
+ * on rejection (so the proxy can pass it directly back to the agent),
+ * or `null` on success.
+ */
+export function enforceSameActorOrErrorResult(
+  args: SameActorArgs,
+): { content: string; isError: true } | null {
+  if (detectRejection(args) == null) return null;
+  return { content: REJECTION_MESSAGE, isError: true };
+}
+
+/**
+ * Filter capable clients by `actorPrincipalId === sourcePrincipalId` and
+ * return the single match's clientId, or `undefined` when zero or more
+ * than one same-user client supports the capability.
+ *
+ * Used by host proxies to auto-resolve a target client when the caller
+ * did not specify one. Skipping when the caller has no principal keeps
+ * the same-user binding closed: an unauthenticated caller cannot piggyback
+ * on a connected user's session.
+ */
+export function pickSameUserAutoResolve(args: {
+  hub: Pick<AssistantEventHub, "listClientsByCapability">;
+  capability: HostProxyCapability;
+  sourceActorPrincipalId: string | undefined;
+}): string | undefined {
+  const { hub, capability, sourceActorPrincipalId } = args;
+  if (sourceActorPrincipalId == null) return undefined;
+  const sameUser = hub
+    .listClientsByCapability(capability)
+    .filter((c) => c.actorPrincipalId === sourceActorPrincipalId);
+  return sameUser.length === 1 ? sameUser[0].clientId : undefined;
+}

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
+import { isHttpAuthDisabled } from "../config/env.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
@@ -52,6 +53,41 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
  */
 export function findLocalGuardianPrincipalId(): string | undefined {
   return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
+}
+
+/**
+ * Translate the synthetic dev-bypass actor principal to the real local
+ * guardian's principalId when running in `DISABLE_HTTP_AUTH=true` mode.
+ *
+ * The dev-bypass `AuthContext` (`runtime/auth/middleware.ts`) injects
+ * `"dev-bypass"` as the actor principal id for every request, but tool-side
+ * trust resolution (`resolveLocalTrustContext`) and SSE registration both
+ * carry the real local guardian principalId. Without this translation, every
+ * targeted host_bash/host_file/host_cu/host_transfer result POST mismatches
+ * the same-user check and is rejected with 403, and conversation/surface/
+ * guardian-action routes resolve trust against the wrong principal.
+ *
+ * Returns the input unchanged when:
+ *   - HTTP auth is enabled (production / non-dev-bypass deployments), OR
+ *   - the input is not literally `"dev-bypass"` (e.g. service tokens).
+ *
+ * Returns the local guardian principalId when both gates are true. Returns
+ * `undefined` when dev-bypass is set but no guardian binding has been created
+ * yet (e.g. fresh install before bootstrap); callers must treat this the
+ * same as a missing principal.
+ */
+export function resolveActorPrincipalIdForLocalGuardian(
+  rawHeader: string | undefined,
+): string | undefined {
+  if (rawHeader !== "dev-bypass" || !isHttpAuthDisabled()) return rawHeader;
+
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) return guardianPrincipalId;
+
+  log.warn(
+    "dev-bypass actor principal received but no vellum guardian binding found; returning undefined",
+  );
+  return undefined;
 }
 
 /**

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -44,6 +44,17 @@ export function buildLocalAuthContext(conversationId: string): AuthContext {
 }
 
 /**
+ * Look up the local vellum guardian's principalId from the contacts table.
+ *
+ * Returns `undefined` when no vellum guardian binding exists (e.g. fresh
+ * install before bootstrap). Callers should treat that case as
+ * "not yet available" and either fall back or proceed without a principalId.
+ */
+export function findLocalGuardianPrincipalId(): string | undefined {
+  return findGuardianForChannel("vellum")?.contact.principalId ?? undefined;
+}
+
+/**
  * Resolve the guardian runtime context for a local connection.
  *
  * Looks up the vellum guardian binding to obtain the `guardianPrincipalId`,
@@ -60,10 +71,8 @@ export function resolveLocalTrustContext(
 ): TrustContext {
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
 
-  // Try contacts-first for the vellum guardian channel
-  const guardianResult = findGuardianForChannel("vellum");
-  if (guardianResult && guardianResult.contact.principalId) {
-    const guardianPrincipalId = guardianResult.contact.principalId;
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) {
     const trustCtx = resolveTrustContext({
       assistantId,
       sourceChannel: "vellum",
@@ -97,13 +106,9 @@ export function resolveLocalTrustContext(
 export function resolveLocalAuthContext(conversationId: string): AuthContext {
   const authContext = buildLocalAuthContext(conversationId);
 
-  // Enrich with the guardian principal ID from contacts-first path
-  const guardianResult = findGuardianForChannel("vellum");
-  if (guardianResult && guardianResult.contact.principalId) {
-    return {
-      ...authContext,
-      actorPrincipalId: guardianResult.contact.principalId,
-    };
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) {
+    return { ...authContext, actorPrincipalId: guardianPrincipalId };
   }
 
   log.warn(

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -59,6 +59,14 @@ export interface PendingInteraction {
   directResolve?: (decision: UserDecision) => void;
   /** When set, the host_bash request should be routed to this specific client. */
   targetClientId?: string;
+  /**
+   * Snapshot of `targetClientId`'s `actorPrincipalId` taken at registration
+   * time. Persisted so the result-route same-actor check compares against
+   * a stable value rather than the live hub — the target client's SSE
+   * subscription may have briefly disconnected between dispatch and result
+   * submission, which would otherwise 403 a legitimate result.
+   */
+  targetActorPrincipalId?: string;
 
   // -- RPC lifecycle (populated by host proxies) --
 

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the GET /v1/clients (list_clients) route.
+ *
+ * Validates the same-user filter applied to client listings:
+ * - Caller sees only clients owned by their `actorPrincipalId`.
+ * - Clients with no stored `actorPrincipalId` are filtered out (fail-closed).
+ * - Dev-bypass mode (`isHttpAuthDisabled()`) returns all clients.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must be set up before importing the route) ──────────────
+
+let fakeHttpAuthDisabled = false;
+
+mock.module("../../../config/env.js", () => ({
+  isHttpAuthDisabled: () => fakeHttpAuthDisabled,
+  hasUngatedHttpAuthDisabled: () => false,
+}));
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────
+
+import {
+  AssistantEventHub,
+  assistantEventHub,
+} from "../../assistant-event-hub.js";
+import { ROUTES } from "../client-routes.js";
+import type { RouteDefinition } from "../types.js";
+
+afterAll(() => {
+  mock.restore();
+});
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+type ListClientsResponse = {
+  clients: Array<{
+    clientId: string;
+    interfaceId: string;
+    capabilities: string[];
+    machineName?: string;
+    connectedAt: string;
+    lastActiveAt: string;
+  }>;
+};
+
+function registerClient(args: {
+  clientId: string;
+  actorPrincipalId?: string;
+}): void {
+  assistantEventHub.subscribe({
+    type: "client",
+    clientId: args.clientId,
+    interfaceId: "macos",
+    capabilities: ["host_bash", "host_file", "host_cu"],
+    actorPrincipalId: args.actorPrincipalId,
+    callback: () => {},
+  });
+}
+
+function clearHub(): void {
+  const ids = assistantEventHub.listClients().map((c) => c.clientId);
+  for (const id of ids) {
+    assistantEventHub.disposeClient(id);
+  }
+}
+
+// Suppress unused-binding warning when AssistantEventHub isn't directly
+// referenced — the import keeps the type available for future extensions.
+void AssistantEventHub;
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("list_clients route — same-user filter", () => {
+  beforeEach(() => {
+    fakeHttpAuthDisabled = false;
+    clearHub();
+  });
+
+  test("returns only clients owned by the calling actor", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-A2", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-B1", actorPrincipalId: "user-B" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-A" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-A1", "client-A2"]);
+  });
+
+  test("filters out cross-user clients when listing as a different user", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-B1", actorPrincipalId: "user-B" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-B" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId);
+    expect(ids).toEqual(["client-B1"]);
+  });
+
+  test("filters out clients with no stored actorPrincipalId (fail-closed)", () => {
+    registerClient({
+      clientId: "client-noprincipal",
+      actorPrincipalId: undefined,
+    });
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-A" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId);
+    expect(ids).toEqual(["client-A1"]);
+  });
+
+  test("filters out all clients when caller has no actorPrincipalId header (fail-closed)", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({}) as ListClientsResponse;
+
+    expect(result.clients).toEqual([]);
+  });
+
+  test("dev-bypass mode returns all clients regardless of actor", () => {
+    fakeHttpAuthDisabled = true;
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+    registerClient({ clientId: "client-B1", actorPrincipalId: "user-B" });
+    registerClient({
+      clientId: "client-noprincipal",
+      actorPrincipalId: undefined,
+    });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-A" },
+    }) as ListClientsResponse;
+
+    const ids = result.clients.map((c) => c.clientId).sort();
+    expect(ids).toEqual(["client-A1", "client-B1", "client-noprincipal"]);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -27,10 +27,7 @@ mock.module("../../../util/logger.js", () => ({
 
 // ── Real imports (after mocks) ────────────────────────────────────────────
 
-import {
-  AssistantEventHub,
-  assistantEventHub,
-} from "../../assistant-event-hub.js";
+import { assistantEventHub } from "../../assistant-event-hub.js";
 import { ROUTES } from "../client-routes.js";
 import type { RouteDefinition } from "../types.js";
 
@@ -77,10 +74,6 @@ function clearHub(): void {
     assistantEventHub.disposeClient(id);
   }
 }
-
-// Suppress unused-binding warning when AssistantEventHub isn't directly
-// referenced — the import keeps the type available for future extensions.
-void AssistantEventHub;
 
 // ── Tests ────────────────────────────────────────────────────────────────
 

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 
 import type { HostProxyCapability } from "../../channels/types.js";
+import { isHttpAuthDisabled } from "../../config/env.js";
 import { datesToISO } from "../../util/json.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { NotFoundError } from "./errors.js";
@@ -33,7 +34,7 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       clients: z.array(z.object({}).passthrough()),
     }),
-    handler: ({ queryParams }) => {
+    handler: ({ queryParams, headers }) => {
       const capability = queryParams?.capability as
         | HostProxyCapability
         | undefined;
@@ -42,8 +43,25 @@ export const ROUTES: RouteDefinition[] = [
         ? assistantEventHub.listClientsByCapability(capability)
         : assistantEventHub.listClients();
 
+      // Defense-in-depth: filter the listing to clients owned by the calling
+      // actor so users cannot enumerate other users' connected client IDs.
+      // Clients with no stored `actorPrincipalId` (legacy SSE subscribers from
+      // before host-proxy-same-user, service-gateway tokens) are filtered out
+      // — fail-closed is the right default for this security boundary.
+      // Dev-bypass mode (DISABLE_HTTP_AUTH=true, mirroring
+      // require-bound-guardian.ts) preserves the previous "return all" behavior
+      // for platform-managed deployments where the platform handles auth.
+      const callerPrincipalId = headers?.["x-vellum-actor-principal-id"];
+      const filtered = isHttpAuthDisabled()
+        ? clients
+        : clients.filter(
+            (c) =>
+              c.actorPrincipalId !== undefined &&
+              c.actorPrincipalId === callerPrincipalId,
+          );
+
       return {
-        clients: clients.map((c) =>
+        clients: filtered.map((c) =>
           datesToISO({
             clientId: c.clientId,
             interfaceId: c.interfaceId,

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -22,7 +22,6 @@ import { z } from "zod";
 
 import type { HostProxyCapability } from "../../channels/types.js";
 import { parseInterfaceId, supportsHostProxy } from "../../channels/types.js";
-import { isHttpAuthDisabled } from "../../config/env.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
@@ -36,7 +35,7 @@ import {
   AssistantEventHub,
   assistantEventHub,
 } from "../assistant-event-hub.js";
-import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -44,28 +43,6 @@ const log = getLogger("events-routes");
 
 /** Keep-alive comment sent to idle clients every 7 s by default. */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
-
-/**
- * Translate the synthetic dev-bypass actor principal to the real local
- * guardian's principalId when running in `DISABLE_HTTP_AUTH=true` mode.
- *
- * The dev-bypass `AuthContext` (`runtime/auth/middleware.ts`) injects
- * `"dev-bypass"` for every request, but tool-side trust resolution
- * (`resolveLocalTrustContext`) returns the real guardian principalId. Without
- * translation, every targeted host_bash/host_file/host_cu request mismatches
- * the same-user check and is rejected. Mirrors `resolveLocalAuthContext`.
- */
-function resolveActorPrincipalId(raw: string | undefined): string | undefined {
-  if (raw !== "dev-bypass" || !isHttpAuthDisabled()) return raw;
-
-  const guardianPrincipalId = findLocalGuardianPrincipalId();
-  if (guardianPrincipalId) return guardianPrincipalId;
-
-  log.warn(
-    "dev-bypass actor principal received but no vellum guardian binding found; registering client without actorPrincipalId",
-  );
-  return undefined;
-}
 
 /**
  * Stream assistant events as Server-Sent Events.
@@ -114,7 +91,7 @@ export function handleSubscribeAssistantEvents(
   // bearer token's AuthContext. May be absent for legacy / service-token
   // connections that have no principal. See `resolveActorPrincipalId` for the
   // dev-bypass translation rationale.
-  const actorPrincipalId = resolveActorPrincipalId(
+  const actorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
     rawActorPrincipalId?.trim() || undefined,
   );
 

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 
 import type { HostProxyCapability } from "../../channels/types.js";
 import { parseInterfaceId, supportsHostProxy } from "../../channels/types.js";
+import { isHttpAuthDisabled } from "../../config/env.js";
 import { emitContactChange } from "../../contacts/contact-events.js";
 import { getOrCreateConversation } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
@@ -35,6 +36,7 @@ import {
   AssistantEventHub,
   assistantEventHub,
 } from "../assistant-event-hub.js";
+import { findLocalGuardianPrincipalId } from "../local-actor-identity.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -42,6 +44,28 @@ const log = getLogger("events-routes");
 
 /** Keep-alive comment sent to idle clients every 7 s by default. */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
+
+/**
+ * Translate the synthetic dev-bypass actor principal to the real local
+ * guardian's principalId when running in `DISABLE_HTTP_AUTH=true` mode.
+ *
+ * The dev-bypass `AuthContext` (`runtime/auth/middleware.ts`) injects
+ * `"dev-bypass"` for every request, but tool-side trust resolution
+ * (`resolveLocalTrustContext`) returns the real guardian principalId. Without
+ * translation, every targeted host_bash/host_file/host_cu request mismatches
+ * the same-user check and is rejected. Mirrors `resolveLocalAuthContext`.
+ */
+function resolveActorPrincipalId(raw: string | undefined): string | undefined {
+  if (raw !== "dev-bypass" || !isHttpAuthDisabled()) return raw;
+
+  const guardianPrincipalId = findLocalGuardianPrincipalId();
+  if (guardianPrincipalId) return guardianPrincipalId;
+
+  log.warn(
+    "dev-bypass actor principal received but no vellum guardian binding found; registering client without actorPrincipalId",
+  );
+  return undefined;
+}
 
 /**
  * Stream assistant events as Server-Sent Events.
@@ -88,8 +112,11 @@ export function handleSubscribeAssistantEvents(
     : null;
   // Verified by RuntimeHttpServer and forwarded by the http-adapter from the
   // bearer token's AuthContext. May be absent for legacy / service-token
-  // connections that have no principal.
-  const actorPrincipalId = rawActorPrincipalId?.trim() || undefined;
+  // connections that have no principal. See `resolveActorPrincipalId` for the
+  // dev-bypass translation rationale.
+  const actorPrincipalId = resolveActorPrincipalId(
+    rawActorPrincipalId?.trim() || undefined,
+  );
 
   if (clientId && !interfaceId) {
     log.error(

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -81,10 +81,15 @@ export function handleSubscribeAssistantEvents(
   const rawClientId = headers?.["x-vellum-client-id"];
   const rawInterfaceId = headers?.["x-vellum-interface-id"];
   const rawMachineName = headers?.["x-vellum-machine-name"];
+  const rawActorPrincipalId = headers?.["x-vellum-actor-principal-id"];
   const clientId = rawClientId?.trim() || null;
   const interfaceId = clientId
     ? parseInterfaceId(rawInterfaceId?.trim())
     : null;
+  // Verified by RuntimeHttpServer and forwarded by the http-adapter from the
+  // bearer token's AuthContext. May be absent for legacy / service-token
+  // connections that have no principal.
+  const actorPrincipalId = rawActorPrincipalId?.trim() || undefined;
 
   if (clientId && !interfaceId) {
     log.error(
@@ -171,6 +176,7 @@ export function handleSubscribeAssistantEvents(
               supportsHostProxy(interfaceId, cap),
             ),
             machineName: rawMachineName?.trim() || undefined,
+            actorPrincipalId,
           })
         : hub.subscribe({
             ...subscriberBase,

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -7,7 +7,6 @@
 import { z } from "zod";
 
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
@@ -79,8 +78,8 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     // cross-user submission even when the attacker can guess or spoof the
     // target's client ID.
     enforceSameActorOrThrow({
-      hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId,
       op: "host_bash",
     });

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -12,6 +12,7 @@ import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
 } from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -44,8 +45,9 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
 
   const submittingClientId =
     headers?.["x-vellum-client-id"]?.trim() || undefined;
-  const submittingActorPrincipalId =
-    headers?.["x-vellum-actor-principal-id"]?.trim() || undefined;
+  const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+    headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
+  );
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -8,6 +8,10 @@ import { z } from "zod";
 
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -72,18 +76,12 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     // for the target client at SSE subscription time. This prevents a
     // cross-user submission even when the attacker can guess or spoof the
     // target's client ID.
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
-    if (!targetActorPrincipalId || !submittingActorPrincipalId) {
-      throw new ForbiddenError(
-        "Submitting actor identity is missing; cannot verify same-user binding for this targeted host bash request.",
-      );
-    }
-    if (submittingActorPrincipalId !== targetActorPrincipalId) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this request. The same authenticated user must submit the result.",
-      );
-    }
+    enforceSameActorOrThrow({
+      hub: assistantEventHub,
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetClientId,
+      op: "host_bash",
+    });
   }
 
   HostBashProxy.instance.resolveResult(requestId, {
@@ -125,8 +123,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host bash request.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
       "404": {
         description: "No pending interaction found for the given requestId.",

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -7,6 +7,7 @@
 import { z } from "zod";
 
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -37,7 +38,10 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     throw new BadRequestError("requestId is required");
   }
 
-  const submittingClientId = headers?.["x-vellum-client-id"]?.trim() || undefined;
+  const submittingClientId =
+    headers?.["x-vellum-client-id"]?.trim() || undefined;
+  const submittingActorPrincipalId =
+    headers?.["x-vellum-actor-principal-id"]?.trim() || undefined;
 
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {
@@ -60,6 +64,24 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     if (submittingClientId !== targetClientId) {
       throw new ForbiddenError(
         `Client "${submittingClientId}" is not the target for this request (expected "${targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+
+    // Defense-in-depth on top of the client-id header binding above: the
+    // submitting actor's principal must match the actor principal stored
+    // for the target client at SSE subscription time. This prevents a
+    // cross-user submission even when the attacker can guess or spoof the
+    // target's client ID.
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
+    if (!targetActorPrincipalId || !submittingActorPrincipalId) {
+      throw new ForbiddenError(
+        "Submitting actor identity is missing; cannot verify same-user binding for this targeted host bash request.",
+      );
+    }
+    if (submittingActorPrincipalId !== targetActorPrincipalId) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this request. The same authenticated user must submit the result.",
       );
     }
   }
@@ -104,7 +126,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this request.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
       },
       "404": {
         description: "No pending interaction found for the given requestId.",

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -12,6 +12,7 @@ import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
 } from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -94,8 +95,9 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     enforceSameActorOrThrow({
       hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -7,7 +7,6 @@
 import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-store.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
@@ -99,8 +98,8 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
       headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
     );
     enforceSameActorOrThrow({
-      hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_cu",
     });

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -8,6 +8,10 @@ import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-store.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -71,10 +75,9 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
 
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.[
-      "x-vellum-client-id"
-    ];
-    const submittingClientId = rawClientId?.trim() || undefined;
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
     if (!submittingClientId) {
       throw new BadRequestError(
         "x-vellum-client-id header is missing for a targeted host CU request.",
@@ -91,21 +94,14 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     // stream. This prevents a different authenticated user with knowledge of
     // both the requestId and target clientId from submitting a result on
     // behalf of the targeted client.
-    const rawActorPrincipalId = (
-      headers as Record<string, string | undefined>
-    )?.["x-vellum-actor-principal-id"];
-    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        `Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.`,
-      );
-    }
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    enforceSameActorOrThrow({
+      hub: assistantEventHub,
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_cu",
+    });
   }
 
   const conversation = findConversation(peeked.conversationId);
@@ -172,8 +168,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host CU request.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal id does not match the target client's stored actor principal id.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
       "404": {
         description:

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -7,8 +7,14 @@
 import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-store.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -65,14 +71,39 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
 
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.["x-vellum-client-id"];
+    const rawClientId = (headers as Record<string, string | undefined>)?.[
+      "x-vellum-client-id"
+    ];
     const submittingClientId = rawClientId?.trim() || undefined;
     if (!submittingClientId) {
-      throw new BadRequestError("x-vellum-client-id header is missing for a targeted host CU request.");
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host CU request.",
+      );
     }
     if (submittingClientId !== peeked.targetClientId) {
       throw new ForbiddenError(
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+
+    // Defense-in-depth: require the submitting actor's principal id to match
+    // the actor principal id captured when the target client opened its SSE
+    // stream. This prevents a different authenticated user with knowledge of
+    // both the requestId and target clientId from submitting a result on
+    // behalf of the targeted client.
+    const rawActorPrincipalId = (
+      headers as Record<string, string | undefined>
+    )?.["x-vellum-actor-principal-id"];
+    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        `Submitting actor does not match the target client's actor for this request. The targeted client's authenticated user must submit the result.`,
       );
     }
   }
@@ -142,7 +173,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this request.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal id does not match the target client's stored actor principal id.",
       },
       "404": {
         description:

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -12,6 +12,7 @@ import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
 } from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -72,8 +73,9 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user somehow obtains the
     // target client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     enforceSameActorOrThrow({
       hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -7,7 +7,6 @@
 import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
@@ -77,8 +76,8 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
       headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
     );
     enforceSameActorOrThrow({
-      hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_file",
     });

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -8,6 +8,10 @@ import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -51,8 +55,8 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
     const headerMap = (headers as Record<string, string | undefined>) ?? {};
-    const rawClientId = headerMap["x-vellum-client-id"];
-    const submittingClientId = rawClientId?.trim() || undefined;
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
     if (!submittingClientId) {
       throw new BadRequestError(
         "x-vellum-client-id header is missing for a targeted host file request.",
@@ -68,19 +72,14 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user somehow obtains the
     // target client id.
-    const rawActorPrincipalId = headerMap["x-vellum-actor-principal-id"];
-    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this request.",
-      );
-    }
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    enforceSameActorOrThrow({
+      hub: assistantEventHub,
+      sourceActorPrincipalId: submittingActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_file",
+    });
   }
 
   HostFileProxy.instance.resolve(requestId, {
@@ -129,8 +128,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host file request.",
       },
       "403": {
-        description:
-          "Submitting client or actor does not match the targeted client/actor for this request.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
       "404": {
         description: "No pending interaction found for the given requestId.",

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -7,8 +7,14 @@
 import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -44,14 +50,35 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
 
   // Validate submitting client matches the targeted client (if any).
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.["x-vellum-client-id"];
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const rawClientId = headerMap["x-vellum-client-id"];
     const submittingClientId = rawClientId?.trim() || undefined;
     if (!submittingClientId) {
-      throw new BadRequestError("x-vellum-client-id header is missing for a targeted host file request.");
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host file request.",
+      );
     }
     if (submittingClientId !== peeked.targetClientId) {
       throw new ForbiddenError(
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. This blocks
+    // cross-user submissions even if a different user somehow obtains the
+    // target client id.
+    const rawActorPrincipalId = headerMap["x-vellum-actor-principal-id"];
+    const submittingActorPrincipalId = rawActorPrincipalId?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this request.",
       );
     }
   }
@@ -103,7 +130,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this request.",
+          "Submitting client or actor does not match the targeted client/actor for this request.",
       },
       "404": {
         description: "No pending interaction found for the given requestId.",

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import { HostTransferProxy } from "../../daemon/host-transfer-proxy.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   BadRequestError,
@@ -66,8 +67,9 @@ function handleTransferContentGet({
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user obtains the target
     // client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     const targetActorPrincipalId =
       assistantEventHub.getActorPrincipalIdForClient(targetClientId);
     if (
@@ -153,8 +155,9 @@ async function handleTransferContentPut({
     // match the actor that opened the target client's SSE stream. This blocks
     // cross-user submissions even if a different user obtains the target
     // client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     const targetActorPrincipalId =
       assistantEventHub.getActorPrincipalIdForClient(targetClientId);
     if (
@@ -232,8 +235,9 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
     // match the actor that opened the target client's SSE stream. Blocks
     // cross-user submissions even if a different user obtains the target
     // client id.
-    const submittingActorPrincipalId =
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
     const targetActorPrincipalId =
       assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
     if (

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -8,7 +8,10 @@
 import { z } from "zod";
 
 import { HostTransferProxy } from "../../daemon/host-transfer-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
@@ -63,24 +66,19 @@ function handleTransferContentGet({
         `Client "${submittingClientId}" is not the owner of this transfer`,
       );
 
-    // Defense-in-depth: also require the submitting actor's principal id to
-    // match the actor that opened the target client's SSE stream. This blocks
-    // cross-user submissions even if a different user obtains the target
-    // client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this transfer.",
-      );
-    }
+    // Defense-in-depth: the submitting actor's principal must match the
+    // actor that opened the target client's SSE stream. Compare against
+    // the value persisted at registration time so a brief reconnect does
+    // not 403 a legitimate fetch.
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      ),
+      targetActorPrincipalId:
+        match.proxy.getTargetActorPrincipalIdForTransfer(transferId),
+      targetClientId,
+      op: "host_transfer",
+    });
   }
 
   const content = match.proxy.getTransferContent(transferId);
@@ -151,24 +149,15 @@ async function handleTransferContentPut({
         `Client "${submittingClientId}" is not the owner of this transfer`,
       );
 
-    // Defense-in-depth: also require the submitting actor's principal id to
-    // match the actor that opened the target client's SSE stream. This blocks
-    // cross-user submissions even if a different user obtains the target
-    // client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this transfer.",
-      );
-    }
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      ),
+      targetActorPrincipalId:
+        match.proxy.getTargetActorPrincipalIdForTransfer(transferId),
+      targetClientId,
+      op: "host_transfer",
+    });
   }
 
   const data = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0);
@@ -231,24 +220,14 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}").`,
       );
 
-    // Defense-in-depth: also require the submitting actor's principal id to
-    // match the actor that opened the target client's SSE stream. Blocks
-    // cross-user submissions even if a different user obtains the target
-    // client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this request.",
-      );
-    }
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      ),
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_transfer",
+    });
   }
 
   HostTransferProxy.instance.resolveTransferResult(requestId, {
@@ -282,8 +261,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted transfer.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
     },
     handler: handleTransferContentGet,
@@ -304,8 +282,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted transfer.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
     },
     handler: handleTransferContentPut,
@@ -334,8 +311,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host transfer request.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
     },
     handler: handleTransferResult,

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -8,8 +8,14 @@
 import { z } from "zod";
 
 import { HostTransferProxy } from "../../daemon/host-transfer-proxy.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 /**
@@ -44,9 +50,35 @@ function handleTransferContentGet({
 
   const targetClientId = match.proxy.getTargetClientIdForTransfer(transferId);
   if (targetClientId != null) {
-    const submittingClientId = (headers as Record<string, string>)["x-vellum-client-id"]?.trim() || undefined;
-    if (!submittingClientId) throw new BadRequestError("x-vellum-client-id header required for targeted transfer");
-    if (submittingClientId !== targetClientId) throw new ForbiddenError(`Client "${submittingClientId}" is not the owner of this transfer`);
+    const headerMap = headers as Record<string, string | undefined>;
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    if (!submittingClientId)
+      throw new BadRequestError(
+        "x-vellum-client-id header required for targeted transfer",
+      );
+    if (submittingClientId !== targetClientId)
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the owner of this transfer`,
+      );
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. This blocks
+    // cross-user submissions even if a different user obtains the target
+    // client id.
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this transfer.",
+      );
+    }
   }
 
   const content = match.proxy.getTransferContent(transferId);
@@ -105,9 +137,35 @@ async function handleTransferContentPut({
 
   const targetClientId = match.proxy.getTargetClientIdForTransfer(transferId);
   if (targetClientId != null) {
-    const submittingClientId = (headers as Record<string, string>)["x-vellum-client-id"]?.trim() || undefined;
-    if (!submittingClientId) throw new BadRequestError("x-vellum-client-id header required for targeted transfer");
-    if (submittingClientId !== targetClientId) throw new ForbiddenError(`Client "${submittingClientId}" is not the owner of this transfer`);
+    const headerMap = headers as Record<string, string | undefined>;
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    if (!submittingClientId)
+      throw new BadRequestError(
+        "x-vellum-client-id header required for targeted transfer",
+      );
+    if (submittingClientId !== targetClientId)
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the owner of this transfer`,
+      );
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. This blocks
+    // cross-user submissions even if a different user obtains the target
+    // client id.
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this transfer.",
+      );
+    }
   }
 
   const data = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0);
@@ -158,10 +216,35 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
   }
 
   if (peeked.targetClientId != null) {
-    const rawClientId = (headers as Record<string, string | undefined>)?.["x-vellum-client-id"];
+    const headerMap = (headers as Record<string, string | undefined>) ?? {};
+    const rawClientId = headerMap["x-vellum-client-id"];
     const submittingClientId = rawClientId?.trim() || undefined;
-    if (!submittingClientId) throw new BadRequestError("x-vellum-client-id header is missing for a targeted host transfer request.");
-    if (submittingClientId !== peeked.targetClientId) throw new ForbiddenError(`Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}").`);
+    if (!submittingClientId)
+      throw new BadRequestError(
+        "x-vellum-client-id header is missing for a targeted host transfer request.",
+      );
+    if (submittingClientId !== peeked.targetClientId)
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}").`,
+      );
+
+    // Defense-in-depth: also require the submitting actor's principal id to
+    // match the actor that opened the target client's SSE stream. Blocks
+    // cross-user submissions even if a different user obtains the target
+    // client id.
+    const submittingActorPrincipalId =
+      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined;
+    const targetActorPrincipalId =
+      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
+    if (
+      !submittingActorPrincipalId ||
+      !targetActorPrincipalId ||
+      submittingActorPrincipalId !== targetActorPrincipalId
+    ) {
+      throw new ForbiddenError(
+        "Submitting actor does not match the target client's actor for this request.",
+      );
+    }
   }
 
   HostTransferProxy.instance.resolveTransferResult(requestId, {
@@ -196,7 +279,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this transfer.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
       },
     },
     handler: handleTransferContentGet,
@@ -218,7 +301,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this transfer.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
       },
     },
     handler: handleTransferContentPut,
@@ -248,7 +331,7 @@ export const ROUTES: RouteDefinition[] = [
       },
       "403": {
         description:
-          "Submitting client does not match the targeted client for this transfer.",
+          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
       },
     },
     handler: handleTransferResult,

--- a/assistant/src/tools/host-filesystem/edit.ts
+++ b/assistant/src/tools/host-filesystem/edit.ts
@@ -92,7 +92,8 @@ class HostFileEditTool implements Tool {
     const replaceAll = input.replace_all === true;
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -123,6 +124,8 @@ class HostFileEditTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        targetClientId,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -63,7 +63,8 @@ class HostFileReadTool implements Tool {
     }
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -94,6 +95,8 @@ class HostFileReadTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        targetClientId,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/transfer.ts
+++ b/assistant/src/tools/host-filesystem/transfer.ts
@@ -93,7 +93,8 @@ class HostFileTransferTool implements Tool {
     const overwrite = input.overwrite === true;
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -103,7 +104,10 @@ class HostFileTransferTool implements Tool {
       !supportsHostProxy(context.transportInterface) &&
       assistantEventHub.listClientsByCapability("host_file").length > 1
     ) {
-      return { content: `Error: multiple clients support host_file. Specify which client to use with \`target_client_id\`. Run \`assistant clients list --capability host_file\` to see client IDs and labels.`, isError: true };
+      return {
+        content: `Error: multiple clients support host_file. Specify which client to use with \`target_client_id\`. Run \`assistant clients list --capability host_file\` to see client IDs and labels.`,
+        isError: true,
+      };
     }
 
     // Validate that host-side paths are absolute.
@@ -136,7 +140,9 @@ class HostFileTransferTool implements Tool {
 
     let resolvedDestPath = destPath;
     if (direction === "to_sandbox") {
-      const pathCheck = sandboxPolicy(destPath, context.workingDir, { mustExist: false });
+      const pathCheck = sandboxPolicy(destPath, context.workingDir, {
+        mustExist: false,
+      });
       if (!pathCheck.ok) {
         return {
           content: `Invalid destination path: ${pathCheck.error}`,
@@ -158,6 +164,7 @@ class HostFileTransferTool implements Tool {
             targetClientId,
           },
           context.signal,
+          context.sourceActorPrincipalId,
         );
       }
       return HostTransferProxy.instance.requestToSandbox(
@@ -169,6 +176,7 @@ class HostFileTransferTool implements Tool {
           targetClientId,
         },
         context.signal,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-filesystem/write.ts
+++ b/assistant/src/tools/host-filesystem/write.ts
@@ -62,7 +62,8 @@ class HostFileWriteTool implements Tool {
     }
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -91,6 +92,8 @@ class HostFileWriteTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        targetClientId,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -181,7 +181,8 @@ class HostShellTool implements Tool {
     const background = input.background === true;
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -236,10 +237,7 @@ class HostShellTool implements Tool {
     // guard both targetClientId != null guards above are bypassed, and the
     // code falls through to local daemon execution — silently running commands
     // inside the Docker container instead of on the intended host machine.
-    if (
-      targetClientId != null &&
-      !HostBashProxy.instance.isAvailable()
-    ) {
+    if (targetClientId != null && !HostBashProxy.instance.isAvailable()) {
       return {
         content: `Error: target client "${targetClientId}" is no longer connected. The specified client may have disconnected since the tool was called. Run \`assistant clients list --capability host_bash\` to see currently connected clients.`,
         isError: true,
@@ -287,6 +285,7 @@ class HostShellTool implements Tool {
           },
           context.conversationId,
           abortController.signal,
+          context.sourceActorPrincipalId,
         );
 
         proxyPromise
@@ -334,6 +333,7 @@ class HostShellTool implements Tool {
         },
         context.conversationId,
         context.signal,
+        context.sourceActorPrincipalId,
       );
     }
 

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -268,6 +268,14 @@ export interface ToolContext {
    * `executeSubagentSpawn` in tools/subagent/spawn.ts.
    */
   overrideProfile?: string;
+  /**
+   * Canonical principal ID of the actor on whose behalf this tool invocation
+   * is running. Sourced from `conversation.trustContext.guardianPrincipalId`.
+   * Used by host proxies to bind cross-client targeted execution to the same
+   * authenticated user identity. May be undefined for legacy/internal flows
+   * with no resolved actor identity.
+   */
+  sourceActorPrincipalId?: string;
 }
 
 export interface Tool {

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -118,6 +118,24 @@ export async function tryIpcProxy(
     }
   });
 
+  // Override caller-supplied identity headers with values derived from the
+  // verified JWT claims. The daemon's IPC adapter (`injectLocalActorHeader`)
+  // preserves any inbound `x-vellum-actor-principal-id`, so without this
+  // step a malicious client could spoof another user's principal id by
+  // setting the header explicitly. Mirrors the HTTP adapter's behavior in
+  // `assistant/src/runtime/routes/http-adapter.ts`.
+  delete headers["x-vellum-actor-principal-id"];
+  delete headers["x-vellum-principal-type"];
+  if (claims) {
+    const sub = parseSub(claims.sub);
+    if (sub.ok) {
+      headers["x-vellum-principal-type"] = sub.principalType;
+      if (sub.actorPrincipalId) {
+        headers["x-vellum-actor-principal-id"] = sub.actorPrincipalId;
+      }
+    }
+  }
+
   let body: Record<string, unknown> | undefined;
   if (req.method !== "GET" && req.method !== "HEAD") {
     const contentType = req.headers.get("content-type") ?? "";


### PR DESCRIPTION
## Summary

Closes Codex security finding [`0926d57e`](https://chatgpt.com/codex/cloud/security/findings/0926d57eb6ac819186f065c5c37aa923) by binding cross-client `target_client_id` routing in the host proxies (`host_bash`, `host_file`, `host_cu`, `host_transfer`) to the source caller's authenticated user identity (`actorPrincipalId`). Cross-user targeted requests are now rejected at three independent gates: proxy request-time, result-route submission, and client listing.

## Self-review result

PASS after 2 rounds of automated review-and-fix (15 PRs total).

## PRs merged into feature branch

**Round 1 — original plan (8 PRs):**
- #29575: feat(event-hub): capture actorPrincipalId on connected client records
- #29583: fix(host-bash): same-user check on proxy request
- #29582: fix(host-file): same-user check on proxy request
- #29584: fix(host-cu): validate target client and same-user check
- #29580: fix(host-bash-result): same-user check on result submission
- #29587: fix(host-file-result): same-user check on result submission
- #29581: fix(host-cu-result): same-user check on result submission
- #29586: fix(client-routes): filter `assistant clients list` to same-user clients

**Round 1 fixes — gap remediation (4 PRs):**
- #29599: fix(host-proxy): correct same-user check in dev-bypass mode (SSE registration)
- #29600: fix(ipc): forward synthetic actor-principal-id header to shared routes
- #29602: fix(host-transfer): bind targeted transfer to same authenticated user
- #29606: refactor(host-proxy): consolidate same-user check into shared `same-actor.ts` helper

**Round 2 fixes — addressed regressions found in round 1 (3 PRs):**
- #29623: fix(host-proxy): close cross-user broadcast leak in auto-resolve and CU dispatch
- #29629: fix(host-proxy): translate dev-bypass actor on host-result routes
- #29630: fix(gateway): overwrite x-vellum-actor-principal-id from verified JWT claims on IPC fast-path

## Identity model

`actorPrincipalId` is the canonical user identity in this codebase — parsed from JWT `sub`, equal to the bound vellum guardian's principal ID for end-user JWTs. Same-user binding maps to `actorPrincipalId` matching, with dev-bypass mode translating `"dev-bypass"` to the local guardian's real principal at SSE registration and on result-route submission.

Part of plan: host-proxy-same-user.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->