### PR TITLE
Make workspace skill discovery derive from valid SKILL.md files

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -155,12 +155,20 @@ describe("skills catalog loading", () => {
     expect(catalog.map((skill) => skill.id)).toEqual(["alpha", "zeta"]);
   });
 
-  test("treats SKILLS.md as authoritative when present", () => {
-    writeSkill("available", "Available Skill", "Present on disk");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- ../invalid-only\n");
+  test("SKILLS.md does not hide valid skill directories", () => {
+    writeSkill("existing", "Existing Skill", "Listed in stale index");
+    writeSkill(
+      "geo-article-writer",
+      "Geo Article Writer",
+      "Valid skill omitted from stale index",
+    );
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- existing\n");
 
     const catalog = loadUserSkillCatalog();
-    expect(catalog).toHaveLength(0);
+    expect(catalog.map((skill) => skill.id)).toEqual([
+      "existing",
+      "geo-article-writer",
+    ]);
   });
 });
 

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -170,6 +170,17 @@ describe("skills catalog loading", () => {
       "geo-article-writer",
     ]);
   });
+
+  test("SKILLS.md nested stale entries do not replace top-level discoveries", () => {
+    writeSkill("foo", "Top-Level Skill", "Valid top-level skill");
+    writeSkill("archive/foo", "Archived Skill", "Stale nested copy");
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- archive/foo\n");
+
+    const catalog = loadUserSkillCatalog();
+    expect(catalog.map((skill) => skill.id)).toEqual(["foo"]);
+    expect(catalog[0].name).toBe("Top-Level Skill");
+    expect(catalog[0].directoryPath).toBe(join(TEST_DIR, "skills", "foo"));
+  });
 });
 
 describe("workspace skills", () => {

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -730,6 +730,9 @@ function discoverSkillDirectories(skillsDir: string): string[] {
 function getManagedSkillDirectories(skillsDir: string): string[] {
   const discoveredDirectories = discoverSkillDirectories(skillsDir);
   const indexedDirectories = getIndexedSkillDirectories(skillsDir) ?? [];
+  const discoveredCanonicalDirectories = new Set(
+    discoveredDirectories.map((directory) => getCanonicalPath(directory)),
+  );
   const directories: string[] = [];
   const seenCanonicalDirectories = new Set<string>();
 
@@ -744,6 +747,9 @@ function getManagedSkillDirectories(skillsDir: string): string[] {
   };
 
   for (const directory of indexedDirectories) {
+    if (!discoveredCanonicalDirectories.has(getCanonicalPath(directory))) {
+      continue;
+    }
     addDirectory(directory);
   }
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -727,6 +727,33 @@ function discoverSkillDirectories(skillsDir: string): string[] {
   return dirs.sort((a, b) => a.localeCompare(b));
 }
 
+function getManagedSkillDirectories(skillsDir: string): string[] {
+  const discoveredDirectories = discoverSkillDirectories(skillsDir);
+  const indexedDirectories = getIndexedSkillDirectories(skillsDir) ?? [];
+  const directories: string[] = [];
+  const seenCanonicalDirectories = new Set<string>();
+
+  const addDirectory = (directory: string): void => {
+    if (!existsSync(directory)) return;
+
+    const canonicalDirectory = getCanonicalPath(directory);
+    if (seenCanonicalDirectories.has(canonicalDirectory)) return;
+
+    seenCanonicalDirectories.add(canonicalDirectory);
+    directories.push(directory);
+  };
+
+  for (const directory of indexedDirectories) {
+    addDirectory(directory);
+  }
+
+  for (const directory of discoveredDirectories) {
+    addDirectory(directory);
+  }
+
+  return directories;
+}
+
 // ─── Catalog loading ─────────────────────────────────────────────────────────
 
 function skillSummaryFromDefinition(
@@ -867,8 +894,7 @@ export function loadSkillCatalog(
 
   // Load managed (user) skills, which take precedence over bundled skills with the same ID
   const skillsDir = getSkillsDir();
-  const indexedDirectories = getIndexedSkillDirectories(skillsDir);
-  const directories = indexedDirectories ?? discoverSkillDirectories(skillsDir);
+  const directories = getManagedSkillDirectories(skillsDir);
 
   for (const directory of directories) {
     const skill = readSkillFromDirectory(directory, skillsDir, "managed");


### PR DESCRIPTION
## Summary
- Makes managed workspace skill discovery scan valid top-level SKILL.md files instead of trusting SKILLS.md as authoritative.
- Keeps SKILLS.md only as an ordering overlay while preserving path and symlink safety.
- Updates stale-index regression coverage for skill catalog discovery.

Part of plan: migrate-off-skills-md.md (PR 1 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Part of JARVIS-710
