### PR TITLE
fix: skip dependency trees in skill watchers

### DIFF
--- a/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
+++ b/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
@@ -32,6 +32,7 @@ interface CapturedWatcher {
 }
 
 const capturedWatchers: CapturedWatcher[] = [];
+let recursiveWatchAvailable = false;
 
 mock.module("node:fs", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -44,7 +45,10 @@ mock.module("node:fs", () => {
       if (typeof args[0] === "function") {
         callback = args[0] as WatchCallback;
       } else {
-        if ((args[0] as { recursive?: boolean } | undefined)?.recursive) {
+        if (
+          (args[0] as { recursive?: boolean } | undefined)?.recursive &&
+          !recursiveWatchAvailable
+        ) {
           throw new Error("recursive watch unavailable");
         }
         callback = args[1] as WatchCallback;
@@ -131,6 +135,7 @@ describe("ConfigWatcher skills watcher reseeding", () => {
 
   beforeEach(() => {
     capturedWatchers.length = 0;
+    recursiveWatchAvailable = false;
     rmSync(SKILLS_DIR, { recursive: true, force: true });
     mkdirSync(SKILLS_DIR, { recursive: true });
     evictCalls = 0;
@@ -163,6 +168,46 @@ describe("ConfigWatcher skills watcher reseeding", () => {
     const skillsWatcher = findWatcher(SKILLS_DIR);
     expect(skillsWatcher).toBeDefined();
     skillsWatcher!.callback("change", "example-skill/SKILL.md");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(1);
+    expect(skillsChangedCalls).toBe(1);
+  });
+
+  test("recursive watcher ignores skipped dependency and staging paths", async () => {
+    recursiveWatchAvailable = true;
+
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    const skillsWatcher = findWatcher(SKILLS_DIR);
+    expect(skillsWatcher).toBeDefined();
+    skillsWatcher!.callback(
+      "change",
+      "example-skill/node_modules/pkg/index.js",
+    );
+    skillsWatcher!.callback(
+      "change",
+      ".install-staging/example-skill/SKILL.md",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(0);
+    expect(skillsChangedCalls).toBe(0);
+
+    skillsWatcher!.callback("change", "example-skill/references/foo.md");
 
     await new Promise((resolve) => setTimeout(resolve, 300));
 
@@ -216,6 +261,59 @@ describe("ConfigWatcher skills watcher reseeding", () => {
     const referencesWatcher = findWatcher(referencesDir);
     expect(referencesWatcher).toBeDefined();
     referencesWatcher!.callback("change", "notes.md");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(1);
+    expect(skillsChangedCalls).toBe(1);
+  });
+
+  test("fallback skips dependency and staging directories", async () => {
+    const skillDir = join(SKILLS_DIR, "example-skill");
+    const nodeModulesDir = join(skillDir, "node_modules");
+    const dependencyDir = join(nodeModulesDir, "pkg");
+    const stagingDir = join(SKILLS_DIR, ".install-staging");
+    const stagedSkillDir = join(stagingDir, "example-skill");
+    const referencesDir = join(skillDir, "references");
+    mkdirSync(dependencyDir, { recursive: true });
+    mkdirSync(stagedSkillDir, { recursive: true });
+    mkdirSync(referencesDir, { recursive: true });
+
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    expect(findWatcher(nodeModulesDir)).toBeUndefined();
+    expect(findWatcher(dependencyDir)).toBeUndefined();
+    expect(findWatcher(stagingDir)).toBeUndefined();
+    expect(findWatcher(stagedSkillDir)).toBeUndefined();
+
+    const skillsWatcher = findWatcher(SKILLS_DIR);
+    const skillWatcher = findWatcher(skillDir);
+    expect(skillsWatcher).toBeDefined();
+    expect(skillWatcher).toBeDefined();
+
+    skillsWatcher!.callback("rename", ".install-staging");
+    skillWatcher!.callback("rename", "node_modules");
+    skillWatcher!.callback("change", "node_modules/pkg/index.js");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(0);
+    expect(skillsChangedCalls).toBe(0);
+
+    const referencesWatcher = findWatcher(referencesDir);
+    expect(referencesWatcher).toBeDefined();
+    referencesWatcher!.callback("change", "foo.md");
 
     await new Promise((resolve) => setTimeout(resolve, 300));
 

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -37,6 +37,27 @@ import { reloadMcpServers } from "./mcp-reload-service.js";
 
 const log = getLogger("config-watcher");
 
+const SKILL_WATCH_SKIPPED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "__pycache__",
+  ".install-staging",
+  ".cache",
+  ".next",
+  ".turbo",
+  ".venv",
+  "dist",
+  "build",
+  "coverage",
+]);
+
+function isSkippedSkillWatchPath(relativePath: string): boolean {
+  if (relativePath === "(unknown)") return false;
+
+  const segments = relativePath.split(/[\\/]+/).filter(Boolean);
+  return segments.some((segment) => SKILL_WATCH_SKIPPED_DIRS.has(segment));
+}
+
 /**
  * Attach a resilient error handler to an FSWatcher so that async errors
  * (e.g. ENXIO when a Unix socket file like `gateway.sock` appears in a
@@ -395,6 +416,8 @@ export class ConfigWatcher {
     if (!existsSync(skillsDir)) return;
 
     const scheduleSkillsReload = (file: string): void => {
+      if (isSkippedSkillWatchPath(file)) return;
+
       this.debounceTimers.schedule("skills:catalog", () => {
         log.info({ file }, "Skill file changed, reloading");
         onConversationEvict();
@@ -473,6 +496,7 @@ export class ConfigWatcher {
 
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
+        if (SKILL_WATCH_SKIPPED_DIRS.has(entry.name)) continue;
         const childDir = join(dirPath, entry.name);
         acc.add(childDir);
         enumerateSkillSubdirectories(childDir, acc);
@@ -504,7 +528,10 @@ export class ConfigWatcher {
         if (childWatchers.has(childDir)) continue;
 
         const watcher = watchDir(childDir, (filename) => {
-          scheduleSkillsReload(formatSkillChangeLabel(childDir, filename));
+          const file = formatSkillChangeLabel(childDir, filename);
+          if (isSkippedSkillWatchPath(file)) return;
+
+          scheduleSkillsReload(file);
           refreshChildWatchers();
         });
         if (watcher) {
@@ -514,6 +541,8 @@ export class ConfigWatcher {
     };
 
     const rootWatcher = watchDir(skillsDir, (filename) => {
+      if (isSkippedSkillWatchPath(filename)) return;
+
       scheduleSkillsReload(filename);
       refreshChildWatchers();
     });


### PR DESCRIPTION
## Summary
- Skips dependency and staging directories in skill file watchers.
- Keeps real nested skill changes triggering eviction and memory refresh.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->