### PR TITLE
Verify SKILLS.md removal across skill loading, memory injection, and workspace migration

### DIFF
--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let TEST_DIR = "";
+const seedUpsertSlugs: string[] = [];
 
 const mockConfig = {
   provider: "anthropic",
@@ -32,6 +33,10 @@ const mockConfig = {
     },
     "web-search": { mode: "your-own", provider: "inference-provider-native" },
   },
+  skills: {
+    entries: {},
+    allowBundled: [],
+  },
 };
 
 mock.module("../util/logger.js", () => ({
@@ -51,7 +56,32 @@ mock.module("../config/loader.js", () => ({
   setNestedValue: () => {},
 }));
 
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => [],
+}));
+
+mock.module("../memory/embedding-backend.js", () => ({
+  embedWithBackend: async (_config: unknown, inputs: unknown[]) => ({
+    provider: "local",
+    model: "test-model",
+    vectors: inputs.map(() => [0.1, 0.2, 0.3]),
+  }),
+  generateSparseEmbedding: () => ({ indices: [1], values: [1] }),
+}));
+
+mock.module("../memory/v2/qdrant.js", () => ({
+  upsertConceptPageEmbedding: async (params: { slug: string }) => {
+    seedUpsertSlugs.push(params.slug);
+  },
+  pruneSlugsWithPrefixExcept: async () => {},
+}));
+
 import { loadSkillCatalog } from "../config/skills.js";
+import {
+  _resetSkillStoreForTests,
+  getSkillCapability,
+  seedV2SkillEntries,
+} from "../memory/v2/skill-store.js";
 import { executeDeleteManagedSkill } from "../tools/skills/delete-managed.js";
 import { SkillLoadTool } from "../tools/skills/load.js";
 import { executeScaffoldManagedSkill } from "../tools/skills/scaffold-managed.js";
