### PR TITLE
Support optional Ollama API keys

### DIFF
--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -2,9 +2,12 @@
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 GEMINI_API_KEY=...
-# Optional for authenticated/proxied Ollama deployments
+# Local Ollama does not need an API key. Set only for authenticated/proxied
+# Ollama-compatible deployments.
 OLLAMA_API_KEY=
-# Optional override (defaults to http://127.0.0.1:11434/v1)
+# Optional override (defaults to http://127.0.0.1:11434/v1).
+# Docker self-hosting against Ollama on the host usually uses:
+# OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
 OLLAMA_BASE_URL=
 
 # --- Remote Access ---

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -40,10 +40,15 @@ cp .env.example .env
 | `ANTHROPIC_API_KEY` | Yes      | —                           | Anthropic Claude API key                          |
 | `OPENAI_API_KEY`    | No       | —                           | OpenAI API key                                    |
 | `GEMINI_API_KEY`    | No       | —                           | Google Gemini API key                             |
-| `OLLAMA_API_KEY`    | No       | —                           | API key for authenticated Ollama deployments      |
-| `OLLAMA_BASE_URL`   | No       | `http://127.0.0.1:11434/v1` | Ollama base URL                                   |
+| `OLLAMA_API_KEY`    | No       | —                           | Optional key for authenticated Ollama-compatible endpoints; not needed for local Ollama |
+| `OLLAMA_BASE_URL`   | No       | `http://127.0.0.1:11434/v1` | Ollama OpenAI-compatible base URL                 |
 | `RUNTIME_HTTP_PORT` | No       | —                           | Enable the HTTP server (required for gateway/web) |
 | `RUNTIME_HTTP_HOST` | No       | `127.0.0.1`                 | HTTP server bind address                          |
+
+Local Ollama does not require an API key. For Docker self-hosting where the
+assistant container needs to reach Ollama running on the host machine, set
+`OLLAMA_BASE_URL=http://host.docker.internal:11434/v1` and make sure Ollama is
+listening somewhere the container can reach.
 
 ## Update Bulletin
 

--- a/assistant/src/providers/__tests__/provider-env-vars.test.ts
+++ b/assistant/src/providers/__tests__/provider-env-vars.test.ts
@@ -27,8 +27,8 @@ describe("getLlmProviderEnvVar", () => {
     expect(getLlmProviderEnvVar("openrouter")).toBe("OPENROUTER_API_KEY");
   });
 
