### PR TITLE
feat(heartbeat): make first heartbeats notify the user proactively [JARVIS-708]

### DIFF
--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -48,6 +48,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   supersedePendingRun: mock(() => true),
   markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
   markStaleRunningAsError: mockMarkStaleRunningAsError,
+  countCompletedHeartbeatRuns: mock(() => 10),
 }));
 
 mock.module("../schedule/recurrence-engine.js", () => ({

--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -21,6 +21,7 @@ const mockSupersedePendingRun = mock(() => true);
 const mockMarkStaleRunsAsMissed = mock(() => 0);
 const mockMarkStaleRunningAsError = mock(() => 0);
 const mockListHeartbeatRuns = mock(() => []);
+const mockCountCompletedHeartbeatRuns = mock(() => 10);
 mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   insertPendingHeartbeatRun: mockInsertPendingHeartbeatRun,
   startHeartbeatRun: mockStartHeartbeatRun,
@@ -30,6 +31,7 @@ mock.module("../heartbeat/heartbeat-run-store.js", () => ({
   markStaleRunsAsMissed: mockMarkStaleRunsAsMissed,
   markStaleRunningAsError: mockMarkStaleRunningAsError,
   listHeartbeatRuns: mockListHeartbeatRuns,
+  countCompletedHeartbeatRuns: mockCountCompletedHeartbeatRuns,
 }));
 
 // ── Feed event mock ───────────────────────────────────────────────
@@ -379,6 +381,8 @@ describe("HeartbeatService", () => {
     mockMarkStaleRunningAsError.mockImplementation(() => 0);
     mockListHeartbeatRuns.mockClear();
     mockListHeartbeatRuns.mockImplementation(() => []);
+    mockCountCompletedHeartbeatRuns.mockClear();
+    mockCountCompletedHeartbeatRuns.mockImplementation(() => 10);
     mockEmitFeedEvent.mockClear();
     mockEmitFeedEvent.mockImplementation(() => Promise.resolve());
 
@@ -1962,6 +1966,57 @@ describe("HeartbeatService", () => {
       );
       expect(missedCalls).toHaveLength(0);
       service.stop();
+    });
+  });
+
+  describe("early heartbeat nudge", () => {
+    test("includes <early-heartbeat> when completedRunCount is 0", () => {
+      const service = createService();
+      const { prompt } = service.buildPrompt("- Check things", [], 0);
+
+      expect(prompt).toContain("<early-heartbeat>");
+      expect(prompt).toContain("first heartbeats");
+    });
+
+    test("includes <early-heartbeat> when completedRunCount is 2", () => {
+      const service = createService();
+      const { prompt } = service.buildPrompt("- Check things", [], 2);
+
+      expect(prompt).toContain("<early-heartbeat>");
+    });
+
+    test("omits <early-heartbeat> when completedRunCount is 3", () => {
+      const service = createService();
+      const { prompt } = service.buildPrompt("- Check things", [], 3);
+
+      expect(prompt).not.toContain("<early-heartbeat>");
+    });
+
+    test("omits <early-heartbeat> when completedRunCount is 10", () => {
+      const service = createService();
+      const { prompt } = service.buildPrompt("- Check things", [], 10);
+
+      expect(prompt).not.toContain("<early-heartbeat>");
+    });
+
+    test("executeRun passes completed run count to buildPrompt", async () => {
+      mockCountCompletedHeartbeatRuns.mockImplementation(() => 0);
+
+      const service = createService();
+      await service.runOnce();
+
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].content).toContain("<early-heartbeat>");
+    });
+
+    test("executeRun omits nudge when enough runs have completed", async () => {
+      mockCountCompletedHeartbeatRuns.mockImplementation(() => 5);
+
+      const service = createService();
+      await service.runOnce();
+
+      expect(processMessageCalls).toHaveLength(1);
+      expect(processMessageCalls[0].content).not.toContain("<early-heartbeat>");
     });
   });
 });

--- a/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-feed-event.test.ts
@@ -15,6 +15,7 @@ mock.module("../heartbeat-run-store.js", () => ({
   markStaleRunsAsMissed: () => 0,
   markStaleRunningAsError: () => 0,
   listHeartbeatRuns: () => [],
+  countCompletedHeartbeatRuns: () => 10,
 }));
 
 // Stub the in-process SSE hub so the writer's publish path is a

