### PR TITLE
Fix JARVIS-712 default profile seeding for local hatch

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -83,6 +83,14 @@ function writeConfig(obj: unknown): void {
   writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
 }
 
+function mergeDefaultConfigAndSeedInferenceProfiles(): void {
+  const defaultConfigMerge = mergeDefaultWorkspaceConfig();
+  seedInferenceProfiles({
+    preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
+    preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests: deepMergeOverwrite (unit) — JSON-null-as-deletion semantics
 //
@@ -417,8 +425,7 @@ describe("loadConfig startup behavior", () => {
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 
-    seedInferenceProfiles();
-    mergeDefaultWorkspaceConfig();
+    mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
 
     expect(config.llm.default.provider).toBe("anthropic");
@@ -454,8 +461,7 @@ describe("loadConfig startup behavior", () => {
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 
-    seedInferenceProfiles();
-    mergeDefaultWorkspaceConfig();
+    mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
     const mainAgentConfig = resolveCallSiteConfig("mainAgent", config.llm);
 
@@ -473,6 +479,79 @@ describe("loadConfig startup behavior", () => {
     });
     expect(raw.llm.activeProfile).toBeUndefined();
     expect(raw.llm.profiles.balanced).toEqual({});
+  });
+
+  test("platform-provided profile fragments are not polluted by managed seeds", () => {
+    writeConfig({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            maxTokens: 16000,
+            effort: "high",
+            thinking: { enabled: true, streamThinking: true },
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: {
+              provider: "openai",
+              model: "gpt-5.4",
+            },
+            profiles: {
+              balanced: {
+                source: "managed",
+                provider: "openai",
+                model: "gpt-5.4",
+                label: "Platform Balanced",
+              },
+            },
+            activeProfile: "balanced",
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const config = loadConfig();
+    const mainAgentConfig = resolveCallSiteConfig("mainAgent", config.llm);
+
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.profiles.balanced).toEqual({
+      source: "managed",
+      provider: "openai",
+      model: "gpt-5.4",
+      label: "Platform Balanced",
+    });
+    expect(mainAgentConfig.provider).toBe("openai");
+    expect(mainAgentConfig.model).toBe("gpt-5.4");
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.profiles.balanced).toEqual({
+      source: "managed",
+      provider: "openai",
+      model: "gpt-5.4",
+      label: "Platform Balanced",
+    });
+    expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
+    expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
   });
 
   test("still quarantines corrupt JSON", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -552,6 +552,17 @@ describe("loadConfig startup behavior", () => {
     });
     expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
     expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const afterRestart = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(afterRestart.llm.activeProfile).toBe("balanced");
+    expect(afterRestart.llm.profiles.balanced).toEqual({
+      source: "managed",
+      provider: "openai",
+      model: "gpt-5.4",
+      label: "Platform Balanced",
+    });
   });
 
   test("still quarantines corrupt JSON", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -565,6 +565,43 @@ describe("loadConfig startup behavior", () => {
     });
   });
 
+  test("quarantines corrupt config before merging hatch overlay", () => {
+    writeFileSync(CONFIG_PATH, "{not valid json");
+
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: {
+              provider: "anthropic",
+              model: "claude-opus-4-7",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const quarantined = readdirSync(WORKSPACE_DIR).filter((n) =>
+      n.startsWith("config.json.corrupt-"),
+    );
+    expect(quarantined.length).toBeGreaterThan(0);
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+    });
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+  });
+
   test("still quarantines corrupt JSON", () => {
     // Corrupt-config quarantine is a recovery path: the broken file is
     // renamed to `config.json.corrupt-<ts>.json` and the daemon proceeds

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -542,8 +542,10 @@ export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult
   if (existsSync(configPath)) {
     try {
       existing = JSON.parse(readFileSync(configPath, "utf-8"));
-    } catch {
-      // If existing config is corrupt, start fresh
+    } catch (err) {
+      quarantineCorruptConfig(configPath, err);
+      // After preserving the corrupt file, start fresh so the default overlay
+      // can still initialize a valid config for this startup.
     }
   }
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -407,6 +407,13 @@ function stripNullLeaves(value: unknown): unknown {
   return out;
 }
 
+function readPlainObject(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
 /**
  * Deep-merge `overrides` into `target`, overwriting leaf values.
  * Recursively merges nested objects; scalars and arrays from `overrides`
@@ -470,6 +477,18 @@ export function deepMergeOverwrite(
   }
 }
 
+export type DefaultWorkspaceConfigMergeResult = {
+  providedLlmProfileNames: Set<string>;
+  providedLlmActiveProfile: boolean;
+};
+
+function emptyDefaultWorkspaceConfigMergeResult(): DefaultWorkspaceConfigMergeResult {
+  return {
+    providedLlmProfileNames: new Set(),
+    providedLlmActiveProfile: false,
+  };
+}
+
 /**
  * Merge default workspace config from the file referenced by
  * VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH into the workspace config on disk.
@@ -479,9 +498,11 @@ export function deepMergeOverwrite(
  * Schema defaults are no longer materialized into the file on load — the
  * in-memory `loadConfig()` cache applies them at access time instead.
  */
-export function mergeDefaultWorkspaceConfig(): void {
+export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult {
   const defaultConfigPath = process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
-  if (!defaultConfigPath || !existsSync(defaultConfigPath)) return;
+  if (!defaultConfigPath || !existsSync(defaultConfigPath)) {
+    return emptyDefaultWorkspaceConfigMergeResult();
+  }
 
   let defaults: unknown;
   try {
@@ -492,7 +513,7 @@ export function mergeDefaultWorkspaceConfig(): void {
       "Failed to read default workspace config from %s",
       defaultConfigPath,
     );
-    return;
+    return emptyDefaultWorkspaceConfigMergeResult();
   }
 
   if (
@@ -500,8 +521,21 @@ export function mergeDefaultWorkspaceConfig(): void {
     typeof defaults !== "object" ||
     Array.isArray(defaults)
   ) {
-    return;
+    return emptyDefaultWorkspaceConfigMergeResult();
   }
+
+  const llmDefaults = readPlainObject(
+    (defaults as Record<string, unknown>).llm,
+  );
+  const providedProfiles = readPlainObject(llmDefaults?.profiles);
+  const mergeResult: DefaultWorkspaceConfigMergeResult = {
+    providedLlmProfileNames: new Set(
+      providedProfiles ? Object.keys(providedProfiles) : [],
+    ),
+    providedLlmActiveProfile:
+      llmDefaults != null &&
+      Object.prototype.hasOwnProperty.call(llmDefaults, "activeProfile"),
+  };
 
   const configPath = getConfigPath();
   let existing: Record<string, unknown> = {};
@@ -510,6 +544,19 @@ export function mergeDefaultWorkspaceConfig(): void {
       existing = JSON.parse(readFileSync(configPath, "utf-8"));
     } catch {
       // If existing config is corrupt, start fresh
+    }
+  }
+
+  if (mergeResult.providedLlmProfileNames.size > 0) {
+    // Default-config profile entries are authoritative fragments. Remove any
+    // old same-name profile first so recursive merge does not leave stale
+    // provider-specific leaves behind.
+    const existingLlm = readPlainObject(existing.llm);
+    const existingProfiles = readPlainObject(existingLlm?.profiles);
+    if (existingProfiles) {
+      for (const name of mergeResult.providedLlmProfileNames) {
+        delete existingProfiles[name];
+      }
     }
   }
 
@@ -536,6 +583,8 @@ export function mergeDefaultWorkspaceConfig(): void {
   } catch {
     log.info("Merged default workspace config from %s", defaultConfigPath);
   }
+
+  return mergeResult;
 }
 
 export function loadConfig(): AssistantConfig {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
@@ -53,24 +51,35 @@ export const MANAGED_PROFILE_NAMES = new Set(
   Object.keys(MANAGED_PROFILE_SEED_DATA),
 );
 
+export type SeedInferenceProfilesOptions = {
+  /**
+   * Managed profile names supplied by the platform/default overlay for this
+   * startup. Those entries are already on disk by the time seeding runs and
+   * should remain authoritative for this boot.
+   */
+  preserveProfileNames?: Iterable<string>;
+  preserveActiveProfile?: boolean;
+};
+
 /**
  * Seed managed inference profiles into the workspace config.
  *
- * Called on every daemon startup after workspace migrations and before
- * the first `loadConfig()`. Managed profiles are overwritten entirely
- * (replace, not merge) so upstream model/effort changes propagate.
- * User-created profiles are never touched; pre-existing profiles
+ * Called on every daemon startup after workspace migrations and default-config
+ * overlays merge, but before the first `loadConfig()`. Managed profiles are
+ * overwritten entirely (replace, not merge) so upstream model/effort changes
+ * propagate. User-created profiles are never touched; pre-existing profiles
  * without a `source` field get `source: "user"` backfilled.
  *
- * Still runs when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set. Lifecycle
- * calls this before merging the hatch overlay so managed profiles exist for the
- * first config load, while the overlay can still override profile/default
- * fields immediately afterward. When that overlay declares a non-Anthropic
- * default provider, seed placeholder profile slots but do not force the
- * Anthropic `balanced` profile active.
+ * Default-config overlays can provide their own profile fragments and active
+ * profile. Lifecycle passes those explicit fields in `options`, letting local
+ * hatches still receive managed Anthropic defaults while platform-owned
+ * profile choices remain authoritative.
  */
-export function seedInferenceProfiles(): void {
+export function seedInferenceProfiles(
+  options: SeedInferenceProfilesOptions = {},
+): void {
   const config = loadRawConfig();
+  const preservedProfileNames = new Set(options.preserveProfileNames ?? []);
 
   if (config.llm == null || typeof config.llm !== "object") {
     config.llm = {};
@@ -85,21 +94,31 @@ export function seedInferenceProfiles(): void {
     resolveEffectiveDefaultProvider(llm) === "anthropic";
 
   for (const [name, seed] of Object.entries(MANAGED_PROFILE_SEED_DATA)) {
+    if (
+      preservedProfileNames.has(name) &&
+      readObject(profiles[name]) !== null
+    ) {
+      continue;
+    }
     profiles[name] = isAnthropicDefault ? { ...seed } : {};
   }
 
+  const activeProfile = readString(llm.activeProfile);
+  const activeProfileExists =
+    activeProfile !== undefined && readObject(profiles[activeProfile]) !== null;
+  const shouldPreserveActiveProfile =
+    options.preserveActiveProfile && activeProfileExists;
+
   if (isAnthropicDefault) {
     // Reset to the default managed profile when the current value is missing.
-    if (
-      typeof llm.activeProfile !== "string" ||
-      !(llm.activeProfile in profiles)
-    ) {
+    if (!activeProfileExists) {
       llm.activeProfile = "balanced";
     }
   } else if (
-    typeof llm.activeProfile !== "string" ||
-    !(llm.activeProfile in profiles) ||
-    MANAGED_PROFILE_NAMES.has(llm.activeProfile)
+    !shouldPreserveActiveProfile &&
+    (activeProfile === undefined ||
+      !activeProfileExists ||
+      MANAGED_PROFILE_NAMES.has(activeProfile))
   ) {
     delete llm.activeProfile;
   }
@@ -130,25 +149,7 @@ export function seedInferenceProfiles(): void {
 }
 
 function resolveEffectiveDefaultProvider(llm: Record<string, unknown>): string {
-  return (
-    readDefaultProviderFromOverlay() ??
-    readString(readObject(llm.default)?.provider) ??
-    "anthropic"
-  );
-}
-
-function readDefaultProviderFromOverlay(): string | undefined {
-  const defaultConfigPath = process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
-  if (!defaultConfigPath) return undefined;
-
-  try {
-    const raw = JSON.parse(readFileSync(defaultConfigPath, "utf-8"));
-    const llm = readObject(raw)?.llm;
-    const defaultBlock = readObject(readObject(llm)?.default);
-    return readString(defaultBlock?.provider);
-  } catch {
-    return undefined;
-  }
+  return readString(readObject(llm.default)?.provider) ?? "anthropic";
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -94,9 +94,12 @@ export function seedInferenceProfiles(
     resolveEffectiveDefaultProvider(llm) === "anthropic";
 
   for (const [name, seed] of Object.entries(MANAGED_PROFILE_SEED_DATA)) {
+    const existingProfile = readObject(profiles[name]);
     if (
-      preservedProfileNames.has(name) &&
-      readObject(profiles[name]) !== null
+      existingProfile !== null &&
+      (preservedProfileNames.has(name) ||
+        (!isAnthropicDefault &&
+          isProviderSpecificManagedProfile(existingProfile)))
     ) {
       continue;
     }
@@ -104,10 +107,17 @@ export function seedInferenceProfiles(
   }
 
   const activeProfile = readString(llm.activeProfile);
+  const activeProfileEntry =
+    activeProfile !== undefined ? readObject(profiles[activeProfile]) : null;
   const activeProfileExists =
-    activeProfile !== undefined && readObject(profiles[activeProfile]) !== null;
+    activeProfile !== undefined && activeProfileEntry !== null;
   const shouldPreserveActiveProfile =
     options.preserveActiveProfile && activeProfileExists;
+  const activeProfileIsManaged = MANAGED_PROFILE_NAMES.has(activeProfile ?? "");
+  const activeProfileIsProviderSpecificManaged =
+    activeProfileIsManaged &&
+    activeProfileEntry !== null &&
+    isProviderSpecificManagedProfile(activeProfileEntry);
 
   if (isAnthropicDefault) {
     // Reset to the default managed profile when the current value is missing.
@@ -118,7 +128,7 @@ export function seedInferenceProfiles(
     !shouldPreserveActiveProfile &&
     (activeProfile === undefined ||
       !activeProfileExists ||
-      MANAGED_PROFILE_NAMES.has(activeProfile))
+      (activeProfileIsManaged && !activeProfileIsProviderSpecificManaged))
   ) {
     delete llm.activeProfile;
   }
@@ -150,6 +160,14 @@ export function seedInferenceProfiles(
 
 function resolveEffectiveDefaultProvider(llm: Record<string, unknown>): string {
   return readString(readObject(llm.default)?.provider) ?? "anthropic";
+}
+
+function isProviderSpecificManagedProfile(
+  profile: Record<string, unknown>,
+): boolean {
+  const provider = readString(profile.provider);
+  if (provider === "anthropic") return false;
+  return provider !== undefined || readString(profile.source) === "managed";
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -499,12 +499,22 @@ export async function runDaemon(): Promise<void> {
       }
     } // end if (dbReady)
 
+    // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
+    // into the workspace config file before profile seeding and the first
+    // loadConfig() call so onboarding/platform preferences are visible to the
+    // seeder and persisted alongside schema defaults.
+    const defaultConfigMerge = mergeDefaultWorkspaceConfig();
+
     // Seed managed inference profiles into the workspace config. Runs after
-    // workspace migrations and before mergeDefaultWorkspaceConfig / loadConfig
-    // so fresh hatches have profiles on disk before the first config load; the
-    // hatch overlay still merges afterward and can override seeded fields.
+    // workspace migrations and default-config merge, but before loadConfig() so
+    // fresh hatches have profiles on disk before the first config load. Any
+    // profile fields explicitly supplied by the default overlay stay
+    // authoritative for this startup.
     try {
-      seedInferenceProfiles();
+      seedInferenceProfiles({
+        preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
+        preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
+      });
       log.info("Inference profile seeding complete");
     } catch (err) {
       log.warn(
@@ -512,11 +522,6 @@ export async function runDaemon(): Promise<void> {
         "Inference profile seeding failed — continuing startup",
       );
     }
-
-    // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
-    // into the workspace config file before the first loadConfig() call so
-    // onboarding preferences are persisted alongside schema defaults.
-    mergeDefaultWorkspaceConfig();
 
     log.info("Daemon startup: loading config");
     const config = loadConfig();


### PR DESCRIPTION
## Summary
- Merge default workspace config before profile seeding so local hosted Anthropic onboarding gets managed profiles on first load.
- Preserve provider-specific platform profile entries and active profile choices instead of overwriting or deep-merging stale managed leaves.
- Add startup config regression coverage for Anthropic hatch, non-Anthropic hatch, and platform-provided profiles.

Closes JARVIS-712

## Original prompt
it please
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->