### PR TITLE
fix: preserve legacy skill index tool inputs

### DIFF
--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -46,7 +46,7 @@ afterEach(() => {
 });
 
 describe("delete_managed_skill tool", () => {
-  test("does not expose legacy index controls in the bundled tool schema", () => {
+  test("keeps legacy index control as a deprecated no-op schema field", () => {
     const tools = JSON.parse(
       readFileSync(
         join(
@@ -61,9 +61,11 @@ describe("delete_managed_skill tool", () => {
     );
 
     expect(deleteTool).toBeDefined();
-    expect(deleteTool.input_schema.properties).not.toHaveProperty(
-      "remove_from_index",
-    );
+    expect(deleteTool.input_schema.properties.remove_from_index).toEqual({
+      type: "boolean",
+      description:
+        "Deprecated no-op compatibility field. Skill deletion does not edit SKILLS.md.",
+    });
   });
 
   test("deletes existing skill without modifying the legacy index", async () => {
@@ -90,6 +92,24 @@ describe("delete_managed_skill tool", () => {
 
     expect(existsSync(indexPath)).toBe(true);
     expect(readFileSync(indexPath, "utf-8")).toBe(staleIndex);
+  });
+
+  test("accepts legacy remove_from_index input without returning index metadata", async () => {
+    createSkill("legacy-delete");
+
+    const result = await executeDeleteManagedSkill(
+      {
+        skill_id: "legacy-delete",
+        remove_from_index: true,
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.deleted).toBe(true);
+    expect(parsed).not.toHaveProperty("index_updated");
+    expect(existsSync(join(TEST_DIR, "skills", "legacy-delete"))).toBe(false);
   });
 
   test("returns error for non-existent skill", async () => {

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 describe("scaffold_managed_skill tool", () => {
-  test("does not expose legacy index controls in the bundled tool schema", () => {
+  test("keeps legacy index control as a deprecated no-op schema field", () => {
     const tools = JSON.parse(
       readFileSync(
         join(
@@ -47,9 +47,11 @@ describe("scaffold_managed_skill tool", () => {
     );
 
     expect(scaffoldTool).toBeDefined();
-    expect(scaffoldTool.input_schema.properties).not.toHaveProperty(
-      "add_to_index",
-    );
+    expect(scaffoldTool.input_schema.properties.add_to_index).toEqual({
+      type: "boolean",
+      description:
+        "Deprecated no-op compatibility field. Skills are discovered from top-level SKILL.md files.",
+    });
   });
 
   test("creates a valid skill discovered from its SKILL.md directory", async () => {
@@ -80,6 +82,25 @@ describe("scaffold_managed_skill tool", () => {
     const skill = catalog.find((s) => s.id === "test-skill");
     expect(skill).toBeDefined();
     expect(skill!.name).toBe("Test Skill");
+  });
+
+  test("accepts legacy add_to_index input without returning index metadata", async () => {
+    const result = await executeScaffoldManagedSkill(
+      {
+        skill_id: "legacy-input",
+        name: "Legacy Input",
+        description: "A test skill",
+        body_markdown: "Do the thing.",
+        add_to_index: true,
+      },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.created).toBe(true);
+    expect(parsed).not.toHaveProperty("index_updated");
+    expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
   });
 
   test("rejects duplicate unless overwrite=true", async () => {

--- a/assistant/src/config/bundled-skills/skill-management/TOOLS.json
+++ b/assistant/src/config/bundled-skills/skill-management/TOOLS.json
@@ -37,6 +37,10 @@
             "type": "array",
             "items": { "type": "string" },
             "description": "Optional list of child skill IDs that this skill includes (metadata only, no auto-activation)."
+          },
+          "add_to_index": {
+            "type": "boolean",
+            "description": "Deprecated no-op compatibility field. Skills are discovered from top-level SKILL.md files."
           }
         },
         "required": ["skill_id", "name", "description", "body_markdown"]
@@ -55,6 +59,10 @@
           "skill_id": {
             "type": "string",
             "description": "The ID of the managed skill to delete."
+          },
+          "remove_from_index": {
+            "type": "boolean",
+            "description": "Deprecated no-op compatibility field. Skill deletion does not edit SKILLS.md."
           }
         },
         "required": ["skill_id"]


### PR DESCRIPTION
## Summary
- Re-adds deprecated no-op skill index inputs to the bundled tool schema so legacy calls pass validation.
- Keeps current responses free of index_updated while covering legacy input tolerance.

Part of plan: migrate-off-skills-md.md
Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->