### PR TITLE
feat(macos): add AppURLs.billingSettings accessor for web billing page

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -80,17 +80,24 @@ public enum AppURLs {
     /// `pro-plan-adjust` feature flag). Resolves to the Next.js web app at
     /// `<webURL>/assistant/settings/billing` for the current build environment.
     ///
-    /// If `VELLUM_WEB_URL` is set but malformed (no scheme/host, non-http(s)),
-    /// falls back to the canonical environment URL via `VellumEnvironment.current.webURL`.
-    /// Force-unwrap on the final `URL(string:)` is safe because both candidate base
-    /// strings are validated/known-good and the path is a literal.
+    /// If `VELLUM_WEB_URL` is set but malformed (no scheme/host, non-http(s),
+    /// or contains a query/fragment), falls back to the canonical environment
+    /// URL via `VellumEnvironment.current.webURL`. Query/fragment are rejected
+    /// because string-concatenating a literal path onto `https://host?foo=bar`
+    /// would produce `https://host?foo=bar/assistant/settings/billing` — the
+    /// path gets absorbed into the query string. Mirrors the validation in
+    /// `docsBaseURL` above. Force-unwrap on the final `URL(string:)` is safe
+    /// because both candidate base strings are validated/known-good and the
+    /// path is a literal.
     public static var billingSettings: URL {
         let candidate = VellumEnvironment.resolvedWebURL
         let base: String
         if let url = URL(string: candidate),
            let scheme = url.scheme?.lowercased(),
            (scheme == "http" || scheme == "https"),
-           url.host != nil {
+           url.host != nil,
+           url.query == nil,
+           url.fragment == nil {
             base = candidate
         } else {
             base = VellumEnvironment.current.webURL

--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VellumAssistantShared
 
 /// Centralized URLs the macOS app links out to.
 ///
@@ -70,6 +71,18 @@ public enum AppURLs {
     /// AI Data Sharing Policy docs — linked from the onboarding AI data consent checkbox.
     public static var dataSharingDocs: URL {
         docsURL(path: "/data-sharing")
+    }
+
+    // MARK: - Web app URLs
+
+    /// Web app billing settings page — opened from the Settings → Billing tab's
+    /// "Adjust Plan" and "Configure Auto Top Ups" buttons (both gated by the
+    /// `pro-plan-adjust` feature flag). Resolves to the Next.js web app at
+    /// `<webURL>/assistant/settings/billing` for the current build environment.
+    /// Force-unwrap is safe: `VellumEnvironment.resolvedWebURL` is always a valid
+    /// absolute URL string and the path is a literal.
+    public static var billingSettings: URL {
+        URL(string: "\(VellumEnvironment.resolvedWebURL)/assistant/settings/billing")!
     }
 
     // MARK: - Source repository

--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -79,10 +79,23 @@ public enum AppURLs {
     /// "Adjust Plan" and "Configure Auto Top Ups" buttons (both gated by the
     /// `pro-plan-adjust` feature flag). Resolves to the Next.js web app at
     /// `<webURL>/assistant/settings/billing` for the current build environment.
-    /// Force-unwrap is safe: `VellumEnvironment.resolvedWebURL` is always a valid
-    /// absolute URL string and the path is a literal.
+    ///
+    /// If `VELLUM_WEB_URL` is set but malformed (no scheme/host, non-http(s)),
+    /// falls back to the canonical environment URL via `VellumEnvironment.current.webURL`.
+    /// Force-unwrap on the final `URL(string:)` is safe because both candidate base
+    /// strings are validated/known-good and the path is a literal.
     public static var billingSettings: URL {
-        URL(string: "\(VellumEnvironment.resolvedWebURL)/assistant/settings/billing")!
+        let candidate = VellumEnvironment.resolvedWebURL
+        let base: String
+        if let url = URL(string: candidate),
+           let scheme = url.scheme?.lowercased(),
+           (scheme == "http" || scheme == "https"),
+           url.host != nil {
+            base = candidate
+        } else {
+            base = VellumEnvironment.current.webURL
+        }
+        return URL(string: "\(base)/assistant/settings/billing")!
     }
 
     // MARK: - Source repository

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -134,4 +134,24 @@ final class AppURLsTests: XCTestCase {
         XCTAssertEqual(AppURLs.docsURL(path: "/pricing").absoluteString, "https://www.vellum.ai/docs/pricing")
         XCTAssertEqual(AppURLs.docsURL(path: "pricing").absoluteString, "https://www.vellum.ai/docs/pricing")
     }
+
+    // MARK: - Billing settings web URL
+
+    func testBillingSettingsHonorsWebURLOverride() {
+        setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        XCTAssertEqual(
+            AppURLs.billingSettings.absoluteString,
+            "https://staging-assistant.vellum.ai/assistant/settings/billing"
+        )
+    }
+
+    func testBillingSettingsStripsTrailingSlash() {
+        setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai/", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        XCTAssertEqual(
+            AppURLs.billingSettings.absoluteString,
+            "https://staging-assistant.vellum.ai/assistant/settings/billing"
+        )
+    }
 }

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -154,4 +154,21 @@ final class AppURLsTests: XCTestCase {
             "https://staging-assistant.vellum.ai/assistant/settings/billing"
         )
     }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideMalformed() {
+        setenv("VELLUM_WEB_URL", "not a url with spaces", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        // Should fall back to the env-default web URL rather than crash.
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("not a url with spaces"))
+    }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideHasNoScheme() {
+        setenv("VELLUM_WEB_URL", "example.com/path", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("example.com"))
+    }
 }

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -171,4 +171,20 @@ final class AppURLsTests: XCTestCase {
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
         XCTAssertFalse(result.contains("example.com"))
     }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideHasQuery() {
+        setenv("VELLUM_WEB_URL", "https://example.com?foo=bar", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("?foo=bar"))
+    }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideHasFragment() {
+        setenv("VELLUM_WEB_URL", "https://example.com#section", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("#section"))
+    }
 }


### PR DESCRIPTION
## Summary
- Add `AppURLs.billingSettings` static accessor that resolves to `<webURL>/assistant/settings/billing` for the current build environment via `VellumEnvironment.resolvedWebURL`
- Add tests covering env-var override and trailing-slash normalization

Part of plan: billing-adjust-plan.md (PR 2 of 3)