### PR TITLE
fix: harden skill refresh and install validation

### DIFF
--- a/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
+++ b/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
@@ -151,4 +151,30 @@ describe("ConfigWatcher skills watcher reseeding", () => {
     expect(evictCalls).toBe(1);
     expect(skillsChangedCalls).toBe(1);
   });
+
+  test("coalesces multiple skill file changes into one catalog refresh", async () => {
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    const skillsWatcher = findWatcher(SKILLS_DIR);
+    expect(skillsWatcher).toBeDefined();
+    skillsWatcher!.callback("change", "example-skill/SKILL.md");
+    skillsWatcher!.callback("change", "example-skill/package.json");
+    skillsWatcher!.callback("change", "other-skill/SKILL.md");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(1);
+    expect(skillsChangedCalls).toBe(1);
+  });
 });

--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -3,19 +3,13 @@
  * `assistant/src/daemon/handlers/skills.ts`.
  *
  * One representative call site (the `installSkill` bundled branch) is
- * exercised — all 5 sites share the same delegation to
- * `maybeSeedMemoryV2Skills`, so a single suite covers behavior. Validates:
- *   - flag + config both on → helper invoked after seedSkillGraphNodes
- *     and the seed observed (callOrder picks up "v2")
- *   - flag off → helper still invoked, but the seed short-circuits
- *   - config.memory.v2.enabled off → helper still invoked, seed short-circuits
+ * exercised — all handler seed sites share the same delegation to
+ * `refreshSkillCapabilityMemories`, so a single suite covers behavior. Validates:
+ *   - handler invokes the centralized refresh helper with the live config.
  *
- * The handler delegates to `maybeSeedMemoryV2Skills` from
- * `daemon/memory-v2-startup.ts`. We mock that module directly so the test
- * does not have to drain the dynamic-import microtask chain. The helper's
- * gate semantics (flag + config + rejection swallowing) are covered by
- * `lifecycle-memory-v2-seed.test.ts`; here we only verify that the
- * handler invokes the helper synchronously with the live config.
+ * The helper's gate semantics (flag + config + rejection swallowing) are
+ * covered by `lifecycle-memory-v2-seed.test.ts`; here we only verify that the
+ * handler delegates to the centralized refresh path synchronously.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -25,14 +19,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const flagsState = { flagEnabled: true, configV2Enabled: true };
 
