### PR TITLE
fix: remove legacy skill index fields from tools

### DIFF
--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -46,7 +46,27 @@ afterEach(() => {
 });
 
 describe("delete_managed_skill tool", () => {
-  test("deletes existing skill while leaving a stale SKILLS.md index unchanged", async () => {
+  test("does not expose legacy index controls in the bundled tool schema", () => {
+    const tools = JSON.parse(
+      readFileSync(
+        join(
+          import.meta.dirname,
+          "../config/bundled-skills/skill-management/TOOLS.json",
+        ),
+        "utf-8",
+      ),
+    );
+    const deleteTool = tools.tools.find(
+      (tool: { name: string }) => tool.name === "delete_managed_skill",
+    );
+
+    expect(deleteTool).toBeDefined();
+    expect(deleteTool.input_schema.properties).not.toHaveProperty(
+      "remove_from_index",
+    );
+  });
+
+  test("deletes existing skill while ignoring legacy index inputs", async () => {
     createSkill("doomed");
     createSkill("survivor");
     const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
@@ -65,7 +85,7 @@ describe("delete_managed_skill tool", () => {
     const parsed = JSON.parse(result.content);
     expect(parsed.deleted).toBe(true);
     expect(parsed.skill_id).toBe("doomed");
-    expect(parsed.index_updated).toBe(false);
+    expect(parsed).not.toHaveProperty("index_updated");
 
     expect(existsSync(join(TEST_DIR, "skills", "doomed"))).toBe(false);
 

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -177,7 +177,7 @@ Run the custom lifecycle verification procedure.
     expect(scaffoldResult.isError).not.toBe(true);
     const scaffoldData = JSON.parse(scaffoldResult.content as string);
     expect(scaffoldData.created).toBe(true);
-    expect(scaffoldData.index_updated).toBe(false);
+    expect(scaffoldData).not.toHaveProperty("index_updated");
 
     // Step 2: Verify SKILL.md was written
     const skillDir = join(TEST_DIR, "skills", "lifecycle-test");
@@ -207,7 +207,7 @@ Run the custom lifecycle verification procedure.
     expect(deleteResult.isError).not.toBe(true);
     const deleteData = JSON.parse(deleteResult.content as string);
     expect(deleteData.deleted).toBe(true);
-    expect(deleteData.index_updated).toBe(false);
+    expect(deleteData).not.toHaveProperty("index_updated");
 
     // Step 5: Verify skill directory is gone from filesystem
     expect(existsSync(skillDir)).toBe(false);

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -32,7 +32,27 @@ afterEach(() => {
 });
 
 describe("scaffold_managed_skill tool", () => {
-  test("creates a valid skill discovered from its SKILL.md directory", async () => {
+  test("does not expose legacy index controls in the bundled tool schema", () => {
+    const tools = JSON.parse(
+      readFileSync(
+        join(
+          import.meta.dirname,
+          "../config/bundled-skills/skill-management/TOOLS.json",
+        ),
+        "utf-8",
+      ),
+    );
+    const scaffoldTool = tools.tools.find(
+      (tool: { name: string }) => tool.name === "scaffold_managed_skill",
+    );
+
+    expect(scaffoldTool).toBeDefined();
+    expect(scaffoldTool.input_schema.properties).not.toHaveProperty(
+      "add_to_index",
+    );
+  });
+
+  test("creates a valid skill discovered from its SKILL.md directory while ignoring legacy inputs", async () => {
     const result = await executeScaffoldManagedSkill(
       {
         skill_id: "test-skill",
@@ -48,7 +68,7 @@ describe("scaffold_managed_skill tool", () => {
     const parsed = JSON.parse(result.content);
     expect(parsed.created).toBe(true);
     expect(parsed.skill_id).toBe("test-skill");
-    expect(parsed.index_updated).toBe(false);
+    expect(parsed).not.toHaveProperty("index_updated");
 
     const skillFile = join(TEST_DIR, "skills", "test-skill", "SKILL.md");
     expect(existsSync(skillFile)).toBe(true);

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -33,10 +33,6 @@
             "type": "boolean",
             "description": "Whether to overwrite an existing skill with the same ID (default: false)."
           },
-          "add_to_index": {
-            "type": "boolean",
-            "description": "Deprecated compatibility input. No-op; managed skills are discovered from top-level SKILL.md files in skill directories."
-          },
           "includes": {
             "type": "array",
             "items": { "type": "string" },
@@ -59,10 +55,6 @@
           "skill_id": {
             "type": "string",
             "description": "The ID of the managed skill to delete."
-          },
-          "remove_from_index": {
-            "type": "boolean",
-            "description": "Deprecated compatibility input. No-op; managed skills disappear when their skill directory is removed."
           }
         },
         "required": ["skill_id"]

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -17,7 +17,6 @@ export async function executeDeleteManagedSkill(
     };
   }
 
-  // remove_from_index is accepted for compatibility; it has no effect.
   const result = deleteManagedSkill(skillId.trim());
 
   if (!result.deleted) {
@@ -28,7 +27,6 @@ export async function executeDeleteManagedSkill(
     content: JSON.stringify({
       deleted: true,
       skill_id: skillId.trim(),
-      index_updated: false,
     }),
     isError: false,
   };

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -83,7 +83,6 @@ export async function executeScaffoldManagedSkill(
     }
   }
 
-  // add_to_index is accepted for compatibility; it has no effect.
   const result = createManagedSkill({
     id: skillId.trim(),
     name: sanitizeFrontmatterValue(name),
@@ -106,7 +105,6 @@ export async function executeScaffoldManagedSkill(
       created: true,
       skill_id: skillId.trim(),
       path: result.path,
-      index_updated: false,
     }),
     isError: false,
   };


### PR DESCRIPTION
## Summary
- Removes legacy SKILLS.md index controls from model-facing skill management tools.
- Keeps executors tolerant of legacy inputs while returning current response shapes.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->