### PR TITLE
refactor(cli): tighten upgrade UUID resolver and dedupe tests

### DIFF
--- a/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
+++ b/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
@@ -24,27 +24,14 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 // ---------------------------------------------------------------------------
 
 import * as assistantConfig from "../lib/assistant-config.js";
-import * as platformClient from "../lib/platform-client.js";
 
+// Both tests in this file have findAssistantByName return a vellum entry,
+// causing resolveTargetAssistant to return at the top branch before any
+// other config helpers run — so we only need to mock this one.
 const findAssistantByNameMock = spyOn(
   assistantConfig,
   "findAssistantByName",
 ).mockReturnValue(null);
-
-const loadAllAssistantsMock = spyOn(
-  assistantConfig,
-  "loadAllAssistants",
-).mockReturnValue([]);
-
-const getActiveAssistantMock = spyOn(
-  assistantConfig,
-  "getActiveAssistant",
-).mockReturnValue(null);
-
-const getPlatformUrlMock = spyOn(
-  platformClient,
-  "getPlatformUrl",
-).mockReturnValue("https://platform.test");
 
 import { upgrade } from "../commands/upgrade.js";
 
@@ -54,12 +41,6 @@ describe("upgrade() rejects --prepare/--finalize for platform-managed entries", 
   beforeEach(() => {
     savedArgv = process.argv;
     findAssistantByNameMock.mockReset();
-    loadAllAssistantsMock.mockReset();
-    loadAllAssistantsMock.mockReturnValue([]);
-    getActiveAssistantMock.mockReset();
-    getActiveAssistantMock.mockReturnValue(null);
-    getPlatformUrlMock.mockReset();
-    getPlatformUrlMock.mockReturnValue("https://platform.test");
   });
 
   function runWithArgv(
@@ -148,9 +129,6 @@ describe("upgrade() rejects --prepare/--finalize for platform-managed entries", 
 
 afterAll(() => {
   findAssistantByNameMock.mockRestore();
-  loadAllAssistantsMock.mockRestore();
-  getActiveAssistantMock.mockRestore();
-  getPlatformUrlMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   if (savedLockfileDir === undefined) {
     delete process.env.VELLUM_LOCKFILE_DIR;

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -58,6 +58,43 @@ const fetchAssistantByIdFromPlatformMock = spyOn(
 
 import { resolveTargetAssistant } from "../commands/upgrade.js";
 
+/**
+ * Run `fn` expecting it to call `process.exit(1)` and emit a `CLI_ERROR:`
+ * line on stderr. Returns the parsed payload so callers can make extra
+ * assertions on its fields.
+ */
+async function expectExitsWithCliError(
+  fn: () => Promise<unknown>,
+  expectedCategory: string,
+): Promise<{ payload: { error: string; message: string; detail?: string } }> {
+  const stderrWrites: string[] = [];
+  const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+    (chunk: unknown) => {
+      stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    },
+  );
+  const mockExit = mock((_code?: number) => {
+    throw new Error("process.exit called");
+  });
+  const origExit = process.exit;
+  process.exit = mockExit as unknown as typeof process.exit;
+  try {
+    await expect(fn()).rejects.toThrow("process.exit called");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  } finally {
+    process.exit = origExit;
+    stderrWriteMock.mockRestore();
+  }
+  const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+  expect(cliErrorLine).toBeDefined();
+  const payload = JSON.parse(
+    (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+  );
+  expect(payload.error).toBe(expectedCategory);
+  return { payload };
+}
+
 describe("resolveTargetAssistant platform fallback", () => {
   beforeEach(() => {
     findAssistantByNameMock.mockReset();
@@ -102,34 +139,10 @@ describe("resolveTargetAssistant platform fallback", () => {
     readPlatformTokenMock.mockReturnValue("platform-token");
     fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce(null);
 
-    const stderrWrites: string[] = [];
-    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
-      (chunk: unknown) => {
-        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
-        return true;
-      },
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-2"),
+      "ASSISTANT_NOT_FOUND",
     );
-
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-2")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
-      expect(cliErrorLine).toBeDefined();
-      const payload = JSON.parse(
-        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
-      );
-      expect(payload.error).toBe("ASSISTANT_NOT_FOUND");
-    } finally {
-      process.exit = origExit;
-      stderrWriteMock.mockRestore();
-    }
   });
 
   test("platform fetch throws auth error → exits AUTH_FAILED", async () => {
@@ -138,34 +151,10 @@ describe("resolveTargetAssistant platform fallback", () => {
       new Error("Authentication failed. Run 'vellum login' to refresh."),
     );
 
-    const stderrWrites: string[] = [];
-    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
-      (chunk: unknown) => {
-        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
-        return true;
-      },
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-auth"),
+      "AUTH_FAILED",
     );
-
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-auth")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
-      expect(cliErrorLine).toBeDefined();
-      const payload = JSON.parse(
-        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
-      );
-      expect(payload.error).toBe("AUTH_FAILED");
-    } finally {
-      process.exit = origExit;
-      stderrWriteMock.mockRestore();
-    }
   });
 
   test("platform fetch throws other error → exits PLATFORM_API_ERROR", async () => {
@@ -174,53 +163,20 @@ describe("resolveTargetAssistant platform fallback", () => {
       new Error("Failed to fetch assistant uuid-1: 500 Internal Server Error"),
     );
 
-    const stderrWrites: string[] = [];
-    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
-      (chunk: unknown) => {
-        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
-        return true;
-      },
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-500"),
+      "PLATFORM_API_ERROR",
     );
-
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-500")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
-      expect(cliErrorLine).toBeDefined();
-      const payload = JSON.parse(
-        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
-      );
-      expect(payload.error).toBe("PLATFORM_API_ERROR");
-    } finally {
-      process.exit = origExit;
-      stderrWriteMock.mockRestore();
-    }
   });
 
   test("name not in lockfile + no platform token → exits ASSISTANT_NOT_FOUND, no platform call", async () => {
     readPlatformTokenMock.mockReturnValue(null);
 
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-3")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(fetchAssistantByIdFromPlatformMock).not.toHaveBeenCalled();
-    } finally {
-      process.exit = origExit;
-    }
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-3"),
+      "ASSISTANT_NOT_FOUND",
+    );
+    expect(fetchAssistantByIdFromPlatformMock).not.toHaveBeenCalled();
   });
 });
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -196,9 +196,14 @@ export async function resolveTargetAssistant(
         detail.includes("Authentication failed") ||
         detail.includes("vellum login")
       ) {
-        const msg = `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`;
-        console.error(msg);
-        emitCliError("AUTH_FAILED", msg, detail);
+        // authHeaders already printed the user-facing
+        // "Authentication failed…" line to stderr before re-throwing; emit
+        // only the structured CLI_ERROR here to avoid a duplicate log.
+        emitCliError(
+          "AUTH_FAILED",
+          `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`,
+          detail,
+        );
       } else {
         const msg = `Failed to look up assistant '${nameArg}' on the platform: ${detail}`;
         console.error(msg);
@@ -210,6 +215,17 @@ export async function resolveTargetAssistant(
       const msg = `No local or platform assistant found with name '${nameArg}'. Make sure you are logged in and this assistant belongs to your account.`;
       console.error(msg);
       emitCliError("ASSISTANT_NOT_FOUND", msg);
+      process.exit(1);
+    }
+
+    // Defensive: the platform helper casts JSON without runtime validation,
+    // so a 200 with a malformed body could yield an object whose `id` is
+    // `undefined`. Reject that explicitly rather than letting `undefined`
+    // flow into the upgrade POST body's `assistant_id` field.
+    if (!platformAssistant.id) {
+      const msg = `Platform returned a malformed response for assistant '${nameArg}'.`;
+      console.error(msg);
+      emitCliError("PLATFORM_API_ERROR", msg);
       process.exit(1);
     }
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -584,21 +584,17 @@ export async function fetchAssistantByIdFromPlatform(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/assistants/${assistantId}/`;
 
-  // authHeaders → fetchOrganizationId can throw with a variety of phrasings
-  // when the session token is bad (e.g. "Failed to fetch organizations from
-  // <url> (401). Try logging in again."). Normalize those to the standard
-  // sentinel so the upgrade command can categorize cleanly as AUTH_FAILED.
+  // authHeaders → fetchOrganizationId throws with the literal status code
+  // in parens (e.g. "Failed to fetch organizations from <url> (401). Try
+  // logging in again."). Normalize 401/403 to the standard sentinel so the
+  // upgrade command can categorize cleanly as AUTH_FAILED. Match on the
+  // parenthesized form so a 500 outage isn't misrouted as auth.
   let headers: Record<string, string>;
   try {
     headers = await authHeaders(token, platformUrl);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (
-      msg.includes("401") ||
-      msg.includes("403") ||
-      msg.includes("logging in again") ||
-      msg.includes("Authentication")
-    ) {
+    if (msg.includes("(401)") || msg.includes("(403)")) {
       throw new Error("Authentication failed. Run 'vellum login' to refresh.");
     }
     throw err;


### PR DESCRIPTION
## Summary
Round-2 self-review follow-ups for cli-upgrade-uuid plan:

- Defensively reject malformed platform responses (`platformAssistant.id` missing) with a clean `PLATFORM_API_ERROR` instead of letting `undefined` flow into the upgrade POST body.
- Narrow the auth-error normalization in `fetchAssistantByIdFromPlatform` to match the actual `fetchOrganizationId` output (`(401)`/`(403)` literals) — drops the over-broad `logging in again` match (which would have caught 500s) and the dead `Authentication` substring.
- Stop double-printing `Authentication failed` to stderr when an auth error is normalized (`authHeaders` already prints it once).
- Dedupe the `stderr.write` + `process.exit` + `CLI_ERROR:` parse boilerplate in `upgrade-resolve.test.ts` into a single helper.
- Remove dead `spyOn` scaffolding in `upgrade-prepare-platform-guard.test.ts` (mocks for `loadAllAssistants`, `getActiveAssistant`, `getPlatformUrl` were never reached because `findAssistantByName` returns first).

Part of plan: cli-upgrade-uuid.md (self-review fix round 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->