--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -15,6 +15,7 @@ import { getDb } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import {
   completeHeartbeatRun,
+  countCompletedHeartbeatRuns,
   insertPendingHeartbeatRun,
   listHeartbeatRuns,
   markStaleRunningAsError,
@@ -212,5 +213,40 @@ describe("heartbeat-run-store", () => {
 
     const rows = listHeartbeatRuns(3);
     expect(rows).toHaveLength(3);
+  });
+
+  test("countCompletedHeartbeatRuns counts only ok rows", () => {
+    const now = Date.now();
+
+    // Insert runs with various statuses
+    const id1 = insertPendingHeartbeatRun(now);
+    startHeartbeatRun(id1);
+    completeHeartbeatRun(id1, { status: "ok", conversationId: "conv-1" });
+
+    const id2 = insertPendingHeartbeatRun(now + 1);
+    startHeartbeatRun(id2);
+    completeHeartbeatRun(id2, { status: "error", error: "something broke" });
+
+    const id3 = insertPendingHeartbeatRun(now + 2);
+    skipHeartbeatRun(id3, "disabled");
+
+    const id4 = insertPendingHeartbeatRun(now + 3);
+    startHeartbeatRun(id4);
+    completeHeartbeatRun(id4, { status: "ok", conversationId: "conv-2" });
+
+    expect(countCompletedHeartbeatRuns()).toBe(2);
+  });
+
+  test("countCompletedHeartbeatRuns returns 0 when no ok rows exist", () => {
+    const now = Date.now();
+
+    const id1 = insertPendingHeartbeatRun(now);
+    startHeartbeatRun(id1);
+    completeHeartbeatRun(id1, { status: "error", error: "fail" });
+
+    const id2 = insertPendingHeartbeatRun(now + 1);
+    skipHeartbeatRun(id2, "outside_active_hours");
+
+    expect(countCompletedHeartbeatRuns()).toBe(0);
   });
 });

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -203,6 +203,19 @@ export function markStaleRunningAsError(
 }
 
 /**
+ * Count the number of heartbeat runs that completed with status `ok`.
+ */
+export function countCompletedHeartbeatRuns(): number {
+  const db = getDb();
+  const row = db
+    .select({ count: sql<number>`count(*)` })
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.status, "ok"))
+    .get();
+  return row?.count ?? 0;
+}
+
+/**
  * List heartbeat runs ordered by `scheduledFor` descending.
  */
 export function listHeartbeatRuns(limit = 20): HeartbeatRunRecord[] {

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -26,6 +26,7 @@ import { getWorkspaceDir, getWorkspacePromptPath } from "../util/platform.js";
 import { stripCommentLines } from "../util/strip-comment-lines.js";
 import {
   completeHeartbeatRun,
+  countCompletedHeartbeatRuns,
   insertPendingHeartbeatRun,
   markStaleRunningAsError,
   markStaleRunsAsMissed,
@@ -43,6 +44,7 @@ const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still ac
 - If you have a thought worth sharing, send it. A follow-up, a useful find, a check-in. Not every beat, but when it feels right.
 - If something has happened since your last journal entry, write one. Even a few sentences. The journal is how future-you stays connected.`;
 
+const EARLY_HEARTBEAT_THRESHOLD = 3;
 const REENGAGEMENT_COOLDOWN_MS = 18 * 60 * 60 * 1000; // 18 hours
 const HEARTBEAT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const HEARTBEAT_ALERT_MARKER = "HEARTBEAT_ALERT";
@@ -733,9 +735,11 @@ export class HeartbeatService {
     let conversationId: string | undefined;
     try {
       const checklist = this.readChecklist();
+      const completedRunCount = countCompletedHeartbeatRuns();
       const { prompt, includedReengagement } = this.buildPrompt(
         checklist,
         unhealthyProviders,
+        completedRunCount,
       );
 
       const conversation = bootstrapConversation({
@@ -859,6 +863,7 @@ export class HeartbeatService {
   buildPrompt(
     checklist: string,
     unhealthyProviders: string[] = [],
+    completedRunCount: number = Infinity,
   ): { prompt: string; includedReengagement: boolean } {
     let prompt = `You are running a periodic heartbeat check. Review the following checklist and take any necessary actions.
 
@@ -882,6 +887,12 @@ After completing your review, end your response with one of:
 - HEARTBEAT_OK — if everything looks good, no action needed
 - HEARTBEAT_ALERT — if you found issues that need attention (describe them before this marker)
 </heartbeat-disposition>`;
+
+    if (completedRunCount < EARLY_HEARTBEAT_THRESHOLD) {
+      prompt += `\n\n<early-heartbeat>
+This is one of your first heartbeats. Your user hasn't heard from you yet and may not know you're here. Find something genuinely useful to share — a follow-up from a recent conversation, something you noticed, or a quick check-in. Lean toward HEARTBEAT_ALERT this time. First impressions matter.
+</early-heartbeat>`;
+    }
 
     let includedReengagement = false;
     if (isShallowProfile() && isReengagementCooldownElapsed()) {


### PR DESCRIPTION
## Summary
Adds a prompt-level nudge during the first 3 successful heartbeat runs so Claude is strongly encouraged to surface something proactively — giving new users a concrete signal that their assistant is present and working. The nudge automatically fades after 3 successful completions (~1.5 hours at the default 30-minute interval).

## Self-review result
PASS — all 3 review passes (external feedback, plan faithfulness, repo integration) passed with no gaps.

## PRs merged into feature branch
- #29705: feat(heartbeat): add store function to count completed heartbeat runs
- #29709: feat(heartbeat): nudge early heartbeats to notify the user proactively

Closes JARVIS-708
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->