### PR TITLE
feat(feature-flags): register auto-credit-topup assistant flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -288,6 +288,14 @@
       "label": "Pro Plan Adjust",
       "description": "Show the 'Adjust Plan' and 'Configure Auto Top Ups' CTAs in the macOS Settings → Billing tab. Both open the web app's billing settings page.",
       "defaultEnabled": false
+    },
+    {
+      "id": "auto-credit-topup",
+      "scope": "assistant",
+      "key": "auto-credit-topup",
+      "label": "Auto Credit Top-Up",
+      "description": "Show the 'Configure Auto Top Ups' CTA in the macOS Settings → Billing tab. Mirrors the platform web flag of the same name that gates the auto-reload card and /v1/organizations/billing/auto-top-up/ API.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Registers the `auto-credit-topup` flag in the canonical assistant feature-flag registry with `scope: assistant`, `defaultEnabled: false`
- Syncs the bundled copies under `assistant/src/config/` and `gateway/src/` so all three JSONs stay byte-identical
- Mirrors the existing platform LD flag of the same name; macOS Settings → Billing will gate the 'Configure Auto Top Ups' CTA on this flag in a follow-up PR

Part of plan: billing-plan-card.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->