### PR TITLE
fix: stage skill installs before discovery

### DIFF
--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -139,8 +139,12 @@ mock.module("../skills/catalog-cache.js", () => ({
 
 mock.module("../skills/catalog-install.js", () => ({
   assertInstalledSkillDiscoverable: () => {},
+  discardSkillInstallBackup: () => {},
+  installSkillDependenciesIfPresent: () => {},
   installSkillLocally: async () => {},
   getRepoSkillsDir: () => undefined,
+  restoreOrRemoveFailedSkillInstall: () => {},
+  snapshotExistingSkillDir: () => null,
 }));
 
 mock.module("../skills/catalog-search.js", () => ({

--- a/assistant/src/__tests__/skills-install-staging.test.ts
+++ b/assistant/src/__tests__/skills-install-staging.test.ts
@@ -1,0 +1,196 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const mockExecSync = mock(() => {});
+
+mock.module("node:child_process", () => ({
+  execSync: mockExecSync,
+}));
+
+import { loadSkillCatalog } from "../config/skills.js";
+import { installSkillLocally } from "../skills/catalog-install.js";
+import { installExternalSkill } from "../skills/skillssh-registry.js";
+
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+const originalFetch = globalThis.fetch;
+
+let workspaceDir: string;
+
+function skillMarkdown(name: string, body: string): string {
+  return `---
+name: "${name}"
+description: "A test skill."
+---
+
+${body}
+`;
+}
+
+function makeTarEntry(name: string, content: string): Buffer {
+  const header = Buffer.alloc(512, 0);
+  const nameBuffer = Buffer.from(name, "utf-8");
+  nameBuffer.copy(header, 0, 0, Math.min(nameBuffer.length, 100));
+
+  Buffer.from("0000644\0", "ascii").copy(header, 100);
+  Buffer.from("0000000\0", "ascii").copy(header, 108);
+  Buffer.from("0000000\0", "ascii").copy(header, 116);
+  Buffer.from(
+    `${content.length.toString(8).padStart(11, "0")}\0`,
+    "ascii",
+  ).copy(header, 124);
+  Buffer.from("00000000000\0", "ascii").copy(header, 136);
+  Buffer.from("        ", "ascii").copy(header, 148);
+  header[156] = "0".charCodeAt(0);
+  Buffer.from("ustar\0", "ascii").copy(header, 257);
+  Buffer.from("00", "ascii").copy(header, 263);
+
+  let sum = 0;
+  for (let i = 0; i < 512; i += 1) sum += header[i] ?? 0;
+  Buffer.from(`${sum.toString(8).padStart(6, "0")}\0 `, "ascii").copy(
+    header,
+    148,
+  );
+
+  const data = Buffer.from(content, "utf-8");
+  const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512, 0);
+  data.copy(padded);
+  return Buffer.concat([header, padded]);
+}
+
+function makeTar(entries: Array<{ name: string; content: string }>): Buffer {
+  return Buffer.concat([
+    ...entries.map((entry) => makeTarEntry(entry.name, entry.content)),
+    Buffer.alloc(1024, 0),
+  ]);
+}
+
+function writeInstalledSkill(skillId: string, name: string): void {
+  const skillDir = join(workspaceDir, "skills", skillId);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), skillMarkdown(name, "Old body."));
+  writeFileSync(join(skillDir, "old.txt"), "keep me\n");
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "skills-install-staging-"));
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  mkdirSync(join(workspaceDir, "skills"), { recursive: true });
+  mockExecSync.mockReset();
+  mockExecSync.mockImplementation(() => {
+    throw new Error("dependency install failed");
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  }
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("staged skill installs", () => {
+  test("catalog dependency failure does not leave a discoverable fresh install", async () => {
+    const archive = gzipSync(
+      makeTar([
+        {
+          name: "SKILL.md",
+          content: skillMarkdown("Demo Skill", "New body."),
+        },
+        {
+          name: "package.json",
+          content: JSON.stringify({ dependencies: { example: "1.0.0" } }),
+        },
+      ]),
+    );
+    globalThis.fetch = mock(
+      async () => new Response(archive),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      installSkillLocally(
+        "demo-skill",
+        {
+          id: "demo-skill",
+          name: "Demo Skill",
+          description: "A test skill.",
+        },
+        false,
+      ),
+    ).rejects.toThrow("dependency install failed");
+
+    expect(
+      existsSync(join(workspaceDir, "skills", "demo-skill", "SKILL.md")),
+    ).toBe(false);
+    expect(loadSkillCatalog().some((skill) => skill.id === "demo-skill")).toBe(
+      false,
+    );
+  });
+
+  test("skills.sh overwrite dependency failure preserves the previous skill", async () => {
+    writeInstalledSkill("demo-skill", "Old Demo Skill");
+
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/contents/skills/demo-skill")) {
+        return new Response(
+          JSON.stringify([
+            {
+              name: "SKILL.md",
+              type: "file",
+              download_url: "https://example.com/SKILL.md",
+            },
+            {
+              name: "package.json",
+              type: "file",
+              download_url: "https://example.com/package.json",
+            },
+            {
+              name: "new.txt",
+              type: "file",
+              download_url: "https://example.com/new.txt",
+            },
+          ]),
+        );
+      }
+      if (url.endsWith("/SKILL.md")) {
+        return new Response(skillMarkdown("New Demo Skill", "New body."));
+      }
+      if (url.endsWith("/package.json")) {
+        return new Response(
+          JSON.stringify({ dependencies: { example: "1.0.0" } }),
+        );
+      }
+      if (url.endsWith("/new.txt")) {
+        return new Response("new file\n");
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      installExternalSkill("owner", "repo", "demo-skill", true),
+    ).rejects.toThrow("dependency install failed");
+
+    const skillDir = join(workspaceDir, "skills", "demo-skill");
+    expect(readFileSync(join(skillDir, "SKILL.md"), "utf-8")).toContain(
+      "Old Demo Skill",
+    );
+    expect(readFileSync(join(skillDir, "old.txt"), "utf-8")).toBe("keep me\n");
+    expect(existsSync(join(skillDir, "new.txt"))).toBe(false);
+    expect(
+      loadSkillCatalog().find((skill) => skill.id === "demo-skill")?.name,
+    ).toBe("Old Demo Skill");
+  });
+});

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1,4 +1,3 @@
-import { execSync } from "node:child_process";
 import {
   existsSync,
   lstatSync,
@@ -8,7 +7,6 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
-import { homedir } from "node:os";
 import { basename, join, relative, sep } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
@@ -44,7 +42,11 @@ import {
 import {
   assertInstalledSkillDiscoverable,
   type CatalogSkill,
+  discardSkillInstallBackup,
+  installSkillDependenciesIfPresent,
   installSkillLocally,
+  restoreOrRemoveFailedSkillInstall,
+  snapshotExistingSkillDir,
 } from "../../skills/catalog-install.js";
 import { filterByQuery } from "../../skills/catalog-search.js";
 import { inferCategory } from "../../skills/category-inference.js";
@@ -262,13 +264,12 @@ function saveConfigWithSuppression(raw: Record<string, unknown>): void {
  * inline in `installSkill()` since `clawhubInstall` only runs the clawhub CLI
  * and writes metadata.
  *
+ * Discoverability verification is handled by the install path before this runs.
+ *
  * NOT used for bundled skills — those have a simpler inline path in
  * `installSkill()` that only auto-enables, broadcasts, and seeds memories.
  */
-function postInstallSkill(skillId: string, skillDir: string): void {
-  // Reload skill catalog so the newly installed skill is picked up
-  assertInstalledSkillDiscoverable(skillId, skillDir);
-
+function postInstallSkill(skillId: string): void {
   // Auto-enable the skill in config
   try {
     const raw = loadRawConfig();
@@ -1070,8 +1071,7 @@ export async function installSkill(spec: {
             spec.contactId,
           );
 
-          const skillDir = join(getWorkspaceSkillsDir(), spec.slug);
-          postInstallSkill(spec.slug, skillDir);
+          postInstallSkill(spec.slug);
           return { success: true, skillId: spec.slug };
         }
       } catch (err) {
@@ -1098,35 +1098,41 @@ export async function installSkill(spec: {
         spec.contactId,
       );
 
-      const skillDir = join(getWorkspaceSkillsDir(), resolved.skillSlug);
-      postInstallSkill(resolved.skillSlug, skillDir);
+      postInstallSkill(resolved.skillSlug);
       return { success: true, skillId: resolved.skillSlug };
     }
 
     // Install from clawhub (community)
-    const result = await clawhubInstall(spec.slug, {
-      version: spec.version,
-      contactId: spec.contactId,
-    });
-    if (!result.success) {
-      return { success: false, error: result.error ?? "Unknown error" };
-    }
-    const rawId = result.skillName ?? spec.slug;
-    const skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
-
-    // clawhubInstall uses the clawhub CLI which doesn't handle bun install, so
-    // install dependencies here before post-install.
-    const skillDir = join(getWorkspaceSkillsDir(), skillId);
-    if (existsSync(join(skillDir, "package.json"))) {
-      const bunPath = `${homedir()}/.bun/bin`;
-      execSync("bun install", {
-        cwd: skillDir,
-        stdio: "inherit",
-        env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    const expectedSkillId = spec.slug.includes("/")
+      ? spec.slug.split("/").pop()!
+      : spec.slug;
+    let backupDir: string | null = null;
+    let skillId = expectedSkillId;
+    backupDir = snapshotExistingSkillDir(expectedSkillId);
+    try {
+      const result = await clawhubInstall(spec.slug, {
+        version: spec.version,
+        contactId: spec.contactId,
       });
+      if (!result.success) {
+        restoreOrRemoveFailedSkillInstall(expectedSkillId, backupDir);
+        return { success: false, error: result.error ?? "Unknown error" };
+      }
+      const rawId = result.skillName ?? spec.slug;
+      skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
+
+      // clawhubInstall uses the clawhub CLI which doesn't handle bun install, so
+      // install dependencies here before post-install.
+      const skillDir = join(getWorkspaceSkillsDir(), skillId);
+      installSkillDependenciesIfPresent(skillDir);
+      assertInstalledSkillDiscoverable(skillId, skillDir);
+      discardSkillInstallBackup(backupDir);
+    } catch (err) {
+      restoreOrRemoveFailedSkillInstall(expectedSkillId, backupDir);
+      throw err;
     }
 
-    postInstallSkill(skillId, skillDir);
+    postInstallSkill(skillId);
     return { success: true, skillId };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -3,8 +3,10 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   realpathSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -256,6 +258,110 @@ export function assertInstalledSkillDiscoverable(
   }
 }
 
+function getInstallStagingRoot(): string {
+  return join(getWorkspaceSkillsDir(), ".install-staging");
+}
+
+export function createSkillInstallStagingDir(): string {
+  const stagingRoot = getInstallStagingRoot();
+  mkdirSync(stagingRoot, { recursive: true });
+  return mkdtempSync(join(stagingRoot, "skill-"));
+}
+
+function createSkillInstallBackupPath(): string {
+  const stagingRoot = getInstallStagingRoot();
+  mkdirSync(stagingRoot, { recursive: true });
+  return join(
+    stagingRoot,
+    `backup-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+}
+
+function assertStagedSkillRoot(skillId: string, stagedDir: string): void {
+  if (!existsSync(join(stagedDir, "SKILL.md"))) {
+    throw new Error(
+      `Installed skill "${skillId}" is missing SKILL.md at the skill root`,
+    );
+  }
+}
+
+export function installSkillDependenciesIfPresent(skillDir: string): void {
+  if (existsSync(join(skillDir, "package.json"))) {
+    const bunPath = `${homedir()}/.bun/bin`;
+    execSync("bun install", {
+      cwd: skillDir,
+      stdio: "inherit",
+      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    });
+  }
+}
+
+export function restoreOrRemoveFailedSkillInstall(
+  skillId: string,
+  backupDir: string | null,
+): void {
+  const skillDir = join(getWorkspaceSkillsDir(), skillId);
+  rmSync(skillDir, { recursive: true, force: true });
+  if (backupDir) {
+    renameSync(backupDir, skillDir);
+  }
+}
+
+export function discardSkillInstallBackup(backupDir: string | null): void {
+  if (backupDir) {
+    rmSync(backupDir, { recursive: true, force: true });
+  }
+}
+
+export function snapshotExistingSkillDir(skillId: string): string | null {
+  const skillDir = join(getWorkspaceSkillsDir(), skillId);
+  if (!existsSync(skillDir)) return null;
+
+  const backupDir = createSkillInstallBackupPath();
+  renameSync(skillDir, backupDir);
+  return backupDir;
+}
+
+export function commitStagedSkillInstall(
+  skillId: string,
+  stagedDir: string,
+): void {
+  assertStagedSkillRoot(skillId, stagedDir);
+
+  const skillDir = join(getWorkspaceSkillsDir(), skillId);
+  let backupDir: string | null = null;
+  let stagedMovedToFinal = false;
+
+  try {
+    backupDir = snapshotExistingSkillDir(skillId);
+    renameSync(stagedDir, skillDir);
+    stagedMovedToFinal = true;
+    assertInstalledSkillDiscoverable(skillId, skillDir);
+    discardSkillInstallBackup(backupDir);
+  } catch (err) {
+    const originalMessage = err instanceof Error ? err.message : String(err);
+    let restoreError: unknown;
+    if (backupDir || stagedMovedToFinal) {
+      try {
+        restoreOrRemoveFailedSkillInstall(skillId, backupDir);
+      } catch (restoreErr) {
+        restoreError = restoreErr;
+      }
+    }
+    rmSync(stagedDir, { recursive: true, force: true });
+    if (restoreError) {
+      const restoreMessage =
+        restoreError instanceof Error
+          ? restoreError.message
+          : String(restoreError);
+      throw new Error(
+        `${originalMessage}; failed to restore previous skill: ${restoreMessage}`,
+      );
+    }
+    throw err;
+  }
+}
+
 export async function installSkillLocally(
   skillId: string,
   catalogEntry: CatalogSkill,
@@ -271,10 +377,7 @@ export async function installSkillLocally(
     );
   }
 
-  if (overwrite && existsSync(skillDir)) {
-    rmSync(skillDir, { recursive: true, force: true });
-  }
-  mkdirSync(skillDir, { recursive: true });
+  const stagedDir = createSkillInstallStagingDir();
 
   // In dev mode, install from the local repo skills directory if available
   const repoSkillsDir = getRepoSkillsDir();
@@ -283,38 +386,36 @@ export async function installSkillLocally(
     : undefined;
 
   let installSource: "repo" | "platform";
-  if (repoSkillSource && existsSync(join(repoSkillSource, "SKILL.md"))) {
-    installSource = "repo";
-    cpSync(repoSkillSource, skillDir, { recursive: true });
-  } else {
-    installSource = "platform";
-    await fetchAndExtractSkill(skillId, skillDir);
-  }
-  log.info(
-    { skillId, source: installSource },
-    "Installed skill from %s",
-    installSource,
-  );
+  try {
+    if (repoSkillSource && existsSync(join(repoSkillSource, "SKILL.md"))) {
+      installSource = "repo";
+      cpSync(repoSkillSource, stagedDir, { recursive: true });
+    } else {
+      installSource = "platform";
+      await fetchAndExtractSkill(skillId, stagedDir);
+    }
 
-  assertInstalledSkillDiscoverable(skillId, skillDir);
+    assertStagedSkillRoot(skillId, stagedDir);
 
-  // Write install metadata
-  writeInstallMeta(skillDir, {
-    origin: "vellum",
-    installedAt: new Date().toISOString(),
-    ...(catalogEntry.version ? { version: catalogEntry.version } : {}),
-    ...(contactId ? { installedBy: contactId } : {}),
-    contentHash: computeSkillHash(skillDir) ?? undefined,
-  });
-
-  // Post-install: install dependencies before reporting success.
-  if (existsSync(join(skillDir, "package.json"))) {
-    const bunPath = `${homedir()}/.bun/bin`;
-    execSync("bun install", {
-      cwd: skillDir,
-      stdio: "inherit",
-      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    writeInstallMeta(stagedDir, {
+      origin: "vellum",
+      installedAt: new Date().toISOString(),
+      ...(catalogEntry.version ? { version: catalogEntry.version } : {}),
+      ...(contactId ? { installedBy: contactId } : {}),
+      contentHash: computeSkillHash(stagedDir) ?? undefined,
     });
+
+    installSkillDependenciesIfPresent(stagedDir);
+    commitStagedSkillInstall(skillId, stagedDir);
+
+    log.info(
+      { skillId, source: installSource },
+      "Installed skill from %s",
+      installSource,
+    );
+  } catch (err) {
+    rmSync(stagedDir, { recursive: true, force: true });
+    throw err;
   }
 }
 

--- a/assistant/src/skills/skillssh-registry.ts
+++ b/assistant/src/skills/skillssh-registry.ts
@@ -1,10 +1,12 @@
-import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
 
 import { getWorkspaceSkillsDir } from "../util/platform.js";
-import { assertInstalledSkillDiscoverable } from "./catalog-install.js";
+import {
+  commitStagedSkillInstall,
+  createSkillInstallStagingDir,
+  installSkillDependenciesIfPresent,
+} from "./catalog-install.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 import type {
   AuditResponse,
@@ -421,9 +423,10 @@ export function validateSkillSlug(slug: string): void {
  *
  * 1. Validates the skill slug for path safety
  * 2. Fetches all files from `skills/<skillSlug>/` in the source repo
- * 3. Writes them to `<workspace>/skills/<skillSlug>/` with path traversal protection
+ * 3. Writes them to a non-discovered staging dir with path traversal protection
  * 4. Writes `install-meta.json` with origin metadata
  * 5. Installs npm dependencies (if package.json exists)
+ * 6. Atomically swaps the staged skill into `<workspace>/skills/<skillSlug>/`
  *
  * Auto-enable and memory seeding are handled by the caller (e.g.
  * `postInstallSkill()` in the daemon, or left to the user for CLI installs).
@@ -450,46 +453,40 @@ export async function installExternalSkill(
 
   const files = await fetchSkillFromGitHub(owner, repo, skillSlug, ref);
 
-  // Clear existing directory on overwrite to remove stale files
-  if (overwrite && existsSync(skillDir)) {
-    rmSync(skillDir, { recursive: true, force: true });
-  }
-  mkdirSync(skillDir, { recursive: true });
+  const stagedDir = createSkillInstallStagingDir();
+  try {
+    // Write files with path traversal protection (follows extractTarToDir pattern)
+    for (const [filename, content] of Object.entries(files)) {
+      const normalized = filename.replace(/\\/g, "/").replace(/^\.\/+/g, "");
+      if (
+        !normalized ||
+        normalized.includes("..") ||
+        normalized.startsWith("/")
+      )
+        continue;
+      const destPath = resolve(stagedDir, normalized);
+      if (
+        !destPath.startsWith(resolve(stagedDir) + sep) &&
+        destPath !== resolve(stagedDir)
+      )
+        continue;
+      mkdirSync(dirname(destPath), { recursive: true });
+      writeFileSync(destPath, content, "utf-8");
+    }
 
-  // Write files with path traversal protection (follows extractTarToDir pattern)
-  for (const [filename, content] of Object.entries(files)) {
-    const normalized = filename.replace(/\\/g, "/").replace(/^\.\/+/g, "");
-    if (!normalized || normalized.includes("..") || normalized.startsWith("/"))
-      continue;
-    const destPath = resolve(skillDir, normalized);
-    if (
-      !destPath.startsWith(resolve(skillDir) + sep) &&
-      destPath !== resolve(skillDir)
-    )
-      continue;
-    mkdirSync(dirname(destPath), { recursive: true });
-    writeFileSync(destPath, content, "utf-8");
-  }
-
-  assertInstalledSkillDiscoverable(skillSlug, skillDir);
-
-  // Write install metadata
-  writeInstallMeta(skillDir, {
-    origin: "skillssh",
-    slug: skillSlug,
-    sourceRepo: `${owner}/${repo}`,
-    installedAt: new Date().toISOString(),
-    ...(contactId ? { installedBy: contactId } : {}),
-    contentHash: computeSkillHash(skillDir) ?? undefined,
-  });
-
-  // Post-install: install dependencies before reporting success.
-  if (existsSync(join(skillDir, "package.json"))) {
-    const bunPath = `${homedir()}/.bun/bin`;
-    execSync("bun install", {
-      cwd: skillDir,
-      stdio: "inherit",
-      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+    writeInstallMeta(stagedDir, {
+      origin: "skillssh",
+      slug: skillSlug,
+      sourceRepo: `${owner}/${repo}`,
+      installedAt: new Date().toISOString(),
+      ...(contactId ? { installedBy: contactId } : {}),
+      contentHash: computeSkillHash(stagedDir) ?? undefined,
     });
+
+    installSkillDependenciesIfPresent(stagedDir);
+    commitStagedSkillInstall(skillSlug, stagedDir);
+  } catch (err) {
+    rmSync(stagedDir, { recursive: true, force: true });
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary
- Stages skill installs until validation and dependency installation succeed.
- Preserves existing skills on overwrite failures and avoids discoverable partial installs.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->