### PR TITLE
Part of JARVIS-709: Distinguish managed credits from BYOK provider billing errors

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -566,11 +566,11 @@ describe("classifyConversationError", () => {
       expect(result.errorCategory).toBe("provider_not_configured");
     });
 
-    it("classifies ProviderError with 402 as credits_exhausted (non-retryable)", () => {
+    it("classifies direct ProviderError with 402 as provider_billing (non-retryable)", () => {
       const err = new ProviderError("Payment Required", "anthropic", 402);
       const result = classifyConversationError(err, baseCtx);
       expect(result.code).toBe("PROVIDER_BILLING");
-      expect(result.errorCategory).toBe("credits_exhausted");
+      expect(result.errorCategory).toBe("provider_billing");
       expect(result.retryable).toBe(false);
     });
 
@@ -614,6 +614,79 @@ describe("classifyConversationError", () => {
         expect(result.errorCategory).toBeDefined();
         expect(result.errorCategory.length).toBeGreaterThan(0);
       }
+    });
+  });
+
+  describe("OpenRouter billing classification", () => {
+    it("keeps managed-proxy OpenRouter 402 responses as credits_exhausted", () => {
+      providerRoutingSources.openrouter = "managed-proxy";
+      const err = new ProviderError(
+        "OpenRouter API error (402): Payment Required",
+        "openrouter",
+        402,
+      );
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.errorCategory).toBe("credits_exhausted");
+      expect(result.retryable).toBe(false);
+      expect(result.userMessage).toContain("Add funds");
+      expect(result.userMessage).toContain("assistant");
+    });
+
+    it("classifies direct Anthropic, OpenAI, and OpenRouter 402 responses as provider_billing", () => {
+      providerRoutingSources.anthropic = "user-key";
+      providerRoutingSources.openai = "user-key";
+      providerRoutingSources.openrouter = "user-key";
+
+      for (const provider of ["anthropic", "openai", "openrouter"]) {
+        const err = new ProviderError(
+          `${provider} API error (402): Payment Required`,
+          provider,
+          402,
+        );
+
+        const result = classifyConversationError(err, baseCtx);
+
+        expect(result.code).toBe("PROVIDER_BILLING");
+        expect(result.errorCategory).toBe("provider_billing");
+        expect(result.retryable).toBe(false);
+        expect(result.userMessage).toContain("provider");
+        expect(result.userMessage).toContain("Settings");
+      }
+    });
+
+    it("classifies OpenRouter 400 credit-limit messages as provider_billing", () => {
+      const cases = [
+        "OpenRouter API error (400): This request requires more credits",
+        "OpenRouter API error (400): You can only afford 1000 tokens",
+      ];
+
+      for (const message of cases) {
+        const err = new ProviderError(message, "openrouter", 400);
+
+        const result = classifyConversationError(err, baseCtx);
+
+        expect(result.code).toBe("PROVIDER_BILLING");
+        expect(result.errorCategory).toBe("provider_billing");
+        expect(result.retryable).toBe(false);
+      }
+    });
+
+    it("classifies managed-proxy OpenRouter insufficient_balance bodies as credits_exhausted", () => {
+      providerRoutingSources.openrouter = "managed-proxy";
+      const err = new ProviderError(
+        'OpenRouter API error (402): {"code":"insufficient_balance","detail":"Managed balance exhausted"}',
+        "openrouter",
+        402,
+      );
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_BILLING");
+      expect(result.errorCategory).toBe("credits_exhausted");
+      expect(result.retryable).toBe(false);
     });
   });
 

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1367,6 +1367,51 @@ describe("OpenRouterProvider reasoning", () => {
   });
 });
 
