### PR TITLE
fix(macos-tests): drop redundant per-test VELLUM_WEB_URL defer cleanup

### DIFF
--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -147,7 +147,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsHonorsWebURLOverride() {
         setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         XCTAssertEqual(
             AppURLs.billingSettings.absoluteString,
             "https://staging-assistant.vellum.ai/assistant/settings/billing"
@@ -156,7 +155,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsStripsTrailingSlash() {
         setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai/", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         XCTAssertEqual(
             AppURLs.billingSettings.absoluteString,
             "https://staging-assistant.vellum.ai/assistant/settings/billing"
@@ -165,7 +163,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideMalformed() {
         setenv("VELLUM_WEB_URL", "not a url with spaces", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         // Should fall back to the env-default web URL rather than crash.
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
@@ -174,7 +171,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideHasNoScheme() {
         setenv("VELLUM_WEB_URL", "example.com/path", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
         XCTAssertFalse(result.contains("example.com"))
@@ -182,7 +178,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideHasQuery() {
         setenv("VELLUM_WEB_URL", "https://example.com?foo=bar", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
         XCTAssertFalse(result.contains("?foo=bar"))
@@ -190,7 +185,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideHasFragment() {
         setenv("VELLUM_WEB_URL", "https://example.com#section", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
         XCTAssertFalse(result.contains("#section"))


### PR DESCRIPTION
## Summary
The setUp/tearDown pair added in #29652 snapshots and restores `VELLUM_WEB_URL` across all tests in `AppURLsTests`. The six per-test `defer { unsetenv("VELLUM_WEB_URL") }` calls in the new billing-settings tests are now both redundant (tearDown handles cleanup) and strictly inferior (they unset rather than restore).

Delete the dead defers.

Part of plan: billing-adjust-plan.md (self-review fix-r2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->