### PR TITLE
Tighten cleanup selector provenance helpers

### DIFF
--- a/assistant/src/__tests__/active-skill-tools.test.ts
+++ b/assistant/src/__tests__/active-skill-tools.test.ts
@@ -56,47 +56,6 @@ describe("deriveActiveSkills (ID-only)", () => {
     expect(deriveActiveSkills(messages).map((e) => e.id)).toEqual(["deploy"]);
   });
 
-  test("normalizes bundled selector provenance from skill_load input", () => {
-    const messages: Message[] = [
-      skillLoadUseMsg("t1", " bundled: system-storage-cleanup "),
-      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
-    ];
-
-    expect(deriveActiveSkills(messages)).toEqual([
-      {
-        id: "system-storage-cleanup",
-        selector: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
-      },
-    ]);
-  });
-
-  test("does not retain plain selector provenance", () => {
-    const messages: Message[] = [
-      skillLoadUseMsg("t1", "system-storage-cleanup"),
-      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
-    ];
-
-    expect(deriveActiveSkills(messages)).toEqual([
-      { id: "system-storage-cleanup" },
-    ]);
-  });
-
-  test("later bundled cleanup marker upgrades plain marker provenance", () => {
-    const messages: Message[] = [
-      skillLoadUseMsg("t1", "system-storage-cleanup"),
-      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
-      skillLoadUseMsg("t2", BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR),
-      toolResultMsg("t2", '<loaded_skill id="system-storage-cleanup" />'),
-    ];
-
-    expect(deriveActiveSkills(messages)).toEqual([
-      {
-        id: "system-storage-cleanup",
-        selector: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
-      },
-    ]);
-  });
-
   test("multiple markers from different skill_load tool results", () => {
     const messages: Message[] = [
       skillLoadUseMsg("t1"),
@@ -231,6 +190,80 @@ describe("deriveActiveSkills (ID-only)", () => {
       toolResultMsg("orphan", '<loaded_skill id="sneaky" />'),
     ];
     expect(deriveActiveSkills(messages).map((e) => e.id)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveActiveSkills — selector provenance
+// ---------------------------------------------------------------------------
+
+describe("deriveActiveSkills — selector provenance", () => {
+  test("normalizes bundled cleanup selector provenance from skill_load input", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", " bundled: system-storage-cleanup "),
+      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([
+      {
+        id: "system-storage-cleanup",
+        selector: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+      },
+    ]);
+  });
+
+  test("does not retain plain selector provenance", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", "system-storage-cleanup"),
+      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([
+      { id: "system-storage-cleanup" },
+    ]);
+  });
+
+  test("does not retain unrelated bundled selector provenance", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", "bundled:app-builder"),
+      toolResultMsg("t1", '<loaded_skill id="app-builder" />'),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([{ id: "app-builder" }]);
+  });
+
+  test("retains bundled cleanup selector provenance with versioned markers", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", "bundled: system-storage-cleanup"),
+      toolResultMsg(
+        "t1",
+        '<loaded_skill id="system-storage-cleanup" version="v1:abc123" />',
+      ),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([
+      {
+        id: "system-storage-cleanup",
+        version: "v1:abc123",
+        selector: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+      },
+    ]);
+  });
+
+  test("later bundled cleanup marker upgrades plain marker provenance", () => {
+    const messages: Message[] = [
+      skillLoadUseMsg("t1", "system-storage-cleanup"),
+      toolResultMsg("t1", '<loaded_skill id="system-storage-cleanup" />'),
+      skillLoadUseMsg("t2", BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR),
+      toolResultMsg("t2", '<loaded_skill id="system-storage-cleanup" />'),
+    ];
+
+    expect(deriveActiveSkills(messages)).toEqual([
+      {
+        id: "system-storage-cleanup",
+        selector: BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
+      },
+    ]);
   });
 });
 

--- a/assistant/src/__tests__/disk-pressure-tools.test.ts
+++ b/assistant/src/__tests__/disk-pressure-tools.test.ts
@@ -305,51 +305,6 @@ describe("disk pressure cleanup tool restrictions", () => {
   });
 
   test("executor fallback keeps only instruction-only skill_load safe during cleanup mode", async () => {
-    writeManagedSkill(
-      "plain-cleanup",
-      `---
-name: plain-cleanup
-description: Plain cleanup
----
-
-This skill is instruction-only but unrelated.
-`,
-    );
-    writeManagedSkill(
-      "dynamic-cleanup",
-      `---
-name: dynamic-cleanup
-description: Dynamic cleanup
----
-
-This skill runs !\`echo unsafe\`.
-`,
-    );
-    writeManagedSkill(
-      "tool-cleanup",
-      `---
-name: tool-cleanup
-description: Tool cleanup
----
-
-This skill declares executable tools.
-`,
-      {
-        version: 1,
-        tools: [
-          {
-            name: "tool_cleanup_run",
-            description: "Run cleanup",
-            category: "test",
-            risk: "low",
-            input_schema: { type: "object", properties: {} },
-            executor: "run.ts",
-            execution_target: "sandbox",
-          },
-        ],
-      },
-    );
-
     const handler = new ToolApprovalHandler();
     const baseContext = {
       workingDir: "/workspace",
@@ -409,27 +364,9 @@ This skill declares executable tools.
       BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
     );
 
-    const dynamicResult = await handler.checkPreExecutionGates(
-      "skill_load",
-      { skill: "dynamic-cleanup" },
-      baseContext,
-      "sandbox",
-      "low",
-      Date.now(),
-      () => undefined,
-    );
-
-    expect(dynamicResult.allowed).toBe(false);
-    if (dynamicResult.allowed) {
-      throw new Error("Expected dynamic skill_load to be rejected");
-    }
-    expect(dynamicResult.result.content).toContain(
-      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
-    );
-
     const unrelatedResult = await handler.checkPreExecutionGates(
       "skill_load",
-      { skill: "plain-cleanup" },
+      { skill: "app-builder" },
       baseContext,
       "sandbox",
       "low",
@@ -439,29 +376,9 @@ This skill declares executable tools.
 
     expect(unrelatedResult.allowed).toBe(false);
     if (unrelatedResult.allowed) {
-      throw new Error(
-        "Expected unrelated instruction-only skill to be rejected",
-      );
+      throw new Error("Expected unrelated skill selector to be rejected");
     }
     expect(unrelatedResult.result.content).toContain(
-      BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
-    );
-
-    const toolManifestResult = await handler.checkPreExecutionGates(
-      "skill_load",
-      { skill: "tool-cleanup" },
-      baseContext,
-      "sandbox",
-      "low",
-      Date.now(),
-      () => undefined,
-    );
-
-    expect(toolManifestResult.allowed).toBe(false);
-    if (toolManifestResult.allowed) {
-      throw new Error("Expected tool-manifest skill_load to be rejected");
-    }
-    expect(toolManifestResult.result.content).toContain(
       BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
     );
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -25,9 +25,8 @@ import { parseFrontmatterFields } from "../skills/frontmatter.js";
 import type { InlineCommandExpansion } from "../skills/inline-command-expansions.js";
 import { parseInlineCommandExpansions } from "../skills/inline-command-expansions.js";
 import {
-  BUNDLED_SKILL_SELECTOR_PREFIX,
   BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR,
-  normalizeBundledSkillSelector,
+  normalizeBundledSystemStorageCleanupSelector,
   SYSTEM_STORAGE_CLEANUP_SKILL_ID,
 } from "../skills/system-storage-cleanup-constants.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
@@ -42,6 +41,7 @@ import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import { getConfig } from "./loader.js";
 
 const log = getLogger("skills");
+const BUNDLED_SKILL_SELECTOR_PREFIX = "bundled:";
 
 // ─── Zod schemas for frontmatter metadata validation ─────────────────────────
 
@@ -1168,7 +1168,8 @@ export function resolveSkillSelector(
   }
 
   if (needle.startsWith(BUNDLED_SKILL_SELECTOR_PREFIX)) {
-    const normalizedSelector = normalizeBundledSkillSelector(needle);
+    const normalizedSelector =
+      normalizeBundledSystemStorageCleanupSelector(needle);
     if (normalizedSelector !== BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR) {
       return {
         error: `The "bundled:" skill selector is only supported for "${BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR}".`,

--- a/assistant/src/skills/active-skill-tools.ts
+++ b/assistant/src/skills/active-skill-tools.ts
@@ -1,6 +1,6 @@
 import type { Message } from "../providers/types.js";
 import { mergeActiveSkillEntry } from "./active-skill-entry-merge.js";
-import { normalizeBundledSkillSelector } from "./system-storage-cleanup-constants.js";
+import { normalizeBundledSystemStorageCleanupSelector } from "./system-storage-cleanup-constants.js";
 
 /** Matches both old (`<loaded_skill id="..." />`) and new versioned
  *  (`<loaded_skill id="..." version="v1:hex" />`) marker formats.
@@ -44,9 +44,12 @@ export function deriveActiveSkills(messages: Message[]): ActiveSkillEntry[] {
       if (block.type === "tool_use" && block.name === "skill_load") {
         const rawSelector =
           typeof block.input.skill === "string" ? block.input.skill : undefined;
-        const selector = rawSelector
-          ? (normalizeBundledSkillSelector(rawSelector) ?? undefined)
-          : undefined;
+        let selector: string | undefined;
+        if (rawSelector) {
+          selector =
+            normalizeBundledSystemStorageCleanupSelector(rawSelector) ??
+            undefined;
+        }
         skillLoadSelectorsByUseId.set(block.id, selector);
       }
     }

--- a/assistant/src/skills/system-storage-cleanup-constants.ts
+++ b/assistant/src/skills/system-storage-cleanup-constants.ts
@@ -1,8 +1,10 @@
-export const BUNDLED_SKILL_SELECTOR_PREFIX = "bundled:";
+const BUNDLED_SKILL_SELECTOR_PREFIX = "bundled:";
 export const SYSTEM_STORAGE_CLEANUP_SKILL_ID = "system-storage-cleanup";
 export const BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR = `${BUNDLED_SKILL_SELECTOR_PREFIX}${SYSTEM_STORAGE_CLEANUP_SKILL_ID}`;
 
-export function normalizeBundledSkillSelector(selector: string): string | null {
+export function normalizeBundledSystemStorageCleanupSelector(
+  selector: string,
+): typeof BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR | null {
   const needle = selector.trim();
   if (!needle.startsWith(BUNDLED_SKILL_SELECTOR_PREFIX)) {
     return null;
@@ -11,18 +13,18 @@ export function normalizeBundledSkillSelector(selector: string): string | null {
   const bundledSkillId = needle
     .slice(BUNDLED_SKILL_SELECTOR_PREFIX.length)
     .trim();
-  if (!bundledSkillId) {
+  if (bundledSkillId !== SYSTEM_STORAGE_CLEANUP_SKILL_ID) {
     return null;
   }
 
-  return `${BUNDLED_SKILL_SELECTOR_PREFIX}${bundledSkillId}`;
+  return BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR;
 }
 
 export function isBundledSystemStorageCleanupSelector(
   selector: string,
 ): boolean {
   return (
-    normalizeBundledSkillSelector(selector) ===
+    normalizeBundledSystemStorageCleanupSelector(selector) ===
     BUNDLED_SYSTEM_STORAGE_CLEANUP_SELECTOR
   );
 }


### PR DESCRIPTION
## Summary
- Narrow bundled selector provenance helpers to the cleanup selector.
- Remove dead cleanup-mode test fixtures for non-bundled skill bodies.
- Group selector-provenance tests separately from marker/version tests.

Part of ATL-462
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->