### PR TITLE
fix(cli): resolve managed assistant UUIDs via platform in upgrade

### DIFF
--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -128,6 +128,78 @@ describe("resolveTargetAssistant platform fallback", () => {
     }
   });
 
+  test("platform fetch throws auth error → exits AUTH_FAILED", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockRejectedValueOnce(
+      new Error("Authentication failed. Run 'vellum login' to refresh."),
+    );
+
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-auth")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+      expect(cliErrorLine).toBeDefined();
+      const payload = JSON.parse(
+        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+      );
+      expect(payload.error).toBe("AUTH_FAILED");
+    } finally {
+      process.exit = origExit;
+      stderrWriteMock.mockRestore();
+    }
+  });
+
+  test("platform fetch throws other error → exits PLATFORM_API_ERROR", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockRejectedValueOnce(
+      new Error("Failed to fetch assistant uuid-1: 500 Internal Server Error"),
+    );
+
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-500")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+      expect(cliErrorLine).toBeDefined();
+      const payload = JSON.parse(
+        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+      );
+      expect(payload.error).toBe("PLATFORM_API_ERROR");
+    } finally {
+      process.exit = origExit;
+      stderrWriteMock.mockRestore();
+    }
+  });
+
   test("name not in lockfile + no platform token → exits ASSISTANT_NOT_FOUND, no platform call", async () => {
     readPlatformTokenMock.mockReturnValue(null);
 

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 // ---------------------------------------------------------------------------
 
 const testDir = mkdtempSync(join(tmpdir(), "cli-upgrade-resolve-test-"));
+const savedLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
 process.env.VELLUM_LOCKFILE_DIR = testDir;
 
 // ---------------------------------------------------------------------------
@@ -228,4 +229,9 @@ afterAll(() => {
   readPlatformTokenMock.mockRestore();
   fetchAssistantByIdFromPlatformMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
+  if (savedLockfileDir === undefined) {
+    delete process.env.VELLUM_LOCKFILE_DIR;
+  } else {
+    process.env.VELLUM_LOCKFILE_DIR = savedLockfileDir;
+  }
 });

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -1,0 +1,159 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Temp directory for lockfile isolation
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "cli-upgrade-resolve-test-"));
+process.env.VELLUM_LOCKFILE_DIR = testDir;
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+import * as assistantConfig from "../lib/assistant-config.js";
+import * as platformClient from "../lib/platform-client.js";
+
+const findAssistantByNameMock = spyOn(
+  assistantConfig,
+  "findAssistantByName",
+).mockReturnValue(null);
+
+const loadAllAssistantsMock = spyOn(
+  assistantConfig,
+  "loadAllAssistants",
+).mockReturnValue([]);
+
+const getActiveAssistantMock = spyOn(
+  assistantConfig,
+  "getActiveAssistant",
+).mockReturnValue(null);
+
+const getPlatformUrlMock = spyOn(
+  platformClient,
+  "getPlatformUrl",
+).mockReturnValue("https://platform.test");
+
+const readPlatformTokenMock = spyOn(
+  platformClient,
+  "readPlatformToken",
+).mockReturnValue(null);
+
+const fetchAssistantByIdFromPlatformMock = spyOn(
+  platformClient,
+  "fetchAssistantByIdFromPlatform",
+).mockResolvedValue(null);
+
+import { resolveTargetAssistant } from "../commands/upgrade.js";
+
+describe("resolveTargetAssistant platform fallback", () => {
+  beforeEach(() => {
+    findAssistantByNameMock.mockReset();
+    findAssistantByNameMock.mockReturnValue(null);
+    loadAllAssistantsMock.mockReset();
+    loadAllAssistantsMock.mockReturnValue([]);
+    getActiveAssistantMock.mockReset();
+    getActiveAssistantMock.mockReturnValue(null);
+    getPlatformUrlMock.mockReset();
+    getPlatformUrlMock.mockReturnValue("https://platform.test");
+    readPlatformTokenMock.mockReset();
+    readPlatformTokenMock.mockReturnValue(null);
+    fetchAssistantByIdFromPlatformMock.mockReset();
+    fetchAssistantByIdFromPlatformMock.mockResolvedValue(null);
+  });
+
+  test("name not in lockfile + token present + platform returns assistant → synthetic entry", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce({
+      id: "uuid-1",
+      name: "uuid-1",
+      status: "active",
+    });
+
+    const entry = await resolveTargetAssistant("uuid-1");
+
+    expect(entry).toEqual({
+      assistantId: "uuid-1",
+      cloud: "vellum",
+      runtimeUrl: "https://platform.test",
+    });
+    expect(fetchAssistantByIdFromPlatformMock).toHaveBeenCalledWith(
+      "platform-token",
+      "uuid-1",
+    );
+  });
+
+  test("name not in lockfile + token present + platform returns null → exits ASSISTANT_NOT_FOUND", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce(null);
+
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-2")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+      expect(cliErrorLine).toBeDefined();
+      const payload = JSON.parse(
+        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+      );
+      expect(payload.error).toBe("ASSISTANT_NOT_FOUND");
+    } finally {
+      process.exit = origExit;
+      stderrWriteMock.mockRestore();
+    }
+  });
+
+  test("name not in lockfile + no platform token → exits ASSISTANT_NOT_FOUND, no platform call", async () => {
+    readPlatformTokenMock.mockReturnValue(null);
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-3")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(fetchAssistantByIdFromPlatformMock).not.toHaveBeenCalled();
+    } finally {
+      process.exit = origExit;
+    }
+  });
+});
+
+afterAll(() => {
+  findAssistantByNameMock.mockRestore();
+  loadAllAssistantsMock.mockRestore();
+  getActiveAssistantMock.mockRestore();
+  getPlatformUrlMock.mockRestore();
+  readPlatformTokenMock.mockRestore();
+  fetchAssistantByIdFromPlatformMock.mockRestore();
+  rmSync(testDir, { recursive: true, force: true });
+});

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -187,10 +187,25 @@ export async function resolveTargetAssistant(
       process.exit(1);
     }
 