-const callOrder: string[] = [];
-
-const mockSeedSkillGraphNodes = mock(() => {
-  callOrder.push("v1");
-});
-// Body installed in `beforeEach` so each test sees a fresh implementation
-// that closes over the up-to-date `flagsState`.
-const mockMaybeSeedMemoryV2Skills = mock(
+const mockRefreshSkillCapabilityMemories = mock(
   (_config: { memory: { v2: { enabled: boolean } } }) => {},
 );
 
@@ -151,6 +138,7 @@ mock.module("../skills/catalog-cache.js", () => ({
 }));
 
 mock.module("../skills/catalog-install.js", () => ({
+  assertInstalledSkillDiscoverable: () => {},
   installSkillLocally: async () => {},
   upsertSkillsIndex: () => {},
   getRepoSkillsDir: () => undefined,
@@ -169,7 +157,7 @@ mock.module("../skills/managed-store.js", () => ({
 
 mock.module("../memory/graph/capability-seed.js", () => ({
   deleteSkillCapabilityNode: () => {},
-  seedSkillGraphNodes: mockSeedSkillGraphNodes,
+  seedSkillGraphNodes: () => {},
   seedUninstalledCatalogSkillMemories: async () => {},
 }));
 
@@ -178,8 +166,8 @@ mock.module("../memory/v2/skill-store.js", () => ({
   getSkillCapability: () => null,
 }));
 
-mock.module("../daemon/memory-v2-startup.js", () => ({
-  maybeSeedMemoryV2Skills: mockMaybeSeedMemoryV2Skills,
+mock.module("../daemon/skill-memory-refresh.js", () => ({
+  refreshSkillCapabilityMemories: mockRefreshSkillCapabilityMemories,
 }));
 
 mock.module("../util/platform.js", () => ({
@@ -222,44 +210,38 @@ describe("v2 skill re-seed gating in skill handlers", () => {
   beforeEach(() => {
     flagsState.flagEnabled = true;
     flagsState.configV2Enabled = true;
-    callOrder.length = 0;
-    mockSeedSkillGraphNodes.mockClear();
-    mockMaybeSeedMemoryV2Skills.mockClear();
-    mockMaybeSeedMemoryV2Skills.mockImplementation((config) => {
-      if (!flagsState.flagEnabled || !config.memory.v2.enabled) return;
-      callOrder.push("v2");
-    });
+    mockRefreshSkillCapabilityMemories.mockClear();
   });
 
-  test("flag + config both on → maybeSeedMemoryV2Skills invoked after seedSkillGraphNodes", async () => {
+  test("flag + config both on → refresh helper invoked with live config", async () => {
     const result = await installSkill({ slug: "bundled-skill" });
 
     expect(result.success).toBe(true);
-    expect(mockSeedSkillGraphNodes).toHaveBeenCalledTimes(1);
-    expect(mockMaybeSeedMemoryV2Skills).toHaveBeenCalledTimes(1);
-    expect(callOrder).toEqual(["v1", "v2"]);
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
+    expect(mockRefreshSkillCapabilityMemories.mock.calls[0]?.[0]).toEqual({
+      memory: { v2: { enabled: true } },
+    });
   });
 
-  test("flag off → seed mock observes the disabled flag and skips", async () => {
+  test("flag off → handler still delegates to refresh helper", async () => {
     flagsState.flagEnabled = false;
 
     const result = await installSkill({ slug: "bundled-skill" });
 
     expect(result.success).toBe(true);
-    expect(mockSeedSkillGraphNodes).toHaveBeenCalledTimes(1);
-    expect(mockMaybeSeedMemoryV2Skills).toHaveBeenCalledTimes(1);
-    expect(callOrder).toEqual(["v1"]);
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
   });
 
-  test("config.memory.v2.enabled off → seed mock observes config and skips", async () => {
+  test("config.memory.v2.enabled off → helper receives disabled config", async () => {
     flagsState.configV2Enabled = false;
 
     const result = await installSkill({ slug: "bundled-skill" });
 
     expect(result.success).toBe(true);
-    expect(mockSeedSkillGraphNodes).toHaveBeenCalledTimes(1);
-    expect(mockMaybeSeedMemoryV2Skills).toHaveBeenCalledTimes(1);
-    expect(callOrder).toEqual(["v1"]);
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
+    expect(mockRefreshSkillCapabilityMemories.mock.calls[0]?.[0]).toEqual({
+      memory: { v2: { enabled: false } },
+    });
   });
 
   // Note: "seed rejection swallowed" is now an internal concern of

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
@@ -38,13 +40,25 @@ const mockEnsureSkillEntry = mock(
     enabled: false,
   }),
 );
+const TEST_SKILLS_DIR = "/tmp/test-skills";
+const installedSkillIds = new Set<string>();
 
 // ---------------------------------------------------------------------------
 // Mock modules — before importing module under test
 // ---------------------------------------------------------------------------
 
 mock.module("../config/skills.js", () => ({
-  loadSkillCatalog: mockCatalogSkills,
+  loadSkillCatalog: () => [
+    ...mockCatalogSkills(),
+    ...[...installedSkillIds].map((id) => ({
+      id,
+      displayName: id,
+      description: `Installed ${id}`,
+      source: "managed",
+      directoryPath: join(TEST_SKILLS_DIR, id),
+      skillFilePath: join(TEST_SKILLS_DIR, id, "SKILL.md"),
+    })),
+  ],
 }));
 
 mock.module("../skills/clawhub.js", () => ({
@@ -100,6 +114,13 @@ mock.module("../skills/catalog-cache.js", () => ({
   getCatalog: mockGetCatalog,
 }));
 mock.module("../skills/catalog-install.js", () => ({
+  assertInstalledSkillDiscoverable: (skillId: string) => {
+    if (!installedSkillIds.has(skillId)) {
+      throw new Error(
+        `Installed skill "${skillId}" is missing SKILL.md at the skill root`,
+      );
+    }
+  },
   installSkillLocally: mockInstallSkillLocally,
 }));
 mock.module("../skills/catalog-search.js", () => ({
@@ -116,7 +137,7 @@ mock.module("../memory/graph/capability-seed.js", () => ({
   seedUninstalledCatalogSkillMemories: async () => {},
 }));
 mock.module("../util/platform.js", () => ({
-  getWorkspaceSkillsDir: () => "/tmp/test-skills",
+  getWorkspaceSkillsDir: () => TEST_SKILLS_DIR,
 }));
 mock.module("../daemon/handlers/shared.js", () => ({
   CONFIG_RELOAD_DEBOUNCE_MS: 100,
@@ -142,6 +163,9 @@ import { installSkill } from "../daemon/handlers/skills.js";
 
 describe("installSkill routing", () => {
   beforeEach(() => {
+    rmSync(TEST_SKILLS_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_SKILLS_DIR, { recursive: true });
+    installedSkillIds.clear();
     mockCatalogSkills.mockReset();
     mockClawhubInstall.mockReset();
     mockInstallExternalSkill.mockReset();
@@ -160,7 +184,28 @@ describe("installSkill routing", () => {
     mockEnsureSkillEntry.mockReturnValue({ enabled: false });
   });
 
+  function writeInstalledSkill(skillId: string): void {
+    const skillDir = join(TEST_SKILLS_DIR, skillId);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---
+name: "${skillId}"
+description: "Installed test skill."
+---
+
+Body.
+`,
+      "utf-8",
+    );
+    installedSkillIds.add(skillId);
+  }
+
   test("install with origin: 'skillssh' and multi-segment slug routes to installExternalSkill", async () => {
+    mockInstallExternalSkill.mockImplementation(async () => {
+      writeInstalledSkill("react-best-practices");
+    });
+
     const result = await installSkill({
       slug: "vercel-labs/agent-skills/react-best-practices",
       origin: "skillssh",
@@ -181,11 +226,17 @@ describe("installSkill routing", () => {
   });
 
   test("install without origin falls through to clawhub for simple slugs", async () => {
+    mockClawhubInstall.mockImplementation(async (slug: string) => {
+      writeInstalledSkill(slug);
+      return { success: true, skillName: slug };
+    });
+
     const result = await installSkill({ slug: "some-clawhub-skill" });
 
     expect(result.success).toBe(true);
     expect(mockClawhubInstall).toHaveBeenCalledTimes(1);
     expect(mockClawhubInstall).toHaveBeenCalledWith("some-clawhub-skill", {
+      contactId: undefined,
       version: undefined,
     });
     // Should not have called installExternalSkill
@@ -193,6 +244,11 @@ describe("installSkill routing", () => {
   });
 
   test("install with origin: 'clawhub' routes directly to clawhub without trying skills.sh", async () => {
+    mockClawhubInstall.mockImplementation(async (slug: string) => {
+      writeInstalledSkill(slug);
+      return { success: true, skillName: slug };
+    });
+
     const result = await installSkill({ slug: "my-skill", origin: "clawhub" });
 
     expect(result.success).toBe(true);
@@ -200,7 +256,28 @@ describe("installSkill routing", () => {
     expect(mockInstallExternalSkill).not.toHaveBeenCalled();
   });
 
+  test("clawhub install fails when the installed skill root is not discoverable", async () => {
+    mockClawhubInstall.mockResolvedValue({
+      success: true,
+      skillName: "missing-root-skill",
+    });
+
+    const result = await installSkill({
+      slug: "missing-root-skill",
+      origin: "clawhub",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("missing SKILL.md");
+    }
+  });
+
   test("multi-segment slug without explicit origin auto-routes to skills.sh", async () => {
+    mockInstallExternalSkill.mockImplementation(async () => {
+      writeInstalledSkill("my-skill");
+    });
+
     const result = await installSkill({ slug: "owner/repo/my-skill" });
 
     expect(result.success).toBe(true);
@@ -217,6 +294,12 @@ describe("installSkill routing", () => {
   });
 
   test("multi-segment slug with origin: 'clawhub' skips skills.sh and routes to clawhub", async () => {
+    mockClawhubInstall.mockImplementation(async (slug: string) => {
+      const skillId = slug.split("/").pop()!;
+      writeInstalledSkill(skillId);
+      return { success: true, skillName: skillId };
+    });
+
     // Even though the slug looks like skills.sh format, explicit origin: "clawhub"
     // should override the auto-detection and go to clawhub
     const result = await installSkill({

--- a/assistant/src/__tests__/skills-install-extract.test.ts
+++ b/assistant/src/__tests__/skills-install-extract.test.ts
@@ -90,4 +90,19 @@ describe("extractTarToDir", () => {
     expect(existsSync(join(tempDir, "windows.txt"))).toBe(false);
     expect(readFileSync(join(tempDir, "SKILL.md"), "utf-8")).toBe("# demo\n");
   });
+
+  test("does not count nested SKILL.md as a valid skill root", () => {
+    const tar = makeTar([
+      { name: "nested/SKILL.md", content: "# nested\n" },
+      { name: "README.md", content: "# wrapper\n" },
+    ]);
+
+    const foundSkillMd = extractTarToDir(tar, tempDir);
+
+    expect(foundSkillMd).toBe(false);
+    expect(existsSync(join(tempDir, "SKILL.md"))).toBe(false);
+    expect(readFileSync(join(tempDir, "nested", "SKILL.md"), "utf-8")).toBe(
+      "# nested\n",
+    );
+  });
 });

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -394,7 +394,7 @@ export class ConfigWatcher {
     if (!existsSync(skillsDir)) return;
 
     const scheduleSkillsReload = (file: string): void => {
-      this.debounceTimers.schedule(`skills:${file}`, () => {
+      this.debounceTimers.schedule("skills:catalog", () => {
         log.info({ file }, "Skill file changed, reloading");
         onConversationEvict();
         onSkillsChanged?.();

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -20,11 +20,7 @@ import {
 } from "../../config/loader.js";
 import { resolveSkillStates, skillFlagKey } from "../../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../../config/skills.js";
-import {
-  deleteSkillCapabilityNode,
-  seedSkillGraphNodes,
-  seedUninstalledCatalogSkillMemories,
-} from "../../memory/graph/capability-seed.js";
+import { deleteSkillCapabilityNode } from "../../memory/graph/capability-seed.js";
 import {
   createTimeout,
   extractText,
@@ -46,6 +42,7 @@ import {
   SKIP_DIRS,
 } from "../../skills/catalog-files.js";
 import {
+  assertInstalledSkillDiscoverable,
   type CatalogSkill,
   installSkillLocally,
 } from "../../skills/catalog-install.js";
@@ -80,12 +77,12 @@ import {
 } from "../../skills/skillssh-registry.js";
 import { getWorkspaceSkillsDir } from "../../util/platform.js";
 import { getConfigWatcher } from "../config-watcher.js";
-import { maybeSeedMemoryV2Skills } from "../memory-v2-startup.js";
 import type {
   SkillDetailResponse,
   SkillFileContentResponse,
   SlimSkillResponse,
 } from "../message-types/skills.js";
+import { refreshSkillCapabilityMemories } from "../skill-memory-refresh.js";
 import { CONFIG_RELOAD_DEBOUNCE_MS, ensureSkillEntry, log } from "./shared.js";
 
 // ─── Provider chain for uninstalled skill file preview ───────────────────────
@@ -268,9 +265,9 @@ function saveConfigWithSuppression(raw: Record<string, unknown>): void {
  * NOT used for bundled skills — those have a simpler inline path in
  * `installSkill()` that only auto-enables, broadcasts, and seeds memories.
  */
-function postInstallSkill(skillId: string, _skillDir: string): void {
+function postInstallSkill(skillId: string, skillDir: string): void {
   // Reload skill catalog so the newly installed skill is picked up
-  loadSkillCatalog();
+  assertInstalledSkillDiscoverable(skillId, skillDir);
 
   // Auto-enable the skill in config
   try {
@@ -287,9 +284,7 @@ function postInstallSkill(skillId: string, _skillDir: string): void {
   }
 
   // Seed skill memories
-  seedSkillGraphNodes();
-  maybeSeedMemoryV2Skills(getConfig());
-  void seedUninstalledCatalogSkillMemories().catch(() => {});
+  refreshSkillCapabilityMemories(getConfig());
 }
 
 // ─── Kind / origin / status derivation ───────────────────────────────────────
@@ -945,9 +940,7 @@ export function enableSkill(
       name: skillId,
       state: "enabled",
     });
-    seedSkillGraphNodes();
-    maybeSeedMemoryV2Skills(getConfig());
-    void seedUninstalledCatalogSkillMemories().catch(() => {});
+    refreshSkillCapabilityMemories(getConfig());
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -968,9 +961,7 @@ export function disableSkill(
       name: skillId,
       state: "disabled",
     });
-    seedSkillGraphNodes();
-    maybeSeedMemoryV2Skills(getConfig());
-    void seedUninstalledCatalogSkillMemories().catch(() => {});
+    refreshSkillCapabilityMemories(getConfig());
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -1059,9 +1050,7 @@ export async function installSkill(spec: {
           "Failed to auto-enable bundled skill",
         );
       }
-      seedSkillGraphNodes();
-      maybeSeedMemoryV2Skills(config);
-      void seedUninstalledCatalogSkillMemories().catch(() => {});
+      refreshSkillCapabilityMemories(config);
       return { success: true, skillId: spec.slug };
     }
 
@@ -1620,9 +1609,7 @@ export async function createSkill(
       );
     }
 
-    seedSkillGraphNodes();
-    maybeSeedMemoryV2Skills(getConfig());
-    void seedUninstalledCatalogSkillMemories().catch(() => {});
+    refreshSkillCapabilityMemories(getConfig());
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -128,6 +128,7 @@ import {
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
+import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
 
 const log = getLogger("lifecycle");
 let diskPressureStartupSampleTimer: ReturnType<typeof setTimeout> | null = null;
@@ -822,20 +823,10 @@ export async function runDaemon(): Promise<void> {
 
       // Seed capability graph nodes (new memory graph system)
       try {
-        const {
-          seedSkillGraphNodes,
-          seedCliGraphNodes,
-          seedUninstalledCatalogSkillMemories,
-        } = await import("../memory/graph/capability-seed.js");
-        seedSkillGraphNodes();
-        maybeSeedMemoryV2Skills(config);
+        const { seedCliGraphNodes } =
+          await import("../memory/graph/capability-seed.js");
+        refreshSkillCapabilityMemories(config);
         await seedCliGraphNodes();
-        void seedUninstalledCatalogSkillMemories().catch((err) =>
-          log.warn(
-            { err },
-            "Uninstalled catalog skill memory seeding failed — continuing",
-          ),
-        );
       } catch (err) {
         log.warn({ err }, "Graph capability seeding failed — continuing");
       }

--- a/assistant/src/daemon/skill-memory-refresh.ts
+++ b/assistant/src/daemon/skill-memory-refresh.ts
@@ -14,10 +14,16 @@ export function refreshSkillCapabilityMemories(
 ): void {
   seedSkillGraphNodes();
   maybeSeedMemoryV2Skills(config);
-  void seedUninstalledCatalogSkillMemories().catch((err) =>
-    log.warn(
-      { err },
-      "Uninstalled catalog skill memory seeding failed — continuing",
-    ),
-  );
+  void seedUninstalledCatalogSkillMemories()
+    .then(() => {
+      // Re-run after the async catalog fetch populates the cache so stale
+      // installed-skill nodes can be pruned without deleting catalog-only nodes.
+      seedSkillGraphNodes();
+    })
+    .catch((err) =>
+      log.warn(
+        { err },
+        "Uninstalled catalog skill memory seeding failed — continuing",
+      ),
+    );
 }

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -15,10 +15,20 @@
  *   - It swallows errors from the embedding backend — the function resolves
  *     and the cache is unchanged from prior state.
  *
- * Hermetic by design: the catalog loader, state resolver, embedding backend,
- * Qdrant module, and feature-flag resolver are all module-mocked so the suite
- * never reaches a real backend or filesystem.
+ * Hermetic by design: the embedding backend, Qdrant module, and feature-flag
+ * resolver are module-mocked so the suite never reaches a real backend. One
+ * regression case uses a temp workspace to exercise disk-discovered skills.
  */
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
@@ -47,8 +57,8 @@ interface PruneCall {
 }
 
 interface TestState {
-  catalog: SkillSummary[];
-  resolved: ResolvedSkill[];
+  catalog: SkillSummary[] | null;
+  resolved: ResolvedSkill[] | null;
   fullCatalog: CatalogSkill[];
   fullCatalogThrows: Error | null;
   flagsEnabled: Record<string, boolean>;
@@ -81,16 +91,39 @@ mock.module("../../../config/loader.js", () => ({
       qdrant: { url: "http://127.0.0.1:6333", vectorSize: 3, onDisk: false },
     },
     mcp: { servers: {} },
-    skills: { entries: {}, allowBundled: null },
+    skills: { entries: {}, allowBundled: [] },
   }),
 }));
 
 mock.module("../../../config/skills.js", () => ({
-  loadSkillCatalog: () => state.catalog,
+  loadSkillCatalog: () => state.catalog ?? loadDiskSkillCatalog(),
 }));
 
 mock.module("../../../config/skill-state.js", () => ({
-  resolveSkillStates: () => state.resolved,
+  resolveSkillStates: (
+    catalog: SkillSummary[],
+    config: { skills?: { allowBundled?: string[] | null } },
+  ) => {
+    if (state.resolved) return state.resolved;
+    return catalog
+      .filter((summary) => {
+        const allowBundled = config.skills?.allowBundled;
+        return !(
+          summary.source === "bundled" &&
+          allowBundled != null &&
+          !allowBundled.includes(summary.id)
+        );
+      })
+      .map((summary) => ({
+        summary,
+        state:
+          summary.source === "managed" ||
+          summary.source === "bundled" ||
+          summary.source === "plugin"
+            ? "enabled"
+            : "disabled",
+      }));
+  },
 }));
 
 mock.module("../../../config/assistant-feature-flags.js", () => ({
@@ -149,6 +182,34 @@ function makeSummary(overrides: Partial<SkillSummary> = {}): SkillSummary {
     source: "managed",
     ...overrides,
   };
+}
+
+function loadDiskSkillCatalog(): SkillSummary[] {
+  const skillsDir = join(process.env.VELLUM_WORKSPACE_DIR!, "skills");
+  return readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const directoryPath = join(skillsDir, entry.name);
+      const skillFilePath = join(directoryPath, "SKILL.md");
+      const content = readFileSync(skillFilePath, "utf-8");
+      const name = content.match(/^name:\s*"([^"]+)"/m)?.[1] ?? entry.name;
+      const description =
+        content.match(/^description:\s*"([^"]+)"/m)?.[1] ?? "";
+      const activationHints = [...content.matchAll(/^\s+-\s+(.+)$/gm)].map(
+        (match) => match[1]!.trim(),
+      );
+      return {
+        id: entry.name,
+        name,
+        displayName: name,
+        description,
+        directoryPath,
+        skillFilePath,
+        source: "managed" as const,
+        activationHints: activationHints.slice(0, 1),
+        avoidWhen: activationHints.slice(1, 2),
+      };
+    });
 }
 
 function resetState(): void {
@@ -383,21 +444,73 @@ describe("seedV2SkillEntries", () => {
     expect(getSkillCapability("skills/unknown-skill")).toBeNull();
   });
 
-  test("seeds disk-discovered managed skills omitted from a stale SKILLS.md index", async () => {
-    const diskDiscovered = makeSummary({
-      id: "geo-article-writer",
-      name: "geo-article-writer",
-      displayName: "Geo Article Writer",
-      description: "Writes local geo articles",
-      activationHints: ["user asks for local article drafts"],
-      avoidWhen: ["user only wants citation extraction"],
-      source: "managed",
+  test("skips stale in-flight seed results when a newer refresh is requested", async () => {
+    const skillA = makeSummary({
+      id: "example-skill-a",
+      displayName: "Skill A",
     });
-    state.catalog = [diskDiscovered];
-    state.resolved = [{ summary: diskDiscovered, state: "enabled" }];
+    const skillB = makeSummary({
+      id: "example-skill-b",
+      displayName: "Skill B",
+    });
+    state.catalog = [skillA];
+    state.resolved = [{ summary: skillA, state: "enabled" }];
+    state.embedReturn = [[0.1, 0.2, 0.3]];
+
+    const firstSeed = seedV2SkillEntries();
+    state.catalog = [skillB];
+    state.resolved = [{ summary: skillB, state: "enabled" }];
+    const secondSeed = seedV2SkillEntries();
+
+    await Promise.all([firstSeed, secondSeed]);
+
+    expect(state.upsertCalls.map((call) => call.slug)).toEqual([
+      "skills/example-skill-b",
+    ]);
+    expect(getSkillCapability("example-skill-a")).toBeNull();
+    expect(getSkillCapability("example-skill-b")?.content).toContain("Skill B");
+  });
+
+  test("seeds disk-discovered managed skills omitted from a stale SKILLS.md index", async () => {
+    const previousWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    const workspaceDir = mkdtempSync(join(tmpdir(), "skill-store-index-"));
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+    state.catalog = null;
+    state.resolved = null;
     state.embedReturn = [[0.7, 0.8, 0.9]];
 
-    await seedV2SkillEntries();
+    try {
+      const skillsDir = join(workspaceDir, "skills");
+      const skillDir = join(skillsDir, "geo-article-writer");
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillsDir, "SKILLS.md"), "- stale-only\n", "utf-8");
+      writeFileSync(
+        join(skillDir, "SKILL.md"),
+        `---
+name: "Geo Article Writer"
+description: "Writes local geo articles"
+metadata:
+  vellum:
+    activation-hints:
+      - user asks for local article drafts
+    avoid-when:
+      - user only wants citation extraction
+---
+
+Write a local article draft.
+`,
+        "utf-8",
+      );
+
+      await seedV2SkillEntries();
+    } finally {
+      if (previousWorkspaceDir === undefined) {
+        delete process.env.VELLUM_WORKSPACE_DIR;
+      } else {
+        process.env.VELLUM_WORKSPACE_DIR = previousWorkspaceDir;
+      }
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
 
     expect(state.upsertCalls).toHaveLength(1);
     expect(state.upsertCalls[0].slug).toBe("skills/geo-article-writer");

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -65,6 +65,10 @@ export function skillSlugFor(id: string): string {
  * successful re-seed so callers always see a consistent snapshot.
  */
 let entries: Map<string, SkillEntry> | null = null;
+let requestedSeedGeneration = 0;
+let processedSeedGeneration = 0;
+let activeSeedDrain: Promise<void> | null = null;
+const seedWaiters: Array<{ generation: number; resolve: () => void }> = [];
 
 /**
  * Seed (or re-seed) skill embeddings into the unified concept-page collection.
@@ -90,7 +94,43 @@ let entries: Map<string, SkillEntry> | null = null;
  *      stale points from prior catalog state (e.g. uninstalled skills).
  *   7. Replace the module-level `entries` cache with the freshly built map.
  */
-export async function seedV2SkillEntries(): Promise<void> {
+export function seedV2SkillEntries(): Promise<void> {
+  const generation = ++requestedSeedGeneration;
+  const waiter = new Promise<void>((resolve) => {
+    seedWaiters.push({ generation, resolve });
+  });
+  if (!activeSeedDrain) {
+    activeSeedDrain = drainSeedQueue().finally(() => {
+      activeSeedDrain = null;
+      if (processedSeedGeneration < requestedSeedGeneration) {
+        activeSeedDrain = drainSeedQueue().finally(() => {
+          activeSeedDrain = null;
+        });
+      }
+    });
+  }
+  return waiter;
+}
+
+async function drainSeedQueue(): Promise<void> {
+  while (processedSeedGeneration < requestedSeedGeneration) {
+    const generationToProcess = requestedSeedGeneration;
+    await runSeedV2SkillEntries(generationToProcess);
+    processedSeedGeneration = generationToProcess;
+    resolveSeedWaiters();
+  }
+}
+
+function resolveSeedWaiters(): void {
+  for (let i = seedWaiters.length - 1; i >= 0; i -= 1) {
+    const waiter = seedWaiters[i]!;
+    if (waiter.generation > processedSeedGeneration) continue;
+    seedWaiters.splice(i, 1);
+    waiter.resolve();
+  }
+}
+
+async function runSeedV2SkillEntries(generation: number): Promise<void> {
   try {
     const config = getConfig();
     const catalog = loadSkillCatalog();
@@ -148,6 +188,13 @@ export async function seedV2SkillEntries(): Promise<void> {
         applyCorrectionIfCalibrated(v, embedded.provider, embedded.model),
       ),
     );
+    if (generation !== requestedSeedGeneration) {
+      log.info(
+        { generation, latestGeneration: requestedSeedGeneration },
+        "Skipping stale v2 skill seed result",
+      );
+      return;
+    }
 
     const now = Date.now();
     const nextEntries = new Map<string, SkillEntry>();
@@ -211,4 +258,8 @@ export function isSkillSlug(slug: string): boolean {
 /** @internal Test-only: clear the module-level cache. */
 export function _resetSkillStoreForTests(): void {
   entries = null;
+  requestedSeedGeneration = 0;
+  processedSeedGeneration = 0;
+  activeSeedDrain = null;
+  seedWaiters.splice(0, seedWaiters.length);
 }

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -12,6 +13,7 @@ import { dirname, join, posix, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
 import { getPlatformBaseUrl } from "../config/env.js";
+import { loadSkillCatalog } from "../config/skills.js";
 import { deleteSkillCapabilityNode } from "../memory/graph/capability-seed.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
@@ -124,7 +126,7 @@ export function readLocalCatalog(repoSkillsDir: string): CatalogSkill[] {
 
 /**
  * Extract all files from a tar archive (uncompressed) into a directory.
- * Returns true if a SKILL.md was found in the archive.
+ * Returns true if a top-level SKILL.md was found in the archive.
  */
 export function extractTarToDir(tarBuffer: Buffer, destDir: string): boolean {
   let foundSkillMd = false;
@@ -178,10 +180,7 @@ export function extractTarToDir(tarBuffer: Buffer, destDir: string): boolean {
         mkdirSync(dirname(destPath), { recursive: true });
         writeFileSync(destPath, tarBuffer.subarray(offset, offset + size));
 
-        if (
-          normalizedPath === "SKILL.md" ||
-          normalizedPath.endsWith("/SKILL.md")
-        ) {
+        if (normalizedPath === "SKILL.md") {
           foundSkillMd = true;
         }
       }
@@ -231,6 +230,32 @@ export function uninstallSkillLocally(skillId: string): void {
   deleteSkillCapabilityNode(skillId);
 }
 
+export function assertInstalledSkillDiscoverable(
+  skillId: string,
+  skillDir = join(getWorkspaceSkillsDir(), skillId),
+): void {
+  const skillFilePath = join(skillDir, "SKILL.md");
+  if (!existsSync(skillFilePath)) {
+    throw new Error(
+      `Installed skill "${skillId}" is missing SKILL.md at the skill root`,
+    );
+  }
+
+  const discovered = loadSkillCatalog().some((skill) => {
+    if (skill.id !== skillId) return false;
+    try {
+      return realpathSync(skill.directoryPath) === realpathSync(skillDir);
+    } catch {
+      return skill.directoryPath === skillDir;
+    }
+  });
+  if (!discovered) {
+    throw new Error(
+      `Installed skill "${skillId}" was not discovered by the skill catalog`,
+    );
+  }
+}
+
 export async function installSkillLocally(
   skillId: string,
   catalogEntry: CatalogSkill,
@@ -246,6 +271,9 @@ export async function installSkillLocally(
     );
   }
 
+  if (overwrite && existsSync(skillDir)) {
+    rmSync(skillDir, { recursive: true, force: true });
+  }
   mkdirSync(skillDir, { recursive: true });
 
   // In dev mode, install from the local repo skills directory if available
@@ -267,6 +295,8 @@ export async function installSkillLocally(
     "Installed skill from %s",
     installSource,
   );
+
+  assertInstalledSkillDiscoverable(skillId, skillDir);
 
   // Write install metadata
   writeInstallMeta(skillDir, {

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { assertInstalledSkillDiscoverable } from "./catalog-install.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 import type {
   AuditResponse,
@@ -469,6 +470,8 @@ export async function installExternalSkill(
     mkdirSync(dirname(destPath), { recursive: true });
     writeFileSync(destPath, content, "utf-8");
   }
+
+  assertInstalledSkillDiscoverable(skillSlug, skillDir);
 
   // Write install metadata
   writeInstallMeta(skillDir, {


### PR DESCRIPTION
## Summary
- Coalesces and centralizes skill memory refreshes.
- Serializes Memory V2 skill reseeding and validates installed skills are discoverable before success.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->