### PR TITLE
Seed cost defaults for heartbeat call site

### DIFF
--- a/assistant/src/__tests__/workspace-migration-066-seed-heartbeat-callsite-cost-default.test.ts
+++ b/assistant/src/__tests__/workspace-migration-066-seed-heartbeat-callsite-cost-default.test.ts
@@ -1,0 +1,285 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+import { seedHeartbeatCallsiteCostDefaultMigration } from "../workspace/migrations/066-seed-heartbeat-callsite-cost-default.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-066-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function configPath(): string {
+  return join(workspaceDir, "config.json");
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(configPath(), JSON.stringify(data, null, 2) + "\n");
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath(), "utf-8"));
+}
+
+beforeEach(() => {
+  freshWorkspace();
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+});
+
+afterEach(() => {
+  delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("066-seed-heartbeat-callsite-cost-default migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(seedHeartbeatCallsiteCostDefaultMigration.id).toBe(
+      "066-seed-heartbeat-callsite-cost-default",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "066-seed-heartbeat-callsite-cost-default",
+    );
+  });
+
+  test("fresh config seeds explicit Anthropic cheap defaults", () => {
+    expect(existsSync(configPath())).toBe(false);
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    expect(existsSync(configPath())).toBe(true);
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.heartbeatAgent).toEqual({
+      provider: "anthropic",
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 2048,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 16_000 },
+    });
+  });
+
+  test("uses matching cost-optimized profile when present", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-sonnet-4-6" },
+        profiles: {
+          "cost-optimized": {
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+      },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.heartbeatAgent).toEqual({
+      profile: "cost-optimized",
+      maxTokens: 2048,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 16_000 },
+    });
+  });
+
+  test("fills missing leaves on legacy heartbeat speed override", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          heartbeatAgent: { speed: "fast" },
+        },
+      },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.heartbeatAgent).toEqual({
+      speed: "fast",
+      provider: "anthropic",
+      model: "claude-haiku-4-5-20251001",
+      maxTokens: 2048,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 16_000 },
+    });
+  });
+
+  test("preserves explicit user model selection unchanged", () => {
+    const heartbeatAgent = {
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      effort: "medium",
+      thinking: { enabled: true },
+      contextWindow: { enabled: false },
+    };
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        callSites: {
+          heartbeatAgent,
+        },
+      },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.heartbeatAgent).toEqual(heartbeatAgent);
+  });
+
+  test("preserves explicit user profile selection unchanged", () => {
+    const heartbeatAgent = {
+      profile: "quality-optimized",
+    };
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            effort: "max",
+            thinking: { enabled: true, streamThinking: true },
+          },
+        },
+        callSites: {
+          heartbeatAgent,
+        },
+      },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.heartbeatAgent).toEqual(heartbeatAgent);
+  });
+
+  test("seeds provider-specific cheap model for OpenAI workspaces", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4" },
+        profiles: {
+          "cost-optimized": {
+            provider: "anthropic",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+      },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.heartbeatAgent).toEqual({
+      provider: "openai",
+      model: "gpt-5.4-nano",
+      maxTokens: 2048,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 16_000 },
+    });
+  });
+
+  test("seeds existing Gemini latency model for Gemini workspaces", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "gemini", model: "gemini-3.1-pro-preview" },
+      },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites: Record<string, Record<string, unknown>> };
+    };
+    expect(config.llm.callSites.heartbeatAgent).toEqual({
+      provider: "gemini",
+      model: "gemini-3-flash",
+      maxTokens: 2048,
+      effort: "low",
+      temperature: 0,
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: { maxInputTokens: 16_000 },
+    });
+  });
+
+  test("skips when VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH is set", () => {
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = "/tmp/overlay.json";
+    writeConfig({
+      llm: { default: { provider: "anthropic" } },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const config = readConfig() as {
+      llm: { callSites?: Record<string, unknown> };
+    };
+    expect(config.llm.callSites).toBeUndefined();
+  });
+
+  test("resolved heartbeat config uses cheap model and bounded context", () => {
+    writeConfig({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          effort: "high",
+          thinking: { enabled: true, streamThinking: true },
+          contextWindow: { maxInputTokens: 200_000 },
+        },
+      },
+    });
+
+    seedHeartbeatCallsiteCostDefaultMigration.run(workspaceDir);
+
+    const onDisk = readConfig() as { llm: unknown };
+    const parsed = LLMSchema.parse(onDisk.llm);
+    const resolved = resolveCallSiteConfig("heartbeatAgent", parsed);
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.maxTokens).toBe(2048);
+    expect(resolved.effort).toBe("low");
+    expect(resolved.temperature).toBe(0);
+    expect(resolved.thinking).toEqual({
+      enabled: false,
+      streamThinking: false,
+    });
+    expect(resolved.contextWindow.maxInputTokens).toBe(16_000);
+  });
+});