-    const platformAssistant = await fetchAssistantByIdFromPlatform(
-      token,
-      nameArg,
-    );
+    let platformAssistant;
+    try {
+      platformAssistant = await fetchAssistantByIdFromPlatform(token, nameArg);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      if (
+        detail.includes("Authentication failed") ||
+        detail.includes("vellum login")
+      ) {
+        const msg = `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`;
+        console.error(msg);
+        emitCliError("AUTH_FAILED", msg, detail);
+      } else {
+        const msg = `Failed to look up assistant '${nameArg}' on the platform: ${detail}`;
+        console.error(msg);
+        emitCliError("PLATFORM_API_ERROR", msg, detail);
+      }
+      process.exit(1);
+    }
     if (!platformAssistant) {
       const msg = `No local or platform assistant found with name '${nameArg}'. Make sure you are logged in and this assistant belongs to your account.`;
       console.error(msg);

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -23,6 +23,7 @@ import {
 } from "../lib/platform-releases";
 import {
   authHeaders,
+  fetchAssistantByIdFromPlatform,
   getPlatformUrl,
   readPlatformToken,
 } from "../lib/platform-client";
@@ -164,10 +165,20 @@ function resolveCloud(entry: AssistantEntry): string {
  * 2. Active assistant set via `vellum use`
  * 3. Sole assistant (when exactly one exists)
  */
-function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
+export async function resolveTargetAssistant(
+  nameArg: string | null,
+): Promise<AssistantEntry> {
   if (nameArg) {
     const entry = findAssistantByName(nameArg);
-    if (!entry) {
+    if (entry) return entry;
+
+    // Local lockfile miss. The macOS app stores its lockfile in a
+    // sandboxed container the CLI can't read, so a platform-managed
+    // assistant identified by UUID won't be found locally even though
+    // it exists. If we have a platform token, try resolving the name
+    // against the platform API and synthesize an in-memory entry.
+    const token = readPlatformToken();
+    if (!token) {
       console.error(`No assistant found with name '${nameArg}'.`);
       emitCliError(
         "ASSISTANT_NOT_FOUND",
@@ -175,7 +186,23 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
       );
       process.exit(1);
     }
-    return entry;
+
+    const platformAssistant = await fetchAssistantByIdFromPlatform(
+      token,
+      nameArg,
+    );
+    if (!platformAssistant) {
+      const msg = `No local or platform assistant found with name '${nameArg}'. Make sure you are logged in and this assistant belongs to your account.`;
+      console.error(msg);
+      emitCliError("ASSISTANT_NOT_FOUND", msg);
+      process.exit(1);
+    }
+
+    return {
+      assistantId: nameArg,
+      cloud: "vellum",
+      runtimeUrl: getPlatformUrl(),
+    };
   }
 
   const active = getActiveAssistant();
@@ -512,7 +539,10 @@ async function upgradeDocker(
   } else {
     console.error(`\n❌ Containers failed to become ready within the timeout.`);
 
-    const logDir = await captureUpgradeFailureLogs(res, `${instanceName}-upgrade-failure`);
+    const logDir = await captureUpgradeFailureLogs(
+      res,
+      `${instanceName}-upgrade-failure`,
+    );
     if (logDir) {
       console.log(`📋 Container logs saved to: ${logDir}`);
     }
@@ -938,7 +968,8 @@ async function resolveLatestAndMaybeSelfUpdate(
     );
     if (installResult.error || installResult.status !== 0) {
       const detail =
-        installResult.error?.message ?? `exited with code ${installResult.status}`;
+        installResult.error?.message ??
+        `exited with code ${installResult.status}`;
       console.error(`\n❌ CLI self-update failed: ${detail}`);
       emitCliError("CLI_UPDATE_FAILED", "CLI self-update failed", detail);
       process.exit(1);
@@ -967,7 +998,7 @@ async function resolveLatestAndMaybeSelfUpdate(
 
 export async function upgrade(): Promise<void> {
   const { name, version, latest, prepare, finalize } = parseArgs();
-  const entry = resolveTargetAssistant(name);
+  const entry = await resolveTargetAssistant(name);
 
   if (prepare) {
     await upgradePrepare(entry, version);


### PR DESCRIPTION
## Summary
- Make `resolveTargetAssistant` in `cli/src/commands/upgrade.ts` async and fall back to the platform API (`fetchAssistantByIdFromPlatform`) when the name arg is not found in the local lockfile and a platform token is available.
- Synthesizes an in-memory `AssistantEntry` with `cloud: 'vellum'` so dispatch routes to `upgradePlatform`. The synthetic entry is never persisted.
- Gated only on token presence — UUID-shape is not a reliable discriminator since local assistants can also have UUID names.
- Adds `upgrade-resolve.test.ts` covering the three branches: platform hit, platform miss, no token.

Fixes `vellum upgrade <UUID> --version <ver>` for platform-managed assistants invoked by the macOS app, whose lockfile lives in the sandboxed container that the CLI cannot read.

Part of plan: cli-upgrade-uuid.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->