### PR TITLE
Part of JARVIS-705: Add assistant timezone resolution primitives

### DIFF
--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import { UiConfigSchema } from "../config/schemas/platform.js";
 import {
+  canonicalizeTimeZone,
   extractUserTimeZoneFromRecall,
   formatTurnTimestamp,
+  resolveTurnTimezoneContext,
 } from "../daemon/date-context.js";
 
 // ---------------------------------------------------------------------------
@@ -86,6 +89,142 @@ describe("extractUserTimeZoneFromRecall", () => {
 });
 
 // ---------------------------------------------------------------------------
+// UiConfigSchema timezone fields
+// ---------------------------------------------------------------------------
+
+describe("UiConfigSchema timezone fields", () => {
+  test("accepts and canonicalizes userTimezone and detectedTimezone", () => {
+    const result = UiConfigSchema.parse({
+      userTimezone: "america/new_york",
+      detectedTimezone: "Asia/Tokyo",
+    });
+
+    expect(result.userTimezone).toBe("America/New_York");
+    expect(result.detectedTimezone).toBe("Asia/Tokyo");
+  });
+
+  test("accepts empty-string clearing sentinels", () => {
+    const result = UiConfigSchema.parse({
+      userTimezone: "",
+      detectedTimezone: "",
+    });
+
+    expect(result.userTimezone).toBe("");
+    expect(result.detectedTimezone).toBe("");
+  });
+
+  test("rejects invalid non-empty userTimezone and detectedTimezone", () => {
+    expect(() =>
+      UiConfigSchema.parse({ userTimezone: "not-a-timezone" }),
+    ).toThrow("ui.userTimezone must be a valid IANA timezone identifier");
+    expect(() =>
+      UiConfigSchema.parse({ detectedTimezone: "Mars/Olympus_Mons" }),
+    ).toThrow("ui.detectedTimezone must be a valid IANA timezone identifier");
+    expect(() => UiConfigSchema.parse({ userTimezone: "+05:30" })).toThrow(
+      "ui.userTimezone must be a valid IANA timezone identifier",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeTimeZone
+// ---------------------------------------------------------------------------
+
+describe("canonicalizeTimeZone", () => {
+  test("returns canonical timezone identifiers and ignores empty values", () => {
+    expect(canonicalizeTimeZone("america/new_york")).toBe("America/New_York");
+    expect(canonicalizeTimeZone("")).toBeNull();
+    expect(canonicalizeTimeZone(null)).toBeNull();
+    expect(canonicalizeTimeZone("not-a-timezone")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTurnTimezoneContext
+// ---------------------------------------------------------------------------
+
+describe("resolveTurnTimezoneContext", () => {
+  test("prefers configured user timezone over automatic sources", () => {
+    const context = resolveTurnTimezoneContext({
+      configuredUserTimeZone: "America/New_York",
+      clientTimezone: "America/Chicago",
+      detectedTimezone: "Asia/Tokyo",
+      hostTimeZone: "Europe/London",
+    });
+
+    expect(context.effectiveTimezone).toBe("America/New_York");
+    expect(context.source).toBe("configuredUserTimezone");
+  });
+
+  test("prefers client timezone over detected and host timezones", () => {
+    const context = resolveTurnTimezoneContext({
+      clientTimezone: "America/Chicago",
+      detectedTimezone: "Asia/Tokyo",
+      hostTimeZone: "Europe/London",
+    });
+
+    expect(context.effectiveTimezone).toBe("America/Chicago");
+    expect(context.source).toBe("clientTimezone");
+  });
+
+  test("prefers detected timezone over host timezone", () => {
+    const context = resolveTurnTimezoneContext({
+      detectedTimezone: "Asia/Tokyo",
+      hostTimeZone: "Europe/London",
+    });
+
+    expect(context.effectiveTimezone).toBe("Asia/Tokyo");
+    expect(context.source).toBe("detectedTimezone");
+  });
+
+  test("uses host timezone before UTC fallback", () => {
+    const context = resolveTurnTimezoneContext({
+      hostTimeZone: "Europe/London",
+    });
+
+    expect(context.effectiveTimezone).toBe("Europe/London");
+    expect(context.source).toBe("hostTimezone");
+  });
+
+  test("falls back to UTC when no timezone resolves", () => {
+    const context = resolveTurnTimezoneContext({
+      configuredUserTimeZone: "not-a-timezone",
+      clientTimezone: "also-invalid",
+      detectedTimezone: "",
+      hostTimeZone: "still-invalid",
+    });
+
+    expect(context.effectiveTimezone).toBe("UTC");
+    expect(context.source).toBe("utcFallback");
+  });
+
+  test("ignores empty strings during runtime resolution", () => {
+    const context = resolveTurnTimezoneContext({
+      configuredUserTimeZone: "",
+      clientTimezone: "",
+      detectedTimezone: "",
+      hostTimeZone: "UTC",
+    });
+
+    expect(context.configuredUserTimezone).toBeNull();
+    expect(context.clientTimezone).toBeNull();
+    expect(context.detectedTimezone).toBeNull();
+    expect(context.effectiveTimezone).toBe("UTC");
+    expect(context.source).toBe("hostTimezone");
+  });
+
+  test("does not use recalled profile timezone in normal turn precedence", () => {
+    const context = resolveTurnTimezoneContext({
+      userTimeZone: "Asia/Tokyo",
+      hostTimeZone: "UTC",
+    });
+
+    expect(context.effectiveTimezone).toBe("UTC");
+    expect(context.source).toBe("hostTimezone");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // formatTurnTimestamp
 // ---------------------------------------------------------------------------
 
@@ -127,11 +266,20 @@ describe("formatTurnTimestamp", () => {
     expect(result).toBe("2026-04-02 (Thursday) 06:52:33 +00:00 (UTC)");
   });
 
-  test("handles user timezone override", () => {
+  test("handles configured user timezone override", () => {
     const result = formatTurnTimestamp({
       nowMs: THU_APR_02_0652,
       hostTimeZone: "UTC",
-      userTimeZone: "Asia/Tokyo",
+      configuredUserTimeZone: "Asia/Tokyo",
+    });
+    expect(result).toBe("2026-04-02 (Thursday) 15:52:33 +09:00 (Asia/Tokyo)");
+  });
+
+  test("uses client timezone when no configured override exists", () => {
+    const result = formatTurnTimestamp({
+      nowMs: THU_APR_02_0652,
+      hostTimeZone: "UTC",
+      clientTimezone: "Asia/Tokyo",
     });
     expect(result).toBe("2026-04-02 (Thursday) 15:52:33 +09:00 (Asia/Tokyo)");
   });

--- a/assistant/src/__tests__/date-context.test.ts
+++ b/assistant/src/__tests__/date-context.test.ts
@@ -93,14 +93,17 @@ describe("extractUserTimeZoneFromRecall", () => {
 // ---------------------------------------------------------------------------
 
 describe("UiConfigSchema timezone fields", () => {
-  test("accepts and canonicalizes userTimezone and detectedTimezone", () => {
+  test("accepts IANA canonical identifiers and aliases", () => {
     const result = UiConfigSchema.parse({
       userTimezone: "america/new_york",
-      detectedTimezone: "Asia/Tokyo",
+      detectedTimezone: "US/Eastern",
     });
 
     expect(result.userTimezone).toBe("America/New_York");
-    expect(result.detectedTimezone).toBe("Asia/Tokyo");
+    expect(result.detectedTimezone).toBe("US/Eastern");
+    expect(UiConfigSchema.parse({ userTimezone: "UTC" }).userTimezone).toBe(
+      "UTC",
+    );
   });
 
   test("accepts empty-string clearing sentinels", () => {
@@ -113,7 +116,7 @@ describe("UiConfigSchema timezone fields", () => {
     expect(result.detectedTimezone).toBe("");
   });
 
-  test("rejects invalid non-empty userTimezone and detectedTimezone", () => {
+  test("rejects invalid non-empty userTimezone and detectedTimezone values", () => {
     expect(() =>
       UiConfigSchema.parse({ userTimezone: "not-a-timezone" }),
     ).toThrow("ui.userTimezone must be a valid IANA timezone identifier");
@@ -123,6 +126,17 @@ describe("UiConfigSchema timezone fields", () => {
     expect(() => UiConfigSchema.parse({ userTimezone: "+05:30" })).toThrow(
       "ui.userTimezone must be a valid IANA timezone identifier",
     );
+  });
+
+  test("rejects ambiguous abbreviations and offset strings", () => {
+    for (const value of ["EST", "PST", "UTC+5:30", "GMT-0800", "+05:30"]) {
+      expect(() => UiConfigSchema.parse({ userTimezone: value })).toThrow(
+        "ui.userTimezone must be a valid IANA timezone identifier",
+      );
+      expect(() => UiConfigSchema.parse({ detectedTimezone: value })).toThrow(
+        "ui.detectedTimezone must be a valid IANA timezone identifier",
+      );
+    }
   });
 });
 

--- a/assistant/src/config/schemas/platform.ts
+++ b/assistant/src/config/schemas/platform.ts
@@ -1,5 +1,38 @@
 import { z } from "zod";
 
+function canonicalizeIanaTimezone(timezone: string): string | null {
+  const trimmed = timezone.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+  if (/^[+-]/.test(trimmed) || /^(?:UTC|GMT)[+-]/i.test(trimmed)) {
+    return null;
+  }
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: trimmed,
+    }).resolvedOptions().timeZone;
+  } catch {
+    return null;
+  }
+}
+
+function timezoneConfigField(path: string) {
+  return z
+    .string({ error: `${path} must be a string` })
+    .transform((value, ctx) => {
+      const canonical = canonicalizeIanaTimezone(value);
+      if (canonical === null) {
+        ctx.addIssue({
+          code: "custom",
+          message: `${path} must be a valid IANA timezone identifier or an empty string`,
+        });
+        return z.NEVER;
+      }
+      return canonical;
+    });
+}
+
 export const PlatformConfigSchema = z
   .object({
     baseUrl: z
@@ -56,11 +89,15 @@ export const DaemonConfigSchema = z
 
 export const UiConfigSchema = z
   .object({
-    userTimezone: z
-      .string({ error: "ui.userTimezone must be a string" })
+    userTimezone: timezoneConfigField("ui.userTimezone")
       .optional()
       .describe(
-        "IANA timezone identifier for displaying dates and times (e.g. 'America/New_York')",
+        "Manual IANA timezone override used for assistant temporal grounding and date/time display (e.g. 'America/New_York'). Use an empty string to clear the setting.",
+      ),
+    detectedTimezone: timezoneConfigField("ui.detectedTimezone")
+      .optional()
+      .describe(
+        "IANA timezone identifier detected from the client environment for assistant temporal grounding when no manual override is configured (e.g. 'America/New_York'). Use an empty string to clear the setting.",
       ),
   })
   .describe(

--- a/assistant/src/config/schemas/platform.ts
+++ b/assistant/src/config/schemas/platform.ts
@@ -1,11 +1,14 @@
 import { z } from "zod";
 
+const IANA_TIMEZONE_IDENTIFIER_RE =
+  /^(?:UTC|[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z0-9_+-]+)+)$/;
+
 function canonicalizeIanaTimezone(timezone: string): string | null {
   const trimmed = timezone.trim();
   if (trimmed.length === 0) {
     return "";
   }
-  if (/^[+-]/.test(trimmed) || /^(?:UTC|GMT)[+-]/i.test(trimmed)) {
+  if (!IANA_TIMEZONE_IDENTIFIER_RE.test(trimmed)) {
     return null;
   }
   try {

--- a/assistant/src/daemon/date-context.ts
+++ b/assistant/src/daemon/date-context.ts
@@ -14,8 +14,29 @@ export interface TemporalContextOptions {
   hostTimeZone?: string;
   /** IANA timezone configured in user settings (if available). */
   configuredUserTimeZone?: string | null;
-  /** IANA timezone inferred from user profile/memory (if available). */
+  /** IANA timezone reported by the active client for the current turn. */
+  clientTimezone?: string | null;
+  /** IANA timezone persisted from prior client environment detection. */
+  detectedTimezone?: string | null;
+  /** Profile timezone candidate accepted by legacy callers; not used for turn resolution. */
   userTimeZone?: string | null;
+}
+
+export type TurnTimezoneSource =
+  | "timeZone"
+  | "configuredUserTimezone"
+  | "clientTimezone"
+  | "detectedTimezone"
+  | "hostTimezone"
+  | "utcFallback";
+
+export interface TurnTimezoneContext {
+  configuredUserTimezone: string | null;
+  clientTimezone: string | null;
+  detectedTimezone: string | null;
+  hostTimezone: string | null;
+  effectiveTimezone: string;
+  source: TurnTimezoneSource;
 }
 
 const WEEKDAY_LONG = [
@@ -86,7 +107,12 @@ function canonicalizeUtcGmtOffsetToken(offsetToken: string): string | null {
   ).padStart(2, "0")}`;
 }
 
-function canonicalizeTimeZone(timeZone: string): string | null {
+export function canonicalizeTimeZone(
+  timeZone: string | null | undefined,
+): string | null {
+  if (timeZone == null) {
+    return null;
+  }
   const trimmed = timeZone.trim();
   if (trimmed.length === 0) {
     return null;
@@ -119,6 +145,17 @@ function canonicalizeTimeZone(timeZone: string): string | null {
   } catch {
     return null;
   }
+}
+
+function firstResolvedTimezone(
+  candidates: Array<[TurnTimezoneSource, string | null]>,
+): { source: TurnTimezoneSource; timeZone: string } | null {
+  for (const [source, timeZone] of candidates) {
+    if (timeZone) {
+      return { source, timeZone };
+    }
+  }
+  return null;
 }
 
 /**
@@ -289,11 +326,41 @@ function formatLocalDate(date: Date, timeZone: string): string {
   ).padStart(2, "0")}`;
 }
 
+export function resolveTurnTimezoneContext(
+  options: TemporalContextOptions = {},
+): TurnTimezoneContext {
+  const configuredUserTimezone = canonicalizeTimeZone(
+    options.configuredUserTimeZone,
+  );
+  const clientTimezone = canonicalizeTimeZone(options.clientTimezone);
+  const detectedTimezone = canonicalizeTimeZone(options.detectedTimezone);
+  const hostTimezone = canonicalizeTimeZone(
+    options.hostTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+  const explicitTimezone = canonicalizeTimeZone(options.timeZone);
+  const selected = firstResolvedTimezone([
+    ["timeZone", explicitTimezone],
+    ["configuredUserTimezone", configuredUserTimezone],
+    ["clientTimezone", clientTimezone],
+    ["detectedTimezone", detectedTimezone],
+    ["hostTimezone", hostTimezone],
+  ]);
+
+  return {
+    configuredUserTimezone,
+    clientTimezone,
+    detectedTimezone,
+    hostTimezone,
+    effectiveTimezone: selected?.timeZone ?? "UTC",
+    source: selected?.source ?? "utcFallback",
+  };
+}
+
 /**
  * Format time as HH:MM:SS with UTC offset and timezone name.
  *
  * Uses the timezone resolution cascade:
- * explicit override → configured user tz → profile user tz → host fallback.
+ * explicit override → configured user tz → client tz → detected tz → host fallback.
  *
  * Returns format: `2026-04-02 (Thursday) 01:52:33 -05:00 (America/Chicago)`
  */
@@ -301,24 +368,7 @@ export function formatTurnTimestamp(
   options: TemporalContextOptions = {},
 ): string {
   const now = new Date(options.nowMs ?? Date.now());
-  const resolvedHostTimeZone =
-    canonicalizeTimeZone(
-      options.hostTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
-    ) ?? "UTC";
-  const resolvedConfiguredUserTimeZone = options.configuredUserTimeZone
-    ? canonicalizeTimeZone(options.configuredUserTimeZone)
-    : null;
-  const resolvedUserTimeZone = options.userTimeZone
-    ? canonicalizeTimeZone(options.userTimeZone)
-    : null;
-  const resolvedTimeZone = options.timeZone
-    ? canonicalizeTimeZone(options.timeZone)
-    : null;
-  const timeZone =
-    resolvedTimeZone ??
-    resolvedConfiguredUserTimeZone ??
-    resolvedUserTimeZone ??
-    resolvedHostTimeZone;
+  const timeZone = resolveTurnTimezoneContext(options).effectiveTimezone;
 
   const dateStr = formatLocalDate(now, timeZone);
   const todayParts = localDateParts(now, timeZone);
@@ -341,4 +391,3 @@ export function formatTurnTimestamp(
 
   return `${dateStr} (${dayName}) ${hour}:${minute}:${second} ${offset} (${timeZone})`;
 }
-


### PR DESCRIPTION
## Summary
- Adds canonical timezone validation for assistant temporal config.
- Introduces reusable turn timezone resolution for later client timezone work.
- Covers precedence and compatibility behavior with focused tests.

Part of JARVIS-705.
Part of plan: assistant-local-timezone.md (PR 1 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->