### PR TITLE
fix: retry legacy skills index migration failures

### DIFF
--- a/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
+++ b/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
@@ -60,6 +60,7 @@ describe("068-remove-legacy-skills-index migration", () => {
       "068-remove-legacy-skills-index",
     );
     expect(removeLegacySkillsIndexMigration.description).toContain("SKILLS.md");
+    expect(removeLegacySkillsIndexMigration.retryFailedCheckpoint).toBe(true);
   });
 
   test("removes only skills/SKILLS.md when present", () => {

--- a/assistant/src/__tests__/workspace-migrations-runner.test.ts
+++ b/assistant/src/__tests__/workspace-migrations-runner.test.ts
@@ -246,6 +246,33 @@ describe("runWorkspaceMigrations", () => {
     expect(m1.run).not.toHaveBeenCalled();
   });
 
+  test("skips failed migrations by default", async () => {
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "failed" },
+      },
+    });
+
+    const m1 = makeMigration("001");
+    await runWorkspaceMigrations(WORKSPACE_DIR, [m1]);
+
+    expect(m1.run).not.toHaveBeenCalled();
+  });
+
+  test("retries failed migrations that opt in", async () => {
+    mockCheckpointContents = JSON.stringify({
+      applied: {
+        "001": { appliedAt: "2025-01-01T00:00:00.000Z", status: "failed" },
+      },
+    });
+
+    const m1 = makeMigration("001");
+    m1.retryFailedCheckpoint = true;
+    await runWorkspaceMigrations(WORKSPACE_DIR, [m1]);
+
+    expect(m1.run).toHaveBeenCalledTimes(1);
+  });
+
   test("supports async migrations", async () => {
     const asyncMigration: WorkspaceMigration = {
       id: "001",

--- a/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
+++ b/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
@@ -18,6 +18,7 @@ function isNotFoundError(err: unknown): boolean {
 export const removeLegacySkillsIndexMigration: WorkspaceMigration = {
   id: "068-remove-legacy-skills-index",
   description: "Remove legacy workspace skills/SKILLS.md index file",
+  retryFailedCheckpoint: true,
 
   run(workspaceDir: string): void {
     const indexPath = join(workspaceDir, "skills", "SKILLS.md");

--- a/assistant/src/workspace/migrations/runner.ts
+++ b/assistant/src/workspace/migrations/runner.ts
@@ -68,12 +68,12 @@ export async function runWorkspaceMigrations(
   workspaceDir: string,
   migrations: WorkspaceMigration[],
 ): Promise<void> {
-  const seen = new Set<string>();
+  const migrationsById = new Map<string, WorkspaceMigration>();
   for (const m of migrations) {
-    if (seen.has(m.id)) {
+    if (migrationsById.has(m.id)) {
       throw new Error(`Duplicate workspace migration id: "${m.id}"`);
     }
-    seen.add(m.id);
+    migrationsById.set(m.id, m);
   }
 
   const checkpoints = loadCheckpoints(workspaceDir);
@@ -82,6 +82,14 @@ export async function runWorkspaceMigrations(
     if (entry.status === "started" || entry.status === "rolling_back") {
       log.warn(
         `Workspace migration "${id}" was interrupted during a previous run; will re-run`,
+      );
+      delete checkpoints.applied[id];
+    } else if (
+      entry.status === "failed" &&
+      migrationsById.get(id)?.retryFailedCheckpoint === true
+    ) {
+      log.warn(
+        `Workspace migration "${id}" failed during a previous run; will retry`,
       );
       delete checkpoints.applied[id];
     }

--- a/assistant/src/workspace/migrations/types.ts
+++ b/assistant/src/workspace/migrations/types.ts
@@ -8,6 +8,10 @@ export interface WorkspaceMigration {
    *  Must be idempotent — safe to re-run if it was interrupted.
    *  Both synchronous and asynchronous migrations are supported. */
   run(workspaceDir: string): void | Promise<void>;
+  /** Retry a prior failed checkpoint on the next run.
+   *  Only set this for migrations whose run() is safe to retry after a
+   *  partially successful failed attempt. */
+  retryFailedCheckpoint?: boolean;
   /** Reverse the migration. Receives the workspace directory path.
    *  Must be idempotent — safe to re-run if it was interrupted.
    *  Both synchronous and asynchronous rollbacks are supported. */


### PR DESCRIPTION
## Summary
- Allows retryable workspace migrations to re-run after transient failures.
- Marks legacy SKILLS.md removal retryable so stale indexes are not permanently preserved.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->