### PR TITLE
fix(cli): accept managed-assistant UUIDs in vellum upgrade

### DIFF
--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -307,19 +307,29 @@ describe("fetchAssistantByIdFromPlatform", () => {
     expect(result).toBeNull();
   });
 
-  test("401 → throws", async () => {
+  test("401 → throws and logs human-readable line", async () => {
     const { fetchMock } = captureFetch(() => {
       return new Response("", { status: 401 });
     });
     globalThis.fetch = fetchMock;
 
-    await expect(
-      fetchAssistantByIdFromPlatform(
-        "vak_test_abc",
-        "uuid-123",
-        "https://platform.test",
-      ),
-    ).rejects.toThrow(/Run 'vellum login'/);
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    console.error = errSpy as unknown as typeof console.error;
+    try {
+      await expect(
+        fetchAssistantByIdFromPlatform(
+          "vak_test_abc",
+          "uuid-123",
+          "https://platform.test",
+        ),
+      ).rejects.toThrow(/Run 'vellum login'/);
+      // Direct-response 401 path must print a human-readable line so
+      // interactive CLI users don't see only the structured CLI_ERROR JSON.
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      console.error = origErr;
+    }
   });
 
   test("auth-shaped error from authHeaders is normalized to standard sentinel", async () => {

--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   existsSync,
   mkdtempSync,
@@ -11,9 +11,11 @@ import { join } from "node:path";
 
 import {
   clearPlatformToken,
+  fetchAssistantByIdFromPlatform,
   getPlatformUrl,
   readPlatformToken,
   savePlatformToken,
+  type HatchedAssistant,
 } from "../lib/platform-client.js";
 
 describe("platform-client token path is env-scoped", () => {
@@ -200,5 +202,123 @@ describe("getPlatformUrl resolution order", () => {
   test("trims whitespace from VELLUM_PLATFORM_URL", () => {
     process.env.VELLUM_PLATFORM_URL = "  https://trimmed.vellum.ai  ";
     expect(getPlatformUrl()).toBe("https://trimmed.vellum.ai");
+  });
+});
+
+describe("fetchAssistantByIdFromPlatform", () => {
+  interface CapturedCall {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body: unknown;
+  }
+
+  function captureFetch(
+    responder: (call: CapturedCall) => Response | Promise<Response>,
+  ): {
+    calls: CapturedCall[];
+    fetchMock: typeof globalThis.fetch;
+  } {
+    const calls: CapturedCall[] = [];
+    const fetchMock = mock(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = typeof url === "string" ? url : url.toString();
+        const rawHeaders = (init?.headers ?? {}) as
+          | Record<string, string>
+          | Headers;
+        const headers: Record<string, string> = {};
+        if (rawHeaders instanceof Headers) {
+          rawHeaders.forEach((v, k) => {
+            headers[k] = v;
+          });
+        } else {
+          Object.assign(headers, rawHeaders);
+        }
+        let parsedBody: unknown = undefined;
+        const b = init?.body;
+        if (typeof b === "string") {
+          try {
+            parsedBody = JSON.parse(b);
+          } catch {
+            parsedBody = b;
+          }
+        }
+        const call: CapturedCall = {
+          url: urlStr,
+          method: init?.method ?? "GET",
+          headers,
+          body: parsedBody,
+        };
+        calls.push(call);
+        return responder(call);
+      },
+    );
+    return {
+      calls,
+      fetchMock: fetchMock as unknown as typeof globalThis.fetch,
+    };
+  }
+
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("200 → returns HatchedAssistant", async () => {
+    const { calls, fetchMock } = captureFetch(() => {
+      return new Response(
+        JSON.stringify({ id: "uuid-123", name: "managed", status: "active" }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchAssistantByIdFromPlatform(
+      "vak_test_abc",
+      "uuid-123",
+      "https://platform.test",
+    );
+
+    expect(result).toEqual({
+      id: "uuid-123",
+      name: "managed",
+      status: "active",
+    } as HatchedAssistant);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("https://platform.test/v1/assistants/uuid-123/");
+    expect(calls[0]!.method).toBe("GET");
+  });
+
+  test("404 → returns null", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("", { status: 404 });
+    });
+    globalThis.fetch = fetchMock;
+
+    const result = await fetchAssistantByIdFromPlatform(
+      "vak_test_abc",
+      "uuid-missing",
+      "https://platform.test",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("401 → throws", async () => {
+    const { fetchMock } = captureFetch(() => {
+      return new Response("", { status: 401 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchAssistantByIdFromPlatform(
+        "vak_test_abc",
+        "uuid-123",
+        "https://platform.test",
+      ),
+    ).rejects.toThrow(/Run 'vellum login'/);
   });
 });

--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -321,4 +321,39 @@ describe("fetchAssistantByIdFromPlatform", () => {
       ),
     ).rejects.toThrow(/Run 'vellum login'/);
   });
+
+  test("auth-shaped error from authHeaders is normalized to standard sentinel", async () => {
+    // Use a session token (non-vak_) so authHeaders calls fetchOrganizationId.
+    // Stub /v1/organizations/ to 401 so fetchOrganizationId throws
+    // "Failed to fetch organizations from ... (401). Try logging in again."
+    // The new normalization path should rewrite that to the standard
+    // "Authentication failed. Run 'vellum login' to refresh." sentinel so
+    // the upgrade command's catch routes it to AUTH_FAILED.
+    const { fetchMock } = captureFetch((call) => {
+      if (call.url.includes("/v1/organizations/")) {
+        return new Response("", { status: 401 });
+      }
+      // Should never reach the assistants endpoint on this path.
+      return new Response("unexpected", { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    // Silence the console.error inside authHeaders' catch block.
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    console.error = errSpy as unknown as typeof console.error;
+    try {
+      await expect(
+        fetchAssistantByIdFromPlatform(
+          "session-token",
+          "uuid-123",
+          "https://platform.test",
+        ),
+      ).rejects.toThrow(
+        "Authentication failed. Run 'vellum login' to refresh.",
+      );
+    } finally {
+      console.error = origErr;
+    }
+  });
 });

--- a/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
+++ b/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
@@ -1,0 +1,160 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Temp directory for lockfile isolation
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "cli-upgrade-prepare-guard-test-"));
+const savedLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+process.env.VELLUM_LOCKFILE_DIR = testDir;
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+import * as assistantConfig from "../lib/assistant-config.js";
+import * as platformClient from "../lib/platform-client.js";
+
+const findAssistantByNameMock = spyOn(
+  assistantConfig,
+  "findAssistantByName",
+).mockReturnValue(null);
+
+const loadAllAssistantsMock = spyOn(
+  assistantConfig,
+  "loadAllAssistants",
+).mockReturnValue([]);
+
+const getActiveAssistantMock = spyOn(
+  assistantConfig,
+  "getActiveAssistant",
+).mockReturnValue(null);
+
+const getPlatformUrlMock = spyOn(
+  platformClient,
+  "getPlatformUrl",
+).mockReturnValue("https://platform.test");
+
+import { upgrade } from "../commands/upgrade.js";
+
+describe("upgrade() rejects --prepare/--finalize for platform-managed entries", () => {
+  let savedArgv: string[];
+
+  beforeEach(() => {
+    savedArgv = process.argv;
+    findAssistantByNameMock.mockReset();
+    loadAllAssistantsMock.mockReset();
+    loadAllAssistantsMock.mockReturnValue([]);
+    getActiveAssistantMock.mockReset();
+    getActiveAssistantMock.mockReturnValue(null);
+    getPlatformUrlMock.mockReset();
+    getPlatformUrlMock.mockReturnValue("https://platform.test");
+  });
+
+  function runWithArgv(
+    argv: string[],
+  ): Promise<{ exitCode: number | undefined; stderr: string[] }> {
+    process.argv = ["bun", "vellum", ...argv];
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    let capturedExit: number | undefined;
+    const mockExit = mock((code?: number) => {
+      capturedExit = code;
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+
+    return upgrade()
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.message === "process.exit called") {
+          return;
+        }
+        throw err;
+      })
+      .then(() => {
+        process.exit = origExit;
+        stderrWriteMock.mockRestore();
+        process.argv = savedArgv;
+        return { exitCode: capturedExit, stderr: stderrWrites };
+      });
+  }
+
+  test("--prepare against cloud=vellum entry emits UNSUPPORTED_TOPOLOGY and exits 1", async () => {
+    findAssistantByNameMock.mockReturnValue({
+      assistantId: "platform-uuid",
+      cloud: "vellum",
+      runtimeUrl: "https://platform.test",
+    });
+
+    const { exitCode, stderr } = await runWithArgv([
+      "upgrade",
+      "platform-uuid",
+      "--prepare",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const cliErrorLine = stderr.find((s) => s.startsWith("CLI_ERROR:"));
+    expect(cliErrorLine).toBeDefined();
+    const payload = JSON.parse(
+      (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+    );
+    expect(payload.error).toBe("UNSUPPORTED_TOPOLOGY");
+    expect(payload.message).toContain("--prepare");
+  });
+
+  test("--finalize against cloud=vellum entry emits UNSUPPORTED_TOPOLOGY and exits 1", async () => {
+    findAssistantByNameMock.mockReturnValue({
+      assistantId: "platform-uuid",
+      cloud: "vellum",
+      runtimeUrl: "https://platform.test",
+    });
+
+    const { exitCode, stderr } = await runWithArgv([
+      "upgrade",
+      "platform-uuid",
+      "--finalize",
+      "--version",
+      "v1.0.0",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const cliErrorLine = stderr.find((s) => s.startsWith("CLI_ERROR:"));
+    expect(cliErrorLine).toBeDefined();
+    const payload = JSON.parse(
+      (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+    );
+    expect(payload.error).toBe("UNSUPPORTED_TOPOLOGY");
+    expect(payload.message).toContain("--finalize");
+  });
+});
+
+afterAll(() => {
+  findAssistantByNameMock.mockRestore();
+  loadAllAssistantsMock.mockRestore();
+  getActiveAssistantMock.mockRestore();
+  getPlatformUrlMock.mockRestore();
+  rmSync(testDir, { recursive: true, force: true });
+  if (savedLockfileDir === undefined) {
+    delete process.env.VELLUM_LOCKFILE_DIR;
+  } else {
+    process.env.VELLUM_LOCKFILE_DIR = savedLockfileDir;
+  }
+});

--- a/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
+++ b/cli/src/__tests__/upgrade-prepare-platform-guard.test.ts
@@ -24,27 +24,14 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 // ---------------------------------------------------------------------------
 
 import * as assistantConfig from "../lib/assistant-config.js";
-import * as platformClient from "../lib/platform-client.js";
 
+// Both tests in this file have findAssistantByName return a vellum entry,
+// causing resolveTargetAssistant to return at the top branch before any
+// other config helpers run — so we only need to mock this one.
 const findAssistantByNameMock = spyOn(
   assistantConfig,
   "findAssistantByName",
 ).mockReturnValue(null);
-
-const loadAllAssistantsMock = spyOn(
-  assistantConfig,
-  "loadAllAssistants",
-).mockReturnValue([]);
-
-const getActiveAssistantMock = spyOn(
-  assistantConfig,
-  "getActiveAssistant",
-).mockReturnValue(null);
-
-const getPlatformUrlMock = spyOn(
-  platformClient,
-  "getPlatformUrl",
-).mockReturnValue("https://platform.test");
 
 import { upgrade } from "../commands/upgrade.js";
 
@@ -54,12 +41,6 @@ describe("upgrade() rejects --prepare/--finalize for platform-managed entries", 
   beforeEach(() => {
     savedArgv = process.argv;
     findAssistantByNameMock.mockReset();
-    loadAllAssistantsMock.mockReset();
-    loadAllAssistantsMock.mockReturnValue([]);
-    getActiveAssistantMock.mockReset();
-    getActiveAssistantMock.mockReturnValue(null);
-    getPlatformUrlMock.mockReset();
-    getPlatformUrlMock.mockReturnValue("https://platform.test");
   });
 
   function runWithArgv(
@@ -148,9 +129,6 @@ describe("upgrade() rejects --prepare/--finalize for platform-managed entries", 
 
 afterAll(() => {
   findAssistantByNameMock.mockRestore();
-  loadAllAssistantsMock.mockRestore();
-  getActiveAssistantMock.mockRestore();
-  getPlatformUrlMock.mockRestore();
   rmSync(testDir, { recursive: true, force: true });
   if (savedLockfileDir === undefined) {
     delete process.env.VELLUM_LOCKFILE_DIR;

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -58,6 +58,43 @@ const fetchAssistantByIdFromPlatformMock = spyOn(
 
 import { resolveTargetAssistant } from "../commands/upgrade.js";
 
+/**
+ * Run `fn` expecting it to call `process.exit(1)` and emit a `CLI_ERROR:`
+ * line on stderr. Returns the parsed payload so callers can make extra
+ * assertions on its fields.
+ */
+async function expectExitsWithCliError(
+  fn: () => Promise<unknown>,
+  expectedCategory: string,
+): Promise<{ payload: { error: string; message: string; detail?: string } }> {
+  const stderrWrites: string[] = [];
+  const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+    (chunk: unknown) => {
+      stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    },
+  );
+  const mockExit = mock((_code?: number) => {
+    throw new Error("process.exit called");
+  });
+  const origExit = process.exit;
+  process.exit = mockExit as unknown as typeof process.exit;
+  try {
+    await expect(fn()).rejects.toThrow("process.exit called");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  } finally {
+    process.exit = origExit;
+    stderrWriteMock.mockRestore();
+  }
+  const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+  expect(cliErrorLine).toBeDefined();
+  const payload = JSON.parse(
+    (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+  );
+  expect(payload.error).toBe(expectedCategory);
+  return { payload };
+}
+
 describe("resolveTargetAssistant platform fallback", () => {
   beforeEach(() => {
     findAssistantByNameMock.mockReset();
@@ -102,34 +139,10 @@ describe("resolveTargetAssistant platform fallback", () => {
     readPlatformTokenMock.mockReturnValue("platform-token");
     fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce(null);
 
-    const stderrWrites: string[] = [];
-    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
-      (chunk: unknown) => {
-        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
-        return true;
-      },
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-2"),
+      "ASSISTANT_NOT_FOUND",
     );
-
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-2")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
-      expect(cliErrorLine).toBeDefined();
-      const payload = JSON.parse(
-        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
-      );
-      expect(payload.error).toBe("ASSISTANT_NOT_FOUND");
-    } finally {
-      process.exit = origExit;
-      stderrWriteMock.mockRestore();
-    }
   });
 
   test("platform fetch throws auth error → exits AUTH_FAILED", async () => {
@@ -138,34 +151,10 @@ describe("resolveTargetAssistant platform fallback", () => {
       new Error("Authentication failed. Run 'vellum login' to refresh."),
     );
 
-    const stderrWrites: string[] = [];
-    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
-      (chunk: unknown) => {
-        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
-        return true;
-      },
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-auth"),
+      "AUTH_FAILED",
     );
-
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-auth")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
-      expect(cliErrorLine).toBeDefined();
-      const payload = JSON.parse(
-        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
-      );
-      expect(payload.error).toBe("AUTH_FAILED");
-    } finally {
-      process.exit = origExit;
-      stderrWriteMock.mockRestore();
-    }
   });
 
   test("platform fetch throws other error → exits PLATFORM_API_ERROR", async () => {
@@ -174,53 +163,20 @@ describe("resolveTargetAssistant platform fallback", () => {
       new Error("Failed to fetch assistant uuid-1: 500 Internal Server Error"),
     );
 
-    const stderrWrites: string[] = [];
-    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
-      (chunk: unknown) => {
-        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
-        return true;
-      },
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-500"),
+      "PLATFORM_API_ERROR",
     );
-
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-500")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
-      expect(cliErrorLine).toBeDefined();
-      const payload = JSON.parse(
-        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
-      );
-      expect(payload.error).toBe("PLATFORM_API_ERROR");
-    } finally {
-      process.exit = origExit;
-      stderrWriteMock.mockRestore();
-    }
   });
 
   test("name not in lockfile + no platform token → exits ASSISTANT_NOT_FOUND, no platform call", async () => {
     readPlatformTokenMock.mockReturnValue(null);
 
-    const mockExit = mock((_code?: number) => {
-      throw new Error("process.exit called");
-    });
-    const origExit = process.exit;
-    process.exit = mockExit as unknown as typeof process.exit;
-    try {
-      await expect(resolveTargetAssistant("uuid-3")).rejects.toThrow(
-        "process.exit called",
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-      expect(fetchAssistantByIdFromPlatformMock).not.toHaveBeenCalled();
-    } finally {
-      process.exit = origExit;
-    }
+    await expectExitsWithCliError(
+      () => resolveTargetAssistant("uuid-3"),
+      "ASSISTANT_NOT_FOUND",
+    );
+    expect(fetchAssistantByIdFromPlatformMock).not.toHaveBeenCalled();
   });
 });
 

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -74,24 +74,27 @@ describe("resolveTargetAssistant platform fallback", () => {
     fetchAssistantByIdFromPlatformMock.mockResolvedValue(null);
   });
 
-  test("name not in lockfile + token present + platform returns assistant → synthetic entry", async () => {
+  test("name not in lockfile + token present + platform returns assistant → synthetic entry uses canonical id", async () => {
+    // Input is mixed-case; platform returns the canonical lower-case id.
+    // The synthetic entry MUST use the platform-returned id, not the raw
+    // user input — `entry.assistantId` flows into the upgrade POST body.
     readPlatformTokenMock.mockReturnValue("platform-token");
     fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce({
-      id: "uuid-1",
-      name: "uuid-1",
+      id: "uuid-canonical",
+      name: "managed",
       status: "active",
     });
 
-    const entry = await resolveTargetAssistant("uuid-1");
+    const entry = await resolveTargetAssistant("UUID-CANONICAL");
 
     expect(entry).toEqual({
-      assistantId: "uuid-1",
+      assistantId: "uuid-canonical",
       cloud: "vellum",
       runtimeUrl: "https://platform.test",
     });
     expect(fetchAssistantByIdFromPlatformMock).toHaveBeenCalledWith(
       "platform-token",
-      "uuid-1",
+      "UUID-CANONICAL",
     );
   });
 

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -1,0 +1,237 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Temp directory for lockfile isolation
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "cli-upgrade-resolve-test-"));
+const savedLockfileDir = process.env.VELLUM_LOCKFILE_DIR;
+process.env.VELLUM_LOCKFILE_DIR = testDir;
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+import * as assistantConfig from "../lib/assistant-config.js";
+import * as platformClient from "../lib/platform-client.js";
+
+const findAssistantByNameMock = spyOn(
+  assistantConfig,
+  "findAssistantByName",
+).mockReturnValue(null);
+
+const loadAllAssistantsMock = spyOn(
+  assistantConfig,
+  "loadAllAssistants",
+).mockReturnValue([]);
+
+const getActiveAssistantMock = spyOn(
+  assistantConfig,
+  "getActiveAssistant",
+).mockReturnValue(null);
+
+const getPlatformUrlMock = spyOn(
+  platformClient,
+  "getPlatformUrl",
+).mockReturnValue("https://platform.test");
+
+const readPlatformTokenMock = spyOn(
+  platformClient,
+  "readPlatformToken",
+).mockReturnValue(null);
+
+const fetchAssistantByIdFromPlatformMock = spyOn(
+  platformClient,
+  "fetchAssistantByIdFromPlatform",
+).mockResolvedValue(null);
+
+import { resolveTargetAssistant } from "../commands/upgrade.js";
+
+describe("resolveTargetAssistant platform fallback", () => {
+  beforeEach(() => {
+    findAssistantByNameMock.mockReset();
+    findAssistantByNameMock.mockReturnValue(null);
+    loadAllAssistantsMock.mockReset();
+    loadAllAssistantsMock.mockReturnValue([]);
+    getActiveAssistantMock.mockReset();
+    getActiveAssistantMock.mockReturnValue(null);
+    getPlatformUrlMock.mockReset();
+    getPlatformUrlMock.mockReturnValue("https://platform.test");
+    readPlatformTokenMock.mockReset();
+    readPlatformTokenMock.mockReturnValue(null);
+    fetchAssistantByIdFromPlatformMock.mockReset();
+    fetchAssistantByIdFromPlatformMock.mockResolvedValue(null);
+  });
+
+  test("name not in lockfile + token present + platform returns assistant → synthetic entry", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce({
+      id: "uuid-1",
+      name: "uuid-1",
+      status: "active",
+    });
+
+    const entry = await resolveTargetAssistant("uuid-1");
+
+    expect(entry).toEqual({
+      assistantId: "uuid-1",
+      cloud: "vellum",
+      runtimeUrl: "https://platform.test",
+    });
+    expect(fetchAssistantByIdFromPlatformMock).toHaveBeenCalledWith(
+      "platform-token",
+      "uuid-1",
+    );
+  });
+
+  test("name not in lockfile + token present + platform returns null → exits ASSISTANT_NOT_FOUND", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockResolvedValueOnce(null);
+
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-2")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+      expect(cliErrorLine).toBeDefined();
+      const payload = JSON.parse(
+        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+      );
+      expect(payload.error).toBe("ASSISTANT_NOT_FOUND");
+    } finally {
+      process.exit = origExit;
+      stderrWriteMock.mockRestore();
+    }
+  });
+
+  test("platform fetch throws auth error → exits AUTH_FAILED", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockRejectedValueOnce(
+      new Error("Authentication failed. Run 'vellum login' to refresh."),
+    );
+
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-auth")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+      expect(cliErrorLine).toBeDefined();
+      const payload = JSON.parse(
+        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+      );
+      expect(payload.error).toBe("AUTH_FAILED");
+    } finally {
+      process.exit = origExit;
+      stderrWriteMock.mockRestore();
+    }
+  });
+
+  test("platform fetch throws other error → exits PLATFORM_API_ERROR", async () => {
+    readPlatformTokenMock.mockReturnValue("platform-token");
+    fetchAssistantByIdFromPlatformMock.mockRejectedValueOnce(
+      new Error("Failed to fetch assistant uuid-1: 500 Internal Server Error"),
+    );
+
+    const stderrWrites: string[] = [];
+    const stderrWriteMock = spyOn(process.stderr, "write").mockImplementation(
+      (chunk: unknown) => {
+        stderrWrites.push(typeof chunk === "string" ? chunk : String(chunk));
+        return true;
+      },
+    );
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-500")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      const cliErrorLine = stderrWrites.find((s) => s.startsWith("CLI_ERROR:"));
+      expect(cliErrorLine).toBeDefined();
+      const payload = JSON.parse(
+        (cliErrorLine ?? "").slice("CLI_ERROR:".length).trim(),
+      );
+      expect(payload.error).toBe("PLATFORM_API_ERROR");
+    } finally {
+      process.exit = origExit;
+      stderrWriteMock.mockRestore();
+    }
+  });
+
+  test("name not in lockfile + no platform token → exits ASSISTANT_NOT_FOUND, no platform call", async () => {
+    readPlatformTokenMock.mockReturnValue(null);
+
+    const mockExit = mock((_code?: number) => {
+      throw new Error("process.exit called");
+    });
+    const origExit = process.exit;
+    process.exit = mockExit as unknown as typeof process.exit;
+    try {
+      await expect(resolveTargetAssistant("uuid-3")).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(fetchAssistantByIdFromPlatformMock).not.toHaveBeenCalled();
+    } finally {
+      process.exit = origExit;
+    }
+  });
+});
+
+afterAll(() => {
+  findAssistantByNameMock.mockRestore();
+  loadAllAssistantsMock.mockRestore();
+  getActiveAssistantMock.mockRestore();
+  getPlatformUrlMock.mockRestore();
+  readPlatformTokenMock.mockRestore();
+  fetchAssistantByIdFromPlatformMock.mockRestore();
+  rmSync(testDir, { recursive: true, force: true });
+  if (savedLockfileDir === undefined) {
+    delete process.env.VELLUM_LOCKFILE_DIR;
+  } else {
+    process.env.VELLUM_LOCKFILE_DIR = savedLockfileDir;
+  }
+});

--- a/cli/src/__tests__/upgrade-resolve.test.ts
+++ b/cli/src/__tests__/upgrade-resolve.test.ts
@@ -56,7 +56,7 @@ const fetchAssistantByIdFromPlatformMock = spyOn(
   "fetchAssistantByIdFromPlatform",
 ).mockResolvedValue(null);
 
-import { resolveTargetAssistant } from "../commands/upgrade.js";
+import { resolveTargetAssistant } from "../lib/upgrade-resolve.js";
 
 /**
  * Run `fn` expecting it to call `process.exit(1)` and emit a `CLI_ERROR:`

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -192,10 +192,7 @@ export async function resolveTargetAssistant(
       platformAssistant = await fetchAssistantByIdFromPlatform(token, nameArg);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      if (
-        detail.includes("Authentication failed") ||
-        detail.includes("vellum login")
-      ) {
+      if (detail.includes("Authentication failed")) {
         // authHeaders already printed the user-facing
         // "Authentication failed…" line to stderr before re-throwing; emit
         // only the structured CLI_ERROR here to avoid a duplicate log.

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -23,6 +23,7 @@ import {
 } from "../lib/platform-releases";
 import {
   authHeaders,
+  fetchAssistantByIdFromPlatform,
   getPlatformUrl,
   readPlatformToken,
 } from "../lib/platform-client";
@@ -164,10 +165,20 @@ function resolveCloud(entry: AssistantEntry): string {
  * 2. Active assistant set via `vellum use`
  * 3. Sole assistant (when exactly one exists)
  */
-function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
+export async function resolveTargetAssistant(
+  nameArg: string | null,
+): Promise<AssistantEntry> {
   if (nameArg) {
     const entry = findAssistantByName(nameArg);
-    if (!entry) {
+    if (entry) return entry;
+
+    // Local lockfile miss. The macOS app stores its lockfile in a
+    // sandboxed container the CLI can't read, so a platform-managed
+    // assistant identified by UUID won't be found locally even though
+    // it exists. If we have a platform token, try resolving the name
+    // against the platform API and synthesize an in-memory entry.
+    const token = readPlatformToken();
+    if (!token) {
       console.error(`No assistant found with name '${nameArg}'.`);
       emitCliError(
         "ASSISTANT_NOT_FOUND",
@@ -175,7 +186,38 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
       );
       process.exit(1);
     }
-    return entry;
+
+    let platformAssistant;
+    try {
+      platformAssistant = await fetchAssistantByIdFromPlatform(token, nameArg);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      if (
+        detail.includes("Authentication failed") ||
+        detail.includes("vellum login")
+      ) {
+        const msg = `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`;
+        console.error(msg);
+        emitCliError("AUTH_FAILED", msg, detail);
+      } else {
+        const msg = `Failed to look up assistant '${nameArg}' on the platform: ${detail}`;
+        console.error(msg);
+        emitCliError("PLATFORM_API_ERROR", msg, detail);
+      }
+      process.exit(1);
+    }
+    if (!platformAssistant) {
+      const msg = `No local or platform assistant found with name '${nameArg}'. Make sure you are logged in and this assistant belongs to your account.`;
+      console.error(msg);
+      emitCliError("ASSISTANT_NOT_FOUND", msg);
+      process.exit(1);
+    }
+
+    return {
+      assistantId: nameArg,
+      cloud: "vellum",
+      runtimeUrl: getPlatformUrl(),
+    };
   }
 
   const active = getActiveAssistant();
@@ -512,7 +554,10 @@ async function upgradeDocker(
   } else {
     console.error(`\n❌ Containers failed to become ready within the timeout.`);
 
-    const logDir = await captureUpgradeFailureLogs(res, `${instanceName}-upgrade-failure`);
+    const logDir = await captureUpgradeFailureLogs(
+      res,
+      `${instanceName}-upgrade-failure`,
+    );
     if (logDir) {
       console.log(`📋 Container logs saved to: ${logDir}`);
     }
@@ -938,7 +983,8 @@ async function resolveLatestAndMaybeSelfUpdate(
     );
     if (installResult.error || installResult.status !== 0) {
       const detail =
-        installResult.error?.message ?? `exited with code ${installResult.status}`;
+        installResult.error?.message ??
+        `exited with code ${installResult.status}`;
       console.error(`\n❌ CLI self-update failed: ${detail}`);
       emitCliError("CLI_UPDATE_FAILED", "CLI self-update failed", detail);
       process.exit(1);
@@ -967,7 +1013,7 @@ async function resolveLatestAndMaybeSelfUpdate(
 
 export async function upgrade(): Promise<void> {
   const { name, version, latest, prepare, finalize } = parseArgs();
-  const entry = resolveTargetAssistant(name);
+  const entry = await resolveTargetAssistant(name);
 
   if (prepare) {
     await upgradePrepare(entry, version);

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -5,8 +5,6 @@ import cliPkg from "../../package.json";
 
 import {
   findAssistantByName,
-  getActiveAssistant,
-  loadAllAssistants,
   saveAssistantEntry,
 } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
@@ -23,10 +21,10 @@ import {
 } from "../lib/platform-releases";
 import {
   authHeaders,
-  fetchAssistantByIdFromPlatform,
   getPlatformUrl,
   readPlatformToken,
 } from "../lib/platform-client";
+import { resolveTargetAssistant } from "../lib/upgrade-resolve.js";
 import {
   createBackup,
   pruneOldBackups,
@@ -157,107 +155,6 @@ function resolveCloud(entry: AssistantEntry): string {
     return "custom";
   }
   return "local";
-}
-
-/**
- * Resolve which assistant to target for the upgrade command. Priority:
- * 1. Explicit name argument
- * 2. Active assistant set via `vellum use`
- * 3. Sole assistant (when exactly one exists)
- */
-export async function resolveTargetAssistant(
-  nameArg: string | null,
-): Promise<AssistantEntry> {
-  if (nameArg) {
-    const entry = findAssistantByName(nameArg);
-    if (entry) return entry;
-
-    // Local lockfile miss. The macOS app stores its lockfile in a
-    // sandboxed container the CLI can't read, so a platform-managed
-    // assistant identified by UUID won't be found locally even though
-    // it exists. If we have a platform token, try resolving the name
-    // against the platform API and synthesize an in-memory entry.
-    const token = readPlatformToken();
-    if (!token) {
-      console.error(`No assistant found with name '${nameArg}'.`);
-      emitCliError(
-        "ASSISTANT_NOT_FOUND",
-        `No assistant found with name '${nameArg}'.`,
-      );
-      process.exit(1);
-    }
-
-    let platformAssistant;
-    try {
-      platformAssistant = await fetchAssistantByIdFromPlatform(token, nameArg);
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      if (detail.includes("Authentication failed")) {
-        // authHeaders already printed the user-facing
-        // "Authentication failed…" line to stderr before re-throwing; emit
-        // only the structured CLI_ERROR here to avoid a duplicate log.
-        emitCliError(
-          "AUTH_FAILED",
-          `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`,
-          detail,
-        );
-      } else {
-        const msg = `Failed to look up assistant '${nameArg}' on the platform: ${detail}`;
-        console.error(msg);
-        emitCliError("PLATFORM_API_ERROR", msg, detail);
-      }
-      process.exit(1);
-    }
-    if (!platformAssistant) {
-      const msg = `No local or platform assistant found with name '${nameArg}'. Make sure you are logged in and this assistant belongs to your account.`;
-      console.error(msg);
-      emitCliError("ASSISTANT_NOT_FOUND", msg);
-      process.exit(1);
-    }
-
-    // Defensive: the platform helper casts JSON without runtime validation,
-    // so a 200 with a malformed body could yield an object whose `id` is
-    // `undefined`. Reject that explicitly rather than letting `undefined`
-    // flow into the upgrade POST body's `assistant_id` field.
-    if (!platformAssistant.id) {
-      const msg = `Platform returned a malformed response for assistant '${nameArg}'.`;
-      console.error(msg);
-      emitCliError("PLATFORM_API_ERROR", msg);
-      process.exit(1);
-    }
-
-    // Use the canonical id from the platform response rather than the raw
-    // user input (which may differ in casing/whitespace). Subsequent code
-    // uses `entry.assistantId` to construct the upgrade POST body's
-    // `assistant_id` field — trusting user input over the server-confirmed
-    // id is a footgun.
-    return {
-      assistantId: platformAssistant.id,
-      cloud: "vellum",
-      runtimeUrl: getPlatformUrl(),
-    };
-  }
-
-  const active = getActiveAssistant();
-  if (active) {
-    const entry = findAssistantByName(active);
-    if (entry) return entry;
-  }
-
-  const all = loadAllAssistants();
-  if (all.length === 1) return all[0];
-
-  if (all.length === 0) {
-    const msg = "No assistants found. Run 'vellum hatch' first.";
-    console.error(msg);
-    emitCliError("ASSISTANT_NOT_FOUND", msg);
-  } else {
-    const msg =
-      "Multiple assistants found. Specify a name or set an active assistant with 'vellum use <name>'.";
-    console.error(msg);
-    emitCliError("ASSISTANT_NOT_FOUND", msg);
-  }
-  process.exit(1);
 }
 
 async function upgradeDocker(

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -196,9 +196,14 @@ export async function resolveTargetAssistant(
         detail.includes("Authentication failed") ||
         detail.includes("vellum login")
       ) {
-        const msg = `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`;
-        console.error(msg);
-        emitCliError("AUTH_FAILED", msg, detail);
+        // authHeaders already printed the user-facing
+        // "Authentication failed…" line to stderr before re-throwing; emit
+        // only the structured CLI_ERROR here to avoid a duplicate log.
+        emitCliError(
+          "AUTH_FAILED",
+          `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`,
+          detail,
+        );
       } else {
         const msg = `Failed to look up assistant '${nameArg}' on the platform: ${detail}`;
         console.error(msg);
@@ -210,6 +215,17 @@ export async function resolveTargetAssistant(
       const msg = `No local or platform assistant found with name '${nameArg}'. Make sure you are logged in and this assistant belongs to your account.`;
       console.error(msg);
       emitCliError("ASSISTANT_NOT_FOUND", msg);
+      process.exit(1);
+    }
+
+    // Defensive: the platform helper casts JSON without runtime validation,
+    // so a 200 with a malformed body could yield an object whose `id` is
+    // `undefined`. Reject that explicitly rather than letting `undefined`
+    // flow into the upgrade POST body's `assistant_id` field.
+    if (!platformAssistant.id) {
+      const msg = `Platform returned a malformed response for assistant '${nameArg}'.`;
+      console.error(msg);
+      emitCliError("PLATFORM_API_ERROR", msg);
       process.exit(1);
     }
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -213,8 +213,13 @@ export async function resolveTargetAssistant(
       process.exit(1);
     }
 
+    // Use the canonical id from the platform response rather than the raw
+    // user input (which may differ in casing/whitespace). Subsequent code
+    // uses `entry.assistantId` to construct the upgrade POST body's
+    // `assistant_id` field — trusting user input over the server-confirmed
+    // id is a footgun.
     return {
-      assistantId: nameArg,
+      assistantId: platformAssistant.id,
       cloud: "vellum",
       runtimeUrl: getPlatformUrl(),
     };
@@ -1014,6 +1019,19 @@ async function resolveLatestAndMaybeSelfUpdate(
 export async function upgrade(): Promise<void> {
   const { name, version, latest, prepare, finalize } = parseArgs();
   const entry = await resolveTargetAssistant(name);
+
+  // --prepare / --finalize are part of the local Docker / Sparkle update
+  // lifecycle (they call createBackup, broadcastUpgradeEvent, and
+  // commitWorkspaceViaGateway against a local gateway). Running them
+  // against a synthetic platform-managed entry would silently 404 and
+  // leave the macOS app expecting a BACKUP_PATH line that never arrives.
+  if ((prepare || finalize) && resolveCloud(entry) === "vellum") {
+    const flag = prepare ? "--prepare" : "--finalize";
+    const msg = `Error: ${flag} is only supported for local Docker assistants, not platform-managed ones.`;
+    console.error(msg);
+    emitCliError("UNSUPPORTED_TOPOLOGY", msg);
+    process.exit(1);
+  }
 
   if (prepare) {
     await upgradePrepare(entry, version);

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -571,6 +571,40 @@ export async function fetchPlatformAssistants(
   return (body.results ?? []).filter((a) => a.status === "active");
 }
 
+/**
+ * Fetch a single platform assistant by its UUID. Returns null on 404
+ * (not found or no access). Throws on auth errors or unexpected
+ * server errors.
+ */
+export async function fetchAssistantByIdFromPlatform(
+  token: string,
+  assistantId: string,
+  platformUrl?: string,
+): Promise<HatchedAssistant | null> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/v1/assistants/${assistantId}/`;
+
+  const response = await fetch(url, {
+    headers: await authHeaders(token, platformUrl),
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("Authentication failed. Run 'vellum login' to refresh.");
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch assistant ${assistantId}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return (await response.json()) as HatchedAssistant;
+}
+
 export interface PlatformUser {
   id: string;
   email: string;

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -584,21 +584,17 @@ export async function fetchAssistantByIdFromPlatform(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/assistants/${assistantId}/`;
 
-  // authHeaders → fetchOrganizationId can throw with a variety of phrasings
-  // when the session token is bad (e.g. "Failed to fetch organizations from
-  // <url> (401). Try logging in again."). Normalize those to the standard
-  // sentinel so the upgrade command can categorize cleanly as AUTH_FAILED.
+  // authHeaders → fetchOrganizationId throws with the literal status code
+  // in parens (e.g. "Failed to fetch organizations from <url> (401). Try
+  // logging in again."). Normalize 401/403 to the standard sentinel so the
+  // upgrade command can categorize cleanly as AUTH_FAILED. Match on the
+  // parenthesized form so a 500 outage isn't misrouted as auth.
   let headers: Record<string, string>;
   try {
     headers = await authHeaders(token, platformUrl);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (
-      msg.includes("401") ||
-      msg.includes("403") ||
-      msg.includes("logging in again") ||
-      msg.includes("Authentication")
-    ) {
+    if (msg.includes("(401)") || msg.includes("(403)")) {
       throw new Error("Authentication failed. Run 'vellum login' to refresh.");
     }
     throw err;

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -584,9 +584,27 @@ export async function fetchAssistantByIdFromPlatform(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/assistants/${assistantId}/`;
 
-  const response = await fetch(url, {
-    headers: await authHeaders(token, platformUrl),
-  });
+  // authHeaders → fetchOrganizationId can throw with a variety of phrasings
+  // when the session token is bad (e.g. "Failed to fetch organizations from
+  // <url> (401). Try logging in again."). Normalize those to the standard
+  // sentinel so the upgrade command can categorize cleanly as AUTH_FAILED.
+  let headers: Record<string, string>;
+  try {
+    headers = await authHeaders(token, platformUrl);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (
+      msg.includes("401") ||
+      msg.includes("403") ||
+      msg.includes("logging in again") ||
+      msg.includes("Authentication")
+    ) {
+      throw new Error("Authentication failed. Run 'vellum login' to refresh.");
+    }
+    throw err;
+  }
+
+  const response = await fetch(url, { headers });
 
   if (response.status === 404) {
     return null;

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -607,6 +607,11 @@ export async function fetchAssistantByIdFromPlatform(
   }
 
   if (response.status === 401 || response.status === 403) {
+    // Direct-response auth failure (authHeaders succeeded, but the assistant
+    // endpoint itself rejected the token). authHeaders has its own internal
+    // log path; this one doesn't, so print here so interactive CLI users see
+    // a human-readable message and don't have to parse JSON stderr.
+    console.error("Authentication failed. Run 'vellum login' to refresh.");
     throw new Error("Authentication failed. Run 'vellum login' to refresh.");
   }
 

--- a/cli/src/lib/upgrade-resolve.ts
+++ b/cli/src/lib/upgrade-resolve.ts
@@ -1,0 +1,113 @@
+import {
+  findAssistantByName,
+  getActiveAssistant,
+  loadAllAssistants,
+} from "./assistant-config.js";
+import type { AssistantEntry } from "./assistant-config.js";
+import {
+  fetchAssistantByIdFromPlatform,
+  getPlatformUrl,
+  readPlatformToken,
+} from "./platform-client.js";
+import { emitCliError } from "./cli-error.js";
+
+/**
+ * Resolve which assistant to target for the upgrade command. Priority:
+ * 1. Explicit name argument
+ * 2. Active assistant set via `vellum use`
+ * 3. Sole assistant (when exactly one exists)
+ */
+export async function resolveTargetAssistant(
+  nameArg: string | null,
+): Promise<AssistantEntry> {
+  if (nameArg) {
+    const entry = findAssistantByName(nameArg);
+    if (entry) return entry;
+
+    // Local lockfile miss. The macOS app stores its lockfile in a
+    // sandboxed container the CLI can't read, so a platform-managed
+    // assistant identified by UUID won't be found locally even though
+    // it exists. If we have a platform token, try resolving the name
+    // against the platform API and synthesize an in-memory entry.
+    const token = readPlatformToken();
+    if (!token) {
+      console.error(`No assistant found with name '${nameArg}'.`);
+      emitCliError(
+        "ASSISTANT_NOT_FOUND",
+        `No assistant found with name '${nameArg}'.`,
+      );
+      process.exit(1);
+    }
+
+    let platformAssistant;
+    try {
+      platformAssistant = await fetchAssistantByIdFromPlatform(token, nameArg);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      if (detail.includes("Authentication failed")) {
+        // authHeaders already printed the user-facing
+        // "Authentication failed…" line to stderr before re-throwing; emit
+        // only the structured CLI_ERROR here to avoid a duplicate log.
+        emitCliError(
+          "AUTH_FAILED",
+          `Authentication failed while looking up assistant '${nameArg}'. Run 'vellum login' to refresh.`,
+          detail,
+        );
+      } else {
+        const msg = `Failed to look up assistant '${nameArg}' on the platform: ${detail}`;
+        console.error(msg);
+        emitCliError("PLATFORM_API_ERROR", msg, detail);
+      }
+      process.exit(1);
+    }
+    if (!platformAssistant) {
+      const msg = `No local or platform assistant found with name '${nameArg}'. Make sure you are logged in and this assistant belongs to your account.`;
+      console.error(msg);
+      emitCliError("ASSISTANT_NOT_FOUND", msg);
+      process.exit(1);
+    }
+
+    // Defensive: the platform helper casts JSON without runtime validation,
+    // so a 200 with a malformed body could yield an object whose `id` is
+    // `undefined`. Reject that explicitly rather than letting `undefined`
+    // flow into the upgrade POST body's `assistant_id` field.
+    if (!platformAssistant.id) {
+      const msg = `Platform returned a malformed response for assistant '${nameArg}'.`;
+      console.error(msg);
+      emitCliError("PLATFORM_API_ERROR", msg);
+      process.exit(1);
+    }
+
+    // Use the canonical id from the platform response rather than the raw
+    // user input (which may differ in casing/whitespace). Subsequent code
+    // uses `entry.assistantId` to construct the upgrade POST body's
+    // `assistant_id` field — trusting user input over the server-confirmed
+    // id is a footgun.
+    return {
+      assistantId: platformAssistant.id,
+      cloud: "vellum",
+      runtimeUrl: getPlatformUrl(),
+    };
+  }
+
+  const active = getActiveAssistant();
+  if (active) {
+    const entry = findAssistantByName(active);
+    if (entry) return entry;
+  }
+
+  const all = loadAllAssistants();
+  if (all.length === 1) return all[0];
+
+  if (all.length === 0) {
+    const msg = "No assistants found. Run 'vellum hatch' first.";
+    console.error(msg);
+    emitCliError("ASSISTANT_NOT_FOUND", msg);
+  } else {
+    const msg =
+      "Multiple assistants found. Specify a name or set an active assistant with 'vellum use <name>'.";
+    console.error(msg);
+    emitCliError("ASSISTANT_NOT_FOUND", msg);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
Make `vellum upgrade <UUID> --version <ver>` work for platform-managed assistants when the user is logged in but the assistant doesn't appear in the local CLI lockfile (the macOS app stores its lockfile in a sandboxed container the CLI binary can't read). Adds a platform-API fallback to `resolveTargetAssistant` in `upgrade.ts`, gated only on platform-token presence.

## Self-review result
PASS after 3 rounds of self-review remediation. Round 1 flagged 3 real gaps (auth-error categorization for `fetchOrganizationId`-shaped 401s, `--prepare`/`--finalize` silent no-op for synthetic platform entries, raw user input vs canonical `platformAssistant.id`). Round 2 flagged 4 (over-broad auth-substring match, double-`console.error` on auth path, repeated test scaffolding, dead test mocks). Round 3 flagged 1 substantive nit (dead OR branch in auth substring match). All addressed.

## PRs merged into feature branch
- #29667: feat(cli): add fetchAssistantByIdFromPlatform helper
- #29668: fix(cli): resolve managed assistant UUIDs via platform in upgrade

### Self-review fix PRs
- #29672: fix(cli): tighten upgrade UUID-resolution edge cases (auth normalization, prepare/finalize guard, canonical id)
- #29676: refactor(cli): tighten upgrade UUID resolver and dedupe tests (narrow auth match, drop double-log, `!platformAssistant.id` guard, test helper, dead-mock cleanup)
- #29679: refactor(cli): drop dead 'vellum login' substring branch

Part of plan: cli-upgrade-uuid.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->