### PR TITLE
Scope bundled cleanup selector semantics

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -39,11 +39,18 @@ mock.module("../skills/active-skill-tools.js", () => {
   const parseMarkers = (messages: Message[]) => {
     // Two-pass approach matching real implementation:
     // 1. Collect tool_use IDs where name === 'skill_load'
-    const skillLoadUseIds = new Set<string>();
+    const skillLoadSelectorsByUseId = new Map<string, string | undefined>();
     for (const msg of messages) {
       for (const block of msg.content) {
         if (block.type === "tool_use" && block.name === "skill_load") {
-          skillLoadUseIds.add(block.id);
+          const rawSelector =
+            typeof block.input.skill === "string"
+              ? block.input.skill
+              : undefined;
+          const selector = rawSelector?.startsWith("bundled:")
+            ? rawSelector
+            : undefined;
+          skillLoadSelectorsByUseId.set(block.id, selector);
         }
       }
     }
@@ -51,19 +58,26 @@ mock.module("../skills/active-skill-tools.js", () => {
     // 2. Parse markers only from tool_result blocks whose tool_use_id matches
     const re = /<loaded_skill\s+id="([^"]+)"(?:\s+version="([^"]+)")?\s*\/>/g;
     const seen = new Set<string>();
-    const entries: Array<{ id: string; version?: string }> = [];
+    const entries: Array<{ id: string; version?: string; selector?: string }> =
+      [];
     for (const msg of messages) {
       for (const block of msg.content) {
         if (block.type !== "tool_result") continue;
-        if (!skillLoadUseIds.has(block.tool_use_id)) continue;
+        if (!skillLoadSelectorsByUseId.has(block.tool_use_id)) continue;
         const text = block.content;
         if (!text) continue;
         for (const match of text.matchAll(re)) {
           if (!seen.has(match[1])) {
             seen.add(match[1]);
-            const entry: { id: string; version?: string } = { id: match[1] };
+            const entry: { id: string; version?: string; selector?: string } = {
+              id: match[1],
+            };
             if (match[2]) {
               entry.version = match[2];
+            }
+            const selector = skillLoadSelectorsByUseId.get(block.tool_use_id);
+            if (selector) {
+              entry.selector = selector;
             }
             entries.push(entry);
           }
@@ -266,12 +280,19 @@ let toolUseCounter = 0;
  * Creates a pair of messages representing a skill_load tool_use followed by
  * its tool_result with the given content (typically a `<loaded_skill>` marker).
  */
-function skillLoadMessages(content: string): Message[] {
+function skillLoadMessages(content: string, selector?: string): Message[] {
   const id = `sl-${++toolUseCounter}`;
   return [
     {
       role: "assistant",
-      content: [{ type: "tool_use", id, name: "skill_load", input: {} }],
+      content: [
+        {
+          type: "tool_use",
+          id,
+          name: "skill_load",
+          input: selector ? { skill: selector } : {},
+        },
+      ],
     },
     {
       role: "user",
@@ -2068,6 +2089,7 @@ describe("versioned markers through session projection", () => {
     const history: Message[] = [
       ...skillLoadMessages(
         '<loaded_skill id="system-storage-cleanup" version="v1:bundled-cleanup" />',
+        "bundled:system-storage-cleanup",
       ),
     ];
 
@@ -2079,6 +2101,41 @@ describe("versioned markers through session projection", () => {
     expect(result.allowedToolNames).toEqual(new Set());
     expect(sessionState.has("system-storage-cleanup")).toBe(false);
     expect(mockRegisteredTools.has("system-storage-cleanup")).toBe(false);
+  });
+
+  test("managed storage cleanup marker re-registers tools after normal edits", () => {
+    mockCatalog = [makeSkill("system-storage-cleanup")];
+    mockManifests = {
+      "system-storage-cleanup": makeManifest(["managed_cleanup_run"]),
+    };
+    mockVersionHashes = {
+      "system-storage-cleanup": "v1:managed-before-edit",
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages(
+        '<loaded_skill id="system-storage-cleanup" version="v1:managed-before-edit" />',
+      ),
+    ];
+
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+
+    mockUnregisteredSkillIds = [];
+    mockVersionHashes = {
+      "system-storage-cleanup": "v1:managed-after-edit",
+    };
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+
+    expect(result.toolDefinitions).toEqual([]);
+    expect(result.allowedToolNames).toEqual(new Set(["managed_cleanup_run"]));
+    expect(sessionState.get("system-storage-cleanup")).toBe(
+      "v1:managed-after-edit",
+    );
+    expect(mockUnregisteredSkillIds).toContain("system-storage-cleanup");
   });
 
   test("storage cleanup marker projects catalog tools when marker version matches", () => {

--- a/assistant/src/__tests__/system-storage-cleanup-skill.test.ts
+++ b/assistant/src/__tests__/system-storage-cleanup-skill.test.ts
@@ -58,4 +58,12 @@ describe("system-storage-cleanup bundled skill", () => {
       expect(body).toContain(protectedText);
     }
   });
+
+  test("only supports the bundled selector for the cleanup skill", () => {
+    const result = loadSkillBySelector("bundled:app-builder");
+
+    expect(result.skill).toBeUndefined();
+    expect(result.errorCode).toBe("invalid_selector");
+    expect(result.error).toContain("bundled:system-storage-cleanup");
+  });
 });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -37,6 +37,9 @@ import { getConfig } from "./loader.js";
 
 const log = getLogger("skills");
 const BUNDLED_SKILL_SELECTOR_PREFIX = "bundled:";
+const BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR =
+  "bundled:system-storage-cleanup";
+const SYSTEM_STORAGE_CLEANUP_SKILL_ID = "system-storage-cleanup";
 
 // ─── Zod schemas for frontmatter metadata validation ─────────────────────────
 
@@ -1166,10 +1169,9 @@ export function resolveSkillSelector(
     const bundledNeedle = needle
       .slice(BUNDLED_SKILL_SELECTOR_PREFIX.length)
       .trim();
-    if (!bundledNeedle) {
+    if (!bundledNeedle || bundledNeedle !== SYSTEM_STORAGE_CLEANUP_SKILL_ID) {
       return {
-        error:
-          'Bundled skill selector must include a skill id after "bundled:".',
+        error: `The "bundled:" skill selector is only supported for "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}".`,
         errorCode: "invalid_selector",
       };
     }

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -31,6 +31,8 @@ import { getLogger } from "../util/logger.js";
 
 const log = getLogger("conversation-skill-tools");
 const SYSTEM_STORAGE_CLEANUP_SKILL_ID = "system-storage-cleanup";
+const BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR =
+  "bundled:system-storage-cleanup";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -227,13 +229,10 @@ export function projectSkillTools(
   const prevActive =
     options?.previouslyActiveSkillIds ?? new Map<string, string>();
 
-  // Index marker versions by skill ID so we can use them during registration.
-  // When a marker carries a version, it records the hash that was active at
-  // load time — useful for detecting drift without re-hashing the directory.
-  const markerVersionById = new Map<string, string>();
+  const markerSelectorById = new Map<string, string>();
   for (const entry of contextEntries) {
-    if (entry.version) {
-      markerVersionById.set(entry.id, entry.version);
+    if (entry.selector) {
+      markerSelectorById.set(entry.id, entry.selector);
     }
   }
 
@@ -294,6 +293,27 @@ export function projectSkillTools(
       continue;
     }
 
+    // Cleanup-mode markers are id-only even when loaded through the bundled
+    // selector. If that exact bundled marker later resolves to a non-bundled
+    // catalog shadow, do not project the shadow's tools.
+    if (
+      skillId === SYSTEM_STORAGE_CLEANUP_SKILL_ID &&
+      skill.source !== "bundled" &&
+      markerSelectorById.get(skillId) ===
+        BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR
+    ) {
+      log.info(
+        { skillId, markerSelector: markerSelectorById.get(skillId) },
+        "Skipping storage cleanup skill tool projection because the bundled marker now resolves to a non-bundled catalog skill",
+      );
+      continue;
+    }
+
+    const manifest = loadManifestForSkill(skill);
+    if (!manifest) {
+      continue;
+    }
+
     // Compute the current version hash for this skill directory
     let currentHash: string;
     try {
@@ -304,27 +324,6 @@ export function projectSkillTools(
         "Failed to compute skill version hash, treating as changed",
       );
       currentHash = `unknown-${Date.now()}`;
-    }
-
-    const markerVersion = markerVersionById.get(skillId);
-    // Cleanup mode loads the bundled cleanup skill through a source-qualified
-    // selector, but the persisted marker is id-only. If that id now resolves
-    // to a managed shadow, do not project the shadow's tools from the marker.
-    if (
-      skillId === SYSTEM_STORAGE_CLEANUP_SKILL_ID &&
-      markerVersion &&
-      markerVersion !== currentHash
-    ) {
-      log.info(
-        { skillId, markerVersion, currentHash },
-        "Skipping storage cleanup skill tool projection because the loaded marker no longer matches the catalog skill",
-      );
-      continue;
-    }
-
-    const manifest = loadManifestForSkill(skill);
-    if (!manifest) {
-      continue;
     }
 
     // Create runtime Tool objects

--- a/assistant/src/skills/active-skill-tools.ts
+++ b/assistant/src/skills/active-skill-tools.ts
@@ -12,8 +12,10 @@ const LOADED_SKILL_RE =
 
 export interface ActiveSkillEntry {
   id: string;
-  /** Present only when the marker includes a `version` attribute. */
+  /** Present only when the marker includes a `version` attribute; retained for versioned marker compatibility. */
   version?: string;
+  /** The selector originally passed to skill_load, when available. */
+  selector?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,11 +36,16 @@ export interface ActiveSkillEntry {
  */
 export function deriveActiveSkills(messages: Message[]): ActiveSkillEntry[] {
   // First pass: collect tool_use IDs that belong to skill_load calls.
-  const skillLoadUseIds = new Set<string>();
+  const skillLoadSelectorsByUseId = new Map<string, string | undefined>();
   for (const msg of messages) {
     for (const block of msg.content) {
       if (block.type === "tool_use" && block.name === "skill_load") {
-        skillLoadUseIds.add(block.id);
+        const rawSelector =
+          typeof block.input.skill === "string" ? block.input.skill : undefined;
+        const selector = rawSelector?.startsWith("bundled:")
+          ? rawSelector
+          : undefined;
+        skillLoadSelectorsByUseId.set(block.id, selector);
       }
     }
   }
@@ -50,7 +57,7 @@ export function deriveActiveSkills(messages: Message[]): ActiveSkillEntry[] {
   for (const msg of messages) {
     for (const block of msg.content) {
       if (block.type !== "tool_result") continue;
-      if (!skillLoadUseIds.has(block.tool_use_id)) continue;
+      if (!skillLoadSelectorsByUseId.has(block.tool_use_id)) continue;
 
       const text = block.content;
       if (!text) continue;
@@ -62,6 +69,10 @@ export function deriveActiveSkills(messages: Message[]): ActiveSkillEntry[] {
           const entry: ActiveSkillEntry = { id };
           if (match[2]) {
             entry.version = match[2];
+          }
+          const selector = skillLoadSelectorsByUseId.get(block.tool_use_id);
+          if (selector) {
+            entry.selector = selector;
           }
           entries.push(entry);
         }

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,7 +1,7 @@
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
 import { isToolAllowedInChannel } from "../channels/permission-profiles.js";
 import type { ChannelId } from "../channels/types.js";
-import { loadSkillBySelector } from "../config/skills.js";
+import { resolveSkillSelector } from "../config/skills.js";
 import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,
@@ -189,11 +189,12 @@ function getDiskPressureSkillLoadBlockReason(
     return null;
   }
 
-  const loaded = loadSkillBySelector(selector);
-  if (!loaded.skill) {
+  const resolved = resolveSkillSelector(selector);
+  if (!resolved.skill) {
     if (
-      loaded.errorCode === "not_found" ||
-      loaded.errorCode === "empty_catalog"
+      resolved.errorCode === "not_found" ||
+      resolved.errorCode === "empty_catalog" ||
+      resolved.errorCode === "invalid_selector"
     ) {
       return `Skill "${selector}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load the bundled "${DISK_PRESSURE_CLEANUP_SKILL_ID}" skill.`;
     }
@@ -201,18 +202,18 @@ function getDiskPressureSkillLoadBlockReason(
   }
 
   if (
-    loaded.skill.id !== DISK_PRESSURE_CLEANUP_SKILL_ID ||
-    loaded.skill.source !== "bundled"
+    resolved.skill.id !== DISK_PRESSURE_CLEANUP_SKILL_ID ||
+    resolved.skill.source !== "bundled"
   ) {
-    return `Skill "${loaded.skill.id}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load the bundled "${DISK_PRESSURE_CLEANUP_SKILL_ID}" skill.`;
+    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load the bundled "${DISK_PRESSURE_CLEANUP_SKILL_ID}" skill.`;
   }
 
-  if (loaded.skill.inlineCommandExpansions?.length) {
-    return `Skill "${loaded.skill.id}" cannot be loaded during disk pressure cleanup mode because it contains inline command expansions. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
+  if (resolved.skill.inlineCommandExpansions?.length) {
+    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode because it contains inline command expansions. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
   }
 
-  if (loaded.skill.toolManifest?.present) {
-    return `Skill "${loaded.skill.id}" cannot be loaded during disk pressure cleanup mode because it declares executable skill tools. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
+  if (resolved.skill.toolManifest?.present) {
+    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode because it declares executable skill tools. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Restrict `bundled:` selector support to the storage cleanup skill instead of introducing general source-qualified loading semantics.
- Validate cleanup-mode `skill_load` through selector resolution metadata instead of fully loading the skill before execution.
- Make cleanup marker projection source-aware so bundled cleanup markers cannot activate managed-shadow tools while legitimate managed cleanup skill edits still re-register normally.

## Validation
- `cd assistant && bun test src/__tests__/conversation-skill-tools.test.ts`
- `cd assistant && bun test src/__tests__/disk-pressure-tools.test.ts src/__tests__/injector-disk-pressure.test.ts src/__tests__/system-storage-cleanup-skill.test.ts src/__tests__/workspace-migration-system-storage-cleanup-skill-release.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun run lint src/config/skills.ts src/tools/tool-approval-handler.ts src/daemon/conversation-skill-tools.ts src/__tests__/conversation-skill-tools.test.ts src/__tests__/disk-pressure-tools.test.ts src/__tests__/injector-disk-pressure.test.ts src/__tests__/system-storage-cleanup-skill.test.ts src/__tests__/workspace-migration-system-storage-cleanup-skill-release.test.ts`

Part of ATL-462
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->