### PR TITLE
Stop catalog and community skill installs from maintaining SKILLS.md

### DIFF
--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -96,15 +96,11 @@ mock.module("../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => null,
   userMessage: () => ({}),
 }));
-mock.module("../runtime/routes/workspace-utils.js", () => ({
-  isTextMimeType: () => true,
-}));
 mock.module("../skills/catalog-cache.js", () => ({
   getCatalog: mockGetCatalog,
 }));
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: mockInstallSkillLocally,
-  upsertSkillsIndex: () => {},
 }));
 mock.module("../skills/catalog-search.js", () => ({
   filterByQuery: () => [],
@@ -112,7 +108,6 @@ mock.module("../skills/catalog-search.js", () => ({
 mock.module("../skills/managed-store.js", () => ({
   createManagedSkill: () => ({ created: true }),
   deleteManagedSkill: () => ({ deleted: true }),
-  removeSkillsIndexEntry: () => {},
   validateManagedSkillId: () => null,
 }));
 mock.module("../memory/graph/capability-seed.js", () => ({
@@ -141,7 +136,6 @@ import { installSkill } from "../daemon/handlers/skills.js";
 // Helpers
 // ---------------------------------------------------------------------------
 
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -167,12 +161,10 @@ describe("installSkill routing", () => {
   });
 
   test("install with origin: 'skillssh' and multi-segment slug routes to installExternalSkill", async () => {
-    const result = await installSkill(
-      {
-        slug: "vercel-labs/agent-skills/react-best-practices",
-        origin: "skillssh",
-      },
-    );
+    const result = await installSkill({
+      slug: "vercel-labs/agent-skills/react-best-practices",
+      origin: "skillssh",
+    });
 
     expect(result.success).toBe(true);
     expect(mockInstallExternalSkill).toHaveBeenCalledTimes(1);
@@ -201,9 +193,7 @@ describe("installSkill routing", () => {
   });
 
   test("install with origin: 'clawhub' routes directly to clawhub without trying skills.sh", async () => {
-    const result = await installSkill(
-      { slug: "my-skill", origin: "clawhub" },
-    );
+    const result = await installSkill({ slug: "my-skill", origin: "clawhub" });
 
     expect(result.success).toBe(true);
     expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
@@ -211,9 +201,7 @@ describe("installSkill routing", () => {
   });
 
   test("multi-segment slug without explicit origin auto-routes to skills.sh", async () => {
-    const result = await installSkill(
-      { slug: "owner/repo/my-skill" },
-    );
+    const result = await installSkill({ slug: "owner/repo/my-skill" });
 
     expect(result.success).toBe(true);
     expect(mockInstallExternalSkill).toHaveBeenCalledTimes(1);
@@ -231,9 +219,10 @@ describe("installSkill routing", () => {
   test("multi-segment slug with origin: 'clawhub' skips skills.sh and routes to clawhub", async () => {
     // Even though the slug looks like skills.sh format, explicit origin: "clawhub"
     // should override the auto-detection and go to clawhub
-    const result = await installSkill(
-      { slug: "owner/repo/my-skill", origin: "clawhub" },
-    );
+    const result = await installSkill({
+      slug: "owner/repo/my-skill",
+      origin: "clawhub",
+    });
 
     expect(result.success).toBe(true);
     expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
@@ -251,9 +240,10 @@ describe("installSkill routing", () => {
       },
     ]);
 
-    const result = await installSkill(
-      { slug: "bundled-skill", origin: "skillssh" },
-    );
+    const result = await installSkill({
+      slug: "bundled-skill",
+      origin: "skillssh",
+    });
 
     expect(result.success).toBe(true);
     // Should have auto-enabled via ensureSkillEntry, not called external install
@@ -266,12 +256,10 @@ describe("installSkill routing", () => {
       new Error("Skill not found in repo"),
     );
 
-    const result = await installSkill(
-      {
-        slug: "owner/repo/nonexistent-skill",
-        origin: "skillssh",
-      },
-    );
+    const result = await installSkill({
+      slug: "owner/repo/nonexistent-skill",
+      origin: "skillssh",
+    });
 
     expect(result.success).toBe(false);
     if (!result.success) {

--- a/assistant/src/__tests__/search-skills-unified.test.ts
+++ b/assistant/src/__tests__/search-skills-unified.test.ts
@@ -124,9 +124,6 @@ mock.module("../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => null,
   userMessage: () => ({}),
 }));
-mock.module("../runtime/routes/workspace-utils.js", () => ({
-  isTextMimeType: () => true,
-}));
 mock.module("../skills/catalog-cache.js", () => ({
   getCatalog: async () => [],
 }));
@@ -136,7 +133,6 @@ mock.module("../skills/catalog-install.js", () => ({
 mock.module("../skills/managed-store.js", () => ({
   createManagedSkill: () => ({ created: true }),
   deleteManagedSkill: () => ({ deleted: true }),
-  removeSkillsIndexEntry: () => {},
   validateManagedSkillId: () => null,
 }));
 mock.module("../memory/graph/capability-seed.js", () => ({
@@ -164,7 +160,6 @@ import { searchSkills } from "../daemon/handlers/skills.js";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/assistant/src/__tests__/skills-file-content-endpoint.test.ts
+++ b/assistant/src/__tests__/skills-file-content-endpoint.test.ts
@@ -199,7 +199,6 @@ mock.module("../skills/skill-file-provider.js", () => ({}));
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
-  upsertSkillsIndex: () => {},
   getRepoSkillsDir: () => undefined,
 }));
 
@@ -230,7 +229,6 @@ mock.module("../skills/install-meta.js", () => ({
 mock.module("../skills/managed-store.js", () => ({
   createManagedSkill: () => ({ created: true }),
   deleteManagedSkill: () => ({ deleted: true }),
-  removeSkillsIndexEntry: () => {},
   validateManagedSkillId: () => null,
 }));
 
@@ -412,10 +410,7 @@ describe("getSkillFileContent — installed skill", () => {
     mockResolvedSkills = [installedSkill("my-skill", skillDir)];
     installFetchForbidden();
 
-    const result = await getSkillFileContent(
-      "my-skill",
-      "SKILL.md\0.png",
-    );
+    const result = await getSkillFileContent("my-skill", "SKILL.md\0.png");
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(400);
@@ -458,10 +453,7 @@ describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
       toSlimSkill: async () => null,
     };
 
-    const result = await getSkillFileContent(
-      "remote-skill",
-      "SKILL.md",
-    );
+    const result = await getSkillFileContent("remote-skill", "SKILL.md");
     expect("error" in result).toBe(false);
     if ("error" in result) return;
     expect(result.path).toBe("SKILL.md");
@@ -478,10 +470,7 @@ describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
 
     // All providers return canHandle=false (default noop)
 
-    const result = await getSkillFileContent(
-      "ghost-skill",
-      "SKILL.md",
-    );
+    const result = await getSkillFileContent("ghost-skill", "SKILL.md");
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
@@ -510,10 +499,7 @@ describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
       toSlimSkill: async () => null,
     };
 
-    const result = await getSkillFileContent(
-      "owner/repo/my-skill",
-      "SKILL.md",
-    );
+    const result = await getSkillFileContent("owner/repo/my-skill", "SKILL.md");
     expect("error" in result).toBe(false);
     if ("error" in result) return;
     expect(result.content).toBe("# skillssh content\n");
@@ -562,10 +548,7 @@ describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
       toSlimSkill: async () => null,
     };
 
-    const result = await getSkillFileContent(
-      "known-skill",
-      "nonexistent.txt",
-    );
+    const result = await getSkillFileContent("known-skill", "nonexistent.txt");
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
@@ -604,10 +587,7 @@ describe("getSkillFileContent — uninstalled skill (provider chain)", () => {
       toSlimSkill: async () => null,
     };
 
-    const result = await getSkillFileContent(
-      "simple-slug",
-      "SKILL.md",
-    );
+    const result = await getSkillFileContent("simple-slug", "SKILL.md");
     // Should be "File not found" (vellum handled but returned null)
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
@@ -626,10 +606,7 @@ describe("getSkillFileContent — skill not found", () => {
     mockResolvedSkills = [];
     installFetchForbidden();
 
-    const result = await getSkillFileContent(
-      "ghost-skill",
-      "SKILL.md",
-    );
+    const result = await getSkillFileContent("ghost-skill", "SKILL.md");
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
     expect(result.status).toBe(404);
@@ -666,10 +643,7 @@ describe("getSkillFileContent — installed skill with missing directory", () =>
     };
     installFetchForbidden();
 
-    const result = await getSkillFileContent(
-      "ghost-installed",
-      "SKILL.md",
-    );
+    const result = await getSkillFileContent("ghost-installed", "SKILL.md");
 
     expect("error" in result).toBe(true);
     if (!("error" in result)) return;
@@ -766,10 +740,7 @@ describe("getSkillFileContent — hidden / SKIP_DIRS rejection", () => {
     mockResolvedSkills = [installedSkill("healthy-skill", skillDir)];
     installFetchForbidden();
 
-    const result = await getSkillFileContent(
-      "healthy-skill",
-      "SKILL.md",
-    );
+    const result = await getSkillFileContent("healthy-skill", "SKILL.md");
     expect("error" in result).toBe(false);
     if ("error" in result) return;
     expect(result.content).toBe("# hello\n");

--- a/assistant/src/__tests__/skills-uninstall.test.ts
+++ b/assistant/src/__tests__/skills-uninstall.test.ts
@@ -53,14 +53,15 @@ afterEach(() => {
 });
 
 describe("assistant skills uninstall", () => {
-  test("removes skill directory and SKILLS.md entry", () => {
+  test("removes skill directory without editing SKILLS.md", () => {
     /**
      * Tests the happy path for uninstalling a skill.
      */
 
     // GIVEN a skill is installed locally
     installFakeSkill("weather");
-    writeSkillsIndex("- weather\n- vellum-self-knowledge\n");
+    const originalIndex = "- weather\n- vellum-self-knowledge\n";
+    writeSkillsIndex(originalIndex);
 
     // WHEN we uninstall the skill
     uninstallSkillLocally("weather");
@@ -68,12 +69,9 @@ describe("assistant skills uninstall", () => {
     // THEN the skill directory should be removed
     expect(existsSync(join(getSkillsDir(), "weather"))).toBe(false);
 
-    // AND the SKILLS.md entry should be removed
+    // AND SKILLS.md should be left unchanged
     const index = readFileSync(getSkillsIndexPath(), "utf-8");
-    expect(index).not.toContain("weather");
-
-    // AND other skills should remain in the index
-    expect(index).toContain("vellum-self-knowledge");
+    expect(index).toBe(originalIndex);
   });
 
   test("errors when skill is not installed", () => {
@@ -118,7 +116,8 @@ describe("assistant skills uninstall", () => {
     writeFileSync(join(skillDir, "SKILL.md"), "# weather\n");
     writeFileSync(join(skillDir, "scripts", "fetch.sh"), "#!/bin/bash\n");
     writeFileSync(join(skillDir, "scripts", "lib", "utils.sh"), "# utils\n");
-    writeSkillsIndex("- weather\n");
+    const originalIndex = "- weather\n";
+    writeSkillsIndex(originalIndex);
 
     // WHEN we uninstall the skill
     uninstallSkillLocally("weather");
@@ -126,8 +125,8 @@ describe("assistant skills uninstall", () => {
     // THEN the entire skill directory tree should be removed
     expect(existsSync(skillDir)).toBe(false);
 
-    // AND the SKILLS.md entry should be removed
+    // AND SKILLS.md should be left unchanged
     const index = readFileSync(getSkillsIndexPath(), "utf-8");
-    expect(index).not.toContain("weather");
+    expect(index).toBe(originalIndex);
   });
 });

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -48,7 +48,6 @@ import {
 import {
   type CatalogSkill,
   installSkillLocally,
-  upsertSkillsIndex,
 } from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
 import { inferCategory } from "../../skills/category-inference.js";
@@ -68,7 +67,6 @@ import {
 import {
   createManagedSkill,
   deleteManagedSkill,
-  removeSkillsIndexEntry,
   validateManagedSkillId,
 } from "../../skills/managed-store.js";
 import type { SkillFileProvider } from "../../skills/skill-file-provider.js";
@@ -262,11 +260,10 @@ function saveConfigWithSuppression(raw: Record<string, unknown>): void {
  * in the daemon. Handles catalog reload, auto-enable, broadcast, and memory
  * seeding.
  *
- * SKILLS.md indexing and dependency installation are handled separately:
- * `installSkillLocally` and `installExternalSkill` handle them internally
- * (so both CLI and daemon callers get correct behavior), while the clawhub
- * path handles them inline in `installSkill()` since `clawhubInstall` only
- * runs the clawhub CLI and writes metadata.
+ * Dependency installation is handled by the install path: catalog and
+ * skills.sh installs handle it internally, while the clawhub path handles it
+ * inline in `installSkill()` since `clawhubInstall` only runs the clawhub CLI
+ * and writes metadata.
  *
  * NOT used for bundled skills — those have a simpler inline path in
  * `installSkill()` that only auto-enables, broadcasts, and seeds memories.
@@ -1044,10 +1041,9 @@ export async function installSkill(spec: {
     if (bundled) {
       // Intentional divergence from postInstallSkill(): bundled skills are
       // shipped with the assistant binary and are already on disk. They skip
-      // SKILLS.md indexing (they're discovered via the bundled catalog, not
-      // the workspace index), dependency installation (deps are pre-bundled),
-      // and catalog reload (the catalog already includes them). Only
-      // auto-enable, broadcast, and seed memories are needed.
+      // dependency installation (deps are pre-bundled) and catalog reload (the
+      // catalog already includes them). Only auto-enable, broadcast, and seed
+      // memories are needed.
       try {
         const raw = loadRawConfig();
         ensureSkillEntry(raw, spec.slug).enabled = true;
@@ -1129,8 +1125,8 @@ export async function installSkill(spec: {
     const rawId = result.skillName ?? spec.slug;
     const skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
 
-    // clawhubInstall uses the clawhub CLI which doesn't handle bun install
-    // or SKILLS.md indexing, so we do those here before post-install.
+    // clawhubInstall uses the clawhub CLI which doesn't handle bun install, so
+    // install dependencies here before post-install.
     const skillDir = join(getWorkspaceSkillsDir(), skillId);
     if (existsSync(join(skillDir, "package.json"))) {
       const bunPath = `${homedir()}/.bun/bin`;
@@ -1140,7 +1136,6 @@ export async function installSkill(spec: {
         env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
       });
     }
-    upsertSkillsIndex(skillId);
 
     postInstallSkill(skillId, skillDir);
     return { success: true, skillId };
@@ -1184,11 +1179,6 @@ export async function uninstallSkill(
         return { success: false, error: "Skill not found" };
       }
       rmSync(skillDir, { recursive: true });
-      try {
-        removeSkillsIndexEntry(skillId);
-      } catch {
-        /* best effort */
-      }
       // Best-effort cleanup of capability memory for uninstalled skill
       // (managed path handles this internally via deleteManagedSkill)
       deleteSkillCapabilityNode(skillId);

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -1,11 +1,9 @@
 import { execSync } from "node:child_process";
-import { randomUUID } from "node:crypto";
 import {
   cpSync,
   existsSync,
   mkdirSync,
   readFileSync,
-  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -44,12 +42,6 @@ export interface CatalogSkill {
 export interface CatalogManifest {
   version: number;
   skills: CatalogSkill[];
-}
-
-// ─── Path helpers ────────────────────────────────────────────────────────────
-
-function getSkillsIndexPath(): string {
-  return join(getWorkspaceSkillsDir(), "SKILLS.md");
 }
 
 /**
@@ -226,49 +218,6 @@ async function fetchAndExtractSkill(
   }
 }
 
-// ─── SKILLS.md index management ──────────────────────────────────────────────
-
-function atomicWriteFile(filePath: string, content: string): void {
-  const dir = dirname(filePath);
-  mkdirSync(dir, { recursive: true });
-  const tmpPath = join(dir, `.tmp-${randomUUID()}`);
-  writeFileSync(tmpPath, content, "utf-8");
-  renameSync(tmpPath, filePath);
-}
-
-export function upsertSkillsIndex(id: string): void {
-  const indexPath = getSkillsIndexPath();
-  let lines: string[] = [];
-  if (existsSync(indexPath)) {
-    lines = readFileSync(indexPath, "utf-8").split("\n");
-  }
-
-  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`^[-*]\\s+(?:\`)?${escaped}(?:\`)?\\s*$`);
-  if (lines.some((line) => pattern.test(line))) return;
-
-  const nonEmpty = lines.filter((l) => l.trim());
-  nonEmpty.push(`- ${id}`);
-  const content = nonEmpty.join("\n");
-  atomicWriteFile(indexPath, content.endsWith("\n") ? content : content + "\n");
-}
-
-function removeSkillsIndexEntry(id: string): void {
-  const indexPath = getSkillsIndexPath();
-  if (!existsSync(indexPath)) return;
-
-  const lines = readFileSync(indexPath, "utf-8").split("\n");
-  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const pattern = new RegExp(`^[-*]\\s+(?:\`)?${escaped}(?:\`)?\\s*$`);
-  const filtered = lines.filter((line) => !pattern.test(line));
-
-  // If nothing changed, skip the write
-  if (filtered.length === lines.length) return;
-
-  const content = filtered.join("\n");
-  atomicWriteFile(indexPath, content.endsWith("\n") ? content : content + "\n");
-}
-
 // ─── Install / uninstall ─────────────────────────────────────────────────────
 
 export function uninstallSkillLocally(skillId: string): void {
@@ -279,7 +228,6 @@ export function uninstallSkillLocally(skillId: string): void {
   }
 
   rmSync(skillDir, { recursive: true, force: true });
-  removeSkillsIndexEntry(skillId);
   deleteSkillCapabilityNode(skillId);
 }
 
@@ -329,9 +277,7 @@ export async function installSkillLocally(
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
 
-  // Post-install: install dependencies first, then index the skill.
-  // Running bun install before upsertSkillsIndex ensures we don't index a
-  // skill whose dependencies failed to install.
+  // Post-install: install dependencies before reporting success.
   if (existsSync(join(skillDir, "package.json"))) {
     const bunPath = `${homedir()}/.bun/bin`;
     execSync("bun install", {
@@ -340,7 +286,6 @@ export async function installSkillLocally(
       env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
     });
   }
-  upsertSkillsIndex(skillId);
 }
 
 // ─── Auto-install (for skill_load) ──────────────────────────────────────────
@@ -379,7 +324,12 @@ export async function resolveCatalog(
         const localIds = new Set(local.map((s) => s.id));
         const merged = [...local, ...remote.filter((s) => !localIds.has(s.id))];
         log.info(
-          { skillId, source: "merged", localCount: local.length, remoteCount: remote.length },
+          {
+            skillId,
+            source: "merged",
+            localCount: local.length,
+            remoteCount: remote.length,
+          },
           "Resolved skills catalog from local+remote merge",
         );
         return merged;
@@ -393,7 +343,10 @@ export async function resolveCatalog(
     }
   }
 
-  log.info({ skillId, source: "remote" }, "Resolved skills catalog from platform API");
+  log.info(
+    { skillId, source: "remote" },
+    "Resolved skills catalog from platform API",
+  );
   return fetchCatalog();
 }
 
@@ -430,16 +383,14 @@ export async function autoInstallFromCatalog(
     return false;
   }
 
-  // If the skill already exists on disk (stale index), re-index it instead
-  // of attempting a fresh install that would fail.
+  // If the skill already exists on disk, reuse it instead of attempting a
+  // fresh install that would fail.
   const skillDir = join(getWorkspaceSkillsDir(), skillId);
   if (existsSync(join(skillDir, "SKILL.md"))) {
-    log.info({ skillId, source: "disk-reindex" }, "Skill already on disk, re-indexing");
-    upsertSkillsIndex(skillId);
+    log.info({ skillId, source: "disk" }, "Skill already on disk");
     return true;
   }
 
-  // installSkillLocally handles dependency installation and SKILLS.md indexing.
   await installSkillLocally(skillId, entry, false);
 
   return true;

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -4,7 +4,6 @@ import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 
 import { getWorkspaceSkillsDir } from "../util/platform.js";
-import { upsertSkillsIndex } from "./catalog-install.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 import type {
   AuditResponse,
@@ -424,7 +423,6 @@ export function validateSkillSlug(slug: string): void {
  * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
  * 4. Writes `install-meta.json` with origin metadata
  * 5. Installs npm dependencies (if package.json exists)
- * 6. Updates SKILLS.md index
  *
  * Auto-enable and memory seeding are handled by the caller (e.g.
  * `postInstallSkill()` in the daemon, or left to the user for CLI installs).
@@ -482,9 +480,7 @@ export async function installExternalSkill(
     contentHash: computeSkillHash(skillDir) ?? undefined,
   });
 
-  // Post-install: install dependencies first, then index the skill.
-  // Running bun install before upsertSkillsIndex ensures we don't index a
-  // skill whose dependencies failed to install.
+  // Post-install: install dependencies before reporting success.
   if (existsSync(join(skillDir, "package.json"))) {
     const bunPath = `${homedir()}/.bun/bin`;
     execSync("bun install", {
@@ -493,5 +489,4 @@ export async function installExternalSkill(
       env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
     });
   }
-  upsertSkillsIndex(skillSlug);
 }


### PR DESCRIPTION
## Summary
- Removes SKILLS.md writes from catalog, skills.sh, clawhub, install, uninstall, and auto-install flows.
- Keeps installed skill reuse based on valid on-disk SKILL.md files.
- Updates install/search/uninstall tests for SKILL.md-based discovery.

Part of plan: migrate-off-skills-md.md (PR 5 of 7)
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->