### PR TITLE
Prompt for TTS voice during Twilio setup

### DIFF
--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -9,7 +9,6 @@ metadata:
     includes:
       - "twilio-setup"
       - "public-ingress"
-      - "elevenlabs-voice"
     activation-hints:
       - "Phone calling setup, Twilio config, placing/receiving calls"
       - "Do NOT improvise Twilio setup from general knowledge"
@@ -25,7 +24,7 @@ When speaking on behalf of your user during calls, refer to yourself as an "assi
 
 # Overview
 
-The calling system uses Twilio's ConversationRelay for both **outbound** and **inbound** voice calls. The text-to-speech voice is provided by the globally configured TTS provider (set via `services.tts.provider`, default: ElevenLabs). The Twilio setup flow checks whether the user has explicitly configured a TTS voice and prompts them to choose one if not.
+The calling system uses Twilio's ConversationRelay for both **outbound** and **inbound** voice calls. The spoken voice is provided by the globally configured TTS provider (`services.tts.provider`). The Twilio setup flow checks whether a usable TTS provider is explicitly configured with its required credentials and voice/reference settings, and prompts the user to set one up if not.
 
 # Initial Setup
 
@@ -51,7 +50,7 @@ assistant config get calls.enabled
 
 ## Step 3: Choose a Voice
 
-If the Twilio setup flow already prompted for and configured a TTS voice, skip this step. Otherwise, voice selection and tuning are handled by the `elevenlabs-voice` skill. Follow the instructions there to pick a curated voice, optionally set up an ElevenLabs API key for advanced selection, or tune voice parameters.
+If the Twilio setup flow already prompted for and configured a usable TTS provider, skip this step. Otherwise, return to the TTS provider setup flow in `twilio-setup` so the user can choose any supported provider, store the provider API key securely, and set any required voice/reference options.
 
 ## Step 4: Verify Setup (Test Call)
 
