### PR TITLE
refactor(cli): drop dead 'vellum login' substring branch

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -192,10 +192,7 @@ export async function resolveTargetAssistant(
       platformAssistant = await fetchAssistantByIdFromPlatform(token, nameArg);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      if (
-        detail.includes("Authentication failed") ||
-        detail.includes("vellum login")
-      ) {
+      if (detail.includes("Authentication failed")) {
         // authHeaders already printed the user-facing
         // "Authentication failed…" line to stderr before re-throwing; emit
         // only the structured CLI_ERROR here to avoid a duplicate log.


### PR DESCRIPTION
## Summary
The catch in resolveTargetAssistant matched both "Authentication failed" and "vellum login". The only thrower (fetchAssistantByIdFromPlatform after round-2's normalization) emits the literal sentinel "Authentication failed. Run 'vellum login' to refresh." — both substrings always match the same message, so the OR branch was dead.

Part of plan: cli-upgrade-uuid.md (self-review fix round 3, final cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->