### PR TITLE
fix: clean up skill install test helpers

### DIFF
--- a/assistant/src/__tests__/clawhub.test.ts
+++ b/assistant/src/__tests__/clawhub.test.ts
@@ -30,52 +30,52 @@ import type { SkillInstallMeta } from "../skills/install-meta.js";
 // ---------------------------------------------------------------------------
 
 describe("clawhubInstall slug validation", () => {
+  function expectInstallError(
+    result: Awaited<ReturnType<typeof clawhubInstall>>,
+  ): string {
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected clawhubInstall to fail");
+    return result.error;
+  }
+
   test("rejects empty slug", async () => {
     const result = await clawhubInstall("");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 
   test("rejects slug starting with a dot", async () => {
     const result = await clawhubInstall(".hidden");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 
   test("rejects slug starting with a hyphen", async () => {
     const result = await clawhubInstall("-dashed");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 
   test("rejects slug with path traversal", async () => {
     const result = await clawhubInstall("../escape");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 
   test("rejects slug with spaces", async () => {
     const result = await clawhubInstall("my skill");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 
   test("rejects slug with double slash", async () => {
     const result = await clawhubInstall("ns//skill");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 
   test("rejects slug ending with slash", async () => {
     const result = await clawhubInstall("skill/");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 
   test("rejects slug with special characters", async () => {
     const result = await clawhubInstall("skill@latest");
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("Invalid skill slug");
+    expect(expectInstallError(result)).toContain("Invalid skill slug");
   });
 });
 
@@ -119,8 +119,10 @@ describe("clawhubInstall staging", () => {
       const result = await clawhubInstall("demo-skill", { projectRoot });
 
       expect(result.success).toBe(true);
-      expect(result.skillName).toBe("demo-skill");
-      expect(result.skillDir).toBe(stagedSkillDir);
+      if (result.success) {
+        expect(result.skillId).toBe("demo-skill");
+        expect(result.skillDir).toBe(stagedSkillDir);
+      }
       expect(readFileSync(join(finalSkillDir, "SKILL.md"), "utf-8")).toBe(
         "# Old Skill\n",
       );

--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -66,7 +66,7 @@ describe("delete_managed_skill tool", () => {
     );
   });
 
-  test("deletes existing skill while ignoring legacy index inputs", async () => {
+  test("deletes existing skill without modifying the legacy index", async () => {
     createSkill("doomed");
     createSkill("survivor");
     const indexPath = join(TEST_DIR, "skills", "SKILLS.md");
@@ -76,7 +76,6 @@ describe("delete_managed_skill tool", () => {
     const result = await executeDeleteManagedSkill(
       {
         skill_id: "doomed",
-        remove_from_index: false,
       },
       makeContext(),
     );

--- a/assistant/src/__tests__/helpers/tar-fixtures.ts
+++ b/assistant/src/__tests__/helpers/tar-fixtures.ts
@@ -1,0 +1,39 @@
+export function makeTarEntry(name: string, content: string): Buffer {
+  const header = Buffer.alloc(512, 0);
+  const nameBuffer = Buffer.from(name, "utf-8");
+  nameBuffer.copy(header, 0, 0, Math.min(nameBuffer.length, 100));
+
+  Buffer.from("0000644\0", "ascii").copy(header, 100);
+  Buffer.from("0000000\0", "ascii").copy(header, 108);
+  Buffer.from("0000000\0", "ascii").copy(header, 116);
+  Buffer.from(
+    `${content.length.toString(8).padStart(11, "0")}\0`,
+    "ascii",
+  ).copy(header, 124);
+  Buffer.from("00000000000\0", "ascii").copy(header, 136);
+  Buffer.from("        ", "ascii").copy(header, 148);
+  header[156] = "0".charCodeAt(0);
+  Buffer.from("ustar\0", "ascii").copy(header, 257);
+  Buffer.from("00", "ascii").copy(header, 263);
+
+  let sum = 0;
+  for (let i = 0; i < 512; i += 1) sum += header[i] ?? 0;
+  Buffer.from(`${sum.toString(8).padStart(6, "0")}\0 `, "ascii").copy(
+    header,
+    148,
+  );
+
+  const data = Buffer.from(content, "utf-8");
+  const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512, 0);
+  data.copy(padded);
+  return Buffer.concat([header, padded]);
+}
+
+export function makeTar(
+  entries: Array<{ name: string; content: string }>,
+): Buffer {
+  return Buffer.concat([
+    ...entries.map((entry) => makeTarEntry(entry.name, entry.content)),
+    Buffer.alloc(1024, 0),
+  ]);
+}

--- a/assistant/src/__tests__/install-skill-routing.test.ts
+++ b/assistant/src/__tests__/install-skill-routing.test.ts
@@ -22,7 +22,7 @@ const mockClawhubInstall = mock(
   ): Promise<{
     success: boolean;
     error?: string;
-    skillName?: string;
+    skillId?: string;
     skillDir?: string;
   }> => ({ success: true }),
 );
@@ -199,7 +199,7 @@ describe("installSkill routing", () => {
       const skillId = slug.includes("/") ? slug.split("/").pop()! : slug;
       const projectRoot = opts?.projectRoot ?? TEST_SKILLS_DIR;
       const skillDir = stageClawhubSkill(projectRoot, skillId);
-      return { success: true, skillName: skillId, skillDir };
+      return { success: true, skillId, skillDir };
     });
     mockInstallExternalSkill.mockResolvedValue(undefined);
     mockGetCatalog.mockResolvedValue([]);
@@ -261,7 +261,7 @@ Body.
         join(TEST_SKILLS_DIR, ".install-staging", "project-0"),
         slug,
       );
-      return { success: true, skillName: slug, skillDir };
+      return { success: true, skillId: slug, skillDir };
     });
 
     const result = await installSkill({ slug: "some-clawhub-skill" });
@@ -283,7 +283,7 @@ Body.
         join(TEST_SKILLS_DIR, ".install-staging", "project-0"),
         slug,
       );
-      return { success: true, skillName: slug, skillDir };
+      return { success: true, skillId: slug, skillDir };
     });
 
     const result = await installSkill({ slug: "my-skill", origin: "clawhub" });
@@ -296,7 +296,14 @@ Body.
   test("clawhub install fails when the installed skill root is not discoverable", async () => {
     mockClawhubInstall.mockResolvedValue({
       success: true,
-      skillName: "missing-root-skill",
+      skillId: "missing-root-skill",
+      skillDir: join(
+        TEST_SKILLS_DIR,
+        ".install-staging",
+        "project-0",
+        "skills",
+        "missing-root-skill",
+      ),
     });
 
     const result = await installSkill({
@@ -337,7 +344,7 @@ Body.
         join(TEST_SKILLS_DIR, ".install-staging", "project-0"),
         skillId,
       );
-      return { success: true, skillName: skillId, skillDir };
+      return { success: true, skillId, skillDir };
     });
 
     // Even though the slug looks like skills.sh format, explicit origin: "clawhub"

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -52,14 +52,13 @@ describe("scaffold_managed_skill tool", () => {
     );
   });
 
-  test("creates a valid skill discovered from its SKILL.md directory while ignoring legacy inputs", async () => {
+  test("creates a valid skill discovered from its SKILL.md directory", async () => {
     const result = await executeScaffoldManagedSkill(
       {
         skill_id: "test-skill",
         name: "Test Skill",
         description: "A test skill",
         body_markdown: "Do the thing.",
-        add_to_index: false,
       },
       makeContext(),
     );

--- a/assistant/src/__tests__/skills-install-extract.test.ts
+++ b/assistant/src/__tests__/skills-install-extract.test.ts
@@ -7,45 +7,9 @@ import {
   extractTarToDir,
   writeSkillFilesToDir,
 } from "../skills/catalog-install.js";
+import { makeTar } from "./helpers/tar-fixtures.js";
 
 let tempDir: string;
-
-function makeTarEntry(name: string, content: string): Buffer {
-  const header = Buffer.alloc(512, 0);
-  const nameBuffer = Buffer.from(name, "utf-8");
-  nameBuffer.copy(header, 0, 0, Math.min(nameBuffer.length, 100));
-
-  const mode = Buffer.from("0000644\0", "ascii");
-  mode.copy(header, 100);
-  Buffer.from("0000000\0", "ascii").copy(header, 108); // uid
-  Buffer.from("0000000\0", "ascii").copy(header, 116); // gid
-
-  const sizeOct = content.length.toString(8).padStart(11, "0") + "\0";
-  Buffer.from(sizeOct, "ascii").copy(header, 124);
-
-  Buffer.from("00000000000\0", "ascii").copy(header, 136); // mtime
-  Buffer.from("        ", "ascii").copy(header, 148); // checksum placeholder
-  header[156] = "0".charCodeAt(0);
-  Buffer.from("ustar\0", "ascii").copy(header, 257);
-  Buffer.from("00", "ascii").copy(header, 263);
-
-  let sum = 0;
-  for (let i = 0; i < 512; i += 1) sum += header[i] ?? 0;
-  const checksum = sum.toString(8).padStart(6, "0");
-  Buffer.from(`${checksum}\0 `, "ascii").copy(header, 148);
-
-  const data = Buffer.from(content, "utf-8");
-  const paddedSize = Math.ceil(data.length / 512) * 512;
-  const padded = Buffer.alloc(paddedSize, 0);
-  data.copy(padded);
-
-  return Buffer.concat([header, padded]);
-}
-
-function makeTar(entries: Array<{ name: string; content: string }>): Buffer {
-  const body = entries.map((entry) => makeTarEntry(entry.name, entry.content));
-  return Buffer.concat([...body, Buffer.alloc(1024, 0)]);
-}
 
 beforeEach(() => {
   tempDir = join(

--- a/assistant/src/__tests__/skills-install-staging.test.ts
+++ b/assistant/src/__tests__/skills-install-staging.test.ts
@@ -20,6 +20,7 @@ mock.module("node:child_process", () => ({
 import { loadSkillCatalog } from "../config/skills.js";
 import { installSkillLocally } from "../skills/catalog-install.js";
 import { installExternalSkill } from "../skills/skillssh-registry.js";
+import { makeTar } from "./helpers/tar-fixtures.js";
 
 const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
 const originalFetch = globalThis.fetch;
@@ -34,44 +35,6 @@ description: "A test skill."
 
 ${body}
 `;
-}
-
-function makeTarEntry(name: string, content: string): Buffer {
-  const header = Buffer.alloc(512, 0);
-  const nameBuffer = Buffer.from(name, "utf-8");
-  nameBuffer.copy(header, 0, 0, Math.min(nameBuffer.length, 100));
-
-  Buffer.from("0000644\0", "ascii").copy(header, 100);
-  Buffer.from("0000000\0", "ascii").copy(header, 108);
-  Buffer.from("0000000\0", "ascii").copy(header, 116);
-  Buffer.from(
-    `${content.length.toString(8).padStart(11, "0")}\0`,
-    "ascii",
-  ).copy(header, 124);
-  Buffer.from("00000000000\0", "ascii").copy(header, 136);
-  Buffer.from("        ", "ascii").copy(header, 148);
-  header[156] = "0".charCodeAt(0);
-  Buffer.from("ustar\0", "ascii").copy(header, 257);
-  Buffer.from("00", "ascii").copy(header, 263);
-
-  let sum = 0;
-  for (let i = 0; i < 512; i += 1) sum += header[i] ?? 0;
-  Buffer.from(`${sum.toString(8).padStart(6, "0")}\0 `, "ascii").copy(
-    header,
-    148,
-  );
-
-  const data = Buffer.from(content, "utf-8");
-  const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512, 0);
-  data.copy(padded);
-  return Buffer.concat([header, padded]);
-}
-
-function makeTar(entries: Array<{ name: string; content: string }>): Buffer {
-  return Buffer.concat([
-    ...entries.map((entry) => makeTarEntry(entry.name, entry.content)),
-    Buffer.alloc(1024, 0),
-  ]);
 }
 
 function writeInstalledSkill(skillId: string, name: string): void {

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1101,10 +1101,7 @@ export async function installSkill(spec: {
     }
 
     // Install from clawhub (community)
-    const expectedSkillId = spec.slug.includes("/")
-      ? spec.slug.split("/").pop()!
-      : spec.slug;
-    let skillId = expectedSkillId;
+    let skillId = spec.slug;
     const clawhubProjectRoot = createSkillInstallStagingDir();
     try {
       const result = await clawhubInstall(spec.slug, {
@@ -1115,11 +1112,9 @@ export async function installSkill(spec: {
       if (!result.success) {
         return { success: false, error: result.error ?? "Unknown error" };
       }
-      const rawId = result.skillName ?? spec.slug;
-      skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
+      skillId = result.skillId;
 
-      const stagedSkillDir =
-        result.skillDir ?? join(clawhubProjectRoot, "skills", skillId);
+      const stagedSkillDir = result.skillDir;
       installSkillDependenciesIfPresent(stagedSkillDir);
       commitStagedSkillInstall(skillId, stagedSkillDir);
     } finally {

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -133,13 +133,17 @@ export function verifyAndRecordSkillHash(slug: string): void {
   }
 }
 
-interface ClawhubInstallResult {
-  success: boolean;
-  skillName?: string;
-  skillDir?: string;
-  version?: string;
-  error?: string;
-}
+type ClawhubInstallResult =
+  | {
+      success: true;
+      skillId: string;
+      skillDir: string;
+      version?: string;
+    }
+  | {
+      success: false;
+      error: string;
+    };
 
 interface ClawhubSearchResultItem {
   name: string;
@@ -235,7 +239,7 @@ function hasRootSkillFile(skillDir: string): boolean {
 function findInstalledClawhubSkillDir(
   slug: string,
   projectRoot?: string,
-): { skillName: string; skillDir: string } | null {
+): { skillId: string; skillDir: string } | null {
   const skillsDir = getClawhubSkillsDir(projectRoot);
   const expectedSkillName = getSkillNameFromSlug(slug);
   const candidates = [
@@ -245,7 +249,7 @@ function findInstalledClawhubSkillDir(
 
   for (const candidate of candidates) {
     if (hasRootSkillFile(candidate)) {
-      return { skillName: expectedSkillName, skillDir: candidate };
+      return { skillId: expectedSkillName, skillDir: candidate };
     }
   }
 
@@ -257,8 +261,8 @@ function findInstalledClawhubSkillDir(
   );
   if (stagedSkills.length !== 1) return null;
 
-  const skillName = stagedSkills[0]!.name;
-  return { skillName, skillDir: join(skillsDir, skillName) };
+  const skillId = stagedSkills[0]!.name;
+  return { skillId, skillDir: join(skillsDir, skillId) };
 }
 
 export async function clawhubInstall(
@@ -301,7 +305,7 @@ export async function clawhubInstall(
 
     return {
       success: true,
-      skillName: installed.skillName,
+      skillId: installed.skillId,
       skillDir: installed.skillDir,
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- Shares tar fixture helpers across install tests.
- Removes stale legacy index input assertions and centralizes ClawHub skill id normalization.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->