### PR TITLE
Bound memory retrieval latency

### DIFF
--- a/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_MEMORY_GRAPH_KIND,
   type DefaultMemoryRetrievalDeps,
   defaultMemoryRetrievalPlugin,
+  readStaticMemoryResult,
   runDefaultMemoryRetrieval,
 } from "../plugins/defaults/memory-retrieval.js";
 import { DEFAULT_TIMEOUTS, runPipeline } from "../plugins/pipeline.js";
@@ -280,6 +281,16 @@ describe("memoryRetrieval pipeline — default vs custom plugin", () => {
     // plugin supplied a block without the default discriminator — this is
     // what drives the agent-loop escape hatch.
     expect(asDefaultGraphPayload(result.memoryGraphBlocks)).toBeNull();
+  });
+
+  test("static fallback preserves PKB and NOW without graph blocks", () => {
+    const result = readStaticMemoryResult();
+
+    expect(result).toEqual({
+      pkbContent: "pkb-default",
+      nowContent: "now-default",
+      memoryGraphBlocks: [],
+    });
   });
 
   test("timeout: terminal that hangs past the budget fails with PluginTimeoutError", async () => {

--- a/assistant/src/__tests__/pipeline-runner.test.ts
+++ b/assistant/src/__tests__/pipeline-runner.test.ts
@@ -549,7 +549,7 @@ describe("DEFAULT_TIMEOUTS", () => {
       turn: null,
       llmCall: null,
       toolExecute: null,
-      memoryRetrieval: null,
+      memoryRetrieval: 5_000,
       historyRepair: null,
       tokenEstimate: null,
       compaction: null,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -84,6 +84,7 @@ import {
   asDefaultGraphPayload,
   type DefaultMemoryRetrievalDeps,
   type GraphMemoryPayload,
+  readStaticMemoryResult,
   runDefaultMemoryRetrieval,
 } from "../plugins/defaults/memory-retrieval.js";
 import { defaultPersistenceTerminal } from "../plugins/defaults/persistence.js";
@@ -1088,14 +1089,27 @@ export async function runAgentLoopImpl(
       onEvent,
       isTrustedActor,
     };
-    const memoryResult: MemoryResult = await runPipeline(
-      "memoryRetrieval",
-      getMiddlewaresFor("memoryRetrieval"),
-      (args) => runDefaultMemoryRetrieval(args, memoryDeps),
-      memoryArgs,
-      memoryPluginTurnCtx,
-      DEFAULT_TIMEOUTS.memoryRetrieval,
-    );
+    let memoryResult: MemoryResult;
+    try {
+      memoryResult = await runPipeline(
+        "memoryRetrieval",
+        getMiddlewaresFor("memoryRetrieval"),
+        (args) => runDefaultMemoryRetrieval(args, memoryDeps),
+        memoryArgs,
+        memoryPluginTurnCtx,
+        DEFAULT_TIMEOUTS.memoryRetrieval,
+      );
+    } catch (err) {
+      if (err instanceof PluginTimeoutError) {
+        rlog.warn(
+          { err, phase: "memory-retrieval" },
+          "memoryRetrieval pipeline timed out — proceeding without graph memory",
+        );
+        memoryResult = readStaticMemoryResult();
+      } else {
+        throw err;
+      }
+    }
 
     // Consume the memory-graph block when the default retriever emitted
     // one. Custom plugins that substitute their own blocks without the

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -412,6 +412,7 @@ export class ConversationGraphMemory {
       "context-load",
       rawUserText ?? userQuery ?? "",
       "",
+      signal,
     );
     if (v2.routed) {
       this.lastInjectedBlock = v2.injectedBlockText;
@@ -561,6 +562,7 @@ export class ConversationGraphMemory {
       "per-turn",
       userLast,
       assistantLast,
+      signal,
     );
     if (v2.routed) {
       this.lastInjectedBlock = v2.injectedBlockText;
@@ -655,6 +657,7 @@ export class ConversationGraphMemory {
     mode: InjectMemoryV2Mode,
     userMessage: string,
     assistantMessage: string,
+    signal: AbortSignal,
   ): Promise<{
     routed: boolean;
     runMessages: Message[];
@@ -680,6 +683,7 @@ export class ConversationGraphMemory {
       messageId: `${this.conversationId}:turn:${currentTurn}`,
       mode,
       config,
+      signal,
     });
 
     if (!result.block) {

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -81,6 +81,7 @@ interface SelectCandidatesParams {
   /** NOW context string (essentials/threads/recent or NOW.md). */
   nowText: string;
   config: AssistantConfig;
+  signal?: AbortSignal;
 }
 
 interface SelectCandidatesResult {
@@ -108,7 +109,8 @@ interface SelectCandidatesResult {
 export async function selectCandidates(
   params: SelectCandidatesParams,
 ): Promise<SelectCandidatesResult> {
-  const { priorState, userText, assistantText, nowText, config } = params;
+  const { priorState, userText, assistantText, nowText, config, signal } =
+    params;
 
   const fromPrior = new Set<string>();
   const fromAnn = new Set<string>();
@@ -129,7 +131,9 @@ export async function selectCandidates(
     .join("\n");
 
   if (annQueryText.length > 0) {
-    const denseResult = await embedWithBackend(config, [annQueryText]);
+    const denseResult = await embedWithBackend(config, [annQueryText], {
+      signal,
+    });
     const dense = await applyCorrectionIfCalibrated(
       denseResult.vectors[0],
       denseResult.provider,
@@ -158,6 +162,7 @@ interface ComputeOwnActivationParams {
   assistantText: string;
   nowText: string;
   config: AssistantConfig;
+  signal?: AbortSignal;
 }
 
 /**
@@ -210,8 +215,15 @@ interface ComputeOwnActivationResult {
 export async function computeOwnActivation(
   params: ComputeOwnActivationParams,
 ): Promise<ComputeOwnActivationResult> {
-  const { candidates, priorState, userText, assistantText, nowText, config } =
-    params;
+  const {
+    candidates,
+    priorState,
+    userText,
+    assistantText,
+    nowText,
+    config,
+    signal,
+  } = params;
 
   const activation = new Map<string, number>();
   const breakdown = new Map<string, OwnActivationBreakdown>();
@@ -223,9 +235,9 @@ export async function computeOwnActivation(
   // NOW context is structured (timestamps, current focus) — outside the
   // cross-encoder's training distribution, so it never participates in rerank.
   const [simUser, simAssistant, simNow] = await Promise.all([
-    simBatch(userText, slugList, config),
-    simBatch(assistantText, slugList, config),
-    simBatch(nowText, slugList, config),
+    simBatch(userText, slugList, config, signal),
+    simBatch(assistantText, slugList, config, signal),
+    simBatch(nowText, slugList, config, signal),
   ]);
 
   interface SlugInputs {

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -81,6 +81,7 @@ export interface InjectMemoryV2BlockParams {
    */
   mode?: InjectMemoryV2Mode;
   config: AssistantConfig;
+  signal?: AbortSignal;
 }
 
 export interface InjectMemoryV2BlockResult {
@@ -124,6 +125,7 @@ export async function injectMemoryV2Block(
     nowText,
     messageId,
     config,
+    signal,
   } = params;
 
   const workspaceDir = getWorkspaceDir();
@@ -145,6 +147,7 @@ export async function injectMemoryV2Block(
     assistantText: assistantMessage,
     nowText,
     config,
+    signal,
   });
 
   // (4) Own activation: A_o = d·prev + c_user·sim_u + c_a·sim_a + c_now·sim_n.
@@ -156,6 +159,7 @@ export async function injectMemoryV2Block(
       assistantText: assistantMessage,
       nowText,
       config,
+      signal,
     });
 
   // (5) Spreading activation across the edge graph (k, hops from config).

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -146,6 +146,7 @@ export async function simBatch(
   text: string,
   candidateSlugs: readonly string[],
   config: AssistantConfig,
+  signal?: AbortSignal,
 ): Promise<Map<string, number>> {
   if (candidateSlugs.length === 0) {
     return new Map();
@@ -157,7 +158,7 @@ export async function simBatch(
   // Sparse uses BM25: the query side encodes binary occurrences per token,
   // and the stored doc vectors carry the IDF · TF-saturated weights — Qdrant
   // dot product then yields the BM25 score directly.
-  const denseResult = await embedWithBackend(config, [text]);
+  const denseResult = await embedWithBackend(config, [text], { signal });
   const denseVector = await applyCorrectionIfCalibrated(
     denseResult.vectors[0],
     denseResult.provider,

--- a/assistant/src/plugins/defaults/memory-retrieval.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval.ts
@@ -93,6 +93,18 @@ export interface DefaultMemoryRetrievalDeps {
 }
 
 /**
+ * Read only the cheap static memory sources. Used as the graceful fallback
+ * when graph retrieval exceeds the turn budget.
+ */
+export function readStaticMemoryResult(): MemoryResult {
+  return {
+    pkbContent: readPkbContext(),
+    nowContent: readNowScratchpad(),
+    memoryGraphBlocks: [],
+  };
+}
+
+/**
  * Run the default retrieval. Always returns a {@link MemoryResult}; skips
  * the memory-graph call entirely when the actor is not trusted (matches the
  * prior agent-loop gate).
@@ -108,17 +120,12 @@ export async function runDefaultMemoryRetrieval(
 ): Promise<MemoryResult> {
   // NOW.md and PKB are read unconditionally — the agent loop decides
   // whether to inject them based on first-turn / post-compaction gating.
-  const pkbContent = readPkbContext();
-  const nowContent = readNowScratchpad();
+  const staticResult = readStaticMemoryResult();
 
   if (!deps.isTrustedActor) {
     // Untrusted actors skip memory-graph retrieval entirely — preserves the
     // pre-plugin gate that lived inline in `conversation-agent-loop.ts`.
-    return {
-      pkbContent,
-      nowContent,
-      memoryGraphBlocks: [],
-    };
+    return staticResult;
   }
 
   const graphResult = await deps.graphMemory.prepareMemory(
@@ -134,8 +141,8 @@ export async function runDefaultMemoryRetrieval(
   };
 
   return {
-    pkbContent,
-    nowContent,
+    pkbContent: staticResult.pkbContent,
+    nowContent: staticResult.nowContent,
     memoryGraphBlocks: [payload],
   };
 }

--- a/assistant/src/plugins/pipeline.ts
+++ b/assistant/src/plugins/pipeline.ts
@@ -64,7 +64,7 @@ export const DEFAULT_TIMEOUTS: Record<PipelineName, number | null> = {
   turn: null,
   llmCall: null,
   toolExecute: null,
-  memoryRetrieval: null,
+  memoryRetrieval: 5_000,
   historyRepair: null,
   tokenEstimate: null,
   compaction: null,


### PR DESCRIPTION
## Summary
- restore the documented 5s timeout for the memoryRetrieval plugin pipeline
- fall back to static PKB/NOW memory when graph memory exceeds the turn budget
- propagate abort signals through memory v2 injection/embedding work so abandoned retrieval can stop

## Why
Local repro logs showed the user message was accepted, but the agent loop did not start until roughly 4m29s later because the turn was blocked in memory retrieval before the LLM call. Memory graph retrieval is auxiliary context, so it should not prevent the assistant from starting a response.

## Validation
- bun test src/__tests__/pipeline-runner.test.ts src/__tests__/memory-retrieval-pipeline.test.ts src/memory/v2/__tests__/injection.test.ts src/memory/v2/__tests__/activation.test.ts src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
- bunx tsc --noEmit
- pre-commit: formatting, eslint, assistant type-check
- pre-push: assistant type-check and eslint

## Follow-up
The web client should separately harden SSE stream-health tracking so an existing stream handle is not treated as proof of a healthy stream. That is defense-in-depth; the observed local delay was backend memory retrieval blocking the agent loop before any assistant tokens existed to stream.