### PR TITLE
feat(macos): add Adjust Plan and Configure Auto Top Ups buttons to billing tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -460,7 +460,10 @@ struct SettingsPanel: View {
         case .permissionsAndPrivacy:
             permissionsAndPrivacyContent
         case .billing:
-            SettingsBillingTab(authManager: authManager)
+            SettingsBillingTab(
+                authManager: authManager,
+                assistantFeatureFlagStore: assistantFeatureFlagStore
+            )
         case .archivedConversations:
             SettingsArchivedConversationsTab(conversationManager: conversationManager)
         case .schedules:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 @MainActor
 struct SettingsBillingTab: View {
     var authManager: AuthManager
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
 
     @State private var summary: BillingSummaryResponse?
     @State private var isLoading: Bool = true
@@ -18,6 +19,11 @@ struct SettingsBillingTab: View {
     private var effectiveAmount: String {
         topUpAmounts.contains(selectedAmount) ? selectedAmount : topUpAmounts.first ?? ""
     }
+
+    var isProPlanAdjustEnabled: Bool {
+        assistantFeatureFlagStore.isEnabled("pro-plan-adjust")
+    }
+
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
@@ -26,6 +32,9 @@ struct SettingsBillingTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             balanceCard
+            if isProPlanAdjustEnabled {
+                adjustPlanCard
+            }
             if isLoading {
                 addFundsSkeleton
             } else if !topUpAmounts.isEmpty {
@@ -160,6 +169,19 @@ struct SettingsBillingTab: View {
         }
     }
 
+    // MARK: - Adjust Plan Card
+
+    private var adjustPlanCard: some View {
+        SettingsCard(title: "Adjust Plan") {
+            VButton(
+                label: "Adjust Plan",
+                style: .primary
+            ) {
+                NSWorkspace.shared.open(AppURLs.billingSettings)
+            }
+        }
+    }
+
     // MARK: - Add Credits Skeleton
 
     private var addFundsSkeleton: some View {
@@ -239,12 +261,22 @@ struct SettingsBillingTab: View {
                 .frame(maxWidth: 200)
             }
 
-            VButton(
-                label: isProcessingTopUp ? "Processing..." : "Add credits",
-                style: .primary,
-                isDisabled: isProcessingTopUp
-            ) {
-                Task { await handleTopUp() }
+            HStack(spacing: VSpacing.sm) {
+                VButton(
+                    label: isProcessingTopUp ? "Processing..." : "Add credits",
+                    style: .primary,
+                    isDisabled: isProcessingTopUp
+                ) {
+                    Task { await handleTopUp() }
+                }
+                if isProPlanAdjustEnabled {
+                    VButton(
+                        label: "Configure Auto Top Ups",
+                        style: .outlined
+                    ) {
+                        NSWorkspace.shared.open(AppURLs.billingSettings)
+                    }
+                }
             }
 
             if let topUpError {
@@ -350,8 +382,13 @@ extension SettingsBillingTab {
     /// without going through the `loadSummary()` async path. Used by
     /// `SettingsBillingTabSubtitleTests` to exercise `addCreditsSubtitleAttributed`
     /// against a known billing summary fixture.
-    init(authManager: AuthManager, initialSummary: BillingSummaryResponse?) {
+    init(
+        authManager: AuthManager,
+        assistantFeatureFlagStore: AssistantFeatureFlagStore,
+        initialSummary: BillingSummaryResponse?
+    ) {
         self.authManager = authManager
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self._summary = State(initialValue: initialSummary)
     }
 }

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class SettingsBillingTabFeatureFlagTests: XCTestCase {
+    func testProPlanAdjustReadsFlagFromStore() {
+        AssistantFeatureFlagResolver.writeCachedFlags(["pro-plan-adjust": true])
+        defer { AssistantFeatureFlagResolver.clearCachedFlags() }
+
+        let store = AssistantFeatureFlagStore()
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: store,
+            initialSummary: nil
+        )
+        XCTAssertTrue(view.isProPlanAdjustEnabled)
+    }
+
+    func testProPlanAdjustDefaultsFalseWhenNoOverride() {
+        AssistantFeatureFlagResolver.clearCachedFlags()
+        let store = AssistantFeatureFlagStore()
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: store,
+            initialSummary: nil
+        )
+        XCTAssertFalse(view.isProPlanAdjustEnabled)
+    }
+}

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
@@ -33,13 +33,21 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
     // MARK: - Tests
 
     func testSubtitleNilWhenSummaryNotLoaded() {
-        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: nil)
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: nil
+        )
         XCTAssertNil(view.addCreditsSubtitleAttributed)
     }
 
     func testSubtitleContainsPricingLink() {
         let summary = makeSummary(maximumBalance: "1000")
-        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: summary)
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: summary
+        )
 
         let attributed = view.addCreditsSubtitleAttributed
         XCTAssertNotNil(attributed)
@@ -62,7 +70,11 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
         defer { unsetenv("VELLUM_DOCS_BASE_URL") }
 
         let summary = makeSummary(maximumBalance: "1000")
-        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: summary)
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: summary
+        )
 
         let attributed = view.addCreditsSubtitleAttributed
         let linkRun = attributed?.runs.first { $0.link != nil }


### PR DESCRIPTION
## Summary
- Inject `AssistantFeatureFlagStore` into `SettingsBillingTab` and read the `pro-plan-adjust` flag
- When the flag is enabled, render an "Adjust Plan" card between Balance and Add Credits, plus a "Configure Auto Top Ups" outlined button next to "Add credits"
- Both new buttons open `AppURLs.billingSettings` (the web app billing settings page)

Part of plan: billing-adjust-plan.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->