### PR TITLE
refactor(oauth): drop managed mode for dropbox, airtable, salesforce

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -132,11 +132,8 @@ function getDeploymentContextDefaults(): Record<string, unknown> {
       "notion-oauth": managed,
       "asana-oauth": managed,
       "todoist-oauth": managed,
-      "dropbox-oauth": managed,
       "discord-oauth": managed,
-      "airtable-oauth": managed,
       "hubspot-oauth": managed,
-      "salesforce-oauth": managed,
     },
   };
 }

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -80,23 +80,11 @@ const TodoistOAuthServiceSchema = BaseServiceSchema.extend({
   mode: ServiceModeSchema.default("your-own"),
 });
 
-const DropboxOAuthServiceSchema = BaseServiceSchema.extend({
-  mode: ServiceModeSchema.default("your-own"),
-});
-
 const DiscordOAuthServiceSchema = BaseServiceSchema.extend({
   mode: ServiceModeSchema.default("your-own"),
 });
 
-const AirtableOAuthServiceSchema = BaseServiceSchema.extend({
-  mode: ServiceModeSchema.default("your-own"),
-});
-
 const HubspotOAuthServiceSchema = BaseServiceSchema.extend({
-  mode: ServiceModeSchema.default("your-own"),
-});
-
-const SalesforceOAuthServiceSchema = BaseServiceSchema.extend({
   mode: ServiceModeSchema.default("your-own"),
 });
 
@@ -174,20 +162,11 @@ export const ServicesSchema = z.object({
   "todoist-oauth": TodoistOAuthServiceSchema.default(
     TodoistOAuthServiceSchema.parse({}),
   ),
-  "dropbox-oauth": DropboxOAuthServiceSchema.default(
-    DropboxOAuthServiceSchema.parse({}),
-  ),
   "discord-oauth": DiscordOAuthServiceSchema.default(
     DiscordOAuthServiceSchema.parse({}),
   ),
-  "airtable-oauth": AirtableOAuthServiceSchema.default(
-    AirtableOAuthServiceSchema.parse({}),
-  ),
   "hubspot-oauth": HubspotOAuthServiceSchema.default(
     HubspotOAuthServiceSchema.parse({}),
-  ),
-  "salesforce-oauth": SalesforceOAuthServiceSchema.default(
-    SalesforceOAuthServiceSchema.parse({}),
   ),
   meet: MeetDaemonServiceSchema.default(MeetDaemonServiceSchema.parse({})),
 });

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -465,7 +465,6 @@ export const PROVIDER_SEED_DATA: Record<
     availableScopes: "https://developers.dropbox.com/oauth-guide",
     authorizeParams: { token_access_type: "offline" },
     loopbackPort: 17327,
-    managedServiceConfigKey: "dropbox-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.dropboxapi.com",
@@ -533,7 +532,6 @@ export const PROVIDER_SEED_DATA: Record<
     availableScopes: "https://airtable.com/developers/web/api/scopes",
     tokenEndpointAuthMethod: "client_secret_basic",
     loopbackPort: 17329,
-    managedServiceConfigKey: "airtable-oauth",
     injectionTemplates: [
       {
         hostPattern: "api.airtable.com",
@@ -609,7 +607,6 @@ export const PROVIDER_SEED_DATA: Record<
     authorizeParams: { prompt: "consent" },
     tokenEndpointAuthMethod: "client_secret_post",
     loopbackPort: 17336,
-    managedServiceConfigKey: "salesforce-oauth",
     // Salesforce REST traffic goes to per-org instance hosts like
     // ``acme.my.salesforce.com`` and ``acme.lightning.force.com``.
     // ``matchHostPattern`` only treats ``*.<domain>`` as a wildcard match —


### PR DESCRIPTION
## Summary
Removes managed-OAuth wiring for **dropbox**, **airtable**, and **salesforce**. These three providers are now BYO-only; the other managed providers (google, outlook, linear, github, notion, asana, todoist, discord, hubspot, twitter) are unchanged.

## What changes
- **`assistant/src/oauth/seed-providers.ts`**: drop the `managedServiceConfigKey` field from each provider's seed entry. The seed sync's `onConflictDoUpdate` (`oauth-store.ts:222`) re-writes this column on every daemon startup, so existing rows in user installs will have their `managed_service_config_key` cleared on next boot.
- **`assistant/src/config/schemas/services.ts`**: drop `DropboxOAuthServiceSchema`, `AirtableOAuthServiceSchema`, `SalesforceOAuthServiceSchema` and their corresponding entries in `ServicesSchema`. Any stale `services.dropbox-oauth` / `airtable-oauth` / `salesforce-oauth` entries in user `config.json` files will be silently stripped — zod's default `z.object` behavior strips unknown keys.
- **`assistant/src/config/loader.ts`**: drop the three entries from `getDeploymentContextDefaults()`'s default-managed services map.

## What stays
- The three providers remain in `seed-providers.ts` with `pingUrl` / `identityUrl` / `identityResponsePaths` intact — identity verification runs for BYO connections too.
- All generic managed-OAuth machinery (`connection-resolver`, `provider-serializer`, CLI commands, macOS client filtering) is unchanged. After this PR, those code paths simply observe `managedServiceConfigKey === null` for these three providers and report `supports_managed_mode: false`.
- The `seed-providers-managed.test.ts` cross-repo invariant still passes — the test only iterates providers that have `managedServiceConfigKey` set, and verifies each one resolves to a `ServicesSchema` key.

## Test plan
- [x] `bun test src/oauth/__tests__/seed-providers-managed.test.ts` (3/3 pass)
- [x] `tsc --noEmit` clean
- [x] `eslint` on the three modified files clean
- [x] Verified the 3 pre-existing `BYOOAuthConnection` test failures also fail on `main` — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->