@@ -74,7 +73,7 @@ You can check their verification status with:
 assistant channel-verification-sessions status --channel phone --json
 ```
 
-After they are verified, ask them what they think of your voice and offer to let them change it. Load up the `elevenlabs-voice` skill and follow the instructions there to see what voices are available and how to update your configured voice. Say something like:
+After they are verified, ask them what they think of your voice and offer to let them change it. If they want a different provider or voice, return to the TTS provider setup flow in `twilio-setup`; for ElevenLabs voice selection specifically, load `elevenlabs-voice`. Say something like:
 
 > Great, you're verified! What did you think of my voice? We can update it if you'd like.
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -25,7 +25,7 @@ When speaking on behalf of your user during calls, refer to yourself as an "assi
 
 # Overview
 
-The calling system uses Twilio's ConversationRelay for both **outbound** and **inbound** voice calls. The text-to-speech voice is provided by the globally configured TTS provider (set via `services.tts.provider`, default: ElevenLabs). After Twilio setup, the assistant prompts the user to choose a voice from a curated list of supported options.
+The calling system uses Twilio's ConversationRelay for both **outbound** and **inbound** voice calls. The text-to-speech voice is provided by the globally configured TTS provider (set via `services.tts.provider`, default: ElevenLabs). The Twilio setup flow checks whether the user has explicitly configured a TTS voice and prompts them to choose one if not.
 
 # Initial Setup
 
@@ -51,7 +51,7 @@ assistant config get calls.enabled
 
 ## Step 3: Choose a Voice
 
-Voice selection and tuning are handled by the `elevenlabs-voice` skill. Follow the instructions there to pick a curated voice, optionally set up an ElevenLabs API key for advanced selection, or tune voice parameters.
+If the Twilio setup flow already prompted for and configured a TTS voice, skip this step. Otherwise, voice selection and tuning are handled by the `elevenlabs-voice` skill. Follow the instructions there to pick a curated voice, optionally set up an ElevenLabs API key for advanced selection, or tune voice parameters.
 
 ## Step 4: Verify Setup (Test Call)
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -683,7 +683,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-05T17:11:32-06:00"
+      "updatedAt": "2026-05-05T16:46:35-06:00"
     },
     {
       "id": "typescript-eval",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -672,13 +672,14 @@
     {
       "id": "twilio-setup",
       "name": "twilio-setup",
-      "description": "Configure Twilio credentials and phone numbers for voice calls",
+      "description": "Configure Twilio credentials, phone numbers, webhooks, and call voice setup",
       "metadata": {
         "emoji": "📱",
         "vellum": {
           "display-name": "Twilio Setup",
           "includes": [
-            "public-ingress"
+            "public-ingress",
+            "elevenlabs-voice"
           ]
         }
       },

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -672,14 +672,13 @@
     {
       "id": "twilio-setup",
       "name": "twilio-setup",
-      "description": "Configure Twilio credentials, phone numbers, webhooks, and call voice setup",
+      "description": "Configure Twilio credentials, phone numbers, webhooks, and TTS service setup for calls",
       "metadata": {
         "emoji": "📱",
         "vellum": {
           "display-name": "Twilio Setup",
           "includes": [
-            "public-ingress",
-            "elevenlabs-voice"
+            "public-ingress"
           ]
         }
       },

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -683,7 +683,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-05T16:46:35-06:00"
+      "updatedAt": "2026-05-05T21:35:56-06:00"
     },
     {
       "id": "typescript-eval",

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: twilio-setup
-description: Configure Twilio credentials, phone numbers, webhooks, and call voice setup
+description: Configure Twilio credentials, phone numbers, webhooks, and TTS service setup for calls
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📱"
   vellum:
     display-name: "Twilio Setup"
-    includes: ["public-ingress", "elevenlabs-voice"]
+    includes: ["public-ingress"]
 ---
 
 You are helping your user configure Twilio for voice calls. Walk through each step below.
@@ -20,11 +20,13 @@ Before you begin, understand how each Twilio value is stored:
 | Account SID  | Config     | `assistant config set twilio.accountSid`                        | No      |
 | Auth Token   | Credential | `assistant credentials set --service twilio --field auth_token` | **Yes** |
 | Phone Number | Config     | `assistant config set twilio.phoneNumber`                       | No      |
-| TTS Voice    | Config     | `voice_config_update setting="tts_voice_id"`                    | No      |
+| TTS Provider | Config     | `voice_config_update setting="tts_provider"`                    | No      |
+| TTS API Key  | Credential | Provider-specific `credential_store` prompt                     | **Yes** |
+| TTS Voice    | Config     | Provider-specific voice/reference setting                       | No      |
 
 - **Config values** (Account SID, Phone Number) are non-sensitive identifiers. Collect them via normal conversation -- the user can paste them in chat or you can use `AskUserQuestion`.
   **Auth Token** is a secret. Collect it securely via `credential_store` prompt -- never accept it pasted in plaintext chat.
-- **TTS Voice** is not a Twilio credential, but phone calls use it for the assistant's spoken voice. Prompt for it during setup if the user has not explicitly configured one yet.
+- **TTS setup** is not a Twilio credential, but phone calls need a usable TTS provider. Prompt for a provider, its API key, and any required provider-specific voice/reference config if TTS has not already been set up.
 
 ## Retrieving Twilio Credentials
 
@@ -48,25 +50,52 @@ assistant config get twilio.phoneNumber
 - If all three Twilio values are non-empty -- Twilio credentials and phone number are configured, but still check the TTS voice before declaring setup complete.
 - Otherwise, continue to the missing steps.
 
-## Checking Current TTS Voice Configuration
+## Checking Current TTS Service Configuration
 
-TTS has runtime defaults, so do not treat a default voice as explicitly configured. Check the raw config values:
+TTS has runtime defaults, so do not treat defaults alone as a usable voice service. Check the raw config values and provider credentials:
 
 ```bash
 assistant config get services.tts.provider
