### PR TITLE
feat(cli): add fetchAssistantByIdFromPlatform helper

### DIFF
--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   existsSync,
   mkdtempSync,
@@ -11,9 +11,11 @@ import { join } from "node:path";
 
 import {
   clearPlatformToken,
+  fetchAssistantByIdFromPlatform,
   getPlatformUrl,
   readPlatformToken,
   savePlatformToken,
+  type HatchedAssistant,
 } from "../lib/platform-client.js";
 
 describe("platform-client token path is env-scoped", () => {
@@ -200,5 +202,123 @@ describe("getPlatformUrl resolution order", () => {
   test("trims whitespace from VELLUM_PLATFORM_URL", () => {
     process.env.VELLUM_PLATFORM_URL = "  https://trimmed.vellum.ai  ";
     expect(getPlatformUrl()).toBe("https://trimmed.vellum.ai");
+  });
+});
+
+describe("fetchAssistantByIdFromPlatform", () => {
+  interface CapturedCall {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: unknown;
+  }
+
+  function captureFetch(
+    responder: (call: CapturedCall) => Response | Promise<Response>,
+  ): {
+    calls: CapturedCall[];
+    fetchMock: typeof globalThis.fetch;
+  } {
+    const calls: CapturedCall[] = [];
+    const fetchMock = mock(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = typeof url === "string" ? url : url.toString();
+        const rawHeaders = (init?.headers ?? {}) as
+          | Record<string, string>
+          | Headers;
+        const headers: Record<string, string> = {};
+        if (rawHeaders instanceof Headers) {
+          rawHeaders.forEach((v, k) => {
+            headers[k] = v;
+          });
+        } else {
+          Object.assign(headers, rawHeaders);
+        }
+        let parsedBody: unknown = undefined;
+        const b = init?.body;
+        if (typeof b === "string") {
+          try {
+            parsedBody = JSON.parse(b);
+          } catch {
+            parsedBody = b;
+          }
+        }
+        const call: CapturedCall = {
+          url: urlStr,
+          method: init?.method ?? "GET",
+          headers,
+          body: parsedBody,
+        };
+        calls.push(call);
+        return responder(call);
+      },
+    );
+    return {
+      calls,
+      fetchMock: fetchMock as unknown as typeof globalThis.fetch,
+    };
+  }
+
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("200 → returns HatchedAssistant", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({ id: "uuid-123", name: "managed", status: "active" }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchAssistantByIdFromPlatform(
+      "vak_test_abc",
+      "uuid-123",
+      "https://platform.test",
+    );
+
+    expect(result).toEqual({
+      id: "uuid-123",
+      name: "managed",
+      status: "active",
+    } as HatchedAssistant);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://platform.test/v1/assistants/uuid-123/");
+    expect(calls[0]!.method).toBe("GET");
+  });
+
+  test("404 → returns null", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("", { status: 404 });
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchAssistantByIdFromPlatform(
+      "vak_test_abc",
+      "uuid-missing",
+      "https://platform.test",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("401 → throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("", { status: 401 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchAssistantByIdFromPlatform(
+        "vak_test_abc",
+        "uuid-123",
+        "https://platform.test",
+      ),
+    ).rejects.toThrow(/Run 'vellum login'/);
   });
 });

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -571,6 +571,40 @@ export async function fetchPlatformAssistants(
   return (body.results ?? []).filter((a) => a.status === "active");
 }
 
+/**
+ * Fetch a single platform assistant by its UUID. Returns null on 404
+ * (not found or no access). Throws on auth errors or unexpected
+ * server errors.
+ */
+export async function fetchAssistantByIdFromPlatform(
+  token: string,
+  assistantId: string,
+  platformUrl?: string,
+): Promise<HatchedAssistant | null> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/v1/assistants/${assistantId}/`;
+
+  const response = await fetch(url, {
+    headers: await authHeaders(token, platformUrl),
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("Authentication failed. Run 'vellum login' to refresh.");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch assistant ${assistantId}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as HatchedAssistant;
+}
+
 export interface PlatformUser {
   id: string;
   email: string;


### PR DESCRIPTION
## Summary
- Add `fetchAssistantByIdFromPlatform` to `cli/src/lib/platform-client.ts` for fetching a single managed assistant by UUID via `GET /v1/assistants/{id}/`.
- Returns `HatchedAssistant` on 200, `null` on 404, throws on auth/other errors.
- Adds tests covering 200, 404, and 401 paths.

Part of plan: cli-upgrade-uuid.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->