### PR TITLE
Part of JARVIS-705: Add automatic timezone mode to macOS settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -5,6 +5,11 @@ import VellumAssistantShared
 struct SettingsAppearanceTab: View {
     private static let knownTimezones: [String] = TimeZone.knownTimeZoneIdentifiers.sorted()
 
+    private enum TimezoneMode: String, Hashable {
+        case automatic
+        case manual
+    }
+
     @ObservedObject var store: SettingsStore
     @State private var newAllowlistDomain = ""
     @State private var isVideoDomainsExpanded: Bool = false
@@ -26,6 +31,7 @@ struct SettingsAppearanceTab: View {
     @State private var voiceRecordingMonitors: [Any] = []
     @State private var voiceModifierHoldTimer: Timer? = nil
     @State private var selectedTimezone: String = ""
+    @State private var timezoneMode: TimezoneMode = .automatic
     @State private var timezoneSearchText: String = ""
     @State private var debouncedTimezoneSearchText: String = ""
     @State private var isTimezoneDropdownOpen: Bool = false
@@ -58,100 +64,125 @@ struct SettingsAppearanceTab: View {
 
             // TIMEZONE section
             SettingsCard(title: "Timezone") {
-                // Searchable timezone picker
-                VStack(spacing: 0) {
-                    HStack {
-                        Text("Closest city")
-                            .font(VFont.bodyMediumLighter)
-                            .foregroundStyle(VColor.contentSecondary)
-                        Spacer()
-                        VSearchBar(placeholder: selectedCityPlaceholder, text: $timezoneSearchText)
-                            .focused($isTimezoneSearchFocused)
-                            .frame(width: 280)
-                    }
-                    .onChange(of: timezoneSearchText) { _, newValue in
-                        isTimezoneDropdownOpen = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                        timezoneSearchDebounceTask?.cancel()
-                        timezoneSearchDebounceTask = Task { @MainActor in
-                            try? await Task.sleep(nanoseconds: 200_000_000)
-                            guard !Task.isCancelled else { return }
-                            debouncedTimezoneSearchText = newValue
-                        }
-                    }
-                    .onChange(of: isTimezoneSearchFocused) { _, focused in
-                        if focused && timezoneSearchText.isEmpty {
-                            // Show all when focused with empty search
-                            isTimezoneDropdownOpen = true
-                        } else if !focused {
-                            isTimezoneDropdownOpen = false
-                        }
-                    }
-                    .onExitCommand {
-                        isTimezoneDropdownOpen = false
-                        isTimezoneSearchFocused = false
-                        timezoneSearchText = ""
-                    }
-
-                    if isTimezoneDropdownOpen {
-                        let filtered = filteredTimezones
-                        if !filtered.isEmpty {
-                            ScrollView {
-                                LazyVStack(alignment: .leading, spacing: VSpacing.xs) {
-                                    ForEach(filtered, id: \.identifier) { entry in
-                                        TimezoneResultRow(
-                                            entry: entry,
-                                            isSelected: entry.identifier == selectedTimezone,
-                                            onSelect: {
-                                                selectedTimezone = entry.identifier
-                                                timezoneSearchText = ""
-                                                isTimezoneDropdownOpen = false
-                                                isTimezoneSearchFocused = false
-                                            }
-                                        )
-                                    }
-                                }
-                                .padding(VSpacing.sm)
-                                .background { OverlayScrollerStyle() }
-                            }
-                            .scrollContentBackground(.hidden)
-                            .frame(maxHeight: 200)
-                            .background(VColor.surfaceLift)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                            .vShadow(VShadow.modalNear)
-                            .vShadow(VShadow.modalFar)
-                            .padding(.top, VSpacing.xs)
-                        }
-                    }
-                }
-                .onChange(of: selectedTimezone) { oldValue, newValue in
-                    guard oldValue != newValue else { return }
-                    if newValue.isEmpty {
-                        store.clearUserTimezone()
-                    } else {
-                        store.saveUserTimezone(newValue)
-                    }
-                }
+                VSegmentControl(
+                    items: [
+                        (label: "Automatic", tag: TimezoneMode.automatic),
+                        (label: "Manual", tag: TimezoneMode.manual),
+                    ],
+                    selection: timezoneModeBinding
+                )
+                .frame(width: 248)
 
                 SettingsDivider()
 
-                HStack {
-                    Text("Time zone")
-                        .font(VFont.bodyMediumLighter)
-                        .foregroundStyle(VColor.contentSecondary)
-                    Spacer()
-                    Text(timezoneDisplayName)
-                        .font(VFont.bodyMediumLighter)
-                        .foregroundStyle(VColor.contentDefault)
+                if timezoneMode == .automatic {
+                    HStack {
+                        Text("Device timezone")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentSecondary)
+                        Spacer()
+                        Text(timezoneDisplayName)
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
+                } else {
+                    // Searchable timezone picker
+                    VStack(spacing: 0) {
+                        HStack {
+                            Text("Closest city")
+                                .font(VFont.bodyMediumLighter)
+                                .foregroundStyle(VColor.contentSecondary)
+                            Spacer()
+                            VSearchBar(placeholder: selectedCityPlaceholder, text: $timezoneSearchText)
+                                .focused($isTimezoneSearchFocused)
+                                .frame(width: 280)
+                        }
+                        .onChange(of: timezoneSearchText) { _, newValue in
+                            isTimezoneDropdownOpen = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            timezoneSearchDebounceTask?.cancel()
+                            timezoneSearchDebounceTask = Task { @MainActor in
+                                try? await Task.sleep(nanoseconds: 200_000_000)
+                                guard !Task.isCancelled else { return }
+                                debouncedTimezoneSearchText = newValue
+                            }
+                        }
+                        .onChange(of: isTimezoneSearchFocused) { _, focused in
+                            if focused && timezoneSearchText.isEmpty {
+                                // Show all when focused with empty search
+                                isTimezoneDropdownOpen = true
+                            } else if !focused {
+                                isTimezoneDropdownOpen = false
+                            }
+                        }
+                        .onExitCommand {
+                            isTimezoneDropdownOpen = false
+                            isTimezoneSearchFocused = false
+                            timezoneSearchText = ""
+                        }
+
+                        if isTimezoneDropdownOpen {
+                            let filtered = filteredTimezones
+                            if !filtered.isEmpty {
+                                ScrollView {
+                                    LazyVStack(alignment: .leading, spacing: VSpacing.xs) {
+                                        ForEach(filtered, id: \.identifier) { entry in
+                                            TimezoneResultRow(
+                                                entry: entry,
+                                                isSelected: entry.identifier == selectedTimezone,
+                                                onSelect: {
+                                                    selectedTimezone = entry.identifier
+                                                    timezoneSearchText = ""
+                                                    isTimezoneDropdownOpen = false
+                                                    isTimezoneSearchFocused = false
+                                                }
+                                            )
+                                        }
+                                    }
+                                    .padding(VSpacing.sm)
+                                    .background { OverlayScrollerStyle() }
+                                }
+                                .scrollContentBackground(.hidden)
+                                .frame(maxHeight: 200)
+                                .background(VColor.surfaceLift)
+                                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                                .vShadow(VShadow.modalNear)
+                                .vShadow(VShadow.modalFar)
+                                .padding(.top, VSpacing.xs)
+                            }
+                        }
+                    }
+                    .onChange(of: selectedTimezone) { oldValue, newValue in
+                        guard oldValue != newValue, timezoneMode == .manual else { return }
+                        if newValue.isEmpty {
+                            store.clearUserTimezone()
+                        } else {
+                            store.saveUserTimezone(newValue)
+                        }
+                    }
+
+                    SettingsDivider()
+
+                    HStack {
+                        Text("Time zone")
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentSecondary)
+                        Spacer()
+                        Text(timezoneDisplayName)
+                            .font(VFont.bodyMediumLighter)
+                            .foregroundStyle(VColor.contentDefault)
+                    }
                 }
             }
             .onAppear {
-                selectedTimezone = store.userTimezone ?? ""
+                saveDetectedDeviceTimezoneIfNeeded()
+                syncTimezoneStateFromStore()
             }
             .onChange(of: store.userTimezone) { _, newStoreValue in
-                let mapped = newStoreValue ?? ""
-                if mapped != selectedTimezone {
-                    selectedTimezone = mapped
-                }
+                syncTimezoneStateFromStore(userTimezone: newStoreValue)
+            }
+            .onChange(of: store.detectedTimezone) { _, _ in
+                guard timezoneMode == .automatic else { return }
+                selectedTimezone = automaticTimezoneIdentifier
             }
 
             // KEYBOARD SHORTCUTS section
@@ -639,6 +670,47 @@ struct SettingsAppearanceTab: View {
         let tz: TimeZone
     }
 
+    private var timezoneModeBinding: Binding<TimezoneMode> {
+        Binding(
+            get: { timezoneMode },
+            set: { newValue in
+                timezoneMode = newValue
+                isTimezoneDropdownOpen = false
+                isTimezoneSearchFocused = false
+                timezoneSearchText = ""
+
+                switch newValue {
+                case .automatic:
+                    saveDetectedDeviceTimezoneIfNeeded()
+                    selectedTimezone = automaticTimezoneIdentifier
+                    store.clearUserTimezone()
+                case .manual:
+                    selectedTimezone = store.userTimezone ?? ""
+                }
+            }
+        )
+    }
+
+    private var automaticTimezoneIdentifier: String {
+        store.detectedTimezone ?? TimeZone.autoupdatingCurrent.identifier
+    }
+
+    private func syncTimezoneStateFromStore(userTimezone: String? = nil) {
+        if let userTimezone = userTimezone ?? store.userTimezone {
+            timezoneMode = .manual
+            selectedTimezone = userTimezone
+        } else {
+            timezoneMode = .automatic
+            selectedTimezone = automaticTimezoneIdentifier
+        }
+    }
+
+    private func saveDetectedDeviceTimezoneIfNeeded() {
+        let deviceTimezone = TimeZone.autoupdatingCurrent.identifier
+        guard store.detectedTimezone != deviceTimezone else { return }
+        store.saveDetectedTimezone(deviceTimezone)
+    }
+
     private var selectedCityPlaceholder: String {
         guard !selectedTimezone.isEmpty,
               TimeZone(identifier: selectedTimezone) != nil else {
@@ -976,4 +1048,3 @@ private struct TimezoneResultRow: View {
         .pointerCursor()
     }
 }
-

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -143,6 +143,7 @@ public final class SettingsStore: ObservableObject {
     @Published var mediaEmbedsEnabledSince: Date?
     @Published var mediaEmbedVideoAllowlistDomains: [String]
     @Published var userTimezone: String?
+    @Published var detectedTimezone: String?
 
     // MARK: - Telegram Integration State
 
@@ -538,19 +539,20 @@ public final class SettingsStore: ObservableObject {
             self.nextConversationShortcut = UserDefaults.standard.string(forKey: "nextConversationShortcut") ?? ""
         }
 
-        // Use defaults for config-dependent properties; the daemon will
-        // provide authoritative values once reachable via loadConfigFromDaemon().
-        let emptyConfig: [String: Any] = [:]
+        // Use local config when a test/local path is provided; otherwise
+        // defaults are replaced once loadConfigFromDaemon() reaches the assistant.
+        let initialConfig = Self.loadConfigFile(path: configPath)
 
         // Load media embed settings (defaults when config is empty)
-        let mediaSettings = Self.loadMediaEmbedSettings(config: emptyConfig)
+        let mediaSettings = Self.loadMediaEmbedSettings(config: initialConfig)
         self.mediaEmbedsEnabled = mediaSettings.enabled
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
-        self.userTimezone = Self.loadUserTimezone(config: emptyConfig)
+        self.userTimezone = Self.loadUserTimezone(config: initialConfig)
+        self.detectedTimezone = Self.loadDetectedTimezone(config: initialConfig)
 
         // Service modes use defaults until daemon provides config
-        loadServiceModes(config: emptyConfig)
+        loadServiceModes(config: initialConfig)
 
         // Seed provider catalog from `LLMProviderRegistry` so the UI has data
         // before the first daemon fetch completes.
@@ -4272,6 +4274,23 @@ public final class SettingsStore: ObservableObject {
         persistUserTimezone()
     }
 
+    /// Saves the device-detected timezone under `ui.detectedTimezone`.
+    ///
+    /// Returns an error string when the value is not a valid IANA timezone.
+    @discardableResult
+    func saveDetectedTimezone(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let canonical = Self.canonicalizeTimeZoneIdentifier(trimmed) else {
+            return "Use an IANA timezone like America/New_York."
+        }
+
+        guard detectedTimezone != canonical else { return nil }
+
+        detectedTimezone = canonical
+        persistDetectedTimezone()
+        return nil
+    }
+
     // MARK: - Media Embed Actions
 
     /// Toggles media embeds on or off and persists the change to the workspace config.
@@ -4401,12 +4420,41 @@ public final class SettingsStore: ObservableObject {
         // its `guard !trimmed.isEmpty` check.
         let tzValue = userTimezone ?? ""
 
+        updateLocalConfig { config in
+            var ui = config["ui"] as? [String: Any] ?? [:]
+            if let userTimezone {
+                ui["userTimezone"] = userTimezone
+            } else {
+                ui.removeValue(forKey: "userTimezone")
+            }
+            config["ui"] = ui
+        }
+
         Task {
             let success = await settingsClient.patchConfig([
                 "ui": ["userTimezone": tzValue]
             ])
             if !success {
                 log.error("Failed to patch config for user timezone")
+            }
+        }
+    }
+
+    private func persistDetectedTimezone() {
+        guard let detectedTimezone else { return }
+
+        updateLocalConfig { config in
+            var ui = config["ui"] as? [String: Any] ?? [:]
+            ui["detectedTimezone"] = detectedTimezone
+            config["ui"] = ui
+        }
+
+        Task {
+            let success = await settingsClient.patchConfig([
+                "ui": ["detectedTimezone": detectedTimezone]
+            ])
+            if !success {
+                log.error("Failed to patch config for detected timezone")
             }
         }
     }
@@ -4487,6 +4535,7 @@ public final class SettingsStore: ObservableObject {
         self.mediaEmbedsEnabledSince = mediaSettings.enabledSince
         self.mediaEmbedVideoAllowlistDomains = mediaSettings.domains
         self.userTimezone = Self.loadUserTimezone(config: config)
+        self.detectedTimezone = Self.loadDetectedTimezone(config: config)
 
         if let services = config["services"] as? [String: Any],
            let webSearch = services["web-search"] as? [String: Any],
@@ -4577,6 +4626,40 @@ public final class SettingsStore: ObservableObject {
             return nil
         }
         return canonicalizeTimeZoneIdentifier(trimmed)
+    }
+
+    private static func loadDetectedTimezone(config: [String: Any]) -> String? {
+        guard let ui = config["ui"] as? [String: Any],
+              let raw = ui["detectedTimezone"] as? String else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+        return canonicalizeTimeZoneIdentifier(trimmed)
+    }
+
+    private static func loadConfigFile(path: String?) -> [String: Any] {
+        guard let path,
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return json
+    }
+
+    private func updateLocalConfig(_ mutate: (inout [String: Any]) -> Void) {
+        guard let configPath else { return }
+        var config = Self.loadConfigFile(path: configPath)
+        mutate(&config)
+
+        do {
+            let data = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: configPath), options: .atomic)
+        } catch {
+            log.error("Failed to update local config file: \(String(describing: error), privacy: .public)")
+        }
     }
 
 }

--- a/clients/macos/vellum-assistantTests/SettingsStoreUserTimezoneTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreUserTimezoneTests.swift
@@ -35,17 +35,19 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
     }
 
     func testLoadsValidConfiguredTimezone() {
-        seed(#"{"ui":{"userTimezone":"America/New_York"}}"#)
+        seed(#"{"ui":{"userTimezone":"America/New_York","detectedTimezone":"America/Los_Angeles"}}"#)
         let store = SettingsStore(configPath: configPath)
 
         XCTAssertEqual(store.userTimezone, "America/New_York")
+        XCTAssertEqual(store.detectedTimezone, "America/Los_Angeles")
     }
 
     func testIgnoresInvalidConfiguredTimezone() {
-        seed(#"{"ui":{"userTimezone":"Not/ARealZone"}}"#)
+        seed(#"{"ui":{"userTimezone":"Not/ARealZone","detectedTimezone":"Also/Invalid"}}"#)
         let store = SettingsStore(configPath: configPath)
 
         XCTAssertNil(store.userTimezone)
+        XCTAssertNil(store.detectedTimezone)
     }
 
     func testSaveUserTimezonePersistsCanonicalIdentifier() {
@@ -61,6 +63,19 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
         XCTAssertEqual(ui?["userTimezone"] as? String, "America/New_York")
     }
 
+    func testSaveDetectedTimezonePersistsCanonicalIdentifier() {
+        seed("{}")
+        let store = SettingsStore(configPath: configPath)
+
+        let error = store.saveDetectedTimezone("america/los_angeles")
+        XCTAssertNil(error)
+        XCTAssertEqual(store.detectedTimezone, "America/Los_Angeles")
+
+        let persisted = readConfig()
+        let ui = persisted["ui"] as? [String: Any]
+        XCTAssertEqual(ui?["detectedTimezone"] as? String, "America/Los_Angeles")
+    }
+
     func testSaveUserTimezoneRejectsInvalidValueWithoutOverwritingExisting() {
         seed(#"{"ui":{"userTimezone":"America/Los_Angeles"}}"#)
         let store = SettingsStore(configPath: configPath)
@@ -74,8 +89,21 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
         XCTAssertEqual(ui?["userTimezone"] as? String, "America/Los_Angeles")
     }
 
+    func testSaveDetectedTimezoneRejectsInvalidValueWithoutOverwritingExisting() {
+        seed(#"{"ui":{"detectedTimezone":"America/New_York"}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        let error = store.saveDetectedTimezone("not/a-timezone")
+        XCTAssertNotNil(error)
+        XCTAssertEqual(store.detectedTimezone, "America/New_York")
+
+        let persisted = readConfig()
+        let ui = persisted["ui"] as? [String: Any]
+        XCTAssertEqual(ui?["detectedTimezone"] as? String, "America/New_York")
+    }
+
     func testClearUserTimezoneRemovesOnlyTimezoneKey() {
-        seed(#"{"ui":{"userTimezone":"America/New_York","mediaEmbeds":{"enabled":true}},"other":"value"}"#)
+        seed(#"{"ui":{"userTimezone":"America/New_York","detectedTimezone":"America/Los_Angeles","mediaEmbeds":{"enabled":true}},"other":"value"}"#)
         let store = SettingsStore(configPath: configPath)
 
         store.clearUserTimezone()
@@ -84,6 +112,23 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
         XCTAssertEqual(persisted["other"] as? String, "value")
         let ui = persisted["ui"] as? [String: Any]
         XCTAssertNil(ui?["userTimezone"])
+        XCTAssertEqual(ui?["detectedTimezone"] as? String, "America/Los_Angeles")
+        XCTAssertNotNil(ui?["mediaEmbeds"])
+    }
+
+    func testAutomaticModeClearingManualOverrideKeepsDetectedTimezone() {
+        seed(#"{"ui":{"userTimezone":"America/New_York","detectedTimezone":"Europe/Berlin","mediaEmbeds":{"enabled":true}}}"#)
+        let store = SettingsStore(configPath: configPath)
+
+        store.clearUserTimezone()
+
+        XCTAssertNil(store.userTimezone)
+        XCTAssertEqual(store.detectedTimezone, "Europe/Berlin")
+
+        let persisted = readConfig()
+        let ui = persisted["ui"] as? [String: Any]
+        XCTAssertNil(ui?["userTimezone"])
+        XCTAssertEqual(ui?["detectedTimezone"] as? String, "Europe/Berlin")
         XCTAssertNotNil(ui?["mediaEmbeds"])
     }
 
@@ -97,7 +142,7 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
     func testUserTimezoneHydratesFromDaemonOnInit() {
         let mock = MockSettingsClient()
         mock.fetchConfigResponse = [
-            "ui": ["userTimezone": "America/New_York"]
+            "ui": ["userTimezone": "America/New_York", "detectedTimezone": "America/Los_Angeles"]
         ]
 
         let store = SettingsStore(settingsClient: mock)
@@ -110,6 +155,7 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
             timeout: 2.0
         )
         XCTAssertGreaterThanOrEqual(mock.fetchConfigCallCount, 1)
+        XCTAssertEqual(store.detectedTimezone, "America/Los_Angeles")
     }
 
     /// Regression: `.daemonDidReconnect` must trigger a config reload
@@ -133,7 +179,7 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
 
         // Daemon comes online with a persisted timezone.
         mock.fetchConfigResponse = [
-            "ui": ["userTimezone": "Europe/Berlin"]
+            "ui": ["userTimezone": "Europe/Berlin", "detectedTimezone": "Europe/Paris"]
         ]
         NotificationCenter.default.post(name: .daemonDidReconnect, object: nil)
 
@@ -144,5 +190,6 @@ final class SettingsStoreUserTimezoneTests: XCTestCase {
             for: [XCTNSPredicateExpectation(predicate: rehydrated, object: nil)],
             timeout: 2.0
         )
+        XCTAssertEqual(store.detectedTimezone, "Europe/Paris")
     }
 }


### PR DESCRIPTION
## Summary
- Adds detected timezone state to macOS settings.
- Introduces Automatic/manual timezone behavior while preserving manual overrides.
- Covers detected timezone load/save behavior in targeted tests.

Apple refs checked (2026-05-05): Foundation TimeZone, SwiftUI Picker.

Part of JARVIS-705.
Part of plan: assistant-local-timezone.md (PR 6 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->