### PR TITLE
Canonicalize cleanup skill selector provenance

### DIFF
--- a/assistant/src/__tests__/active-skill-tools.test.ts
+++ b/assistant/src/__tests__/active-skill-tools.test.ts
@@ -2,18 +2,17 @@ import { describe, expect, test } from "bun:test";
 
 import type { Message } from "../providers/types.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
+import { BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR } from "../skills/system-storage-cleanup-constants.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /** Build an assistant message with a skill_load tool_use block. */
-function skillLoadUseMsg(id: string): Message {
+function skillLoadUseMsg(id: string, skill = "test"): Message {
   return {
     role: "assistant",
-    content: [
-      { type: "tool_use", id, name: "skill_load", input: { skill: "test" } },
-    ],
+    content: [{ type: "tool_use", id, name: "skill_load", input: { skill } }],
   };
 }
 
@@ -55,6 +54,31 @@ describe("deriveActiveSkills (ID-only)", () => {
       toolResultMsg("t1", 'Skill loaded.\n\n<loaded_skill id="deploy" />'),
     ];
     expect(deriveActiveSkills(messages).map((e) => e.id)).toEqual(["deploy"]);
+  });
+
+  test("normalizes bundled selector provenance from skill_load input", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", " bundled: system-storage-cleanup "),
+      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([
+      {
+        id: "system-storage-cleanup",
+        selector: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+      },
+    ]);
+  });
+
+  test("does not retain plain selector provenance", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", "system-storage-cleanup"),
+      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([
+      { id: "system-storage-cleanup" },
+    ]);
   });
 
   test("multiple markers from different skill_load tool results", () => {

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -34,64 +34,6 @@ mock.module("../config/skills.js", () => ({
   loadSkillCatalog: () => mockCatalog,
 }));
 
-mock.module("../skills/active-skill-tools.js", () => {
-  // Shared parsing logic for deriveActiveSkills
-  const parseMarkers = (messages: Message[]) => {
-    // Two-pass approach matching real implementation:
-    // 1. Collect tool_use IDs where name === 'skill_load'
-    const skillLoadSelectorsByUseId = new Map<string, string | undefined>();
-    for (const msg of messages) {
-      for (const block of msg.content) {
-        if (block.type === "tool_use" && block.name === "skill_load") {
-          const rawSelector =
-            typeof block.input.skill === "string"
-              ? block.input.skill
-              : undefined;
-          const selector = rawSelector?.startsWith("bundled:")
-            ? rawSelector
-            : undefined;
-          skillLoadSelectorsByUseId.set(block.id, selector);
-        }
-      }
-    }
-
-    // 2. Parse markers only from tool_result blocks whose tool_use_id matches
-    const re = /<loaded_skill\s+id="([^"]+)"(?:\s+version="([^"]+)")?\s*\/>/g;
-    const seen = new Set<string>();
-    const entries: Array<{ id: string; version?: string; selector?: string }> =
-      [];
-    for (const msg of messages) {
-      for (const block of msg.content) {
-        if (block.type !== "tool_result") continue;
-        if (!skillLoadSelectorsByUseId.has(block.tool_use_id)) continue;
-        const text = block.content;
-        if (!text) continue;
-        for (const match of text.matchAll(re)) {
-          if (!seen.has(match[1])) {
-            seen.add(match[1]);
-            const entry: { id: string; version?: string; selector?: string } = {
-              id: match[1],
-            };
-            if (match[2]) {
-              entry.version = match[2];
-            }
-            const selector = skillLoadSelectorsByUseId.get(block.tool_use_id);
-            if (selector) {
-              entry.selector = selector;
-            }
-            entries.push(entry);
-          }
-        }
-      }
-    }
-    return entries;
-  };
-
-  return {
-    deriveActiveSkills: (messages: Message[]) => parseMarkers(messages),
-  };
-});
-
 mock.module("../skills/tool-manifest.js", () => ({
   parseToolManifestFile: (filePath: string) => {
     // Extract skill ID from path: /skills/<id>/TOOLS.json → <id>
@@ -2089,7 +2031,7 @@ describe("versioned markers through session projection", () => {
     const history: Message[] = [
       ...skillLoadMessages(
         '<loaded_skill id="system-storage-cleanup" version="v1:bundled-cleanup" />',
-        "bundled:system-storage-cleanup",
+        "bundled: system-storage-cleanup",
       ),
     ];
 
@@ -2138,7 +2080,7 @@ describe("versioned markers through session projection", () => {
     expect(mockUnregisteredSkillIds).toContain("system-storage-cleanup");
   });
 
-  test("storage cleanup marker projects catalog tools when marker version matches", () => {
+  test("managed storage cleanup marker without bundled selector projects catalog tools", () => {
     mockCatalog = [makeSkill("system-storage-cleanup")];
     mockManifests = {
       "system-storage-cleanup": makeManifest(["shadow_cleanup_run"]),

--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
 import type { SkillProjectionContext } from "../daemon/conversation-tool-setup.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
+import { BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR } from "../skills/system-storage-cleanup-constants.js";
 import type { Tool } from "../tools/types.js";
 import type { DiskUsageInfo } from "../util/disk-usage.js";
 
@@ -360,7 +361,7 @@ This skill declares executable tools.
 
     const safeResult = await handler.checkPreExecutionGates(
       "skill_load",
-      { skill: "bundled:system-storage-cleanup" },
+      { skill: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR },
       baseContext,
       "sandbox",
       "low",
@@ -373,6 +374,40 @@ This skill declares executable tools.
       throw new Error("Expected instruction-only bundled skill_load to pass");
     }
     expect(safeResult.tool.name).toBe("skill_load");
+
+    const whitespaceSelectorResult = await handler.checkPreExecutionGates(
+      "skill_load",
+      { skill: "bundled: system-storage-cleanup" },
+      baseContext,
+      "sandbox",
+      "low",
+      Date.now(),
+      () => undefined,
+    );
+
+    expect(whitespaceSelectorResult.allowed).toBe(true);
+    if (!whitespaceSelectorResult.allowed) {
+      throw new Error("Expected normalized bundled selector to pass");
+    }
+    expect(whitespaceSelectorResult.tool.name).toBe("skill_load");
+
+    const plainCleanupResult = await handler.checkPreExecutionGates(
+      "skill_load",
+      { skill: "system-storage-cleanup" },
+      baseContext,
+      "sandbox",
+      "low",
+      Date.now(),
+      () => undefined,
+    );
+
+    expect(plainCleanupResult.allowed).toBe(false);
+    if (plainCleanupResult.allowed) {
+      throw new Error("Expected plain cleanup skill selector to be rejected");
+    }
+    expect(plainCleanupResult.result.content).toContain(
+      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+    );
 
     const dynamicResult = await handler.checkPreExecutionGates(
       "skill_load",
@@ -389,7 +424,7 @@ This skill declares executable tools.
       throw new Error("Expected dynamic skill_load to be rejected");
     }
     expect(dynamicResult.result.content).toContain(
-      'can only load the bundled "system-storage-cleanup" skill',
+      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
     );
 
     const unrelatedResult = await handler.checkPreExecutionGates(
@@ -409,7 +444,7 @@ This skill declares executable tools.
       );
     }
     expect(unrelatedResult.result.content).toContain(
-      'can only load the bundled "system-storage-cleanup" skill',
+      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
     );
 
     const toolManifestResult = await handler.checkPreExecutionGates(
@@ -427,7 +462,7 @@ This skill declares executable tools.
       throw new Error("Expected tool-manifest skill_load to be rejected");
     }
     expect(toolManifestResult.result.content).toContain(
-      'can only load the bundled "system-storage-cleanup" skill',
+      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
     );
 
     writeManagedSkill(
@@ -462,12 +497,12 @@ This managed skill shadows the bundled cleanup skill.
       throw new Error("Expected managed shadow cleanup skill to be rejected");
     }
     expect(shadowResult.result.content).toContain(
-      'can only load the bundled "system-storage-cleanup" skill',
+      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
     );
 
     const bundledShadowResult = await handler.checkPreExecutionGates(
       "skill_load",
-      { skill: "bundled:system-storage-cleanup" },
+      { skill: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR },
       baseContext,
       "sandbox",
       "low",

--- a/assistant/src/__tests__/injector-disk-pressure.test.ts
+++ b/assistant/src/__tests__/injector-disk-pressure.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../plugins/registry.js";
 import type { Injector, TurnContext } from "../plugins/types.js";
 import type { Message } from "../providers/types.js";
+import { BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR } from "../skills/system-storage-cleanup-constants.js";
 
 function findInjector(name: string): Injector {
   const injector = defaultInjectorsPlugin.injectors?.find(
@@ -83,7 +84,7 @@ Unrelated work remains blocked until disk usage drops below the critical thresho
 </disk_pressure_warning>`);
     expect(DISK_PRESSURE_WARNING_PROMPT).toContain("skill_load");
     expect(DISK_PRESSURE_WARNING_PROMPT).toContain(
-      "bundled:system-storage-cleanup",
+      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
     );
     expect(DISK_PRESSURE_WARNING_PROMPT).not.toContain(
       "Prefer safe inspection steps first",

--- a/assistant/src/__tests__/system-storage-cleanup-skill.test.ts
+++ b/assistant/src/__tests__/system-storage-cleanup-skill.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { loadSkillBySelector, loadSkillCatalog } from "../config/skills.js";
+import { BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR } from "../skills/system-storage-cleanup-constants.js";
 
 describe("system-storage-cleanup bundled skill", () => {
   test("is bundled without tools or inline command expansions", () => {
@@ -22,7 +23,7 @@ describe("system-storage-cleanup bundled skill", () => {
     expect(exactResult.skill?.id).toBe("system-storage-cleanup");
     expect(exactResult.skill?.source).toBe("bundled");
 
-    const result = loadSkillBySelector("bundled:system-storage-cleanup");
+    const result = loadSkillBySelector(BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR);
 
     expect(result.error).toBeUndefined();
     expect(result.skill).toBeDefined();
@@ -65,5 +66,13 @@ describe("system-storage-cleanup bundled skill", () => {
     expect(result.skill).toBeUndefined();
     expect(result.errorCode).toBe("invalid_selector");
     expect(result.error).toContain("bundled:system-storage-cleanup");
+  });
+
+  test("normalizes whitespace in the bundled cleanup selector", () => {
+    const result = loadSkillBySelector("bundled: system-storage-cleanup");
+
+    expect(result.error).toBeUndefined();
+    expect(result.skill?.id).toBe("system-storage-cleanup");
+    expect(result.skill?.source).toBe("bundled");
   });
 });

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -24,6 +24,12 @@ import {
 import { parseFrontmatterFields } from "../skills/frontmatter.js";
 import type { InlineCommandExpansion } from "../skills/inline-command-expansions.js";
 import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
+import {
+  BUNDLED_SKILL_SELECTOR_PREFIX,
+  BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+  normalizeBundledSkillSelector,
+  SYSTEM_STORAGE_CLEANUP_SKILL_ID,
+} from "../skills/system-storage-cleanup-constants.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import { getLogger } from "../util/logger.js";
@@ -36,10 +42,6 @@ import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { getConfig } from "./loader.js";
 
 const log = getLogger("skills");
-const BUNDLED_SKILL_SELECTOR_PREFIX = "bundled:";
-const BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR =
-  "bundled:system-storage-cleanup";
-const SYSTEM_STORAGE_CLEANUP_SKILL_ID = "system-storage-cleanup";
 
 // ─── Zod schemas for frontmatter metadata validation ─────────────────────────
 
@@ -1166,15 +1168,14 @@ export function resolveSkillSelector(
   }
 
   if (needle.startsWith(BUNDLED_SKILL_SELECTOR_PREFIX)) {
-    const bundledNeedle = needle
-      .slice(BUNDLED_SKILL_SELECTOR_PREFIX.length)
-      .trim();
-    if (!bundledNeedle || bundledNeedle !== SYSTEM_STORAGE_CLEANUP_SKILL_ID) {
+    const normalizedSelector = normalizeBundledSkillSelector(needle);
+    if (normalizedSelector !== BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR) {
       return {
         error: `The "bundled:" skill selector is only supported for "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}".`,
         errorCode: "invalid_selector",
       };
     }
+    const bundledNeedle = SYSTEM_STORAGE_CLEANUP_SKILL_ID;
 
     const bundledSkills = loadBundledSkills();
     if (bundledSkills.length === 0) {

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -19,6 +19,10 @@ import { loadSkillCatalog } from "../config/skills.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { ActiveSkillEntry } from "../skills/active-skill-tools.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
+import {
+  BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+  SYSTEM_STORAGE_CLEANUP_SKILL_ID,
+} from "../skills/system-storage-cleanup-constants.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import {
@@ -30,9 +34,6 @@ import { createSkillToolsFromManifest } from "../tools/skills/skill-tool-factory
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("conversation-skill-tools");
-const SYSTEM_STORAGE_CLEANUP_SKILL_ID = "system-storage-cleanup";
-const BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR =
-  "bundled:system-storage-cleanup";
 
 // ---------------------------------------------------------------------------
 // Public types

--- a/assistant/src/plugins/defaults/injectors.ts
+++ b/assistant/src/plugins/defaults/injectors.ts
@@ -52,6 +52,7 @@ import { getInContextPkbPaths } from "../../daemon/pkb-context-tracker.js";
 import { buildPkbReminder } from "../../daemon/pkb-reminder-builder.js";
 import { isMemoryV2ReadActive } from "../../memory/context-search/sources/memory-v2.js";
 import { searchPkbFiles } from "../../memory/pkb/pkb-search.js";
+import { BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR } from "../../skills/system-storage-cleanup-constants.js";
 import { getLogger } from "../../util/logger.js";
 import { registerPlugin } from "../registry.js";
 import {
@@ -106,7 +107,7 @@ Storage is critically low and normal work is suspended until space is freed.
 
 Your first user-visible paragraph must warn the user that storage is critically low and normal work is suspended.
 
-Before taking cleanup actions, call \`skill_load\` with \`skill: "bundled:system-storage-cleanup"\` and follow the bundled cleanup skill. Do not rely on any previously loaded cleanup skill unless it came from that bundled selector.
+Before taking cleanup actions, call \`skill_load\` with \`skill: "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}"\` and follow the bundled cleanup skill. Do not rely on any previously loaded cleanup skill unless it came from that bundled selector.
 
 Unrelated work remains blocked until disk usage drops below the critical threshold or the guardian explicitly overrides the lock. Background processes and trusted-contact messages remain blocked while this cleanup mode is active.
 </disk_pressure_warning>`;

--- a/assistant/src/skills/active-skill-tools.ts
+++ b/assistant/src/skills/active-skill-tools.ts
@@ -1,4 +1,5 @@
 import type { Message } from "../providers/types.js";
+import { normalizeBundledSkillSelector } from "./system-storage-cleanup-constants.js";
 
 /** Matches both old (`<loaded_skill id="..." />`) and new versioned
  *  (`<loaded_skill id="..." version="v1:hex" />`) marker formats.
@@ -14,7 +15,7 @@ export interface ActiveSkillEntry {
   id: string;
   /** Present only when the marker includes a `version` attribute; retained for versioned marker compatibility. */
   version?: string;
-  /** The selector originally passed to skill_load, when available. */
+  /** Canonical bundled selector originally passed to skill_load, when available. */
   selector?: string;
 }
 
@@ -42,8 +43,8 @@ export function deriveActiveSkills(messages: Message[]): ActiveSkillEntry[] {
       if (block.type === "tool_use" && block.name === "skill_load") {
         const rawSelector =
           typeof block.input.skill === "string" ? block.input.skill : undefined;
-        const selector = rawSelector?.startsWith("bundled:")
-          ? rawSelector
+        const selector = rawSelector
+          ? (normalizeBundledSkillSelector(rawSelector) ?? undefined)
           : undefined;
         skillLoadSelectorsByUseId.set(block.id, selector);
       }

--- a/assistant/src/skills/system-storage-cleanup-constants.ts
+++ b/assistant/src/skills/system-storage-cleanup-constants.ts
@@ -1,0 +1,28 @@
+export const BUNDLED_SKILL_SELECTOR_PREFIX = "bundled:";
+export const SYSTEM_STORAGE_CLEANUP_SKILL_ID = "system-storage-cleanup";
+export const BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR = `${BUNDLED_SKILL_SELECTOR_PREFIX}${SYSTEM_STORAGE_CLEANUP_SKILL_ID}`;
+
+export function normalizeBundledSkillSelector(selector: string): string | null {
+  const needle = selector.trim();
+  if (!needle.startsWith(BUNDLED_SKILL_SELECTOR_PREFIX)) {
+    return null;
+  }
+
+  const bundledSkillId = needle
+    .slice(BUNDLED_SKILL_SELECTOR_PREFIX.length)
+    .trim();
+  if (!bundledSkillId) {
+    return null;
+  }
+
+  return `${BUNDLED_SKILL_SELECTOR_PREFIX}${bundledSkillId}`;
+}
+
+export function isBundledSystemStorageCleanupSelector(
+  selector: string,
+): boolean {
+  return (
+    normalizeBundledSkillSelector(selector) ===
+    BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR
+  );
+}

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -10,6 +10,11 @@ import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { createOrReuseToolGrantRequest } from "../runtime/tool-grant-request-helper.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
+import {
+  BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+  isBundledSystemStorageCleanupSelector,
+  SYSTEM_STORAGE_CLEANUP_SKILL_ID,
+} from "../skills/system-storage-cleanup-constants.js";
 import { getLogger } from "../util/logger.js";
 import { getAllTools, getTool } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
@@ -151,7 +156,6 @@ export async function waitForInlineGrant(
 }
 
 const UI_SURFACE_TOOLS = new Set(["ui_show", "ui_update", "ui_dismiss"]);
-const DISK_PRESSURE_CLEANUP_SKILL_ID = "system-storage-cleanup";
 
 function requiresGuardianApprovalForActor(
   toolName: string,
@@ -185,35 +189,40 @@ function getDiskPressureSkillLoadBlockReason(
   input: Record<string, unknown>,
 ): string | null {
   const selector = input.skill;
-  if (typeof selector !== "string" || selector.trim().length === 0) {
-    return null;
+  if (
+    typeof selector !== "string" ||
+    !isBundledSystemStorageCleanupSelector(selector)
+  ) {
+    return `Skill "${String(selector ?? "")}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}".`;
   }
 
-  const resolved = resolveSkillSelector(selector);
+  const resolved = resolveSkillSelector(
+    BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+  );
   if (!resolved.skill) {
     if (
       resolved.errorCode === "not_found" ||
       resolved.errorCode === "empty_catalog" ||
       resolved.errorCode === "invalid_selector"
     ) {
-      return `Skill "${selector}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load the bundled "${DISK_PRESSURE_CLEANUP_SKILL_ID}" skill.`;
+      return `Skill "${selector}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}".`;
     }
     return null;
   }
 
   if (
-    resolved.skill.id !== DISK_PRESSURE_CLEANUP_SKILL_ID ||
+    resolved.skill.id !== SYSTEM_STORAGE_CLEANUP_SKILL_ID ||
     resolved.skill.source !== "bundled"
   ) {
-    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load the bundled "${DISK_PRESSURE_CLEANUP_SKILL_ID}" skill.`;
+    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode. Cleanup mode can only load "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}".`;
   }
 
   if (resolved.skill.inlineCommandExpansions?.length) {
-    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode because it contains inline command expansions. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
+    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode because it contains inline command expansions. Load an instruction-only cleanup skill such as "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}" instead.`;
   }
 
   if (resolved.skill.toolManifest?.present) {
-    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode because it declares executable skill tools. Load an instruction-only cleanup skill such as "system-storage-cleanup" instead.`;
+    return `Skill "${resolved.skill.id}" cannot be loaded during disk pressure cleanup mode because it declares executable skill tools. Load an instruction-only cleanup skill such as "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}" instead.`;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Centralize the system storage cleanup skill id and bundled selector constants.
- Require cleanup mode to load the canonical bundled cleanup selector instead of accepting plain id resolution.
- Normalize bundled selector provenance before loaded-skill projection so managed shadows remain blocked.

Part of ATL-462
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->