### PR TITLE
Part of JARVIS-705: Send macOS client timezone with messages

### DIFF
--- a/clients/macos/vellum-assistantTests/MessageClientTimezoneTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageClientTimezoneTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import VellumAssistantShared
+
+final class MessageClientTimezoneTests: XCTestCase {
+    func testMessageBodyIncludesLocalTimezoneAndExistingHostFields() {
+        let body = MessageClient.messageBody(
+            content: "Hello",
+            conversationKey: "conversation-123",
+            attachmentIds: ["attachment-123"],
+            conversationType: "manual",
+            automated: true,
+            bypassSecretCheck: true,
+            clientMessageId: "message-123",
+            inferenceProfile: "balanced",
+            riskThreshold: "medium"
+        )
+
+        let expectedTimezone = TimeZone.autoupdatingCurrent.identifier
+        XCTAssertFalse(expectedTimezone.isEmpty)
+        XCTAssertEqual(MessageClient.clientTimezone, expectedTimezone)
+        XCTAssertEqual(body["clientTimezone"] as? String, expectedTimezone)
+
+        XCTAssertEqual(body["conversationKey"] as? String, "conversation-123")
+        XCTAssertEqual(body["content"] as? String, "Hello")
+        XCTAssertEqual(body["sourceChannel"] as? String, "vellum")
+        XCTAssertEqual(body["interface"] as? String, "macos")
+        XCTAssertEqual(body["hostHomeDir"] as? String, NSHomeDirectory())
+        XCTAssertEqual(body["hostUsername"] as? String, NSUserName())
+        XCTAssertEqual(body["attachmentIds"] as? [String], ["attachment-123"])
+        XCTAssertEqual(body["conversationType"] as? String, "manual")
+        XCTAssertEqual(body["automated"] as? Bool, true)
+        XCTAssertEqual(body["bypassSecretCheck"] as? Bool, true)
+        XCTAssertEqual(body["clientMessageId"] as? String, "message-123")
+        XCTAssertEqual(body["inferenceProfile"] as? String, "balanced")
+        XCTAssertEqual(body["riskThreshold"] as? String, "medium")
+    }
+
+    func testMessageBodyOmitsEmptyTimezone() {
+        let body = MessageClient.messageBody(
+            content: "Hello",
+            conversationKey: "conversation-123",
+            clientTimezone: ""
+        )
+
+        XCTAssertNil(body["clientTimezone"])
+        XCTAssertEqual(body["sourceChannel"] as? String, "vellum")
+        XCTAssertEqual(body["interface"] as? String, "macos")
+        XCTAssertEqual(body["hostHomeDir"] as? String, NSHomeDirectory())
+        XCTAssertEqual(body["hostUsername"] as? String, NSUserName())
+    }
+}

--- a/clients/shared/Network/MessageClient.swift
+++ b/clients/shared/Network/MessageClient.swift
@@ -63,6 +63,80 @@ public struct MessageClient: MessageClientProtocol {
         return NSUserName()
     }
 
