### PR TITLE
fix: watch nested skill directories without recursive fs.watch

### DIFF
--- a/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
+++ b/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
@@ -28,14 +28,10 @@ type WatchCallback = (eventType: string, filename: string | null) => void;
 interface CapturedWatcher {
   dir: string;
   callback: WatchCallback;
+  closed: boolean;
 }
 
 const capturedWatchers: CapturedWatcher[] = [];
-
-const fakeWatcher = {
-  close: () => {},
-  on: () => {},
-};
 
 mock.module("node:fs", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -48,11 +44,24 @@ mock.module("node:fs", () => {
       if (typeof args[0] === "function") {
         callback = args[0] as WatchCallback;
       } else {
+        if ((args[0] as { recursive?: boolean } | undefined)?.recursive) {
+          throw new Error("recursive watch unavailable");
+        }
         callback = args[1] as WatchCallback;
       }
 
-      capturedWatchers.push({ dir, callback });
-      return fakeWatcher;
+      const capturedWatcher: CapturedWatcher = {
+        dir,
+        callback,
+        closed: false,
+      };
+      capturedWatchers.push(capturedWatcher);
+      return {
+        close: () => {
+          capturedWatcher.closed = true;
+        },
+        on: () => {},
+      };
     },
   };
 });
@@ -104,7 +113,15 @@ mock.module("../signals/user-message.js", () => ({
 const { ConfigWatcher } = await import("../daemon/config-watcher.js");
 
 function findWatcher(dir: string): CapturedWatcher | undefined {
+  return capturedWatchers.find((w) => w.dir === dir && !w.closed);
+}
+
+function findCapturedWatcher(dir: string): CapturedWatcher | undefined {
   return capturedWatchers.find((w) => w.dir === dir);
+}
+
+function capturedWatcherCount(dir: string): number {
+  return capturedWatchers.filter((w) => w.dir === dir).length;
 }
 
 describe("ConfigWatcher skills watcher reseeding", () => {
@@ -114,6 +131,7 @@ describe("ConfigWatcher skills watcher reseeding", () => {
 
   beforeEach(() => {
     capturedWatchers.length = 0;
+    rmSync(SKILLS_DIR, { recursive: true, force: true });
     mkdirSync(SKILLS_DIR, { recursive: true });
     evictCalls = 0;
     skillsChangedCalls = 0;
@@ -176,5 +194,97 @@ describe("ConfigWatcher skills watcher reseeding", () => {
 
     expect(evictCalls).toBe(1);
     expect(skillsChangedCalls).toBe(1);
+  });
+
+  test("fallback watches existing nested skill directories", async () => {
+    const referencesDir = join(SKILLS_DIR, "example-skill", "references");
+    mkdirSync(referencesDir, { recursive: true });
+
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    const referencesWatcher = findWatcher(referencesDir);
+    expect(referencesWatcher).toBeDefined();
+    referencesWatcher!.callback("change", "notes.md");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(1);
+    expect(skillsChangedCalls).toBe(1);
+  });
+
+  test("fallback adds watchers for new nested skill directories without duplicates", () => {
+    const skillDir = join(SKILLS_DIR, "example-skill");
+    const toolsDir = join(skillDir, "tools");
+    const generatedDir = join(toolsDir, "generated");
+    mkdirSync(skillDir, { recursive: true });
+
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    const skillWatcher = findWatcher(skillDir);
+    expect(skillWatcher).toBeDefined();
+
+    mkdirSync(generatedDir, { recursive: true });
+    skillWatcher!.callback("rename", "tools");
+    skillWatcher!.callback("rename", "tools");
+
+    expect(findWatcher(toolsDir)).toBeDefined();
+    expect(findWatcher(generatedDir)).toBeDefined();
+    expect(capturedWatcherCount(toolsDir)).toBe(1);
+    expect(capturedWatcherCount(generatedDir)).toBe(1);
+  });
+
+  test("fallback closes stale nested watchers when directories are removed", () => {
+    const skillDir = join(SKILLS_DIR, "example-skill");
+    const referencesDir = join(skillDir, "references");
+    const deepDir = join(referencesDir, "deep");
+    mkdirSync(deepDir, { recursive: true });
+
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    expect(findWatcher(referencesDir)).toBeDefined();
+    expect(findWatcher(deepDir)).toBeDefined();
+
+    rmSync(referencesDir, { recursive: true, force: true });
+    const skillWatcher = findWatcher(skillDir);
+    expect(skillWatcher).toBeDefined();
+    skillWatcher!.callback("rename", "references");
+
+    expect(findWatcher(referencesDir)).toBeUndefined();
+    expect(findWatcher(deepDir)).toBeUndefined();
+    expect(findCapturedWatcher(referencesDir)?.closed).toBe(true);
+    expect(findCapturedWatcher(deepDir)?.closed).toBe(true);
   });
 });

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -4,13 +4,14 @@
  * for changes.
  */
 import {
+  type Dirent,
   existsSync,
   type FSWatcher,
   mkdirSync,
   readdirSync,
   watch,
 } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import type { MemoryCleanupConfig } from "../config/schemas/memory-lifecycle.js";
@@ -446,39 +447,69 @@ export class ConfigWatcher {
       }
     };
 
+    const formatSkillChangeLabel = (
+      dirPath: string,
+      filename: string,
+    ): string => {
+      if (filename === "(unknown)") {
+        const relativeDir = relative(skillsDir, dirPath);
+        return relativeDir || "(unknown)";
+      }
+      const relativeFile = relative(skillsDir, join(dirPath, filename));
+      return relativeFile || filename;
+    };
+
+    const enumerateSkillSubdirectories = (
+      dirPath: string,
+      acc: Set<string>,
+    ): boolean => {
+      let entries: Dirent[];
+      try {
+        entries = readdirSync(dirPath, { withFileTypes: true });
+      } catch (err) {
+        log.warn({ err, dirPath }, "Failed to enumerate skill directories");
+        return dirPath !== skillsDir;
+      }
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const childDir = join(dirPath, entry.name);
+        acc.add(childDir);
+        enumerateSkillSubdirectories(childDir, acc);
+      }
+      return true;
+    };
+
+    const closeChildWatcher = (dirPath: string, watcher: FSWatcher): void => {
+      watcher.close();
+      childWatchers.delete(dirPath);
+      removeWatcher(watcher);
+    };
+
     const refreshChildWatchers = (): void => {
       const nextChildDirs = new Set<string>();
-
-      try {
-        const entries = readdirSync(skillsDir, { withFileTypes: true });
-        for (const entry of entries) {
-          if (!entry.isDirectory()) continue;
-          const childDir = join(skillsDir, entry.name);
-          nextChildDirs.add(childDir);
-
-          if (childWatchers.has(childDir)) continue;
-
-          const watcher = watchDir(childDir, (filename) => {
-            const label =
-              filename === "(unknown)"
-                ? entry.name
-                : `${entry.name}/${filename}`;
-            scheduleSkillsReload(label);
-          });
-          if (watcher) {
-            childWatchers.set(childDir, watcher);
-          }
+      if (!enumerateSkillSubdirectories(skillsDir, nextChildDirs)) {
+        for (const [childDir, watcher] of childWatchers.entries()) {
+          closeChildWatcher(childDir, watcher);
         }
-      } catch (err) {
-        log.warn({ err, skillsDir }, "Failed to enumerate skill directories");
         return;
       }
 
       for (const [childDir, watcher] of childWatchers.entries()) {
         if (nextChildDirs.has(childDir)) continue;
-        watcher.close();
-        childWatchers.delete(childDir);
-        removeWatcher(watcher);
+        closeChildWatcher(childDir, watcher);
+      }
+
+      for (const childDir of nextChildDirs) {
+        if (childWatchers.has(childDir)) continue;
+
+        const watcher = watchDir(childDir, (filename) => {
+          scheduleSkillsReload(formatSkillChangeLabel(childDir, filename));
+          refreshChildWatchers();
+        });
+        if (watcher) {
+          childWatchers.set(childDir, watcher);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- Recursively watches skill subdirectories when recursive fs.watch is unavailable.
- Covers nested skill file changes triggering eviction and memory refresh.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->