### PR TITLE
fix(host-proxy): persist target actor at registration; consolidate host_transfer routes

### DIFF
--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -102,10 +102,19 @@ function registerPending(
   requestId: string,
   overrides: Partial<PendingInteraction> = {},
 ): void {
+  // Mirror the production proxy behavior: capture the target's actor
+  // principal at registration time so the result-route check compares
+  // against the persisted value rather than a live hub lookup.
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? clientActorPrincipals.get(overrides.targetClientId)
+      : undefined);
   pendingStore.set(requestId, {
     conversationId: "conv-1",
     kind: "host_bash",
     ...overrides,
+    targetActorPrincipalId,
   });
 }
 
@@ -163,8 +172,8 @@ describe("handleHostBashResult", () => {
   describe("targeted request (targetClientId set)", () => {
     test("accepts when x-vellum-client-id matches targetClientId", async () => {
       const requestId = "req-targeted-match";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-1");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
@@ -182,8 +191,8 @@ describe("handleHostBashResult", () => {
 
     test("trims whitespace from x-vellum-client-id before comparing", async () => {
       const requestId = "req-targeted-trim";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-1");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
@@ -202,8 +211,8 @@ describe("handleHostBashResult", () => {
   describe("targeted request — actor principal binding", () => {
     test("accepts when submitting actor matches target client's actor", async () => {
       const requestId = "req-actor-match";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-shared");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       const result = await handleHostBashResult({
         body: bashBody(requestId),
@@ -220,8 +229,8 @@ describe("handleHostBashResult", () => {
 
     test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
       const requestId = "req-actor-mismatch";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       expect(() =>
         handleHostBashResult({
@@ -236,8 +245,8 @@ describe("handleHostBashResult", () => {
 
     test("interaction is NOT resolved on cross-actor 403 (still pending)", () => {
       const requestId = "req-actor-mismatch-stays";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       try {
         handleHostBashResult({
@@ -257,8 +266,8 @@ describe("handleHostBashResult", () => {
 
     test("throws ForbiddenError (403) when x-vellum-actor-principal-id header is missing entirely", () => {
       const requestId = "req-actor-missing";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       expect(() =>
         handleHostBashResult({
@@ -270,8 +279,8 @@ describe("handleHostBashResult", () => {
 
     test("interaction is NOT resolved when submitting actor is missing (still pending)", () => {
       const requestId = "req-actor-missing-stays";
-      registerPending(requestId, { targetClientId: "client-abc" });
       clientActorPrincipals.set("client-abc", "principal-victim");
+      registerPending(requestId, { targetClientId: "client-abc" });
 
       try {
         handleHostBashResult({

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -112,10 +112,16 @@ function registerPending(
   requestId: string,
   overrides: Partial<PendingInteraction> = {},
 ): void {
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? actorPrincipalByClient.get(overrides.targetClientId)
+      : undefined);
   const entry: PendingInteraction = {
     conversationId: "conv-cu-1",
     kind: "host_cu",
     ...overrides,
+    targetActorPrincipalId,
   };
   pendingStore.set(requestId, entry);
 }
@@ -162,8 +168,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-cu-targeted-match";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
@@ -181,8 +187,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-cu-targeted-trim";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
@@ -293,8 +299,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
   describe("targeted + actor-principal-id binding", () => {
     test("accepts when submitting actor matches target client's stored actor", async () => {
       const requestId = "req-cu-actor-match";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostCuResult({
         body: cuBody(requestId),
@@ -311,8 +317,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
       const requestId = "req-cu-actor-mismatch";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostCuResult({
@@ -327,8 +333,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("interaction NOT consumed on 403 actor mismatch", () => {
       const requestId = "req-cu-actor-mismatch-stays";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       try {
         handleHostCuResult({
@@ -348,8 +354,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor header is missing", () => {
       const requestId = "req-cu-actor-missing";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostCuResult({
@@ -377,8 +383,8 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor header is whitespace only", () => {
       const requestId = "req-cu-actor-whitespace";
-      registerPending(requestId, { targetClientId: "client-A" });
       actorPrincipalByClient.set("client-A", "user-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostCuResult({

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -94,10 +94,16 @@ function registerPending(
   requestId: string,
   overrides: Partial<PendingInteraction> = {},
 ): void {
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? clientActors.get(overrides.targetClientId)
+      : undefined);
   pendingStore.set(requestId, {
     conversationId: "conv-1",
     kind: "host_file",
     ...overrides,
+    targetActorPrincipalId,
   });
 }
 
@@ -124,8 +130,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and resolves the interaction", async () => {
       const requestId = "req-file-targeted-match";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
@@ -143,8 +149,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("trims whitespace from header before comparing", async () => {
       const requestId = "req-file-targeted-trim";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       const result = await handleHostFileResult({
         body: fileBody(requestId),
@@ -285,8 +291,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
   describe("targeted + actor principal mismatch", () => {
     test("throws ForbiddenError (403) when submitting actor does not match target client's actor", () => {
       const requestId = "req-file-actor-mismatch";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostFileResult({
@@ -301,8 +307,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("interaction is NOT consumed on actor-mismatch 403", () => {
       const requestId = "req-file-actor-mismatch-stays";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       try {
         handleHostFileResult({
@@ -326,8 +332,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
   describe("targeted + missing x-vellum-actor-principal-id header", () => {
     test("throws ForbiddenError (403) when submitting actor header is absent", () => {
       const requestId = "req-file-actor-missing";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostFileResult({
@@ -339,8 +345,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("throws ForbiddenError (403) when submitting actor header is empty string", () => {
       const requestId = "req-file-actor-empty";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       expect(() =>
         handleHostFileResult({
@@ -355,8 +361,8 @@ describe("handleHostFileResult — targetClientId guard", () => {
 
     test("interaction is NOT consumed when submitting actor is missing", () => {
       const requestId = "req-file-actor-missing-stays";
-      registerPending(requestId, { targetClientId: "client-A" });
       clientActors.set("client-A", "actor-1");
+      registerPending(requestId, { targetClientId: "client-A" });
 
       try {
         handleHostFileResult({

--- a/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
@@ -47,6 +47,11 @@ mock.module("../daemon/host-transfer-proxy.js", () => ({
         getTargetClientIdForTransfer(_transferId: string) {
           return stubTargetClientId;
         },
+        getTargetActorPrincipalIdForTransfer(_transferId: string) {
+          return stubTargetClientId
+            ? clientActors.get(stubTargetClientId)
+            : undefined;
+        },
         getTransferContent(transferId: string) {
           getTransferContentCalls.push(transferId);
           return {
@@ -109,10 +114,19 @@ const TEST_TRANSFER_ID = "transfer-abc";
 const TEST_REQUEST_ID = "req-1";
 
 function registerPending(overrides: Partial<PendingInteraction> = {}): void {
+  // Mirror the production proxy: capture the target's actor principal at
+  // registration time so the result-route check compares against a stable
+  // value rather than the live hub.
+  const targetActorPrincipalId =
+    overrides.targetActorPrincipalId ??
+    (overrides.targetClientId
+      ? clientActors.get(overrides.targetClientId)
+      : undefined);
   pendingStore.set(TEST_REQUEST_ID, {
     conversationId: "conv-1",
     kind: "host_transfer",
     ...overrides,
+    targetActorPrincipalId,
   });
 }
 
@@ -472,8 +486,8 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
 
   describe("targeted + correct x-vellum-client-id header", () => {
     test("returns { accepted: true } and calls resolveTransferResult", async () => {
-      registerHostTransferPending("client-A");
       clientActors.set("client-A", "actor-1");
+      registerHostTransferPending("client-A");
       const result = await handleTransferResult({
         body: resultBody(),
         headers: {
@@ -487,8 +501,8 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
     });
 
     test("trims whitespace from header before comparing", async () => {
-      registerHostTransferPending("client-A");
       clientActors.set("client-A", "actor-1");
+      registerHostTransferPending("client-A");
       const result = await handleTransferResult({
         body: resultBody(),
         headers: {

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -171,6 +171,12 @@ export class HostBashProxy {
         timer,
         detachAbort,
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
         metadata: { timeoutSec },
       });
 

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -235,6 +235,10 @@ export class HostCuProxy {
         conversationId,
         kind: "host_cu",
         targetClientId,
+        targetActorPrincipalId:
+          targetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
+            : undefined,
         rpcResolve: resolve,
         rpcReject: reject,
         timer,

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -180,6 +180,12 @@ export class HostFileProxy {
         conversationId,
         kind: "host_file",
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
         rpcResolve: resolve,
         rpcReject: reject,
         timer,

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -36,6 +36,13 @@ interface TransferEntry {
   sha256?: string;
   fileBuffer?: Buffer;
   targetClientId?: string;
+  /**
+   * Snapshot of `targetClientId`'s `actorPrincipalId` taken at registration
+   * time. Persisted so the GET/PUT content routes compare against a stable
+   * value rather than the live hub — the target client's SSE subscription
+   * may briefly disconnect between dispatch and content fetch/upload.
+   */
+  targetActorPrincipalId?: string;
 }
 
 /**
@@ -248,12 +255,24 @@ export class HostTransferProxy {
             sha256,
             fileBuffer,
             targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
           });
 
           pendingInteractions.register(requestId, {
             conversationId: input.conversationId,
             kind: "host_transfer",
             targetClientId: resolvedTargetClientId,
+            targetActorPrincipalId:
+              resolvedTargetClientId != null
+                ? assistantEventHub.getActorPrincipalIdForClient(
+                    resolvedTargetClientId,
+                  )
+                : undefined,
             rpcResolve: resolve,
             rpcReject: reject,
             timer,
@@ -425,12 +444,24 @@ export class HostTransferProxy {
         filePath: input.destPath,
         overwrite: input.overwrite,
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
       });
 
       pendingInteractions.register(requestId, {
         conversationId: input.conversationId,
         kind: "host_transfer",
         targetClientId: resolvedTargetClientId,
+        targetActorPrincipalId:
+          resolvedTargetClientId != null
+            ? assistantEventHub.getActorPrincipalIdForClient(
+                resolvedTargetClientId,
+              )
+            : undefined,
         rpcResolve: resolve,
         rpcReject: reject,
         timer,
@@ -672,6 +703,15 @@ export class HostTransferProxy {
    */
   getTargetClientIdForTransfer(transferId: string): string | null {
     return this.transfers.get(transferId)?.targetClientId ?? null;
+  }
+
+  /**
+   * Look up the persisted `targetActorPrincipalId` for a given transferId
+   * without consuming the entry. Routes call this for the same-actor
+   * binding check so it's stable across brief SSE reconnects.
+   */
+  getTargetActorPrincipalIdForTransfer(transferId: string): string | undefined {
+    return this.transfers.get(transferId)?.targetActorPrincipalId;
   }
 
   dispose(): void {

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -47,24 +47,54 @@ export type SameActorOp =
   | "host_cu"
   | "host_transfer";
 
-export interface SameActorArgs {
+/**
+ * Args for the live-lookup variant: caller supplies the hub + target client
+ * id, and the helper looks up the target's actor principal in real time.
+ * Used at proxy request time (registration), where the SSE subscription is
+ * present by definition.
+ */
+export interface SameActorLiveArgs {
   hub: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
   sourceActorPrincipalId: string | undefined;
   targetClientId: string;
   op: SameActorOp;
 }
 
+/**
+ * Args for the persisted-value variant: caller supplies a target actor
+ * principal id captured at registration time. Used at result-submission
+ * time, where the SSE subscription may have briefly disconnected and the
+ * live hub lookup would falsely 403 a legitimate result.
+ */
+export interface SameActorPersistedArgs {
+  sourceActorPrincipalId: string | undefined;
+  targetActorPrincipalId: string | undefined;
+  targetClientId: string;
+  op: SameActorOp;
+}
+
+export type SameActorArgs = SameActorLiveArgs;
+
 type RejectionReason = "missing_source" | "missing_target" | "mismatch";
+
+function isLive(
+  args: SameActorLiveArgs | SameActorPersistedArgs,
+): args is SameActorLiveArgs {
+  return (args as SameActorLiveArgs).hub != null;
+}
 
 /**
  * Internal: returns the rejection reason or `undefined` when the source
  * matches the target. Always logs on rejection so all callers share the
  * same audit shape.
  */
-function detectRejection(args: SameActorArgs): RejectionReason | undefined {
-  const { hub, sourceActorPrincipalId, targetClientId, op } = args;
-  const targetActorPrincipalId =
-    hub.getActorPrincipalIdForClient(targetClientId);
+function detectRejection(
+  args: SameActorLiveArgs | SameActorPersistedArgs,
+): RejectionReason | undefined {
+  const { sourceActorPrincipalId, targetClientId, op } = args;
+  const targetActorPrincipalId = isLive(args)
+    ? args.hub.getActorPrincipalIdForClient(targetClientId)
+    : args.targetActorPrincipalId;
 
   let reason: RejectionReason | undefined;
   if (sourceActorPrincipalId == null) {
@@ -93,8 +123,15 @@ function detectRejection(args: SameActorArgs): RejectionReason | undefined {
  * Route-flavored variant: throws {@link ForbiddenError} on rejection so
  * the existing route adapter maps it to HTTP 403. Returns void on
  * success.
+ *
+ * Accepts EITHER {@link SameActorLiveArgs} (live hub lookup, used at
+ * proxy registration time) OR {@link SameActorPersistedArgs} (compare
+ * against a value captured earlier, used at result-submission time so a
+ * brief SSE reconnect doesn't 403 a legitimate result).
  */
-export function enforceSameActorOrThrow(args: SameActorArgs): void {
+export function enforceSameActorOrThrow(
+  args: SameActorLiveArgs | SameActorPersistedArgs,
+): void {
   if (detectRejection(args) != null) {
     throw new ForbiddenError(REJECTION_MESSAGE);
   }
@@ -103,10 +140,11 @@ export function enforceSameActorOrThrow(args: SameActorArgs): void {
 /**
  * Proxy-flavored variant: returns a tool-execution-shaped error result
  * on rejection (so the proxy can pass it directly back to the agent),
- * or `null` on success.
+ * or `null` on success. Always uses the live hub lookup — proxy
+ * registration runs while the target SSE subscription is active.
  */
 export function enforceSameActorOrErrorResult(
-  args: SameActorArgs,
+  args: SameActorLiveArgs,
 ): { content: string; isError: true } | null {
   if (detectRejection(args) == null) return null;
   return { content: REJECTION_MESSAGE, isError: true };

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -59,6 +59,14 @@ export interface PendingInteraction {
   directResolve?: (decision: UserDecision) => void;
   /** When set, the host_bash request should be routed to this specific client. */
   targetClientId?: string;
+  /**
+   * Snapshot of `targetClientId`'s `actorPrincipalId` taken at registration
+   * time. Persisted so the result-route same-actor check compares against
+   * a stable value rather than the live hub — the target client's SSE
+   * subscription may have briefly disconnected between dispatch and result
+   * submission, which would otherwise 403 a legitimate result.
+   */
+  targetActorPrincipalId?: string;
 
   // -- RPC lifecycle (populated by host proxies) --
 

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -7,7 +7,6 @@
 import { z } from "zod";
 
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
@@ -79,8 +78,8 @@ function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     // cross-user submission even when the attacker can guess or spoof the
     // target's client ID.
     enforceSameActorOrThrow({
-      hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId,
       op: "host_bash",
     });

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -7,7 +7,6 @@
 import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-store.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
@@ -99,8 +98,8 @@ function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
       headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
     );
     enforceSameActorOrThrow({
-      hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_cu",
     });

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -7,7 +7,6 @@
 import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import {
   enforceSameActorOrThrow,
   SAME_ACTOR_FORBIDDEN_DESCRIPTION,
@@ -77,8 +76,8 @@ function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
       headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
     );
     enforceSameActorOrThrow({
-      hub: assistantEventHub,
       sourceActorPrincipalId: submittingActorPrincipalId,
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
       targetClientId: peeked.targetClientId,
       op: "host_file",
     });

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -8,7 +8,10 @@
 import { z } from "zod";
 
 import { HostTransferProxy } from "../../daemon/host-transfer-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
+} from "../auth/same-actor.js";
 import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
@@ -63,24 +66,19 @@ function handleTransferContentGet({
         `Client "${submittingClientId}" is not the owner of this transfer`,
       );
 
-    // Defense-in-depth: also require the submitting actor's principal id to
-    // match the actor that opened the target client's SSE stream. This blocks
-    // cross-user submissions even if a different user obtains the target
-    // client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this transfer.",
-      );
-    }
+    // Defense-in-depth: the submitting actor's principal must match the
+    // actor that opened the target client's SSE stream. Compare against
+    // the value persisted at registration time so a brief reconnect does
+    // not 403 a legitimate fetch.
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      ),
+      targetActorPrincipalId:
+        match.proxy.getTargetActorPrincipalIdForTransfer(transferId),
+      targetClientId,
+      op: "host_transfer",
+    });
   }
 
   const content = match.proxy.getTransferContent(transferId);
@@ -151,24 +149,15 @@ async function handleTransferContentPut({
         `Client "${submittingClientId}" is not the owner of this transfer`,
       );
 
-    // Defense-in-depth: also require the submitting actor's principal id to
-    // match the actor that opened the target client's SSE stream. This blocks
-    // cross-user submissions even if a different user obtains the target
-    // client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this transfer.",
-      );
-    }
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      ),
+      targetActorPrincipalId:
+        match.proxy.getTargetActorPrincipalIdForTransfer(transferId),
+      targetClientId,
+      op: "host_transfer",
+    });
   }
 
   const data = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0);
@@ -231,24 +220,14 @@ function handleTransferResult({ body, headers }: RouteHandlerArgs) {
         `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}").`,
       );
 
-    // Defense-in-depth: also require the submitting actor's principal id to
-    // match the actor that opened the target client's SSE stream. Blocks
-    // cross-user submissions even if a different user obtains the target
-    // client id.
-    const submittingActorPrincipalId = resolveActorPrincipalIdForLocalGuardian(
-      headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
-    const targetActorPrincipalId =
-      assistantEventHub.getActorPrincipalIdForClient(peeked.targetClientId);
-    if (
-      !submittingActorPrincipalId ||
-      !targetActorPrincipalId ||
-      submittingActorPrincipalId !== targetActorPrincipalId
-    ) {
-      throw new ForbiddenError(
-        "Submitting actor does not match the target client's actor for this request.",
-      );
-    }
+    enforceSameActorOrThrow({
+      sourceActorPrincipalId: resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      ),
+      targetActorPrincipalId: peeked.targetActorPrincipalId,
+      targetClientId: peeked.targetClientId,
+      op: "host_transfer",
+    });
   }
 
   HostTransferProxy.instance.resolveTransferResult(requestId, {
@@ -282,8 +261,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted transfer.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
     },
     handler: handleTransferContentGet,
@@ -304,8 +282,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted transfer.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
     },
     handler: handleTransferContentPut,
@@ -334,8 +311,7 @@ export const ROUTES: RouteDefinition[] = [
           "x-vellum-client-id header is missing for a targeted host transfer request.",
       },
       "403": {
-        description:
-          "Submitting client does not match the targeted client, or the submitting actor's principal does not match the target client's actor.",
+        description: SAME_ACTOR_FORBIDDEN_DESCRIPTION,
       },
     },
     handler: handleTransferResult,


### PR DESCRIPTION
Round-3 fix for plan host-proxy-same-user.md addressing two review findings on the feature-branch PR (#29633):

- Codex P1 (live-hub vs. persisted target actor)
- Devin advisory (inline same-actor checks in host-transfer-routes)

Same-actor helper now accepts either {hub, targetClientId} or {targetActorPrincipalId}. Proxies persist target actor on PendingInteraction at registration; transfer proxy also persists on TransferEntry for GET/PUT content routes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->