### PR TITLE
Stop scaffolded custom skills from maintaining SKILLS.md

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1227,9 +1227,8 @@ graph TB
 
     subgraph "2. Persist (Filesystem)"
         SCAFFOLD["scaffold_managed_skill<br/>───────────────<br/>RiskLevel: High<br/>Requires user consent"]
-        MANAGED_STORE["managed-store.ts<br/>───────────────<br/>validateManagedSkillId()<br/>buildSkillMarkdown()<br/>createManagedSkill()<br/>upsertSkillsIndexEntry()"]
+        MANAGED_STORE["managed-store.ts<br/>───────────────<br/>validateManagedSkillId()<br/>buildSkillMarkdown()<br/>createManagedSkill()"]
         SKILL_DIR["~/.vellum/workspace/skills/&lt;id&gt;/<br/>SKILL.md (frontmatter + body)"]
-        INDEX["~/.vellum/workspace/skills/<br/>SKILLS.md (index)"]
     end
 
     subgraph "3. Load & Use"
@@ -1240,7 +1239,6 @@ graph TB
     subgraph "4. Delete"
         DELETE["delete_managed_skill<br/>───────────────<br/>RiskLevel: High<br/>Requires user consent"]
         RM_DIR["rmSync skill directory"]
-        RM_INDEX["removeSkillsIndexEntry()"]
     end
 
     subgraph "File Watcher"
@@ -1257,17 +1255,14 @@ graph TB
 
     SCAFFOLD --> MANAGED_STORE
     MANAGED_STORE --> SKILL_DIR
-    MANAGED_STORE --> INDEX
 
     SKILL_DIR --> WATCHER
-    INDEX --> WATCHER
     WATCHER --> EVICT
 
     SKILL_DIR --> SKILL_LOAD
     SKILL_LOAD --> SESSION
 
     DELETE --> RM_DIR
