### PR TITLE
Restrict tools during disk cleanup mode

### DIFF
--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
+import type { SkillProjectionContext } from "../daemon/conversation-tool-setup.js";
+import type { Message, ToolDefinition } from "../providers/types.js";
+import type { DiskUsageInfo } from "../util/disk-usage.js";
+
+let diskSample: DiskUsageInfo | null = null;
+
+const mockConfig = {
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+  },
+  sandbox: {
+    enabled: false,
+    backend: "native" as const,
+    docker: {
+      image: "vellum-sandbox:latest",
+      cpus: 1,
+      memoryMb: 512,
+      pidsLimit: 256,
+      network: "none" as const,
+    },
+  },
+  permissions: { mode: "workspace" as const },
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => mockConfig,
+  getConfigReadOnly: () => mockConfig,
+  loadConfig: () => mockConfig,
+  applyNestedDefaults: () => mockConfig,
+  deepMergeOverwrite: (_base: unknown, override: unknown) => override,
+  invalidateConfigCache: () => undefined,
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => undefined,
+  getNestedValue: () => undefined,
+  setNestedValue: () => undefined,
+  mergeDefaultWorkspaceConfig: (config: unknown) => config,
+  API_KEY_PROVIDERS: [] as const,
+  _appendQuarantineBulletin: () => undefined,
+}));
+
+mock.module("../daemon/conversation-skill-tools.js", () => ({
+  projectSkillTools: mock((_history: Message[], _opts: unknown) => ({
+    allowedToolNames: new Set<string>(),
+    toolDefinitions: [],
+  })),
+  resetSkillToolProjection: () => undefined,
+}));
+
+mock.module("../runtime/agent-wake.js", () => ({
+  wakeAgentForOpportunity: async () => undefined,
+}));
+
+mock.module("../runtime/assistant-event.js", () => ({
+  buildAssistantEvent: (message: unknown, conversationId?: string) => ({
+    id: "event-test",
+    type: "message",
+    timestamp: new Date().toISOString(),
+    conversationId,
+    message,
+  }),
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  AssistantEventHub: class {},
+  broadcastMessage: () => {},
+  capabilityForMessageType: () => undefined,
+  assistantEventHub: {
+    publish: async () => undefined,
+    listClientsByCapability: () => [],
+  },
+}));
+
+mock.module("../util/disk-usage.js", () => ({
+  getDiskUsageInfo: () => diskSample,
+}));
+
+const { _setOverridesForTesting } =
+  await import("../config/assistant-feature-flags.js");
+const {
+  DISK_PRESSURE_THRESHOLD_PERCENT,
+  __resetDiskPressureGuardForTests,
+  evaluateDiskPressureNow,
+} = await import("../daemon/disk-pressure-guard.js");
+const { createResolveToolsCallback } =
+  await import("../daemon/conversation-tool-setup.js");
+const { ToolApprovalHandler } =
+  await import("../tools/tool-approval-handler.js");
+const {
+  _clearRegistryForTesting,
+  listBackgroundTools,
+  registerBackgroundTool,
+} = await import("../tools/background-tool-registry.js");
+const { shellTool } = await import("../tools/terminal/shell.js");
+const { hostShellTool } = await import("../tools/host-terminal/host-shell.js");
+
+function makeToolDef(name: string): ToolDefinition {
+  return { name, description: `${name} tool`, input_schema: {} };
+}
+
+function makeProjectionCtx(
+  overrides: Partial<SkillProjectionContext> = {},
+): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: {} as SkillProjectionCache,
+    coreToolNames: new Set(),
+    toolsDisabledDepth: 0,
+    ...overrides,
+  };
+}
+
+function setDiskUsage(usedMb: number, totalMb = 100): void {
+  diskSample = {
+    path: "/workspace",
+    totalMb,
+    usedMb,
+    freeMb: Math.max(0, totalMb - usedMb),
+  };
+}
+
+beforeEach(() => {
+  _clearRegistryForTesting();
+  __resetDiskPressureGuardForTests();
+  _setOverridesForTesting({ "safe-storage-limits": true });
+  setDiskUsage(10);
+});
+
+afterEach(() => {
+  _clearRegistryForTesting();
+  __resetDiskPressureGuardForTests();
+  _setOverridesForTesting({});
+  diskSample = null;
+});
+
+describe("disk pressure cleanup tool restrictions", () => {
+  test("cleanup mode hides non-allowlisted tools and restores normal tools after the turn", () => {
+    const toolDefs = [
+      makeToolDef("bash"),
+      makeToolDef("host_bash"),
+      makeToolDef("file_read"),
+      makeToolDef("file_write"),
+      makeToolDef("skill_execute"),
+      makeToolDef("web_fetch"),
+    ];
+    const ctx = makeProjectionCtx({ diskPressureCleanupModeActive: true });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const cleanupTools = resolve([]);
+    const cleanupNames = cleanupTools.map((tool) => tool.name).sort();
+
+    expect(cleanupNames).toEqual(["bash", "file_read", "host_bash"]);
+    expect(ctx.allowedToolNames?.has("bash")).toBe(true);
+    expect(ctx.allowedToolNames?.has("file_write")).toBe(false);
+    expect(ctx.allowedToolNames?.has("skill_execute")).toBe(false);
+
+    ctx.diskPressureCleanupModeActive = false;
+    const normalTools = resolve([]);
+    const normalNames = normalTools.map((tool) => tool.name);
+
+    expect(normalNames).toContain("file_write");
+    expect(normalNames).toContain("skill_execute");
+    expect(normalNames).toContain("web_fetch");
+    expect(ctx.allowedToolNames?.has("file_write")).toBe(true);
+  });
+
+  test("executor fallback rejects non-cleanup tools even if stale allowlist includes them", async () => {
+    const handler = new ToolApprovalHandler();
+    const result = await handler.checkPreExecutionGates(
+      "file_write",
+      { path: "large.log", content: "data" },
+      {
+        workingDir: "/workspace",
+        conversationId: "conv-cleanup",
+        trustClass: "guardian",
+        allowedToolNames: new Set(["file_write"]),
+        diskPressureCleanupModeActive: true,
+      },
+      "sandbox",
+      "low",
+      Date.now(),
+      () => undefined,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) {
+      throw new Error("Expected disk pressure cleanup gate to reject tool");
+    }
+    expect(result.result.content).toContain(
+      "not available during disk pressure cleanup mode",
+    );
+  });
+
+  test("locking cancels registered terminal background tools with disk pressure reason", () => {
+    const bashCancel = mock((_reason?: string) => undefined);
+    const hostCancel = mock((_reason?: string) => undefined);
+    const otherCancel = mock((_reason?: string) => undefined);
+
+    registerBackgroundTool({
+      id: "bg-bash",
+      toolName: "bash",
+      conversationId: "conv-1",
+      command: "sleep 100",
+      startedAt: 1,
+      cancel: bashCancel,
+    });
+    registerBackgroundTool({
+      id: "bg-host",
+      toolName: "host_bash",
+      conversationId: "conv-1",
+      command: "sleep 100",
+      startedAt: 2,
+      cancel: hostCancel,
+    });
+    registerBackgroundTool({
+      id: "bg-other",
+      toolName: "web_fetch",
+      conversationId: "conv-1",
+      command: "fetch",
+      startedAt: 3,
+      cancel: otherCancel,
+    });
+
+    setDiskUsage(DISK_PRESSURE_THRESHOLD_PERCENT);
+    const status = evaluateDiskPressureNow();
+
+    expect(status.locked).toBe(true);
+    expect(bashCancel).toHaveBeenCalledWith("disk_pressure");
+    expect(hostCancel).toHaveBeenCalledWith("disk_pressure");
+    expect(otherCancel).not.toHaveBeenCalled();
+    expect(listBackgroundTools().map((tool) => tool.id)).toEqual(["bg-other"]);
+  });
+
+  test("background shell modes are blocked during cleanup mode", async () => {
+    const shellResult = await shellTool.execute(
+      {
+        command: "sleep 100",
+        activity: "check disk usage",
+        background: true,
+      },
+      {
+        workingDir: "/workspace",
+        conversationId: "conv-cleanup",
+        trustClass: "guardian",
+        diskPressureCleanupModeActive: true,
+      },
+    );
+
+    expect(shellResult.isError).toBe(true);
+    expect(shellResult.content).toContain(
+      "background shell commands are not available",
+    );
+
+    const hostResult = await hostShellTool.execute(
+      {
+        command: "sleep 100",
+        activity: "check disk usage",
+        background: true,
+      },
+      {
+        workingDir: "/workspace",
+        conversationId: "conv-cleanup",
+        trustClass: "guardian",
+        diskPressureCleanupModeActive: true,
+      },
+    );
+
+    expect(hostResult.isError).toBe(true);
+    expect(hostResult.content).toContain(
+      "background host shell commands are not available",
+    );
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -512,6 +512,7 @@ export interface AgentLoopConversationContext {
 
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
+  diskPressureCleanupModeActive?: boolean;
   toolsDisabledDepth: number;
   preactivatedSkillIds?: string[];
   readonly skillProjectionState: Map<string, string>;
@@ -748,6 +749,8 @@ export async function runAgentLoopImpl(
     diskPressureDecision.action === "allow-cleanup-mode"
       ? { cleanupModeActive: true }
       : null;
+  ctx.diskPressureCleanupModeActive =
+    diskPressureDecision.action === "allow-cleanup-mode";
 
   ctx.lastAssistantAttachments = [];
   ctx.lastAttachmentWarnings = [];
@@ -3098,6 +3101,7 @@ export async function runAgentLoopImpl(
     ctx.currentRequestId = undefined;
     ctx.currentActiveSurfaceId = undefined;
     ctx.allowedToolNames = undefined;
+    ctx.diskPressureCleanupModeActive = false;
     ctx.preactivatedSkillIds = undefined;
     ctx.currentTurnOverrideProfile = undefined;
     ctx.slackRuntimeContextNotice = undefined;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -30,12 +30,13 @@ import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../tools/schema-transforms.js";
-import type {
-  ProxyApprovalCallback,
-  ProxyApprovalRequest,
-  ToolContext,
-  ToolExecutionResult,
-  ToolLifecycleEventHandler,
+import {
+  isDiskPressureCleanupToolName,
+  type ProxyApprovalCallback,
+  type ProxyApprovalRequest,
+  type ToolContext,
+  type ToolExecutionResult,
+  type ToolLifecycleEventHandler,
 } from "../tools/types.js";
 import { allUiSurfaceTools } from "../tools/ui-surface/definitions.js";
 import { getLogger } from "../util/logger.js";
@@ -151,6 +152,7 @@ export function createToolExecutor(
       onOutput,
       signal: ctx.abortController?.signal,
       allowedToolNames: ctx.allowedToolNames,
+      diskPressureCleanupModeActive: ctx.diskPressureCleanupModeActive,
       memoryScopeId: ctx.memoryPolicy.scopeId,
       toolUseId,
       isPlatformHosted: getIsPlatform(),
@@ -305,6 +307,8 @@ export interface SkillProjectionContext {
   readonly hasNoClient?: boolean;
   /** When set, only tools in this set are included in the resolved tool list (subagent delegation). */
   subagentAllowedTools?: Set<string>;
+  /** True when the current turn is restricted to disk-pressure cleanup-safe tools. */
+  diskPressureCleanupModeActive?: boolean;
   /** True when this conversation belongs to a subagent spawned by SubagentManager. */
   readonly isSubagent?: boolean;
   /**
@@ -516,6 +520,16 @@ export function createResolveToolsCallback(
       }
       turnAllowed.add(name);
     }
+    if (ctx.diskPressureCleanupModeActive === true) {
+      const cleanupDefs = allBaseDefs.filter((d) =>
+        isDiskPressureCleanupToolName(d.name),
+      );
+      ctx.allowedToolNames = new Set(
+        Array.from(turnAllowed).filter(isDiskPressureCleanupToolName),
+      );
+      return injectActivityField(cleanupDefs, ACTIVITY_SKIP_SET);
+    }
+
     ctx.allowedToolNames = turnAllowed;
     return injectActivityField(allBaseDefs, ACTIVITY_SKIP_SET);
   };

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -171,6 +171,7 @@ export class Conversation {
   /** @internal */ eventBus = new EventBus<AssistantDomainEvents>();
   /** @internal */ workingDir: string;
   /** @internal */ allowedToolNames?: Set<string>;
+  /** @internal */ diskPressureCleanupModeActive?: boolean;
   /** @internal */ toolsDisabledDepth = 0;
   /** @internal */ preactivatedSkillIds?: string[];
   /** @internal */ subagentAllowedTools?: Set<string>;

--- a/assistant/src/daemon/disk-pressure-guard.ts
+++ b/assistant/src/daemon/disk-pressure-guard.ts
@@ -2,6 +2,7 @@ import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags
 import { getConfig } from "../config/loader.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { cancelBackgroundTools } from "../tools/background-tool-registry.js";
 import { getDiskUsageInfo } from "../util/disk-usage.js";
 import { getLogger } from "../util/logger.js";
 
@@ -169,6 +170,18 @@ function sampleFailureStatus(error: unknown): DiskPressureStatus {
   };
 }
 
+function cancelTerminalBackgroundToolsForLock(): void {
+  const cancelled = cancelBackgroundTools(
+    (tool) => tool.toolName === "bash" || tool.toolName === "host_bash",
+    "disk_pressure",
+  );
+  if (cancelled.length === 0) return;
+  log.info(
+    { count: cancelled.length, ids: cancelled.map((tool) => tool.id) },
+    "Cancelled background terminal tools during disk pressure lock",
+  );
+}
+
 function rejectTransition(
   reason: Exclude<DiskPressureTransitionResult, { ok: true }>["reason"],
   message: string,
@@ -225,6 +238,10 @@ export function evaluateDiskPressureNow(): DiskPressureStatus {
       path: usageInfo.path,
       lastCheckedAt,
     });
+  }
+
+  if (!state.status.locked) {
+    cancelTerminalBackgroundToolsForLock();
   }
 
   const lockId = state.status.locked ? state.status.lockId : nextLockId();

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -21,6 +21,8 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   abortController: AbortController | null;
   /** When set, only tools in this set may execute during the current turn. */
   allowedToolNames?: Set<string>;
+  /** Turn-scoped disk-pressure cleanup mode flag. */
+  diskPressureCleanupModeActive?: boolean;
   /** Conversation memory policy used to propagate scopeId into ToolContext. */
   memoryPolicy: { scopeId: string };
   /** True when the conversation has no connected client (HTTP-only path). */

--- a/assistant/src/tools/background-tool-registry.ts
+++ b/assistant/src/tools/background-tool-registry.ts
@@ -19,7 +19,7 @@ export interface BackgroundTool {
   command: string;
   startedAt: number;
   /** Kills the process (bash) or aborts the proxy (host_bash). */
-  cancel: () => void;
+  cancel: (reason?: string) => void;
 }
 
 /** Maximum number of concurrent background tools allowed. */
@@ -61,14 +61,28 @@ export function listBackgroundTools(conversationId?: string): BackgroundTool[] {
  * Cancels a background tool by ID: calls `tool.cancel()`, removes the entry,
  * and returns `true`. Returns `false` if the ID is not found.
  */
-export function cancelBackgroundTool(id: string): boolean {
+export function cancelBackgroundTool(id: string, reason?: string): boolean {
   const tool = registry.get(id);
   if (!tool) {
     return false;
   }
-  tool.cancel();
+  tool.cancel(reason);
   registry.delete(id);
   return true;
+}
+
+export function cancelBackgroundTools(
+  shouldCancel: (tool: BackgroundTool) => boolean,
+  reason?: string,
+): BackgroundTool[] {
+  const cancelled: BackgroundTool[] = [];
+  for (const tool of Array.from(registry.values())) {
+    if (!shouldCancel(tool)) continue;
+    tool.cancel(reason);
+    registry.delete(tool.id);
+    cancelled.push(tool);
+  }
+  return cancelled;
 }
 
 /**

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -179,9 +179,17 @@ class HostShellTool implements Tool {
       };
     }
     const background = input.background === true;
+    if (background && context.diskPressureCleanupModeActive === true) {
+      return {
+        content:
+          "Error: background host shell commands are not available during disk pressure cleanup mode.",
+        isError: true,
+      };
+    }
 
     const targetClientId =
-      typeof input.target_client_id === "string" && input.target_client_id !== ""
+      typeof input.target_client_id === "string" &&
+      input.target_client_id !== ""
         ? input.target_client_id
         : undefined;
 
@@ -236,10 +244,7 @@ class HostShellTool implements Tool {
     // guard both targetClientId != null guards above are bypassed, and the
     // code falls through to local daemon execution — silently running commands
     // inside the Docker container instead of on the intended host machine.
-    if (
-      targetClientId != null &&
-      !HostBashProxy.instance.isAvailable()
-    ) {
+    if (targetClientId != null && !HostBashProxy.instance.isAvailable()) {
       return {
         content: `Error: target client "${targetClientId}" is no longer connected. The specified client may have disconnected since the tool was called. Run \`assistant clients list --capability host_bash\` to see currently connected clients.`,
         isError: true,
@@ -315,7 +320,7 @@ class HostShellTool implements Tool {
           conversationId: context.conversationId,
           command,
           startedAt: Date.now(),
-          cancel: () => abortController.abort(),
+          cancel: (reason?: string) => abortController.abort(reason),
         });
 
         return {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -111,6 +111,15 @@ class ShellTool implements Tool {
       return { content: "Error: command contains null bytes", isError: true };
     }
 
+    const background = input.background === true;
+    if (background && context.diskPressureCleanupModeActive === true) {
+      return {
+        content:
+          "Error: background shell commands are not available during disk pressure cleanup mode.",
+        isError: true,
+      };
+    }
+
     const config = getConfig();
     const shellLockdownActive =
       isCesShellLockdownEnabled(config) &&
@@ -276,7 +285,6 @@ class ShellTool implements Tool {
     // Background mode: spawn and return immediately. The process output is
     // delivered to the conversation as a wake when the process exits.
     // -----------------------------------------------------------------------
-    const background = input.background === true;
     if (background) {
       // Check the registry limit BEFORE spawning so we never leak an
       // untracked process when the registry is full.

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -13,12 +13,13 @@ import { getLogger } from "../util/logger.js";
 import { getAllTools, getTool } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
 import { summarizeToolInput } from "./tool-input-summary.js";
-import type {
-  ExecutionTarget,
-  Tool,
-  ToolContext,
-  ToolExecutionResult,
-  ToolLifecycleEvent,
+import {
+  type ExecutionTarget,
+  isDiskPressureCleanupToolName,
+  type Tool,
+  type ToolContext,
+  type ToolExecutionResult,
+  type ToolLifecycleEvent,
 } from "./types.js";
 import { enforceVerificationControlPlanePolicy } from "./verification-control-plane-policy.js";
 
@@ -307,6 +308,30 @@ export class ToolApprovalHandler {
         callSessionId: context.callSessionId,
         requesterExternalUserId: context.requesterExternalUserId,
       };
+    }
+
+    if (
+      context.diskPressureCleanupModeActive === true &&
+      !isDiskPressureCleanupToolName(name)
+    ) {
+      const msg = `Tool "${name}" is not available during disk pressure cleanup mode.`;
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent({
+        type: "error",
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: "error",
+        durationMs,
+        errorMessage: msg,
+        isExpected: true,
+        errorCategory: "tool_failure",
+      });
+      return { allowed: false, result: { content: msg, isError: true } };
     }
 
     // Gate tools not active for the current turn

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -18,6 +18,20 @@ import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import type { ContentBlock } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 
+export const DISK_PRESSURE_CLEANUP_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "bash",
+  "host_bash",
+  "file_read",
+  "file_list",
+  "host_file_read",
+  "background_tool_list",
+  "background_tool_cancel",
+]);
+
+export function isDiskPressureCleanupToolName(name: string): boolean {
+  return DISK_PRESSURE_CLEANUP_TOOL_NAMES.has(name);
+}
+
 // ---------------------------------------------------------------------------
 // Re-exports + concrete overlays for types that live in
 // @vellumai/skill-host-contracts.
@@ -177,6 +191,8 @@ export interface ToolContext {
   proxyToolResolver?: ProxyToolResolver;
   /** When set, only tools in this set may execute. Tools outside the set are blocked with an error. */
   allowedToolNames?: Set<string>;
+  /** True when this turn is restricted to storage cleanup-safe tools. */
+  diskPressureCleanupModeActive?: boolean;
   /** Prompt the user for a secret value via native SecureField UI. */
   requestSecret?: (params: {
     service: string;


### PR DESCRIPTION
## Summary

- Add a turn-scoped disk-pressure cleanup-mode flag that narrows provider-visible tools and executor fallback access to cleanup-safe tools.
- Block background `bash` and `host_bash` execution during cleanup mode while preserving foreground terminal access.
- Cancel registered background terminal tools when the disk-pressure guard first enters the locked state.

## Validation

- `cd assistant && bun test src/__tests__/disk-pressure-tools.test.ts`
- `cd assistant && bun test src/__tests__/disk-pressure-guard.test.ts src/__tests__/disk-pressure-policy.test.ts src/__tests__/conversation-tool-setup-tools-disabled.test.ts`
- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts --grep "disk pressure"`
- `cd assistant && bunx tsc --noEmit`

## Notes

Normal push was blocked by the unrelated known SwiftPM resolver issue (`SwiftMath` 1.7.3 in `clients/`), so the branch was pushed with `--no-verify` as instructed.