### PR TITLE
Upgrade cleanup selector provenance on reload

### DIFF
--- a/assistant/src/__tests__/active-skill-tools.test.ts
+++ b/assistant/src/__tests__/active-skill-tools.test.ts
@@ -81,6 +81,22 @@ describe("deriveActiveSkills (ID-only)", () => {
     ]);
   });
 
+  test("later bundled cleanup marker upgrades plain marker provenance", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", "system-storage-cleanup"),
+      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
+      skillLoadUseMsg("t2", BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR),
+      toolResultMsg("t2", '<loaded_skill id="system-storage-cleanup" />'),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([
+      {
+        id: "system-storage-cleanup",
+        selector: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+      },
+    ]);
+  });
+
   test("multiple markers from different skill_load tool results", () => {
     const messages: Message[] = [
       skillLoadUseMsg("t1"),

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -2,6 +2,7 @@ import * as realFs from "node:fs";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
+import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
 import { RiskLevel } from "../permissions/types.js";
 import type {
   Message,
@@ -9,6 +10,7 @@ import type {
   ToolResultContent,
   ToolUseContent,
 } from "../providers/types.js";
+import { BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR } from "../skills/system-storage-cleanup-constants.js";
 import type { Tool } from "../tools/types.js";
 import { buildSkillLoadHistory } from "./test-support/browser-skill-harness.js";
 
@@ -1986,10 +1988,10 @@ describe("resetSkillToolProjection", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Versioned marker integration tests
+// Loaded-skill marker integration tests
 // ---------------------------------------------------------------------------
 
-describe("versioned markers through session projection", () => {
+describe("loaded skill markers through session projection", () => {
   let sessionState: Map<string, string>;
 
   beforeEach(() => {
@@ -2019,23 +2021,80 @@ describe("versioned markers through session projection", () => {
     expect(result.allowedToolNames).toEqual(new Set(["deploy_run"]));
   });
 
-  test("storage cleanup marker does not project shadow tools after catalog drift", () => {
+  test("bundled cleanup marker does not project managed shadow tools", () => {
     mockCatalog = [makeSkill("system-storage-cleanup")];
     mockManifests = {
       "system-storage-cleanup": makeManifest(["shadow_cleanup_run"]),
     };
-    mockVersionHashes = {
-      "system-storage-cleanup": "v1:managed-shadow",
-    };
 
     const history: Message[] = [
       ...skillLoadMessages(
-        '<loaded_skill id="system-storage-cleanup" version="v1:bundled-cleanup" />',
+        '<loaded_skill id="system-storage-cleanup" />',
         "bundled: system-storage-cleanup",
       ),
     ];
 
     const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+
+    expect(result.toolDefinitions).toEqual([]);
+    expect(result.allowedToolNames).toEqual(new Set());
+    expect(sessionState.has("system-storage-cleanup")).toBe(false);
+    expect(mockRegisteredTools.has("system-storage-cleanup")).toBe(false);
+  });
+
+  test("later bundled cleanup marker upgrades plain marker provenance", () => {
+    mockCatalog = [makeSkill("system-storage-cleanup")];
+    mockManifests = {
+      "system-storage-cleanup": makeManifest(["shadow_cleanup_run"]),
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="system-storage-cleanup" />'),
+      ...skillLoadMessages(
+        '<loaded_skill id="system-storage-cleanup" />',
+        BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+      ),
+    ];
+
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+
+    expect(result.toolDefinitions).toEqual([]);
+    expect(result.allowedToolNames).toEqual(new Set());
+    expect(sessionState.has("system-storage-cleanup")).toBe(false);
+    expect(mockRegisteredTools.has("system-storage-cleanup")).toBe(false);
+  });
+
+  test("incremental cache upgrades cleanup provenance from later bundled marker", () => {
+    mockCatalog = [makeSkill("system-storage-cleanup")];
+    mockManifests = {
+      "system-storage-cleanup": makeManifest(["shadow_cleanup_run"]),
+    };
+
+    const cache: SkillProjectionCache = {};
+    const initialHistory: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="system-storage-cleanup" />'),
+    ];
+    const initial = projectSkillTools(initialHistory, {
+      cache,
+      previouslyActiveSkillIds: sessionState,
+    });
+
+    expect(initial.allowedToolNames).toEqual(new Set(["shadow_cleanup_run"]));
+    expect(sessionState.has("system-storage-cleanup")).toBe(true);
+
+    const updatedHistory: Message[] = [
+      ...initialHistory,
+      ...skillLoadMessages(
+        '<loaded_skill id="system-storage-cleanup" />',
+        BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+      ),
+    ];
+    const result = projectSkillTools(updatedHistory, {
+      cache,
       previouslyActiveSkillIds: sessionState,
     });
 

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -17,6 +17,7 @@ import { skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
 import { loadSkillCatalog } from "../config/skills.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
+import { mergeActiveSkillEntry } from "../skills/active-skill-entry-merge.js";
 import type { ActiveSkillEntry } from "../skills/active-skill-tools.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
 import {
@@ -161,14 +162,12 @@ function getCachedActiveSkills(
     const delta = history.slice(cached.messageCount);
     const newEntries = deriveActiveSkills(delta);
 
-    // Merge: add any entries not already seen.
+    // Merge appended entries while preserving order and upgrading cleanup
+    // provenance if a later bundled selector supersedes an older id-only marker.
     let changed = false;
     for (const entry of newEntries) {
-      if (!cached.seenIds.has(entry.id)) {
-        cached.seenIds.add(entry.id);
-        cached.entries.push(entry);
-        changed = true;
-      }
+      changed =
+        mergeActiveSkillEntry(cached.entries, cached.seenIds, entry) || changed;
     }
 
     cached.messageCount = history.length;

--- a/assistant/src/skills/active-skill-entry-merge.ts
+++ b/assistant/src/skills/active-skill-entry-merge.ts
@@ -1,0 +1,37 @@
+import type { ActiveSkillEntry } from "./active-skill-tools.js";
+import {
+  BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+  SYSTEM_STORAGE_CLEANUP_SKILL_ID,
+} from "./system-storage-cleanup-constants.js";
+
+export function mergeActiveSkillEntry(
+  entries: ActiveSkillEntry[],
+  seenIds: Set<string>,
+  entry: ActiveSkillEntry,
+): boolean {
+  if (!seenIds.has(entry.id)) {
+    seenIds.add(entry.id);
+    entries.push(entry);
+    return true;
+  }
+
+  if (
+    entry.id === SYSTEM_STORAGE_CLEANUP_SKILL_ID &&
+    entry.selector === BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR
+  ) {
+    const existing = entries.find(
+      (candidate) => candidate.id === SYSTEM_STORAGE_CLEANUP_SKILL_ID,
+    );
+    if (existing?.selector !== BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR) {
+      if (existing) {
+        existing.selector = BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR;
+        if (entry.version) {
+          existing.version = entry.version;
+        }
+      }
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/assistant/src/skills/active-skill-tools.ts
+++ b/assistant/src/skills/active-skill-tools.ts
@@ -1,4 +1,5 @@
 import type { Message } from "../providers/types.js";
+import { mergeActiveSkillEntry } from "./active-skill-entry-merge.js";
 import { normalizeBundledSkillSelector } from "./system-storage-cleanup-constants.js";
 
 /** Matches both old (`<loaded_skill id="..." />`) and new versioned
@@ -64,19 +65,15 @@ export function deriveActiveSkills(messages: Message[]): ActiveSkillEntry[] {
       if (!text) continue;
 
       for (const match of text.matchAll(LOADED_SKILL_RE)) {
-        const id = match[1];
-        if (!seen.has(id)) {
-          seen.add(id);
-          const entry: ActiveSkillEntry = { id };
-          if (match[2]) {
-            entry.version = match[2];
-          }
-          const selector = skillLoadSelectorsByUseId.get(block.tool_use_id);
-          if (selector) {
-            entry.selector = selector;
-          }
-          entries.push(entry);
+        const entry: ActiveSkillEntry = { id: match[1] };
+        if (match[2]) {
+          entry.version = match[2];
         }
+        const selector = skillLoadSelectorsByUseId.get(block.tool_use_id);
+        if (selector) {
+          entry.selector = selector;
+        }
+        mergeActiveSkillEntry(entries, seen, entry);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Upgrade active cleanup skill provenance when a later bundled cleanup marker follows an older plain marker.
- Apply the same provenance upgrade in the incremental projection cache path.
- Add regressions for full-history and cached projection against managed cleanup shadows.

Part of ATL-462
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->