### PR TITLE
fix(auth): use native_auth_start + code exchange + per-environment URL scheme on macOS (ATL-454)

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -765,6 +765,15 @@ case "$VELLUM_ENVIRONMENT" in
 esac
 echo "BUNDLE_ID=$BUNDLE_ID"
 
+# Derive a per-environment URL scheme for native auth callbacks.
+# Matches the iOS xcconfig pattern (App-Dev.xcconfig → vellum-assistant-dev,
+# App-Staging.xcconfig → vellum-assistant-staging, App.xcconfig → vellum-assistant).
+case "$VELLUM_ENVIRONMENT" in
+    production) BUNDLE_URL_SCHEME="vellum-assistant" ;;
+    *)          BUNDLE_URL_SCHEME="vellum-assistant-${VELLUM_ENVIRONMENT}" ;;
+esac
+echo "BUNDLE_URL_SCHEME=$BUNDLE_URL_SCHEME"
+
 # ---------------------------------------------------------------------------
 # Resolve dock display name from the environment-scoped XDG config directory.
 # Mirrors VellumPaths.configDir (Swift) and getConfigDir() (TS):
@@ -1491,7 +1500,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
             <string>$BUNDLE_ID.auth</string>
             <key>CFBundleURLSchemes</key>
             <array>
-                <string>vellum-assistant</string>
+                <string>$BUNDLE_URL_SCHEME</string>
             </array>
         </dict>
     </array>

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -151,7 +151,9 @@ public final class AuthManager {
         defer { isSubmitting = false }
 
         do {
-            let stateParam = generateRandomString(length: 32)
+            guard let stateParam = generateRandomString(length: 32) else {
+                throw AuthServiceError.authCallbackFailed("Failed to generate secure random state.")
+            }
 
             // Build /accounts/native/start?state={state}. The server
             // determines the callback scheme from settings.ENVIRONMENT
@@ -284,9 +286,14 @@ public final class AuthManager {
         }
     }
 
-    private func generateRandomString(length: Int) -> String {
+    /// Generate a cryptographically random base64url string.
+    /// Returns `nil` if the system RNG is unavailable — callers must
+    /// treat this as a fatal condition since the state parameter is the
+    /// sole CSRF defense on the auth callback.
+    private func generateRandomString(length: Int) -> String? {
         var bytes = [UInt8](repeating: 0, count: length)
-        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else { return nil }
         return Data(bytes).base64URLEncodedString()
     }
 

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -28,7 +28,21 @@ public final class AuthManager {
     public var errorMessage: String?
 
     private let authService = AuthService.shared
-    private static let callbackScheme = "vellum-assistant"
+    /// Read the URL scheme from the bundle's CFBundleURLTypes rather than
+    /// hardcoding it. Each environment gets its own scheme at build time
+    /// (e.g. vellum-assistant-dev, vellum-assistant-staging). Falls back
+    /// to "vellum-assistant" if the plist entry is missing.
+    private static let callbackScheme: String = {
+        guard let urlTypes = Bundle.main.infoDictionary?["CFBundleURLTypes"] as? [[String: Any]],
+              let schemes = urlTypes.first?["CFBundleURLSchemes"] as? [String],
+              let scheme = schemes.first,
+              !scheme.isEmpty,
+              !scheme.contains("$")
+        else {
+            return "vellum-assistant"
+        }
+        return scheme
+    }()
     private var webAuthSession: ASWebAuthenticationSession?
 
     /// Optional hook invoked after a successful authentication (both the fresh

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -159,16 +159,18 @@ public final class AuthManager {
                 throw AuthServiceError.authCallbackFailed("Missing callback URL components.")
             }
 
-            guard let returnedState = queryItems.first(where: { $0.name == "state" })?.value else {
+            let returnedState = queryItems.first(where: { $0.name == "state" })?.value
+
+            if let authError = queryItems.first(where: { $0.name == "error" })?.value, !authError.isEmpty {
+                throw AuthServiceError.authCallbackFailed("Auth error: \(authError)")
+            }
+
+            guard let returnedState else {
                 throw AuthServiceError.authCallbackFailed("Callback missing state.")
             }
 
             guard returnedState == stateParam else {
                 throw AuthServiceError.authCallbackFailed("State mismatch — possible CSRF.")
-            }
-
-            if let authError = queryItems.first(where: { $0.name == "error" })?.value, !authError.isEmpty {
-                throw AuthServiceError.authCallbackFailed("Auth error: \(authError)")
             }
 
             guard let code = queryItems.first(where: { $0.name == "code" })?.value, !code.isEmpty else {

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -138,40 +138,57 @@ public final class AuthManager {
 
         do {
             let stateParam = generateRandomString(length: 32)
-            let returnTo = "/accounts/native/callback?state=\(stateParam)"
-            var allowedReturnToChars = CharacterSet.urlQueryAllowed
-            allowedReturnToChars.remove(charactersIn: "?=&+")
-            guard let encodedReturnTo = returnTo.addingPercentEncoding(withAllowedCharacters: allowedReturnToChars) else {
+
+            // Build /accounts/native/start?state={state}. The server
+            // determines the callback scheme from settings.ENVIRONMENT
+            // — the client no longer sends it (ATL-454).
+            guard var startComponents = URLComponents(string: VellumEnvironment.resolvedWebURL) else {
                 throw AuthServiceError.invalidURL
             }
-            let loginURLString = "\(VellumEnvironment.resolvedWebURL)/account/login?returnTo=\(encodedReturnTo)"
-            guard let loginURL = URL(string: loginURLString) else {
+            startComponents.path = "/accounts/native/start"
+            startComponents.queryItems = [URLQueryItem(name: "state", value: stateParam)]
+
+            guard let loginURL = startComponents.url else {
                 throw AuthServiceError.invalidURL
             }
 
             let callbackURL = try await performWebAuth(url: loginURL, callbackScheme: Self.callbackScheme)
 
             guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
-                  let sessionToken = components.queryItems?.first(where: { $0.name == "session_token" })?.value,
-                  let returnedState = components.queryItems?.first(where: { $0.name == "state" })?.value else {
-                throw AuthServiceError.authCallbackFailed("Missing session token or state in callback.")
+                  let queryItems = components.queryItems else {
+                throw AuthServiceError.authCallbackFailed("Missing callback URL components.")
+            }
+
+            guard let returnedState = queryItems.first(where: { $0.name == "state" })?.value else {
+                throw AuthServiceError.authCallbackFailed("Callback missing state.")
             }
 
             guard returnedState == stateParam else {
-                throw AuthServiceError.authCallbackFailed("Invalid state parameter.")
+                throw AuthServiceError.authCallbackFailed("State mismatch — possible CSRF.")
             }
+
+            if let authError = queryItems.first(where: { $0.name == "error" })?.value, !authError.isEmpty {
+                throw AuthServiceError.authCallbackFailed("Auth error: \(authError)")
+            }
+
+            guard let code = queryItems.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+                throw AuthServiceError.authCallbackFailed("Callback missing authorization code.")
+            }
+
+            // Exchange the one-time code for a session token via POST.
+            // The code is short-lived (30 s) and single-use (ATL-454).
+            let sessionToken = try await exchangeCodeForSession(code: code)
 
             await SessionTokenManager.setTokenAsync(sessionToken)
 
-            // Validate the session and populate user state
             let session = try await authService.getSession()
             if session.status == 200, session.meta?.is_authenticated != false, let user = session.data?.user {
                 state = .authenticated(user)
-                log.info("Login completed via Django auth flow for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
+                log.info("Login completed via native auth flow for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
                 await resolveOrganizationIdAfterAuth()
                 await postAuthenticationHook?()
             } else {
-                log.error("Session validation after Django auth flow did not return authenticated user. status=\(session.status, privacy: .public)")
+                log.error("Session validation after native auth flow did not return authenticated user. status=\(session.status, privacy: .public)")
                 errorMessage = "Authentication was not completed. Please try again."
             }
         } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
@@ -180,6 +197,38 @@ public final class AuthManager {
             log.error("Login failed: baseURL=\(VellumEnvironment.resolvedPlatformURL, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             errorMessage = "Unable to sign in. Please try again."
         }
+    }
+
+    /// Exchange a one-time authorization code for a session token.
+    private func exchangeCodeForSession(code: String) async throws -> String {
+        guard var exchangeComponents = URLComponents(string: VellumEnvironment.resolvedWebURL) else {
+            throw AuthServiceError.invalidURL
+        }
+        exchangeComponents.path = "/accounts/native/exchange"
+
+        guard let exchangeURL = exchangeComponents.url else {
+            throw AuthServiceError.invalidURL
+        }
+
+        var request = URLRequest(url: exchangeURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: ["code": code])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw AuthServiceError.authCallbackFailed("Code exchange failed with status \(statusCode).")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sessionToken = json["session_token"] as? String,
+              !sessionToken.isEmpty else {
+            throw AuthServiceError.authCallbackFailed("Code exchange returned invalid response.")
+        }
+
+        return sessionToken
     }
 
     /// Logs out by deleting the server session, clearing local tokens and


### PR DESCRIPTION
## Summary

Updates the macOS desktop app to use the new `/accounts/native/start` + code exchange flow (ATL-454) and adds per-environment URL scheme support.

### What changed

1. **`AuthManager.startWorkOSLogin()`** — builds a URL to `/accounts/native/start?state={state}` instead of `/account/login?returnTo=...`. The server determines the callback scheme from `settings.ENVIRONMENT`.
2. **Code exchange** — new `exchangeCodeForSession(code:)` method POSTs the one-time auth code to `/accounts/native/exchange` over HTTPS to get the session token. Session keys never transit the custom URL scheme.
3. **Per-environment URL scheme** — `build.sh` derives `BUNDLE_URL_SCHEME` from `VELLUM_ENVIRONMENT` (`dev` → `vellum-assistant-dev`, `staging` → `vellum-assistant-staging`, `production` → `vellum-assistant`). `AuthManager.swift` reads the scheme from `CFBundleURLSchemes` at runtime, matching the iOS `NativeAuthPlugin.swift` pattern.
4. **Error handling** — error param checked before state in callback (better diagnostics when server redirects with error but no state). `SecRandomCopyBytes` return value validated (was silently discarded).

### Why this is needed

The previous flow embedded raw Django session keys in custom URL scheme redirects (`vellum-assistant://auth/callback?session_token=<key>`). Any app can register a custom URL scheme on macOS — an attacker could intercept the redirect and steal the session. The hardcoded `vellum-assistant` scheme also broke environment isolation (all builds shared one scheme).

### Why it's safe

- **Mirrors proven iOS implementation** — the `NativeAuthPlugin.swift` pattern (dynamic scheme from `CFBundleURLSchemes`, code exchange POST, error-before-state ordering) is already shipping in production iOS builds.
- **Server fallback exists** — the platform PR (#5837, merged) includes a legacy macOS callback path: if a macOS client without this update calls the callback, it falls back to `_default_scheme()` with a warning log.
- **No retry on exchange** — correct, codes are single-use via atomic `cache.delete()` gate.
- **`!scheme.contains("$")` guard** — if the build variable isn't substituted, the literal `$BUNDLE_URL_SCHEME` string would appear in the plist. The guard catches this and falls back to `"vellum-assistant"`.

### Alternatives considered

- **Keep hardcoded scheme** — rejected. Breaks environment isolation and diverges from how iOS already handles this correctly via per-target xcconfigs.
- **Derive scheme from `VellumEnvironment` in Swift** — rejected. Reading from `CFBundleURLSchemes` is the standard Apple pattern and stays in sync with Info.plist registration automatically. See [Apple — Defining a Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app).
- **Ephemeral browser sessions (`prefersEphemeralWebBrowserSession = true`)** — iOS uses this to avoid stale WorkOS cookie loops. macOS keeps `false` (persistent) so users leverage existing Safari SSO sessions. Acceptable trade-off: if a user hits a stale cookie error, retrying clears it.

### References

- [Apple — ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession)
- [Apple — Defining a Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)
- [RFC 8252 — OAuth 2.0 for Native Apps](https://datatracker.ietf.org/doc/html/rfc8252)
- iOS reference: `vellum-assistant-platform/web/ios/App/App/NativeAuthPlugin.swift`

### Companion PRs

1. [vellum-ai/vellum-assistant-platform#5837](https://github.com/vellum-ai/vellum-assistant-platform/pull/5837) — server-side auth code exchange (merged)
2. [vellum-ai/vellum-assistant-platform#5858](https://github.com/vellum-ai/vellum-assistant-platform/pull/5858) — default allowlist + `vel up` environment sync (merge first)

## Review & Testing Checklist for Human

- [ ] Build in Xcode locally and verify login works with `vel up`
- [ ] Verify dev/staging builds register the correct environment-specific URL scheme in the generated Info.plist (`BUNDLE_URL_SCHEME` in build output)
- [ ] Confirm production build still registers `vellum-assistant`

### Root cause analysis

1. **How did the code get into this state?** The macOS auth flow predates the iOS Capacitor plugin. It went directly to `/account/login?returnTo=...`, bypassing `/accounts/native/start` entirely. The iOS plugin was built with proper per-environment schemes (xcconfigs + dynamic bundle reading), but the macOS client was never updated to match.

2. **What mistakes led to it?** The macOS and iOS auth implementations diverged without a shared abstraction. `build.sh` already derived per-environment `BUNDLE_ID` but didn't apply the same pattern to URL schemes — an inconsistency that was invisible until ATL-454 required both platforms to use the same server endpoint.

3. **Warning signs missed?** The asymmetry between `BUNDLE_ID` (per-environment) and `CFBundleURLSchemes` (hardcoded) in `build.sh` was a signal. Also, `AuthManager.swift` had a hardcoded string while the iOS equivalent read from the bundle — same functionality, different implementation.

4. **Prevention:** When adding a new auth flow to one platform, verify the other platform follows the same pattern. The iOS xcconfig + dynamic bundle reading pattern should be the canonical reference for native auth clients.

5. **AGENTS.md update:** Not needed — this is a one-time alignment. The existing cross-platform guidance in `clients/AGENTS.md` is sufficient.

### Notes

CI skips macOS builds — Xcode build verification must be done locally before merge.

Link to Devin session: https://app.devin.ai/sessions/3a7c696ea3824c998e056526f2e277e6
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
