### PR TITLE
fix(auth): use ephemeral browser sessions for native auth (ATL-461)

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -237,6 +237,10 @@ public final class AuthManager {
                     continuation.resume(throwing: AuthServiceError.authCallbackFailed("No callback URL received."))
                 }
             }
+            // Use an ephemeral (private) session so each auth attempt starts
+            // with a clean cookie jar. Without this, stale WorkOS cookies
+            // from a failed attempt (e.g. signup_closed) persist and cause
+            // an infinite error loop on retry.
             session.prefersEphemeralWebBrowserSession = true
             session.presentationContextProvider = WebAuthPresentationContext.shared
             self.webAuthSession = session

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -237,7 +237,7 @@ public final class AuthManager {
                     continuation.resume(throwing: AuthServiceError.authCallbackFailed("No callback URL received."))
                 }
             }
-            session.prefersEphemeralWebBrowserSession = false
+            session.prefersEphemeralWebBrowserSession = true
             session.presentationContextProvider = WebAuthPresentationContext.shared
             self.webAuthSession = session
             session.start()


### PR DESCRIPTION
## Prompt / plan

Switch `prefersEphemeralWebBrowserSession` from `false` to `true` in `AuthManager.swift` so each native auth attempt starts with a clean cookie jar — matching the iOS `NativeAuthPlugin.swift` behavior.

Linear: https://linear.app/vellum/issue/ATL-461/macos-switch-to-ephemeral-browser-sessions-for-native-auth-match-ios

### Why this is needed

With persistent sessions (`false`), if a user hits a WorkOS error (e.g. `signup_closed`), the stale WorkOS cookie persists across retries and can cause an infinite error loop. iOS already avoids this by using ephemeral sessions.

### Trade-off

Ephemeral sessions mean the user won't benefit from existing Safari SSO sessions (they'll re-enter credentials each time). Acceptable because:
1. Native auth login is infrequent (once per session)
2. Avoiding stale cookie loops is more important than saving one credential entry
3. iOS already makes this trade-off successfully

### References

- [Apple — ASWebAuthenticationSession.prefersEphemeralWebBrowserSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralbrowsersession)
- iOS implementation: `vellum-assistant-platform/web/ios/App/App/NativeAuthPlugin.swift` (lines 254-259)

## Test plan

- Local Xcode build verification required (CI skips macOS checks)
- Verify login flow works with ephemeral session — user should see the WorkOS login page each time (no SSO auto-login from Safari cookies)
- Verify that after a failed login attempt, retrying does not loop on the same error

Link to Devin session: https://app.devin.ai/sessions/3a7c696ea3824c998e056526f2e277e6
Requested by: @ashleeradka
