### PR TITLE
Keep skill_load visible during storage cleanup mode

### DIFF
--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -1,11 +1,18 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
 import type { SkillProjectionContext } from "../daemon/conversation-tool-setup.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
+import type { Tool } from "../tools/types.js";
 import type { DiskUsageInfo } from "../util/disk-usage.js";
 
 let diskSample: DiskUsageInfo | null = null;
+let projectedSkillToolNames = new Set<string>();
+let testWorkspaceDir: string | null = null;
+let previousWorkspaceDir: string | undefined;
 
 const mockConfig = {
   timeouts: {
@@ -45,7 +52,7 @@ mock.module("../config/loader.js", () => ({
 
 mock.module("../daemon/conversation-skill-tools.js", () => ({
   projectSkillTools: mock((_history: Message[], _opts: unknown) => ({
-    allowedToolNames: new Set<string>(),
+    allowedToolNames: new Set(projectedSkillToolNames),
     toolDefinitions: [],
   })),
   resetSkillToolProjection: () => undefined,
@@ -95,11 +102,27 @@ const {
   listBackgroundTools,
   registerBackgroundTool,
 } = await import("../tools/background-tool-registry.js");
+const { registerMcpTools, registerTool, unregisterAllMcpTools } =
+  await import("../tools/registry.js");
 const { shellTool } = await import("../tools/terminal/shell.js");
 const { hostShellTool } = await import("../tools/host-terminal/host-shell.js");
+const { skillLoadTool } = await import("../tools/skills/load.js");
 
 function makeToolDef(name: string): ToolDefinition {
   return { name, description: `${name} tool`, input_schema: {} };
+}
+
+function makeMcpTool(name: string): Tool {
+  return {
+    name,
+    description: `${name} tool`,
+    category: "mcp",
+    defaultRiskLevel: "low" as Tool["defaultRiskLevel"],
+    origin: "mcp",
+    ownerMcpServerId: "example",
+    getDefinition: () => makeToolDef(name),
+    execute: async () => ({ content: "", isError: false }),
+  };
 }
 
 function makeProjectionCtx(
@@ -123,29 +146,72 @@ function setDiskUsage(usedMb: number, totalMb = 100): void {
   };
 }
 
+function writeManagedSkill(
+  id: string,
+  body: string,
+  toolsJson?: Record<string, unknown>,
+): void {
+  if (!testWorkspaceDir) {
+    throw new Error("test workspace not initialized");
+  }
+  const skillDir = join(testWorkspaceDir, "skills", id);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), body);
+  if (toolsJson) {
+    writeFileSync(join(skillDir, "TOOLS.json"), JSON.stringify(toolsJson));
+  }
+}
+
 beforeEach(() => {
+  previousWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  testWorkspaceDir = mkdtempSync(join(tmpdir(), "vellum-disk-pressure-tools-"));
+  process.env.VELLUM_WORKSPACE_DIR = testWorkspaceDir;
   _clearRegistryForTesting();
+  registerTool(skillLoadTool);
+  unregisterAllMcpTools();
   __resetDiskPressureGuardForTests();
   _setOverridesForTesting({ "safe-storage-limits": true });
+  projectedSkillToolNames = new Set<string>();
   setDiskUsage(10);
 });
 
 afterEach(() => {
   _clearRegistryForTesting();
+  unregisterAllMcpTools();
   __resetDiskPressureGuardForTests();
   _setOverridesForTesting({});
+  projectedSkillToolNames = new Set<string>();
   diskSample = null;
+  if (previousWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceDir;
+  }
+  previousWorkspaceDir = undefined;
+  if (testWorkspaceDir) {
+    rmSync(testWorkspaceDir, { recursive: true, force: true });
+  }
+  testWorkspaceDir = null;
 });
 
 describe("disk pressure cleanup tool restrictions", () => {
   test("cleanup mode hides non-allowlisted tools and restores normal tools after the turn", () => {
+    projectedSkillToolNames = new Set(["cleanup_skill_action"]);
+    registerMcpTools([makeMcpTool("mcp__example__lookup")]);
+
     const toolDefs = [
       makeToolDef("bash"),
       makeToolDef("host_bash"),
       makeToolDef("file_read"),
+      makeToolDef("skill_load"),
       makeToolDef("file_write"),
+      makeToolDef("file_edit"),
+      makeToolDef("host_file_write"),
+      makeToolDef("host_file_edit"),
       makeToolDef("skill_execute"),
       makeToolDef("web_fetch"),
+      makeToolDef("web_search"),
+      makeToolDef("ui_show"),
     ];
     const ctx = makeProjectionCtx({ diskPressureCleanupModeActive: true });
     const resolve = createResolveToolsCallback(toolDefs, ctx)!;
@@ -153,10 +219,33 @@ describe("disk pressure cleanup tool restrictions", () => {
     const cleanupTools = resolve([]);
     const cleanupNames = cleanupTools.map((tool) => tool.name).sort();
 
-    expect(cleanupNames).toEqual(["bash", "file_read", "host_bash"]);
-    expect(ctx.allowedToolNames?.has("bash")).toBe(true);
-    expect(ctx.allowedToolNames?.has("file_write")).toBe(false);
-    expect(ctx.allowedToolNames?.has("skill_execute")).toBe(false);
+    expect(cleanupNames).toEqual([
+      "bash",
+      "file_read",
+      "host_bash",
+      "skill_load",
+    ]);
+    expect(ctx.allowedToolNames).toEqual(
+      new Set(["bash", "file_read", "host_bash", "skill_load"]),
+    );
+    // Disk-pressure runtime instructions may direct the assistant to load
+    // system-storage-cleanup, so cleanup projection must keep skill_load.
+    expect(cleanupNames).toContain("skill_load");
+    for (const hiddenName of [
+      "file_write",
+      "file_edit",
+      "host_file_write",
+      "host_file_edit",
+      "skill_execute",
+      "web_fetch",
+      "web_search",
+      "ui_show",
+      "mcp__example__lookup",
+      "cleanup_skill_action",
+    ]) {
+      expect(cleanupNames).not.toContain(hiddenName);
+      expect(ctx.allowedToolNames?.has(hiddenName)).toBe(false);
+    }
 
     ctx.diskPressureCleanupModeActive = false;
     const normalTools = resolve([]);
@@ -165,33 +254,208 @@ describe("disk pressure cleanup tool restrictions", () => {
     expect(normalNames).toContain("file_write");
     expect(normalNames).toContain("skill_execute");
     expect(normalNames).toContain("web_fetch");
+    expect(normalNames).toContain("ui_show");
+    expect(normalNames).toContain("mcp__example__lookup");
     expect(ctx.allowedToolNames?.has("file_write")).toBe(true);
+    expect(ctx.allowedToolNames?.has("cleanup_skill_action")).toBe(true);
   });
 
   test("executor fallback rejects non-cleanup tools even if stale allowlist includes them", async () => {
     const handler = new ToolApprovalHandler();
-    const result = await handler.checkPreExecutionGates(
-      "file_write",
-      { path: "large.log", content: "data" },
+
+    async function expectCleanupGateRejects(
+      name: string,
+      input: Record<string, unknown>,
+    ): Promise<void> {
+      const result = await handler.checkPreExecutionGates(
+        name,
+        input,
+        {
+          workingDir: "/workspace",
+          conversationId: "conv-cleanup",
+          trustClass: "guardian",
+          allowedToolNames: new Set([name]),
+          diskPressureCleanupModeActive: true,
+        },
+        "sandbox",
+        "low",
+        Date.now(),
+        () => undefined,
+      );
+
+      expect(result.allowed).toBe(false);
+      if (result.allowed) {
+        throw new Error("Expected disk pressure cleanup gate to reject tool");
+      }
+      expect(result.result.content).toContain(
+        "not available during disk pressure cleanup mode",
+      );
+    }
+
+    await expectCleanupGateRejects("file_write", {
+      path: "large.log",
+      content: "data",
+    });
+    await expectCleanupGateRejects("skill_execute", {
+      tool: "cleanup_skill_action",
+      input: {},
+    });
+  });
+
+  test("executor fallback keeps only instruction-only skill_load safe during cleanup mode", async () => {
+    writeManagedSkill(
+      "plain-cleanup",
+      `---
+name: plain-cleanup
+description: Plain cleanup
+---
+
+This skill is instruction-only but unrelated.
+`,
+    );
+    writeManagedSkill(
+      "dynamic-cleanup",
+      `---
+name: dynamic-cleanup
+description: Dynamic cleanup
+---
+
+This skill runs !\`echo unsafe\`.
+`,
+    );
+    writeManagedSkill(
+      "tool-cleanup",
+      `---
+name: tool-cleanup
+description: Tool cleanup
+---
+
+This skill declares executable tools.
+`,
       {
-        workingDir: "/workspace",
-        conversationId: "conv-cleanup",
-        trustClass: "guardian",
-        allowedToolNames: new Set(["file_write"]),
-        diskPressureCleanupModeActive: true,
+        version: 1,
+        tools: [
+          {
+            name: "tool_cleanup_run",
+            description: "Run cleanup",
+            category: "test",
+            risk: "low",
+            input_schema: { type: "object", properties: {} },
+            executor: "run.ts",
+            execution_target: "sandbox",
+          },
+        ],
       },
+    );
+
+    const handler = new ToolApprovalHandler();
+    const baseContext = {
+      workingDir: "/workspace",
+      conversationId: "conv-cleanup",
+      trustClass: "guardian" as const,
+      allowedToolNames: new Set(["skill_load"]),
+      diskPressureCleanupModeActive: true,
+    };
+
+    const safeResult = await handler.checkPreExecutionGates(
+      "skill_load",
+      { skill: "system-storage-cleanup" },
+      baseContext,
       "sandbox",
       "low",
       Date.now(),
       () => undefined,
     );
 
-    expect(result.allowed).toBe(false);
-    if (result.allowed) {
-      throw new Error("Expected disk pressure cleanup gate to reject tool");
+    expect(safeResult.allowed).toBe(true);
+    if (!safeResult.allowed) {
+      throw new Error("Expected instruction-only bundled skill_load to pass");
     }
-    expect(result.result.content).toContain(
-      "not available during disk pressure cleanup mode",
+    expect(safeResult.tool.name).toBe("skill_load");
+
+    const dynamicResult = await handler.checkPreExecutionGates(
+      "skill_load",
+      { skill: "dynamic-cleanup" },
+      baseContext,
+      "sandbox",
+      "low",
+      Date.now(),
+      () => undefined,
+    );
+
+    expect(dynamicResult.allowed).toBe(false);
+    if (dynamicResult.allowed) {
+      throw new Error("Expected dynamic skill_load to be rejected");
+    }
+    expect(dynamicResult.result.content).toContain(
+      'can only load the bundled "system-storage-cleanup" skill',
+    );
+
+    const unrelatedResult = await handler.checkPreExecutionGates(
+      "skill_load",
+      { skill: "plain-cleanup" },
+      baseContext,
+      "sandbox",
+      "low",
+      Date.now(),
+      () => undefined,
+    );
+
+    expect(unrelatedResult.allowed).toBe(false);
+    if (unrelatedResult.allowed) {
+      throw new Error(
+        "Expected unrelated instruction-only skill to be rejected",
+      );
+    }
+    expect(unrelatedResult.result.content).toContain(
+      'can only load the bundled "system-storage-cleanup" skill',
+    );
+
+    const toolManifestResult = await handler.checkPreExecutionGates(
+      "skill_load",
+      { skill: "tool-cleanup" },
+      baseContext,
+      "sandbox",
+      "low",
+      Date.now(),
+      () => undefined,
+    );
+
+    expect(toolManifestResult.allowed).toBe(false);
+    if (toolManifestResult.allowed) {
+      throw new Error("Expected tool-manifest skill_load to be rejected");
+    }
+    expect(toolManifestResult.result.content).toContain(
+      'can only load the bundled "system-storage-cleanup" skill',
+    );
+
+    writeManagedSkill(
+      "system-storage-cleanup",
+      `---
+name: system-storage-cleanup
+description: Shadow cleanup
+---
+
+This managed skill shadows the bundled cleanup skill.
+`,
+    );
+
+    const shadowResult = await handler.checkPreExecutionGates(
+      "skill_load",
+      { skill: "system-storage-cleanup" },
+      baseContext,
+      "sandbox",
+      "low",
+      Date.now(),
+      () => undefined,
+    );
+
+    expect(shadowResult.allowed).toBe(false);
+    if (shadowResult.allowed) {
+      throw new Error("Expected managed shadow cleanup skill to be rejected");
+    }
+    expect(shadowResult.result.content).toContain(
+      'can only load the bundled "system-storage-cleanup" skill',
     );
   });
 

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,6 +1,7 @@
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
 import { isToolAllowedInChannel } from "../channels/permission-profiles.js";
 import type { ChannelId } from "../channels/types.js";
+import { loadSkillBySelector, loadSkillCatalog } from "../config/skills.js";
 import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,
@@ -9,6 +10,11 @@ import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { createOrReuseToolGrantRequest } from "../runtime/tool-grant-request-helper.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
+import {
+  indexCatalogById,
+  traverseIncludes,
+  validateIncludes,
+} from "../skills/include-graph.js";
 import { getLogger } from "../util/logger.js";
 import { getAllTools, getTool } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
@@ -150,6 +156,7 @@ export async function waitForInlineGrant(
 }
 
 const UI_SURFACE_TOOLS = new Set(["ui_show", "ui_update", "ui_dismiss"]);
+const DISK_PRESSURE_CLEANUP_SKILL_ID = "system-storage-cleanup";
 
 function requiresGuardianApprovalForActor(
   toolName: string,
@@ -177,6 +184,59 @@ function guardianApprovalDeniedMessage(
     return `Permission denied for "${toolName}": this action requires guardian approval from a verified channel identity.`;
   }
   return `Permission denied for "${toolName}": this action requires guardian approval and the current actor is not the guardian.`;
+}
+
+function getDiskPressureSkillLoadBlockReason(
+  input: Record<string, unknown>,
+): string | null {
+  const selector = input.skill;
+  if (typeof selector !== "string" || selector.trim().length === 0) {
+    return null;
+  }
+
+  const loaded = loadSkillBySelector(selector);
+  if (!loaded.skill) {
+    if (
+      loaded.errorCode === "not_found" ||
+      loaded.errorCode === "empty_catalog"
+    ) {
+      return `Skill "${selector}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load the bundled "${DISK_PRESSURE_CLEANUP_SKILL_ID}" skill.`;
+    }
+    return null;
+  }
+
+  if (
+    loaded.skill.id !== DISK_PRESSURE_CLEANUP_SKILL_ID ||
+    loaded.skill.source !== "bundled"
+  ) {
+    return `Skill "${loaded.skill.id}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load the bundled "${DISK_PRESSURE_CLEANUP_SKILL_ID}" skill.`;
+  }
+
+  const catalogIndex = indexCatalogById(loadSkillCatalog());
+  const includeValidation = validateIncludes(loaded.skill.id, catalogIndex);
+  if (!includeValidation.ok) {
+    return `Skill "${loaded.skill.id}" cannot be loaded during disk pressure cleanup mode because its included skills cannot be validated.`;
+  }
+
+  const includedSkillIds = traverseIncludes(
+    loaded.skill.id,
+    catalogIndex,
+  ).visited;
+  for (const skillId of includedSkillIds) {
+    const skill =
+      skillId === loaded.skill.id ? loaded.skill : catalogIndex.get(skillId);
+    if (!skill) continue;
+
+    if (skill.inlineCommandExpansions?.length) {
+      return `Skill "${skill.id}" cannot be loaded during disk pressure cleanup mode because it contains inline command expansions. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
+    }
+
+    if (skill.toolManifest?.present) {
+      return `Skill "${skill.id}" cannot be loaded during disk pressure cleanup mode because it declares executable skill tools. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
+    }
+  }
+
+  return null;
 }
 
 export type PreExecutionGateResult =
@@ -332,6 +392,32 @@ export class ToolApprovalHandler {
         errorCategory: "tool_failure",
       });
       return { allowed: false, result: { content: msg, isError: true } };
+    }
+
+    if (
+      context.diskPressureCleanupModeActive === true &&
+      name === "skill_load"
+    ) {
+      const msg = getDiskPressureSkillLoadBlockReason(input);
+      if (msg) {
+        const durationMs = Date.now() - startTime;
+        emitLifecycleEvent({
+          type: "error",
+          toolName: name,
+          executionTarget,
+          input,
+          workingDir: context.workingDir,
+          conversationId: context.conversationId,
+          requestId: context.requestId,
+          riskLevel,
+          decision: "error",
+          durationMs,
+          errorMessage: msg,
+          isExpected: true,
+          errorCategory: "tool_failure",
+        });
+        return { allowed: false, result: { content: msg, isError: true } };
+      }
     }
 
     // Gate tools not active for the current turn

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -24,6 +24,7 @@ export const DISK_PRESSURE_CLEANUP_TOOL_NAMES: ReadonlySet<string> = new Set([
   "file_read",
   "file_list",
   "host_file_read",
+  "skill_load",
   "background_tool_list",
   "background_tool_cancel",
 ]);


### PR DESCRIPTION
## Summary
- Allow `skill_load` during disk-pressure cleanup mode.
- Extend cleanup-mode regression coverage so `skill_execute`, write, web, UI, MCP, and skill-origin tools remain hidden or blocked.

## Tests
- cd assistant && bun test src/__tests__/disk-pressure-tools.test.ts

Part of ATL-462
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->