### PR TITLE
fix(macos): preserve existing avatar when signing into reused managed assistant

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -903,6 +903,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Called from both the first-launch and non-first-launch paths in `proceedToApp`
     /// so that auth-gate onboarding flows also persist avatar traits on the assistant.
     func syncOnboardingAvatarIfNeeded() {
+        // When the managed bootstrap reused an existing assistant (hatched
+        // elsewhere, e.g. the web platform), the daemon already has the
+        // user's chosen avatar. Reload it instead of overwriting with the
+        // random traits generated for the hatching animation.
+        if onboardingState?.hasExistingManagedAssistant == true {
+            log.info("[avatarSync] syncOnboardingAvatarIfNeeded: reused existing managed assistant — reloading daemon avatar instead of syncing onboarding traits")
+            onboardingState = nil
+            AvatarAppearanceManager.shared.reloadAvatar()
+            return
+        }
+
         guard let body = onboardingState?.hatchAvatarBodyShape,
               let eyes = onboardingState?.hatchAvatarEyeStyle,
               let color = onboardingState?.hatchAvatarColor else {


### PR DESCRIPTION
When signing into the macOS desktop app for the first time with an assistant already hatched via the web platform, the hatching animation generates random avatar traits which then get synced to the daemon by `syncOnboardingAvatarIfNeeded`, overwriting the user's original avatar. This adds a guard to skip the trait sync when `hasExistingManagedAssistant` is true and instead reload the daemon's existing avatar — mirroring the web platform's existing guard in `HatchingScreen.tsx` which checks `fetchCharacterTraits` before saving.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/ee866af56ca94e4aa1eef857df5bb495
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->