### PR TITLE
fix(cli): tighten upgrade UUID-resolution edge cases

### DIFF
--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -321,4 +321,39 @@ describe("fetchAssistantByIdFromPlatform", () => {
       ),
     ).rejects.toThrow(/Run 'vellum login'/);
   });
+
+  test("auth-shaped error from authHeaders is normalized to standard sentinel", async () => {
+    // Use a session token (non-vak_) so authHeaders calls fetchOrganizationId.
+    // Stub /v1/organizations/ to 401 so fetchOrganizationId throws
+    // "Failed to fetch organizations from ... (401). Try logging in again."
+    // The new normalization path should rewrite that to the standard
+    // "Authentication failed. Run 'vellum login' to refresh." sentinel so
+    // the upgrade command's catch routes it to AUTH_FAILED.
+    const { fetchMock } = captureFetch((call) => {
+      if (call.url.includes("/v1/organizations/")) {
+        return new Response("", { status: 401 });
+      }
+      // Should never reach the assistants endpoint on this path.
+      return new Response("unexpected", { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    // Silence the console.error inside authHeaders' catch block.
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    console.error = errSpy as unknown as typeof console.error;
+    try {
+      await expect(
+        fetchAssistantByIdFromPlatform(
+          "session-token",
+          "uuid-123",
+          "https://platform.test",
+        ),
+      ).rejects.toThrow(
+        "Authentication failed. Run 'vellum login' to refresh.",
+      );
+    } finally {
+      console.error = origErr;
+    }
+  });
 });

--- a/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
+++ b/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
@@ -1,0 +1,160 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Temp directory for lockfile isolation
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "cli-upgrade-prepare-guard-test-"));
+const savedLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+process.env.VELLUM_LOCKFILE_DIR = testDir;
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+import * as assistantConfig from "../lib/assistant-config.js";
+import * as platformClient from "../lib/platform-client.js";
+
+const findAssistantByNameMock = spyOn(
+  assistantConfig,
+  "findAssistantByName",
+).mockReturnValue(null);
+
+const loadAllAssistantsMock = spyOn(
+  assistantConfig,
+  "loadAllAssistants",
+).mockReturnValue([]);
+
+const getActiveAssistantMock = spyOn(
+  assistantConfig,
+  "getActiveAssistant",
+).mockReturnValue(null);
+
+const getPlatformUrlMock = spyOn(
+  platformClient,
+  "getPlatformUrl",
+).mockReturnValue("https://platform.test");
+
+import { upgrade } from "../commands/upgrade.js";
+
+describe("upgrade() rejects --prepare/--finalize for platform-managed entries", () => {
+  let savedArgv: string[];
+
+  beforeEach(() => {
+    savedArgv = process.argv;
+    findAssistantByNameMock.mockReset();
+    loadAllAssistantsMock.mockReset();
+    loadAllAssistantsMock.mockReturnValue([]);
+    getActiveAssistantMock.mockReset();
+    getActiveAssistantMock.mockReturnValue(null);
+    getPlatformUrlMock.mockReset();
+    getPlatformUrlMock.mockReturnValue("https://platform.test");
+  });
+
+  function runWithArgv(
+    argv: string[],
+  ): Promise<{ exitCode: number | undefined; stderr: string[] }> {
+    process.argv = ["bun", "vellum", ...argv];
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    let capturedExit: number | undefined;
+    const mockExit = mock((code?: number) => {
+      capturedExit = code;
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    return upgrade()
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.message === "process.exit called") {
+          return;
+        }
+        throw err;
+      })
+      .then(() => {
+        process.exit = origExit;
+        stderrWriteMock.mockRestore();
+        process.argv = savedArgv;
+        return { exitCode: capturedExit, stderr: stderrWrites };
+      });
+  }
+
+  test("--prepare against cloud=vellum entry emits UNSUPPORTED_TOPOLOGY and exits 1", async () => {
+    findAssistantByNameMock.mockReturnValue({
+      assistantId: "platform-uuid",
+      cloud: "vellum",
+      runtimeUrl: "https://platform.test",
+    });
+
+    const { exitCode, stderr } = await runWithArgv([
+      "upgrade",
+      "platform-uuid",
+      "--prepare",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const cliErrorLine = stderr.find((s) => s.startsWith("CLI_ERROR:"));
+    expect(cliErrorLine).toBeDefined();
+    const payload = JSON.parse(
+      (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+    );
+    expect(payload.error).toBe("UNSUPPORTED_TOPOLOGY");
+    expect(payload.message).toContain("--prepare");
+  });
+
+  test("--finalize against cloud=vellum entry emits UNSUPPORTED_TOPOLOGY and exits 1", async () => {
+    findAssistantByNameMock.mockReturnValue({
+      assistantId: "platform-uuid",
+      cloud: "vellum",
+      runtimeUrl: "https://platform.test",
+    });
+
+    const { exitCode, stderr } = await runWithArgv([
+      "upgrade",
+      "platform-uuid",
+      "--finalize",
+      "--version",
+      "v1.0.0",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const cliErrorLine = stderr.find((s) => s.startsWith("CLI_ERROR:"));
+    expect(cliErrorLine).toBeDefined();
+    const payload = JSON.parse(
+      (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+    );
+    expect(payload.error).toBe("UNSUPPORTED_TOPOLOGY");
+    expect(payload.message).toContain("--finalize");
+  });
+});
+
+afterAll(() => {
+  findAssistantByNameMock.mockRestore();
+  loadAllAssistantsMock.mockRestore();
+  getActiveAssistantMock.mockRestore();
+  getPlatformUrlMock.mockRestore();
+  rmSync(testDir, { recursive: true, force: true });
+  if (savedLockfileDir === undefined) {
+    delete process.env.VELLUM_LOCKFILE_DIR;
+  } else {
+    process.env.VELLUM_LOCKFILE_DIR = savedLockfileDir;
+  }
+});

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -74,24 +74,27 @@ describe("resolveTargetAssistant platform fallback", () => {
     fetchAssistantByIdFromPlatformMock.mockResolvedValue(null);
   });
 
-  test("name not in lockfile + token present + platform returns assistant → synthetic entry", async () => {
+  test("name not in lockfile + token present + platform returns assistant → synthetic entry uses canonical id", async () => {
+    // Input is mixed-case; platform returns the canonical lower-case id.
+    // The synthetic entry MUST use the platform-returned id, not the raw
+    // user input — `entry.assistantId` flows into the upgrade POST body.
     readPlatformTokenMock.mockReturnValue("platform-token");
     fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce({
-      id: "uuid-1",
-      name: "uuid-1",
+      id: "uuid-canonical",
+      name: "managed",
       status: "active",
     });
 
-    const entry = await resolveTargetAssistant("uuid-1");
+    const entry = await resolveTargetAssistant("UUID-CANONICAL");
 
     expect(entry).toEqual({
-      assistantId: "uuid-1",
+      assistantId: "uuid-canonical",
       cloud: "vellum",
       runtimeUrl: "https://platform.test",
     });
     expect(fetchAssistantByIdFromPlatformMock).toHaveBeenCalledWith(
       "platform-token",
-      "uuid-1",
+      "UUID-CANONICAL",
     );
   });
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -213,8 +213,13 @@ export async function resolveTargetAssistant(
       process.exit(1);
     }
 
+    // Use the canonical id from the platform response rather than the raw
+    // user input (which may differ in casing/whitespace). Subsequent code
+    // uses `entry.assistantId` to construct the upgrade POST body's
+    // `assistant_id` field — trusting user input over the server-confirmed
+    // id is a footgun.
     return {
-      assistantId: nameArg,
+      assistantId: platformAssistant.id,
       cloud: "vellum",
       runtimeUrl: getPlatformUrl(),
     };
@@ -1014,6 +1019,19 @@ async function resolveLatestAndMaybeSelfUpdate(
 export async function upgrade(): Promise<void> {
   const { name, version, latest, prepare, finalize } = parseArgs();
   const entry = await resolveTargetAssistant(name);
+
+  // --prepare / --finalize are part of the local Docker / Sparkle update
+  // lifecycle (they call createBackup, broadcastUpgradeEvent, and
+  // commitWorkspaceViaGateway against a local gateway). Running them
+  // against a synthetic platform-managed entry would silently 404 and
+  // leave the macOS app expecting a BACKUP_PATH line that never arrives.
+  if ((prepare || finalize) && resolveCloud(entry) === "vellum") {
+    const flag = prepare ? "--prepare" : "--finalize";
+    const msg = `Error: ${flag} is only supported for local Docker assistants, not platform-managed ones.`;
+    console.error(msg);
+    emitCliError("UNSUPPORTED_TOPOLOGY", msg);
+    process.exit(1);
+  }
 
   if (prepare) {
     await upgradePrepare(entry, version);

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -584,9 +584,27 @@ export async function fetchAssistantByIdFromPlatform(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/assistants/${assistantId}/`;
 
-  const response = await fetch(url, {
-    headers: await authHeaders(token, platformUrl),
-  });
+  // authHeaders → fetchOrganizationId can throw with a variety of phrasings
+  // when the session token is bad (e.g. "Failed to fetch organizations from
+  // <url> (401). Try logging in again."). Normalize those to the standard
+  // sentinel so the upgrade command can categorize cleanly as AUTH_FAILED.
+  let headers: Record<string, string>;
+  try {
+    headers = await authHeaders(token, platformUrl);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (
+      msg.includes("401") ||
+      msg.includes("403") ||
+      msg.includes("logging in again") ||
+      msg.includes("Authentication")
+    ) {
+      throw new Error("Authentication failed. Run 'vellum login' to refresh.");
+    }
+    throw err;
+  }
+
+  const response = await fetch(url, { headers });
 
   if (response.status === 404) {
     return null;


### PR DESCRIPTION
## Summary
Self-review follow-ups for cli-upgrade-uuid plan:

- Normalize auth-error messages from `authHeaders`/`fetchOrganizationId` so the upgrade command's catch correctly emits `AUTH_FAILED` (not `PLATFORM_API_ERROR`) when an expired token surfaces as a 401 from the org-id fetch.
- Reject `--prepare`/`--finalize` for platform-managed (`cloud: vellum`) assistants — those flags are part of the local Docker / Sparkle lifecycle and were silently no-op'ing for synthetic platform entries.
- Use the platform-returned canonical `id` for the synthetic `AssistantEntry` instead of the raw user input, so the upgrade POST body always sends the server-confirmed identifier.

Part of plan: cli-upgrade-uuid.md (self-review fix round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->