### PR TITLE
fix: pin @socketsecurity/cli to 1.1.91 in socket-autofix.yml

### DIFF
--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -57,7 +57,7 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run socket fix
-        run: bunx @socketsecurity/cli fix --autopilot --pr-limit 3 --minimum-release-age 1w
+        run: bunx @socketsecurity/cli@1.1.91 fix --autopilot --pr-limit 3 --minimum-release-age 1w
         env:
           SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }}
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes ATL-370.

`bunx @socketsecurity/cli` (unpinned) fetches the latest version from the npm
registry at run time. The step receives SOCKET_CLI_API_TOKEN and GITHUB_TOKEN,
and the workflow grants contents:write + pull-requests:write — making an
unpinned package exec a supply-chain risk.

Pin to 1.1.91 (current latest). Update this pin when new releases are vetted.

Part of plan: atl-370-socket-cli-pin.md (PR 1 of 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->