### PR TITLE
fix(macos-tests): unbreak SettingsBillingTabFeatureFlagTests under swift test

### DIFF
--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -3,11 +3,14 @@ import XCTest
 
 final class AppURLsTests: XCTestCase {
     private var originalEnvValue: String?
+    private var originalWebEnvValue: String?
 
     override func setUp() {
         super.setUp()
         originalEnvValue = ProcessInfo.processInfo.environment["VELLUM_DOCS_BASE_URL"]
         unsetenv("VELLUM_DOCS_BASE_URL")
+        originalWebEnvValue = ProcessInfo.processInfo.environment["VELLUM_WEB_URL"]
+        unsetenv("VELLUM_WEB_URL")
     }
 
     override func tearDown() {
@@ -15,6 +18,11 @@ final class AppURLsTests: XCTestCase {
             setenv("VELLUM_DOCS_BASE_URL", value, 1)
         } else {
             unsetenv("VELLUM_DOCS_BASE_URL")
+        }
+        if let value = originalWebEnvValue {
+            setenv("VELLUM_WEB_URL", value, 1)
+        } else {
+            unsetenv("VELLUM_WEB_URL")
         }
         super.tearDown()
     }

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
@@ -4,11 +4,36 @@ import XCTest
 
 @MainActor
 final class SettingsBillingTabFeatureFlagTests: XCTestCase {
+    private let proPlanAdjustKey = "pro-plan-adjust"
+
+    /// Build a registry containing only the `pro-plan-adjust` entry. Mirrors the
+    /// pattern in `AssistantFeatureFlagResolverTests.makeRegistry` — passing an
+    /// explicit registry avoids depending on `Bundle.main` resources, which are
+    /// only populated for the bundled `.app` (not the SPM test target).
+    private func makeRegistry(defaultEnabled: Bool) -> FeatureFlagRegistry {
+        FeatureFlagRegistry(
+            version: 1,
+            flags: [
+                FeatureFlagDefinition(
+                    id: "pro-plan-adjust",
+                    scope: .assistant,
+                    key: proPlanAdjustKey,
+                    label: "Pro Plan Adjust",
+                    description: "Show the 'Adjust Plan' and 'Configure Auto Top Ups' CTAs in the macOS Settings → Billing tab.",
+                    defaultEnabled: defaultEnabled
+                )
+            ]
+        )
+    }
+
     func testProPlanAdjustReadsFlagFromStore() {
-        AssistantFeatureFlagResolver.writeCachedFlags(["pro-plan-adjust": true])
+        AssistantFeatureFlagResolver.writeCachedFlags([proPlanAdjustKey: true])
         defer { AssistantFeatureFlagResolver.clearCachedFlags() }
 
-        let store = AssistantFeatureFlagStore()
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false)
+        )
         let view = SettingsBillingTab(
             authManager: AuthManager(),
             assistantFeatureFlagStore: store,
@@ -19,7 +44,10 @@ final class SettingsBillingTabFeatureFlagTests: XCTestCase {
 
     func testProPlanAdjustDefaultsFalseWhenNoOverride() {
         AssistantFeatureFlagResolver.clearCachedFlags()
-        let store = AssistantFeatureFlagStore()
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false)
+        )
         let view = SettingsBillingTab(
             authManager: AuthManager(),
             assistantFeatureFlagStore: store,


### PR DESCRIPTION
## Summary
Two test-hygiene fixes caught during plan self-review:

- `SettingsBillingTabFeatureFlagTests` was constructing `AssistantFeatureFlagStore()` with no explicit registry, but the bundled `feature-flag-registry.json` is only loaded via `Bundle.main` for the `.app` bundle — not for the SPM test target. Under `swift test`, `registryDefaults` would be empty and `isEnabled("pro-plan-adjust")` would fall through the `?? true` fallback, breaking the `XCTAssertFalse` assertion. Pass an explicit registry mirroring `AssistantFeatureFlagResolverTests.makeRegistry`.
- `AppURLsTests` symmetrically saved/restored `VELLUM_DOCS_BASE_URL` in setUp/tearDown but only used per-test `defer { unsetenv("VELLUM_WEB_URL") }` for the new billing tests, clobbering any value from the developer's shell. Snapshot `VELLUM_WEB_URL` in setUp and restore it in tearDown.

Part of plan: billing-adjust-plan.md (self-review fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->