### PR TITLE
fix: keep v2 skill seed queue draining

### DIFF
--- a/assistant/src/memory/v2/__tests__/skill-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-store.test.ts
@@ -440,6 +440,64 @@ describe("seedV2SkillEntries", () => {
     expect(getSkillCapability("example-skill-b")?.content).toContain("Skill B");
   });
 
+  test("continues draining when waiter continuations enqueue additional generations", async () => {
+    const skillA = makeSummary({
+      id: "example-skill-a",
+      displayName: "Skill A",
+    });
+    const skillB = makeSummary({
+      id: "example-skill-b",
+      displayName: "Skill B",
+    });
+    const skillC = makeSummary({
+      id: "example-skill-c",
+      displayName: "Skill C",
+    });
+
+    function useSkill(skill: SkillSummary, dense: number[]): void {
+      state.catalog = [skill];
+      state.resolved = [{ summary: skill, state: "enabled" }];
+      state.embedReturn = [dense];
+    }
+
+    useSkill(skillA, [0.1, 0.2, 0.3]);
+    const firstSeed = seedV2SkillEntries();
+    const secondSeed = firstSeed.then(() => {
+      useSkill(skillB, [0.4, 0.5, 0.6]);
+      return seedV2SkillEntries();
+    });
+    const thirdSeed = secondSeed.then(() => {
+      useSkill(skillC, [0.7, 0.8, 0.9]);
+      return seedV2SkillEntries();
+    });
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await expect(
+        Promise.race([
+          Promise.all([firstSeed, secondSeed, thirdSeed]),
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error("seed queue stalled")),
+              500,
+            );
+          }),
+        ]),
+      ).resolves.toBeDefined();
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+
+    expect(state.upsertCalls.map((call) => call.slug)).toEqual([
+      "skills/example-skill-a",
+      "skills/example-skill-b",
+      "skills/example-skill-c",
+    ]);
+    expect(getSkillCapability("example-skill-a")).toBeNull();
+    expect(getSkillCapability("example-skill-b")).toBeNull();
+    expect(getSkillCapability("example-skill-c")?.content).toContain("Skill C");
+  });
+
   test("seeds disk-discovered managed skills omitted from a stale SKILLS.md index", async () => {
     const previousWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
     const workspaceDir = mkdtempSync(join(tmpdir(), "skill-store-index-"));

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -99,17 +99,18 @@ export function seedV2SkillEntries(): Promise<void> {
   const waiter = new Promise<void>((resolve) => {
     seedWaiters.push({ generation, resolve });
   });
-  if (!activeSeedDrain) {
-    activeSeedDrain = drainSeedQueue().finally(() => {
-      activeSeedDrain = null;
-      if (processedSeedGeneration < requestedSeedGeneration) {
-        activeSeedDrain = drainSeedQueue().finally(() => {
-          activeSeedDrain = null;
-        });
-      }
-    });
-  }
+  startSeedDrainIfNeeded();
   return waiter;
+}
+
+function startSeedDrainIfNeeded(): void {
+  if (activeSeedDrain) return;
+  if (processedSeedGeneration >= requestedSeedGeneration) return;
+
+  activeSeedDrain = drainSeedQueue().finally(() => {
+    activeSeedDrain = null;
+    startSeedDrainIfNeeded();
+  });
 }
 
 async function drainSeedQueue(): Promise<void> {


### PR DESCRIPTION
## Summary
- Reworks Memory V2 skill seed queue scheduling so later generations cannot strand waiters.
- Adds regression coverage for queued seed runs.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->