+assistant credentials inspect --service elevenlabs --field api_key --json
+assistant credentials inspect --service fish-audio --field api_key --json
+assistant credentials inspect --service deepgram --field api_key --json
+assistant credentials inspect --service xai --field api_key --json
 assistant config get services.tts.providers.elevenlabs.voiceId
 assistant config get services.tts.providers.fish-audio.referenceId
 assistant config get services.tts.providers.xai.voiceId
 ```
 
-Treat the TTS voice as already configured when the active provider has a non-empty raw voice value:
+Treat TTS as already configured only when the effective provider has its required credentials/config:
 
-- Provider `(not set)` or `elevenlabs`: `services.tts.providers.elevenlabs.voiceId` is set.
-- Provider `fish-audio`: `services.tts.providers.fish-audio.referenceId` is set.
-- Provider `xai`: `services.tts.providers.xai.voiceId` is set.
-- Provider `deepgram`: no voice-selection prompt is needed.
+- `elevenlabs` or provider `(not set)`: `elevenlabs/api_key` is stored. A custom `services.tts.providers.elevenlabs.voiceId` is optional; if missing, ask whether they want to choose a voice.
+- `fish-audio`: `fish-audio/api_key` is stored and `services.tts.providers.fish-audio.referenceId` is non-empty.
+- `deepgram`: `deepgram/api_key` is stored. No voice selection is required.
+- `xai`: `xai/api_key` is stored. `services.tts.providers.xai.voiceId` is optional because xAI has a default voice.
 
-If no TTS voice has been explicitly configured, prompt the user to choose one before finishing setup. For the default ElevenLabs flow, follow the included `elevenlabs-voice` skill and use `voice_config_update setting="tts_voice_id" value="<selected-voice-id>"`.
+If the effective provider is missing its API key or required voice/reference config, prompt the user to set up a TTS provider before finishing Twilio setup. If `services.tts.provider` is `(not set)` and a non-ElevenLabs provider is already configured with credentials, ask whether to switch to it with `voice_config_update setting="tts_provider" value="<provider-id>"`.
+
+### TTS Provider Setup Flow
+
+Ask which TTS provider they want to use for phone-call speech:
+
+- **ElevenLabs** -- low-latency Twilio-native path; requires an ElevenLabs API key. Voice selection is optional but recommended.
+- **Fish Audio** -- expressive synthesized-play path; requires a Fish Audio API key and voice reference ID.
+- **Deepgram** -- synthesized-play path; uses the Deepgram API key and default model, with no separate voice selection.
+- **xAI** -- synthesized-play path; requires an xAI API key and can use the default `eve` voice or another supported xAI voice.
+
+After they choose a provider:
+
+1. Set it with `voice_config_update setting="tts_provider" value="<provider-id>"`.
+2. Collect the provider API key securely. Never ask the user to paste an API key in chat.
+   - ElevenLabs: `credential_store action="prompt" service="elevenlabs" field="api_key" label="ElevenLabs API Key" description="Enter your ElevenLabs API key" placeholder="sk_..."`
+   - Fish Audio: `credential_store action="prompt" service="fish-audio" field="api_key" label="Fish Audio API Key" description="Enter your Fish Audio API key" placeholder="sk-..."`
+   - Deepgram: `credential_store action="prompt" service="deepgram" field="api_key" label="Deepgram API Key" description="Enter your Deepgram API key" placeholder="dg_..."`
+   - xAI: `credential_store action="prompt" service="xai" field="api_key" label="xAI API Key" description="Enter your xAI API key" placeholder="xai-..."`
+3. Configure provider-specific voice settings when needed:
+   - ElevenLabs: offer to load `elevenlabs-voice` so the user can pick a curated voice; set it with `voice_config_update setting="tts_voice_id" value="<selected-voice-id>"`.
+   - Fish Audio: ask for the voice reference ID and set it with `voice_config_update setting="fish_audio_reference_id" value="<reference-id>"`.
+   - Deepgram: no additional voice setting is required.
+   - xAI: optional voices are `eve`, `ara`, `rex`, `sal`, and `leo`; set one only if requested with `assistant config set services.tts.providers.xai.voiceId "<voice-id>"`.
 
 # Twilio Setup Steps
 
@@ -74,7 +103,7 @@ Follow the steps below in order to fully configure Twilio in preparation to make
 
 ## Step 1: Check Current Configuration
 
-Refer to "Checking Current Configuration" above to see the current state of the user's Twilio setup. If Twilio credentials and phone number are configured, skip to the TTS voice check before declaring setup complete. Otherwise, continue to the missing steps below.
+Refer to "Checking Current Configuration" above to see the current state of the user's Twilio setup. If Twilio credentials and phone number are configured, skip to the TTS service check before declaring setup complete. Otherwise, continue to the missing steps below.
 
 ## Step 2: Collect and Store Credentials
 
@@ -205,13 +234,13 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"
 ```
 
-## Step 5: Configure TTS Voice If Missing
+## Step 5: Configure TTS Service If Missing
 
-Refer to "Checking Current TTS Voice Configuration" above. If a TTS voice has already been explicitly configured, do not prompt again.
+Refer to "Checking Current TTS Service Configuration" above. If a usable TTS provider is already configured with its required credentials and provider-specific voice/reference settings, do not prompt again.
 
-If no TTS voice is configured, tell the user: **"One more thing before calls are ready: choose the voice I should use on phone calls. I can pick a good default from the curated voices, or you can choose one."**
+If TTS is not set up, tell the user: **"One more thing before calls are ready: choose the text-to-speech provider I should use for phone calls. I'll collect the provider API key securely and set any required voice options."**
 
-Then follow the included `elevenlabs-voice` skill to select and set a voice. Do not skip this prompt just because the runtime has an ElevenLabs default -- the goal is to get an explicit user preference before calls go live.
+Then follow the TTS provider setup flow above. Do not skip this prompt just because the runtime has a default provider or default voice -- the goal is to ensure a provider with credentials is actually usable before calls go live.
 
 ## Clearing Credentials
 

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: twilio-setup
-description: Configure Twilio credentials and phone numbers for voice calls
+description: Configure Twilio credentials, phone numbers, webhooks, and call voice setup
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📱"
   vellum:
     display-name: "Twilio Setup"
-    includes: ["public-ingress"]
+    includes: ["public-ingress", "elevenlabs-voice"]
 ---
 
 You are helping your user configure Twilio for voice calls. Walk through each step below.
