### PR TITLE
fix: preserve nested legacy indexed skills

### DIFF
--- a/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
+++ b/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
-import { loadSkillBySelector } from "../config/skills.js";
+import { loadSkillBySelector, loadSkillCatalog } from "../config/skills.js";
 import { removeLegacySkillsIndexMigration } from "../workspace/migrations/068-remove-legacy-skills-index.js";
 
 let workspaceDir: string;
@@ -34,13 +34,13 @@ afterEach(() => {
   }
 });
 
-function writeSkill(skillId: string): string {
+function writeSkill(skillId: string, body = "Body."): string {
   const skillDir = join(workspaceDir, "skills", skillId);
   mkdirSync(skillDir, { recursive: true });
   const skillFilePath = join(skillDir, "SKILL.md");
   writeFileSync(
     skillFilePath,
-    `---\nname: "${skillId}"\ndescription: "Test skill."\n---\n\nBody.\n`,
+    `---\nname: "${skillId}"\ndescription: "Test skill."\n---\n\n${body}\n`,
     "utf-8",
   );
   return skillFilePath;
@@ -109,6 +109,70 @@ describe("068-remove-legacy-skills-index migration", () => {
     expect(loaded.skill).toBeDefined();
     expect(loaded.skill!.id).toBe("omitted-skill");
     expect(loaded.skill!.body).toBe("Body.");
+  });
+
+  test("copies nested indexed skills to top-level discovery location", () => {
+    const legacyIndexPath = writeLegacyIndex("- org/my-skill\n");
+    const nestedSkillPath = writeSkill("org/my-skill");
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    const topLevelSkillPath = join(
+      workspaceDir,
+      "skills",
+      "my-skill",
+      "SKILL.md",
+    );
+    expect(existsSync(legacyIndexPath)).toBe(false);
+    expect(existsSync(nestedSkillPath)).toBe(true);
+    expect(readFileSync(topLevelSkillPath, "utf-8")).toContain("org/my-skill");
+
+    const catalogSkill = loadSkillCatalog().find(
+      (skill) => skill.id === "my-skill",
+    );
+    expect(catalogSkill).toBeDefined();
+    expect(catalogSkill!.directoryPath).toBe(
+      join(workspaceDir, "skills", "my-skill"),
+    );
+
+    const loaded = loadSkillBySelector("my-skill");
+    expect(loaded.error).toBeUndefined();
+    expect(loaded.skill!.id).toBe("my-skill");
+    expect(loaded.skill!.body).toBe("Body.");
+  });
+
+  test("does not overwrite an existing top-level skill when preserving nested indexed skills", () => {
+    const legacyIndexPath = writeLegacyIndex("- org/my-skill\n");
+    const nestedSkillPath = writeSkill("org/my-skill", "Nested body.");
+    const topLevelSkillPath = writeSkill("my-skill", "Top-level body.");
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    expect(existsSync(legacyIndexPath)).toBe(false);
+    expect(readFileSync(nestedSkillPath, "utf-8")).toContain("Nested body.");
+    expect(readFileSync(topLevelSkillPath, "utf-8")).toContain(
+      "Top-level body.",
+    );
+
+    const loaded = loadSkillBySelector("my-skill");
+    expect(loaded.error).toBeUndefined();
+    expect(loaded.skill!.body).toBe("Top-level body.");
+  });
+
+  test("does not follow legacy index entries outside the skills root", () => {
+    const legacyIndexPath = writeLegacyIndex("- ../outside/my-skill\n");
+    const outsideSkillDir = join(workspaceDir, "outside", "my-skill");
+    mkdirSync(outsideSkillDir, { recursive: true });
+    writeFileSync(
+      join(outsideSkillDir, "SKILL.md"),
+      "---\nname: Outside\ndescription: Outside skill.\n---\n\nOutside.\n",
+      "utf-8",
+    );
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    expect(existsSync(legacyIndexPath)).toBe(false);
+    expect(existsSync(join(workspaceDir, "skills", "my-skill"))).toBe(false);
   });
 
   test("is safe to re-run", () => {

--- a/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
+++ b/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
@@ -1,5 +1,12 @@
 import * as fs from "node:fs";
-import { join } from "node:path";
+import {
+  basename,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+  resolve,
+} from "node:path";
 
 import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
@@ -15,13 +22,159 @@ function isNotFoundError(err: unknown): boolean {
   );
 }
 
+function isInsideDirectory(rootDir: string, candidatePath: string): boolean {
+  const rootRealPath = fs.realpathSync(rootDir);
+  const candidateRealPath = fs.realpathSync(candidatePath);
+  const relativePath = relative(rootRealPath, candidateRealPath);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith("..") && !isAbsolute(relativePath))
+  );
+}
+
+function parseLegacySkillIndexEntry(line: string): string | null {
+  const match = line.match(/^\s*[-*]\s+(.+?)\s*$/);
+  if (!match) return null;
+
+  let entry = match[1].trim();
+  const markdownLink = entry.match(/^\[.+?\]\((.+?)\)$/);
+  if (markdownLink) {
+    entry = markdownLink[1].trim();
+  } else {
+    entry = entry.split(/\s+/)[0]?.trim() ?? "";
+  }
+
+  entry = entry.replace(/^`|`$/g, "");
+  if (!entry || entry.includes("\0") || isAbsolute(entry)) return null;
+
+  const normalized = normalize(entry);
+  if (
+    normalized === "." ||
+    normalized.startsWith("..") ||
+    isAbsolute(normalized)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function parseLegacySkillIndexEntries(contents: string): string[] {
+  const entries = new Set<string>();
+  for (const line of contents.split(/\r?\n/)) {
+    const entry = parseLegacySkillIndexEntry(line);
+    if (entry) entries.add(entry);
+  }
+  return [...entries];
+}
+
+function preserveNestedIndexedSkill(
+  tempRootDir: string,
+  skillsDir: string,
+  relativeSkillDir: string,
+): void {
+  const skillName = basename(relativeSkillDir);
+  if (!skillName || skillName === relativeSkillDir) return;
+
+  const sourceDir = resolve(skillsDir, relativeSkillDir);
+  const destinationDir = join(skillsDir, skillName);
+  if (fs.existsSync(destinationDir)) {
+    log.warn(
+      { destinationDir, sourceDir },
+      "Skipping nested indexed skill preservation because top-level destination already exists",
+    );
+    return;
+  }
+
+  try {
+    if (!fs.existsSync(sourceDir)) return;
+    if (!isInsideDirectory(skillsDir, sourceDir)) {
+      log.warn(
+        { relativeSkillDir, sourceDir },
+        "Skipping nested indexed skill that resolves outside skills root",
+      );
+      return;
+    }
+
+    const sourceStat = fs.lstatSync(sourceDir);
+    if (!sourceStat.isDirectory()) return;
+
+    const skillFilePath = join(sourceDir, "SKILL.md");
+    if (!fs.existsSync(skillFilePath)) return;
+    if (!isInsideDirectory(sourceDir, skillFilePath)) {
+      log.warn(
+        { skillFilePath, sourceDir },
+        "Skipping nested indexed skill with SKILL.md outside skill directory",
+      );
+      return;
+    }
+
+    const skillFileStat = fs.lstatSync(skillFilePath);
+    if (!skillFileStat.isFile()) return;
+
+    fs.mkdirSync(tempRootDir, { recursive: true });
+    const tempDir = join(tempRootDir, skillName);
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+
+    fs.cpSync(sourceDir, tempDir, {
+      dereference: false,
+      errorOnExist: true,
+      force: false,
+      recursive: true,
+    });
+
+    if (fs.existsSync(destinationDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      log.warn(
+        { destinationDir, sourceDir },
+        "Skipping nested indexed skill preservation because destination appeared during copy",
+      );
+      return;
+    }
+
+    fs.renameSync(tempDir, destinationDir);
+    log.info(
+      { destinationDir, sourceDir },
+      "Preserved nested indexed skill at top-level skills directory",
+    );
+  } catch (err) {
+    if (isNotFoundError(err)) return;
+    log.warn(
+      { err, relativeSkillDir, sourceDir, destinationDir },
+      "Failed to preserve nested indexed skill",
+    );
+    throw err;
+  }
+}
+
+function preserveNestedIndexedSkills(
+  workspaceDir: string,
+  skillsDir: string,
+  indexPath: string,
+): void {
+  const contents = fs.readFileSync(indexPath, "utf-8");
+  const tempRootDir = join(
+    workspaceDir,
+    ".workspace-migration-068-remove-legacy-skills-index",
+  );
+  for (const relativeSkillDir of parseLegacySkillIndexEntries(contents)) {
+    preserveNestedIndexedSkill(tempRootDir, skillsDir, relativeSkillDir);
+  }
+  if (fs.existsSync(tempRootDir)) {
+    fs.rmSync(tempRootDir, { recursive: true, force: true });
+  }
+}
+
 export const removeLegacySkillsIndexMigration: WorkspaceMigration = {
   id: "068-remove-legacy-skills-index",
   description: "Remove legacy workspace skills/SKILLS.md index file",
   retryFailedCheckpoint: true,
 
   run(workspaceDir: string): void {
-    const indexPath = join(workspaceDir, "skills", "SKILLS.md");
+    const skillsDir = join(workspaceDir, "skills");
+    const indexPath = join(skillsDir, "SKILLS.md");
 
     try {
       const stat = fs.lstatSync(indexPath);
@@ -31,6 +184,10 @@ export const removeLegacySkillsIndexMigration: WorkspaceMigration = {
           "Legacy SKILLS.md path is not a file; leaving it in place",
         );
         return;
+      }
+
+      if (stat.isFile()) {
+        preserveNestedIndexedSkills(workspaceDir, skillsDir, indexPath);
       }
 
       fs.unlinkSync(indexPath);


### PR DESCRIPTION
## Summary
- Preserves discoverability for nested skills that were previously listed in SKILLS.md.
- Keeps legacy index removal idempotent and safe.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->