### PR TITLE
Reseed skill capability memories when workspace skills change

### DIFF
--- a/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
+++ b/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const WORKSPACE_DIR = mkdtempSync(join(tmpdir(), "vellum-skills-watch-"));
+const SKILLS_DIR = join(WORKSPACE_DIR, "skills");
+process.env.VELLUM_WORKSPACE_DIR = WORKSPACE_DIR;
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+  truncateForLog: (v: string) => v,
+}));
+
+type WatchCallback = (eventType: string, filename: string | null) => void;
+
+interface CapturedWatcher {
+  dir: string;
+  callback: WatchCallback;
+}
+
+const capturedWatchers: CapturedWatcher[] = [];
+
+const fakeWatcher = {
+  close: () => {},
+  on: () => {},
+};
+
+mock.module("node:fs", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = require("node:fs");
+  return {
+    ...actual,
+    watch: (dir: string, ...args: unknown[]) => {
+      let callback: WatchCallback;
+
+      if (typeof args[0] === "function") {
+        callback = args[0] as WatchCallback;
+      } else {
+        callback = args[1] as WatchCallback;
+      }
+
+      capturedWatchers.push({ dir, callback });
+      return fakeWatcher;
+    },
+  };
+});
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    memory: { v2: { enabled: false } },
+  }),
+  invalidateConfigCache: () => {},
+}));
+
+mock.module("../memory/embedding-backend.js", () => ({
+  clearEmbeddingBackendCache: () => {},
+}));
+
+mock.module("../memory/cleanup-schedule-state.js", () => ({
+  resetCleanupScheduleThrottle: () => {},
+}));
+
+mock.module("../providers/registry.js", () => ({
+  initializeProviders: async () => {},
+}));
+
+mock.module("../daemon/mcp-reload-service.js", () => ({
+  reloadMcpServers: async () => {},
+}));
+
+mock.module("../signals/bash.js", () => ({
+  handleBashSignal: () => {},
+}));
+
+mock.module("../signals/cancel.js", () => ({
+  handleCancelSignal: () => {},
+}));
+
+mock.module("../signals/conversation-undo.js", () => ({
+  handleConversationUndoSignal: () => {},
+}));
+
+mock.module("../signals/emit-event.js", () => ({
+  handleEmitEventSignal: () => {},
+}));
+
+mock.module("../signals/user-message.js", () => ({
+  handleUserMessageSignal: () => {},
+}));
+
+const { ConfigWatcher } = await import("../daemon/config-watcher.js");
+
+function findWatcher(dir: string): CapturedWatcher | undefined {
+  return capturedWatchers.find((w) => w.dir === dir);
+}
+
+describe("ConfigWatcher skills watcher reseeding", () => {
+  let watcher: InstanceType<typeof ConfigWatcher>;
+  let evictCalls: number;
+  let skillsChangedCalls: number;
+
+  beforeEach(() => {
+    capturedWatchers.length = 0;
+    mkdirSync(SKILLS_DIR, { recursive: true });
+    evictCalls = 0;
+    skillsChangedCalls = 0;
+    watcher = new ConfigWatcher();
+  });
+
+  afterEach(() => {
+    watcher.stop();
+  });
+
+  afterAll(() => {
+    rmSync(WORKSPACE_DIR, { recursive: true, force: true });
+  });
+
+  test("watched skill file changes evict conversations and refresh skill memories", async () => {
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    const skillsWatcher = findWatcher(SKILLS_DIR);
+    expect(skillsWatcher).toBeDefined();
+    skillsWatcher!.callback("change", "example-skill/SKILL.md");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(1);
+    expect(skillsChangedCalls).toBe(1);
+  });
+});

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -133,6 +133,8 @@ export class ConfigWatcher {
    * Start all file watchers. `onConversationEvict` is called when watched
    * files change and conversations need to be evicted for reload.
    * `onIdentityChanged` is called when IDENTITY.md changes on disk.
+   * `onSkillsChanged` is called after skill directory changes evict
+   * conversations.
    */
   start(
     onConversationEvict: () => void,
@@ -140,6 +142,7 @@ export class ConfigWatcher {
     onSoundsConfigChanged?: () => void,
     onAvatarChanged?: () => void,
     onConfigChanged?: () => void,
+    onSkillsChanged?: () => void,
   ): void {
     const workspaceDir = getWorkspaceDir();
 
@@ -215,7 +218,7 @@ export class ConfigWatcher {
 
     this.startSignalsWatcher();
     this.startUsersWatcher(onConversationEvict);
-    this.startSkillsWatchers(onConversationEvict);
+    this.startSkillsWatchers(onConversationEvict, onSkillsChanged);
   }
 
   stop(): void {
@@ -383,7 +386,10 @@ export class ConfigWatcher {
     }
   }
 
-  private startSkillsWatchers(onConversationEvict: () => void): void {
+  private startSkillsWatchers(
+    onConversationEvict: () => void,
+    onSkillsChanged?: () => void,
+  ): void {
     const skillsDir = getWorkspaceSkillsDir();
     if (!existsSync(skillsDir)) return;
 
@@ -391,6 +397,7 @@ export class ConfigWatcher {
       this.debounceTimers.schedule(`skills:${file}`, () => {
         log.info({ file }, "Skill file changed, reloading");
         onConversationEvict();
+        onSkillsChanged?.();
       });
     };
 

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -42,6 +42,7 @@ import { refreshSurfacesForApp } from "./conversation-surfaces.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import type { ConversationCreateOptions } from "./handlers/shared.js";
 import { setGlobalSkillIpcSender } from "./meet-host-supervisor.js";
+import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
 
 const log = getLogger("server");
 
@@ -274,6 +275,7 @@ export class DaemonServer {
       () => this.broadcastSoundsConfigUpdated(),
       () => this.broadcastAvatarUpdated(),
       () => this.broadcastConfigChanged(),
+      () => refreshSkillCapabilityMemories(getConfig()),
     );
 
     this.syncIdentityToPlatform();

--- a/assistant/src/daemon/skill-memory-refresh.ts
+++ b/assistant/src/daemon/skill-memory-refresh.ts
@@ -1,0 +1,23 @@
+import { getConfig } from "../config/loader.js";
+import type { AssistantConfig } from "../config/schema.js";
+import {
+  seedSkillGraphNodes,
+  seedUninstalledCatalogSkillMemories,
+} from "../memory/graph/capability-seed.js";
+import { getLogger } from "../util/logger.js";
+import { maybeSeedMemoryV2Skills } from "./memory-v2-startup.js";
+
+const log = getLogger("skill-memory-refresh");
+
+export function refreshSkillCapabilityMemories(
+  config: AssistantConfig = getConfig(),
+): void {
+  seedSkillGraphNodes();
+  maybeSeedMemoryV2Skills(config);
+  void seedUninstalledCatalogSkillMemories().catch((err) =>
+    log.warn(
+      { err },
+      "Uninstalled catalog skill memory seeding failed — continuing",
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a shared skill memory refresh helper for v1 and Memory V2 skill capability stores.
- Wires workspace skill file watcher changes to reseed skill memories after conversation eviction.
- Adds regression coverage for skill watcher reseeding callbacks.

Part of plan: migrate-off-skills-md.md (PR 3 of 7)
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->