### PR TITLE
fix: clean up macOS billing error presentation

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -2337,16 +2337,29 @@ describe("session-agent-loop", () => {
     });
 
     test("clears state even when agent loop throws", async () => {
+      const events: ServerMessage[] = [];
       const ctx = makeCtx({
         agentLoopRun: async () => {
           throw new Error("unexpected crash");
         },
       });
 
-      await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+      await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
 
       expect(ctx.processing).toBe(false);
       expect(ctx.abortController).toBeNull();
+      expect(events.find((event) => event.type === "error")).toMatchObject({
+        type: "error",
+        code: "CONVERSATION_PROCESSING_FAILED",
+        errorCategory: "processing_failed",
+      });
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toMatchObject({
+        type: "conversation_error",
+        code: "CONVERSATION_PROCESSING_FAILED",
+        errorCategory: "processing_failed",
+      });
     });
 
     test("drains queue after completion", async () => {

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -50,6 +50,10 @@ let lastCreateOptions: Record<string, unknown> | null = null;
 let lastConstructorOptions: Record<string, unknown> | null = null;
 let shouldThrow: Error | null = null;
 
+function userMsg(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
 // Simulate OpenAI.APIError
 class FakeAPIError extends Error {
   status: number;
@@ -1294,10 +1298,6 @@ describe("effort config passthrough", () => {
 // ---------------------------------------------------------------------------
 
 describe("OpenRouterProvider reasoning", () => {
-  function userMsg(text: string): Message {
-    return { role: "user", content: [{ type: "text", text }] };
-  }
-
   beforeEach(() => {
     fakeChunks = [textChunk("OK"), usageChunk(10, 2)];
     lastCreateParams = null;
@@ -1368,10 +1368,6 @@ describe("OpenRouterProvider reasoning", () => {
 });
 
 describe("OpenRouterProvider Anthropic-compatible errors", () => {
-  function userMsg(text: string): Message {
-    return { role: "user", content: [{ type: "text", text }] };
-  }
-
   test("retags Anthropic ProviderError instances as OpenRouter errors", async () => {
     const provider = new OpenRouterProvider("or-key", "anthropic/claude-4.5");
     const abortReason = createAbortReason(
@@ -1418,10 +1414,6 @@ describe("OpenRouterProvider Anthropic-compatible errors", () => {
 
 describe("OpenAIProvider reasoning_effort", () => {
   let provider: OpenAIProvider;
-
-  function userMsg(text: string): Message {
-    return { role: "user", content: [{ type: "text", text }] };
-  }
 
   beforeEach(() => {
     fakeChunks = [textChunk("OK"), usageChunk(10, 2)];

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -796,6 +796,7 @@ export async function runAgentLoopImpl(
         code: DISK_PRESSURE_ERROR_CODE,
         message,
         category: DISK_PRESSURE_ERROR_CATEGORY,
+        errorCategory: DISK_PRESSURE_ERROR_CATEGORY,
       });
       onEvent({
         type: "conversation_error",
@@ -3058,6 +3059,7 @@ export async function runAgentLoopImpl(
         conversationId: ctx.conversationId,
         code: classified.code,
         message: classified.userMessage,
+        errorCategory: classified.errorCategory,
       });
       onEvent(buildConversationErrorMessage(ctx.conversationId, classified));
     }

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -241,6 +241,8 @@ export interface ErrorMessage {
   message: string;
   /** Categorizes the error so the client can offer contextual actions (e.g. "Send Anyway" for secret_blocked). */
   category?: string;
+  /** Machine-readable conversation error category for clients that need source-aware recovery UI. */
+  errorCategory?: string;
 }
 
 export interface MessageQueued {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatErrorToastView.swift
@@ -203,20 +203,22 @@ struct ChatConversationErrorToast: View {
     }
 }
 
-// MARK: - Credits Exhausted Banner
+// MARK: - Above Composer Action Banner
 
-/// Inline banner shown when the user's credits are exhausted.
-/// Uses a warm, encouraging tone with a visual gauge and clear CTA.
-struct CreditsExhaustedBanner: View {
-    let onAddFunds: () -> Void
+private struct AboveComposerActionBanner: View {
+    let title: String
+    let subtitle: String
+    let actionLabel: String
+    let signpost: StaticString
+    let onAction: () -> Void
 
     var body: some View {
         HStack(spacing: VSpacing.xl) {
             VStack(alignment: .leading, spacing: 2) {
-                Text("💰  Your balance has run out")
+                Text(title)
                     .font(VFont.bodySmallEmphasised)
                     .foregroundStyle(VColor.contentEmphasized)
-                Text("Add funds to pick up where you left off.")
+                Text(subtitle)
                     .font(VFont.bodyMediumDefault)
                     .foregroundStyle(VColor.contentSecondary)
             }
@@ -224,8 +226,8 @@ struct CreditsExhaustedBanner: View {
 
             Spacer(minLength: 0)
 
-            VButton(label: "Add Funds", style: .primary) {
-                onAddFunds()
+            VButton(label: actionLabel, style: .primary) {
+                onAction()
             }
         }
         .padding(VSpacing.lg)
@@ -239,7 +241,25 @@ struct CreditsExhaustedBanner: View {
             )
         )
         .transition(.move(edge: .bottom).combined(with: .opacity))
-        .layoutHangSignpost("chat.creditsExhaustedBanner")
+        .layoutHangSignpost(signpost)
+    }
+}
+
+// MARK: - Credits Exhausted Banner
+
+/// Inline banner shown when the user's credits are exhausted.
+/// Uses a warm, encouraging tone with a visual gauge and clear CTA.
+struct CreditsExhaustedBanner: View {
+    let onAddFunds: () -> Void
+
+    var body: some View {
+        AboveComposerActionBanner(
+            title: "💰  Your balance has run out",
+            subtitle: "Add funds to pick up where you left off.",
+            actionLabel: "Add Funds",
+            signpost: "chat.creditsExhaustedBanner",
+            onAction: onAddFunds
+        )
     }
 }
 
@@ -253,35 +273,13 @@ struct ProviderBillingBanner: View {
     let onOpenSettings: () -> Void
 
     var body: some View {
-        HStack(spacing: VSpacing.xl) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Your API key needs credits")
-                    .font(VFont.bodySmallEmphasised)
-                    .foregroundStyle(VColor.contentEmphasized)
-                Text("Add funds with your provider or lower the model token limit.")
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(VColor.contentSecondary)
-            }
-            .layoutPriority(1)
-
-            Spacer(minLength: 0)
-
-            VButton(label: "Open Settings", style: .primary) {
-                onOpenSettings()
-            }
-        }
-        .padding(VSpacing.lg)
-        .background(VColor.surfaceActive)
-        .clipShape(
-            UnevenRoundedRectangle(
-                topLeadingRadius: VRadius.lg,
-                bottomLeadingRadius: 0,
-                bottomTrailingRadius: 0,
-                topTrailingRadius: VRadius.lg
-            )
+        AboveComposerActionBanner(
+            title: "Your API key needs credits",
+            subtitle: "Add funds with your provider or lower the model token limit.",
+            actionLabel: "Open Settings",
+            signpost: "chat.providerBillingBanner",
+            onAction: onOpenSettings
         )
-        .transition(.move(edge: .bottom).combined(with: .opacity))
-        .layoutHangSignpost("chat.providerBillingBanner")
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -353,7 +353,8 @@ struct ChatView: View {
             )
             .animation(nil, value: queuedMessages.isEmpty)
 
-            if let error = viewModel.errorManager.conversationError, error.isManagedCreditsExhausted {
+            if let error = viewModel.errorManager.conversationError,
+               error.presentationSurface == .managedCreditsBanner {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
                     CreditsExhaustedBanner(
                         onAddFunds: { onAddFunds?() }
@@ -363,7 +364,8 @@ struct ChatView: View {
                 .animation(nil, value: queuedMessages.isEmpty)
             }
 
-            if let error = viewModel.errorManager.conversationError, error.isProviderBilling {
+            if let error = viewModel.errorManager.conversationError,
+               error.presentationSurface == .providerBillingBanner {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
                     ProviderBillingBanner(
                         onOpenSettings: { onOpenModelsAndServices?() }
@@ -384,7 +386,8 @@ struct ChatView: View {
                 .animation(nil, value: queuedMessages.isEmpty)
             }
 
-            if let error = viewModel.errorManager.conversationError, error.isProviderNotConfigured {
+            if let error = viewModel.errorManager.conversationError,
+               error.presentationSurface == .missingApiKeyBanner {
                 centeredChatColumn(width: max(layoutMetrics.chatColumnWidth - 2 * VSpacing.xl, 0)) {
                     MissingApiKeyBanner(
                         onOpenSettings: { onOpenModelsAndServices?() },

--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -414,10 +414,7 @@ final class ConversationManager: ConversationRestorerDelegate {
             return self.isLatestToolUseRecipient(viewModel)
         }
         viewModel.shouldCreateInlineErrorMessage = { error in
-            !error.isManagedCreditsExhausted
-                && !error.isProviderBilling
-                && !error.isProviderNotConfigured
-                && !error.isManagedKeyInvalid
+            error.shouldCreateInlineErrorMessage
         }
         viewModel.onManagedKeyInvalid = { [weak self] in
             guard let self else { return }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -685,9 +685,7 @@ struct ErrorToastOverlay: View {
     var body: some View {
         VStack(alignment: .center, spacing: VSpacing.xs) {
             if let conversationError = errorManager.conversationError,
-               !conversationError.isManagedCreditsExhausted,
-               !conversationError.isProviderBilling,
-               !conversationError.isProviderNotConfigured,
+               !conversationError.shouldSuppressGenericErrorSurface,
                !errorManager.isConversationErrorDisplayedInline {
                 ChatConversationErrorToast(
                     error: conversationError,

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1476,11 +1476,8 @@ final class ChatViewModelTests: XCTestCase {
     func testProviderBillingCreditsExhaustedIsManagedCreditsExhausted() {
         viewModel.conversationId = "sess-1"
 
-        let errorMsg = ConversationErrorMessage(
-            conversationId: "sess-1",
-            code: .providerBilling,
+        let errorMsg = billingConversationErrorMessage(
             userMessage: "Your Vellum balance has run out.",
-            retryable: false,
             errorCategory: "credits_exhausted"
         )
         viewModel.handleServerMessage(.conversationError(errorMsg))
@@ -1491,17 +1488,16 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(error?.isManagedCreditsExhausted == true)
         XCTAssertTrue(error?.isCreditsExhausted == true)
         XCTAssertFalse(error?.isProviderBilling == true)
+        XCTAssertEqual(error?.presentationSurface, .managedCreditsBanner)
+        XCTAssertTrue(error?.shouldSuppressGenericErrorSurface == true)
         XCTAssertTrue(error?.recoverySuggestion.contains("Vellum account") == true)
     }
 
     func testProviderBillingErrorCategoryIsProviderBillingNotCreditsExhausted() {
         viewModel.conversationId = "sess-1"
 
-        let errorMsg = ConversationErrorMessage(
-            conversationId: "sess-1",
-            code: .providerBilling,
+        let errorMsg = billingConversationErrorMessage(
             userMessage: "Your provider API key needs credits.",
-            retryable: false,
             errorCategory: "provider_billing"
         )
         viewModel.handleServerMessage(.conversationError(errorMsg))
@@ -1512,18 +1508,43 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(error?.isManagedCreditsExhausted == true)
         XCTAssertFalse(error?.isCreditsExhausted == true)
         XCTAssertTrue(error?.isProviderBilling == true)
+        XCTAssertEqual(error?.presentationSurface, .providerBillingBanner)
+        XCTAssertTrue(error?.shouldSuppressGenericErrorSurface == true)
         XCTAssertTrue(error?.recoverySuggestion.contains("provider") == true)
         XCTAssertFalse(error?.recoverySuggestion.contains("Add credits") == true)
+    }
+
+    func testProviderBillingCodeWithoutErrorCategoryUsesVersionSkewFallback() {
+        viewModel.conversationId = "sess-1"
+
+        let errorMsg = billingConversationErrorMessage(
+            userMessage: "Your provider API key needs credits.",
+            errorCategory: nil
+        )
+        viewModel.handleServerMessage(.conversationError(errorMsg))
+
+        XCTAssertTrue(viewModel.conversationError?.isProviderBilling == true)
+        XCTAssertEqual(viewModel.conversationError?.presentationSurface, .providerBillingBanner)
+    }
+
+    func testProviderBillingCodeWithNonBillingErrorCategoryDoesNotUseProviderBillingBanner() {
+        viewModel.conversationId = "sess-1"
+
+        let errorMsg = billingConversationErrorMessage(
+            userMessage: "The provider request failed.",
+            errorCategory: "provider_api_error"
+        )
+        viewModel.handleServerMessage(.conversationError(errorMsg))
+
+        XCTAssertFalse(viewModel.conversationError?.isProviderBilling == true)
+        XCTAssertEqual(viewModel.conversationError?.presentationSurface, .generic)
     }
 
     func testConversationErrorPreservesProviderBillingErrorCategory() {
         viewModel.conversationId = "sess-1"
 
-        let errorMsg = ConversationErrorMessage(
-            conversationId: "sess-1",
-            code: .providerBilling,
+        let errorMsg = billingConversationErrorMessage(
             userMessage: "Your provider API key needs credits.",
-            retryable: false,
             errorCategory: "regenerate:provider_billing"
         )
         viewModel.handleServerMessage(.conversationError(errorMsg))
@@ -1540,11 +1561,9 @@ final class ChatViewModelTests: XCTestCase {
     func testConversationManagerViewModelSuppressesProviderBillingInlineErrorMessage() {
         let managerViewModel = makeConversationManagerViewModel(conversationId: "sess-provider-billing")
 
-        let errorMsg = ConversationErrorMessage(
+        let errorMsg = billingConversationErrorMessage(
             conversationId: "sess-provider-billing",
-            code: .providerBilling,
             userMessage: "Your provider API key needs credits.",
-            retryable: false,
             errorCategory: "provider_billing"
         )
         managerViewModel.handleServerMessage(.conversationError(errorMsg))
@@ -1552,17 +1571,16 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(managerViewModel.messages.count, 0)
         XCTAssertEqual(managerViewModel.errorText, "Your provider API key needs credits.")
         XCTAssertTrue(managerViewModel.conversationError?.isProviderBilling == true)
+        XCTAssertEqual(managerViewModel.conversationError?.presentationSurface, .providerBillingBanner)
         XCTAssertFalse(managerViewModel.errorManager.isConversationErrorDisplayedInline)
     }
 
     func testConversationManagerViewModelSuppressesManagedCreditsInlineErrorMessage() {
         let managerViewModel = makeConversationManagerViewModel(conversationId: "sess-managed-credits")
 
-        let errorMsg = ConversationErrorMessage(
+        let errorMsg = billingConversationErrorMessage(
             conversationId: "sess-managed-credits",
-            code: .providerBilling,
             userMessage: "Your Vellum balance has run out.",
-            retryable: false,
             errorCategory: "credits_exhausted"
         )
         managerViewModel.handleServerMessage(.conversationError(errorMsg))
@@ -1570,6 +1588,7 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(managerViewModel.messages.count, 0)
         XCTAssertEqual(managerViewModel.errorText, "Your Vellum balance has run out.")
         XCTAssertTrue(managerViewModel.conversationError?.isManagedCreditsExhausted == true)
+        XCTAssertEqual(managerViewModel.conversationError?.presentationSurface, .managedCreditsBanner)
         XCTAssertFalse(managerViewModel.errorManager.isConversationErrorDisplayedInline)
     }
 
@@ -1590,6 +1609,20 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertTrue(managerViewModel.messages[0].isError)
         XCTAssertEqual(managerViewModel.messages[0].text, "The provider request failed.")
         XCTAssertTrue(managerViewModel.errorManager.isConversationErrorDisplayedInline)
+    }
+
+    private func billingConversationErrorMessage(
+        conversationId: String = "sess-1",
+        userMessage: String,
+        errorCategory: String?
+    ) -> ConversationErrorMessage {
+        ConversationErrorMessage(
+            conversationId: conversationId,
+            code: .providerBilling,
+            userMessage: userMessage,
+            retryable: false,
+            errorCategory: errorCategory
+        )
     }
 
     private func makeConversationManagerViewModel(conversationId: String) -> ChatViewModel {

--- a/clients/shared/Features/Chat/ChatConversationError.swift
+++ b/clients/shared/Features/Chat/ChatConversationError.swift
@@ -95,6 +95,14 @@ public enum ConversationErrorCategory: Equatable, Sendable {
     }
 }
 
+/// Preferred UI surface for a conversation-level error.
+public enum ConversationErrorPresentationSurface: Equatable, Sendable {
+    case managedCreditsBanner
+    case providerBillingBanner
+    case missingApiKeyBanner
+    case generic
+}
+
 /// Typed error state for conversation-level errors from the daemon.
 public struct ConversationError: Equatable {
     public let category: ConversationErrorCategory
@@ -143,6 +151,27 @@ public struct ConversationError: Equatable {
         Self.isProviderBilling(category: category, errorCategory: errorCategory)
     }
 
+    public var presentationSurface: ConversationErrorPresentationSurface {
+        if isManagedCreditsExhausted {
+            return .managedCreditsBanner
+        }
+        if isProviderBilling {
+            return .providerBillingBanner
+        }
+        if isProviderNotConfigured {
+            return .missingApiKeyBanner
+        }
+        return .generic
+    }
+
+    public var shouldSuppressGenericErrorSurface: Bool {
+        presentationSurface != .generic
+    }
+
+    public var shouldCreateInlineErrorMessage: Bool {
+        !shouldSuppressGenericErrorSurface && !isManagedKeyInvalid
+    }
+
     /// Whether this error indicates that no provider is configured for inference.
     public var isProviderNotConfigured: Bool {
         category == .providerNotConfigured
@@ -174,6 +203,6 @@ public struct ConversationError: Equatable {
         if errorCategory?.hasSuffix("provider_billing") == true {
             return true
         }
-        return category == .providerBilling
+        return category == .providerBilling && errorCategory == nil
     }
 }


### PR DESCRIPTION
## Summary
- Centralize macOS conversation error presentation decisions for banner, toast, and inline suppression paths.
- Share the above-composer billing banner chrome and reduce duplicated billing test fixtures.
- Include classified errorCategory metadata on generic stream error events so web clients can route billing errors before conversation_error arrives.

Fixes gaps identified during plan review for macos-provider-billing-ux.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->