@@ -68,9 +98,69 @@ function makeContext(): ToolContext {
 beforeEach(() => {
   TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
   mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
+  seedUpsertSlugs.length = 0;
+  _resetSkillStoreForTests();
 });
 
 describe("managed skill lifecycle: scaffold → catalog → prompt → delete", () => {
+  test("valid managed skill without SKILLS.md works across catalog, skill_load, and Memory V2 seeding", async () => {
+    const skillId = "e2e-custom-skill";
+    const skillSlug = `skills/${skillId}`;
+    const skillDir = join(TEST_DIR, "skills", skillId);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---
+name: "E2E Custom Skill"
+description: "Exercises custom managed skill loading."
+metadata:
+  vellum:
+    activation-hints:
+      - user asks for custom lifecycle verification
+---
+
+Run the custom lifecycle verification procedure.
+`,
+      "utf-8",
+    );
+
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
+
+    const catalog = loadSkillCatalog();
+    const catalogSkill = catalog.find((s) => s.id === skillId);
+    expect(catalogSkill).toBeDefined();
+    expect(catalogSkill!.source).toBe("managed");
+    expect(catalogSkill!.displayName).toBe("E2E Custom Skill");
+
+    const skillLoadTool = new (SkillLoadTool as any)() as InstanceType<
+      typeof SkillLoadTool
+    >;
+    const loadResult = await skillLoadTool.execute(
+      { skill: skillId },
+      makeContext(),
+    );
+    expect(loadResult.isError).not.toBe(true);
+    expect(loadResult.content as string).toContain("Skill: E2E Custom Skill");
+    expect(loadResult.content as string).toContain("ID: e2e-custom-skill");
+    expect(loadResult.content as string).toContain(
+      "Run the custom lifecycle verification procedure.",
+    );
+
+    await seedV2SkillEntries();
+
+    expect(seedUpsertSlugs).toContain(skillSlug);
+    const capability = getSkillCapability(skillSlug);
+    expect(capability).not.toBeNull();
+    expect(capability!.id).toBe("e2e-custom-skill");
+    expect(capability!.content).toContain('The "E2E Custom Skill" skill');
+    expect(capability!.content).toContain(
+      "Exercises custom managed skill loading.",
+    );
+    expect(capability!.content).toContain(
+      "Use when: user asks for custom lifecycle verification.",
+    );
+  }, 15_000);
+
   test("full lifecycle: create skill, verify in catalog and prompt, then delete", async () => {
     // Step 1: Scaffold a managed skill
     const scaffoldResult = await executeScaffoldManagedSkill(

--- a/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
+++ b/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
@@ -10,15 +10,24 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { loadSkillBySelector } from "../config/skills.js";
 import { removeLegacySkillsIndexMigration } from "../workspace/migrations/068-remove-legacy-skills-index.js";
 
 let workspaceDir: string;
+let previousWorkspaceDir: string | undefined;
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-068-test-"));
+  previousWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
 });
 
 afterEach(() => {
+  if (previousWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceDir;
+  }
   if (existsSync(workspaceDir)) {
     rmSync(workspaceDir, { recursive: true, force: true });
   }
@@ -76,6 +85,25 @@ describe("068-remove-legacy-skills-index migration", () => {
     expect(existsSync(join(workspaceDir, "skills", "alpha", "SKILL.md"))).toBe(
       true,
     );
+  });
+
+  test("removing a stale SKILLS.md index preserves loadability for omitted valid skill directories", () => {
+    const skillsDir = join(workspaceDir, "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    const legacyIndexPath = join(skillsDir, "SKILLS.md");
+    writeFileSync(legacyIndexPath, "- indexed-skill\n", "utf-8");
+
+    writeSkill("indexed-skill");
+    writeSkill("omitted-skill");
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    expect(existsSync(legacyIndexPath)).toBe(false);
+    const loaded = loadSkillBySelector("omitted-skill");
+    expect(loaded.error).toBeUndefined();
+    expect(loaded.skill).toBeDefined();
+    expect(loaded.skill!.id).toBe("omitted-skill");
+    expect(loaded.skill!.body).toBe("Body.");
   });
 
   test("is safe to re-run", () => {

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -662,17 +662,17 @@ describe("injectMemoryV2Block", () => {
   // Unified pool — skills as `skills/<id>` slugs
   // ---------------------------------------------------------------------------
 
-  test("renders a skill-only block via the skills/ slug prefix", async () => {
+  test("renders a retrieved skills/<id> slug under Skills You Can Use", async () => {
     // No concept-page candidates this turn — the only ANN hit is a skill
     // slug. The render path branches on `skills/` prefix: it pulls the
     // entry from the skill-store cache (mocked) and emits the bullet under
     // the `### Skills You Can Use` subsection.
-    stageTurn([{ slug: "skills/example-skill-a", denseScore: 0.9 }]);
+    stageTurn([{ slug: "skills/retrieved-skill", denseScore: 0.9 }]);
     stageSkills([
       {
-        id: "example-skill-a",
+        id: "retrieved-skill",
         content:
-          'The "Example Skill A" skill (example-skill-a) is available. Helps with examples.',
+          'The "Retrieved Skill" skill (retrieved-skill) is available. Helps with retrieved skills.',
       },
     ]);
 
@@ -687,16 +687,18 @@ describe("injectMemoryV2Block", () => {
       config: makeConfig(),
     });
 
-    expect(result.toInject).toEqual(["skills/example-skill-a"]);
+    expect(result.toInject).toEqual(["skills/retrieved-skill"]);
     expect(result.block).not.toBeNull();
     expect(result.block).not.toContain("<memory>");
     expect(result.block).not.toContain("</memory>");
     expect(result.block).not.toContain("## What I Remember Right Now");
     expect(result.block).not.toContain("### alice-vscode");
-    expect(result.block).toContain("### Skills You Can Use");
-    expect(result.block).toContain(
-      '- The "Example Skill A" skill (example-skill-a) is available. Helps with examples. → use skill_load to activate',
+    const headerIdx = result.block!.indexOf("### Skills You Can Use");
+    const skillIdx = result.block!.indexOf(
+      '- The "Retrieved Skill" skill (retrieved-skill) is available. Helps with retrieved skills. → use skill_load to activate',
     );
+    expect(headerIdx).toBeGreaterThan(-1);
+    expect(skillIdx).toBeGreaterThan(headerIdx);
   });
 
   test("renders concept-page sections before the skills subsection in mixed blocks", async () => {


### PR DESCRIPTION
## Summary
- Adds end-to-end verification for SKILL.md-based managed skill discovery through skill_load and Memory V2.
- Verifies skills/<id> injection renders under Skills You Can Use.
- Verifies stale SKILLS.md migration removal preserves loadability of valid skills.

Part of plan: migrate-off-skills-md.md (PR 7 of 7)
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->