### PR TITLE
Part of JARVIS-709: Test macOS billing banner routing

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1537,6 +1537,71 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.conversationError?.isCreditsExhausted == true)
     }
 
+    func testConversationManagerViewModelSuppressesProviderBillingInlineErrorMessage() {
+        let managerViewModel = makeConversationManagerViewModel(conversationId: "sess-provider-billing")
+
+        let errorMsg = ConversationErrorMessage(
+            conversationId: "sess-provider-billing",
+            code: .providerBilling,
+            userMessage: "Your provider API key needs credits.",
+            retryable: false,
+            errorCategory: "provider_billing"
+        )
+        managerViewModel.handleServerMessage(.conversationError(errorMsg))
+
+        XCTAssertEqual(managerViewModel.messages.count, 0)
+        XCTAssertEqual(managerViewModel.errorText, "Your provider API key needs credits.")
+        XCTAssertTrue(managerViewModel.conversationError?.isProviderBilling == true)
+        XCTAssertFalse(managerViewModel.errorManager.isConversationErrorDisplayedInline)
+    }
+
+    func testConversationManagerViewModelSuppressesManagedCreditsInlineErrorMessage() {
+        let managerViewModel = makeConversationManagerViewModel(conversationId: "sess-managed-credits")
+
+        let errorMsg = ConversationErrorMessage(
+            conversationId: "sess-managed-credits",
+            code: .providerBilling,
+            userMessage: "Your Vellum balance has run out.",
+            retryable: false,
+            errorCategory: "credits_exhausted"
+        )
+        managerViewModel.handleServerMessage(.conversationError(errorMsg))
+
+        XCTAssertEqual(managerViewModel.messages.count, 0)
+        XCTAssertEqual(managerViewModel.errorText, "Your Vellum balance has run out.")
+        XCTAssertTrue(managerViewModel.conversationError?.isManagedCreditsExhausted == true)
+        XCTAssertFalse(managerViewModel.errorManager.isConversationErrorDisplayedInline)
+    }
+
+    func testConversationManagerViewModelKeepsGenericErrorsInline() {
+        let managerViewModel = makeConversationManagerViewModel(conversationId: "sess-provider-api")
+
+        let errorMsg = ConversationErrorMessage(
+            conversationId: "sess-provider-api",
+            code: .providerApi,
+            userMessage: "The provider request failed.",
+            retryable: true,
+            errorCategory: "provider_api_error"
+        )
+        managerViewModel.handleServerMessage(.conversationError(errorMsg))
+
+        XCTAssertEqual(managerViewModel.messages.count, 1)
+        XCTAssertEqual(managerViewModel.messages[0].role, .assistant)
+        XCTAssertTrue(managerViewModel.messages[0].isError)
+        XCTAssertEqual(managerViewModel.messages[0].text, "The provider request failed.")
+        XCTAssertTrue(managerViewModel.errorManager.isConversationErrorDisplayedInline)
+    }
+
+    private func makeConversationManagerViewModel(conversationId: String) -> ChatViewModel {
+        let manager = ConversationManager(
+            connectionManager: connectionManager,
+            eventStreamClient: connectionManager.eventStreamClient
+        )
+        let managerViewModel = manager.makeViewModel()
+        managerViewModel.conversationId = conversationId
+        return managerViewModel
+    }
+
     func testConversationErrorSetsRecoverySuggestion() {
         viewModel.conversationId = "sess-1"
 


### PR DESCRIPTION
## Summary
- Adds focused tests for managed credits and provider billing inline-error suppression.
- Verifies provider billing uses banner routing rather than inline assistant messages.

Part of plan: macos-provider-billing-ux.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->