### PR TITLE
feat(billing): add subscription + plan-catalog fetchers

### DIFF
--- a/clients/macos/vellum-assistantTests/BillingServiceSubscriptionTests.swift
+++ b/clients/macos/vellum-assistantTests/BillingServiceSubscriptionTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Wire-protocol decoding tests for `SubscriptionResponse` and `PlanCatalogResponse`.
+///
+/// These lock in the byte-for-byte JSON shape produced by the Django serializers
+/// in `vellum-assistant-platform/django/app/billing/`:
+/// - `SubscriptionResponseSerializer` (`subscription_serializers.py`)
+/// - `/plans/` static catalog payload (`plan_views.py`)
+///
+/// Any drift in field names or types on the server side will fail decoding here.
+final class BillingServiceSubscriptionTests: XCTestCase {
+    func testSubscriptionResponseDecodesProActiveFixture() throws {
+        let json = """
+        {
+            "plan_id": "pro",
+            "status": "active",
+            "renewal_date": "2026-06-01T00:00:00Z",
+            "current_period_end": "2026-06-01T00:00:00Z",
+            "cancel_at_period_end": false,
+            "cancel_at": null
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SubscriptionResponse.self, from: json)
+
+        XCTAssertEqual(decoded.plan_id, "pro")
+        XCTAssertEqual(decoded.status, "active")
+        XCTAssertEqual(decoded.renewal_date, "2026-06-01T00:00:00Z")
+        XCTAssertEqual(decoded.current_period_end, "2026-06-01T00:00:00Z")
+        XCTAssertFalse(decoded.cancel_at_period_end)
+        XCTAssertNil(decoded.cancel_at)
+    }
+
+    func testSubscriptionResponseDecodesBasePlanWithoutStripeFixture() throws {
+        let json = """
+        {
+            "plan_id": "base",
+            "status": null,
+            "renewal_date": null,
+            "current_period_end": null,
+            "cancel_at_period_end": false,
+            "cancel_at": null
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(SubscriptionResponse.self, from: json)
+
+        XCTAssertEqual(decoded.plan_id, "base")
+        XCTAssertNil(decoded.status)
+        XCTAssertNil(decoded.renewal_date)
+        XCTAssertNil(decoded.current_period_end)
+        XCTAssertFalse(decoded.cancel_at_period_end)
+        XCTAssertNil(decoded.cancel_at)
+    }
+
+    func testPlanCatalogResponseDecodesBaseAndProEntries() throws {
+        let json = """
+        {
+            "plans": [
+                {
+                    "id": "base",
+                    "name": "Base",
+                    "price_cents": 0,
+                    "billing_interval": "month",
+                    "included_features": [
+                        "Pay-as-you-go credits",
+                        "Default machine size"
+                    ]
+                },
+                {
+                    "id": "pro",
+                    "name": "Pro",
+                    "price_cents": 2500,
+                    "billing_interval": "month",
+                    "included_features": [
+                        "Larger machine size",
+                        "Bundled credits",
+                        "Managed email subdomain",
+                        "Managed Twilio phone numbers",
+                        "90-day grace period on cancellation before managed resources are released"
+                    ]
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(PlanCatalogResponse.self, from: json)
+
+        XCTAssertEqual(decoded.plans.count, 2)
+
+        let base = decoded.plans[0]
+        XCTAssertEqual(base.id, "base")
+        XCTAssertEqual(base.name, "Base")
+        XCTAssertEqual(base.price_cents, 0)
+        XCTAssertEqual(base.billing_interval, "month")
+        XCTAssertFalse(base.included_features.isEmpty)
+        XCTAssertEqual(base.included_features.first, "Pay-as-you-go credits")
+
+        let pro = decoded.plans[1]
+        XCTAssertEqual(pro.id, "pro")
+        XCTAssertEqual(pro.name, "Pro")
+        XCTAssertEqual(pro.price_cents, 2500)
+        XCTAssertEqual(pro.billing_interval, "month")
+        XCTAssertFalse(pro.included_features.isEmpty)
+        XCTAssertTrue(pro.included_features.contains("Larger machine size"))
+    }
+}

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -338,3 +338,24 @@ public struct ReferralCodeResponse: Codable, Sendable {
     /// Credits granted to the referrer (the user sharing the link).
     public let referrer_credit_amount: String
 }
+
+public struct SubscriptionResponse: Codable, Sendable {
+    public let plan_id: String           // "base" | "pro"
+    public let status: String?           // active | trialing | past_due | canceled | incomplete | incomplete_expired | unpaid | paused | nil
+    public let renewal_date: String?     // ISO 8601, mirrors current_period_end
+    public let current_period_end: String?
+    public let cancel_at_period_end: Bool
+    public let cancel_at: String?        // ISO 8601
+}
+
+public struct PlanCatalogEntry: Codable, Sendable {
+    public let id: String                // "base" | "pro"
+    public let name: String              // "Base" | "Pro"
+    public let price_cents: Int
+    public let billing_interval: String  // "month"
+    public let included_features: [String]
+}
+
+public struct PlanCatalogResponse: Codable, Sendable {
+    public let plans: [PlanCatalogEntry]
+}

--- a/clients/shared/App/Auth/BillingService.swift
+++ b/clients/shared/App/Auth/BillingService.swift
@@ -275,4 +275,106 @@ public final class BillingService {
 
         return checkoutURL
     }
+
+    /// Fetch the current organization's subscription state.
+    public func getSubscription() async throws -> SubscriptionResponse {
+        let urlString = "\(VellumEnvironment.resolvedPlatformURL)/v1/organizations/billing/subscription/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET organizations/billing/subscription/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(SubscriptionResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Fetch the static plan catalog (Base + Pro).
+    public func getPlanCatalog() async throws -> PlanCatalogResponse {
+        let urlString = "\(VellumEnvironment.resolvedPlatformURL)/v1/organizations/billing/plans/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard let organizationId = UserDefaults.standard.string(forKey: "connectedOrganizationId") else {
+            throw PlatformAPIError.authenticationRequired
+        }
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET organizations/billing/plans/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(PlanCatalogResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `SubscriptionResponse`, `PlanCatalogEntry`, and `PlanCatalogResponse` types in `AuthModels.swift`, mirroring the Django serializers in `vellum-assistant-platform/django/app/billing/`
- Adds `BillingService.getSubscription()` and `getPlanCatalog()` following the same auth/error pattern as `getBillingSummary()`
- Adds decoding round-trip tests to lock in the wire-protocol shape

Part of plan: billing-plan-card.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->