### PR TITLE
fix: remove stale SKILLS.md cleanup plumbing

### DIFF
--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -40,15 +46,17 @@ afterEach(() => {
 });
 
 describe("delete_managed_skill tool", () => {
-  test("deletes existing skill without updating SKILLS.md", async () => {
+  test("deletes existing skill while leaving a stale SKILLS.md index unchanged", async () => {
     createSkill("doomed");
     createSkill("survivor");
     const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
-    writeFileSync(indexPath, "- doomed\n- survivor\n");
+    const staleIndex = "- doomed\n- survivor\n";
+    writeFileSync(indexPath, staleIndex);
 
     const result = await executeDeleteManagedSkill(
       {
         skill_id: "doomed",
+        remove_from_index: false,
       },
       makeContext(),
     );
@@ -62,6 +70,7 @@ describe("delete_managed_skill tool", () => {
     expect(existsSync(join(TEST_DIR, "skills", "doomed"))).toBe(false);
 
     expect(existsSync(indexPath)).toBe(true);
+    expect(readFileSync(indexPath, "utf-8")).toBe(staleIndex);
   });
 
   test("returns error for non-existent skill", async () => {

--- a/assistant/src/__tests__/get-skill-detail-audit.test.ts
+++ b/assistant/src/__tests__/get-skill-detail-audit.test.ts
@@ -150,13 +150,11 @@ mock.module("../skills/clawhub-files.js", () => ({
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
-  upsertSkillsIndex: () => {},
 }));
 
 mock.module("../skills/managed-store.js", () => ({
   createManagedSkill: () => ({ created: true }),
   deleteManagedSkill: () => ({ deleted: true }),
-  removeSkillsIndexEntry: () => {},
   validateManagedSkillId: () => null,
 }));
 
@@ -187,8 +185,6 @@ import { getSkill } from "../daemon/handlers/skills.js";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -152,7 +152,6 @@ mock.module("../skills/catalog-cache.js", () => ({
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
-  upsertSkillsIndex: () => {},
   getRepoSkillsDir: () => undefined,
 }));
 
@@ -163,7 +162,6 @@ mock.module("../skills/catalog-search.js", () => ({
 mock.module("../skills/managed-store.js", () => ({
   createManagedSkill: () => ({ created: true }),
   deleteManagedSkill: () => ({ deleted: true }),
-  removeSkillsIndexEntry: () => {},
   validateManagedSkillId: () => null,
 }));
 

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -239,7 +239,6 @@ describe("createManagedSkill", () => {
     });
 
     expect(result.created).toBe(true);
-    expect(result.indexUpdated).toBe(false);
     expect(result.error).toBeUndefined();
     expect(existsSync(result.path)).toBe(true);
 
@@ -335,20 +334,6 @@ describe("createManagedSkill", () => {
     const skill = catalog.find((s) => s.id === "discovered-skill");
     expect(skill).toBeDefined();
     expect(skill!.name).toBe("Discovered");
-  });
-
-  test("accepts deprecated addToIndex without creating SKILLS.md", () => {
-    const result = createManagedSkill({
-      id: "compat-no-index",
-      name: "Compat No Index",
-      description: "Compatibility input is ignored",
-      bodyMarkdown: "Body.",
-      addToIndex: false,
-    });
-
-    expect(result.created).toBe(true);
-    expect(result.indexUpdated).toBe(false);
-    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
   });
 });
 
@@ -454,7 +439,6 @@ describe("deleteManagedSkill", () => {
 
     const result = deleteManagedSkill("to-delete");
     expect(result.deleted).toBe(true);
-    expect(result.indexUpdated).toBe(false);
     expect(existsSync(join(TEST_DIR, "skills", "to-delete"))).toBe(false);
 
     const catalog = loadSkillCatalog(undefined, [join(TEST_DIR, "skills")]);
@@ -473,7 +457,7 @@ describe("deleteManagedSkill", () => {
     expect(result.error).toContain("traversal");
   });
 
-  test("accepts deprecated removeFromIndex without editing SKILLS.md", () => {
+  test("delete leaves a stale SKILLS.md index unchanged", () => {
     createManagedSkill({
       id: "keep-index",
       name: "Keep Index",
@@ -485,9 +469,8 @@ describe("deleteManagedSkill", () => {
       "- keep-index\n- survivor\n",
     );
 
-    const result = deleteManagedSkill("keep-index", false);
+    const result = deleteManagedSkill("keep-index");
     expect(result.deleted).toBe(true);
-    expect(result.indexUpdated).toBe(false);
 
     const indexContent = readFileSync(
       join(TEST_DIR, "skills", "SKILLS.md"),
@@ -511,7 +494,6 @@ describe("deleteManagedSkill", () => {
     const skillsDir = join(TEST_DIR, "skills");
     const result = deleteManagedSkill("delete-no-index");
     expect(result.deleted).toBe(true);
-    expect(result.indexUpdated).toBe(false);
     expect(existsSync(join(skillsDir, "delete-no-index"))).toBe(false);
     expect(existsSync(join(skillsDir, "SKILLS.md"))).toBe(false);
   });

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -39,6 +39,7 @@ describe("scaffold_managed_skill tool", () => {
         name: "Test Skill",
         description: "A test skill",
         body_markdown: "Do the thing.",
+        add_to_index: false,
       },
       makeContext(),
     );

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -115,10 +115,6 @@ describe("skill_load tool", () => {
       "Runs release checks",
       "1. Run tests",
     );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- release-checklist\n",
-    );
 
     const result = await executeSkillLoad({ skill: "release-checklist" });
     expect(result.isError).toBe(false);
@@ -140,7 +136,6 @@ describe("skill_load tool", () => {
       "Handles incidents",
       "Page primary responder",
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- oncall\n");
 
     const result = await executeSkillLoad({ skill: "oncall runbook" });
     expect(result.isError).toBe(false);
@@ -165,10 +160,6 @@ describe("skill_load tool", () => {
       "Release flow",
       "Run release checklist",
     );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- incident-response\n- release-checklist\n",
-    );
 
     const result = await executeSkillLoad({ skill: "incident" });
     expect(result.isError).toBe(false);
@@ -182,10 +173,6 @@ describe("skill_load tool", () => {
   test("returns an error when name resolution is ambiguous", async () => {
     writeSkill("skill-a", "Shared Name", "First", "Body A");
     writeSkill("skill-b", "Shared Name", "Second", "Body B");
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- skill-a\n- skill-b\n",
-    );
 
     const result = await executeSkillLoad({ skill: "Shared Name" });
     expect(result.isError).toBe(true);
@@ -200,7 +187,6 @@ describe("skill_load tool", () => {
       "Test versioning",
       "Original body",
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- versioned\n");
 
     const result1 = await executeSkillLoad({ skill: "versioned" });
     const match1 = result1.content.match(
@@ -229,7 +215,6 @@ describe("skill_load tool", () => {
 
   test("returns an error when skill is missing", async () => {
     writeSkill("existing", "Existing Skill", "Exists", "Body");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- existing\n");
 
     const result = await executeSkillLoad({ skill: "does-not-exist" });
     expect(result.isError).toBe(true);
@@ -270,7 +255,6 @@ describe("skill_load tool", () => {
       "A skill with no children",
       "Do the thing",
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- standalone\n");
 
     const result = await executeSkillLoad({ skill: "standalone" });
     expect(result.isError).toBe(false);
@@ -284,7 +268,6 @@ describe("skill_load tool", () => {
       "Should have one marker",
       "Step 1",
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- single-marker\n");
 
     const result = await executeSkillLoad({ skill: "single-marker" });
     expect(result.isError).toBe(false);
@@ -296,7 +279,6 @@ describe("skill_load tool", () => {
     writeSkillWithIncludes("parent", "Parent", "Has missing child", "Body", [
       "missing-child",
     ]);
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- parent\n");
 
     const result = await executeSkillLoad({ skill: "parent" });
     expect(result.isError).toBe(true);
@@ -312,10 +294,6 @@ describe("skill_load tool", () => {
     writeSkillWithIncludes("skill-b", "Skill B", "Cycles", "Body B", [
       "skill-a",
     ]);
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- skill-a\n- skill-b\n",
-    );
 
     const result = await executeSkillLoad({ skill: "skill-a" });
     expect(result.isError).toBe(true);
@@ -332,10 +310,6 @@ describe("skill_load tool", () => {
       ["valid-child"],
     );
     writeSkill("valid-child", "Valid Child", "A child", "Child body");
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- valid-parent\n- valid-child\n",
-    );
 
     const result = await executeSkillLoad({ skill: "valid-parent" });
     expect(result.isError).toBe(false);
@@ -350,7 +324,6 @@ describe("skill_load tool", () => {
       join(skillDir, "SKILL.md"),
       '---\nname: "Marker Missing"\ndescription: "test"\nmetadata: {"vellum":{"includes":["nonexistent"]}}\n---\n\nBody.\n',
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- marker-missing\n");
 
     const result = await executeSkillLoad({ skill: "marker-missing" });
     expect(result.isError).toBe(true);
@@ -371,10 +344,6 @@ describe("skill_load tool", () => {
       join(dirB, "SKILL.md"),
       '---\nname: "Cycle B"\ndescription: "test"\nmetadata: {"vellum":{"includes":["cycle-a"]}}\n---\n\nBody B.\n',
     );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- cycle-a\n- cycle-b\n",
-    );
 
     const result = await executeSkillLoad({ skill: "cycle-a" });
     expect(result.isError).toBe(true);
@@ -384,7 +353,6 @@ describe("skill_load tool", () => {
 
   test("succeeds when skill has no includes", async () => {
     writeSkill("no-includes", "No Includes", "Plain skill", "Body");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- no-includes\n");
 
     const result = await executeSkillLoad({ skill: "no-includes" });
     expect(result.isError).toBe(false);
@@ -399,10 +367,6 @@ describe("skill_load tool", () => {
       join(parentDir, "SKILL.md"),
       '---\nname: "Parent"\ndescription: "Has children"\nmetadata: {"vellum":{"includes":["child-skill"]}}\n---\n\nParent body.\n',
     );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- parent-with-children\n- child-skill\n",
-    );
 
     const result = await executeSkillLoad({ skill: "parent-with-children" });
     expect(result.isError).toBe(false);
@@ -413,7 +377,6 @@ describe("skill_load tool", () => {
 
   test('skill_load output shows "none" when no includes', async () => {
     writeSkill("solo-skill", "Solo", "No children", "Body");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- solo-skill\n");
 
     const result = await executeSkillLoad({ skill: "solo-skill" });
     expect(result.isError).toBe(false);
@@ -434,10 +397,6 @@ describe("skill_load tool", () => {
       "Parent with includes",
       "Parent instructions.",
       ["e2e-child"],
-    );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- e2e-parent\n- e2e-child\n",
     );
 
     // Load the parent
@@ -478,10 +437,6 @@ describe("skill_load tool", () => {
       "Top-level",
       "Grandparent body",
       ["child"],
-    );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- grandparent\n- child\n- grandchild\n",
     );
 
     const result = await executeSkillLoad({ skill: "grandparent" });
@@ -534,10 +489,6 @@ describe("skill_load tool", () => {
       "Root body",
       ["branch-a", "branch-b"],
     );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- diamond-root\n- branch-a\n- branch-b\n- shared-leaf\n",
-    );
 
     const result = await executeSkillLoad({ skill: "diamond-root" });
     expect(result.isError).toBe(false);
@@ -576,7 +527,6 @@ describe("skill_load tool", () => {
       "Body",
       ["self-ref"],
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- self-ref\n");
 
     const result = await executeSkillLoad({ skill: "self-ref" });
     expect(result.isError).toBe(true);
@@ -601,7 +551,6 @@ describe("skill_load tool", () => {
       join(skillDir, "references", "TROUBLESHOOTING.md"),
       "# Troubleshooting\n\nFix things here.",
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- with-refs\n");
 
     const result = await executeSkillLoad({ skill: "with-refs" });
     expect(result.isError).toBe(false);
@@ -624,7 +573,6 @@ describe("skill_load tool", () => {
 
   test("skill without references/ directory loads normally", async () => {
     writeSkill("no-refs", "No Refs", "No references dir", "Just body.");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- no-refs\n");
 
     const result = await executeSkillLoad({ skill: "no-refs" });
     expect(result.isError).toBe(false);
@@ -650,8 +598,6 @@ describe("skill_load tool", () => {
     writeFileSync(outsideSecretPath, "TOP_SECRET_DO_NOT_LOAD");
     symlinkSync(outsideSecretPath, join(skillDir, "references", "secret.md"));
 
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- refs-symlink\n");
-
     const result = await executeSkillLoad({ skill: "refs-symlink" });
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Body.");
@@ -675,7 +621,6 @@ describe("skill_load tool", () => {
       join(skillDir, "references", "data.json"),
       '{"key": "value"}',
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- refs-filter\n");
 
     const result = await executeSkillLoad({ skill: "refs-filter" });
     expect(result.isError).toBe(false);
@@ -695,7 +640,6 @@ describe("skill_load tool", () => {
       join(skillDir, "SKILL.md"),
       '---\nname: "Empty Includes"\ndescription: "Has empty array"\nmetadata: {"vellum":{"includes":[]}}\n---\n\nBody.\n',
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- empty-includes\n");
 
     const result = await executeSkillLoad({ skill: "empty-includes" });
     expect(result.isError).toBe(false);
@@ -746,11 +690,6 @@ describe("skill_load tool", () => {
         },
       },
     ]);
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- skill-with-tools\n",
-    );
-
     const result = await executeSkillLoad({ skill: "skill-with-tools" });
     expect(result.isError).toBe(false);
 
@@ -784,7 +723,6 @@ describe("skill_load tool", () => {
 
   test("skill without TOOLS.json does not include tool schemas section", async () => {
     writeSkill("no-tools", "No Tools", "No tools manifest", "Body.");
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- no-tools\n");
 
     const result = await executeSkillLoad({ skill: "no-tools" });
     expect(result.isError).toBe(false);
@@ -817,10 +755,6 @@ describe("skill_load tool", () => {
         },
       },
     ]);
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      "- parent-tools\n- child-tools\n",
-    );
 
     const result = await executeSkillLoad({ skill: "parent-tools" });
     expect(result.isError).toBe(false);
@@ -845,17 +779,11 @@ describe("skill_load tool", () => {
       "Parent body",
       ["dep-a"],
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- auto-parent\n");
 
     // Mock autoInstallFromCatalog to succeed and write the skill to disk
     mockAutoInstall.mockImplementation((skillId: string) => {
       if (skillId === "dep-a") {
         writeSkill("dep-a", "Dep A", "A dependency", "Dep A body");
-        // Add to SKILLS.md so catalog reload finds it
-        writeFileSync(
-          join(TEST_DIR, "skills", "SKILLS.md"),
-          "- auto-parent\n- dep-a\n",
-        );
         return Promise.resolve(true);
       }
       return Promise.resolve(false);
@@ -873,7 +801,6 @@ describe("skill_load tool", () => {
     writeSkillWithIncludes("trans-a", "Trans A", "Top level", "Body A", [
       "trans-b",
     ]);
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- trans-a\n");
 
     let round = 0;
     mockAutoInstall.mockImplementation((skillId: string) => {
@@ -882,20 +809,12 @@ describe("skill_load tool", () => {
         writeSkillWithIncludes("trans-b", "Trans B", "Mid level", "Body B", [
           "trans-c",
         ]);
-        writeFileSync(
-          join(TEST_DIR, "skills", "SKILLS.md"),
-          "- trans-a\n- trans-b\n",
-        );
         round++;
         return Promise.resolve(true);
       }
       if (skillId === "trans-c") {
         // Second round: install C
         writeSkill("trans-c", "Trans C", "Leaf", "Body C");
-        writeFileSync(
-          join(TEST_DIR, "skills", "SKILLS.md"),
-          "- trans-a\n- trans-b\n- trans-c\n",
-        );
         return Promise.resolve(true);
       }
       return Promise.resolve(false);
@@ -917,7 +836,6 @@ describe("skill_load tool", () => {
       "Body",
       ["dep-x"],
     );
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- fail-parent\n");
 
     // autoInstallFromCatalog throws an error
     mockAutoInstall.mockImplementation((skillId: string) => {
@@ -939,7 +857,6 @@ describe("skill_load tool", () => {
     writeSkillWithIncludes("loop-root", "Loop Root", "Infinite deps", "Body", [
       "loop-dep-0",
     ]);
-    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- loop-root\n");
 
     let installCount = 0;
     mockAutoInstall.mockImplementation((skillId: string) => {
@@ -955,12 +872,6 @@ describe("skill_load tool", () => {
           "Body",
           [nextDepId],
         );
-        // Update SKILLS.md to include all installed deps so far
-        const entries = ["- loop-root\n"];
-        for (let i = 0; i < installCount; i++) {
-          entries.push(`- loop-dep-${i}\n`);
-        }
-        writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), entries.join(""));
         return Promise.resolve(true);
       }
       return Promise.resolve(false);

--- a/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/skills-files-catalog-fallback.test.ts
@@ -164,7 +164,6 @@ mock.module("../skills/skill-file-provider.js", () => ({}));
 
 mock.module("../skills/catalog-install.js", () => ({
   installSkillLocally: async () => {},
-  upsertSkillsIndex: () => {},
 }));
 
 mock.module("../skills/catalog-search.js", () => ({
@@ -188,7 +187,6 @@ mock.module("../skills/skillssh-registry.js", () => ({
 mock.module("../skills/managed-store.js", () => ({
   createManagedSkill: () => ({ created: true }),
   deleteManagedSkill: () => ({ deleted: true }),
-  removeSkillsIndexEntry: () => {},
   validateManagedSkillId: () => null,
 }));
 
@@ -237,7 +235,6 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
 
 function makeSummary(overrides: Partial<SkillSummary>): SkillSummary {
   return {

--- a/assistant/src/__tests__/skills-uninstall.test.ts
+++ b/assistant/src/__tests__/skills-uninstall.test.ts
@@ -53,64 +53,36 @@ afterEach(() => {
 });
 
 describe("assistant skills uninstall", () => {
-  test("removes skill directory without editing SKILLS.md", () => {
-    /**
-     * Tests the happy path for uninstalling a skill.
-     */
-
-    // GIVEN a skill is installed locally
+  test("removes skill directory while leaving a stale SKILLS.md index unchanged", () => {
     installFakeSkill("weather");
     const originalIndex = "- weather\n- vellum-self-knowledge\n";
     writeSkillsIndex(originalIndex);
 
-    // WHEN we uninstall the skill
     uninstallSkillLocally("weather");
 
-    // THEN the skill directory should be removed
     expect(existsSync(join(getSkillsDir(), "weather"))).toBe(false);
 
-    // AND SKILLS.md should be left unchanged
     const index = readFileSync(getSkillsIndexPath(), "utf-8");
     expect(index).toBe(originalIndex);
   });
 
   test("errors when skill is not installed", () => {
-    /**
-     * Tests that uninstalling a non-existent skill throws an error.
-     */
-
-    // GIVEN no skills are installed
-    // WHEN we try to uninstall a nonexistent skill
-    // THEN it should throw an error
     expect(() => uninstallSkillLocally("nonexistent")).toThrow(
       'Skill "nonexistent" is not installed.',
     );
   });
 
-  test("works when SKILLS.md does not exist", () => {
-    /**
-     * Tests that uninstall works even if the SKILLS.md index file is missing.
-     */
-
-    // GIVEN a skill directory exists but no SKILLS.md
+  test("works when no stale SKILLS.md index exists", () => {
     installFakeSkill("weather");
 
-    // WHEN we uninstall the skill
     uninstallSkillLocally("weather");
 
-    // THEN the skill directory should be removed
     expect(existsSync(join(getSkillsDir(), "weather"))).toBe(false);
 
-    // AND no SKILLS.md should have been created
     expect(existsSync(getSkillsIndexPath())).toBe(false);
   });
 
-  test("removes skill with nested files", () => {
-    /**
-     * Tests that uninstall recursively removes skills with nested directories.
-     */
-
-    // GIVEN a skill with nested files is installed
+  test("removes skill with nested files while leaving a stale SKILLS.md index unchanged", () => {
     const skillDir = join(getSkillsDir(), "weather");
     mkdirSync(join(skillDir, "scripts", "lib"), { recursive: true });
     writeFileSync(join(skillDir, "SKILL.md"), "# weather\n");
@@ -119,13 +91,10 @@ describe("assistant skills uninstall", () => {
     const originalIndex = "- weather\n";
     writeSkillsIndex(originalIndex);
 
-    // WHEN we uninstall the skill
     uninstallSkillLocally("weather");
 
-    // THEN the entire skill directory tree should be removed
     expect(existsSync(skillDir)).toBe(false);
 
-    // AND SKILLS.md should be left unchanged
     const index = readFileSync(getSkillsIndexPath(), "utf-8");
     expect(index).toBe(originalIndex);
   });

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -86,6 +86,20 @@ describe("skills catalog loading", () => {
     expect(catalog.map((skill) => skill.id)).toEqual(["first", "second"]);
   });
 
+  test("managed skill overrides bundled skill with the same id", () => {
+    writeSkill(
+      "skill-management",
+      "Custom Skill Management",
+      "Managed override",
+    );
+
+    const skill = loadSkillCatalog().find((s) => s.id === "skill-management");
+    expect(skill).toBeDefined();
+    expect(skill!.source).toBe("managed");
+    expect(skill!.name).toBe("Custom Skill Management");
+    expect(skill!.bundled).toBeUndefined();
+  });
+
   test("does not discover symlinked skill directories that point outside ~/.vellum/workspace/skills", () => {
     const externalSkillDir = join(TEST_DIR, "outside", "external-skill");
     mkdirSync(externalSkillDir, { recursive: true });
@@ -201,6 +215,18 @@ describe("workspace skills", () => {
     expect(result.skill!.id).toBe("ws-load");
     expect(result.skill!.body).toBe("Full workspace body here");
     expect(result.skill!.source).toBe("workspace");
+  });
+
+  test("workspace skill overrides managed skill with the same id", () => {
+    writeSkill("shared-id", "Managed Shared", "Managed version");
+    writeWorkspaceSkill("shared-id", "Workspace Shared", "Workspace version");
+
+    const skill = loadSkillCatalog(workspaceSkillsDir).find(
+      (s) => s.id === "shared-id",
+    );
+    expect(skill).toBeDefined();
+    expect(skill!.source).toBe("workspace");
+    expect(skill!.name).toBe("Workspace Shared");
   });
 });
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -635,10 +635,6 @@ function discoverSkillDirectories(skillsDir: string): string[] {
   return dirs.sort((a, b) => a.localeCompare(b));
 }
 
-function getManagedSkillDirectories(skillsDir: string): string[] {
-  return discoverSkillDirectories(skillsDir);
-}
-
 // ─── Catalog loading ─────────────────────────────────────────────────────────
 
 function skillSummaryFromDefinition(
@@ -779,7 +775,7 @@ export function loadSkillCatalog(
 
   // Load managed (user) skills, which take precedence over bundled skills with the same ID
   const skillsDir = getSkillsDir();
-  const directories = getManagedSkillDirectories(skillsDir);
+  const directories = discoverSkillDirectories(skillsDir);
 
   for (const directory of directories) {
     const skill = readSkillFromDirectory(directory, skillsDir, "managed");

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -147,8 +147,6 @@ interface CreateManagedSkillParams {
   bodyMarkdown: string;
   emoji?: string;
   overwrite?: boolean;
-  /** @deprecated Managed skills are discovered from SKILL.md files. No-op. */
-  addToIndex?: boolean;
   includes?: string[];
   version?: string;
   contactId?: string;
@@ -157,8 +155,6 @@ interface CreateManagedSkillParams {
 interface CreateManagedSkillResult {
   created: boolean;
   path: string;
-  /** @deprecated Always false; managed skills are discovered from SKILL.md files. */
-  indexUpdated: boolean;
   error?: string;
 }
 
@@ -170,7 +166,6 @@ export function createManagedSkill(
     return {
       created: false,
       path: "",
-      indexUpdated: false,
       error: validationError,
     };
   }
@@ -179,7 +174,6 @@ export function createManagedSkill(
     return {
       created: false,
       path: "",
-      indexUpdated: false,
       error: "name is required",
     };
   }
@@ -187,7 +181,6 @@ export function createManagedSkill(
     return {
       created: false,
       path: "",
-      indexUpdated: false,
       error: "description is required",
     };
   }
@@ -199,7 +192,6 @@ export function createManagedSkill(
     return {
       created: false,
       path: skillFilePath,
-      indexUpdated: false,
       error: `Managed skill "${params.id}" already exists. Set overwrite=true to replace it.`,
     };
   }
@@ -234,30 +226,24 @@ export function createManagedSkill(
     "Created managed skill",
   );
 
-  return { created: true, path: skillFilePath, indexUpdated: false };
+  return { created: true, path: skillFilePath };
 }
 
 interface DeleteManagedSkillResult {
   deleted: boolean;
-  /** @deprecated Always false; managed skills are discovered from SKILL.md files. */
-  indexUpdated: boolean;
   error?: string;
 }
 
-export function deleteManagedSkill(
-  id: string,
-  _removeFromIndex = true,
-): DeleteManagedSkillResult {
+export function deleteManagedSkill(id: string): DeleteManagedSkillResult {
   const validationError = validateManagedSkillId(id);
   if (validationError) {
-    return { deleted: false, indexUpdated: false, error: validationError };
+    return { deleted: false, error: validationError };
   }
 
   const skillDir = getManagedSkillDir(id);
   if (!existsSync(skillDir)) {
     return {
       deleted: false,
-      indexUpdated: false,
       error: `Managed skill "${id}" not found`,
     };
   }
@@ -266,5 +252,5 @@ export function deleteManagedSkill(
   deleteSkillCapabilityNode(id);
   log.info({ id, path: skillDir }, "Deleted managed skill");
 
-  return { deleted: true, indexUpdated: false };
+  return { deleted: true };
 }

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -28,7 +28,7 @@ export async function executeDeleteManagedSkill(
     content: JSON.stringify({
       deleted: true,
       skill_id: skillId.trim(),
-      index_updated: result.indexUpdated,
+      index_updated: false,
     }),
     isError: false,
   };

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -106,7 +106,7 @@ export async function executeScaffoldManagedSkill(
       created: true,
       skill_id: skillId.trim(),
       path: result.path,
-      index_updated: result.indexUpdated,
+      index_updated: false,
     }),
     isError: false,
   };


### PR DESCRIPTION
## Summary
- Removes stale managed-skill index plumbing and obsolete mocks.
- Cleans tests so SKILLS.md appears only in explicit stale-index coverage.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->