+    internal static var clientTimezone: String? {
+        let identifier = TimeZone.autoupdatingCurrent.identifier
+        return identifier.isEmpty ? nil : identifier
+    }
+
+    internal static func messageBody(
+        content: String?,
+        conversationKey: String,
+        attachmentIds: [String] = [],
+        conversationType: String? = nil,
+        automated: Bool? = nil,
+        bypassSecretCheck: Bool? = nil,
+        onboarding: PreChatOnboardingContext? = nil,
+        clientMessageId: String? = nil,
+        inferenceProfile: String? = nil,
+        riskThreshold: String? = nil,
+        clientTimezone: String? = MessageClient.clientTimezone
+    ) -> [String: Any] {
+        var body: [String: Any] = [
+            "conversationKey": conversationKey,
+            "sourceChannel": "vellum",
+            "interface": Self.interfaceValue
+        ]
+        if let content, !content.isEmpty {
+            body["content"] = content
+        }
+        if !attachmentIds.isEmpty {
+            body["attachmentIds"] = attachmentIds
+        }
+        if let conversationType {
+            body["conversationType"] = conversationType
+        }
+        if automated == true {
+            body["automated"] = true
+        }
+        if bypassSecretCheck == true {
+            body["bypassSecretCheck"] = true
+        }
+        if let clientMessageId {
+            body["clientMessageId"] = clientMessageId
+        }
+        if let inferenceProfile {
+            body["inferenceProfile"] = inferenceProfile
+        }
+        if let riskThreshold {
+            body["riskThreshold"] = riskThreshold
+        }
+        if let hostHomeDir = Self.hostHomeDir {
+            body["hostHomeDir"] = hostHomeDir
+        }
+        if let hostUsername = Self.hostUsername {
+            body["hostUsername"] = hostUsername
+        }
+        if let clientTimezone, !clientTimezone.isEmpty {
+            body["clientTimezone"] = clientTimezone
+        }
+        if let onboarding {
+            var onboardingDict: [String: Any] = [
+                "tools": onboarding.tools,
+                "tasks": onboarding.tasks,
+                "tone": onboarding.tone
+            ]
+            if let userName = onboarding.userName {
+                onboardingDict["userName"] = userName
+            }
+            if let assistantName = onboarding.assistantName {
+                onboardingDict["assistantName"] = assistantName
+            }
+            body["onboarding"] = onboardingDict
+        }
+
+        return body
+    }
+
     public func uploadAttachment(filename: String, mimeType: String, data: String, filePath: String? = nil) async -> AttachmentUploadResult {
         let isFileBacked = data.isEmpty && filePath != nil
         log.info("[send-pipeline] attachment upload start — filename=\(filename, privacy: .public), mimeType=\(mimeType, privacy: .public), fileBacked=\(isFileBacked, privacy: .public)")
@@ -167,55 +241,18 @@ public struct MessageClient: MessageClientProtocol {
     ) async -> MessageSendResult {
         log.info("[send-pipeline] message request start — uploadedAttachmentIds=\(attachmentIds.count)")
 
-        var body: [String: Any] = [
-            "conversationKey": conversationKey,
-            "sourceChannel": "vellum",
-            "interface": Self.interfaceValue
-        ]
-        if let content, !content.isEmpty {
-            body["content"] = content
-        }
-        if !attachmentIds.isEmpty {
-            body["attachmentIds"] = attachmentIds
-        }
-        if let conversationType {
-            body["conversationType"] = conversationType
-        }
-        if automated == true {
-            body["automated"] = true
-        }
-        if bypassSecretCheck == true {
-            body["bypassSecretCheck"] = true
-        }
-        if let clientMessageId {
-            body["clientMessageId"] = clientMessageId
-        }
-        if let inferenceProfile {
-            body["inferenceProfile"] = inferenceProfile
-        }
-        if let riskThreshold {
-            body["riskThreshold"] = riskThreshold
-        }
-        if let hostHomeDir = Self.hostHomeDir {
-            body["hostHomeDir"] = hostHomeDir
-        }
-        if let hostUsername = Self.hostUsername {
-            body["hostUsername"] = hostUsername
-        }
-        if let onboarding {
-            var onboardingDict: [String: Any] = [
-                "tools": onboarding.tools,
-                "tasks": onboarding.tasks,
-                "tone": onboarding.tone
-            ]
-            if let userName = onboarding.userName {
-                onboardingDict["userName"] = userName
-            }
-            if let assistantName = onboarding.assistantName {
-                onboardingDict["assistantName"] = assistantName
-            }
-            body["onboarding"] = onboardingDict
-        }
+        let body = Self.messageBody(
+            content: content,
+            conversationKey: conversationKey,
+            attachmentIds: attachmentIds,
+            conversationType: conversationType,
+            automated: automated,
+            bypassSecretCheck: bypassSecretCheck,
+            onboarding: onboarding,
+            clientMessageId: clientMessageId,
+            inferenceProfile: inferenceProfile,
+            riskThreshold: riskThreshold
+        )
 
         do {
             let response = try await GatewayHTTPClient.post(


### PR DESCRIPTION
## Summary
- Adds the current macOS timezone to chat message POST bodies.
- Keeps timezone metadata out of unrelated upload/request paths.
- Covers message body behavior with targeted Swift tests.

Apple refs checked (2026-05-05): Foundation TimeZone autoupdatingCurrent and identifier documentation.

Part of JARVIS-705.
Part of plan: assistant-local-timezone.md (PR 5 of 8)