### PR TITLE
fix: pin @socketsecurity/cli to 1.1.91 in socket-autofix.yml

### DIFF
--- a/.github/workflows/socket-autofix.yml
+++ b/.github/workflows/socket-autofix.yml
@@ -57,7 +57,7 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run socket fix
-        run: bunx @socketsecurity/cli fix --autopilot --pr-limit 3 --minimum-release-age 1w
+        run: bunx @socketsecurity/cli@1.1.91 fix --autopilot --pr-limit 3 --minimum-release-age 1w
         env:
           SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_CLI_API_TOKEN }}
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes ATL-370. Pins `@socketsecurity/cli` to `1.1.91` in `.github/workflows/socket-autofix.yml` so the unpinned `bunx` invocation can no longer fetch and execute an arbitrary newly-published version of the package at run time. The step holds `SOCKET_CLI_API_TOKEN` and `GITHUB_TOKEN` and the workflow grants `contents: write` + `pull-requests: write`, so leaving it unpinned was a supply-chain risk.

Bump this pin manually after vetting future releases.

## Self-review result

- Plan faithfulness: PASS
- Slop / reuse: PASS
- Repo integration: 2 out-of-scope findings (kept off this PR by design):
  - `.github/workflows/pr-skills.yaml:72` runs `npx prettier` unpinned with no local install — same shape, smaller blast radius. Worth a follow-up ticket.
  - No documented convention in `AGENTS.md`/`docs/socket.md` requiring `bunx`/`npx` pins.
- External feedback (Devin Review): no issues.

## PRs merged into feature branch
- #29685: fix: pin @socketsecurity/cli to 1.1.91 in socket-autofix.yml

Part of plan: atl-370-socket-cli-pin.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->