### PR TITLE
Remove legacy SKILLS.md files and document SKILL.md plus memory-based discovery

### DIFF
--- a/assistant/docs/skills.md
+++ b/assistant/docs/skills.md
@@ -6,20 +6,22 @@ This document describes the security model for the Vellum Assistant skill system
 
 Skills extend the assistant's capabilities by providing instructions (via `SKILL.md`) and optional custom tools (via `TOOLS.json`). Skills can be **bundled** (shipped with the application), **managed** (user-installed via `scaffold_managed_skill`), **workspace** (project-local), or **extra** (additional directories configured by the user).
 
+For managed skills, the installed source of truth is a valid directory at `~/.vellum/workspace/skills/<id>/` containing a top-level `SKILL.md` with standardized frontmatter. The assistant parses that frontmatter at startup and when skill directories change, then seeds Memory V2 skill entries under `skills/<id>` so the assistant can discover available skills from memory. The legacy `SKILLS.md` index is removed by workspace migration and is no longer created by install or scaffold paths.
+
 Because skills can introduce arbitrary tool behavior, they are subject to stricter permission defaults than core tools.
 
 ## Permission Defaults for Skill Tools
 
 Skill-origin tools follow a stricter default permission policy than core tools:
 
-| Scenario                                          | Core tool behavior            | Skill tool behavior |
-| ------------------------------------------------- | ----------------------------- | ------------------- |
+| Scenario                                          | Core tool behavior                  | Skill tool behavior |
+| ------------------------------------------------- | ----------------------------------- | ------------------- |
 | Low risk, no matching rule                        | Auto-allowed (at default threshold) | **Prompted**        |
-| Medium risk, no matching rule                     | Prompted                      | Prompted            |
-| High risk, no matching rule                       | Prompted                      | Prompted            |
-| Allow rule matches, non-high risk                 | Auto-allowed                  | Auto-allowed        |
-| Allow rule matches, high risk, containerized bash | Auto-allowed (runtime check)  | Auto-allowed        |
-| Allow rule matches, high risk, other              | Prompted                      | Prompted            |
+| Medium risk, no matching rule                     | Prompted                            | Prompted            |
+| High risk, no matching rule                       | Prompted                            | Prompted            |
+| Allow rule matches, non-high risk                 | Auto-allowed                        | Auto-allowed        |
+| Allow rule matches, high risk, containerized bash | Auto-allowed (runtime check)        | Auto-allowed        |
+| Allow rule matches, high risk, other              | Prompted                            | Prompted            |
 
 Even if a skill's `TOOLS.json` declares `"risk": "low"` for one of its tools, the permission checker will prompt the user unless an explicit trust rule in `~/.vellum/protected/trust.json` allows it. This prevents third-party skill tools from silently auto-executing.
 

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -35,7 +35,6 @@ import {
   createManagedSkill,
   deleteManagedSkill,
   readSkillVersion,
-  removeSkillsIndexEntry,
   validateManagedSkillId,
 } from "../skills/managed-store.js";
 
@@ -227,46 +226,6 @@ describe("buildSkillMarkdown", () => {
     // Backslashes should be preserved literally, not interpreted as escape sequences
     expect(skill!.name).toBe("path\\\\name");
     expect(skill!.description).toBe("has \\n in it");
-  });
-});
-
-describe("legacy SKILLS.md index removal helper", () => {
-  test("remove handles * bullet entries", () => {
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "* doomed\n- survivor\n",
-    );
-    removeSkillsIndexEntry("doomed");
-    const content = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(content).not.toContain("doomed");
-    expect(content).toContain("survivor");
-  });
-
-  test("remove handles markdown link entries", () => {
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- [My Skill](my-skill/SKILL.md)\n- survivor\n",
-    );
-    removeSkillsIndexEntry("my-skill");
-    const content = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(content).not.toContain("my-skill");
-    expect(content).toContain("survivor");
-  });
-
-  test("remove from index handles missing entry gracefully", () => {
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- other-skill\n");
-    removeSkillsIndexEntry("nonexistent");
-    const content = readFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "utf-8",
-    );
-    expect(content).toContain("other-skill");
   });
 });
 

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -66,42 +66,27 @@ describe("skills catalog loading", () => {
       rmSync(skillsDir, { recursive: true, force: true });
   });
 