@@ -20,9 +20,11 @@ Before you begin, understand how each Twilio value is stored:
 | Account SID  | Config     | `assistant config set twilio.accountSid`                        | No      |
 | Auth Token   | Credential | `assistant credentials set --service twilio --field auth_token` | **Yes** |
 | Phone Number | Config     | `assistant config set twilio.phoneNumber`                       | No      |
+| TTS Voice    | Config     | `voice_config_update setting="tts_voice_id"`                    | No      |
 
 - **Config values** (Account SID, Phone Number) are non-sensitive identifiers. Collect them via normal conversation -- the user can paste them in chat or you can use `AskUserQuestion`.
   **Auth Token** is a secret. Collect it securely via `credential_store` prompt -- never accept it pasted in plaintext chat.
+- **TTS Voice** is not a Twilio credential, but phone calls use it for the assistant's spoken voice. Prompt for it during setup if the user has not explicitly configured one yet.
 
 ## Retrieving Twilio Credentials
 
@@ -43,8 +45,28 @@ assistant credentials inspect --service twilio --field auth_token --json  # chec
 assistant config get twilio.phoneNumber
 ```
 
-- If all three config values are non-empty -- Twilio is fully configured. Offer to show status or reconfigure.
+- If all three Twilio values are non-empty -- Twilio credentials and phone number are configured, but still check the TTS voice before declaring setup complete.
 - Otherwise, continue to the missing steps.
+
+## Checking Current TTS Voice Configuration
+
+TTS has runtime defaults, so do not treat a default voice as explicitly configured. Check the raw config values:
+
+```bash
+assistant config get services.tts.provider
+assistant config get services.tts.providers.elevenlabs.voiceId
+assistant config get services.tts.providers.fish-audio.referenceId
+assistant config get services.tts.providers.xai.voiceId
+```
+
+Treat the TTS voice as already configured when the active provider has a non-empty raw voice value:
+
+- Provider `(not set)` or `elevenlabs`: `services.tts.providers.elevenlabs.voiceId` is set.
+- Provider `fish-audio`: `services.tts.providers.fish-audio.referenceId` is set.
+- Provider `xai`: `services.tts.providers.xai.voiceId` is set.
+- Provider `deepgram`: no voice-selection prompt is needed.
+
+If no TTS voice has been explicitly configured, prompt the user to choose one before finishing setup. For the default ElevenLabs flow, follow the included `elevenlabs-voice` skill and use `voice_config_update setting="tts_voice_id" value="<selected-voice-id>"`.
 
 # Twilio Setup Steps
 
@@ -52,7 +74,7 @@ Follow the steps below in order to fully configure Twilio in preparation to make
 
 ## Step 1: Check Current Configuration
 
-Refer to "Checking Current Configuration" above to see the current state of the user's Twilio setup. If Twilio appears to be fully configured. Offer to show status or reconfigure. Otherwise, continue to the missing steps below.
+Refer to "Checking Current Configuration" above to see the current state of the user's Twilio setup. If Twilio credentials and phone number are configured, skip to the TTS voice check before declaring setup complete. Otherwise, continue to the missing steps below.
 
 ## Step 2: Collect and Store Credentials
 
@@ -182,6 +204,14 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
   -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"
 ```
+
+## Step 5: Configure TTS Voice If Missing
+
+Refer to "Checking Current TTS Voice Configuration" above. If a TTS voice has already been explicitly configured, do not prompt again.
+
+If no TTS voice is configured, tell the user: **"One more thing before calls are ready: choose the voice I should use on phone calls. I can pick a good default from the curated voices, or you can choose one."**
+
+Then follow the included `elevenlabs-voice` skill to select and set a voice. Do not skip this prompt just because the runtime has an ElevenLabs default -- the goal is to get an explicit user preference before calls go live.
 
 ## Clearing Credentials
 

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -47,7 +47,7 @@ assistant credentials inspect --service twilio --field auth_token --json  # chec
 assistant config get twilio.phoneNumber
 ```
 
-- If all three Twilio values are non-empty -- Twilio credentials and phone number are configured, but still check the TTS voice before declaring setup complete.
+- If all three Twilio values are non-empty -- Twilio credentials and phone number are configured, but still check the TTS service before declaring setup complete.
 - Otherwise, continue to the missing steps.
 
 ## Checking Current TTS Service Configuration


### PR DESCRIPTION
## Summary
- Add explicit TTS service checks to Twilio setup so runtime defaults alone do not count as usable call voice configuration.
- Prompt the user to choose any supported TTS provider and collect that provider API key securely, with provider-specific voice/reference settings only where needed.
- Remove the ElevenLabs-specific auto-include from phone-call setup and regenerate first-party skill catalog metadata.

## Original prompt
update the twilio skill to prompt for a TTS voice service configuration if tts voice hasn't already been configured