-  test("returns undefined for ollama (keyless provider)", () => {
-    expect(getLlmProviderEnvVar("ollama")).toBeUndefined();
+  test("returns OLLAMA_API_KEY for ollama optional authenticated endpoints", () => {
+    expect(getLlmProviderEnvVar("ollama")).toBe("OLLAMA_API_KEY");
   });
 
   test("returns undefined for search providers (out of scope)", () => {
@@ -71,8 +71,8 @@ describe("getAnyProviderEnvVar", () => {
     expect(getAnyProviderEnvVar("perplexity")).toBe("PERPLEXITY_API_KEY");
   });
 
-  test("returns undefined for ollama (keyless LLM provider)", () => {
-    expect(getAnyProviderEnvVar("ollama")).toBeUndefined();
+  test("returns OLLAMA_API_KEY for ollama optional authenticated endpoints", () => {
+    expect(getAnyProviderEnvVar("ollama")).toBe("OLLAMA_API_KEY");
   });
 
   test("returns undefined for unknown provider", () => {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -440,9 +440,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       },
     ],
     defaultModel: "llama3.2",
-    subtitle: "Run local models via Ollama. No API key required.",
+    subtitle: "Run local models via Ollama. No API key required for local use.",
     setupMode: "keyless",
-    setupHint: "Install Ollama locally and pull the models you want to use.",
+    setupHint:
+      "Install Ollama locally and pull the models you want to use. Add a key only for authenticated Ollama-compatible endpoints.",
+    envVar: "OLLAMA_API_KEY",
     credentialsGuide: {
       description:
         "Download and install Ollama, then pull models via `ollama pull <model>`.",

--- a/assistant/src/providers/provider-env-vars.ts
+++ b/assistant/src/providers/provider-env-vars.ts
@@ -14,8 +14,10 @@
  * `getAnyProviderEnvVar` (LLM-first, then search) when you accept either
  * kind — e.g. the generic `getProviderKeyAsync` env-var fallback.
  *
- * Each helper returns `undefined` for keyless providers (e.g. Ollama),
- * unknown IDs, and providers outside the helper's scope.
+ * Each helper returns `undefined` for providers without a declared env var,
+ * unknown IDs, and providers outside the helper's scope. Ollama remains
+ * keyless for local use but declares `OLLAMA_API_KEY` for authenticated
+ * Ollama-compatible endpoints.
  */
 import { PROVIDER_CATALOG } from "./model-catalog.js";
 

--- a/assistant/src/providers/provider-env-vars.ts
+++ b/assistant/src/providers/provider-env-vars.ts
@@ -40,8 +40,7 @@ export function getSearchProviderEnvVar(
 /**
  * Resolve a provider env-var name from either source — LLM catalog first,
  * then the search-provider mirror. Returns `undefined` when no provider
- * scope declares an env var for the given ID (keyless LLM providers like
- * Ollama, unknown IDs, etc.).
+ * scope declares an env var for the given ID.
  */
 export function getAnyProviderEnvVar(providerId: string): string | undefined {
   return (

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -216,7 +216,7 @@ export async function initializeProviders(
     routingSources.set("gemini", geminiCreds.source);
   }
 
-  // Ollama (keyless provider — always init when configured or key present)
+  // Ollama (keyless locally — always init when configured or a key is present)
   const ollamaKey = await getProviderKeyAsync("ollama");
   if (config.llm.default.provider === "ollama" || ollamaKey) {
     const model = resolveModel(config, "ollama");

--- a/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
+++ b/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
@@ -112,8 +112,8 @@ describe("getProviderKeyAsync env-var fallback (regression #27126)", () => {
     expect(await getProviderKeyAsync("unknown-provider")).toBeUndefined();
   });
 
-  test("returns undefined for keyless ollama even if env has unrelated keys", async () => {
-    process.env.BRAVE_API_KEY = "brave-env-test";
-    expect(await getProviderKeyAsync("ollama")).toBeUndefined();
+  test("returns OLLAMA_API_KEY for authenticated Ollama-compatible endpoints", async () => {
+    process.env.OLLAMA_API_KEY = "ollama-env-test";
+    expect(await getProviderKeyAsync("ollama")).toBe("ollama-env-test");
   });
 });

--- a/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
+++ b/assistant/src/security/__tests__/provider-key-env-fallback.test.ts
@@ -54,6 +54,7 @@ describe("getProviderKeyAsync env-var fallback (regression #27126)", () => {
     "PERPLEXITY_API_KEY",
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
+    "OLLAMA_API_KEY",
   ];
 
   beforeEach(() => {
@@ -115,5 +116,10 @@ describe("getProviderKeyAsync env-var fallback (regression #27126)", () => {
   test("returns OLLAMA_API_KEY for authenticated Ollama-compatible endpoints", async () => {
     process.env.OLLAMA_API_KEY = "ollama-env-test";
     expect(await getProviderKeyAsync("ollama")).toBe("ollama-env-test");
+  });
+
+  test("ignores empty OLLAMA_API_KEY env var for local Ollama", async () => {
+    process.env.OLLAMA_API_KEY = "";
+    expect(await getProviderKeyAsync("ollama")).toBeUndefined();
   });
 });

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -535,8 +535,8 @@ export async function bulkSetSecureKeysAsync(
  *
  * Env var names are resolved via `getAnyProviderEnvVar`, which covers both
  * LLM providers (sourced from `PROVIDER_CATALOG`) and search providers
- * (sourced from `SEARCH_PROVIDER_ENV_VAR_NAMES`). Keyless providers (e.g.
- * Ollama) return `undefined` and fall through to a stored-only lookup.
+ * (sourced from `SEARCH_PROVIDER_ENV_VAR_NAMES`). Providers without a
+ * declared env var return `undefined` and fall through to a stored-only lookup.
  *
  * Use this instead of raw `getSecureKeyAsync` when looking up provider
  * API keys so that env-var-only setups continue to work.

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -551,7 +551,9 @@ export async function getProviderKeyAsync(
     (await getSecureKeyAsync(provider));
   if (stored) return stored;
   const envVar = getAnyProviderEnvVar(provider);
-  return envVar ? process.env[envVar] : undefined;
+  if (!envVar) return undefined;
+  const fromEnv = process.env[envVar]?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/workspace/migrations/068-release-notes-ollama-connection.ts
+++ b/assistant/src/workspace/migrations/068-release-notes-ollama-connection.ts
@@ -1,0 +1,61 @@
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("workspace-migration-068-release-notes-ollama-connection");
+
+const MIGRATION_ID = "068-release-notes-ollama-connection";
+const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
+
+const RELEASE_NOTE = `${MARKER}
+## Local Ollama connections
+
+Local Ollama still works without an API key. You can now save an optional
+Ollama API key for authenticated proxies, and Docker self-hosted setups can
+pass \`OLLAMA_BASE_URL\` so the assistant reaches the host's Ollama server.
+`;
+
+export const releaseNotesOllamaConnectionMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description: "Append release notes for local Ollama connection settings",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+
+    try {
+      if (existsSync(updatesPath)) {
+        const existing = readFileSync(updatesPath, "utf-8");
+        if (existing.includes(MARKER)) {
+          return;
+        }
+        const needsLeadingNewline = !existing.endsWith("\n\n");
+        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+        appendFileSync(
+          updatesPath,
+          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
+          "utf-8",
+        );
+      } else {
+        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
+      }
+      log.info({ path: updatesPath }, "Appended Ollama connection release note");
+    } catch (err) {
+      log.warn(
+        { err, path: updatesPath },
+        "Failed to append Ollama connection release note to UPDATES.md",
+      );
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
+    // processes and deletes on its own.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -65,6 +65,7 @@ import { unwindMainAgentOpusSeedMigration } from "./064-unwind-main-agent-opus-s
 import { bumpStaleHeartbeatIntervalMigration } from "./065-bump-stale-heartbeat-interval.js";
 import { seedHeartbeatCallsiteCostDefaultMigration } from "./066-seed-heartbeat-callsite-cost-default.js";
 import { releaseNotesSafeStorageLimitsMigration } from "./067-release-notes-safe-storage-limits.js";
+import { releaseNotesOllamaConnectionMigration } from "./068-release-notes-ollama-connection.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -141,4 +142,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   bumpStaleHeartbeatIntervalMigration,
   seedHeartbeatCallsiteCostDefaultMigration,
   releaseNotesSafeStorageLimitsMigration,
+  releaseNotesOllamaConnectionMigration,
 ];

--- a/cli/src/lib/__tests__/docker.test.ts
+++ b/cli/src/lib/__tests__/docker.test.ts
@@ -44,6 +44,17 @@ function buildGatewayArgs(
 }
 
 describe("buildServiceRunArgs — assistant", () => {
+  const savedOllamaBaseUrl = process.env.OLLAMA_BASE_URL;
+
+  beforeEach(() => {
+    delete process.env.OLLAMA_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedOllamaBaseUrl === undefined) delete process.env.OLLAMA_BASE_URL;
+    else process.env.OLLAMA_BASE_URL = savedOllamaBaseUrl;
+  });
+
   test("does not grant elevated capabilities or disable security profiles", () => {
     const args = buildAssistantArgs();
     expect(args).not.toContain("--privileged");
@@ -88,6 +99,21 @@ describe("buildServiceRunArgs — assistant", () => {
     const portIndex = args.indexOf(portSpec);
     expect(portIndex).toBeGreaterThan(0);
     expect(args[portIndex - 1]).toBe("-p");
+  });
+
+  test("adds host-gateway mapping when Ollama uses host.docker.internal", () => {
+    process.env.OLLAMA_BASE_URL = "http://host.docker.internal:11434/v1";
+
+    const args = buildAssistantArgs();
+    const hostIndex = args.indexOf("--add-host");
+    expect(hostIndex).toBeGreaterThan(0);
+    expect(args[hostIndex + 1]).toBe("host.docker.internal=host-gateway");
+  });
+
+  test("omits host-gateway mapping when Ollama host routing is not requested", () => {
+    const args = buildAssistantArgs();
+    expect(args).not.toContain("--add-host");
+    expect(args).not.toContain("host.docker.internal=host-gateway");
   });
 
   test("forwards GUARDIAN_BOOTSTRAP_SECRET into the assistant container when provided, so the runtime can validate the gateway's x-bootstrap-secret header and close the published-port bypass", () => {

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -955,6 +955,8 @@ export async function startLocalDaemon(
       // config dir) to the same location as the CLI that spawned it.
       for (const key of [
         "ANTHROPIC_API_KEY",
+        "OLLAMA_API_KEY",
+        "OLLAMA_BASE_URL",
         "APP_VERSION",
         "GATEWAY_SECURITY_DIR",
         "CREDENTIAL_SECURITY_DIR",

--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -266,6 +266,12 @@ function resolveVolume(
   return claim.dockerVolume(instanceName);
 }
 
+function shouldAddHostGateway(extraAssistantEnv?: Record<string, string>): boolean {
+  const ollamaBaseUrl =
+    extraAssistantEnv?.OLLAMA_BASE_URL ?? process.env.OLLAMA_BASE_URL;
+  return ollamaBaseUrl?.includes("host.docker.internal") === true;
+}
+
 /**
  * Build `docker run` argument arrays for each container in the StatefulSet.
  * Returns `Record<ServiceName, () => string[]>` — callers evaluate lazily.
@@ -356,6 +362,10 @@ export function buildServiceRunArgs(
           for (const [k, v] of Object.entries(extraAssistantEnv)) {
             args.push("-e", `${k}=${v}`);
           }
+        }
+
+        if (shouldAddHostGateway(extraAssistantEnv)) {
+          args.push("--add-host", "host.docker.internal=host-gateway");
         }
 
         if (avatarDevicePath && existsSync(avatarDevicePath)) {

--- a/cli/src/lib/statefulset.ts
+++ b/cli/src/lib/statefulset.ts
@@ -181,6 +181,7 @@ export const DOCKER_STATEFUL_SET_SPEC: DockerStatefulSetSpec = {
         ...Object.values(PROVIDER_ENV_VAR_NAMES).map(
           (v): HostEnv => ({ kind: "host", name: v }),
         ),
+        { kind: "host", name: "OLLAMA_BASE_URL" },
         { kind: "host", name: "VELLUM_ENVIRONMENT" },
         { kind: "host", name: "VELLUM_PLATFORM_URL" },
       ],

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -21,6 +21,7 @@ export const LLM_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   anthropic: "ANTHROPIC_API_KEY",
   openai: "OPENAI_API_KEY",
   gemini: "GEMINI_API_KEY",
+  ollama: "OLLAMA_API_KEY",
   fireworks: "FIREWORKS_API_KEY",
   openrouter: "OPENROUTER_API_KEY",
 };

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -42,6 +42,7 @@ enum APIKeyManager {
         "brave",
         "fireworks",
         "gemini",
+        "ollama",
         "openai",
         "openrouter",
         "perplexity",

--- a/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/APIKeysSheet.swift
@@ -1,7 +1,19 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Sheet for managing API keys across all key-required inference providers.
+private func supportsInferenceAPIKey(_ provider: ProviderCatalogEntry) -> Bool {
+    provider.apiKeyPlaceholder != nil || provider.envVar != nil
+}
+
+private func requiresInferenceAPIKey(_ provider: ProviderCatalogEntry) -> Bool {
+    provider.apiKeyPlaceholder != nil
+}
+
+private func apiKeyPlaceholder(for provider: ProviderCatalogEntry) -> String {
+    provider.apiKeyPlaceholder ?? "Bearer token"
+}
+
+/// Sheet for managing API keys across all configurable inference providers.
 ///
 /// Each provider row shows its current key status (configured / not configured)
 /// and expands inline to reveal an `APIKeyTextField` for entry. Keys are
@@ -39,10 +51,9 @@ struct APIKeysSheet: View {
 
     // MARK: - Computed
 
-    /// Providers that require an API key, derived from the store's provider
-    /// catalog. Excludes keyless providers like Ollama.
-    private var keyRequiredProviders: [ProviderCatalogEntry] {
-        store.providerCatalog.filter { $0.apiKeyPlaceholder != nil }
+    /// Providers that support API key storage, derived from the provider catalog.
+    private var keyConfigurableProviders: [ProviderCatalogEntry] {
+        store.providerCatalog.filter { supportsInferenceAPIKey($0) }
     }
 
     // MARK: - Body
@@ -77,7 +88,7 @@ struct APIKeysSheet: View {
             }
         } message: {
             if let provider = providerToRemove {
-                Text("Remove the \(store.dynamicProviderDisplayName(provider)) API key? Profiles using this provider will stop working until a new key is added.")
+                Text(removeConfirmationMessage(for: provider))
             }
         }
     }
@@ -90,7 +101,7 @@ struct APIKeysSheet: View {
                 Text("Provider API Keys")
                     .font(VFont.titleSmall)
                     .foregroundStyle(VColor.contentDefault)
-                Text("Add API keys for the LLM providers you want to use.")
+                Text("Add API keys for providers that require them. Local Ollama works without a key.")
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -123,9 +134,9 @@ struct APIKeysSheet: View {
     private var providerList: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(keyRequiredProviders, id: \.id) { provider in
+                ForEach(keyConfigurableProviders, id: \.id) { provider in
                     providerRow(provider)
-                    if provider.id != keyRequiredProviders.last?.id {
+                    if provider.id != keyConfigurableProviders.last?.id {
                         SettingsDivider()
                             .padding(.horizontal, VSpacing.lg)
                     }
@@ -141,6 +152,10 @@ struct APIKeysSheet: View {
         let isConfigured = keyStatuses[provider.id] == true
         let isExpanded = expandedProvider == provider.id
         let isSaving = saving[provider.id] == true
+        let requiresKey = requiresInferenceAPIKey(provider)
+        let keyLabel = requiresKey
+            ? "\(provider.displayName) API Key"
+            : "\(provider.displayName) API Key (Optional)"
 
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
             // Header: provider name + masked key + actions
@@ -151,6 +166,10 @@ struct APIKeysSheet: View {
                         .foregroundStyle(VColor.contentDefault)
                     if isConfigured, !isExpanded, let masked = maskedKeys[provider.id] {
                         Text(masked)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                    } else if !requiresKey && !isConfigured && !isExpanded {
+                        Text("No key is needed for local Ollama. Add one only for an authenticated proxy.")
                             .font(VFont.labelDefault)
                             .foregroundStyle(VColor.contentTertiary)
                     }
@@ -169,8 +188,17 @@ struct APIKeysSheet: View {
                         }
                     }
                 } else if !isConfigured && !isExpanded {
-                    VButton(label: "Add Key", style: .outlined, size: .compact) {
-                        expandProvider(provider.id)
+                    if requiresKey {
+                        VButton(label: "Add Key", style: .outlined, size: .compact) {
+                            expandProvider(provider.id)
+                        }
+                    } else {
+                        HStack(spacing: VSpacing.sm) {
+                            VTag("No Key Needed", color: VColor.contentTertiary, icon: .check)
+                            VButton(label: "Add Optional Key", style: .outlined, size: .compact) {
+                                expandProvider(provider.id)
+                            }
+                        }
                     }
                 }
             }
@@ -179,13 +207,13 @@ struct APIKeysSheet: View {
             if isExpanded {
                 VStack(alignment: .leading, spacing: VSpacing.sm) {
                     APIKeyTextField(
-                        label: "\(provider.displayName) API Key",
+                        label: keyLabel,
                         hasKey: isConfigured,
                         text: Binding(
                             get: { keyTexts[provider.id] ?? "" },
                             set: { keyTexts[provider.id] = $0 }
                         ),
-                        emptyPlaceholder: provider.apiKeyPlaceholder ?? "Enter your API key",
+                        emptyPlaceholder: apiKeyPlaceholder(for: provider),
                         errorMessage: errors[provider.id]
                     )
                     .disabled(isSaving)
@@ -264,10 +292,19 @@ struct APIKeysSheet: View {
         showToast("\(store.dynamicProviderDisplayName(providerId)) API key removed", .success)
     }
 
+    private func removeConfirmationMessage(for providerId: String) -> String {
+        let displayName = store.dynamicProviderDisplayName(providerId)
+        let provider = keyConfigurableProviders.first { $0.id == providerId }
+        if let provider, !requiresInferenceAPIKey(provider) {
+            return "Remove the \(displayName) API key? Local connections will continue to work unless this endpoint requires bearer authentication."
+        }
+        return "Remove the \(displayName) API key? Profiles using this provider will stop working until a new key is added."
+    }
+
     // MARK: - Key Status Loading
 
     private func loadAllKeyStatuses() async {
-        for provider in keyRequiredProviders {
+        for provider in keyConfigurableProviders {
             let hasKey = await APIKeyManager.hasKey(for: provider.id)
             keyStatuses[provider.id] = hasKey
             if hasKey {

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import VellumAssistantShared
 
+private func supportsInferenceServiceAPIKey(_ provider: ProviderCatalogEntry) -> Bool {
+    provider.apiKeyPlaceholder != nil || provider.envVar != nil
+}
+
 /// Card for the inference service with Managed/Your Own mode toggle.
 ///
 /// Shows different content based on mode and auth state:
@@ -358,7 +362,10 @@ struct InferenceServiceCard: View {
     /// "API Keys" action button lives in the consolidated `secondaryActionsRow`.
     private var apiKeysSection: some View {
         let configuredProviders = store.providerCatalog
-            .filter { $0.apiKeyPlaceholder != nil && (providerKeyStatuses[$0.id] ?? nil) == true }
+            .filter {
+                supportsInferenceServiceAPIKey($0)
+                    && (providerKeyStatuses[$0.id] ?? nil) == true
+            }
 
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
             Text("API Keys")
@@ -400,9 +407,9 @@ struct InferenceServiceCard: View {
         .padding(.vertical, VSpacing.lg)
     }
 
-    /// Fetches the key-exists status for every key-required provider.
+    /// Fetches the key-exists status for every provider with configurable key storage.
     private func loadProviderKeyStatuses() async {
-        for provider in store.providerCatalog where provider.apiKeyPlaceholder != nil {
+        for provider in store.providerCatalog where supportsInferenceServiceAPIKey(provider) {
             providerKeyStatuses[provider.id] = await APIKeyManager.keyStatus(for: provider.id)
         }
     }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -2610,6 +2610,14 @@ extension ImageGenModelSetRequest {
 /// Backed by generated `ModelInfo`.
 public typealias ModelInfoMessage = ModelInfo
 
+extension ProviderCatalogEntry {
+    /// The wire DTO carries model-selection fields only; setup metadata comes
+    /// from the bundled LLM provider registry.
+    public var envVar: String? {
+        LLMProviderRegistry.provider(id: id)?.envVar
+    }
+}
+
 // MARK: - Equatable conformance for generated types
 // Added here (not in GeneratedAPITypes.swift) because generated files must not
 // be edited manually. Swift only auto-synthesizes Equatable when the

--- a/clients/shared/Tests/LLMProviderRegistryTests.swift
+++ b/clients/shared/Tests/LLMProviderRegistryTests.swift
@@ -70,7 +70,7 @@ final class LLMProviderRegistryTests: XCTestCase {
         let ollama = LLMProviderRegistry.provider(id: "ollama")
         XCTAssertNotNil(ollama)
         XCTAssertEqual(ollama?.setupMode, .keyless)
-        XCTAssertNil(ollama?.envVar)
+        XCTAssertEqual(ollama?.envVar, "OLLAMA_API_KEY")
         XCTAssertNil(ollama?.apiKeyPlaceholder)
         XCTAssertNil(ollama?.credentialsGuide)
     }

--- a/clients/shared/Utilities/LLMProviderRegistry.swift
+++ b/clients/shared/Utilities/LLMProviderRegistry.swift
@@ -138,8 +138,8 @@ public struct LLMProviderEntry: Decodable {
     /// Brief help text guiding the user through setup.
     public let setupHint: String
     /// Name of the environment variable the provider conventionally reads
-    /// its API key from (e.g. `ANTHROPIC_API_KEY`). `nil` for keyless
-    /// providers.
+    /// its API key from (e.g. `ANTHROPIC_API_KEY`). Local keyless providers
+    /// may still expose an optional env var for authenticated endpoints.
     public let envVar: String?
     /// Example placeholder text shown in the API-key input field to hint
     /// at the key format (e.g. `"sk-ant-api03-..."`). `nil` for keyless
@@ -396,10 +396,10 @@ private let fallbackCatalog = LLMProviderCatalog(
         LLMProviderEntry(
             id: "ollama",
             displayName: "Ollama",
-            subtitle: "Run open-source models locally with Ollama. No API key required.",
+            subtitle: "Run open-source models locally with Ollama. No API key required for local use.",
             setupMode: .keyless,
-            setupHint: "Install Ollama locally and pull a model to get started.",
-            envVar: nil,
+            setupHint: "Install Ollama locally and pull a model to get started. Add a key only for authenticated Ollama-compatible endpoints.",
+            envVar: "OLLAMA_API_KEY",
             apiKeyPlaceholder: nil,
             credentialsGuide: nil,
             defaultModel: "llama3.2",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -356,9 +356,10 @@
     {
       "id": "ollama",
       "displayName": "Ollama",
-      "subtitle": "Run local models via Ollama. No API key required.",
+      "subtitle": "Run local models via Ollama. No API key required for local use.",
       "setupMode": "keyless",
-      "setupHint": "Install Ollama locally and pull the models you want to use.",
+      "setupHint": "Install Ollama locally and pull the models you want to use. Add a key only for authenticated Ollama-compatible endpoints.",
+      "envVar": "OLLAMA_API_KEY",
       "credentialsGuide": {
         "description": "Download and install Ollama, then pull models via `ollama pull <model>`.",
         "url": "https://ollama.com/download",


### PR DESCRIPTION
## Summary
- Keep local Ollama keyless while declaring `OLLAMA_API_KEY` for authenticated Ollama-compatible endpoints.
- Add Ollama to the macOS API Keys sheet as an optional credential and sync it through the assistant secret store.
- Forward `OLLAMA_BASE_URL` for local/Docker self-hosted launches and document using `host.docker.internal:11434/v1` for host Ollama.

Closes JARVIS-711

## Original prompt
Investigate and resolve JARVIS-711: connect a local Ollama instance to local/self-hosted Vellum, including whether the macOS app should allow setting an Ollama API key.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->