### PR TITLE
Part of JARVIS-705: Inject effective and device timezone context

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -20,6 +20,7 @@ const conversationDiskViewRealSnapshot = {
     "../memory/conversation-disk-view.js",
   ) as Record<string, unknown>),
 };
+let mockUiConfig: { userTimezone?: string; detectedTimezone?: string } = {};
 
 // ── Module mocks (must precede imports of the module under test) ─────
 
@@ -60,7 +61,7 @@ mock.module("../config/loader.js", () => ({
     },
     rateLimit: { maxRequestsPerMinute: 0 },
     workspaceGit: { turnCommitMaxWaitMs: 10 },
-    ui: {},
+    ui: mockUiConfig,
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},
@@ -265,6 +266,10 @@ let mockInjectionBlocks: {
   pkbSystemReminder?: string;
   unifiedTurnContext?: string;
 } = {};
+const buildUnifiedTurnContextBlockMock = mock(
+  (options: Record<string, unknown>) =>
+    `<turn_context>\ncurrent_time: ${String(options.timestamp)}\n</turn_context>`,
+);
 const applyRuntimeInjectionsMock = mock(
   async (msgs: Message[], _options?: unknown) => ({
     messages: msgs,
@@ -306,6 +311,7 @@ const getSlackCompactionWatermarkForPrefixMock = mock(
 );
 mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   applyRuntimeInjections: applyRuntimeInjectionsMock,
+  buildUnifiedTurnContextBlock: buildUnifiedTurnContextBlockMock,
   stripInjectionsForCompaction: (msgs: Message[]) => msgs,
   findLastInjectedNowContent: () => null,
   readNowScratchpad: () => null,
@@ -326,8 +332,40 @@ mock.module("../daemon/conversation-runtime-assembly.js", () => ({
   assembleSlackActiveThreadFocusBlock: () => null,
 }));
 
+const resolveTurnTimezoneContextMock = mock(
+  (options: {
+    configuredUserTimeZone?: string | null;
+    clientTimezone?: string | null;
+    detectedTimezone?: string | null;
+    hostTimeZone?: string | null;
+  }) => ({
+    configuredUserTimezone: options.configuredUserTimeZone ?? null,
+    clientTimezone: options.clientTimezone ?? null,
+    detectedTimezone: options.detectedTimezone ?? null,
+    hostTimezone: options.hostTimeZone ?? "UTC",
+    effectiveTimezone:
+      options.configuredUserTimeZone ??
+      options.clientTimezone ??
+      options.detectedTimezone ??
+      options.hostTimeZone ??
+      "UTC",
+    source: options.configuredUserTimeZone
+      ? "configuredUserTimezone"
+      : options.clientTimezone
+        ? "clientTimezone"
+        : options.detectedTimezone
+          ? "detectedTimezone"
+          : options.hostTimeZone
+            ? "hostTimezone"
+            : "utcFallback",
+  }),
+);
+const formatTurnTimestampMock = mock(
+  (_options?: unknown) => "2026-01-01 (Thursday) 00:00:00 +00:00 (UTC)",
+);
 mock.module("../daemon/date-context.js", () => ({
-  formatTurnTimestamp: () => "2026-01-01 (Thursday) 00:00:00 +00:00 (UTC)",
+  formatTurnTimestamp: formatTurnTimestampMock,
+  resolveTurnTimezoneContext: resolveTurnTimezoneContextMock,
 }));
 
 mock.module("../daemon/history-repair.js", () => ({
@@ -597,6 +635,7 @@ function makeCtx(
 // ── Tests ────────────────────────────────────────────────────────────
 
 beforeEach(() => {
+  mockUiConfig = {};
   mockEstimateTokens = 1000;
   mockReducerStepFn = null;
   mockOverflowAction = "fail_gracefully";
@@ -626,6 +665,9 @@ beforeEach(() => {
     () => {},
   );
   applyRuntimeInjectionsMock.mockClear();
+  buildUnifiedTurnContextBlockMock.mockClear();
+  resolveTurnTimezoneContextMock.mockClear();
+  formatTurnTimestampMock.mockClear();
   mockSlackChronologicalContext = null;
   loadSlackChronologicalContextMock.mockClear();
   getSlackCompactionWatermarkForPrefixMock.mockClear();
@@ -638,6 +680,56 @@ beforeEach(() => {
 });
 
 describe("session-agent-loop", () => {
+  describe("timezone turn context", () => {
+    test("passes ctx.clientTimezone and ui.detectedTimezone into timezone resolution", async () => {
+      mockUiConfig = {
+        userTimezone: "America/New_York",
+        detectedTimezone: "America/Chicago",
+      };
+      const ctx = makeCtx({ clientTimezone: "America/Los_Angeles" });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(resolveTurnTimezoneContextMock).toHaveBeenCalled();
+      const timezoneOptions = resolveTurnTimezoneContextMock.mock.calls[0]?.[0];
+      expect(timezoneOptions).toMatchObject({
+        configuredUserTimeZone: "America/New_York",
+        clientTimezone: "America/Los_Angeles",
+        detectedTimezone: "America/Chicago",
+      });
+    });
+
+    test("passes resolved canonical timezones into unified turn context", async () => {
+      mockUiConfig = {
+        userTimezone: "US/Eastern",
+        detectedTimezone: "US/Central",
+      };
+      resolveTurnTimezoneContextMock.mockImplementationOnce(() => ({
+        configuredUserTimezone: "America/New_York",
+        clientTimezone: "America/Los_Angeles",
+        detectedTimezone: "America/Chicago",
+        hostTimezone: "America/Denver",
+        effectiveTimezone: "America/New_York",
+        source: "configuredUserTimezone",
+      }));
+      const ctx = makeCtx({ clientTimezone: "US/Pacific" });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(formatTurnTimestampMock).toHaveBeenCalledWith({
+        timeZone: "America/New_York",
+      });
+      expect(buildUnifiedTurnContextBlockMock).toHaveBeenCalled();
+      const turnContextOptions =
+        buildUnifiedTurnContextBlockMock.mock.calls[0]?.[0];
+      expect(turnContextOptions).toMatchObject({
+        configuredUserTimezone: "America/New_York",
+        clientTimezone: "America/Los_Angeles",
+        detectedTimezone: "America/Chicago",
+      });
+    });
+  });
+
   describe("pre-flight checks", () => {
     test("throws if called without an abortController", async () => {
       const ctx = makeCtx();

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1437,6 +1437,64 @@ describe("buildUnifiedTurnContextBlock", () => {
     expect(text).toContain("time_since_last_message: yesterday");
     expect(text).toContain("canonical_actor_identity: user-1");
   });
+
+  test("timezone mismatch: omits extra lines when there is no manual override", () => {
+    const text = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02 (Thursday) 08:00:00 -04:00 (America/New_York)",
+      clientTimezone: "America/New_York",
+      detectedTimezone: "America/New_York",
+    });
+
+    expect(text).toContain(
+      "current_time: 2026-04-02 (Thursday) 08:00:00 -04:00 (America/New_York)",
+    );
+    expect(text).not.toContain("configured_user_timezone:");
+    expect(text).not.toContain("client_device_timezone:");
+    expect(text).not.toContain("timezone_update_available:");
+  });
+
+  test("timezone mismatch: omits extra lines when configured and client timezone match", () => {
+    const text = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02 (Thursday) 08:00:00 -04:00 (America/New_York)",
+      configuredUserTimezone: "America/New_York",
+      clientTimezone: "America/New_York",
+      detectedTimezone: "America/New_York",
+    });
+
+    expect(text).not.toContain("configured_user_timezone:");
+    expect(text).not.toContain("client_device_timezone:");
+    expect(text).not.toContain("timezone_update_available:");
+  });
+
+  test("timezone mismatch: emits configured and client device timezone when they differ", () => {
+    const text = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02 (Thursday) 08:00:00 -04:00 (America/New_York)",
+      configuredUserTimezone: "America/New_York",
+      clientTimezone: "America/Los_Angeles",
+      detectedTimezone: "America/Los_Angeles",
+    });
+
+    expect(text).toContain("configured_user_timezone: America/New_York");
+    expect(text).toContain("client_device_timezone: America/Los_Angeles");
+  });
+
+  test("timezone mismatch: emits CLI affordance only in mismatch case", () => {
+    const mismatchText = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02 (Thursday) 08:00:00 -04:00 (America/New_York)",
+      configuredUserTimezone: "America/New_York",
+      clientTimezone: "America/Los_Angeles",
+    });
+    const matchingText = buildUnifiedTurnContextBlock({
+      timestamp: "2026-04-02 (Thursday) 08:00:00 -04:00 (America/New_York)",
+      configuredUserTimezone: "America/New_York",
+      clientTimezone: "America/New_York",
+    });
+
+    expect(mismatchText).toContain(
+      'timezone_update_available: after explicit user confirmation, persist client_device_timezone with `assistant config set ui.userTimezone "America/Los_Angeles"`',
+    );
+    expect(matchingText).not.toContain("timezone_update_available:");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -184,7 +184,10 @@ import type { SkillProjectionCache } from "./conversation-skill-tools.js";
 import { markSurfaceCompleted } from "./conversation-surfaces.js";
 import { resolveTrustClass } from "./conversation-tool-setup.js";
 import { recordUsage } from "./conversation-usage.js";
-import { formatTurnTimestamp } from "./date-context.js";
+import {
+  formatTurnTimestamp,
+  resolveTurnTimezoneContext,
+} from "./date-context.js";
 import { getDiskPressureStatus } from "./disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "./disk-pressure-policy.js";
 import { deepRepairHistory } from "./history-repair.js";
@@ -511,6 +514,7 @@ export interface AgentLoopConversationContext {
   voiceCallControlPrompt?: string;
   transportHints?: string[];
   slackRuntimeContextNotice?: string;
+  clientTimezone?: string;
 
   readonly coreToolNames: Set<string>;
   allowedToolNames?: Set<string>;
@@ -1320,14 +1324,16 @@ export async function runAgentLoopImpl(
 
     // Compute fresh turn timestamp for date grounding.
     // Absolute "now" is always anchored to assistant host clock, while local
-    // date semantics prefer configured user timezone, then recalled memory.
+    // date semantics prefer configured user timezone, then device timezones.
     const hostTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const configuredUserTimeZone = getConfig().ui.userTimezone ?? null;
-    const recalledUserTimeZone = null;
-    const timestamp = formatTurnTimestamp({
+    const timezoneContext = resolveTurnTimezoneContext({
+      configuredUserTimeZone: config.ui.userTimezone ?? null,
+      clientTimezone: ctx.clientTimezone ?? null,
+      detectedTimezone: config.ui.detectedTimezone ?? null,
       hostTimeZone,
-      configuredUserTimeZone,
-      userTimeZone: recalledUserTimeZone,
+    });
+    const timestamp = formatTurnTimestamp({
+      timeZone: timezoneContext.effectiveTimezone,
     });
 
     // Resolve the inbound actor context for the unified <turn_context> block.
@@ -1381,15 +1387,21 @@ export async function runAgentLoopImpl(
       }
     }
 
+    const baseTurnContext = {
+      timestamp,
+      interfaceName,
+      channelName,
+      configuredUserTimezone: timezoneContext.configuredUserTimezone,
+      clientTimezone: timezoneContext.clientTimezone,
+      detectedTimezone: timezoneContext.detectedTimezone,
+      timeSinceLastMessage,
+    };
     const unifiedTurnContextStr = buildUnifiedTurnContextBlock(
       isGuardian
-        ? { timestamp, interfaceName, channelName, timeSinceLastMessage }
+        ? baseTurnContext
         : {
-            timestamp,
-            interfaceName,
-            channelName,
+            ...baseTurnContext,
             actorContext: resolvedInboundActorContext,
-            timeSinceLastMessage,
           },
     );
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -789,6 +789,9 @@ export interface UnifiedTurnContextOptions {
   interfaceName?: string;
   channelName?: string;
   actorContext?: InboundActorContext | null;
+  configuredUserTimezone?: string | null;
+  clientTimezone?: string | null;
+  detectedTimezone?: string | null;
   /**
    * Human-readable duration since the previous user message (e.g. "14h ago",
    * "yesterday", "3d ago"). Only populated when the gap exceeds 12 hours so
@@ -831,6 +834,25 @@ export function buildUnifiedTurnContextBlock(
 
   const lines: string[] = ["<turn_context>"];
   lines.push(`current_time: ${options.timestamp}`);
+  const configuredUserTimezone = options.configuredUserTimezone ?? null;
+  const clientDeviceTimezone =
+    options.clientTimezone ?? options.detectedTimezone ?? null;
+  const hasTimezoneMismatch =
+    configuredUserTimezone !== null &&
+    clientDeviceTimezone !== null &&
+    configuredUserTimezone !== clientDeviceTimezone;
+  if (hasTimezoneMismatch) {
+    const sanitizedConfiguredTimezone = sanitizeInlineContextValue(
+      configuredUserTimezone,
+    );
+    const sanitizedClientDeviceTimezone =
+      sanitizeInlineContextValue(clientDeviceTimezone);
+    lines.push(`configured_user_timezone: ${sanitizedConfiguredTimezone}`);
+    lines.push(`client_device_timezone: ${sanitizedClientDeviceTimezone}`);
+    lines.push(
+      `timezone_update_available: after explicit user confirmation, persist client_device_timezone with \`assistant config set ui.userTimezone "${sanitizedClientDeviceTimezone}"\``,
+    );
+  }
   if (options.timeSinceLastMessage) {
     lines.push(`time_since_last_message: ${options.timeSinceLastMessage}`);
   }


### PR DESCRIPTION
## Summary
- Uses resolved timezone context for turn timestamps.
- Adds compact mismatch facts when manual timezone differs from device timezone.
- Exposes the existing config CLI update path only after a mismatch.

Part of JARVIS-705.
Part of plan: assistant-local-timezone.md (PR 4 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->