### PR TITLE
feat(macos): redesign billing Plan card with live subscription state

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PlanCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PlanCard.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Top-of-billing-tab summary of the org's current plan.
+///
+/// Mirrors `vellum-assistant-platform/web/src/components/app/settings/PlanCard.tsx`.
+/// Renders a compact card showing the current plan (Pro / Base) with an SF Symbol
+/// (`crown.fill` / `leaf.fill`), a short feature subtitle, and a primary CTA that
+/// invokes `onManage`. Both the Pro "Manage" and Base "Upgrade to Pro" buttons fan
+/// into the same callback so the parent owns navigation behavior.
+///
+/// SF Symbols are used directly instead of going through the `VIcon` (lucide)
+/// registry: both glyphs ship with macOS so there's no asset bundling, they
+/// render at any size with native antialiasing, and keeping a one-off off the
+/// `VIcon` registry avoids a guard-test cascade.
+///
+/// The renewal/cancel subtitle line is rendered by the parent (`SettingsBillingTab`)
+/// next to this card — see `planSection` there. Keeping the subtitle outside this
+/// component keeps `PlanCard` purely presentational over the props it receives.
+@MainActor
+struct PlanCard: View {
+    let subscription: SubscriptionResponse?
+    let plans: [PlanCatalogEntry]?
+    let isLoading: Bool
+    let error: String?
+    let onManage: () -> Void
+
+    /// Resolved display state — exposed internally so tests can assert the
+    /// branch chosen for a given (subscription, plans, isLoading, error)
+    /// combination without going through SwiftUI rendering inspection.
+    enum DisplayState: Equatable {
+        case loading
+        case loaded(planName: String, subtitle: String, buttonLabel: String, isPro: Bool)
+        case error(String)
+    }
+
+    var displayState: DisplayState {
+        if isLoading {
+            return .loading
+        }
+        if let subscription, let plans, let currentPlan = plans.first(where: { $0.id == subscription.plan_id }) {
+            let isPro = subscription.plan_id == "pro"
+            return .loaded(
+                planName: isPro ? "PRO Plan" : "Basic Plan",
+                subtitle: currentPlan.included_features.prefix(3).joined(separator: ", "),
+                buttonLabel: isPro ? "Manage" : "Upgrade to Pro",
+                isPro: isPro
+            )
+        }
+        return .error(error ?? "Unable to load plan information.")
+    }
+
+    var body: some View {
+        switch displayState {
+        case .loading:
+            loadingCard
+        case let .loaded(planName, subtitle, buttonLabel, isPro):
+            loadedCard(planName: planName, subtitle: subtitle, buttonLabel: buttonLabel, isPro: isPro)
+        case let .error(message):
+            errorCard(message: message)
+        }
+    }
+
+    // MARK: - Loaded
+
+    private func loadedCard(planName: String, subtitle: String, buttonLabel: String, isPro: Bool) -> some View {
+        SettingsCard(title: "Plan", subtitle: "Manage your subscription tier and billing.") {
+            HStack(alignment: .center, spacing: VSpacing.md) {
+                Image(systemName: isPro ? "crown.fill" : "leaf.fill")
+                    .font(.system(size: 18))
+                    .foregroundStyle(VColor.contentEmphasized)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(planName)
+                        .font(VFont.titleSmall)
+                        .foregroundStyle(VColor.contentEmphasized)
+                    Text(subtitle)
+                        .font(VFont.bodySmallDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                Spacer()
+
+                VButton(
+                    label: buttonLabel,
+                    style: isPro ? .outlined : .primary
+                ) {
+                    onManage()
+                }
+            }
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingCard: some View {
+        SettingsCard(title: "Plan", subtitle: "Manage your subscription tier and billing.") {
+            HStack(alignment: .center, spacing: VSpacing.md) {
+                VSkeletonBone(width: 120, height: 16)
+                Spacer()
+                VSkeletonBone(width: 80, height: 28)
+            }
+            .accessibilityHidden(true)
+        }
+    }
+
+    // MARK: - Error
+
+    private func errorCard(message: String) -> some View {
+        SettingsCard(title: "Plan", subtitle: "Manage your subscription tier and billing.") {
+            HStack(spacing: VSpacing.sm) {
+                VIconView(.circleAlert, size: 14)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+                Text(message)
+                    .font(VFont.bodyMediumLighter)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -206,7 +206,7 @@ struct SettingsBillingTab: View {
         PlanCard(
             subscription: subscription,
             plans: plans,
-            isLoading: subscription == nil && planError == nil,
+            isLoading: (subscription == nil || plans == nil) && planError == nil,
             error: planError,
             onManage: { NSWorkspace.shared.open(AppURLs.billingSettings) }
         )
@@ -377,40 +377,60 @@ struct SettingsBillingTab: View {
         planError = nil
 
         // Always refresh the billing summary. When `pro-plan-adjust` is on we
-        // also fetch the subscription + plan catalog in parallel; while the flag
-        // is off those endpoints aren't called so users on the legacy billing
-        // tab don't pay for unused requests. Each fetch has its own `do/catch`
-        // so a flaky `/subscription/` call still lets the balance card render
-        // (and vice versa).
-        async let summaryTask = BillingService.shared.getBillingSummary()
+        // also fetch the subscription + plan catalog in parallel; while the
+        // flag is off those endpoints aren't called so users on the legacy
+        // billing tab don't pay for unused requests. Each fetch has its own
+        // `do/catch` so a flaky `/subscription/` call still lets the balance
+        // card render (and vice versa).
+        //
+        // Critically, we resolve the billing summary BEFORE awaiting the plan
+        // metadata so a slow `/subscription/` or `/plans/` call doesn't keep
+        // the balance card in skeleton state. Both `async let`s are still
+        // launched concurrently, so total wall-clock time is unchanged — but
+        // the balance UI flips out of loading as soon as the summary call
+        // returns, independent of plan-metadata latency.
         if isProPlanAdjustEnabled {
+            async let summaryTask = BillingService.shared.getBillingSummary()
             async let subscriptionTask = BillingService.shared.getSubscription()
             async let plansTask = BillingService.shared.getPlanCatalog()
 
             do {
-                subscription = try await subscriptionTask
+                var result = try await summaryTask
+                if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: result) {
+                    result = bootstrapped
+                }
+                summary = result
+            } catch {
+                if summary == nil {
+                    self.error = "Unable to load billing information. Please try again."
+                }
+            }
+            isLoading = false
+
+            do {
+                let sub = try await subscriptionTask
                 let catalog = try await plansTask
+                subscription = sub
                 plans = catalog.plans
             } catch {
                 if subscription == nil {
                     planError = "Unable to load plan information."
                 }
             }
-        }
-
-        do {
-            var result = try await summaryTask
-            if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: result) {
-                result = bootstrapped
+        } else {
+            do {
+                var result = try await BillingService.shared.getBillingSummary()
+                if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: result) {
+                    result = bootstrapped
+                }
+                summary = result
+            } catch {
+                if summary == nil {
+                    self.error = "Unable to load billing information. Please try again."
+                }
             }
-            summary = result
-        } catch {
-            if summary == nil {
-                self.error = "Unable to load billing information. Please try again."
-            }
+            isLoading = false
         }
-
-        isLoading = false
     }
 
     /// Formats an ISO 8601 timestamp as a long-style locale date (e.g.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -8,6 +8,9 @@ struct SettingsBillingTab: View {
     var assistantFeatureFlagStore: AssistantFeatureFlagStore
 
     @State private var summary: BillingSummaryResponse?
+    @State private var subscription: SubscriptionResponse?
+    @State private var plans: [PlanCatalogEntry]?
+    @State private var planError: String?
     @State private var isLoading: Bool = true
     @State private var error: String?
     @State private var selectedAmount: String = ""
@@ -24,6 +27,10 @@ struct SettingsBillingTab: View {
         assistantFeatureFlagStore.isEnabled("pro-plan-adjust")
     }
 
+    var isAutoCreditTopUpEnabled: Bool {
+        assistantFeatureFlagStore.isEnabled("auto-credit-topup")
+    }
+
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
@@ -31,10 +38,10 @@ struct SettingsBillingTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            balanceCard
             if isProPlanAdjustEnabled {
-                adjustPlanCard
+                planSection
             }
+            balanceCard
             if isLoading {
                 addFundsSkeleton
             } else if !topUpAmounts.isEmpty {
@@ -169,16 +176,51 @@ struct SettingsBillingTab: View {
         }
     }
 
-    // MARK: - Adjust Plan Card
+    // MARK: - Plan Section
 
-    private var adjustPlanCard: some View {
-        SettingsCard(title: "Adjust Plan") {
-            VButton(
-                label: "Adjust Plan",
-                style: .primary
-            ) {
-                NSWorkspace.shared.open(AppURLs.billingSettings)
-            }
+    /// Resolved subtitle line shown beneath the `PlanCard` for Pro subscriptions.
+    /// Exposed for testability — see `PlanCardTests.testCancellingSubscriptionRendersCancelLine`.
+    /// Returns `nil` when nothing should render below the card (loading, base
+    /// plan, etc.).
+    enum PlanRenewalLine: Equatable {
+        case renews(String)
+        case cancels(String)
+    }
+
+    var planRenewalLine: PlanRenewalLine? {
+        guard let sub = subscription, sub.plan_id == "pro" else { return nil }
+        if !sub.cancel_at_period_end, let renewalISO = sub.current_period_end {
+            return .renews(formatRenewalDate(renewalISO))
+        }
+        if sub.cancel_at_period_end, let cancelISO = sub.cancel_at ?? sub.current_period_end {
+            return .cancels(formatRenewalDate(cancelISO))
+        }
+        return nil
+    }
+
+    /// Renders the new rich `PlanCard` plus a renewal-or-cancel subtitle line for
+    /// Pro subscriptions. The subtitle lives in the parent so `PlanCard` stays a
+    /// pure presentational view over its props.
+    @ViewBuilder
+    private var planSection: some View {
+        PlanCard(
+            subscription: subscription,
+            plans: plans,
+            isLoading: subscription == nil && planError == nil,
+            error: planError,
+            onManage: { NSWorkspace.shared.open(AppURLs.billingSettings) }
+        )
+        switch planRenewalLine {
+        case let .renews(date):
+            Text("Renews on \(date).")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.contentTertiary)
+        case let .cancels(date):
+            Text("Cancels on \(date).")
+                .font(VFont.bodySmallDefault)
+                .foregroundStyle(VColor.systemMidStrong)
+        case .none:
+            EmptyView()
         }
     }
 
@@ -269,7 +311,7 @@ struct SettingsBillingTab: View {
                 ) {
                     Task { await handleTopUp() }
                 }
-                if isProPlanAdjustEnabled {
+                if isAutoCreditTopUpEnabled {
                     VButton(
                         label: "Configure Auto Top Ups",
                         style: .outlined
@@ -332,19 +374,58 @@ struct SettingsBillingTab: View {
             isLoading = true
         }
         error = nil
+        planError = nil
+
+        // Always refresh the billing summary. When `pro-plan-adjust` is on we
+        // also fetch the subscription + plan catalog in parallel; while the flag
+        // is off those endpoints aren't called so users on the legacy billing
+        // tab don't pay for unused requests. Each fetch has its own `do/catch`
+        // so a flaky `/subscription/` call still lets the balance card render
+        // (and vice versa).
+        async let summaryTask = BillingService.shared.getBillingSummary()
+        if isProPlanAdjustEnabled {
+            async let subscriptionTask = BillingService.shared.getSubscription()
+            async let plansTask = BillingService.shared.getPlanCatalog()
+
+            do {
+                subscription = try await subscriptionTask
+                let catalog = try await plansTask
+                plans = catalog.plans
+            } catch {
+                if subscription == nil {
+                    planError = "Unable to load plan information."
+                }
+            }
+        }
+
         do {
-            var result = try await BillingService.shared.getBillingSummary()
+            var result = try await summaryTask
             if let bootstrapped = await BillingService.shared.bootstrapBillingSummaryIfNeeded(summary: result) {
                 result = bootstrapped
             }
             summary = result
         } catch {
-            // Only show error if we have no cached data to display
             if summary == nil {
                 self.error = "Unable to load billing information. Please try again."
             }
         }
+
         isLoading = false
+    }
+
+    /// Formats an ISO 8601 timestamp as a long-style locale date (e.g.
+    /// `April 1, 2026`). Mirrors `formatGraceDate` in
+    /// `web/src/lib/billing/use-billing-portal-session.ts` so the macOS and web
+    /// surfaces render the same string for a given subscription. Falls back to
+    /// the raw ISO string if parsing fails so the user still sees something.
+    private func formatRenewalDate(_ iso: String) -> String {
+        let parser = ISO8601DateFormatter()
+        parser.formatOptions = [.withInternetDateTime]
+        guard let date = parser.date(from: iso) else { return iso }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
     }
 
     private func handleTopUp() async {
@@ -378,17 +459,21 @@ struct SettingsBillingTab: View {
 // MARK: - Test Support
 
 extension SettingsBillingTab {
-    /// Test-only convenience initializer that pre-populates the `summary` `@State`
-    /// without going through the `loadSummary()` async path. Used by
-    /// `SettingsBillingTabSubtitleTests` to exercise `addCreditsSubtitleAttributed`
-    /// against a known billing summary fixture.
+    /// Test-only convenience initializer that pre-populates the `summary`,
+    /// `subscription`, and `plans` `@State` values without going through the
+    /// `loadSummary()` async path. Used by `SettingsBillingTabSubtitleTests`
+    /// and `PlanCardTests` to exercise the rendered output against known fixtures.
     init(
         authManager: AuthManager,
         assistantFeatureFlagStore: AssistantFeatureFlagStore,
-        initialSummary: BillingSummaryResponse?
+        initialSummary: BillingSummaryResponse?,
+        initialSubscription: SubscriptionResponse? = nil,
+        initialPlans: [PlanCatalogEntry]? = nil
     ) {
         self.authManager = authManager
         self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self._summary = State(initialValue: initialSummary)
+        self._subscription = State(initialValue: initialSubscription)
+        self._plans = State(initialValue: initialPlans)
     }
 }

--- a/clients/macos/vellum-assistantTests/PlanCardTests.swift
+++ b/clients/macos/vellum-assistantTests/PlanCardTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Behavioral tests for the new `PlanCard` and the `SettingsBillingTab.planRenewalLine`
+/// derivation. These exercise the resolved view-model (`PlanCard.DisplayState`,
+/// `SettingsBillingTab.PlanRenewalLine`) rather than the rendered SwiftUI tree —
+/// the test target doesn't depend on ViewInspector, so we assert on the props the
+/// view computes from its inputs.
+@MainActor
+final class PlanCardTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makePlanCatalog() -> [PlanCatalogEntry] {
+        [
+            PlanCatalogEntry(
+                id: "base",
+                name: "Base",
+                price_cents: 0,
+                billing_interval: "month",
+                included_features: [
+                    "Pay-as-you-go credits",
+                    "Default machine size"
+                ]
+            ),
+            PlanCatalogEntry(
+                id: "pro",
+                name: "Pro",
+                price_cents: 2500,
+                billing_interval: "month",
+                included_features: [
+                    "Larger machine size",
+                    "Bundled credits",
+                    "Managed email subdomain",
+                    "Managed Twilio phone numbers",
+                    "90-day grace period on cancellation"
+                ]
+            )
+        ]
+    }
+
+    private func makeProSubscription(
+        cancelAtPeriodEnd: Bool = false,
+        cancelAt: String? = nil,
+        currentPeriodEnd: String? = "2026-06-01T00:00:00Z"
+    ) -> SubscriptionResponse {
+        SubscriptionResponse(
+            plan_id: "pro",
+            status: "active",
+            renewal_date: currentPeriodEnd,
+            current_period_end: currentPeriodEnd,
+            cancel_at_period_end: cancelAtPeriodEnd,
+            cancel_at: cancelAt
+        )
+    }
+
+    private func makeBaseSubscription() -> SubscriptionResponse {
+        SubscriptionResponse(
+            plan_id: "base",
+            status: nil,
+            renewal_date: nil,
+            current_period_end: nil,
+            cancel_at_period_end: false,
+            cancel_at: nil
+        )
+    }
+
+    // MARK: - PlanCard.DisplayState
+
+    func testProSubscriptionRendersCrownAndManageButton() {
+        let card = PlanCard(
+            subscription: makeProSubscription(),
+            plans: makePlanCatalog(),
+            isLoading: false,
+            error: nil,
+            onManage: {}
+        )
+
+        guard case let .loaded(planName, subtitle, buttonLabel, isPro) = card.displayState else {
+            XCTFail("Expected .loaded state for pro subscription, got \(card.displayState)")
+            return
+        }
+        XCTAssertEqual(planName, "PRO Plan")
+        XCTAssertEqual(buttonLabel, "Manage")
+        XCTAssertTrue(isPro)
+        XCTAssertEqual(
+            subtitle,
+            "Larger machine size, Bundled credits, Managed email subdomain",
+            "Subtitle should be the first 3 features comma-joined"
+        )
+    }
+
+    func testBaseSubscriptionRendersUpgradeCTA() {
+        let card = PlanCard(
+            subscription: makeBaseSubscription(),
+            plans: makePlanCatalog(),
+            isLoading: false,
+            error: nil,
+            onManage: {}
+        )
+
+        guard case let .loaded(planName, subtitle, buttonLabel, isPro) = card.displayState else {
+            XCTFail("Expected .loaded state for base subscription, got \(card.displayState)")
+            return
+        }
+        XCTAssertEqual(planName, "Basic Plan")
+        XCTAssertEqual(buttonLabel, "Upgrade to Pro")
+        XCTAssertFalse(isPro)
+        XCTAssertEqual(
+            subtitle,
+            "Pay-as-you-go credits, Default machine size",
+            "Subtitle should join all features when there are fewer than 3"
+        )
+    }
+
+    func testLoadingStateShortCircuitsBeforeData() {
+        let card = PlanCard(
+            subscription: nil,
+            plans: nil,
+            isLoading: true,
+            error: nil,
+            onManage: {}
+        )
+        XCTAssertEqual(card.displayState, .loading)
+    }
+
+    func testErrorStateWhenSubscriptionMissing() {
+        let card = PlanCard(
+            subscription: nil,
+            plans: nil,
+            isLoading: false,
+            error: "Boom",
+            onManage: {}
+        )
+        XCTAssertEqual(card.displayState, .error("Boom"))
+    }
+
+    // MARK: - SettingsBillingTab.planRenewalLine
+
+    func testCancellingSubscriptionRendersCancelLine() {
+        let cancelISO = "2026-09-15T00:00:00Z"
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: nil,
+            initialSubscription: makeProSubscription(
+                cancelAtPeriodEnd: true,
+                cancelAt: cancelISO,
+                currentPeriodEnd: "2026-06-01T00:00:00Z"
+            ),
+            initialPlans: makePlanCatalog()
+        )
+
+        guard case let .cancels(formatted) = view.planRenewalLine else {
+            XCTFail("Expected .cancels for cancelling subscription, got \(String(describing: view.planRenewalLine))")
+            return
+        }
+        // The exact rendered string depends on the test runner's locale, but we
+        // can verify the year is present (long-style date) and the source ISO
+        // resolved cleanly rather than falling through to the raw string.
+        XCTAssertTrue(formatted.contains("2026"), "Expected long-style date containing 2026, got \(formatted)")
+        XCTAssertNotEqual(formatted, cancelISO, "Should have parsed and reformatted, not echoed raw ISO")
+    }
+
+    func testActiveProSubscriptionRendersRenewsLine() {
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: nil,
+            initialSubscription: makeProSubscription(cancelAtPeriodEnd: false),
+            initialPlans: makePlanCatalog()
+        )
+
+        guard case let .renews(formatted) = view.planRenewalLine else {
+            XCTFail("Expected .renews for active pro subscription, got \(String(describing: view.planRenewalLine))")
+            return
+        }
+        XCTAssertTrue(formatted.contains("2026"))
+    }
+
+    func testBaseSubscriptionRendersNoRenewalLine() {
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: nil,
+            initialSubscription: makeBaseSubscription(),
+            initialPlans: makePlanCatalog()
+        )
+        XCTAssertNil(view.planRenewalLine)
+    }
+
+    /// Stripe sometimes flips `cancel_at_period_end=true` before populating
+    /// `cancel_at`. The line should still render using `current_period_end` as
+    /// the fallback so the user isn't left without an end-date during that
+    /// brief Stripe scheduling window.
+    func testCancellingSubscriptionWithoutExplicitCancelAtFallsBackToPeriodEnd() {
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
+            initialSummary: nil,
+            initialSubscription: makeProSubscription(
+                cancelAtPeriodEnd: true,
+                cancelAt: nil,
+                currentPeriodEnd: "2026-06-01T00:00:00Z"
+            ),
+            initialPlans: makePlanCatalog()
+        )
+
+        guard case let .cancels(formatted) = view.planRenewalLine else {
+            XCTFail("Expected .cancels using current_period_end fallback")
+            return
+        }
+        XCTAssertTrue(formatted.contains("2026"))
+    }
+}

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabFeatureFlagTests.swift
@@ -5,11 +5,12 @@ import XCTest
 @MainActor
 final class SettingsBillingTabFeatureFlagTests: XCTestCase {
     private let proPlanAdjustKey = "pro-plan-adjust"
+    private let autoCreditTopUpKey = "auto-credit-topup"
 
-    /// Build a registry containing only the `pro-plan-adjust` entry. Mirrors the
-    /// pattern in `AssistantFeatureFlagResolverTests.makeRegistry` — passing an
-    /// explicit registry avoids depending on `Bundle.main` resources, which are
-    /// only populated for the bundled `.app` (not the SPM test target).
+    /// Build a registry containing the `pro-plan-adjust` and `auto-credit-topup`
+    /// entries. Mirrors the pattern in `AssistantFeatureFlagResolverTests.makeRegistry`
+    /// — passing an explicit registry avoids depending on `Bundle.main` resources,
+    /// which are only populated for the bundled `.app` (not the SPM test target).
     private func makeRegistry(defaultEnabled: Bool) -> FeatureFlagRegistry {
         FeatureFlagRegistry(
             version: 1,
@@ -19,7 +20,15 @@ final class SettingsBillingTabFeatureFlagTests: XCTestCase {
                     scope: .assistant,
                     key: proPlanAdjustKey,
                     label: "Pro Plan Adjust",
-                    description: "Show the 'Adjust Plan' and 'Configure Auto Top Ups' CTAs in the macOS Settings → Billing tab.",
+                    description: "Show the Plan card and 'Configure Auto Top Ups' CTAs in the macOS Settings → Billing tab.",
+                    defaultEnabled: defaultEnabled
+                ),
+                FeatureFlagDefinition(
+                    id: "auto-credit-topup",
+                    scope: .assistant,
+                    key: autoCreditTopUpKey,
+                    label: "Auto Credit Top-Up",
+                    description: "Show the 'Configure Auto Top Ups' CTA in the macOS Settings → Billing tab.",
                     defaultEnabled: defaultEnabled
                 )
             ]
@@ -54,5 +63,58 @@ final class SettingsBillingTabFeatureFlagTests: XCTestCase {
             initialSummary: nil
         )
         XCTAssertFalse(view.isProPlanAdjustEnabled)
+    }
+
+    func testAutoTopUpButtonReadsFlagFromStore() {
+        AssistantFeatureFlagResolver.writeCachedFlags([autoCreditTopUpKey: true])
+        defer { AssistantFeatureFlagResolver.clearCachedFlags() }
+
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false)
+        )
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: store,
+            initialSummary: nil
+        )
+        XCTAssertTrue(view.isAutoCreditTopUpEnabled)
+    }
+
+    func testAutoTopUpButtonDefaultsFalseWhenNoOverride() {
+        AssistantFeatureFlagResolver.clearCachedFlags()
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false)
+        )
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: store,
+            initialSummary: nil
+        )
+        XCTAssertFalse(view.isAutoCreditTopUpEnabled)
+    }
+
+    /// Regression: previously the auto-top-up CTA was gated on `pro-plan-adjust`,
+    /// so flipping that flag also flipped the auto-top-up button. Confirm the two
+    /// flags are now fully decoupled.
+    func testAutoTopUpButtonIndependentOfProPlanAdjust() {
+        AssistantFeatureFlagResolver.writeCachedFlags([
+            proPlanAdjustKey: true,
+            autoCreditTopUpKey: false
+        ])
+        defer { AssistantFeatureFlagResolver.clearCachedFlags() }
+
+        let store = AssistantFeatureFlagStore(
+            notificationCenter: NotificationCenter(),
+            registry: makeRegistry(defaultEnabled: false)
+        )
+        let view = SettingsBillingTab(
+            authManager: AuthManager(),
+            assistantFeatureFlagStore: store,
+            initialSummary: nil
+        )
+        XCTAssertTrue(view.isProPlanAdjustEnabled)
+        XCTAssertFalse(view.isAutoCreditTopUpEnabled)
     }
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -286,7 +286,7 @@
       "scope": "assistant",
       "key": "pro-plan-adjust",
       "label": "Pro Plan Adjust",
-      "description": "Show the 'Adjust Plan' and 'Configure Auto Top Ups' CTAs in the macOS Settings → Billing tab. Both open the web app's billing settings page.",
+      "description": "Show the rich Plan card (current plan, features, Manage/Upgrade CTA) at the top of the macOS Settings → Billing tab. The 'Configure Auto Top Ups' CTA is gated separately on `auto-credit-topup`.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Replaces the simple 'Adjust Plan' card with a rich Plan card (crown / leaf SF Symbol, plan name, top-3 features, Manage/Upgrade CTA), moved to the top of the Billing tab
- Wires the card to live `/v1/organizations/billing/subscription/` + `/v1/organizations/billing/plans/` data via `BillingService.getSubscription()` / `getPlanCatalog()`
- Decouples 'Configure Auto Top Ups' from `pro-plan-adjust` and gates it on the new `auto-credit-topup` flag instead

Part of plan: billing-plan-card.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->