### PR TITLE
feat(macos): Adjust Plan and Configure Auto Top Ups buttons in billing tab (gated by pro-plan-adjust)

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VellumAssistantShared
 
 /// Centralized URLs the macOS app links out to.
 ///
@@ -70,6 +71,38 @@ public enum AppURLs {
     /// AI Data Sharing Policy docs — linked from the onboarding AI data consent checkbox.
     public static var dataSharingDocs: URL {
         docsURL(path: "/data-sharing")
+    }
+
+    // MARK: - Web app URLs
+
+    /// Web app billing settings page — opened from the Settings → Billing tab's
+    /// "Adjust Plan" and "Configure Auto Top Ups" buttons (both gated by the
+    /// `pro-plan-adjust` feature flag). Resolves to the Next.js web app at
+    /// `<webURL>/assistant/settings/billing` for the current build environment.
+    ///
+    /// If `VELLUM_WEB_URL` is set but malformed (no scheme/host, non-http(s),
+    /// or contains a query/fragment), falls back to the canonical environment
+    /// URL via `VellumEnvironment.current.webURL`. Query/fragment are rejected
+    /// because string-concatenating a literal path onto `https://host?foo=bar`
+    /// would produce `https://host?foo=bar/assistant/settings/billing` — the
+    /// path gets absorbed into the query string. Mirrors the validation in
+    /// `docsBaseURL` above. Force-unwrap on the final `URL(string:)` is safe
+    /// because both candidate base strings are validated/known-good and the
+    /// path is a literal.
+    public static var billingSettings: URL {
+        let candidate = VellumEnvironment.resolvedWebURL
+        let base: String
+        if let url = URL(string: candidate),
+           let scheme = url.scheme?.lowercased(),
+           (scheme == "http" || scheme == "https"),
+           url.host != nil,
+           url.query == nil,
+           url.fragment == nil {
+            base = candidate
+        } else {
+            base = VellumEnvironment.current.webURL
+        }
+        return URL(string: "\(base)/assistant/settings/billing")!
     }
 
     // MARK: - Source repository

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -460,7 +460,10 @@ struct SettingsPanel: View {
         case .permissionsAndPrivacy:
             permissionsAndPrivacyContent
         case .billing:
-            SettingsBillingTab(authManager: authManager)
+            SettingsBillingTab(
+                authManager: authManager,
+                assistantFeatureFlagStore: assistantFeatureFlagStore
+            )
         case .archivedConversations:
             SettingsArchivedConversationsTab(conversationManager: conversationManager)
         case .schedules:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 @MainActor
 struct SettingsBillingTab: View {
     var authManager: AuthManager
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
 
     @State private var summary: BillingSummaryResponse?
     @State private var isLoading: Bool = true
@@ -18,6 +19,11 @@ struct SettingsBillingTab: View {
     private var effectiveAmount: String {
         topUpAmounts.contains(selectedAmount) ? selectedAmount : topUpAmounts.first ?? ""
     }
+
+    var isProPlanAdjustEnabled: Bool {
+        assistantFeatureFlagStore.isEnabled("pro-plan-adjust")
+    }
+
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
@@ -26,6 +32,9 @@ struct SettingsBillingTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             balanceCard
+            if isProPlanAdjustEnabled {
+                adjustPlanCard
+            }
             if isLoading {
                 addFundsSkeleton
             } else if !topUpAmounts.isEmpty {
@@ -160,6 +169,19 @@ struct SettingsBillingTab: View {
         }
     }
 
+    // MARK: - Adjust Plan Card
+
+    private var adjustPlanCard: some View {
+        SettingsCard(title: "Adjust Plan") {
+            VButton(
+                label: "Adjust Plan",
+                style: .primary
+            ) {
+                NSWorkspace.shared.open(AppURLs.billingSettings)
+            }
+        }
+    }
+
     // MARK: - Add Credits Skeleton
 
     private var addFundsSkeleton: some View {
@@ -239,12 +261,22 @@ struct SettingsBillingTab: View {
                 .frame(maxWidth: 200)
             }
 
-            VButton(
-                label: isProcessingTopUp ? "Processing..." : "Add credits",
-                style: .primary,
-                isDisabled: isProcessingTopUp
-            ) {
-                Task { await handleTopUp() }
+            HStack(spacing: VSpacing.sm) {
+                VButton(
+                    label: isProcessingTopUp ? "Processing..." : "Add credits",
+                    style: .primary,
+                    isDisabled: isProcessingTopUp
+                ) {
+                    Task { await handleTopUp() }
+                }
+                if isProPlanAdjustEnabled {
+                    VButton(
+                        label: "Configure Auto Top Ups",
+                        style: .outlined
+                    ) {
+                        NSWorkspace.shared.open(AppURLs.billingSettings)
+                    }
+                }
             }
 
             if let topUpError {
@@ -350,8 +382,13 @@ extension SettingsBillingTab {
     /// without going through the `loadSummary()` async path. Used by
     /// `SettingsBillingTabSubtitleTests` to exercise `addCreditsSubtitleAttributed`
     /// against a known billing summary fixture.
-    init(authManager: AuthManager, initialSummary: BillingSummaryResponse?) {
+    init(
+        authManager: AuthManager,
+        assistantFeatureFlagStore: AssistantFeatureFlagStore,
+        initialSummary: BillingSummaryResponse?
+    ) {
         self.authManager = authManager
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self._summary = State(initialValue: initialSummary)
     }
 }

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -134,4 +134,57 @@ final class AppURLsTests: XCTestCase {
         XCTAssertEqual(AppURLs.docsURL(path: "/pricing").absoluteString, "https://www.vellum.ai/docs/pricing")
         XCTAssertEqual(AppURLs.docsURL(path: "pricing").absoluteString, "https://www.vellum.ai/docs/pricing")
     }
+
+    // MARK: - Billing settings web URL
+
+    func testBillingSettingsHonorsWebURLOverride() {
+        setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        XCTAssertEqual(
+            AppURLs.billingSettings.absoluteString,
+            "https://staging-assistant.vellum.ai/assistant/settings/billing"
+        )
+    }
+
+    func testBillingSettingsStripsTrailingSlash() {
+        setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai/", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        XCTAssertEqual(
+            AppURLs.billingSettings.absoluteString,
+            "https://staging-assistant.vellum.ai/assistant/settings/billing"
+        )
+    }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideMalformed() {
+        setenv("VELLUM_WEB_URL", "not a url with spaces", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        // Should fall back to the env-default web URL rather than crash.
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("not a url with spaces"))
+    }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideHasNoScheme() {
+        setenv("VELLUM_WEB_URL", "example.com/path", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("example.com"))
+    }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideHasQuery() {
+        setenv("VELLUM_WEB_URL", "https://example.com?foo=bar", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("?foo=bar"))
+    }
+
+    func testBillingSettingsFallsBackWhenWebURLOverrideHasFragment() {
+        setenv("VELLUM_WEB_URL", "https://example.com#section", 1)
+        defer { unsetenv("VELLUM_WEB_URL") }
+        let result = AppURLs.billingSettings.absoluteString
+        XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
+        XCTAssertFalse(result.contains("#section"))
+    }
 }

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -147,7 +147,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsHonorsWebURLOverride() {
         setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         XCTAssertEqual(
             AppURLs.billingSettings.absoluteString,
             "https://staging-assistant.vellum.ai/assistant/settings/billing"
@@ -156,7 +155,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsStripsTrailingSlash() {
         setenv("VELLUM_WEB_URL", "https://staging-assistant.vellum.ai/", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         XCTAssertEqual(
             AppURLs.billingSettings.absoluteString,
             "https://staging-assistant.vellum.ai/assistant/settings/billing"
@@ -165,7 +163,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideMalformed() {
         setenv("VELLUM_WEB_URL", "not a url with spaces", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         // Should fall back to the env-default web URL rather than crash.
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
@@ -174,7 +171,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideHasNoScheme() {
         setenv("VELLUM_WEB_URL", "example.com/path", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
         XCTAssertFalse(result.contains("example.com"))
@@ -182,7 +178,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideHasQuery() {
         setenv("VELLUM_WEB_URL", "https://example.com?foo=bar", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
         XCTAssertFalse(result.contains("?foo=bar"))
@@ -190,7 +185,6 @@ final class AppURLsTests: XCTestCase {
 
     func testBillingSettingsFallsBackWhenWebURLOverrideHasFragment() {
         setenv("VELLUM_WEB_URL", "https://example.com#section", 1)
-        defer { unsetenv("VELLUM_WEB_URL") }
         let result = AppURLs.billingSettings.absoluteString
         XCTAssertTrue(result.hasSuffix("/assistant/settings/billing"))
         XCTAssertFalse(result.contains("#section"))

--- a/clients/macos/vellum-assistantTests/AppURLsTests.swift
+++ b/clients/macos/vellum-assistantTests/AppURLsTests.swift
@@ -3,11 +3,14 @@ import XCTest
 
 final class AppURLsTests: XCTestCase {
     private var originalEnvValue: String?
+    private var originalWebEnvValue: String?
 
     override func setUp() {
         super.setUp()
         originalEnvValue = ProcessInfo.processInfo.environment["VELLUM_DOCS_BASE_URL"]
         unsetenv("VELLUM_DOCS_BASE_URL")
+        originalWebEnvValue = ProcessInfo.processInfo.environment["VELLUM_WEB_URL"]
+        unsetenv("VELLUM_WEB_URL")
     }
 
     override func tearDown() {
@@ -15,6 +18,11 @@ final class AppURLsTests: XCTestCase {
             setenv("VELLUM_DOCS_BASE_URL", value, 1)
         } else {
             unsetenv("VELLUM_DOCS_BASE_URL")
+        }
+        if let value = originalWebEnvValue {
+            setenv("VELLUM_WEB_URL", value, 1)
+        } else {
+            unsetenv("VELLUM_WEB_URL")
         }
         super.tearDown()
     }

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
@@ -4,11 +4,36 @@ import XCTest
 
 @MainActor
 final class SettingsBillingTabFeatureFlagTests: XCTestCase {
+    private let proPlanAdjustKey = "pro-plan-adjust"
+
+    /// Build a registry containing only the `pro-plan-adjust` entry. Mirrors the
+    /// pattern in `AssistantFeatureFlagResolverTests.makeRegistry` — passing an
+    /// explicit registry avoids depending on `Bundle.main` resources, which are
+    /// only populated for the bundled `.app` (not the SPM test target).
+    private func makeRegistry(defaultEnabled: Bool) -> FeatureFlagRegistry {
+        FeatureFlagRegistry(
+            version: 1,
+            flags: [
+                FeatureFlagDefinition(
+                    id: "pro-plan-adjust",
+                    scope: .assistant,
+                    key: proPlanAdjustKey,
+                    label: "Pro Plan Adjust",
+                    description: "Show the 'Adjust Plan' and 'Configure Auto Top Ups' CTAs in the macOS Settings → Billing tab.",
+                    defaultEnabled: defaultEnabled
+                )
+            ]
+        )
+    }
+
     func testProPlanAdjustReadsFlagFromStore() {
-        AssistantFeatureFlagResolver.writeCachedFlags(["pro-plan-adjust": true])
+        AssistantFeatureFlagResolver.writeCachedFlags([proPlanAdjustKey: true])
         defer { AssistantFeatureFlagResolver.clearCachedFlags() }
 
-        let store = AssistantFeatureFlagStore()
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false)
+        )
         let view = SettingsBillingTab(
             authManager: AuthManager(),
             assistantFeatureFlagStore: store,
@@ -19,7 +44,10 @@ final class SettingsBillingTabFeatureFlagTests: XCTestCase {
 
     func testProPlanAdjustDefaultsFalseWhenNoOverride() {
         AssistantFeatureFlagResolver.clearCachedFlags()
-        let store = AssistantFeatureFlagStore()
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false)
+        )
         let view = SettingsBillingTab(
             authManager: AuthManager(),
             assistantFeatureFlagStore: store,

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class SettingsBillingTabFeatureFlagTests: XCTestCase {
+    func testProPlanAdjustReadsFlagFromStore() {
+        AssistantFeatureFlagResolver.writeCachedFlags(["pro-plan-adjust": true])
+        defer { AssistantFeatureFlagResolver.clearCachedFlags() }
+
+        let store = AssistantFeatureFlagStore()
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: store,
+            initialSummary: nil
+        )
+        XCTAssertTrue(view.isProPlanAdjustEnabled)
+    }
+
+    func testProPlanAdjustDefaultsFalseWhenNoOverride() {
+        AssistantFeatureFlagResolver.clearCachedFlags()
+        let store = AssistantFeatureFlagStore()
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: store,
+            initialSummary: nil
+        )
+        XCTAssertFalse(view.isProPlanAdjustEnabled)
+    }
+}

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
@@ -33,13 +33,21 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
     // MARK: - Tests
 
     func testSubtitleNilWhenSummaryNotLoaded() {
-        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: nil)
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: nil
+        )
         XCTAssertNil(view.addCreditsSubtitleAttributed)
     }
 
     func testSubtitleContainsPricingLink() {
         let summary = makeSummary(maximumBalance: "1000")
-        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: summary)
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: summary
+        )
 
         let attributed = view.addCreditsSubtitleAttributed
         XCTAssertNotNil(attributed)
@@ -62,7 +70,11 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
         defer { unsetenv("VELLUM_DOCS_BASE_URL") }
 
         let summary = makeSummary(maximumBalance: "1000")
-        let view = SettingsBillingTab(authManager: AuthManager(), initialSummary: summary)
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: summary
+        )
 
         let attributed = view.addCreditsSubtitleAttributed
         let linkRun = attributed?.runs.first { $0.link != nil }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -272,6 +272,14 @@
       "label": "Analyze Conversation",
       "description": "Show the 'Analyze' / 'Analyze conversation' option in conversation context menus and the conversation title actions dropdown.",
       "defaultEnabled": false
+    },
+    {
+      "id": "pro-plan-adjust",
+      "scope": "assistant",
+      "key": "pro-plan-adjust",
+      "label": "Pro Plan Adjust",
+      "description": "Show the 'Adjust Plan' and 'Configure Auto Top Ups' CTAs in the macOS Settings → Billing tab. Both open the web app's billing settings page.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds two buttons to the macOS Settings → Billing tab gated by the existing `pro-plan-adjust` LaunchDarkly feature flag:
- An "Adjust Plan" card with a primary button between Balance and Add Credits.
- A "Configure Auto Top Ups" outlined button next to "Add credits".

Both open `<webURL>/assistant/settings/billing` via the new `AppURLs.billingSettings` accessor (validated, with fallback for malformed `VELLUM_WEB_URL` overrides). The flag already exists in the platform's LaunchDarkly Terraform (`vellum-assistant-platform/terraform/gcp/env/prod/vellum-assistant/main.tf:696`) — no cross-repo work required.

## Self-review result
GAPS FOUND across 2 rounds, 3 gaps fixed across 2 fix PRs. Round 3 returned PASS for all 4 review passes.

## PRs merged into feature branch
- #29647: feat(feature-flags): register pro-plan-adjust assistant flag
- #29648: feat(macos): add AppURLs.billingSettings accessor for web billing page
- #29651: feat(macos): add Adjust Plan and Configure Auto Top Ups buttons to billing tab

### Fix PRs
- #29652: fix(macos-tests): unbreak SettingsBillingTabFeatureFlagTests under swift test
- #29653: fix(macos-tests): drop redundant per-test VELLUM_WEB_URL defer cleanup

Part of plan: billing-adjust-plan.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->