### PR TITLE
Use the storage cleanup skill from disk pressure runtime context

### DIFF
--- a/assistant/src/__tests__/injector-disk-pressure.test.ts
+++ b/assistant/src/__tests__/injector-disk-pressure.test.ts
@@ -57,7 +57,7 @@ describe("disk-pressure-warning injector", () => {
     _setOverridesForTesting({ "safe-storage-limits": true });
   });
 
-  test("emits the exact cleanup prompt while safe storage limits are enabled", async () => {
+  test("emits the concise cleanup skill prompt while safe storage limits are enabled", async () => {
     const block = await diskPressureInjector.produce(
       makeContext({
         injectionInputs: { diskPressureContext: cleanupContext },
@@ -73,14 +73,19 @@ describe("disk-pressure-warning injector", () => {
       DEFAULT_INJECTOR_ORDER.diskPressureWarning,
     );
     expect(DISK_PRESSURE_WARNING_PROMPT).toBe(`<disk_pressure_warning>
-Disk usage is critically low: this assistant is in storage cleanup mode because the workspace volume is at least 95% full.
+Storage is critically low and normal work is suspended until space is freed.
 
-In your first paragraph, warn the user that storage is critically low and that normal work is suspended until space is freed.
+Your first user-visible paragraph must warn the user that storage is critically low and normal work is suspended.
 
-Then help the user clean up storage. Prefer safe inspection steps first, such as checking available space and finding large directories. Ask before deleting files or caches unless the user has already clearly approved the specific cleanup action.
+Before taking cleanup actions, call \`skill_load\` with \`skill: "system-storage-cleanup"\` and follow that skill. If the skill is already loaded, follow it directly.
 
-Do not work on unrelated tasks until disk usage drops below the critical threshold or the user explicitly overrides the lock. Background processes and messages from trusted contacts are blocked while this cleanup mode is active.
+Unrelated work remains blocked until disk usage drops below the critical threshold or the guardian explicitly overrides the lock. Background processes and trusted-contact messages remain blocked while this cleanup mode is active.
 </disk_pressure_warning>`);
+    expect(DISK_PRESSURE_WARNING_PROMPT).toContain("skill_load");
+    expect(DISK_PRESSURE_WARNING_PROMPT).toContain("system-storage-cleanup");
+    expect(DISK_PRESSURE_WARNING_PROMPT).not.toContain(
+      "Prefer safe inspection steps first",
+    );
   });
 
   test("omits the prompt when cleanup context is null or inactive", async () => {

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -102,13 +102,13 @@ function readInjectionInputs(ctx: TurnContext): TurnInjectionInputs {
 }
 
 export const DISK_PRESSURE_WARNING_PROMPT = `<disk_pressure_warning>
-Disk usage is critically low: this assistant is in storage cleanup mode because the workspace volume is at least 95% full.
+Storage is critically low and normal work is suspended until space is freed.
 
-In your first paragraph, warn the user that storage is critically low and that normal work is suspended until space is freed.
+Your first user-visible paragraph must warn the user that storage is critically low and normal work is suspended.
 
-Then help the user clean up storage. Prefer safe inspection steps first, such as checking available space and finding large directories. Ask before deleting files or caches unless the user has already clearly approved the specific cleanup action.
+Before taking cleanup actions, call \`skill_load\` with \`skill: "system-storage-cleanup"\` and follow that skill. If the skill is already loaded, follow it directly.
 
-Do not work on unrelated tasks until disk usage drops below the critical threshold or the user explicitly overrides the lock. Background processes and messages from trusted contacts are blocked while this cleanup mode is active.
+Unrelated work remains blocked until disk usage drops below the critical threshold or the guardian explicitly overrides the lock. Background processes and trusted-contact messages remain blocked while this cleanup mode is active.
 </disk_pressure_warning>`;
 
 function isSafeStorageLimitsEnabled(): boolean {


### PR DESCRIPTION
## Summary
- Replace the disk-pressure cleanup playbook with a concise runtime instruction to load `system-storage-cleanup`.
- Keep the warning first and preserve cleanup-mode blocking constraints.

## Tests
- `cd assistant && bun test src/__tests__/injector-disk-pressure.test.ts`

Part of ATL-462
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->