### PR TITLE
fix: remove unused macOS error overlay callback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowErrorOverlay.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowErrorOverlay.swift
@@ -17,10 +17,6 @@ struct MainWindowErrorOverlay: View {
             if let viewModel = activeViewModel {
                 ErrorToastOverlay(
                     errorManager: viewModel.errorManager,
-                    onOpenModelsAndServices: {
-                        settingsStore.pendingSettingsTab = .modelsAndServices
-                        windowState.selection = .panel(.settings)
-                    },
                     onRetryConversationError: { viewModel.retryAfterConversationError() },
                     onCopyDebugInfo: { viewModel.copyConversationErrorDebugDetails() },
                     onDismissConversationError: { viewModel.dismissConversationError() },

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -674,7 +674,6 @@ struct MainWindowView: View {
 /// toast is visible.
 struct ErrorToastOverlay: View {
     let errorManager: ChatErrorManager
-    let onOpenModelsAndServices: () -> Void
     let onRetryConversationError: () -> Void
     let onCopyDebugInfo: () -> Void
     let onDismissConversationError: () -> Void


### PR DESCRIPTION
## Summary
- Remove unused Models & Services callback wiring from the generic error toast overlay.
- Keep provider billing settings routing in the above-composer banner path.

Fixes follow-up slop review feedback on macos-provider-billing-ux.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->