--- a/assistant/src/workspace/migrations/066-seed-heartbeat-callsite-cost-default.ts
+++ b/assistant/src/workspace/migrations/066-seed-heartbeat-callsite-cost-default.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Seed a cheap, bounded default for the `heartbeatAgent` LLM call site.
+ *
+ * Heartbeats are default-on and now run frequently, so they should not inherit
+ * the workspace's active chat profile. The default managed profile is Sonnet
+ * with high effort and thinking enabled, which is appropriate for interactive
+ * chat but too expensive for a periodic background triage pass.
+ *
+ * Preserve user-owned model selection. If `heartbeatAgent` already has a
+ * `profile`, `provider`, or `model`, this migration leaves the entry unchanged
+ * so call-site leaves do not silently override the selected profile/model.
+ * Speed-only legacy entries from migration 038 are treated as defaultable.
+ */
+export const seedHeartbeatCallsiteCostDefaultMigration: WorkspaceMigration = {
+  id: "066-seed-heartbeat-callsite-cost-default",
+  description:
+    "Seed cost-optimized defaults for the heartbeatAgent LLM call site",
+  run(workspaceDir: string): void {
+    if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
+
+    const configPath = join(workspaceDir, "config.json");
+    const configExisted = existsSync(configPath);
+
+    let config: Record<string, unknown> = {};
+    if (configExisted) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    }
+
+    const llm = readObject(config.llm) ?? {};
+    const defaultBlock = readObject(llm.default);
+    const provider = readString(defaultBlock?.provider) ?? "anthropic";
+    const cheapModel = resolveCheapModel(provider);
+    if (cheapModel === undefined) return;
+
+    const callSites = readObject(llm.callSites) ?? {};
+    const existing = readObject(callSites.heartbeatAgent) ?? {};
+    if (hasExplicitModelSelection(existing)) return;
+
+    const seeded: Record<string, unknown> = { ...existing };
+    let changed = false;
+
+    const profiles = readObject(llm.profiles) ?? {};
+    const costProfile = readObject(profiles["cost-optimized"]);
+    if (readString(costProfile?.provider) === provider) {
+      seeded.profile = "cost-optimized";
+    } else {
+      seeded.provider = provider;
+      seeded.model = cheapModel;
+    }
+    changed = true;
+
+    changed = seedMissingLeaf(seeded, "maxTokens", 2048) || changed;
+    changed = seedMissingLeaf(seeded, "effort", "low") || changed;
+    changed = seedMissingLeaf(seeded, "temperature", 0) || changed;
+
+    const thinking = readObject(seeded.thinking) ?? {};
+    const seededThinking = { ...thinking };
+    const enabledChanged = seedMissingLeaf(seededThinking, "enabled", false);
+    const streamThinkingChanged = seedMissingLeaf(
+      seededThinking,
+      "streamThinking",
+      false,
+    );
+    const thinkingChanged = enabledChanged || streamThinkingChanged;
+    if (thinkingChanged || readObject(seeded.thinking) === null) {
+      seeded.thinking = seededThinking;
+      changed = true;
+    }
+
+    const contextWindow = readObject(seeded.contextWindow) ?? {};
+    const seededContextWindow = { ...contextWindow };
+    const contextChanged = seedMissingLeaf(
+      seededContextWindow,
+      "maxInputTokens",
+      16_000,
+    );
+    if (contextChanged || readObject(seeded.contextWindow) === null) {
+      seeded.contextWindow = seededContextWindow;
+      changed = true;
+    }
+
+    if (!changed) return;
+
+    callSites.heartbeatAgent = seeded;
+    llm.callSites = callSites;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only: removing the seeded default would make frequent
+    // heartbeats inherit the user's potentially expensive chat profile again.
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers — self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const CHEAP_MODELS_BY_PROVIDER: Record<string, string> = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openai: "gpt-5.4-nano",
+  gemini: "gemini-3-flash",
+  ollama: "llama3.2",
+  fireworks: "accounts/fireworks/models/kimi-k2p5",
+  openrouter: "anthropic/claude-haiku-4.5",
+};
+
+function resolveCheapModel(provider: string): string | undefined {
+  return CHEAP_MODELS_BY_PROVIDER[provider];
+}
+
+function hasExplicitModelSelection(value: Record<string, unknown>): boolean {
+  return "profile" in value || "provider" in value || "model" in value;
+}
+
+function seedMissingLeaf(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): boolean {
+  if (key in target) return false;
+  target[key] = value;
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -63,6 +63,7 @@ import { dropMemoryV2EdgesJsonMigration } from "./062-drop-memory-v2-edges-json.
 import { releaseNotesDynamicModelContextMigration } from "./063-release-notes-dynamic-model-context.js";
 import { unwindMainAgentOpusSeedMigration } from "./064-unwind-main-agent-opus-seed.js";
 import { bumpStaleHeartbeatIntervalMigration } from "./065-bump-stale-heartbeat-interval.js";
+import { seedHeartbeatCallsiteCostDefaultMigration } from "./066-seed-heartbeat-callsite-cost-default.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -137,4 +138,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesDynamicModelContextMigration,
   unwindMainAgentOpusSeedMigration,
   bumpStaleHeartbeatIntervalMigration,
+  seedHeartbeatCallsiteCostDefaultMigration,
 ];


### PR DESCRIPTION
## Summary
- Seed heartbeatAgent to a low-cost bounded call-site default for frequent background runs
- Use the managed cost-optimized profile when it matches the workspace provider, otherwise seed provider-specific cheap models
- Cap heartbeat output/context, disable thinking, and preserve existing explicit user call-site choices

## Testing
- cd assistant && bun test src/__tests__/workspace-migration-066-seed-heartbeat-callsite-cost-default.test.ts
- cd assistant && bun test src/__tests__/heartbeat-service.test.ts
- cd assistant && bun test src/heartbeat/__tests__/heartbeat-feed-event.test.ts
- cd assistant && bun test src/runtime/routes/__tests__/heartbeat-routes.test.ts
- cd assistant && bun test src/__tests__/workspace-migration-065-bump-stale-heartbeat-interval.test.ts
- cd assistant && bunx tsc --noEmit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->