### PR TITLE
fix: normalize legacy SKILL.md index entries

### DIFF
--- a/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
+++ b/assistant/src/__tests__/workspace-migration-remove-legacy-skills-index.test.ts
@@ -54,6 +54,25 @@ function writeLegacyIndex(contents = "- alpha\n"): string {
   return legacyIndexPath;
 }
 
+function expectNestedSkillPreserved(
+  legacyIndexPath: string,
+  nestedSkillPath: string,
+): void {
+  const topLevelSkillPath = join(
+    workspaceDir,
+    "skills",
+    "my-skill",
+    "SKILL.md",
+  );
+  expect(existsSync(legacyIndexPath)).toBe(false);
+  expect(existsSync(nestedSkillPath)).toBe(true);
+  expect(readFileSync(topLevelSkillPath, "utf-8")).toContain("org/my-skill");
+
+  const loaded = loadSkillBySelector("my-skill");
+  expect(loaded.error).toBeUndefined();
+  expect(loaded.skill!.id).toBe("my-skill");
+}
+
 describe("068-remove-legacy-skills-index migration", () => {
   test("has correct id and description", () => {
     expect(removeLegacySkillsIndexMigration.id).toBe(
@@ -139,6 +158,26 @@ describe("068-remove-legacy-skills-index migration", () => {
     expect(loaded.error).toBeUndefined();
     expect(loaded.skill!.id).toBe("my-skill");
     expect(loaded.skill!.body).toBe("Body.");
+  });
+
+  test("copies nested indexed skills from plain entries that point to SKILL.md", () => {
+    const legacyIndexPath = writeLegacyIndex("- org/my-skill/SKILL.md\n");
+    const nestedSkillPath = writeSkill("org/my-skill");
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    expectNestedSkillPreserved(legacyIndexPath, nestedSkillPath);
+  });
+
+  test("copies nested indexed skills from markdown links that point to SKILL.md", () => {
+    const legacyIndexPath = writeLegacyIndex(
+      "- [My Skill](org/my-skill/skill.md)\n",
+    );
+    const nestedSkillPath = writeSkill("org/my-skill");
+
+    removeLegacySkillsIndexMigration.run(workspaceDir);
+
+    expectNestedSkillPreserved(legacyIndexPath, nestedSkillPath);
   });
 
   test("does not overwrite an existing top-level skill when preserving nested indexed skills", () => {

--- a/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
+++ b/assistant/src/workspace/migrations/068-remove-legacy-skills-index.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import {
   basename,
+  dirname,
   isAbsolute,
   join,
   normalize,
@@ -54,6 +55,11 @@ function parseLegacySkillIndexEntry(line: string): string | null {
     isAbsolute(normalized)
   ) {
     return null;
+  }
+
+  if (basename(normalized).toLowerCase() === "skill.md") {
+    const skillDir = dirname(normalized);
+    return skillDir === "." ? null : skillDir;
   }
 
   return normalized;


### PR DESCRIPTION
## Summary
- Normalizes legacy SKILLS.md entries that point directly to SKILL.md before preserving nested skills.
- Adds migration coverage for list and markdown-link file entries.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->