### PR TITLE
feat(macos): show machine ID alongside assistant ID on developer tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -29,6 +29,7 @@ struct SettingsDeveloperTab: View {
     @State private var awakeStates: [String: Bool] = [:]
     @State private var transitioningStates: Set<String> = []
     @State private var platformUuid: String?
+    @State private var machineId: String?
 
     // -- Advanced dev state --
     @State private var macOSFlagStates: [MacOSFeatureFlagState] = []
@@ -251,6 +252,10 @@ struct SettingsDeveloperTab: View {
                         }
                     }
 
+                if let machineId, !machineId.isEmpty {
+                    infoRow(label: "Machine ID", value: machineId, mono: true)
+                }
+
                 let home = assistant.home
                 homeRow(home: home)
             }
@@ -459,6 +464,7 @@ struct SettingsDeveloperTab: View {
     private func resolvePlatformUuid() {
         guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) else {
             platformUuid = nil
+            machineId = nil
             return
         }
         let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId")
@@ -470,6 +476,22 @@ struct SettingsDeveloperTab: View {
             userId: userId,
             credentialStorage: FileCredentialStorage()
         )
+        fetchMachineId(orgId: orgId)
+    }
+
+    private func fetchMachineId(orgId: String?) {
+        machineId = nil
+        guard let orgId, let platformId = platformUuid else { return }
+        Task {
+            do {
+                let result = try await AuthService.shared.getAssistant(id: platformId, organizationId: orgId)
+                if case .found(let assistant) = result {
+                    machineId = assistant.machine_id
+                }
+            } catch {
+                // Best-effort dev info — silently skip on failure.
+            }
+        }
     }
 
     // MARK: - Switch Assistant

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsDeveloperTab.swift
@@ -30,6 +30,7 @@ struct SettingsDeveloperTab: View {
     @State private var transitioningStates: Set<String> = []
     @State private var platformUuid: String?
     @State private var machineId: String?
+    @State private var machineIdTask: Task<Void, Never>?
 
     // -- Advanced dev state --
     @State private var macOSFlagStates: [MacOSFeatureFlagState] = []
@@ -464,6 +465,7 @@ struct SettingsDeveloperTab: View {
     private func resolvePlatformUuid() {
         guard let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }) else {
             platformUuid = nil
+            machineIdTask?.cancel()
             machineId = nil
             return
         }
@@ -480,16 +482,18 @@ struct SettingsDeveloperTab: View {
     }
 
     private func fetchMachineId(orgId: String?) {
+        machineIdTask?.cancel()
         machineId = nil
         guard let orgId, let platformId = platformUuid else { return }
-        Task {
+        machineIdTask = Task {
             do {
                 let result = try await AuthService.shared.getAssistant(id: platformId, organizationId: orgId)
+                try Task.checkCancellation()
                 if case .found(let assistant) = result {
                     machineId = assistant.machine_id
                 }
             } catch {
-                // Best-effort dev info — silently skip on failure.
+                // Cancelled, network failure, decode error — best-effort dev info.
             }
         }
     }

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -118,11 +118,12 @@ public struct PlatformAssistant: Codable, Sendable {
     /// Present when the platform includes recovery-mode state in the assistant payload.
     /// `nil` when the field is absent (e.g. older platform versions or endpoints that omit it).
     public let recovery_mode: PlatformAssistantRecoveryMode?
+    public let machine_id: String?
 
     /// Maps Swift property names to JSON keys. `recovery_mode` is stored as
     /// `maintenance_mode` in the platform API response.
     enum CodingKeys: String, CodingKey {
-        case id, name, description, created_at, status
+        case id, name, description, created_at, status, machine_id
         case recovery_mode = "maintenance_mode"
     }
 
@@ -132,7 +133,8 @@ public struct PlatformAssistant: Codable, Sendable {
         description: String? = nil,
         created_at: String? = nil,
         status: String? = nil,
-        recovery_mode: PlatformAssistantRecoveryMode? = nil
+        recovery_mode: PlatformAssistantRecoveryMode? = nil,
+        machine_id: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -140,6 +142,7 @@ public struct PlatformAssistant: Codable, Sendable {
         self.created_at = created_at
         self.status = status
         self.recovery_mode = recovery_mode
+        self.machine_id = machine_id
     }
 }
 


### PR DESCRIPTION
surface machine ID in developer tab

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->