### PR TITLE
Part of JARVIS-705: Carry client timezone through conversation transport

### DIFF
--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -182,6 +182,8 @@ export interface ProcessConversationContext {
   forceCompact(): Promise<ContextWindowResult>;
   /** Set transport-derived hints for the conversation. */
   setTransportHints(hints: string[] | undefined): void;
+  /** IANA timezone reported by the active client for the current turn. */
+  clientTimezone?: string;
   /**
    * Apply client-reported host env (home dir, username) from transport
    * metadata, gating on `supportsHostProxy` so non-host-proxy interfaces
@@ -189,6 +191,10 @@ export interface ProcessConversationContext {
    * `DaemonServer.applyTransportMetadata` and the queue-drain path below.
    */
   applyHostEnvFromTransport(transport: ConversationTransportMetadata): void;
+  /** Apply the per-turn client timezone reported by transport metadata. */
+  applyClientTimezoneFromTransport(
+    transport: ConversationTransportMetadata,
+  ): void;
 }
 
 function resolveQueuedTurnContext(
@@ -423,6 +429,7 @@ async function drainSingleMessage(
     // setter used by DaemonServer.applyTransportMetadata so create/reuse
     // and queue-drain stay in sync without duplicating the gate logic.
     conversation.applyHostEnvFromTransport(next.transport);
+    conversation.applyClientTimezoneFromTransport(next.transport);
   }
 
   // Re-preactivate host-proxy skills for interactive desktop turns. The
@@ -865,6 +872,7 @@ async function drainBatch(
   if (head.transport) {
     conversation.setTransportHints(buildTransportHints(head.transport));
     conversation.applyHostEnvFromTransport(head.transport);
+    conversation.applyClientTimezoneFromTransport(head.transport);
   }
 
   // Re-preactivate host-proxy skills for interactive desktop turns.

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -118,6 +118,7 @@ import {
   createToolExecutor,
 } from "./conversation-tool-setup.js";
 import { refreshWorkspaceTopLevelContextIfNeeded as refreshWorkspaceImpl } from "./conversation-workspace.js";
+import { canonicalizeTimeZone } from "./date-context.js";
 import type { HostAppControlProxy } from "./host-app-control-proxy.js";
 import { HostCuProxy } from "./host-cu-proxy.js";
 import type {
@@ -309,6 +310,7 @@ export class Conversation {
    * @internal
    */
   hostUsername?: string;
+  /** @internal */ clientTimezone?: string;
   public readonly traceEmitter: TraceEmitter;
   /** @internal */ hasSystemPromptOverride: boolean;
   /** @internal */ readonly graphMemory: ConversationGraphMemory;
@@ -1128,6 +1130,13 @@ export class Conversation {
     ) {
       this.workspaceTopLevelDirty = true;
     }
+  }
+
+  applyClientTimezoneFromTransport(
+    transport: ConversationTransportMetadata,
+  ): void {
+    this.clientTimezone =
+      canonicalizeTimeZone(transport.clientTimezone) ?? undefined;
   }
 
   setAssistantId(assistantId: string | null): void {

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -29,6 +29,8 @@ interface BaseTransportMetadata {
   uxBrief?: string;
   /** Chat type from the gateway (e.g. "private", "group", "supergroup", "channel"). */
   chatType?: string;
+  /** IANA timezone reported by the active client for the current turn. */
+  clientTimezone?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds client timezone metadata to conversation transport.
- Applies per-message timezone state before agent turns.
- Clears stale client timezone when current transport omits or rejects it.

Part of JARVIS-705.
Part of plan: assistant-local-timezone.md (PR 2 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->