### PR TITLE
[codex] Fix local hatch TTFT latency

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -69,7 +69,9 @@ import {
   getConfig,
   invalidateConfigCache,
   loadConfig,
+  mergeDefaultWorkspaceConfig,
 } from "../config/loader.js";
+import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import { _setStorePath } from "../security/encrypted-store.js";
 
 // ---------------------------------------------------------------------------
@@ -274,6 +276,8 @@ describe("loadConfig startup behavior", () => {
     ensureTestDir();
     const resetPaths = [
       CONFIG_PATH,
+      join(WORKSPACE_DIR, "default-config.json"),
+      join(WORKSPACE_DIR, "hatch-overlay.json"),
       join(WORKSPACE_DIR, "keys.enc"),
       join(WORKSPACE_DIR, "data"),
       join(WORKSPACE_DIR, "data", "memory"),
@@ -295,11 +299,13 @@ describe("loadConfig startup behavior", () => {
     if (existsSync(updatesPath)) rmSync(updatesPath, { force: true });
     ensureTestDir();
     _setStorePath(join(WORKSPACE_DIR, "keys.enc"));
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
     invalidateConfigCache();
   });
 
   afterEach(() => {
     _setStorePath(null);
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
     invalidateConfigCache();
   });
 
@@ -389,6 +395,43 @@ describe("loadConfig startup behavior", () => {
     // Sanity: schema-defaulted nested fields are materialized
     expect(raw.memory?.v2?.bm25_b).toBe(0.4);
     expect(raw.dataDir).toBeUndefined();
+  });
+
+  test("hatch default overlay does not suppress first-load inference profiles", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: {
+              provider: "anthropic",
+              model: "claude-opus-4-7",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    seedInferenceProfiles();
+    mergeDefaultWorkspaceConfig();
+    const config = loadConfig();
+
+    expect(config.llm.default.provider).toBe("anthropic");
+    expect(config.llm.default.model).toBe("claude-opus-4-7");
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+    });
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
   });
 
   test("still quarantines corrupt JSON", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -64,6 +64,7 @@ afterAll(() => {
   mock.restore();
 });
 
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import {
   deepMergeOverwrite,
   getConfig,
@@ -432,6 +433,46 @@ describe("loadConfig startup behavior", () => {
     });
     expect(raw.llm.activeProfile).toBe("balanced");
     expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+  });
+
+  test("non-Anthropic hatch overlay does not activate Anthropic managed profile", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: {
+              provider: "openai",
+              model: "gpt-5.4",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    seedInferenceProfiles();
+    mergeDefaultWorkspaceConfig();
+    const config = loadConfig();
+    const mainAgentConfig = resolveCallSiteConfig("mainAgent", config.llm);
+
+    expect(config.llm.default.provider).toBe("openai");
+    expect(config.llm.default.model).toBe("gpt-5.4");
+    expect(config.llm.activeProfile).toBeUndefined();
+    expect(config.llm.profiles.balanced?.provider).toBeUndefined();
+    expect(mainAgentConfig.provider).toBe("openai");
+    expect(mainAgentConfig.model).toBe("gpt-5.4");
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    expect(raw.llm.activeProfile).toBeUndefined();
+    expect(raw.llm.profiles.balanced).toEqual({});
   });
 
   test("still quarantines corrupt JSON", () => {

--- a/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
@@ -158,6 +158,40 @@ describe("runDefaultMemoryRetrieval", () => {
     expect(result.nowContent).toBe("now-default");
   });
 
+  test("soft-times out graph retrieval and keeps PKB/NOW", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const hangingPrepare = mock(
+      (
+        _msgs: Message[],
+        _cfg: AssistantConfig,
+        signal: AbortSignal,
+        _onEvent: (msg: ServerMessage) => void,
+      ) => {
+        capturedSignal = signal;
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        });
+      },
+    );
+    const graphMemory = {
+      prepareMemory: hangingPrepare,
+    } as unknown as ConversationGraphMemory;
+    const deps = makeDeps({
+      graphMemory,
+      isTrustedActor: true,
+      graphRetrievalBudgetMs: 20,
+    });
+
+    const result = await runDefaultMemoryRetrieval(makeMemoryArgs(), deps);
+
+    expect(result.pkbContent).toBe("pkb-default");
+    expect(result.nowContent).toBe("now-default");
+    expect(result.memoryGraphBlocks).toEqual([]);
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
   test("passes through null PKB and NOW when the files are absent", async () => {
     readPkbContextMock.mockImplementation(() => null);
     readNowContextMock.mockImplementation(() => null);
@@ -314,7 +348,7 @@ describe("memoryRetrieval pipeline — default vs custom plugin", () => {
         (innerArgs: MemoryArgs) => runDefaultMemoryRetrieval(innerArgs, deps),
         args,
         makeTurnCtx(),
-        30, // tiny budget — real production path uses 5_000ms
+        30, // tiny pipeline budget to keep the test fast
       );
     } catch (err) {
       caught = err;

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
@@ -63,7 +65,9 @@ export const MANAGED_PROFILE_NAMES = new Set(
  * Still runs when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set. Lifecycle
  * calls this before merging the hatch overlay so managed profiles exist for the
  * first config load, while the overlay can still override profile/default
- * fields immediately afterward.
+ * fields immediately afterward. When that overlay declares a non-Anthropic
+ * default provider, seed placeholder profile slots but do not force the
+ * Anthropic `balanced` profile active.
  */
 export function seedInferenceProfiles(): void {
   const config = loadRawConfig();
@@ -77,17 +81,27 @@ export function seedInferenceProfiles(): void {
     llm.profiles = {};
   }
   const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+  const isAnthropicDefault =
+    resolveEffectiveDefaultProvider(llm) === "anthropic";
 
   for (const [name, seed] of Object.entries(MANAGED_PROFILE_SEED_DATA)) {
-    profiles[name] = { ...seed };
+    profiles[name] = isAnthropicDefault ? { ...seed } : {};
   }
 
-  // Reset to the default managed profile when the current value is missing.
-  if (
+  if (isAnthropicDefault) {
+    // Reset to the default managed profile when the current value is missing.
+    if (
+      typeof llm.activeProfile !== "string" ||
+      !(llm.activeProfile in profiles)
+    ) {
+      llm.activeProfile = "balanced";
+    }
+  } else if (
     typeof llm.activeProfile !== "string" ||
-    !(llm.activeProfile in profiles)
+    !(llm.activeProfile in profiles) ||
+    MANAGED_PROFILE_NAMES.has(llm.activeProfile)
   ) {
-    llm.activeProfile = "balanced";
+    delete llm.activeProfile;
   }
 
   const profileOrder = Array.isArray(llm.profileOrder)
@@ -113,4 +127,36 @@ export function seedInferenceProfiles(): void {
   }
 
   saveRawConfig(config);
+}
+
+function resolveEffectiveDefaultProvider(llm: Record<string, unknown>): string {
+  return (
+    readDefaultProviderFromOverlay() ??
+    readString(readObject(llm.default)?.provider) ??
+    "anthropic"
+  );
+}
+
+function readDefaultProviderFromOverlay(): string | undefined {
+  const defaultConfigPath = process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+  if (!defaultConfigPath) return undefined;
+
+  try {
+    const raw = JSON.parse(readFileSync(defaultConfigPath, "utf-8"));
+    const llm = readObject(raw)?.llm;
+    const defaultBlock = readObject(readObject(llm)?.default);
+    return readString(defaultBlock?.provider);
+  } catch {
+    return undefined;
+  }
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -60,13 +60,12 @@ export const MANAGED_PROFILE_NAMES = new Set(
  * User-created profiles are never touched; pre-existing profiles
  * without a `source` field get `source: "user"` backfilled.
  *
- * No-op when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set (same guard
- * as migration 052) because the platform-provided default-config overlay
- * is the authoritative source for profile seeds.
+ * Still runs when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set. Lifecycle
+ * calls this before merging the hatch overlay so managed profiles exist for the
+ * first config load, while the overlay can still override profile/default
+ * fields immediately afterward.
  */
 export function seedInferenceProfiles(): void {
-  if (process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH) return;
-
   const config = loadRawConfig();
 
   if (config.llm == null || typeof config.llm !== "object") {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -499,10 +499,10 @@ export async function runDaemon(): Promise<void> {
       }
     } // end if (dbReady)
 
-    // Seed managed inference profiles into the workspace config. Runs
-    // after workspace migrations (which may have created the initial
-    // profile slots) and before mergeDefaultWorkspaceConfig / loadConfig
-    // so the profiles are on disk for the first config load.
+    // Seed managed inference profiles into the workspace config. Runs after
+    // workspace migrations and before mergeDefaultWorkspaceConfig / loadConfig
+    // so fresh hatches have profiles on disk before the first config load; the
+    // hatch overlay still merges afterward and can override seeded fields.
     try {
       seedInferenceProfiles();
       log.info("Inference profile seeding complete");

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -412,6 +412,7 @@ export class ConversationGraphMemory {
       "context-load",
       rawUserText ?? userQuery ?? "",
       "",
+      signal,
     );
     if (v2.routed) {
       this.lastInjectedBlock = v2.injectedBlockText;
@@ -561,6 +562,7 @@ export class ConversationGraphMemory {
       "per-turn",
       userLast,
       assistantLast,
+      signal,
     );
     if (v2.routed) {
       this.lastInjectedBlock = v2.injectedBlockText;
@@ -655,6 +657,7 @@ export class ConversationGraphMemory {
     mode: InjectMemoryV2Mode,
     userMessage: string,
     assistantMessage: string,
+    signal: AbortSignal,
   ): Promise<{
     routed: boolean;
     runMessages: Message[];
@@ -680,6 +683,7 @@ export class ConversationGraphMemory {
       messageId: `${this.conversationId}:turn:${currentTurn}`,
       mode,
       config,
+      signal,
     });
 
     if (!result.block) {

--- a/assistant/src/memory/v2/__tests__/qdrant.test.ts
+++ b/assistant/src/memory/v2/__tests__/qdrant.test.ts
@@ -190,6 +190,22 @@ describe("memory v2 qdrant — collection lifecycle", () => {
     expect(state.collectionExistsCalls).toBe(1);
   });
 
+  test("deduplicates concurrent collection creation", async () => {
+    state.collectionExistsBeforeCreate = false;
+
+    await Promise.all([
+      ensureConceptPageCollection(),
+      ensureConceptPageCollection(),
+      ensureConceptPageCollection(),
+    ]);
+
+    expect(state.collectionExistsCalls).toBe(1);
+    expect(state.createCollectionCalls).toBe(1);
+    expect(state.createIndexCalls).toEqual([
+      { field_name: "slug", field_schema: "keyword" },
+    ]);
+  });
+
   test("treats 409-on-create as success (concurrent creation race)", async () => {
     state.collectionExistsBeforeCreate = false;
     const conflict = Object.assign(new Error("Conflict"), { status: 409 });

--- a/assistant/src/memory/v2/activation.ts
+++ b/assistant/src/memory/v2/activation.ts
@@ -81,6 +81,7 @@ interface SelectCandidatesParams {
   /** NOW context string (essentials/threads/recent or NOW.md). */
   nowText: string;
   config: AssistantConfig;
+  signal?: AbortSignal;
 }
 
 interface SelectCandidatesResult {
@@ -108,7 +109,8 @@ interface SelectCandidatesResult {
 export async function selectCandidates(
   params: SelectCandidatesParams,
 ): Promise<SelectCandidatesResult> {
-  const { priorState, userText, assistantText, nowText, config } = params;
+  const { priorState, userText, assistantText, nowText, config, signal } =
+    params;
 
   const fromPrior = new Set<string>();
   const fromAnn = new Set<string>();
@@ -129,12 +131,16 @@ export async function selectCandidates(
     .join("\n");
 
   if (annQueryText.length > 0) {
-    const denseResult = await embedWithBackend(config, [annQueryText]);
+    throwIfAborted(signal);
+    const denseResult = await embedWithBackend(config, [annQueryText], {
+      signal,
+    });
     const dense = await applyCorrectionIfCalibrated(
       denseResult.vectors[0],
       denseResult.provider,
       denseResult.model,
     );
+    throwIfAborted(signal);
     const sparse = generateSparseEmbedding(annQueryText);
     const limit =
       config.memory.v2.ann_candidate_limit ?? UNLIMITED_ANN_CANDIDATE_LIMIT;
@@ -158,6 +164,7 @@ interface ComputeOwnActivationParams {
   assistantText: string;
   nowText: string;
   config: AssistantConfig;
+  signal?: AbortSignal;
 }
 
 /**
@@ -210,8 +217,15 @@ interface ComputeOwnActivationResult {
 export async function computeOwnActivation(
   params: ComputeOwnActivationParams,
 ): Promise<ComputeOwnActivationResult> {
-  const { candidates, priorState, userText, assistantText, nowText, config } =
-    params;
+  const {
+    candidates,
+    priorState,
+    userText,
+    assistantText,
+    nowText,
+    config,
+    signal,
+  } = params;
 
   const activation = new Map<string, number>();
   const breakdown = new Map<string, OwnActivationBreakdown>();
@@ -223,9 +237,9 @@ export async function computeOwnActivation(
   // NOW context is structured (timestamps, current focus) — outside the
   // cross-encoder's training distribution, so it never participates in rerank.
   const [simUser, simAssistant, simNow] = await Promise.all([
-    simBatch(userText, slugList, config),
-    simBatch(assistantText, slugList, config),
-    simBatch(nowText, slugList, config),
+    simBatch(userText, slugList, config, { signal }),
+    simBatch(assistantText, slugList, config, { signal }),
+    simBatch(nowText, slugList, config, { signal }),
   ]);
 
   interface SlugInputs {
@@ -265,6 +279,7 @@ export async function computeOwnActivation(
   let inPoolSet: ReadonlySet<string> = new Set();
   const rerankCfg = config.memory.v2.rerank;
   if (rerankCfg?.enabled) {
+    throwIfAborted(signal);
     const topSlugs = inputs
       .slice()
       .sort((a, b) => b.preRerank - a.preRerank)
@@ -277,6 +292,7 @@ export async function computeOwnActivation(
         topSlugs,
         config,
       );
+      throwIfAborted(signal);
       userRerankBoost = normalizeRerankScores(userScores, rerankCfg.alpha);
       assistantRerankBoost = normalizeRerankScores(
         assistantScores,
@@ -326,6 +342,12 @@ function normalizeRerankScores(
     out.set(slug, alpha * (raw / maxScore));
   }
   return out;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -81,6 +81,7 @@ export interface InjectMemoryV2BlockParams {
    */
   mode?: InjectMemoryV2Mode;
   config: AssistantConfig;
+  signal?: AbortSignal;
 }
 
 export interface InjectMemoryV2BlockResult {
@@ -124,30 +125,36 @@ export async function injectMemoryV2Block(
     nowText,
     messageId,
     config,
+    signal,
   } = params;
 
   const workspaceDir = getWorkspaceDir();
 
   // (1) Hydrate. Missing rows are normal at conversation start — proceed
   // with an effective empty prior state so the first turn can still inject.
+  throwIfAborted(signal);
   const priorState = await hydrate(database, conversationId);
 
   // (2) Topology. `getEdgeIndex` walks concept-page frontmatter and caches
   // the result module-locally; an empty workspace yields an empty index.
+  throwIfAborted(signal);
   const edgeIndex = await getEdgeIndex(workspaceDir);
 
   // (3) Candidate set: prior-state survivors above epsilon ∪ ANN top-50.
   // `selectCandidates` also returns `fromPrior` / `fromAnn` provenance sets so
   // telemetry can attribute each candidate back to its source.
+  throwIfAborted(signal);
   const { candidates, fromPrior, fromAnn } = await selectCandidates({
     priorState,
     userText: userMessage,
     assistantText: assistantMessage,
     nowText,
     config,
+    signal,
   });
 
   // (4) Own activation: A_o = d·prev + c_user·sim_u + c_a·sim_a + c_now·sim_n.
+  throwIfAborted(signal);
   const { activation: ownActivation, breakdown: ownBreakdown } =
     await computeOwnActivation({
       candidates,
@@ -156,9 +163,11 @@ export async function injectMemoryV2Block(
       assistantText: assistantMessage,
       nowText,
       config,
+      signal,
     });
 
   // (5) Spreading activation across the edge graph (k, hops from config).
+  throwIfAborted(signal);
   const { k, hops, top_k, epsilon } = config.memory.v2;
   const { final: finalActivation, contribution: spreadContribution } =
     spreadActivation(ownActivation, edgeIndex, k, hops);
@@ -317,6 +326,12 @@ export async function injectMemoryV2Block(
   }
 
   return { block, toInject: newlyInjected };
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -62,6 +62,7 @@ export interface ConceptPageQueryResult {
 
 let _client: QdrantRestClient | null = null;
 let _collectionReady = false;
+let _collectionReadyPromise: Promise<void> | null = null;
 
 /** Lazily create a Qdrant REST client bound to the resolved URL. */
 function getClient(): QdrantRestClient {
@@ -85,7 +86,15 @@ function getClient(): QdrantRestClient {
  */
 export async function ensureConceptPageCollection(): Promise<void> {
   if (_collectionReady) return;
+  if (_collectionReadyPromise) return _collectionReadyPromise;
 
+  _collectionReadyPromise = ensureConceptPageCollectionOnce().finally(() => {
+    _collectionReadyPromise = null;
+  });
+  return _collectionReadyPromise;
+}
+
+async function ensureConceptPageCollectionOnce(): Promise<void> {
   const client = getClient();
   const config = getConfig();
   const vectorSize = config.memory.qdrant.vectorSize;
@@ -526,4 +535,5 @@ function pointIdForSlug(slug: string): string {
 export function _resetMemoryV2QdrantForTests(): void {
   _client = null;
   _collectionReady = false;
+  _collectionReadyPromise = null;
 }

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -146,6 +146,7 @@ export async function simBatch(
   text: string,
   candidateSlugs: readonly string[],
   config: AssistantConfig,
+  options?: { signal?: AbortSignal },
 ): Promise<Map<string, number>> {
   if (candidateSlugs.length === 0) {
     return new Map();
@@ -157,12 +158,16 @@ export async function simBatch(
   // Sparse uses BM25: the query side encodes binary occurrences per token,
   // and the stored doc vectors carry the IDF · TF-saturated weights — Qdrant
   // dot product then yields the BM25 score directly.
-  const denseResult = await embedWithBackend(config, [text]);
+  throwIfAborted(options?.signal);
+  const denseResult = await embedWithBackend(config, [text], {
+    signal: options?.signal,
+  });
   const denseVector = await applyCorrectionIfCalibrated(
     denseResult.vectors[0],
     denseResult.provider,
     denseResult.model,
   );
+  throwIfAborted(options?.signal);
   const sparseVector = generateBm25QueryEmbedding(text);
 
   const hits = await hybridQueryConceptPages(
@@ -193,6 +198,12 @@ export async function simBatch(
   }
 
   return scores;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory-retrieval.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval.ts
@@ -32,6 +32,7 @@ import {
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type { ConversationGraphMemory } from "../../memory/graph/conversation-graph-memory.js";
 import type { Message } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
 import { registerPlugin } from "../registry.js";
 import {
   type MemoryArgs,
@@ -49,6 +50,15 @@ import {
  * hatch for custom retrievers.
  */
 export const DEFAULT_MEMORY_GRAPH_KIND = "default.graph" as const;
+
+const log = getLogger("default-memory-retrieval");
+
+/**
+ * Foreground turns should not wait on cold embedding/model/Qdrant startup.
+ * Warm memory retrieval is normally well under this budget; cold-start work
+ * continues through background jobs and the next turn can pick it up.
+ */
+const DEFAULT_MEMORY_GRAPH_RETRIEVAL_BUDGET_MS = 2_000;
 
 /**
  * Shape of the single block the default memory-graph retriever emits.
@@ -90,6 +100,8 @@ export interface DefaultMemoryRetrievalDeps {
   readonly onEvent: (msg: ServerMessage) => void;
   /** True when the actor for this turn is trusted (guardian-class). */
   readonly isTrustedActor: boolean;
+  /** Override for tests; `null` disables the foreground soft budget. */
+  readonly graphRetrievalBudgetMs?: number | null;
 }
 
 /**
@@ -121,12 +133,14 @@ export async function runDefaultMemoryRetrieval(
     };
   }
 
-  const graphResult = await deps.graphMemory.prepareMemory(
-    deps.messages,
-    deps.config,
-    args.signal,
-    deps.onEvent,
-  );
+  const graphResult = await prepareGraphMemoryWithBudget(args, deps);
+  if (!graphResult) {
+    return {
+      pkbContent,
+      nowContent,
+      memoryGraphBlocks: [],
+    };
+  }
 
   const payload: GraphMemoryPayload = {
     kind: DEFAULT_MEMORY_GRAPH_KIND,
@@ -138,6 +152,69 @@ export async function runDefaultMemoryRetrieval(
     nowContent,
     memoryGraphBlocks: [payload],
   };
+}
+
+async function prepareGraphMemoryWithBudget(
+  args: MemoryArgs,
+  deps: DefaultMemoryRetrievalDeps,
+): Promise<Awaited<
+  ReturnType<ConversationGraphMemory["prepareMemory"]>
+> | null> {
+  const budgetMs =
+    deps.graphRetrievalBudgetMs === undefined
+      ? DEFAULT_MEMORY_GRAPH_RETRIEVAL_BUDGET_MS
+      : deps.graphRetrievalBudgetMs;
+
+  if (budgetMs === null) {
+    return deps.graphMemory.prepareMemory(
+      deps.messages,
+      deps.config,
+      args.signal,
+      deps.onEvent,
+    );
+  }
+
+  if (args.signal.aborted) return null;
+
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort();
+  args.signal.addEventListener("abort", abortFromParent, { once: true });
+
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const graphPromise = deps.graphMemory
+    .prepareMemory(deps.messages, deps.config, controller.signal, deps.onEvent)
+    .then(
+      (result) => ({ status: "ok" as const, result }),
+      (err) => ({ status: "error" as const, err }),
+    );
+
+  const timeoutPromise = new Promise<{ status: "timeout" }>((resolve) => {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+      resolve({ status: "timeout" });
+    }, budgetMs);
+  });
+
+  try {
+    const winner = await Promise.race([graphPromise, timeoutPromise]);
+    if (winner.status === "ok") return winner.result;
+    if (winner.status === "timeout") {
+      log.warn(
+        { budgetMs },
+        "Memory graph retrieval exceeded foreground budget; continuing without graph memory",
+      );
+      return null;
+    }
+
+    if (timedOut || controller.signal.aborted) return null;
+    throw winner.err;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    args.signal.removeEventListener("abort", abortFromParent);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes slow local bare-metal TTFT on fresh hatches by addressing two startup-path issues:

- Seed managed inference profiles even when the hatch default-config overlay is present, so the first turn uses the balanced managed profile instead of falling through to the Opus-heavy `llm.default`.
- Add a 2s foreground soft budget around graph memory retrieval so cold local embedding/model/Qdrant startup cannot block the main agent turn before provider submission.
- Deduplicate memory v2 concept-page Qdrant collection creation and thread abort signals through v2 activation/injection so timed-out foreground retrieval stops promptly where possible.

## Root Cause

Fresh local hatches set `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH`, which suppressed runtime profile seeding before the first config load. After that was fixed, the remaining delay came from foreground memory retrieval waiting on cold local embedding startup and Qdrant v2 setup before `LLM call start`.

## Validation

- `bun test src/__tests__/memory-retrieval-pipeline.test.ts`
- `bun test src/memory/v2/__tests__/qdrant.test.ts`
- `bun test src/memory/v2/__tests__/activation.test.ts src/memory/v2/__tests__/injection.test.ts src/memory/v2/__tests__/sim.test.ts`
- `bun test src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts`
- `bun test src/__tests__/config-loader-backfill.test.ts`
- `bun test src/memory/v2/__tests__/skill-store.test.ts`
- `bun test src/__tests__/lifecycle-memory-v2-seed.test.ts`
- `bunx tsc --noEmit`
- `git diff --check`

Also verified manually on local macOS bare-metal: first response under 5s, next message faster.