### PR TITLE
Add stale SKILLS.md regression coverage for skill_load and skill memory seeding

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -237,6 +237,32 @@ describe("skill_load tool", () => {
     expect(result.content).not.toContain("<loaded_skill");
   });
 
+  test("loads a valid disk-discovered skill omitted from stale SKILLS.md", async () => {
+    writeSkill("existing", "Existing Skill", "Exists", "Existing body");
+    writeSkill(
+      "geo-article-writer",
+      "Geo Article Writer",
+      "Writes local geo articles",
+      "Draft the article.",
+    );
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- existing\n");
+
+    const result = await executeSkillLoad({ skill: "geo-article-writer" });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("ID: geo-article-writer");
+    const markers = result.content.match(/<loaded_skill/g) || [];
+    expect(markers.length).toBe(1);
+    expect(result.content).toMatch(
+      /<loaded_skill id="geo-article-writer" version="v1:[a-f0-9]{64}" \/>/,
+    );
+
+    const missing = await executeSkillLoad({ skill: "does-not-exist" });
+    expect(missing.isError).toBe(true);
+    expect(missing.content).toContain("No skill matched");
+    expect(missing.content).not.toContain("<loaded_skill");
+  });
+
   test('successful skill_load output shows "none" for skills without includes', async () => {
     writeSkill(
       "standalone",

--- a/assistant/src/__tests__/skill-memory.test.ts
+++ b/assistant/src/__tests__/skill-memory.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { SkillSummary } from "../config/skills.js";
 import { fromSkillSummary } from "../skills/skill-memory.js";
 
-function makeSkillSummary(
-  overrides: Partial<SkillSummary> = {},
-): SkillSummary {
+function makeSkillSummary(overrides: Partial<SkillSummary> = {}): SkillSummary {
   return {
     id: "test-skill",
     name: "test-skill",
@@ -61,5 +59,27 @@ describe("fromSkillSummary", () => {
     const input = fromSkillSummary(entry);
     expect(input.id).toBe("my-id");
     expect(input.description).toBe("Does amazing things");
+  });
+
+  test("maps custom managed skill metadata required by Memory V2 rendering", () => {
+    const entry = makeSkillSummary({
+      id: "geo-article-writer",
+      name: "geo-article-writer",
+      displayName: "Geo Article Writer",
+      description: "Writes local geo articles",
+      source: "managed",
+      activationHints: ["user asks for local article drafts"],
+      avoidWhen: ["user only wants citation extraction"],
+    });
+
+    const input = fromSkillSummary(entry);
+
+    expect(input).toEqual({
+      id: "geo-article-writer",
+      displayName: "Geo Article Writer",
+      description: "Writes local geo articles",
+      activationHints: ["user asks for local article drafts"],
+      avoidWhen: ["user only wants citation extraction"],
+    });
   });
 });

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -383,6 +383,38 @@ describe("seedV2SkillEntries", () => {
     expect(getSkillCapability("skills/unknown-skill")).toBeNull();
   });
 
+  test("seeds disk-discovered managed skills omitted from a stale SKILLS.md index", async () => {
+    const diskDiscovered = makeSummary({
+      id: "geo-article-writer",
+      name: "geo-article-writer",
+      displayName: "Geo Article Writer",
+      description: "Writes local geo articles",
+      activationHints: ["user asks for local article drafts"],
+      avoidWhen: ["user only wants citation extraction"],
+      source: "managed",
+    });
+    state.catalog = [diskDiscovered];
+    state.resolved = [{ summary: diskDiscovered, state: "enabled" }];
+    state.embedReturn = [[0.7, 0.8, 0.9]];
+
+    await seedV2SkillEntries();
+
+    expect(state.upsertCalls).toHaveLength(1);
+    expect(state.upsertCalls[0].slug).toBe("skills/geo-article-writer");
+
+    const entry = getSkillCapability("geo-article-writer");
+    expect(entry).not.toBeNull();
+    expect(entry?.id).toBe("geo-article-writer");
+    expect(entry?.content).toContain('The "Geo Article Writer" skill');
+    expect(entry?.content).toContain("Writes local geo articles");
+    expect(entry?.content).toContain(
+      "Use when: user asks for local article drafts.",
+    );
+    expect(entry?.content).toContain(
+      "Avoid when: user only wants citation extraction.",
+    );
+  });
+
   test("swallows errors from embedWithBackend and leaves prior cache intact", async () => {
     const skillA = makeSummary({ id: "example-skill-a" });
     state.catalog = [skillA];


### PR DESCRIPTION
## Summary
- Adds skill_load regression coverage for stale SKILLS.md indexes that omit valid SKILL.md directories.
- Adds Memory V2 skill seeding coverage for disk-discovered managed skills.
- Expands skill memory mapping coverage for custom managed skill metadata.

Part of plan: migrate-off-skills-md.md (PR 2 of 7)
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->