+describe("OpenRouterProvider Anthropic-compatible errors", () => {
+  function userMsg(text: string): Message {
+    return { role: "user", content: [{ type: "text", text }] };
+  }
+
+  test("retags Anthropic ProviderError instances as OpenRouter errors", async () => {
+    const provider = new OpenRouterProvider("or-key", "anthropic/claude-4.5");
+    const abortReason = createAbortReason(
+      "user_cancel",
+      "openrouter-provider-test",
+    );
+    const cause = new Error("upstream cause");
+    const innerError = new ProviderError(
+      "Anthropic API error (402): Payment Required",
+      "anthropic",
+      402,
+      { cause, retryAfterMs: 1250, abortReason },
+    );
+
+    (
+      provider as unknown as {
+        anthropicInner: {
+          sendMessage: OpenRouterProvider["sendMessage"];
+        };
+      }
+    ).anthropicInner = {
+      sendMessage: async () => {
+        throw innerError;
+      },
+    };
+
+    try {
+      await provider.sendMessage([userMsg("hi")]);
+      throw new Error("expected sendMessage to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderError);
+      expect((error as ProviderError).provider).toBe("openrouter");
+      expect((error as ProviderError).statusCode).toBe(402);
+      expect((error as ProviderError).retryAfterMs).toBe(1250);
+      expect((error as ProviderError).abortReason).toBe(abortReason);
+      expect((error as Error).cause).toBe(cause);
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Reasoning effort → OpenAI reasoning_effort mapping
 // ---------------------------------------------------------------------------

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -46,6 +46,15 @@ const MANAGED_USAGE_LIMIT_PATTERNS = [
   /current plan allows/i,
 ];
 
+const MANAGED_BALANCE_PATTERNS = [/"code"\s*:\s*"insufficient_balance"/i];
+
+const PROVIDER_BILLING_PATTERNS = [
+  /credit balance is too low/i,
+  /insufficient.*credits?/i,
+  /requires more credits/i,
+  /can only afford/i,
+];
+
 // Overloaded patterns — provider is capacity-constrained (distinct from rate limiting)
 const OVERLOADED_PATTERNS = [/overloaded/i];
 
@@ -269,13 +278,10 @@ function classifyCore(
       };
     }
     if (error.statusCode === 402) {
-      return {
-        code: "PROVIDER_BILLING",
-        userMessage:
-          "You've run out of credits. Add funds to continue using the assistant.",
-        retryable: false,
-        errorCategory: "credits_exhausted",
-      };
+      if (isManagedBalanceError(error, message)) {
+        return managedBalanceClassification();
+      }
+      return providerBillingClassification();
     }
     if (error.statusCode === 429) {
       if (isManagedUsageLimitError(error, message)) {
@@ -350,13 +356,8 @@ function classifyCore(
           errorCategory: "tool_ordering",
         };
       }
-      if (/credit balance is too low|insufficient.*credits?/i.test(message)) {
-        return {
-          code: "PROVIDER_BILLING",
-          userMessage: "Your API key has insufficient credits.",
-          retryable: false,
-          errorCategory: "provider_billing",
-        };
+      if (isProviderBillingError(message)) {
+        return providerBillingClassification();
       }
       if (
         /invalid.*api.?key|invalid.*x-api-key|authentication.?error|invalid.authentication/i.test(
@@ -421,6 +422,43 @@ function isManagedUsageLimitError(error: unknown, message: string): boolean {
     return true;
   }
   return MANAGED_USAGE_LIMIT_PATTERNS.some((p) => p.test(message));
+}
+
+function isManagedBalanceError(error: ProviderError, message: string): boolean {
+  if (getProviderRoutingSource(error.provider) === "managed-proxy") {
+    return true;
+  }
+  return MANAGED_BALANCE_PATTERNS.some((p) => p.test(message));
+}
+
+function isProviderBillingError(message: string): boolean {
+  return PROVIDER_BILLING_PATTERNS.some((p) => p.test(message));
+}
+
+function managedBalanceClassification(): Omit<
+  ClassifiedConversationError,
+  "debugDetails"
+> {
+  return {
+    code: "PROVIDER_BILLING",
+    userMessage:
+      "You've run out of credits. Add funds to continue using the assistant.",
+    retryable: false,
+    errorCategory: "credits_exhausted",
+  };
+}
+
+function providerBillingClassification(): Omit<
+  ClassifiedConversationError,
+  "debugDetails"
+> {
+  return {
+    code: "PROVIDER_BILLING",
+    userMessage:
+      "Your API provider account or key needs credits. Add funds with the provider or update the key in Settings.",
+    retryable: false,
+    errorCategory: "provider_billing",
+  };
 }
 
 function classifyByMessage(

--- a/assistant/src/providers/openrouter/client.ts
+++ b/assistant/src/providers/openrouter/client.ts
@@ -1,3 +1,4 @@
+import { ProviderError } from "../../util/errors.js";
 import { AnthropicProvider } from "../anthropic/client.js";
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
 import { isThinkingConfigEnabled } from "../thinking-config.js";
@@ -137,6 +138,13 @@ export class OpenRouterProvider extends OpenAIChatCompletionsProvider {
           maxTokens: error.maxTokens,
           statusCode: error.statusCode,
           cause: error,
+        });
+      }
+      if (error instanceof ProviderError && error.provider !== this.name) {
+        throw new ProviderError(error.message, this.name, error.statusCode, {
+          cause: error.cause ?? error,
+          retryAfterMs: error.retryAfterMs,
+          abortReason: error.abortReason,
         });
       }
       throw error;


### PR DESCRIPTION
## Summary
- Distinguishes managed proxy 402 billing failures from BYOK provider billing failures.
- Retags OpenRouter Anthropic-compatible provider errors back to OpenRouter.
- Adds focused tests for OpenRouter and managed insufficient-balance classification.

Part of plan: macos-provider-billing-ux.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->