### PR TITLE
Part of JARVIS-705: Accept client timezone on message posts

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7712,6 +7712,8 @@ paths:
                   type: string
                 slashCommand:
                   type: string
+                clientTimezone:
+                  type: string
                 inferenceProfile:
                   anyOf:
                     - type: string

--- a/assistant/src/__tests__/http-user-message-parity.test.ts
+++ b/assistant/src/__tests__/http-user-message-parity.test.ts
@@ -252,12 +252,24 @@ async function sendMessage(
   content: string,
   conversationObj: import("../daemon/conversation.js").Conversation,
   extra: Record<string, unknown> = {},
+  options: {
+    onGetOrCreateConversation?: (
+      conversationId: string,
+      opts?: Record<string, unknown>,
+    ) => void;
+  } = {},
 ) {
   return callHandler(
     (args) =>
       handleSendMessage(args, {
         sendMessageDeps: {
-          getOrCreateConversation: async () => conversationObj,
+          getOrCreateConversation: async (conversationId, opts) => {
+            options.onGetOrCreateConversation?.(
+              conversationId,
+              opts as Record<string, unknown> | undefined,
+            );
+            return conversationObj;
+          },
           assistantEventHub: { publish: async () => {} } as any,
           resolveAttachments: () => [],
         },
@@ -322,6 +334,100 @@ describe("HTTP POST /v1/messages does not intercept recording intents (by design
     const res = await sendMessage("stop recording", conversation);
 
     expect(res.status).toBe(202);
+    expect(persistUserMessage).toHaveBeenCalledTimes(1);
+    expect(runAgentLoop).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// CLIENT TIMEZONE — optional HTTP metadata
+// ============================================================================
+describe("HTTP POST /v1/messages clientTimezone transport metadata", () => {
+  beforeEach(() => {
+    routeGuardianReplyMock.mockClear();
+    listPendingByDestinationMock.mockClear();
+    listCanonicalMock.mockClear();
+    addMessageMock.mockClear();
+  });
+
+  test("passes canonical clientTimezone through host-proxy transport", async () => {
+    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+    let capturedOptions: Record<string, unknown> | undefined;
+
+    const res = await sendMessage(
+      "hello",
+      conversation,
+      { clientTimezone: "america/new_york" },
+      {
+        onGetOrCreateConversation: (_conversationId, opts) => {
+          capturedOptions = opts;
+        },
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(capturedOptions).toEqual({
+      transport: {
+        channelId: "vellum",
+        interfaceId: "macos",
+        clientTimezone: "America/New_York",
+      },
+    });
+  });
+
+  test("passes canonical clientTimezone through non-host-proxy transport", async () => {
+    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+    let capturedOptions: Record<string, unknown> | undefined;
+
+    const res = await sendMessage(
+      "hello",
+      conversation,
+      { interface: "ios", clientTimezone: "europe/london" },
+      {
+        onGetOrCreateConversation: (_conversationId, opts) => {
+          capturedOptions = opts;
+        },
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(capturedOptions).toEqual({
+      transport: {
+        channelId: "vellum",
+        interfaceId: "ios",
+        clientTimezone: "Europe/London",
+      },
+    });
+  });
+
+  test("drops invalid clientTimezone without rejecting the message", async () => {
+    const persistUserMessage = mock(async () => "persisted-msg-id");
+    const runAgentLoop = mock(async () => undefined);
+    const conversation = makeConversation({ persistUserMessage, runAgentLoop });
+    let capturedOptions: Record<string, unknown> | undefined;
+
+    const res = await sendMessage(
+      "hello",
+      conversation,
+      { clientTimezone: "not-a-timezone" },
+      {
+        onGetOrCreateConversation: (_conversationId, opts) => {
+          capturedOptions = opts;
+        },
+      },
+    );
+
+    expect(res.status).toBe(202);
+    expect(capturedOptions).toEqual({
+      transport: {
+        channelId: "vellum",
+        interfaceId: "macos",
+      },
+    });
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
   });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -39,6 +39,7 @@ import {
   resolveSlash,
 } from "../../daemon/conversation-slash.js";
 import { getOrCreateConversation as getOrCreateConversationInstance } from "../../daemon/conversation-store.js";
+import { canonicalizeTimeZone } from "../../daemon/date-context.js";
 import {
   getCannedFirstGreeting,
   isWakeUpGreeting,
@@ -1095,6 +1096,7 @@ export async function handleSendMessage(
     bypassSecretCheck?: boolean;
     hostHomeDir?: string;
     hostUsername?: string;
+    clientTimezone?: unknown;
     clientId?: string;
     clientMessageId?: string;
     inferenceProfile?: string | null;
@@ -1174,6 +1176,10 @@ export async function handleSendMessage(
       )}`,
     );
   }
+  const clientTimezone =
+    typeof body.clientTimezone === "string"
+      ? (canonicalizeTimeZone(body.clientTimezone) ?? undefined)
+      : undefined;
 
   // When conversationKey is omitted, derive a stable default from
   // sourceChannel + sourceInterface so that repeated calls from the same
@@ -1293,10 +1299,12 @@ export async function handleSendMessage(
         interfaceId: sourceInterface,
         hostHomeDir: body.hostHomeDir,
         hostUsername: body.hostUsername,
+        ...(clientTimezone ? { clientTimezone } : {}),
       } satisfies HostProxyTransportMetadata)
     : ({
         channelId: sourceChannel,
         interfaceId: sourceInterface,
+        ...(clientTimezone ? { clientTimezone } : {}),
       } satisfies NonHostProxyTransportMetadata);
 
   const conversation = await smDeps.getOrCreateConversation(
@@ -2274,6 +2282,7 @@ export const ROUTES: RouteDefinition[] = [
         .optional(),
       conversationType: z.string().optional(),
       slashCommand: z.string().optional(),
+      clientTimezone: z.string().optional(),
       inferenceProfile: z.string().nullable().optional(),
       riskThreshold: z.enum(VALID_RISK_THRESHOLDS).optional(),
     }),


### PR DESCRIPTION
## Summary
- Accepts optional clientTimezone in message POST bodies.
- Canonicalizes valid timezone metadata into conversation transport.
- Drops invalid timezone input without rejecting chat messages.

Part of JARVIS-705.
Part of plan: assistant-local-timezone.md (PR 3 of 8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->