### PR TITLE
Part of JARVIS-709: Add shared Swift state for provider billing errors

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1473,6 +1473,70 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.conversationError?.recoverySuggestion.contains("Vellum-managed") == true)
     }
 
+    func testProviderBillingCreditsExhaustedIsManagedCreditsExhausted() {
+        viewModel.conversationId = "sess-1"
+
+        let errorMsg = ConversationErrorMessage(
+            conversationId: "sess-1",
+            code: .providerBilling,
+            userMessage: "Your Vellum balance has run out.",
+            retryable: false,
+            errorCategory: "credits_exhausted"
+        )
+        viewModel.handleServerMessage(.conversationError(errorMsg))
+
+        let error = viewModel.conversationError
+        XCTAssertEqual(error?.category, .providerBilling)
+        XCTAssertEqual(error?.errorCategory, "credits_exhausted")
+        XCTAssertTrue(error?.isManagedCreditsExhausted == true)
+        XCTAssertTrue(error?.isCreditsExhausted == true)
+        XCTAssertFalse(error?.isProviderBilling == true)
+        XCTAssertTrue(error?.recoverySuggestion.contains("Vellum account") == true)
+    }
+
+    func testProviderBillingErrorCategoryIsProviderBillingNotCreditsExhausted() {
+        viewModel.conversationId = "sess-1"
+
+        let errorMsg = ConversationErrorMessage(
+            conversationId: "sess-1",
+            code: .providerBilling,
+            userMessage: "Your provider API key needs credits.",
+            retryable: false,
+            errorCategory: "provider_billing"
+        )
+        viewModel.handleServerMessage(.conversationError(errorMsg))
+
+        let error = viewModel.conversationError
+        XCTAssertEqual(error?.category, .providerBilling)
+        XCTAssertEqual(error?.errorCategory, "provider_billing")
+        XCTAssertFalse(error?.isManagedCreditsExhausted == true)
+        XCTAssertFalse(error?.isCreditsExhausted == true)
+        XCTAssertTrue(error?.isProviderBilling == true)
+        XCTAssertTrue(error?.recoverySuggestion.contains("provider") == true)
+        XCTAssertFalse(error?.recoverySuggestion.contains("Add credits") == true)
+    }
+
+    func testConversationErrorPreservesProviderBillingErrorCategory() {
+        viewModel.conversationId = "sess-1"
+
+        let errorMsg = ConversationErrorMessage(
+            conversationId: "sess-1",
+            code: .providerBilling,
+            userMessage: "Your provider API key needs credits.",
+            retryable: false,
+            errorCategory: "regenerate:provider_billing"
+        )
+        viewModel.handleServerMessage(.conversationError(errorMsg))
+
+        XCTAssertEqual(
+            viewModel.conversationError?.errorCategory,
+            "regenerate:provider_billing",
+            "ConversationErrorMessage.errorCategory should be preserved in ConversationError"
+        )
+        XCTAssertTrue(viewModel.conversationError?.isProviderBilling == true)
+        XCTAssertFalse(viewModel.conversationError?.isCreditsExhausted == true)
+    }
+
     func testConversationErrorSetsRecoverySuggestion() {
         viewModel.conversationId = "sess-1"
 

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -70,7 +70,7 @@ public enum ConversationErrorCategory: Equatable, Sendable {
         case .providerApi:
             return "This is usually temporary — click Retry, or check your API key in Settings if it persists."
         case .providerBilling:
-            return "Please add credits to your account or update your API key in Settings."
+            return "Add funds with your provider or update your API key in Settings."
         case .providerOrdering:
             return "This is usually temporary — click Retry to continue."
         case .providerWebSearch:
@@ -110,7 +110,7 @@ public struct ConversationError: Equatable {
         self.category = ConversationErrorCategory(from: msg.code)
         self.message = msg.userMessage
         self.isRetryable = msg.retryable
-        self.recoverySuggestion = self.category.recoverySuggestion
+        self.recoverySuggestion = Self.recoverySuggestion(for: self.category, errorCategory: msg.errorCategory)
         self.conversationId = msg.conversationId
         self.debugDetails = msg.debugDetails
         self.errorCategory = msg.errorCategory
@@ -120,16 +120,27 @@ public struct ConversationError: Equatable {
         self.category = category
         self.message = message
         self.isRetryable = isRetryable
-        self.recoverySuggestion = category.recoverySuggestion
+        self.recoverySuggestion = Self.recoverySuggestion(for: category, errorCategory: errorCategory)
         self.conversationId = conversationId
         self.debugDetails = debugDetails
         self.errorCategory = errorCategory
     }
 
-    /// Whether this error indicates that the user's credits are exhausted.
+    /// Whether this error indicates that Vellum-managed credits are exhausted.
     /// Matches both plain "credits_exhausted" and prefixed variants like "regenerate:credits_exhausted".
+    public var isManagedCreditsExhausted: Bool {
+        Self.isManagedCreditsExhausted(errorCategory)
+    }
+
+    /// Compatibility alias for existing managed-credits UI checks.
     public var isCreditsExhausted: Bool {
-        errorCategory?.hasSuffix("credits_exhausted") == true
+        isManagedCreditsExhausted
+    }
+
+    /// Whether this error indicates billing trouble with the user's configured provider.
+    /// Matches both plain "provider_billing" and prefixed variants like "regenerate:provider_billing".
+    public var isProviderBilling: Bool {
+        Self.isProviderBilling(category: category, errorCategory: errorCategory)
     }
 
     /// Whether this error indicates that no provider is configured for inference.
@@ -140,5 +151,29 @@ public struct ConversationError: Equatable {
     /// Whether this error indicates the managed assistant API key is invalid and should be reprovisioned.
     public var isManagedKeyInvalid: Bool {
         category == .managedKeyInvalid
+    }
+
+    private static func recoverySuggestion(for category: ConversationErrorCategory, errorCategory: String?) -> String {
+        if isManagedCreditsExhausted(errorCategory) {
+            return "Add credits to your Vellum account or switch to your API key in Settings."
+        }
+        if isProviderBilling(category: category, errorCategory: errorCategory) {
+            return ConversationErrorCategory.providerBilling.recoverySuggestion
+        }
+        return category.recoverySuggestion
+    }
+
+    private static func isManagedCreditsExhausted(_ errorCategory: String?) -> Bool {
+        errorCategory?.hasSuffix("credits_exhausted") == true
+    }
+
+    private static func isProviderBilling(category: ConversationErrorCategory, errorCategory: String?) -> Bool {
+        if isManagedCreditsExhausted(errorCategory) {
+            return false
+        }
+        if errorCategory?.hasSuffix("provider_billing") == true {
+            return true
+        }
+        return category == .providerBilling
     }
 }


### PR DESCRIPTION
## Summary
- Adds Swift chat error helpers for managed credits versus provider billing.
- Preserves managed credits compatibility while modeling BYOK provider billing separately.
- Adds focused ChatViewModel coverage for billing category preservation.

Part of plan: macos-provider-billing-ux.md (PR 2 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->