### PR TITLE
feat(heartbeat): add store function to count completed heartbeat runs

### DIFF
--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -15,6 +15,7 @@ import { getDb } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import {
   completeHeartbeatRun,
+  countCompletedHeartbeatRuns,
   insertPendingHeartbeatRun,
   listHeartbeatRuns,
   markStaleRunningAsError,
@@ -212,5 +213,40 @@ describe("heartbeat-run-store", () => {
 
     const rows = listHeartbeatRuns(3);
     expect(rows).toHaveLength(3);
+  });
+
+  test("countCompletedHeartbeatRuns counts only ok rows", () => {
+    const now = Date.now();
+
+    // Insert runs with various statuses
+    const id1 = insertPendingHeartbeatRun(now);
+    startHeartbeatRun(id1);
+    completeHeartbeatRun(id1, { status: "ok", conversationId: "conv-1" });
+
+    const id2 = insertPendingHeartbeatRun(now + 1);
+    startHeartbeatRun(id2);
+    completeHeartbeatRun(id2, { status: "error", error: "something broke" });
+
+    const id3 = insertPendingHeartbeatRun(now + 2);
+    skipHeartbeatRun(id3, "disabled");
+
+    const id4 = insertPendingHeartbeatRun(now + 3);
+    startHeartbeatRun(id4);
+    completeHeartbeatRun(id4, { status: "ok", conversationId: "conv-2" });
+
+    expect(countCompletedHeartbeatRuns()).toBe(2);
+  });
+
+  test("countCompletedHeartbeatRuns returns 0 when no ok rows exist", () => {
+    const now = Date.now();
+
+    const id1 = insertPendingHeartbeatRun(now);
+    startHeartbeatRun(id1);
+    completeHeartbeatRun(id1, { status: "error", error: "fail" });
+
+    const id2 = insertPendingHeartbeatRun(now + 1);
+    skipHeartbeatRun(id2, "outside_active_hours");
+
+    expect(countCompletedHeartbeatRuns()).toBe(0);
   });
 });

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -203,6 +203,19 @@ export function markStaleRunningAsError(
 }
 
 /**
+ * Count the number of heartbeat runs that completed with status `ok`.
+ */
+export function countCompletedHeartbeatRuns(): number {
+  const db = getDb();
+  const row = db
+    .select({ count: sql<number>`count(*)` })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.status, "ok"))
+    .get();
+  return row?.count ?? 0;
+}
+
+/**
  * List heartbeat runs ordered by `scheduledFor` descending.
  */
 export function listHeartbeatRuns(limit = 20): HeartbeatRunRecord[] {


### PR DESCRIPTION
## Summary
- Add `countCompletedHeartbeatRuns()` function to heartbeat run store
- Queries SQLite for heartbeat runs with status 'ok'
- Add unit tests for the new function

Part of plan: early-heartbeat-notify.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->