### PR TITLE
[codex] Show assistant picker after platform login

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -193,45 +193,104 @@ extension AppDelegate {
         authWindow = window
     }
 
+    /// Shared post-login path for sign-ins that happen while the app is
+    /// already running on a local or remote assistant. It mirrors the
+    /// re-auth router instead of blindly provisioning the current assistant,
+    /// so platform assistants hatched elsewhere are offered alongside local
+    /// lockfile entries.
+    func handlePlatformLoginSucceeded() {
+        Task { @MainActor [weak self] in
+            await self?.handlePlatformLoginSucceededAsync()
+        }
+    }
+
+    private func handlePlatformLoginSucceededAsync() async {
+        guard authManager.isAuthenticated else { return }
+
+        do {
+            _ = try await AuthService.shared.resolveOrganizationId()
+        } catch is CancellationError {
+            return
+        } catch {
+            log.warning("Post-login organization resolution failed — continuing with current assistant: \(error.localizedDescription, privacy: .public)")
+        }
+
+        let router = ReturningUserRouter()
+        do {
+            let landscape = try await router.fetchLandscape()
+            switch router.decide(for: landscape) {
+            case .showAssistantPicker:
+                log.info("Post-login router → showAssistantPicker")
+                showAssistantPicker(landscape: landscape)
+                return
+            case .showHostingPicker:
+                log.info("Post-login router → showHostingPicker")
+                showAuthWindow(forceOnboarding: true)
+                return
+            case .autoConnect:
+                break
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            log.warning("Post-login assistant routing failed — continuing with current assistant: \(error.localizedDescription, privacy: .public)")
+        }
+
+        completePostLoginForCurrentAssistant()
+    }
+
+    private func completePostLoginForCurrentAssistant() {
+        // Re-bootstrap actor credentials first so the actor token is available
+        // when local assistant API key provisioning waits for it. Managed
+        // assistants derive identity from the platform session.
+        if !isCurrentAssistantManaged {
+            ensureActorCredentials()
+        }
+
+        localBootstrapDidComplete = false
+        ensureLocalAssistantApiKey()
+
+        if isCurrentAssistantManaged {
+            reconnectManagedAssistant()
+        }
+    }
+
     /// Show the assistant picker in the auth window. Builds picker items
     /// from both the lockfile and the platform list (via the landscape) so
     /// platform-only assistants (hatched on another device) are included.
     private func showAssistantPicker(landscape: ReturningUserRouter.AssistantLandscape) {
-        // Index platform names by ID so lockfile items can show real names
         let platformById = Dictionary(
             landscape.platformAssistants.map { ($0.id, $0) },
             uniquingKeysWith: { first, _ in first }
         )
-
-        // Lockfile entries (current-env, both local and managed)
-        let localItems = landscape.currentEnvironmentLockfileAssistants
-            .map { entry in
-                AssistantPickerItem.from(
-                    lockfile: entry,
-                    platformName: platformById[entry.assistantId]?.name
-                )
-            }
-
-        // Platform entries — exclude any already represented in the lockfile
-        let lockfileIds = Set(landscape.currentEnvironmentLockfileAssistants.map(\.assistantId))
-        let platformItems = landscape.platformAssistants
-            .filter { !lockfileIds.contains($0.id) }
-            .map(AssistantPickerItem.from(platform:))
-
-        let items = localItems + platformItems
+        let items = AssistantPickerItem.from(landscape: landscape)
 
         let pickerView = AssistantPickerView(
             assistants: items,
             onConnect: { [weak self] assistantId in
-                LockfileAssistant.setActiveAssistantId(assistantId)
-                // Fire-and-forget: tell the platform this is the active
-                // assistant. Failure is non-fatal — the local lockfile is
-                // the source of truth for which assistant to connect to.
-                if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+                guard let self else { return false }
+                guard let target = AssistantPickerSelectionResolver.resolveLockfileAssistant(
+                    assistantId: assistantId,
+                    platformAssistants: platformById
+                ) else {
+                    let alert = NSAlert()
+                    alert.messageText = "Could not connect to assistant"
+                    alert.informativeText = "The selected assistant could not be saved locally. Please try again."
+                    alert.alertStyle = .warning
+                    alert.runModal()
+                    return false
+                }
+
+                // Fire-and-forget for managed assistants: tell the platform
+                // this is the active assistant. Failure is non-fatal — the
+                // lockfile is the client source of truth for which assistant
+                // to connect to.
+                if target.isManaged,
+                   let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
                     Task {
                         do {
                             try await AuthService.shared.activateAssistant(
-                                id: assistantId,
+                                id: target.assistantId,
                                 organizationId: orgId
                             )
                         } catch {
@@ -239,7 +298,26 @@ extension AppDelegate {
                         }
                     }
                 }
-                self?.proceedToApp()
+
+                self.authWindow?.close()
+                self.authWindow = nil
+
+                if self.hasSetupApp {
+                    if LockfileAssistant.loadActiveAssistantId() == target.assistantId {
+                        self.completePostLoginForCurrentAssistant()
+                        self.showMainWindow()
+                    } else {
+                        self.performSwitchAssistant(
+                            to: target,
+                            managedAuthenticationAlreadyVerified: target.isManaged
+                        )
+                    }
+                } else {
+                    LockfileAssistant.setActiveAssistantId(target.assistantId)
+                    SentryDeviceInfo.updateAssistantTag(target.assistantId)
+                    self.proceedToApp()
+                }
+                return true
             },
             onSignOut: { [weak self] in
                 Task {
@@ -261,8 +339,39 @@ extension AppDelegate {
                 let y = visibleFrame.midY - targetHeight / 2
                 window.setFrame(NSRect(x: x, y: y, width: targetWidth, height: targetHeight), display: true, animate: true)
             }
+            NSApp.activateAsDockAppIfNeeded()
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
         } else {
-            showAuthWindow()
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 460, height: 620),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentViewController = NSHostingController(rootView: pickerView)
+            window.titleVisibility = .hidden
+            window.titlebarAppearsTransparent = true
+            window.isMovableByWindowBackground = true
+            window.backgroundColor = NSColor(VColor.surfaceOverlay)
+            window.isReleasedWhenClosed = false
+            window.contentMinSize = NSSize(width: 420, height: 580)
+
+            let targetWidth: CGFloat = 460
+            let targetHeight: CGFloat = 620
+            if let visibleFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame {
+                let x = visibleFrame.midX - targetWidth / 2
+                let y = visibleFrame.midY - targetHeight / 2
+                window.setFrame(NSRect(x: x, y: y, width: targetWidth, height: targetHeight), display: true)
+            } else {
+                window.setContentSize(NSSize(width: targetWidth, height: targetHeight))
+                window.center()
+            }
+
+            authWindow = window
+            NSApp.activateAsDockAppIfNeeded()
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
         }
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -758,16 +758,7 @@ extension AppDelegate {
             await authManager.loginWithToast(showToast: { [weak self] msg, style in
                 self?.mainWindow?.windowState.showToast(message: msg, style: style)
             }, onSuccess: { [weak self] in
-                guard let self else { return }
-                if !self.isCurrentAssistantManaged {
-                    self.ensureActorCredentials()
-                }
-                self.localBootstrapDidComplete = false
-                self.ensureLocalAssistantApiKey()
-
-                if self.isCurrentAssistantManaged {
-                    self.reconnectManagedAssistant()
-                }
+                self?.handlePlatformLoginSucceeded()
             })
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Drawers.swift
@@ -50,20 +50,7 @@ extension MainWindowView {
                         await authManager.loginWithToast(showToast: { msg, style in
                             windowState.showToast(message: msg, style: style)
                         }, onSuccess: {
-                            // Re-bootstrap actor credentials and local assistant API key
-                            // so the app can authenticate to the local assistant again.
-                            // Mirrors the pattern in SettingsPanel and proceedToApp().
-                            if !(AppDelegate.shared?.isCurrentAssistantManaged ?? false) {
-                                AppDelegate.shared?.ensureActorCredentials()
-                            }
-                            AppDelegate.shared?.localBootstrapDidComplete = false
-                            AppDelegate.shared?.ensureLocalAssistantApiKey()
-
-                            // For managed assistants, re-establish the connection now that
-                            // the user has a valid session token.
-                            if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
-                                AppDelegate.shared?.reconnectManagedAssistant()
-                            }
+                            AppDelegate.shared?.handlePlatformLoginSucceeded()
                         })
                     }
                 },

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -424,25 +424,7 @@ struct SettingsPanel: View {
         switch selectedTab {
         case .general:
             SettingsGeneralTab(store: store, connectionManager: connectionManager, authManager: authManager, onClose: onClose, showToast: showToast, onSignIn: {
-                // Re-bootstrap actor credentials first so the actor token is
-                // available when ensureLocalAssistantApiKey() waits for it.
-                // This mirrors the pattern in proceedToApp() and
-                // performSwitchAssistant(). Managed assistants derive identity
-                // from the platform session, so skip for them.
-                if !(AppDelegate.shared?.isCurrentAssistantManaged ?? false) {
-                    AppDelegate.shared?.ensureActorCredentials()
-                }
-                // Reset before provisioning so a stale flag from a previous
-                // bootstrap cycle doesn't cause awaitLocalBootstrapCompleted
-                // to skip the wait. Mirrors the reset in proceedToApp().
-                AppDelegate.shared?.localBootstrapDidComplete = false
-                AppDelegate.shared?.ensureLocalAssistantApiKey()
-
-                // For managed assistants, re-establish the connection now that
-                // the user has a valid session token.
-                if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
-                    AppDelegate.shared?.reconnectManagedAssistant()
-                }
+                AppDelegate.shared?.handlePlatformLoginSucceeded()
             })
         case .modelsAndServices:
             modelsAndServicesContent

--- a/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/AssistantPickerView.swift
@@ -10,7 +10,7 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Assis
 @MainActor
 struct AssistantPickerView: View {
     let assistants: [AssistantPickerItem]
-    let onConnect: (String) -> Void
+    let onConnect: (String) -> Bool
     let onSignOut: () -> Void
 
     @State private var connectingId: String?
@@ -87,7 +87,9 @@ struct AssistantPickerView: View {
             } else {
                 VButton(label: "Connect", style: .outlined) {
                     connectingId = item.id
-                    onConnect(item.id)
+                    if !onConnect(item.id) {
+                        connectingId = nil
+                    }
                 }
                 .disabled(connectingId != nil)
             }
@@ -132,5 +134,70 @@ struct AssistantPickerItem: Identifiable {
             subtitle: "Managed",
             isManaged: true
         )
+    }
+
+    /// Build picker items from the router landscape. Platform results are
+    /// authoritative for managed assistants when available, but local lockfile
+    /// entries must remain visible so a user who signs in after hatching
+    /// locally can choose either assistant.
+    @MainActor
+    static func from(landscape: ReturningUserRouter.AssistantLandscape) -> [AssistantPickerItem] {
+        let platformById = Dictionary(
+            landscape.platformAssistants.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        let lockfileItems = landscape.currentEnvironmentLockfileAssistants
+            .map { entry in
+                AssistantPickerItem.from(
+                    lockfile: entry,
+                    platformName: platformById[entry.assistantId]?.name
+                )
+            }
+
+        let lockfileIds = Set(landscape.currentEnvironmentLockfileAssistants.map(\.assistantId))
+        let platformItems = landscape.platformAssistants
+            .filter { !lockfileIds.contains($0.id) }
+            .map(AssistantPickerItem.from(platform:))
+
+        return lockfileItems + platformItems
+    }
+}
+
+enum AssistantPickerSelectionResolver {
+    /// Resolves a selected picker row to a lockfile entry. Platform-only rows
+    /// are materialized locally first so the normal assistant switch/connect
+    /// path can load transport configuration from the lockfile.
+    @MainActor
+    static func resolveLockfileAssistant(
+        assistantId: String,
+        platformAssistants: [String: PlatformAssistant],
+        lockfilePath: String? = nil,
+        runtimeURL: String = VellumEnvironment.resolvedPlatformURL
+    ) -> LockfileAssistant? {
+        if let existing = LockfileAssistant.loadByName(
+            assistantId,
+            lockfilePath: lockfilePath
+        ), existing.isCurrentEnvironment {
+            return existing
+        }
+
+        guard let platformAssistant = platformAssistants[assistantId] else {
+            return nil
+        }
+
+        let persisted = LockfileAssistant.ensureManagedEntry(
+            assistantId: platformAssistant.id,
+            runtimeUrl: runtimeURL,
+            hatchedAt: platformAssistant.created_at ?? Date().iso8601String,
+            lockfilePath: lockfilePath
+        )
+        guard persisted else { return nil }
+
+        if let name = platformAssistant.name {
+            IdentityInfo.seedCache(name: name, forAssistantId: platformAssistant.id)
+        }
+
+        return LockfileAssistant.loadByName(platformAssistant.id, lockfilePath: lockfilePath)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ImageGenerationServiceCard.swift
@@ -145,9 +145,7 @@ struct ImageGenerationServiceCard: View {
             ) {
                 Task {
                     await authManager.loginWithToast(showToast: showToast, onSuccess: {
-                        if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
-                            AppDelegate.shared?.reconnectManagedAssistant()
-                        }
+                        AppDelegate.shared?.handlePlatformLoginSucceeded()
                     })
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceServiceCard.swift
@@ -342,9 +342,7 @@ struct InferenceServiceCard: View {
             ) {
                 Task {
                     await authManager.loginWithToast(showToast: showToast, onSuccess: {
-                        if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
-                            AppDelegate.shared?.reconnectManagedAssistant()
-                        }
+                        AppDelegate.shared?.handlePlatformLoginSucceeded()
                     })
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/IntegrationDetailModal.swift
@@ -202,9 +202,7 @@ struct IntegrationDetailModal: View {
                     integrationEmptyState(buttonLabel: "Log in to Vellum", buttonIcon: VIcon.logOut.rawValue) {
                         Task {
                             await authManager.loginWithToast(showToast: showToast, onSuccess: {
-                                if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
-                                    AppDelegate.shared?.reconnectManagedAssistant()
-                                }
+                                AppDelegate.shared?.handlePlatformLoginSucceeded()
                                 Task { await store.fetchManagedOAuthConnections(providerKey: providerKey, userId: currentUserId) }
                             })
                         }

--- a/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/WebSearchServiceCard.swift
@@ -226,9 +226,7 @@ struct WebSearchServiceCard: View {
             ) {
                 Task {
                     await authManager.loginWithToast(showToast: showToast, onSuccess: {
-                        if AppDelegate.shared?.isCurrentAssistantManaged ?? false {
-                            AppDelegate.shared?.reconnectManagedAssistant()
-                        }
+                        AppDelegate.shared?.handlePlatformLoginSucceeded()
                     })
                 }
             }

--- a/clients/macos/vellum-assistantTests/AssistantPickerSelectionResolverTests.swift
+++ b/clients/macos/vellum-assistantTests/AssistantPickerSelectionResolverTests.swift
@@ -1,0 +1,112 @@
+import VellumAssistantShared
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class AssistantPickerSelectionResolverTests: XCTestCase {
+    private var tempDir: URL!
+    private var lockfilePath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        lockfilePath = tempDir.appendingPathComponent(".vellum.lock.json").path
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        lockfilePath = nil
+        super.tearDown()
+    }
+
+    func testPickerItemsIncludeLocalAndPlatformOnlyAssistants() {
+        let local = makeLocalAssistant(id: "local-1")
+        let platform = PlatformAssistant(id: "managed-1", name: "Cloud Assistant")
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [local],
+            platformAssistants: [platform],
+            platformWasConsulted: true
+        )
+
+        let items = AssistantPickerItem.from(landscape: landscape)
+
+        XCTAssertEqual(items.map(\.id), ["local-1", "managed-1"])
+        XCTAssertEqual(items.map(\.subtitle), ["Local", "Managed"])
+        XCTAssertEqual(items.map(\.isManaged), [false, true])
+    }
+
+    func testResolvingPlatformOnlySelectionPersistsManagedLockfileEntry() throws {
+        let platform = PlatformAssistant(
+            id: "managed-1",
+            name: "Cloud Assistant",
+            created_at: "2026-01-01T00:00:00Z"
+        )
+
+        let resolved = AssistantPickerSelectionResolver.resolveLockfileAssistant(
+            assistantId: "managed-1",
+            platformAssistants: ["managed-1": platform],
+            lockfilePath: lockfilePath,
+            runtimeURL: "https://platform.example.com"
+        )
+
+        XCTAssertEqual(resolved?.assistantId, "managed-1")
+        XCTAssertEqual(resolved?.cloud, "vellum")
+        XCTAssertEqual(resolved?.runtimeUrl, "https://platform.example.com")
+        XCTAssertEqual(resolved?.hatchedAt, "2026-01-01T00:00:00Z")
+
+        let persisted = LockfileAssistant.loadByName("managed-1", lockfilePath: lockfilePath)
+        XCTAssertEqual(persisted?.cloud, "vellum")
+        XCTAssertEqual(persisted?.runtimeUrl, "https://platform.example.com")
+    }
+
+    func testResolvingExistingSelectionKeepsLocalLockfileEntry() throws {
+        try writeLockfile([
+            "assistants": [
+                [
+                    "assistantId": "local-1",
+                    "cloud": "local",
+                    "hatchedAt": "2026-01-01T00:00:00Z",
+                ],
+            ],
+        ])
+
+        let resolved = AssistantPickerSelectionResolver.resolveLockfileAssistant(
+            assistantId: "local-1",
+            platformAssistants: [:],
+            lockfilePath: lockfilePath,
+            runtimeURL: "https://platform.example.com"
+        )
+
+        XCTAssertEqual(resolved?.assistantId, "local-1")
+        XCTAssertEqual(resolved?.cloud, "local")
+        XCTAssertNil(resolved?.runtimeUrl)
+    }
+
+    private func makeLocalAssistant(id: String) -> LockfileAssistant {
+        LockfileAssistant(
+            assistantId: id,
+            runtimeUrl: nil,
+            bearerToken: nil,
+            cloud: "local",
+            project: nil,
+            region: nil,
+            zone: nil,
+            instanceId: nil,
+            hatchedAt: nil,
+            baseDataDir: nil,
+            gatewayPort: nil,
+            instanceDir: nil
+        )
+    }
+
+    private func writeLockfile(_ json: [String: Any]) throws {
+        let data = try JSONSerialization.data(
+            withJSONObject: json,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: URL(fileURLWithPath: lockfilePath), options: .atomic)
+    }
+}

--- a/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
+++ b/clients/macos/vellum-assistantTests/ReturningUserRouterTests.swift
@@ -161,6 +161,20 @@ final class ReturningUserRouterTests: XCTestCase {
         XCTAssertEqual(router.decide(for: landscape), .autoConnect)
     }
 
+    func testStaleManagedLockfileEntryShowsHostingPickerWhenPlatformConsulted() {
+        let router = makeRouter()
+        let landscape = ReturningUserRouter.AssistantLandscape(
+            lockfileAssistants: [makeManagedAssistant(id: "stale-managed")],
+            platformAssistants: [],
+            platformWasConsulted: true
+        )
+        // The platform list is authoritative for managed assistants once
+        // consulted. If the only managed lockfile entry is absent from the
+        // platform list, treat it as stale and send the user to setup.
+        XCTAssertEqual(landscape.totalCount, 0)
+        XCTAssertEqual(router.decide(for: landscape), .showHostingPicker)
+    }
+
     func testManagedLockfileEntryCountedWhenPlatformNotConsulted() {
         let router = makeRouter()
         let landscape = ReturningUserRouter.AssistantLandscape(


### PR DESCRIPTION
## Summary
- route successful in-app platform logins through the returning-user assistant router
- reuse the existing assistant picker when platform assistants and local lockfile assistants are both available
- materialize platform-only picker selections into the lockfile before connecting or switching

## Why
Users can hatch a managed assistant on the web, then install the macOS app, hatch and chat with a local bare-metal assistant while logged out, and only sign in later. The old running-app login callbacks only provisioned credentials for the current local assistant, so the previously hatched platform assistant was never offered. This makes the post-login path match the existing re-auth/reconnect picker behavior.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients --filter 'ReturningUserRouterTests|AssistantPickerSelectionResolverTests'`
- pre-push hook: Swift build for `clients/` and design-token guard