-  test("parses markdown list path entries from SKILLS.md", () => {
-    writeSkill("alpha", "Alpha Skill", "First skill");
-    writeSkill("beta", "Beta Skill", "Second skill");
+  test("discovers valid skill directories alphabetically", () => {
+    writeSkill("zeta", "Zeta Skill", "Zeta");
+    writeSkill("alpha", "Alpha Skill", "Alpha");
+
+    const catalog = loadUserSkillCatalog();
+    expect(catalog.map((skill) => skill.id)).toEqual(["alpha", "zeta"]);
+  });
+
+  test("ignores stale SKILLS.md while discovering valid skill directories", () => {
+    writeSkill("first", "First Skill", "First");
+    writeSkill("second", "Second Skill", "Second");
     writeFileSync(
       join(TEST_DIR, "skills", "SKILLS.md"),
-      "- alpha\n- beta/SKILL.md\n",
+      "- second\n- missing\n",
     );
 
     const catalog = loadUserSkillCatalog();
-    expect(catalog.map((skill) => skill.id)).toEqual(["alpha", "beta"]);
+    expect(catalog.map((skill) => skill.id)).toEqual(["first", "second"]);
   });
 
-  test("resolves markdown links from SKILLS.md", () => {
-    writeSkill("lint", "Lint Skill", "Runs lint checks");
-    writeSkill("test", "Test Skill", "Runs test checks");
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- [Lint](lint)\n- [Tests](test)\n",
-    );
-
-    const catalog = loadUserSkillCatalog();
-    expect(catalog.map((skill) => skill.id)).toEqual(["lint", "test"]);
-  });
-
-  test("rejects SKILLS.md entries that resolve outside ~/.vellum/workspace/skills", () => {
-    writeSkill("safe", "Safe Skill", "Safe skill");
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- ../escape\n- /tmp/absolute\n- safe\n",
-    );
-
-    const catalog = loadUserSkillCatalog();
-    expect(catalog.map((skill) => skill.id)).toEqual(["safe"]);
-  });
-
-  test("rejects symlinked SKILLS.md entries that point outside ~/.vellum/workspace/skills", () => {
+  test("does not discover symlinked skill directories that point outside ~/.vellum/workspace/skills", () => {
     const externalSkillDir = join(TEST_DIR, "outside", "external-skill");
     mkdirSync(externalSkillDir, { recursive: true });
     writeFileSync(
@@ -110,7 +95,6 @@ describe("skills catalog loading", () => {
     );
 
     symlinkSync(externalSkillDir, join(TEST_DIR, "skills", "linked-skill"));
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- linked-skill\n");
 
     const catalog = loadUserSkillCatalog();
     expect(catalog).toHaveLength(0);
@@ -129,57 +113,9 @@ describe("skills catalog loading", () => {
     );
 
     symlinkSync(externalSkillFile, join(linkedSkillDir, "SKILL.md"));
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- linked-file-skill\n",
-    );
 
     const catalog = loadUserSkillCatalog();
     expect(catalog).toHaveLength(0);
-  });
-
-  test("uses SKILLS.md ordering when index exists", () => {
-    writeSkill("first", "First Skill", "First");
-    writeSkill("second", "Second Skill", "Second");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- second\n- first\n");
-
-    const catalog = loadUserSkillCatalog();
-    expect(catalog.map((skill) => skill.id)).toEqual(["second", "first"]);
-  });
-
-  test("falls back to auto-discovery when SKILLS.md is missing", () => {
-    writeSkill("zeta", "Zeta Skill", "Zeta");
-    writeSkill("alpha", "Alpha Skill", "Alpha");
-
-    const catalog = loadUserSkillCatalog();
-    expect(catalog.map((skill) => skill.id)).toEqual(["alpha", "zeta"]);
-  });
-
-  test("SKILLS.md does not hide valid skill directories", () => {
-    writeSkill("existing", "Existing Skill", "Listed in stale index");
-    writeSkill(
-      "geo-article-writer",
-      "Geo Article Writer",
-      "Valid skill omitted from stale index",
-    );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- existing\n");
-
-    const catalog = loadUserSkillCatalog();
-    expect(catalog.map((skill) => skill.id)).toEqual([
-      "existing",
-      "geo-article-writer",
-    ]);
-  });
-
-  test("SKILLS.md nested stale entries do not replace top-level discoveries", () => {
-    writeSkill("foo", "Top-Level Skill", "Valid top-level skill");
-    writeSkill("archive/foo", "Archived Skill", "Stale nested copy");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- archive/foo\n");
-
-    const catalog = loadUserSkillCatalog();
-    expect(catalog.map((skill) => skill.id)).toEqual(["foo"]);
-    expect(catalog[0].name).toBe("Top-Level Skill");
-    expect(catalog[0].directoryPath).toBe(join(TEST_DIR, "skills", "foo"));
   });
 });
 
@@ -467,7 +403,6 @@ describe("includes frontmatter parsing", () => {
 
   test("parses valid includes array", () => {
     writeSkillWithIncludes("parent", '["child-a", "child-b"]');
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill).toBeDefined();
@@ -476,7 +411,6 @@ describe("includes frontmatter parsing", () => {
 
   test("trims whitespace in includes entries", () => {
     writeSkillWithIncludes("parent", '["  child-a  ", " child-b "]');
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill!.includes).toEqual(["child-a", "child-b"]);
@@ -484,7 +418,6 @@ describe("includes frontmatter parsing", () => {
 
   test("removes empty strings from includes", () => {
     writeSkillWithIncludes("parent", '["child-a", "", "  ", "child-b"]');
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill!.includes).toEqual(["child-a", "child-b"]);
@@ -492,7 +425,6 @@ describe("includes frontmatter parsing", () => {
 
   test("deduplicates includes preserving first-seen order", () => {
     writeSkillWithIncludes("parent", '["child-a", "child-b", "child-a"]');
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill!.includes).toEqual(["child-a", "child-b"]);
@@ -500,7 +432,6 @@ describe("includes frontmatter parsing", () => {
 
   test("returns undefined for invalid JSON", () => {
     writeSkillWithIncludes("parent", "not-json");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill!.includes).toBeUndefined();
@@ -508,7 +439,6 @@ describe("includes frontmatter parsing", () => {
 
   test("returns undefined for non-array JSON", () => {
     writeSkillWithIncludes("parent", '"just-a-string"');
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill!.includes).toBeUndefined();
@@ -516,7 +446,6 @@ describe("includes frontmatter parsing", () => {
 
   test("returns undefined for array with non-string elements", () => {
     writeSkillWithIncludes("parent", "[123, true]");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill!.includes).toBeUndefined();
@@ -524,7 +453,6 @@ describe("includes frontmatter parsing", () => {
 
   test("returns undefined for empty array", () => {
     writeSkillWithIncludes("parent", "[]");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "parent");
     expect(skill!.includes).toBeUndefined();
@@ -532,7 +460,6 @@ describe("includes frontmatter parsing", () => {
 
   test("skill without includes has undefined includes", () => {
     writeSkill("no-includes", "No Includes", "Test");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- no-includes\n");
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "no-includes");
     expect(skill!.includes).toBeUndefined();

--- a/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
+++ b/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
@@ -1,0 +1,111 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { removeLegacySkillsIndexMigration } from "../workspace/migrations/068-remove-legacy-skills-index.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-068-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeSkill(skillId: string): string {
+  const skillDir = join(workspaceDir, "skills", skillId);
+  mkdirSync(skillDir, { recursive: true });
+  const skillFilePath = join(skillDir, "SKILL.md");
+  writeFileSync(
+    skillFilePath,
+    `---\nname: "${skillId}"\ndescription: "Test skill."\n---\n\nBody.\n`,
+    "utf-8",
+  );
+  return skillFilePath;
+}
+
+describe("068-remove-legacy-skills-index migration", () => {
+  test("has correct id and description", () => {
+    expect(removeLegacySkillsIndexMigration.id).toBe(
+      "068-remove-legacy-skills-index",
+    );
+    expect(removeLegacySkillsIndexMigration.description).toContain("SKILLS.md");
+  });
+
+  test("removes only skills/SKILLS.md when present", () => {
+    const skillsDir = join(workspaceDir, "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    const legacyIndexPath = join(skillsDir, "SKILLS.md");
+    writeFileSync(legacyIndexPath, "- alpha\n", "utf-8");
+
+    const alphaSkillPath = writeSkill("alpha");
+    const betaSkillPath = writeSkill("beta");
+    const topLevelSkillPath = join(skillsDir, "SKILL.md");
+    writeFileSync(
+      topLevelSkillPath,
+      "---\nname: Root\ndescription: Root file.\n---\n\nRoot.\n",
+      "utf-8",
+    );
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    expect(existsSync(legacyIndexPath)).toBe(false);
+    expect(readFileSync(alphaSkillPath, "utf-8")).toContain("alpha");
+    expect(readFileSync(betaSkillPath, "utf-8")).toContain("beta");
+    expect(readFileSync(topLevelSkillPath, "utf-8")).toContain("Root");
+  });
+
+  test("is a no-op when skills/SKILLS.md is absent", () => {
+    writeSkill("alpha");
+
+    expect(() =>
+      removeLegacySkillsIndexMigration.run(workspaceDir),
+    ).not.toThrow();
+    expect(existsSync(join(workspaceDir, "skills", "alpha", "SKILL.md"))).toBe(
+      true,
+    );
+  });
+
+  test("is safe to re-run", () => {
+    const skillsDir = join(workspaceDir, "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    const legacyIndexPath = join(skillsDir, "SKILLS.md");
+    writeFileSync(legacyIndexPath, "- alpha\n", "utf-8");
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+    expect(() =>
+      removeLegacySkillsIndexMigration.run(workspaceDir),
+    ).not.toThrow();
+    expect(existsSync(legacyIndexPath)).toBe(false);
+  });
+
+  test("does not recursively delete a directory named SKILLS.md", () => {
+    const legacyIndexDir = join(workspaceDir, "skills", "SKILLS.md");
+    mkdirSync(legacyIndexDir, { recursive: true });
+    writeFileSync(join(legacyIndexDir, "nested.txt"), "keep\n", "utf-8");
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    expect(readFileSync(join(legacyIndexDir, "nested.txt"), "utf-8")).toBe(
+      "keep\n",
+    );
+  });
+
+  test("down() is a no-op", () => {
+    expect(() =>
+      removeLegacySkillsIndexMigration.down(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -203,10 +203,6 @@ export function getBundledSkillsDir(): string {
   return join(dir, "bundled-skills");
 }
 
-function getSkillsIndexPath(skillsDir: string): string {
-  return join(skillsDir, "SKILLS.md");
-}
-
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
 
 interface ParsedFrontmatter {
@@ -618,94 +614,6 @@ function loadBundledSkills(): SkillSummary[] {
   return skills;
 }
 
-// ─── Index parsing ───────────────────────────────────────────────────────────
-
-function parseIndexEntry(line: string): string | null {
-  const bulletMatch = line.trim().match(/^[-*]\s+(.+)$/);
-  if (!bulletMatch) return null;
-
-  let entry = bulletMatch[1].trim();
-  const markdownLinkMatch = entry.match(/^\[[^\]]+\]\(([^)]+)\)$/);
-  if (markdownLinkMatch) {
-    entry = markdownLinkMatch[1].trim();
-  }
-
-  if (entry.startsWith("`") && entry.endsWith("`")) {
-    entry = entry.slice(1, -1).trim();
-  }
-
-  return entry.length > 0 ? entry : null;
-}
-
-function resolveIndexEntryToDirectory(
-  skillsDir: string,
-  entry: string,
-): string | null {
-  if (isAbsolute(entry)) {
-    log.warn(
-      { entry },
-      "Skipping SKILLS.md entry because absolute paths are not allowed",
-    );
-    return null;
-  }
-
-  const resolvedEntryPath = resolve(skillsDir, entry);
-  const resolvedDirectory =
-    basename(resolvedEntryPath).toLowerCase() === "skill.md"
-      ? dirname(resolvedEntryPath)
-      : resolvedEntryPath;
-
-  const relativePath = getRelativeToSkillsRoot(skillsDir, resolvedDirectory);
-  if (relativePath.length === 0) {
-    log.warn(
-      { entry },
-      "Skipping SKILLS.md entry that resolves to the skills root",
-    );
-    return null;
-  }
-  if (isOutsideSkillsRoot(skillsDir, resolvedDirectory)) {
-    log.warn(
-      { entry, resolvedDirectory: getCanonicalPath(resolvedDirectory) },
-      "Skipping SKILLS.md entry that resolves outside ~/.vellum/workspace/skills",
-    );
-    return null;
-  }
-
-  return resolvedDirectory;
-}
-
-function getIndexedSkillDirectories(skillsDir: string): string[] | null {
-  const indexPath = getSkillsIndexPath(skillsDir);
-  if (!existsSync(indexPath)) return null;
-
-  let rawIndex = "";
-  try {
-    rawIndex = readFileSync(indexPath, "utf-8");
-  } catch (err) {
-    log.warn(
-      { err, indexPath },
-      "Failed to read SKILLS.md; treating as empty catalog",
-    );
-    return [];
-  }
-
-  const directories: string[] = [];
-  const seen = new Set<string>();
-
-  for (const line of rawIndex.split(/\r?\n/)) {
-    const parsedEntry = parseIndexEntry(line);
-    if (!parsedEntry) continue;
-
-    const directory = resolveIndexEntryToDirectory(skillsDir, parsedEntry);
-    if (!directory || seen.has(directory)) continue;
-
-    seen.add(directory);
-    directories.push(directory);
-  }
-
-  return directories;
-}
-
 function discoverSkillDirectories(skillsDir: string): string[] {
   if (!existsSync(skillsDir)) return [];
 
@@ -728,36 +636,7 @@ function discoverSkillDirectories(skillsDir: string): string[] {
 }
 
 function getManagedSkillDirectories(skillsDir: string): string[] {
-  const discoveredDirectories = discoverSkillDirectories(skillsDir);
-  const indexedDirectories = getIndexedSkillDirectories(skillsDir) ?? [];
-  const discoveredCanonicalDirectories = new Set(
-    discoveredDirectories.map((directory) => getCanonicalPath(directory)),
-  );
-  const directories: string[] = [];
-  const seenCanonicalDirectories = new Set<string>();
-
-  const addDirectory = (directory: string): void => {
-    if (!existsSync(directory)) return;
-
-    const canonicalDirectory = getCanonicalPath(directory);
-    if (seenCanonicalDirectories.has(canonicalDirectory)) return;
-
-    seenCanonicalDirectories.add(canonicalDirectory);
-    directories.push(directory);
-  };
-
-  for (const directory of indexedDirectories) {
-    if (!discoveredCanonicalDirectories.has(getCanonicalPath(directory))) {
-      continue;
-    }
-    addDirectory(directory);
-  }
-
-  for (const directory of discoveredDirectories) {
-    addDirectory(directory);
-  }
-
-  return directories;
+  return discoverSkillDirectories(skillsDir);
 }
 
 // ─── Catalog loading ─────────────────────────────────────────────────────────
@@ -1196,7 +1075,7 @@ export function resolveSkillSelector(
   const catalog = loadSkillCatalog(workspaceSkillsDir);
   if (catalog.length === 0) {
     return {
-      error: `No skills are available. Configure ${getWorkspaceDirDisplay()}/skills/SKILLS.md or add skill directories.`,
+      error: `No skills are available. Add skill directories under ${getWorkspaceDirDisplay()}/skills/.`,
       errorCode: "empty_catalog",
     };
   }

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -43,10 +43,6 @@ function getManagedSkillDir(id: string): string {
   return join(getManagedSkillsDir(), id);
 }
 
-function getSkillsIndexPath(): string {
-  return join(getManagedSkillsDir(), "SKILLS.md");
-}
-
 // ─── SKILL.md generation ─────────────────────────────────────────────────────
 
 interface BuildSkillMarkdownInput {
@@ -104,42 +100,6 @@ function atomicWriteFile(filePath: string, content: string): void {
   const tmpPath = join(dir, `.tmp-${randomUUID()}`);
   writeFileSync(tmpPath, content, "utf-8");
   renameSync(tmpPath, filePath);
-}
-
-// ─── SKILLS.md index management ──────────────────────────────────────────────
-
-function readIndexLines(): string[] {
-  const indexPath = getSkillsIndexPath();
-  if (!existsSync(indexPath)) return [];
-  return readFileSync(indexPath, "utf-8").split("\n");
-}
-
-function writeIndexLines(lines: string[]): void {
-  const content = lines.join("\n");
-  atomicWriteFile(
-    getSkillsIndexPath(),
-    content.endsWith("\n") ? content : content + "\n",
-  );
-}
-
-function indexEntryRegex(id: string): RegExp {
-  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  // Match both - and * bullets, optional backticks, optional markdown link wrapping,
-  // and optional /SKILL.md suffix (inside or outside link parens)
-  return new RegExp(
-    `^[-*]\\s+(?:\`)?(?:\\[.*?\\]\\()?${escaped}(?:/SKILL\\.md)?(?:\\))?(?:\`)?\\s*$`,
-  );
-}
-
-export function removeSkillsIndexEntry(id: string): void {
-  const lines = readIndexLines();
-  const pattern = indexEntryRegex(id);
-  const filtered = lines.filter((line) => !pattern.test(line));
-  if (filtered.length === lines.length) {
-    return; // not found
-  }
-  writeIndexLines(filtered.filter((l) => l.trim()));
-  log.info({ id }, "Removed managed skill from SKILLS.md index");
 }
 
 // ─── Version metadata ─────────────────────────────────────────────────────────

--- a/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
+++ b/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
@@ -1,0 +1,49 @@
+import { lstatSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-068-remove-legacy-skills-index");
+
+function isNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    err.code === "ENOENT"
+  );
+}
+
+export const removeLegacySkillsIndexMigration: WorkspaceMigration = {
+  id: "068-remove-legacy-skills-index",
+  description: "Remove legacy workspace skills/SKILLS.md index file",
+
+  run(workspaceDir: string): void {
+    const indexPath = join(workspaceDir, "skills", "SKILLS.md");
+
+    try {
+      const stat = lstatSync(indexPath);
+      if (!stat.isFile() && !stat.isSymbolicLink()) {
+        log.warn(
+          { path: indexPath },
+          "Legacy SKILLS.md path is not a file; leaving it in place",
+        );
+        return;
+      }
+
+      unlinkSync(indexPath);
+      log.info({ path: indexPath }, "Removed legacy skills index file");
+    } catch (err) {
+      if (isNotFoundError(err)) return;
+      log.warn(
+        { err, path: indexPath },
+        "Failed to remove legacy skills index file",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: SKILLS.md is no longer a supported skill catalog format.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -65,6 +65,7 @@ import { unwindMainAgentOpusSeedMigration } from "./064-unwind-main-agent-opus-s
 import { bumpStaleHeartbeatIntervalMigration } from "./065-bump-stale-heartbeat-interval.js";
 import { seedHeartbeatCallsiteCostDefaultMigration } from "./066-seed-heartbeat-callsite-cost-default.js";
 import { releaseNotesSafeStorageLimitsMigration } from "./067-release-notes-safe-storage-limits.js";
+import { removeLegacySkillsIndexMigration } from "./068-remove-legacy-skills-index.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -141,4 +142,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   bumpStaleHeartbeatIntervalMigration,
   seedHeartbeatCallsiteCostDefaultMigration,
   releaseNotesSafeStorageLimitsMigration,
+  removeLegacySkillsIndexMigration,
 ];

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -232,17 +232,19 @@ The assistant can create, test, and persist new skills at runtime. This is usefu
 #### Workflow
 
 1. **Evaluate**: The assistant drafts a TypeScript snippet and tests it in a sandbox via `evaluate_typescript_code`. Iterates until it passes.
-2. **Persist**: After successful evaluation and explicit user consent, the assistant calls `scaffold_managed_skill` to write the skill to `~/.vellum/workspace/skills/<id>/`.
+2. **Persist**: After successful evaluation and explicit user consent, the assistant calls `scaffold_managed_skill` to write the skill to `~/.vellum/workspace/skills/<id>/SKILL.md`.
 3. **Load**: The assistant calls `skill_load` with the new skill ID to load its instructions.
 4. **Delete**: To remove a managed skill, use `delete_managed_skill`.
+
+Installed managed skills are discovered from valid directories under `~/.vellum/workspace/skills/<id>/` that contain a top-level `SKILL.md` with standardized frontmatter. On startup and skill directory changes, the assistant parses that frontmatter and seeds Memory V2 entries under `skills/<id>`; those memory entries represent available skills to the assistant. The legacy `SKILLS.md` index is removed by workspace migration and is no longer created by current install or scaffold paths.
 
 #### Tools
 
 | Tool | Risk Level | Description |
 |------|-----------|-------------|
 | `evaluate_typescript_code` | High | Run a TypeScript snippet in a sandbox. Returns structured JSON with `ok`, `exitCode`, `result`, `stdout`, `stderr`. |
-| `scaffold_managed_skill` | High | Write a managed skill to `~/.vellum/workspace/skills/<id>/`. Creates `SKILL.md` with frontmatter (including optional `includes` for child skills) and updates `SKILLS.md` index. |
-| `delete_managed_skill` | High | Remove a managed skill directory and its index entry. |
+| `scaffold_managed_skill` | High | Write a managed skill to `~/.vellum/workspace/skills/<id>/`. Creates `SKILL.md` with frontmatter, including optional `includes` for child skills. |
+| `delete_managed_skill` | High | Remove a managed skill directory. |
 
 All three tools require explicit user approval before execution (Risk Level = High).
 


### PR DESCRIPTION
## Summary
- Removes SKILLS.md parsing from skill discovery.
- Adds an idempotent workspace migration that deletes only skills/SKILLS.md.
- Updates docs and tests for SKILL.md plus memory-based skill discovery.

Part of plan: migrate-off-skills-md.md (PR 6 of 7)
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->