### PR TITLE
fix: watch skill build outputs

### DIFF
--- a/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
+++ b/assistant/src/__tests__/config-watcher-skill-reseed.test.ts
@@ -215,6 +215,32 @@ describe("ConfigWatcher skills watcher reseeding", () => {
     expect(skillsChangedCalls).toBe(1);
   });
 
+  test("recursive watcher reloads skill memories for build output changes", async () => {
+    recursiveWatchAvailable = true;
+
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    const skillsWatcher = findWatcher(SKILLS_DIR);
+    expect(skillsWatcher).toBeDefined();
+    skillsWatcher!.callback("change", "example-skill/dist/index.js");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(1);
+    expect(skillsChangedCalls).toBe(1);
+  });
+
   test("coalesces multiple skill file changes into one catalog refresh", async () => {
     watcher.start(
       () => {
@@ -319,6 +345,45 @@ describe("ConfigWatcher skills watcher reseeding", () => {
 
     expect(evictCalls).toBe(1);
     expect(skillsChangedCalls).toBe(1);
+  });
+
+  test("fallback watches skill build output directories", async () => {
+    const distDir = join(SKILLS_DIR, "example-skill", "dist");
+    const buildDir = join(SKILLS_DIR, "example-skill", "build");
+    mkdirSync(distDir, { recursive: true });
+    mkdirSync(buildDir, { recursive: true });
+
+    watcher.start(
+      () => {
+        evictCalls++;
+      },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        skillsChangedCalls++;
+      },
+    );
+
+    const distWatcher = findWatcher(distDir);
+    const buildWatcher = findWatcher(buildDir);
+    expect(distWatcher).toBeDefined();
+    expect(buildWatcher).toBeDefined();
+
+    distWatcher!.callback("change", "index.js");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(1);
+    expect(skillsChangedCalls).toBe(1);
+
+    buildWatcher!.callback("change", "tool.js");
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(evictCalls).toBe(2);
+    expect(skillsChangedCalls).toBe(2);
   });
 
   test("fallback adds watchers for new nested skill directories without duplicates", () => {

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -46,8 +46,6 @@ const SKILL_WATCH_SKIPPED_DIRS = new Set([
   ".next",
   ".turbo",
   ".venv",
-  "dist",
-  "build",
   "coverage",
 ]);
 


### PR DESCRIPTION
## Summary
- Allows skill watcher refreshes for dist/build tool outputs.
- Keeps dependency and staging directories skipped.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->