-    DELETE --> RM_INDEX
     RM_DIR --> WATCHER
 ```
 
@@ -1275,7 +1270,7 @@ graph TB
 
 - `evaluate_typescript_code` always forces `sandbox.enabled = true` regardless of global config.
 - Snippet contract: must export `default` or `run` with signature `(input: unknown) => unknown | Promise<unknown>`.
-- Managed-store writes are atomic (tmp file + rename) to prevent partial `SKILL.md` or `SKILLS.md` files.
+- Managed-store writes are atomic (tmp file + rename) to prevent partial `SKILL.md` files.
 - After persist or delete, the file watcher triggers conversation eviction; the next turn runs in a fresh conversation. The model's system prompt instructs it to continue normally.
 - macOS UI shows Inspect and Delete controls for managed skills only (source = "managed").
 - `skill_load` validates the recursive include graph (via `include-graph.ts`) before emitting output. Missing children and cycles produce `isError: true` with no `<loaded_skill>` marker. Valid includes produce an "Included Skills (immediate)" metadata section showing child ID, name, description, and path.

--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -1,10 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -35,12 +29,6 @@ function createSkill(id: string): void {
     join(skillDir, "SKILL.md"),
     '---\nname: "Test"\ndescription: "Test"\n---\n\nBody.\n',
   );
-  // Update SKILLS.md
-  const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
-  const existing = existsSync(indexPath)
-    ? readFileSync(indexPath, "utf-8")
-    : "";
-  writeFileSync(indexPath, existing + `- ${id}\n`);
 }
 
 beforeEach(() => {
@@ -52,9 +40,11 @@ afterEach(() => {
 });
 
 describe("delete_managed_skill tool", () => {
-  test("deletes existing skill and updates index", async () => {
+  test("deletes existing skill without updating SKILLS.md", async () => {
     createSkill("doomed");
     createSkill("survivor");
+    const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
+    writeFileSync(indexPath, "- doomed\n- survivor\n");
 
     const result = await executeDeleteManagedSkill(
       {
@@ -67,16 +57,11 @@ describe("delete_managed_skill tool", () => {
     const parsed = JSON.parse(result.content);
     expect(parsed.deleted).toBe(true);
     expect(parsed.skill_id).toBe("doomed");
-    expect(parsed.index_updated).toBe(true);
+    expect(parsed.index_updated).toBe(false);
 
     expect(existsSync(join(TEST_DIR, "skills", "doomed"))).toBe(false);
 
-    const indexContent = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(indexContent).not.toContain("doomed");
-    expect(indexContent).toContain("survivor");
+    expect(existsSync(indexPath)).toBe(true);
   });
 
   test("returns error for non-existent skill", async () => {

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -87,9 +87,11 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     expect(scaffoldResult.isError).not.toBe(true);
     const scaffoldData = JSON.parse(scaffoldResult.content as string);
     expect(scaffoldData.created).toBe(true);
+    expect(scaffoldData.index_updated).toBe(false);
 
     // Step 2: Verify SKILL.md was written
-    const skillMdPath = join(TEST_DIR, "skills", "lifecycle-test", "SKILL.md");
+    const skillDir = join(TEST_DIR, "skills", "lifecycle-test");
+    const skillMdPath = join(skillDir, "SKILL.md");
     expect(existsSync(skillMdPath)).toBe(true);
     const skillContent = readFileSync(skillMdPath, "utf-8");
     expect(skillContent).toContain('name: "Lifecycle Test"');
@@ -102,6 +104,7 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     expect(found).toBeDefined();
     expect(found!.name).toBe("Lifecycle Test");
     expect(found!.description).toBe("Integration test skill.");
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
 
     // Step 4: Delete the skill
     const deleteResult = await executeDeleteManagedSkill(
@@ -114,20 +117,15 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     expect(deleteResult.isError).not.toBe(true);
     const deleteData = JSON.parse(deleteResult.content as string);
     expect(deleteData.deleted).toBe(true);
+    expect(deleteData.index_updated).toBe(false);
 
-    // Step 5: Verify skill is gone from filesystem
-    expect(existsSync(skillMdPath)).toBe(false);
+    // Step 5: Verify skill directory is gone from filesystem
+    expect(existsSync(skillDir)).toBe(false);
 
     // Step 6: Verify skill no longer in catalog
     const catalogAfter = loadSkillCatalog();
     expect(catalogAfter.find((s) => s.id === "lifecycle-test")).toBeUndefined();
-
-    // Step 7: Verify SKILLS.md index no longer has the entry
-    const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
-    if (existsSync(indexPath)) {
-      const indexContent = readFileSync(indexPath, "utf-8");
-      expect(indexContent).not.toContain("lifecycle-test");
-    }
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
   });
 
   test("scaffold with overwrite replaces existing skill", async () => {
@@ -166,13 +164,12 @@ describe("managed skill lifecycle: scaffold → catalog → prompt → delete", 
     expect(skillContent).toContain("Updated body.");
     expect(skillContent).not.toContain("Original body.");
 
-    // Index should still have exactly one entry
-    const indexContent = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    const matches = indexContent.match(/overwrite-test/g);
-    expect(matches?.length).toBe(1);
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
+
+    const catalog = loadSkillCatalog();
+    const skill = catalog.find((s) => s.id === "overwrite-test");
+    expect(skill).toBeDefined();
+    expect(skill!.name).toBe("V2");
   });
 
   test("delete non-existent skill returns error", async () => {

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -36,7 +36,6 @@ import {
   deleteManagedSkill,
   readSkillVersion,
   removeSkillsIndexEntry,
-  upsertSkillsIndexEntry,
   validateManagedSkillId,
 } from "../skills/managed-store.js";
 
@@ -142,7 +141,7 @@ describe("buildSkillMarkdown", () => {
     });
 
     // Load it back via loadSkillCatalog (which uses parseFrontmatter)
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog();
     const skill = catalog.find((s) => s.id === "roundtrip-test");
     expect(skill).toBeDefined();
     expect(skill!.name).toBe('Say "hello" & back\\slash');
@@ -159,7 +158,7 @@ describe("buildSkillMarkdown", () => {
       bodyMarkdown: "Body.",
     });
 
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog();
     const skill = catalog.find((s) => s.id === "backslash-n-test");
     expect(skill).toBeDefined();
     expect(skill!.name).toBe("path\\name");
@@ -205,7 +204,7 @@ describe("buildSkillMarkdown", () => {
       includes: ["child-x", "child-y"],
     });
 
-    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const catalog = loadSkillCatalog();
     const skill = catalog.find((s) => s.id === "roundtrip-includes");
     expect(skill).toBeDefined();
     expect(skill!.includes).toEqual(["child-x", "child-y"]);
@@ -231,60 +230,7 @@ describe("buildSkillMarkdown", () => {
   });
 });
 
-describe("SKILLS.md index management", () => {
-  test("SKILLS.md is created when absent", () => {
-    upsertSkillsIndexEntry("my-skill");
-    const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
-    expect(existsSync(indexPath)).toBe(true);
-    const content = readFileSync(indexPath, "utf-8");
-    expect(content).toContain("- my-skill");
-  });
-
-  test("index add is idempotent", () => {
-    upsertSkillsIndexEntry("my-skill");
-    upsertSkillsIndexEntry("my-skill");
-    const content = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    const matches = content.match(/- my-skill/g);
-    expect(matches?.length).toBe(1);
-  });
-
-  test("delete removes directory and index entry", () => {
-    // Set up a skill
-    const skillDir = join(TEST_DIR, "skills", "doomed");
-    mkdirSync(skillDir, { recursive: true });
-    writeFileSync(join(skillDir, "SKILL.md"), "test");
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- doomed\n- survivor\n",
-    );
-
-    const result = deleteManagedSkill("doomed");
-    expect(result.deleted).toBe(true);
-    expect(result.indexUpdated).toBe(true);
-    expect(existsSync(skillDir)).toBe(false);
-
-    const content = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(content).not.toContain("doomed");
-    expect(content).toContain("survivor");
-  });
-
-  test("upsert recognizes * bullet entries", () => {
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "* existing-skill\n");
-    upsertSkillsIndexEntry("existing-skill");
-    const content = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    const matches = content.match(/existing-skill/g);
-    expect(matches?.length).toBe(1);
-  });
-
+describe("legacy SKILLS.md index removal helper", () => {
   test("remove handles * bullet entries", () => {
     writeFileSync(
       join(TEST_DIR, "skills", "SKILLS.md"),
@@ -313,20 +259,6 @@ describe("SKILLS.md index management", () => {
     expect(content).toContain("survivor");
   });
 
-  test("upsert recognizes markdown link entries as existing", () => {
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- [My Skill](my-skill/SKILL.md)\n",
-    );
-    upsertSkillsIndexEntry("my-skill");
-    const content = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    const matches = content.match(/my-skill/g);
-    expect(matches?.length).toBe(1);
-  });
-
   test("remove from index handles missing entry gracefully", () => {
     writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- other-skill\n");
     removeSkillsIndexEntry("nonexistent");
@@ -348,6 +280,7 @@ describe("createManagedSkill", () => {
     });
 
     expect(result.created).toBe(true);
+    expect(result.indexUpdated).toBe(false);
     expect(result.error).toBeUndefined();
     expect(existsSync(result.path)).toBe(true);
 
@@ -429,35 +362,34 @@ describe("createManagedSkill", () => {
     expect(result.error).toContain("description is required");
   });
 
-  test("updates SKILLS.md index", () => {
+  test("does not create SKILLS.md and is discovered through SKILL.md directory", () => {
     createManagedSkill({
-      id: "indexed-skill",
-      name: "Indexed",
-      description: "Gets indexed",
+      id: "discovered-skill",
+      name: "Discovered",
+      description: "Found by directory discovery",
       bodyMarkdown: "Body.",
     });
 
-    const indexContent = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(indexContent).toContain("- indexed-skill");
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    const skill = catalog.find((s) => s.id === "discovered-skill");
+    expect(skill).toBeDefined();
+    expect(skill!.name).toBe("Discovered");
   });
 
-  test("skips index when addToIndex=false", () => {
-    createManagedSkill({
-      id: "no-index",
-      name: "No Index",
-      description: "Not indexed",
+  test("accepts deprecated addToIndex without creating SKILLS.md", () => {
+    const result = createManagedSkill({
+      id: "compat-no-index",
+      name: "Compat No Index",
+      description: "Compatibility input is ignored",
       bodyMarkdown: "Body.",
       addToIndex: false,
     });
 
-    const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
-    if (existsSync(indexPath)) {
-      const content = readFileSync(indexPath, "utf-8");
-      expect(content).not.toContain("no-index");
-    }
+    expect(result.created).toBe(true);
+    expect(result.indexUpdated).toBe(false);
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
   });
 });
 
@@ -563,7 +495,11 @@ describe("deleteManagedSkill", () => {
 
     const result = deleteManagedSkill("to-delete");
     expect(result.deleted).toBe(true);
+    expect(result.indexUpdated).toBe(false);
     expect(existsSync(join(TEST_DIR, "skills", "to-delete"))).toBe(false);
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    expect(catalog.find((s) => s.id === "to-delete")).toBeUndefined();
   });
 
   test("returns error for non-existent skill", () => {
@@ -578,13 +514,17 @@ describe("deleteManagedSkill", () => {
     expect(result.error).toContain("traversal");
   });
 
-  test("skips index removal when removeFromIndex=false", () => {
+  test("accepts deprecated removeFromIndex without editing SKILLS.md", () => {
     createManagedSkill({
       id: "keep-index",
       name: "Keep Index",
       description: "Index stays",
       bodyMarkdown: "Body.",
     });
+    writeFileSync(
+      join(TEST_DIR, "skills", "SKILLS.md"),
+      "- keep-index\n- survivor\n",
+    );
 
     const result = deleteManagedSkill("keep-index", false);
     expect(result.deleted).toBe(true);
@@ -595,42 +535,26 @@ describe("deleteManagedSkill", () => {
       "utf-8",
     );
     expect(indexContent).toContain("- keep-index");
+    expect(indexContent).toContain("- survivor");
+
+    const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
+    expect(catalog.find((s) => s.id === "keep-index")).toBeUndefined();
   });
 
-  test("succeeds even when index cleanup throws", () => {
+  test("delete does not create or edit SKILLS.md", () => {
     createManagedSkill({
-      id: "index-fail",
-      name: "Index Fail",
-      description: "Index removal will throw",
+      id: "delete-no-index",
+      name: "Delete No Index",
+      description: "No index write",
       bodyMarkdown: "Body.",
     });
 
-    // Intercept the atomic write (.tmp- file) used by removeSkillsIndexEntry
     const skillsDir = join(TEST_DIR, "skills");
-    const originalWrite = fs.writeFileSync;
-    const spy = spyOn(fs, "writeFileSync").mockImplementation(((
-      path: fs.PathOrFileDescriptor,
-      data: string | NodeJS.ArrayBufferView,
-      options?: fs.WriteFileOptions,
-    ) => {
-      if (
-        typeof path === "string" &&
-        path.startsWith(skillsDir) &&
-        path.includes(".tmp-")
-      ) {
-        throw new Error("Simulated write failure");
-      }
-      return originalWrite(path, data, options);
-    }) as typeof fs.writeFileSync);
-
-    try {
-      const result = deleteManagedSkill("index-fail");
-      expect(result.deleted).toBe(true);
-      expect(result.indexUpdated).toBe(false);
-      expect(existsSync(join(skillsDir, "index-fail"))).toBe(false);
-    } finally {
-      spy.mockRestore();
-    }
+    const result = deleteManagedSkill("delete-no-index");
+    expect(result.deleted).toBe(true);
+    expect(result.indexUpdated).toBe(false);
+    expect(existsSync(join(skillsDir, "delete-no-index"))).toBe(false);
+    expect(existsSync(join(skillsDir, "SKILLS.md"))).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -11,6 +11,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import { loadSkillCatalog } from "../config/skills.js";
 import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
 import type { ToolContext } from "../tools/types.js";
 
@@ -31,7 +32,7 @@ afterEach(() => {
 });
 
 describe("scaffold_managed_skill tool", () => {
-  test("creates a valid skill and index entry", async () => {
+  test("creates a valid skill discovered from its SKILL.md directory", async () => {
     const result = await executeScaffoldManagedSkill(
       {
         skill_id: "test-skill",
@@ -46,18 +47,19 @@ describe("scaffold_managed_skill tool", () => {
     const parsed = JSON.parse(result.content);
     expect(parsed.created).toBe(true);
     expect(parsed.skill_id).toBe("test-skill");
-    expect(parsed.index_updated).toBe(true);
+    expect(parsed.index_updated).toBe(false);
 
     const skillFile = join(TEST_DIR, "skills", "test-skill", "SKILL.md");
     expect(existsSync(skillFile)).toBe(true);
     const content = readFileSync(skillFile, "utf-8");
     expect(content).toContain('name: "Test Skill"');
 
-    const indexContent = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(indexContent).toContain("- test-skill");
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
+
+    const catalog = loadSkillCatalog();
+    const skill = catalog.find((s) => s.id === "test-skill");
+    expect(skill).toBeDefined();
+    expect(skill!.name).toBe("Test Skill");
   });
 
   test("rejects duplicate unless overwrite=true", async () => {
@@ -258,7 +260,7 @@ describe("scaffold_managed_skill tool", () => {
     expect(result.content).toContain("traversal");
   });
 
-  test("e2e: scaffold child then parent with includes, verify files and index", async () => {
+  test("e2e: scaffold child then parent with includes, verify file discovery", async () => {
     const childResult = await executeScaffoldManagedSkill(
       {
         skill_id: "e2e-child",
@@ -288,11 +290,12 @@ describe("scaffold_managed_skill tool", () => {
     expect(parentContent).toContain("    includes:");
     expect(parentContent).toContain("      - e2e-child");
 
-    const indexContent = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(indexContent).toContain("- e2e-child");
-    expect(indexContent).toContain("- e2e-parent");
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
+
+    const catalog = loadSkillCatalog();
+    expect(catalog.find((s) => s.id === "e2e-child")).toBeDefined();
+    const parent = catalog.find((s) => s.id === "e2e-parent");
+    expect(parent).toBeDefined();
+    expect(parent!.includes).toEqual(["e2e-child"]);
   });
 });

--- a/assistant/src/config/bundled-skills/skill-management/SKILL.md
+++ b/assistant/src/config/bundled-skills/skill-management/SKILL.md
@@ -18,6 +18,6 @@ Manage the lifecycle of custom managed skills in `{workspaceDir}/skills`.
 ## Capabilities
 
 - **Scaffold** a new managed skill with YAML frontmatter and markdown body
-- **Delete** an existing managed skill and remove it from the SKILLS.md index
+- **Delete** an existing managed skill directory
 
-Skills created via `scaffold_managed_skill` become available for `skill_load` immediately.
+Skills created via `scaffold_managed_skill` become available for `skill_load` when a valid top-level `SKILL.md` is written under the skill directory.

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "scaffold_managed_skill",
-      "description": "Create or update a managed skill in {workspaceDir}/skills. The skill becomes available for skill_load immediately. Never persist a skill without explicit user consent. Before persisting, test the snippet: write to a temp file with bash and run with `bun run /tmp/vellum-eval/snippet.ts`. Iterate up to 3 attempts, then ask the user. Clean up temp files after. Do not use file_write for temp files outside the working directory. After a skill is written, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
+      "description": "Create or update a managed skill in {workspaceDir}/skills. The skill becomes available for skill_load when a valid top-level SKILL.md is written under the skill directory. Never persist a skill without explicit user consent. Before persisting, test the snippet: write to a temp file with bash and run with `bun run /tmp/vellum-eval/snippet.ts`. Iterate up to 3 attempts, then ask the user. Clean up temp files after. Do not use file_write for temp files outside the working directory. After a skill is written, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {
@@ -35,7 +35,7 @@
           },
           "add_to_index": {
             "type": "boolean",
-            "description": "Whether to add the skill to SKILLS.md index (default: true)."
+            "description": "Deprecated compatibility input. No-op; managed skills are discovered from top-level SKILL.md files in skill directories."
           },
           "includes": {
             "type": "array",
@@ -50,7 +50,7 @@
     },
     {
       "name": "delete_managed_skill",
-      "description": "Delete a managed skill from {workspaceDir}/skills and remove it from the SKILLS.md index. Never delete a skill without explicit user confirmation. After deletion, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
+      "description": "Delete a managed skill directory from {workspaceDir}/skills. Never delete a skill without explicit user confirmation. After deletion, the next turn may run in a recreated conversation due to file-watcher eviction - continue normally.",
       "category": "skills",
       "risk": "high",
       "input_schema": {
@@ -62,7 +62,7 @@
           },
           "remove_from_index": {
             "type": "boolean",
-            "description": "Whether to remove the skill from SKILLS.md index (default: true)."
+            "description": "Deprecated compatibility input. No-op; managed skills disappear when their skill directory is removed."
           }
         },
         "required": ["skill_id"]

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -197,7 +197,7 @@ interface CreateManagedSkillParams {
 interface CreateManagedSkillResult {
   created: boolean;
   path: string;
-  /** @deprecated Managed skills no longer update SKILLS.md; always false. */
+  /** @deprecated Always false; managed skills are discovered from SKILL.md files. */
   indexUpdated: boolean;
   error?: string;
 }
@@ -279,7 +279,7 @@ export function createManagedSkill(
 
 interface DeleteManagedSkillResult {
   deleted: boolean;
-  /** @deprecated Managed skills no longer update SKILLS.md; always false. */
+  /** @deprecated Always false; managed skills are discovered from SKILL.md files. */
   indexUpdated: boolean;
   error?: string;
 }

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -131,19 +131,6 @@ function indexEntryRegex(id: string): RegExp {
   );
 }
 
-export function upsertSkillsIndexEntry(id: string): void {
-  const lines = readIndexLines();
-  const pattern = indexEntryRegex(id);
-  if (lines.some((line) => pattern.test(line))) {
-    return; // already present
-  }
-  // Append new entry
-  const nonEmpty = lines.filter((l) => l.trim());
-  nonEmpty.push(`- ${id}`);
-  writeIndexLines(nonEmpty);
-  log.info({ id }, "Added managed skill to SKILLS.md index");
-}
-
 export function removeSkillsIndexEntry(id: string): void {
   const lines = readIndexLines();
   const pattern = indexEntryRegex(id);
@@ -200,6 +187,7 @@ interface CreateManagedSkillParams {
   bodyMarkdown: string;
   emoji?: string;
   overwrite?: boolean;
+  /** @deprecated Managed skills are discovered from SKILL.md files. No-op. */
   addToIndex?: boolean;
   includes?: string[];
   version?: string;
@@ -209,6 +197,7 @@ interface CreateManagedSkillParams {
 interface CreateManagedSkillResult {
   created: boolean;
   path: string;
+  /** @deprecated Managed skills no longer update SKILLS.md; always false. */
   indexUpdated: boolean;
   error?: string;
 }
@@ -285,24 +274,19 @@ export function createManagedSkill(
     "Created managed skill",
   );
 
-  let indexUpdated = false;
-  if (params.addToIndex !== false) {
-    upsertSkillsIndexEntry(params.id);
-    indexUpdated = true;
-  }
-
-  return { created: true, path: skillFilePath, indexUpdated };
+  return { created: true, path: skillFilePath, indexUpdated: false };
 }
 
 interface DeleteManagedSkillResult {
   deleted: boolean;
+  /** @deprecated Managed skills no longer update SKILLS.md; always false. */
   indexUpdated: boolean;
   error?: string;
 }
 
 export function deleteManagedSkill(
   id: string,
-  removeFromIndex = true,
+  _removeFromIndex = true,
 ): DeleteManagedSkillResult {
   const validationError = validateManagedSkillId(id);
   if (validationError) {
@@ -322,19 +306,5 @@ export function deleteManagedSkill(
   deleteSkillCapabilityNode(id);
   log.info({ id, path: skillDir }, "Deleted managed skill");
 
-  let indexUpdated = false;
-  if (removeFromIndex) {
-    try {
-      removeSkillsIndexEntry(id);
-      indexUpdated = true;
-    } catch (err) {
-      // Best-effort: skill dir is already gone, don't fail the whole delete
-      log.warn(
-        { id, err },
-        "Failed to update skills index after deleting managed skill",
-      );
-    }
-  }
-
-  return { deleted: true, indexUpdated };
+  return { deleted: true, indexUpdated: false };
 }

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -17,9 +17,8 @@ export async function executeDeleteManagedSkill(
     };
   }
 
-  const removeFromIndex = input.remove_from_index !== false;
-
-  const result = deleteManagedSkill(skillId.trim(), removeFromIndex);
+  // remove_from_index is accepted for compatibility but no longer changes behavior.
+  const result = deleteManagedSkill(skillId.trim());
 
   if (!result.deleted) {
     return { content: `Error: ${result.error}`, isError: true };

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -17,7 +17,7 @@ export async function executeDeleteManagedSkill(
     };
   }
 
-  // remove_from_index is accepted for compatibility but no longer changes behavior.
+  // remove_from_index is accepted for compatibility; it has no effect.
   const result = deleteManagedSkill(skillId.trim());
 
   if (!result.deleted) {

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -83,7 +83,7 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
-  // add_to_index is accepted for compatibility but no longer changes behavior.
+  // add_to_index is accepted for compatibility; it has no effect.
   const result = createManagedSkill({
     id: skillId.trim(),
     name: sanitizeFrontmatterValue(name),

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -83,6 +83,7 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
+  // add_to_index is accepted for compatibility but no longer changes behavior.
   const result = createManagedSkill({
     id: skillId.trim(),
     name: sanitizeFrontmatterValue(name),
@@ -93,7 +94,6 @@ export async function executeScaffoldManagedSkill(
         ? sanitizeFrontmatterValue(input.emoji)
         : undefined,
     overwrite: input.overwrite === true,
-    addToIndex: input.add_to_index !== false,
     includes,
   });
 


### PR DESCRIPTION
## Summary
- Stops managed skill create/delete flows from creating or updating SKILLS.md.
- Keeps compatibility inputs/outputs while marking index behavior as deprecated or no-op.
- Updates skill-management docs and lifecycle tests for directory-based discovery.

Part of plan: migrate-off-skills-md.md (PR 4 of 7)
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->