### PR TITLE
[codex] Guard proactive app builds

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -172,6 +172,7 @@ let mockConversationRow: Record<string, unknown> = {
   totalEstimatedCost: 0,
   title: null,
 };
+let mockMessageById: Record<string, unknown> | null = null;
 mock.module("../memory/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   updateConversationUsage: () => {},
@@ -192,7 +193,7 @@ mock.module("../memory/conversation-crud.js", () => ({
     updateConversationSlackContextWatermarkMock,
   updateConversationTitle: () => {},
   getConversationOriginChannel: () => null,
-  getMessageById: () => null,
+  getMessageById: () => mockMessageById,
   getLastUserTimestampBefore: () => 0,
 }));
 
@@ -444,6 +445,17 @@ mock.module("../memory/llm-request-log-store.js", () => ({
   backfillMessageIdOnLogs: () => {},
 }));
 
+let mockHasProactiveArtifactCompleted = true;
+let mockTryClaimProactiveArtifactTrigger = false;
+const runProactiveArtifactJobMock = mock(
+  async (_params: Record<string, unknown>) => {},
+);
+mock.module("../proactive-artifact/index.js", () => ({
+  hasProactiveArtifactCompleted: () => mockHasProactiveArtifactCompleted,
+  tryClaimProactiveArtifactTrigger: () => mockTryClaimProactiveArtifactTrigger,
+  runProactiveArtifactJob: runProactiveArtifactJobMock,
+}));
+
 // ── Imports (after mocks) ────────────────────────────────────────────
 
 import {
@@ -456,7 +468,7 @@ import {
 
 type AgentLoopRun = (
   messages: Message[],
-  onEvent: (event: AgentEvent) => void,
+  onEvent: (event: AgentEvent) => void | Promise<void>,
   signal?: AbortSignal,
   requestId?: string,
   onCheckpoint?: (
@@ -621,6 +633,10 @@ beforeEach(() => {
     totalEstimatedCost: 0,
     title: null,
   };
+  mockMessageById = null;
+  mockHasProactiveArtifactCompleted = true;
+  mockTryClaimProactiveArtifactTrigger = false;
+  runProactiveArtifactJobMock.mockClear();
   clearStrippedInjectionMetadataForConversationMock.mockClear();
   clearStrippedInjectionMetadataForConversationMock.mockImplementation(
     () => {},
@@ -645,6 +661,92 @@ describe("session-agent-loop", () => {
       await expect(
         runAgentLoopImpl(ctx, "hello", "msg-1", () => {}),
       ).rejects.toThrow("runAgentLoop called without prior persistUserMessage");
+    });
+  });
+
+  describe("proactive artifact trigger", () => {
+    test("suppresses proactive app build when the foreground turn used app tools", async () => {
+      mockConversationRow = {
+        ...mockConversationRow,
+        id: "test-conv",
+        conversationType: "standard",
+      };
+      mockMessageById = {
+        id: "user-msg-1",
+        conversationId: "test-conv",
+        createdAt: 1000,
+      };
+      mockHasProactiveArtifactCompleted = false;
+      mockTryClaimProactiveArtifactTrigger = true;
+
+      const agentLoopRun: AgentLoopRun = async (
+        messages,
+        onEvent,
+        _signal,
+        _requestId,
+        onCheckpoint,
+      ) => {
+        await onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "I'll build that app." }],
+          },
+        });
+        await onEvent({
+          type: "tool_use",
+          id: "tool-1",
+          name: "app_create",
+          input: { name: "Flow" },
+        });
+        await onEvent({
+          type: "tool_result",
+          toolUseId: "tool-1",
+          content: "{}",
+          isError: false,
+        });
+        await onCheckpoint?.({
+          turnIndex: 0,
+          toolCount: 1,
+          hasToolUse: true,
+          history: messages,
+        });
+        await onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Done." }],
+          },
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text" as const, text: "Done." }],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({
+        conversationId: "test-conv",
+        agentLoopRun,
+      });
+      await runAgentLoopImpl(
+        ctx,
+        "build a kanban app",
+        "user-msg-1",
+        () => {},
+        {
+          isUserMessage: true,
+        },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(runProactiveArtifactJobMock).toHaveBeenCalledTimes(1);
+      expect(runProactiveArtifactJobMock.mock.calls[0]?.[0]).toMatchObject({
+        conversationId: "test-conv",
+        suppressAppBuild: true,
+      });
     });
   });
 

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -137,6 +137,8 @@ export interface EventHandlerState {
   readonly directiveWarnings: string[];
   readonly toolUseIdToName: Map<string, string>;
   currentTurnToolNames: string[];
+  /** Sticky for the whole run: this turn created/refreshed an app. */
+  appBuildToolUsedThisRun: boolean;
   /** Tracks whether the first text delta has been emitted this turn for activity state transitions. */
   firstTextDeltaEmitted: boolean;
   /** Tracks whether a thinking delta has been emitted this turn for activity state transitions. */
@@ -219,6 +221,7 @@ export function createEventHandlerState(): EventHandlerState {
     directiveWarnings: [],
     toolUseIdToName: new Map(),
     currentTurnToolNames: [],
+    appBuildToolUsedThisRun: false,
     firstTextDeltaEmitted: false,
     firstThinkingDeltaEmitted: false,
     lastCompletedToolName: undefined,
@@ -365,6 +368,9 @@ export function handleToolUse(
 ): void {
   state.toolUseIdToName.set(event.id, event.name);
   state.currentTurnToolNames.push(event.name);
+  if (event.name === "app_create" || event.name === "app_refresh") {
+    state.appBuildToolUsedThisRun = true;
+  }
   state.toolCallTimestamps.set(event.id, { startedAt: Date.now() });
   state.currentToolUseId = event.id;
   state.currentTurnToolUseIds.push(event.id);

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2984,6 +2984,7 @@ export async function runAgentLoopImpl(
                   conversationId: ctx.conversationId,
                   userMessageCutoff: userMsg.createdAt,
                   assistantMessageId: state.lastAssistantMessageId,
+                  suppressAppBuild: state.appBuildToolUsedThisRun,
                   broadcastMessage,
                 });
               } catch (err) {

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -95,11 +95,15 @@ let mockApps: Array<{
   id: string;
   name: string;
   createdAt: number;
+  updatedAt?: number;
+  conversationIds?: string[];
 }> = [];
 let addAppConvCalls: Array<{ appId: string; conversationId: string }> = [];
 
 mock.module("../memory/app-store.js", () => ({
   listApps: () => mockApps,
+  listAppsByConversation: (conversationId: string) =>
+    mockApps.filter((app) => app.conversationIds?.includes(conversationId)),
   addAppConversationId: (appId: string, conversationId: string) => {
     addAppConvCalls.push({ appId, conversationId });
     return true;
@@ -391,6 +395,7 @@ describe("runProactiveArtifactJob", () => {
           id: "app-123",
           name: "Budget Tracker",
           createdAt: buildStartedAt + 100,
+          updatedAt: buildStartedAt + 100,
         },
       ];
 
@@ -520,6 +525,52 @@ describe("runProactiveArtifactJob", () => {
       expect(addMessageCalls).toHaveLength(0);
       expect(emitSignalCalls).toHaveLength(0);
       expect(releaseClaimCalls).toBe(1);
+    });
+
+    test("app decision with foreground app tool suppresses background build permanently", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesApp;
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        suppressAppBuild: true,
+        broadcastMessage: mockBroadcast,
+      });
+
+      expect(bootstrapCalls).toHaveLength(0);
+      expect(processMessageCalls).toHaveLength(0);
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+      expect(releaseClaimCalls).toBe(0);
+    });
+
+    test("app decision with recent app activity in source conversation suppresses background build permanently", async () => {
+      rawAllRows = defaultTranscript;
+      decisionResponse = decisionYesApp;
+      mockApps = [
+        {
+          id: "app-main",
+          name: "Budget Tracker",
+          createdAt: 1200,
+          updatedAt: 1300,
+          conversationIds: ["conv-1"],
+        },
+      ];
+
+      await runProactiveArtifactJob({
+        conversationId: "conv-1",
+        userMessageCutoff: 1000,
+        assistantMessageId: "msg-4",
+        broadcastMessage: mockBroadcast,
+      });
+
+      expect(bootstrapCalls).toHaveLength(0);
+      expect(processMessageCalls).toHaveLength(0);
+      expect(addMessageCalls).toHaveLength(0);
+      expect(emitSignalCalls).toHaveLength(0);
+      expect(releaseClaimCalls).toBe(0);
     });
 
     test("document build - build provider unavailable → releases claim for retry", async () => {

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -18,7 +18,11 @@ import { v4 as uuid } from "uuid";
 import { processMessage } from "../daemon/process-message.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { saveDocument } from "../documents/document-store.js";
-import { addAppConversationId, listApps } from "../memory/app-store.js";
+import {
+  addAppConversationId,
+  listApps,
+  listAppsByConversation,
+} from "../memory/app-store.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { rawAll } from "../memory/raw-query.js";
 import type { BroadcastFn } from "../notifications/adapters/macos.js";
@@ -43,6 +47,7 @@ export async function runProactiveArtifactJob(params: {
   conversationId: string;
   userMessageCutoff: number;
   assistantMessageId: string | undefined;
+  suppressAppBuild?: boolean;
   broadcastMessage: BroadcastFn;
 }): Promise<void> {
   let buildSucceeded = false;
@@ -114,6 +119,22 @@ export async function runProactiveArtifactJob(params: {
     let artifactId: string;
 
     if (artifactType === "app") {
+      const suppressionReason = getAppBuildSuppressionReason({
+        conversationId: params.conversationId,
+        userMessageCutoff: params.userMessageCutoff,
+        suppressAppBuild: params.suppressAppBuild,
+      });
+      if (suppressionReason) {
+        log.info(
+          {
+            conversationId: params.conversationId,
+            artifactTitle,
+            suppressionReason,
+          },
+          "Skipping proactive app build because foreground app work already exists",
+        );
+        return;
+      }
       artifactId = await buildApp({
         artifactTitle,
         artifactDescription,
@@ -199,6 +220,27 @@ export async function runProactiveArtifactJob(params: {
 }
 
 // ── App build ─────────────────────────────────────────────────────────
+
+function getAppBuildSuppressionReason(params: {
+  conversationId: string;
+  userMessageCutoff: number;
+  suppressAppBuild?: boolean;
+}): string | null {
+  if (params.suppressAppBuild) {
+    return "foreground-turn-used-app-tool";
+  }
+
+  const recentApps = listAppsByConversation(params.conversationId).filter(
+    (app) =>
+      app.createdAt >= params.userMessageCutoff ||
+      app.updatedAt >= params.userMessageCutoff,
+  );
+  if (recentApps.length > 0) {
+    return "conversation-has-recent-app-activity";
+  }
+
+  return null;
+}
 
 async function buildApp(params: {
   artifactTitle: string;


### PR DESCRIPTION
## Summary

- Track foreground `app_create` / `app_refresh` usage through the main agent turn and pass that signal into the proactive artifact job.
- Suppress proactive app builds when the foreground turn already built/refreshed an app, or when the source conversation already has recent app activity after the triggering user message.
- Add regression coverage for both same-turn app tool suppression and recent app activity suppression.

## Why

The proactive artifact background job could decide to build an app at the same time the main agent was already building one for the same request. That produced duplicate, similar-but-different apps. The fix treats foreground app work as satisfying the proactive artifact opportunity and keeps the one-shot claim in place so it does not retry later.

## Validation

- `bun test src/proactive-artifact/job.test.ts`
- `bun test src/__tests__/conversation-agent-loop.test.ts`
- `bunx tsc --noEmit`
- `bun run lint`
- Commit hook: formatting, lint, type-check
- Pre-push hook: changed-file lint and assistant type-check