### PR TITLE
[codex] Send native auth callback scheme

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -155,20 +155,25 @@ public final class AuthManager {
                 throw AuthServiceError.authCallbackFailed("Failed to generate secure random state.")
             }
 
-            // Build /accounts/native/start?state={state}. The server
-            // determines the callback scheme from settings.ENVIRONMENT
-            // — the client no longer sends it (ATL-454).
+            // Build /accounts/native/start?scheme={scheme}&state={state}.
+            // The platform validates the callback scheme against its native
+            // auth allowlist before redirecting to WorkOS.
             guard var startComponents = URLComponents(string: VellumEnvironment.resolvedWebURL) else {
                 throw AuthServiceError.invalidURL
             }
             startComponents.path = "/accounts/native/start"
-            startComponents.queryItems = [URLQueryItem(name: "state", value: stateParam)]
+            let callbackScheme = Self.callbackScheme
+            startComponents.queryItems = [
+                URLQueryItem(name: "scheme", value: callbackScheme),
+                URLQueryItem(name: "state", value: stateParam),
+            ]
 
             guard let loginURL = startComponents.url else {
                 throw AuthServiceError.invalidURL
             }
 
-            let callbackURL = try await performWebAuth(url: loginURL, callbackScheme: Self.callbackScheme)
+            log.info("Starting native auth flow with callbackScheme=\(callbackScheme, privacy: .public)")
+            let callbackURL = try await performWebAuth(url: loginURL, callbackScheme: callbackScheme)
 
             guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
                   let queryItems = components.queryItems else {


### PR DESCRIPTION
## Summary
- include the resolved native callback scheme in the macOS native auth start URL
- log the callback scheme immediately before starting `ASWebAuthenticationSession`

## Why
Local macOS builds use `vellum-assistant-local`, and the platform validates the requested callback scheme before redirecting to WorkOS. Sending the scheme makes the client/server contract explicit and makes Django logs show the callback scheme being requested.

## Companion PR
- Platform local allowlist fix: https://github.com/vellum-ai/vellum-assistant-platform/pull/5911

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path clients --target VellumAssistantLib`
- pre-push Swift build and design token guard passed