### PR TITLE
fix: remove stale skill index test scaffolding

### DIFF
--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -74,7 +74,6 @@ describe("Dynamic Skill Authoring Workflow moved to tool descriptions", () => {
       join(skillsDir, "test-skill", "SKILL.md"),
       '---\nname: "Test Skill"\ndescription: "For testing."\n---\n\nDo testing.\n',
     );
-    writeFileSync(join(skillsDir, "SKILLS.md"), "- test-skill\n");
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "I am Vellum.");
 
     const result = buildSystemPrompt();

--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -34,7 +34,6 @@ import {
   buildSkillMarkdown,
   createManagedSkill,
   deleteManagedSkill,
-  readSkillVersion,
   validateManagedSkillId,
 } from "../skills/managed-store.js";
 
@@ -45,6 +44,22 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(join(TEST_DIR, "skills"), { recursive: true, force: true });
 });
+
+interface TestInstallMeta {
+  origin?: string;
+  version?: string;
+  installedAt?: string;
+  installedBy?: string;
+}
+
+function readInstallMetaFile(skillId: string): TestInstallMeta {
+  return JSON.parse(
+    readFileSync(
+      join(TEST_DIR, "skills", skillId, "install-meta.json"),
+      "utf-8",
+    ),
+  );
+}
 
 describe("validateManagedSkillId", () => {
   test("accepts valid slug IDs", () => {
@@ -500,18 +515,17 @@ describe("deleteManagedSkill", () => {
 });
 
 describe("version metadata", () => {
-  test("readSkillVersion returns null for non-existent skill", () => {
-    expect(readSkillVersion("nonexistent")).toBeNull();
-  });
-
-  test("readSkillVersion returns null when skill exists but has no version.json", () => {
+  test("createManagedSkill writes install-meta.json without version when version is omitted", () => {
     createManagedSkill({
       id: "no-version",
       name: "No Version",
       description: "Created without version",
       bodyMarkdown: "Body.",
     });
-    expect(readSkillVersion("no-version")).toBeNull();
+
+    const meta = readInstallMetaFile("no-version");
+    expect(meta.origin).toBe("custom");
+    expect(meta.version).toBeUndefined();
   });
 
   test("createManagedSkill writes install-meta.json when version is provided", () => {
@@ -523,8 +537,8 @@ describe("version metadata", () => {
       version: "v1:abc123",
     });
 
-    const version = readSkillVersion("versioned");
-    expect(version).toBe("v1:abc123");
+    const meta = readInstallMetaFile("versioned");
+    expect(meta.version).toBe("v1:abc123");
   });
 
   test("install-meta.json contains valid JSON with origin, version, and installedAt", () => {
@@ -543,10 +557,13 @@ describe("version metadata", () => {
       "install-meta.json",
     );
     expect(existsSync(metaPath)).toBe(true);
-    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    const meta = readInstallMetaFile("version-meta");
     expect(meta.origin).toBe("custom");
     expect(meta.version).toBe("v1:deadbeef");
     expect(typeof meta.installedAt).toBe("string");
+    if (typeof meta.installedAt !== "string") {
+      throw new Error("installedAt must be a string");
+    }
     // installedAt should be a valid ISO date
     expect(new Date(meta.installedAt).toISOString()).toBe(meta.installedAt);
   });
@@ -567,7 +584,7 @@ describe("version metadata", () => {
       "install-meta.json",
     );
     expect(existsSync(metaPath)).toBe(true);
-    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    const meta = readInstallMetaFile("with-contact");
     expect(meta.origin).toBe("custom");
     expect(meta.installedBy).toBe("contact-uuid-456");
   });
@@ -580,7 +597,8 @@ describe("version metadata", () => {
       bodyMarkdown: "Body.",
       version: "v1:first",
     });
-    expect(readSkillVersion("update-version")).toBe("v1:first");
+
+    expect(readInstallMetaFile("update-version").version).toBe("v1:first");
 
     createManagedSkill({
       id: "update-version",
@@ -590,28 +608,37 @@ describe("version metadata", () => {
       version: "v1:second",
       overwrite: true,
     });
-    expect(readSkillVersion("update-version")).toBe("v1:second");
+    expect(readInstallMetaFile("update-version").version).toBe("v1:second");
   });
 
-  test("readSkillVersion returns null for corrupted install-meta.json", () => {
+  test("overwrite removes legacy version.json", () => {
     createManagedSkill({
-      id: "corrupt-version",
-      name: "Corrupt",
-      description: "Will corrupt meta file",
+      id: "legacy-version",
+      name: "Legacy",
+      description: "Has legacy metadata",
       bodyMarkdown: "Body.",
-      version: "v1:valid",
+      version: "v1:first",
     });
 
-    // Corrupt the install-meta.json
-    const metaPath = join(
+    const legacyMetaPath = join(
       TEST_DIR,
       "skills",
-      "corrupt-version",
-      "install-meta.json",
+      "legacy-version",
+      "version.json",
     );
-    writeFileSync(metaPath, "{invalid json!!!", "utf-8");
+    writeFileSync(legacyMetaPath, '{"version":"legacy"}', "utf-8");
+    expect(existsSync(legacyMetaPath)).toBe(true);
 
-    expect(readSkillVersion("corrupt-version")).toBeNull();
+    createManagedSkill({
+      id: "legacy-version",
+      name: "Legacy Updated",
+      description: "Has current metadata",
+      bodyMarkdown: "Body.",
+      version: "v1:second",
+      overwrite: true,
+    });
+
+    expect(existsSync(legacyMetaPath)).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -102,10 +102,6 @@ describe("skill_load feature flag enforcement", () => {
       "Toggle email channel behavior",
       "Use the feature.",
     );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      `- ${DECLARED_SKILL_ID}\n`,
-    );
 
     _setOverridesForTesting({ [DECLARED_FLAG_KEY]: false });
 
@@ -123,10 +119,6 @@ describe("skill_load feature flag enforcement", () => {
       "Toggle email channel behavior",
       "Use the feature.",
     );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      `- ${DECLARED_SKILL_ID}\n`,
-    );
 
     _setOverridesForTesting({ [DECLARED_FLAG_KEY]: true });
 
@@ -142,10 +134,6 @@ describe("skill_load feature flag enforcement", () => {
       "Email Channel",
       "Toggle email channel behavior",
       "Use the feature.",
-    );
-    writeFileSync(
-      join(TEST_DIR, "skills", "SKILLS.md"),
-      `- ${DECLARED_SKILL_ID}\n`,
     );
 
     // No overrides — uses registry defaults

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -184,7 +184,6 @@ describe("buildSystemPrompt", () => {
       join(skillsDir, "release-checklist", "SKILL.md"),
       '---\nname: "Release Checklist"\ndescription: "Deployment checks."\n---\n\nRun checks.\n',
     );
-    writeFileSync(join(skillsDir, "SKILLS.md"), "- release-checklist\n");
 
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "Custom identity");
     const result = buildSystemPrompt();
@@ -200,7 +199,6 @@ describe("buildSystemPrompt", () => {
       join(skillsDir, "incident-response", "SKILL.md"),
       '---\nname: "Incident Response"\ndescription: "Triage and mitigation."\n---\n\nFollow runbook.\n',
     );
-    writeFileSync(join(skillsDir, "SKILLS.md"), "- incident-response\n");
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "Identity content");
     writeFileSync(join(TEST_DIR, "SOUL.md"), "Soul content");
 

--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -19,14 +19,7 @@
  * resolver are module-mocked so the suite never reaches a real backend. One
  * regression case uses a temp workspace to exercise disk-discovered skills.
  */
-import {
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -35,6 +28,9 @@ import { makeMockLogger } from "../../../__tests__/helpers/mock-logger.js";
 import type { ResolvedSkill } from "../../../config/skill-state.js";
 import type { SkillSummary } from "../../../config/skills.js";
 import type { CatalogSkill } from "../../../skills/catalog-install.js";
+
+const { loadSkillCatalog: realLoadSkillCatalog } =
+  await import("../../../config/skills.js");
 
 mock.module("../../../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
@@ -96,7 +92,8 @@ mock.module("../../../config/loader.js", () => ({
 }));
 
 mock.module("../../../config/skills.js", () => ({
-  loadSkillCatalog: () => state.catalog ?? loadDiskSkillCatalog(),
+  loadSkillCatalog: (...args: Parameters<typeof realLoadSkillCatalog>) =>
+    state.catalog ?? realLoadSkillCatalog(...args),
 }));
 
 mock.module("../../../config/skill-state.js", () => ({
@@ -182,34 +179,6 @@ function makeSummary(overrides: Partial<SkillSummary> = {}): SkillSummary {
     source: "managed",
     ...overrides,
   };
-}
-
-function loadDiskSkillCatalog(): SkillSummary[] {
-  const skillsDir = join(process.env.VELLUM_WORKSPACE_DIR!, "skills");
-  return readdirSync(skillsDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => {
-      const directoryPath = join(skillsDir, entry.name);
-      const skillFilePath = join(directoryPath, "SKILL.md");
-      const content = readFileSync(skillFilePath, "utf-8");
-      const name = content.match(/^name:\s*"([^"]+)"/m)?.[1] ?? entry.name;
-      const description =
-        content.match(/^description:\s*"([^"]+)"/m)?.[1] ?? "";
-      const activationHints = [...content.matchAll(/^\s+-\s+(.+)$/gm)].map(
-        (match) => match[1]!.trim(),
-      );
-      return {
-        id: entry.name,
-        name,
-        displayName: name,
-        description,
-        directoryPath,
-        skillFilePath,
-        source: "managed" as const,
-        activationHints: activationHints.slice(0, 1),
-        avoidWhen: activationHints.slice(1, 2),
-      };
-    });
 }
 
 function resetState(): void {

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
@@ -104,38 +103,8 @@ function atomicWriteFile(filePath: string, content: string): void {
 
 // ─── Version metadata ─────────────────────────────────────────────────────────
 
-interface SkillVersionMeta {
-  version: string;
-  installedAt: string;
-}
-
 function getVersionMetaPath(id: string): string {
   return join(getManagedSkillDir(id), "version.json");
-}
-
-export function readSkillVersion(id: string): string | null {
-  // Try install-meta.json first (new format)
-  const installMetaPath = join(getManagedSkillDir(id), "install-meta.json");
-  if (existsSync(installMetaPath)) {
-    try {
-      const raw = readFileSync(installMetaPath, "utf-8");
-      const meta = JSON.parse(raw) as { version?: string };
-      if (meta.version) return meta.version;
-    } catch {
-      // Fall through to legacy path
-    }
-  }
-
-  // Fall back to legacy version.json
-  const metaPath = getVersionMetaPath(id);
-  if (!existsSync(metaPath)) return null;
-  try {
-    const raw = readFileSync(metaPath, "utf-8");
-    const meta: SkillVersionMeta = JSON.parse(raw);
-    return meta.version ?? null;
-  } catch {
-    return null;
-  }
 }
 
 // ─── Create / Delete ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Removes stale SKILLS.md fixtures from unrelated tests.
- Drops duplicate test-only catalog parsing and dead managed-store version wrapper.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->