### PR TITLE
Closes JARVIS-705: Add local timezone release note

### DIFF
--- a/assistant/src/__tests__/workspace-migration-068-release-notes-local-timezone.test.ts
+++ b/assistant/src/__tests__/workspace-migration-068-release-notes-local-timezone.test.ts
@@ -1,0 +1,90 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { releaseNotesLocalTimezoneMigration } from "../workspace/migrations/068-release-notes-local-timezone.js";
+
+const MIGRATION_ID = "068-release-notes-local-timezone";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-068-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function updatesPath(): string {
+  return join(workspaceDir, "UPDATES.md");
+}
+
+function markerCount(content: string): number {
+  return content.split(MARKER).length - 1;
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("workspace migration 068-release-notes-local-timezone", () => {
+  test("has the correct id", () => {
+    expect(releaseNotesLocalTimezoneMigration.id).toBe(MIGRATION_ID);
+  });
+
+  test("creates UPDATES.md with marker and key copy when file is absent", () => {
+    expect(existsSync(updatesPath())).toBe(false);
+
+    releaseNotesLocalTimezoneMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content).toContain(MARKER);
+    expect(content).toContain("Local timezone grounding");
+    expect(content).toContain("device timezone");
+    expect(content).toContain("Manual timezone overrides still win");
+  });
+
+  test("is idempotent when run twice", () => {
+    releaseNotesLocalTimezoneMigration.run(workspaceDir);
+    releaseNotesLocalTimezoneMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(markerCount(content)).toBe(1);
+    expect(content.match(/Local timezone grounding/g)?.length).toBe(1);
+  });
+
+  test("appends to existing UPDATES.md when marker is absent", () => {
+    const prior = "## Prior\n\nExisting release note.\n";
+    writeFileSync(updatesPath(), prior, "utf-8");
+
+    releaseNotesLocalTimezoneMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(prior)).toBe(true);
+    expect(content).toContain(MARKER);
+  });
+
+  test("is a no-op when marker is already present", () => {
+    const seeded = `## Prior\n\n${MARKER}\nAlready announced.\n`;
+    writeFileSync(updatesPath(), seeded, "utf-8");
+
+    releaseNotesLocalTimezoneMigration.run(workspaceDir);
+
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(seeded);
+  });
+});

--- a/assistant/src/workspace/migrations/068-release-notes-local-timezone.ts
+++ b/assistant/src/workspace/migrations/068-release-notes-local-timezone.ts
@@ -1,0 +1,65 @@
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-068-release-notes-local-timezone");
+
+const MIGRATION_ID = "068-release-notes-local-timezone";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+const RELEASE_NOTE = `${MARKER}
+## Local timezone grounding
+
+The assistant now grounds \`current_time\` in your local timezone across clients,
+instead of falling back to UTC when the client can report the device timezone.
+
+Manual timezone overrides still win when configured, and the assistant can help
+update a stale override after you confirm that your device timezone should be
+used going forward.
+`;
+
+export const releaseNotesLocalTimezoneMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description:
+    "Append release notes for local timezone grounding to UPDATES.md",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+
+    try {
+      if (existsSync(updatesPath)) {
+        const existing = readFileSync(updatesPath, "utf-8");
+        if (existing.includes(MARKER)) {
+          return;
+        }
+        const needsLeadingNewline = !existing.endsWith("\n\n");
+        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+        appendFileSync(
+          updatesPath,
+          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
+          "utf-8",
+        );
+      } else {
+        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
+      }
+      log.info({ path: updatesPath }, "Appended local timezone release note");
+    } catch (err) {
+      log.warn(
+        { err, path: updatesPath },
+        "Failed to append local timezone release note to UPDATES.md",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
+    // processes and deletes on its own.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -65,6 +65,7 @@ import { unwindMainAgentOpusSeedMigration } from "./064-unwind-main-agent-opus-s
 import { bumpStaleHeartbeatIntervalMigration } from "./065-bump-stale-heartbeat-interval.js";
 import { seedHeartbeatCallsiteCostDefaultMigration } from "./066-seed-heartbeat-callsite-cost-default.js";
 import { releaseNotesSafeStorageLimitsMigration } from "./067-release-notes-safe-storage-limits.js";
+import { releaseNotesLocalTimezoneMigration } from "./068-release-notes-local-timezone.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -141,4 +142,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   bumpStaleHeartbeatIntervalMigration,
   seedHeartbeatCallsiteCostDefaultMigration,
   releaseNotesSafeStorageLimitsMigration,
+  releaseNotesLocalTimezoneMigration,
 ];


### PR DESCRIPTION
## Summary
- Add release-note migration 068 for local timezone grounding
- Register the migration in the workspace migration registry
- Cover marker-based idempotency and append behavior with a focused test

## Testing
- cd assistant && bun test src/__tests__/workspace-migration-068-release-notes-local-timezone.test.ts

Closes JARVIS-705
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->