### PR TITLE
fix(oauth): update Todoist identity URL to /api/v1/sync

### DIFF
--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -403,7 +403,7 @@ export const PROVIDER_SEED_DATA: Record<
       },
     ],
     appType: "App",
-    identityUrl: "https://api.todoist.com/sync/v9/sync",
+    identityUrl: "https://api.todoist.com/api/v1/sync",
     identityMethod: "POST",
     identityHeaders: { "Content-Type": "application/x-www-form-urlencoded" },
     identityBody: "sync_token=*&resource_types=[%22user%22]",


### PR DESCRIPTION
## Summary
Mirror of platform-side fix. Todoist deprecated `/sync/v9/sync` (now returns HTTP 410 Gone) and routes callers to `/api/v1/`. Updates the stale URL in the assistant runtime's seed data so any downstream code reading `identityUrl` from the seeded provider config matches what the platform now uses.

## Companion PR
- `vellum-assistant-platform` — same one-line change in `provider_registry.json` is the fix that actually resolves the live OAuth-callback warning we observed on dev.

## Test plan
- [ ] Re-seed providers on a fresh assistant install (`assistant/src/oauth/seed-providers.ts` is consumed at seed time) and verify the seeded Todoist row's `identityUrl` reads `/api/v1/sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->