### PR TITLE
Drop onboarding model collection; seed per-provider custom-* profiles

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -550,6 +550,26 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["custom-balanced"]).toBeUndefined();
     expect(raw.llm.profiles["custom-quality-optimized"]).toBeUndefined();
     expect(raw.llm.profiles["custom-cost-optimized"]).toBeUndefined();
+    // The unrecognized provider should be rewritten on disk so subsequent
+    // loads don't trip Zod's enum validation warning.
+    expect(raw.llm.default.provider).toBe("anthropic");
+  });
+
+  test("preserves user-supplied non-catalog model on every restart (ollama custom model)", () => {
+    // Models the ollama case: catalog lists only `llama3.2` but the user has
+    // pulled `codellama`. The seeder must NOT silently overwrite their pick.
+    writeConfig({
+      llm: { default: { provider: "ollama", model: "codellama" } },
+    });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    let raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default.model).toBe("codellama");
+
+    // Re-run to confirm idempotency — the user's model survives every restart.
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default.model).toBe("codellama");
   });
 
   test("syncs llm.default.model to active profile when missing or inconsistent, respects explicit user values", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -83,6 +83,14 @@ function writeConfig(obj: unknown): void {
   writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
 }
 
+function mergeDefaultConfigAndSeedInferenceProfiles(): void {
+  const defaultConfigMerge = mergeDefaultWorkspaceConfig();
+  seedInferenceProfiles({
+    preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
+    preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests: deepMergeOverwrite (unit) — JSON-null-as-deletion semantics
 //
@@ -417,8 +425,7 @@ describe("loadConfig startup behavior", () => {
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 
-    seedInferenceProfiles();
-    mergeDefaultWorkspaceConfig();
+    mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
 
     expect(config.llm.default.provider).toBe("anthropic");
@@ -435,7 +442,166 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
   });
 
-  test("non-Anthropic hatch overlay does not activate Anthropic managed profile", () => {
+  test("non-Anthropic hatch overlay seeds custom-* profiles and activates custom-balanced", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: {
+              provider: "openai",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const config = loadConfig();
+    const mainAgentConfig = resolveCallSiteConfig("mainAgent", config.llm);
+
+    expect(config.llm.activeProfile).toBe("custom-balanced");
+    expect(config.llm.profiles["custom-balanced"]?.provider).toBe("openai");
+    expect(config.llm.profiles["custom-balanced"]?.model).toBe("gpt-5.4-mini");
+    expect(config.llm.profiles["custom-quality-optimized"]?.provider).toBe(
+      "openai",
+    );
+    expect(config.llm.profiles["custom-cost-optimized"]?.provider).toBe(
+      "openai",
+    );
+    expect(config.llm.profiles.balanced?.provider).toBe("anthropic");
+    expect(config.llm.profiles["quality-optimized"]?.provider).toBe(
+      "anthropic",
+    );
+    expect(config.llm.profiles["cost-optimized"]?.provider).toBe("anthropic");
+    expect(config.llm.default.provider).toBe("openai");
+    expect(config.llm.default.model).toBe("gpt-5.4-mini");
+    expect(mainAgentConfig.provider).toBe("openai");
+    expect(mainAgentConfig.model).toBe("gpt-5.4-mini");
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("custom-balanced");
+    expect(raw.llm.default.model).toBe(
+      raw.llm.profiles["custom-balanced"].model,
+    );
+  });
+
+  test("unknown overlay provider falls back to Anthropic seeding", () => {
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: {
+              provider: "unknownprov",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles["custom-balanced"]).toBeUndefined();
+    expect(raw.llm.profiles["custom-quality-optimized"]).toBeUndefined();
+    expect(raw.llm.profiles["custom-cost-optimized"]).toBeUndefined();
+  });
+
+  test("syncs llm.default.model to active profile when missing or inconsistent, respects explicit user values", () => {
+    // 1. Missing on disk → write to active profile's model.
+    const overlayMissing = join(WORKSPACE_DIR, "overlay-missing.json");
+    writeFileSync(
+      overlayMissing,
+      JSON.stringify({ llm: { default: { provider: "openai" } } }, null, 2) +
+        "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayMissing;
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    let raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default.model).toBe(
+      raw.llm.profiles["custom-balanced"].model,
+    );
+
+    // 2. Inconsistent (previous default model belongs to a different provider)
+    //    is overwritten on the next seed run.
+    rmSync(CONFIG_PATH);
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "claude-opus-4-7" },
+      },
+    });
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayMissing;
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default.model).toBe(
+      raw.llm.profiles["custom-balanced"].model,
+    );
+
+    // 3. Platform overlay supplies an explicit, internally-coherent
+    //    profile/active/default — the user's explicit choice is preserved.
+    rmSync(CONFIG_PATH);
+    const explicit = join(WORKSPACE_DIR, "overlay-explicit.json");
+    writeFileSync(
+      explicit,
+      JSON.stringify(
+        {
+          llm: {
+            default: { provider: "openai", model: "gpt-5.4" },
+            profiles: {
+              balanced: {
+                source: "managed",
+                provider: "openai",
+                model: "gpt-5.4",
+                label: "Platform Balanced",
+              },
+            },
+            activeProfile: "balanced",
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = explicit;
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.default.model).toBe("gpt-5.4");
+  });
+
+  test("platform-provided profile fragments are not polluted by managed seeds", () => {
+    writeConfig({
+      llm: {
+        default: {
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+        },
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            maxTokens: 16000,
+            effort: "high",
+            thinking: { enabled: true, streamThinking: true },
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(
       overlayPath,
@@ -446,6 +612,15 @@ describe("loadConfig startup behavior", () => {
               provider: "openai",
               model: "gpt-5.4",
             },
+            profiles: {
+              balanced: {
+                source: "managed",
+                provider: "openai",
+                model: "gpt-5.4",
+                label: "Platform Balanced",
+              },
+            },
+            activeProfile: "balanced",
           },
         },
         null,
@@ -454,25 +629,77 @@ describe("loadConfig startup behavior", () => {
     );
     process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
 
-    seedInferenceProfiles();
-    mergeDefaultWorkspaceConfig();
+    mergeDefaultConfigAndSeedInferenceProfiles();
     const config = loadConfig();
     const mainAgentConfig = resolveCallSiteConfig("mainAgent", config.llm);
 
-    expect(config.llm.default.provider).toBe("openai");
-    expect(config.llm.default.model).toBe("gpt-5.4");
-    expect(config.llm.activeProfile).toBeUndefined();
-    expect(config.llm.profiles.balanced?.provider).toBeUndefined();
+    expect(config.llm.activeProfile).toBe("balanced");
+    expect(config.llm.profiles.balanced).toEqual({
+      source: "managed",
+      provider: "openai",
+      model: "gpt-5.4",
+      label: "Platform Balanced",
+    });
     expect(mainAgentConfig.provider).toBe("openai");
     expect(mainAgentConfig.model).toBe("gpt-5.4");
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-    expect(raw.llm.default).toEqual({
+    expect(raw.llm.profiles.balanced).toEqual({
+      source: "managed",
       provider: "openai",
       model: "gpt-5.4",
+      label: "Platform Balanced",
     });
-    expect(raw.llm.activeProfile).toBeUndefined();
-    expect(raw.llm.profiles.balanced).toEqual({});
+    expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
+    expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const afterRestart = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(afterRestart.llm.activeProfile).toBe("balanced");
+    expect(afterRestart.llm.profiles.balanced).toEqual({
+      source: "managed",
+      provider: "openai",
+      model: "gpt-5.4",
+      label: "Platform Balanced",
+    });
+  });
+
+  test("quarantines corrupt config before merging hatch overlay", () => {
+    writeFileSync(CONFIG_PATH, "{not valid json");
+
+    const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify(
+        {
+          llm: {
+            default: {
+              provider: "anthropic",
+              model: "claude-opus-4-7",
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const quarantined = readdirSync(WORKSPACE_DIR).filter((n) =>
+      n.startsWith("config.json.corrupt-"),
+    );
+    expect(quarantined.length).toBeGreaterThan(0);
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.default).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+    });
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
   });
 
   test("still quarantines corrupt JSON", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -490,6 +490,39 @@ describe("loadConfig startup behavior", () => {
     );
   });
 
+  test("re-hatch from openai to anthropic resets stale custom-balanced active profile", () => {
+    // Pre-seed an OpenAI-style workspace: custom-balanced is active, default is
+    // openai. Simulates a workspace that previously hatched against OpenAI.
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4-mini" },
+        profiles: {
+          "custom-balanced": {
+            source: "managed",
+            provider: "openai",
+            model: "gpt-5.4-mini",
+          },
+        },
+        activeProfile: "custom-balanced",
+      },
+    });
+
+    const overlayPath = join(WORKSPACE_DIR, "rehatch-anthropic.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify({ llm: { default: { provider: "anthropic" } } }, null, 2) +
+        "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("balanced");
+    expect(raw.llm.default.provider).toBe("anthropic");
+    expect(raw.llm.default.model).toBe("claude-sonnet-4-6");
+  });
+
   test("unknown overlay provider falls back to Anthropic seeding", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -125,6 +125,33 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     ).toThrow(BadRequestError);
   });
 
+  test("rejects edits to custom-balanced", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "custom-balanced" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects edits to custom-quality-optimized", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "custom-quality-optimized" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects edits to custom-cost-optimized", () => {
+    expect(() =>
+      replaceRoute.handler({
+        pathParams: { name: "custom-cost-optimized" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).toThrow(BadRequestError);
+  });
+
   test("allows edits to a user-defined profile", () => {
     savedRaw = null;
     const result = replaceRoute.handler({
@@ -161,6 +188,30 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
     await expect(
       patchRoute.handler({
         body: { llm: { profiles: { "cost-optimized": null } } },
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("rejects deletion of custom-balanced via null", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { "custom-balanced": null } } },
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("rejects deletion of custom-quality-optimized via null", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { "custom-quality-optimized": null } } },
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("rejects deletion of custom-cost-optimized via null", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { "custom-cost-optimized": null } } },
       }),
     ).rejects.toThrow(BadRequestError);
   });

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -404,6 +404,13 @@ function stripNullLeaves(value: unknown): unknown {
   return out;
 }
 
+function readPlainObject(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
 /**
  * Deep-merge `overrides` into `target`, overwriting leaf values.
  * Recursively merges nested objects; scalars and arrays from `overrides`
@@ -467,6 +474,18 @@ export function deepMergeOverwrite(
   }
 }
 
+export type DefaultWorkspaceConfigMergeResult = {
+  providedLlmProfileNames: Set<string>;
+  providedLlmActiveProfile: boolean;
+};
+
+function emptyDefaultWorkspaceConfigMergeResult(): DefaultWorkspaceConfigMergeResult {
+  return {
+    providedLlmProfileNames: new Set(),
+    providedLlmActiveProfile: false,
+  };
+}
+
 /**
  * Merge default workspace config from the file referenced by
  * VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH into the workspace config on disk.
@@ -476,9 +495,11 @@ export function deepMergeOverwrite(
  * Schema defaults are no longer materialized into the file on load — the
  * in-memory `loadConfig()` cache applies them at access time instead.
  */
-export function mergeDefaultWorkspaceConfig(): void {
+export function mergeDefaultWorkspaceConfig(): DefaultWorkspaceConfigMergeResult {
   const defaultConfigPath = process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
-  if (!defaultConfigPath || !existsSync(defaultConfigPath)) return;
+  if (!defaultConfigPath || !existsSync(defaultConfigPath)) {
+    return emptyDefaultWorkspaceConfigMergeResult();
+  }
 
   let defaults: unknown;
   try {
@@ -489,7 +510,7 @@ export function mergeDefaultWorkspaceConfig(): void {
       "Failed to read default workspace config from %s",
       defaultConfigPath,
     );
-    return;
+    return emptyDefaultWorkspaceConfigMergeResult();
   }
 
   if (
@@ -497,16 +518,44 @@ export function mergeDefaultWorkspaceConfig(): void {
     typeof defaults !== "object" ||
     Array.isArray(defaults)
   ) {
-    return;
+    return emptyDefaultWorkspaceConfigMergeResult();
   }
+
+  const llmDefaults = readPlainObject(
+    (defaults as Record<string, unknown>).llm,
+  );
+  const providedProfiles = readPlainObject(llmDefaults?.profiles);
+  const mergeResult: DefaultWorkspaceConfigMergeResult = {
+    providedLlmProfileNames: new Set(
+      providedProfiles ? Object.keys(providedProfiles) : [],
+    ),
+    providedLlmActiveProfile:
+      llmDefaults != null &&
+      Object.prototype.hasOwnProperty.call(llmDefaults, "activeProfile"),
+  };
 
   const configPath = getConfigPath();
   let existing: Record<string, unknown> = {};
   if (existsSync(configPath)) {
     try {
       existing = JSON.parse(readFileSync(configPath, "utf-8"));
-    } catch {
-      // If existing config is corrupt, start fresh
+    } catch (err) {
+      quarantineCorruptConfig(configPath, err);
+      // After preserving the corrupt file, start fresh so the default overlay
+      // can still initialize a valid config for this startup.
+    }
+  }
+
+  if (mergeResult.providedLlmProfileNames.size > 0) {
+    // Default-config profile entries are authoritative fragments. Remove any
+    // old same-name profile first so recursive merge does not leave stale
+    // provider-specific leaves behind.
+    const existingLlm = readPlainObject(existing.llm);
+    const existingProfiles = readPlainObject(existingLlm?.profiles);
+    if (existingProfiles) {
+      for (const name of mergeResult.providedLlmProfileNames) {
+        delete existingProfiles[name];
+      }
     }
   }
 
@@ -533,6 +582,8 @@ export function mergeDefaultWorkspaceConfig(): void {
   } catch {
     log.info("Merged default workspace config from %s", defaultConfigPath);
   }
+
+  return mergeResult;
 }
 
 export function loadConfig(): AssistantConfig {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -185,6 +185,8 @@ export function seedInferenceProfiles(
   if (!isAnthropicDefault) {
     for (const [name, template] of Object.entries(CUSTOM_PROFILE_TEMPLATES)) {
       if (preservedProfileNames.has(name)) continue;
+      const existing = readObject(profiles[name]);
+      if (existing !== null && readString(existing.source) === "user") continue;
       profiles[name] = materializeProfile(template, resolvedProvider);
     }
   }

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -1,7 +1,4 @@
-import {
-  isModelInCatalog,
-  PROVIDER_CATALOG,
-} from "../providers/model-catalog.js";
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { resolveModelIntent } from "../providers/model-intents.js";
 import type { ModelIntent } from "../providers/types.js";
 import { loadRawConfig, saveRawConfig } from "./loader.js";
@@ -145,26 +142,40 @@ export function seedInferenceProfiles(
 
   const requestedProvider =
     readString(readObject(llm.default)?.provider) ?? "anthropic";
+  const isKnownProvider = KNOWN_PROVIDERS.has(requestedProvider);
   const resolvedProvider: NonNullable<ProfileEntry["provider"]> =
-    KNOWN_PROVIDERS.has(requestedProvider)
+    isKnownProvider
       ? (requestedProvider as NonNullable<ProfileEntry["provider"]>)
       : "anthropic";
   const isAnthropicDefault = resolvedProvider === "anthropic";
 
+  // Persist the resolved provider when the overlay supplied an unrecognized
+  // value, so the on-disk config doesn't keep emitting Zod warnings for
+  // `unknownprov` on every load.
+  if (!isKnownProvider) {
+    const defaultBlock = (readObject(llm.default) ?? {}) as Record<
+      string,
+      unknown
+    >;
+    defaultBlock.provider = resolvedProvider;
+    llm.default = defaultBlock;
+  }
+
   for (const [name, template] of Object.entries(ANTHROPIC_PROFILE_TEMPLATES)) {
     if (preservedProfileNames.has(name)) continue;
-    // Preserve a previously overlay-supplied non-Anthropic version of an
-    // Anthropic-managed name (e.g. platform-managed `balanced` with provider
-    // `openai`). The overlay file is consumed and archived after first use,
-    // so `preservedProfileNames` is only populated on the boot where the
-    // overlay is merged — on subsequent boots the on-disk shape is the only
-    // signal that the profile was platform-supplied.
+    // Preserve a previously overlay-supplied profile whose provider matches
+    // the resolved default — that's the platform-managed case where the
+    // overlay file has already been consumed and archived. Only valid for
+    // non-Anthropic resolutions; when the default is Anthropic the daemon
+    // owns these names and re-seeds with Anthropic data so a stale openai
+    // `balanced` doesn't keep routing through the wrong provider after a
+    // re-hatch back to Anthropic.
     const existing = readObject(profiles[name]);
     const existingProvider = readString(existing?.provider);
     if (
       existing !== null &&
-      existingProvider !== undefined &&
-      existingProvider !== "anthropic"
+      !isAnthropicDefault &&
+      existingProvider === resolvedProvider
     ) {
       continue;
     }
@@ -213,9 +224,13 @@ export function seedInferenceProfiles(
 
   // Sync `llm.default.model` to the active profile's model so the providers
   // registry sees a coherent provider/model pair. Only writes when the on-disk
-  // default model is missing or belongs to a different provider's catalog —
-  // a user-supplied model that's valid for the resolved provider is preserved.
-  // Skipped when the overlay owns the active profile (platform mode).
+  // default model is missing or unambiguously belongs to a *different*
+  // provider's catalog (e.g. `claude-opus-4-7` paired with `provider: openai`).
+  // A user-supplied model not listed in any provider's catalog is preserved —
+  // ollama and openrouter expose far more models than `PROVIDER_CATALOG` lists,
+  // and silently overwriting `codellama`/`phi3`/etc. on every restart would
+  // break those users' configs. Skipped when the overlay owns the active
+  // profile (platform mode).
   if (!shouldPreserveActiveProfile) {
     const activeEntry = readObject(profiles[activeProfileName]);
     const activeModel = readString(activeEntry?.model);
@@ -225,10 +240,16 @@ export function seedInferenceProfiles(
         unknown
       >;
       const currentModel = readString(defaultBlock.model);
-      const currentModelMatchesProvider =
+      const modelBelongsToOtherProvider =
         currentModel !== undefined &&
-        isModelInCatalog(resolvedProvider, currentModel);
-      if (!currentModelMatchesProvider) {
+        PROVIDER_CATALOG.some(
+          (p) =>
+            p.id !== resolvedProvider &&
+            p.models.some((m) => m.id === currentModel),
+        );
+      const shouldOverwriteDefaultModel =
+        currentModel === undefined || modelBelongsToOtherProvider;
+      if (shouldOverwriteDefaultModel) {
         defaultBlock.model = activeModel;
         llm.default = defaultBlock;
       }

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -187,21 +187,20 @@ export function seedInferenceProfiles(
   const shouldPreserveActiveProfile =
     options.preserveActiveProfile === true && requestedActiveExists;
 
-  // Decide whether the existing active profile is still appropriate.
-  // Anthropic-managed names whose on-disk provider is still `anthropic` go
-  // stale when the resolved default flips to a non-Anthropic provider — a
-  // re-hatch should land the user on `custom-balanced` rather than leaving
-  // them on an Anthropic profile they didn't pick.
+  // Decide whether the existing active profile is still appropriate. A managed
+  // profile whose provider no longer matches the resolved default goes stale
+  // (e.g. re-hatching anthropic→openai leaves `balanced` pointing at anthropic;
+  // re-hatching openai→anthropic leaves `custom-balanced` pointing at openai).
+  // Either direction should land the user on the new default's `balanced`
+  // counterpart rather than routing the main agent to a stale provider.
+  // User-created profiles are left alone — those are the user's choice.
   let keepActiveProfile = shouldPreserveActiveProfile;
   if (!keepActiveProfile && requestedActiveExists) {
-    const isAnthropicManagedName =
-      requestedActiveProfile! in ANTHROPIC_PROFILE_TEMPLATES;
+    const isManagedName = MANAGED_PROFILE_NAMES.has(requestedActiveProfile!);
     const activeProvider = readString(requestedActiveEntry?.provider);
-    const activeIsStaleAnthropic =
-      !isAnthropicDefault &&
-      isAnthropicManagedName &&
-      activeProvider === "anthropic";
-    keepActiveProfile = !activeIsStaleAnthropic;
+    const managedActiveProviderMismatch =
+      isManagedName && activeProvider !== resolvedProvider;
+    keepActiveProfile = !managedActiveProviderMismatch;
   }
 
   let activeProfileName: string;

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -1,5 +1,9 @@
-import { readFileSync } from "node:fs";
-
+import {
+  isModelInCatalog,
+  PROVIDER_CATALOG,
+} from "../providers/model-catalog.js";
+import { resolveModelIntent } from "../providers/model-intents.js";
+import type { ModelIntent } from "../providers/types.js";
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import {
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
@@ -7,41 +11,44 @@ import {
 } from "./schemas/llm.js";
 
 /**
- * Declarative seed data for daemon-managed inference profiles.
- *
- * These profiles are overwritten on every startup so upstream model
- * updates propagate automatically. User-created profiles (keyed by
- * different names) are never touched.
+ * Template for a daemon-managed inference profile. The profile's model is
+ * resolved at seed time from `PROVIDER_MODEL_INTENTS` so the catalog stays the
+ * single source of truth for "which model does this intent map to?".
  */
-const MANAGED_PROFILE_SEED_DATA: Record<string, ProfileEntry> = {
+type ManagedProfileTemplate = Omit<ProfileEntry, "provider" | "model"> & {
+  intent: ModelIntent;
+};
+
+/**
+ * Anthropic-managed profiles. Always seeded so users can target Anthropic via
+ * their own key, even when the resolved default provider is something else.
+ */
+const ANTHROPIC_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   balanced: {
+    intent: "balanced",
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
-    provider: "anthropic",
-    model: "claude-sonnet-4-6",
     maxTokens: 16000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
   "quality-optimized": {
+    intent: "quality-optimized",
     source: "managed",
     label: "Quality",
     description: "Best results with the most capable model",
-    provider: "anthropic",
-    model: "claude-opus-4-7",
     maxTokens: 32000,
     effort: "max",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
   "cost-optimized": {
+    intent: "latency-optimized",
     source: "managed",
     label: "Speed",
     description: "Fastest responses at lower cost",
-    provider: "anthropic",
-    model: "claude-haiku-4-5-20251001",
     maxTokens: 8192,
     effort: "low",
     thinking: { enabled: false, streamThinking: false },
@@ -49,28 +56,82 @@ const MANAGED_PROFILE_SEED_DATA: Record<string, ProfileEntry> = {
   },
 };
 
-export const MANAGED_PROFILE_NAMES = new Set(
-  Object.keys(MANAGED_PROFILE_SEED_DATA),
-);
+/**
+ * Custom-provider profile templates. Materialized at seed time when the
+ * resolved default provider is non-Anthropic, using `resolveModelIntent` to
+ * pick the model.
+ */
+const CUSTOM_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
+  "custom-balanced": {
+    intent: "balanced",
+    source: "managed",
+    label: "Balanced (Custom Provider)",
+    description: "Good balance of quality, cost, and speed",
+    maxTokens: 16000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  "custom-quality-optimized": {
+    intent: "quality-optimized",
+    source: "managed",
+    label: "Quality (Custom Provider)",
+    description: "Best results with the most capable model",
+    maxTokens: 32000,
+    effort: "max",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+  "custom-cost-optimized": {
+    intent: "latency-optimized",
+    source: "managed",
+    label: "Speed (Custom Provider)",
+    description: "Fastest responses at lower cost",
+    maxTokens: 8192,
+    effort: "low",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+  },
+};
+
+export const MANAGED_PROFILE_NAMES = new Set([
+  ...Object.keys(ANTHROPIC_PROFILE_TEMPLATES),
+  ...Object.keys(CUSTOM_PROFILE_TEMPLATES),
+]);
+
+const KNOWN_PROVIDERS = new Set(PROVIDER_CATALOG.map((entry) => entry.id));
+
+export type SeedInferenceProfilesOptions = {
+  /**
+   * Managed profile names supplied by the platform/default overlay for this
+   * startup. Those entries are already on disk by the time seeding runs and
+   * should remain authoritative for this boot.
+   */
+  preserveProfileNames?: Iterable<string>;
+  preserveActiveProfile?: boolean;
+};
 
 /**
  * Seed managed inference profiles into the workspace config.
  *
- * Called on every daemon startup after workspace migrations and before
- * the first `loadConfig()`. Managed profiles are overwritten entirely
- * (replace, not merge) so upstream model/effort changes propagate.
- * User-created profiles are never touched; pre-existing profiles
- * without a `source` field get `source: "user"` backfilled.
+ * Called on every daemon startup after workspace migrations and default-config
+ * overlay merge, but before the first `loadConfig()`. The 3 Anthropic-managed
+ * profiles (`balanced`, `quality-optimized`, `cost-optimized`) are always
+ * written so users can target Anthropic via their own key. When the resolved
+ * default provider is non-Anthropic, the 3 `custom-*` profiles are also
+ * materialized using `resolveModelIntent` against that provider, and
+ * `custom-balanced` becomes the active profile for fresh hatches.
  *
- * Still runs when `VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH` is set. Lifecycle
- * calls this before merging the hatch overlay so managed profiles exist for the
- * first config load, while the overlay can still override profile/default
- * fields immediately afterward. When that overlay declares a non-Anthropic
- * default provider, seed placeholder profile slots but do not force the
- * Anthropic `balanced` profile active.
+ * Default-config overlays can provide their own profile fragments and active
+ * profile. Lifecycle passes those explicit fields in `options`, letting local
+ * hatches still receive managed defaults while platform-owned profile choices
+ * remain authoritative.
  */
-export function seedInferenceProfiles(): void {
+export function seedInferenceProfiles(
+  options: SeedInferenceProfilesOptions = {},
+): void {
   const config = loadRawConfig();
+  const preservedProfileNames = new Set(options.preserveProfileNames ?? []);
 
   if (config.llm == null || typeof config.llm !== "object") {
     config.llm = {};
@@ -81,36 +142,112 @@ export function seedInferenceProfiles(): void {
     llm.profiles = {};
   }
   const profiles = llm.profiles as Record<string, Record<string, unknown>>;
-  const isAnthropicDefault =
-    resolveEffectiveDefaultProvider(llm) === "anthropic";
 
-  for (const [name, seed] of Object.entries(MANAGED_PROFILE_SEED_DATA)) {
-    profiles[name] = isAnthropicDefault ? { ...seed } : {};
+  const requestedProvider =
+    readString(readObject(llm.default)?.provider) ?? "anthropic";
+  const resolvedProvider: NonNullable<ProfileEntry["provider"]> =
+    KNOWN_PROVIDERS.has(requestedProvider)
+      ? (requestedProvider as NonNullable<ProfileEntry["provider"]>)
+      : "anthropic";
+  const isAnthropicDefault = resolvedProvider === "anthropic";
+
+  for (const [name, template] of Object.entries(ANTHROPIC_PROFILE_TEMPLATES)) {
+    if (preservedProfileNames.has(name)) continue;
+    // Preserve a previously overlay-supplied non-Anthropic version of an
+    // Anthropic-managed name (e.g. platform-managed `balanced` with provider
+    // `openai`). The overlay file is consumed and archived after first use,
+    // so `preservedProfileNames` is only populated on the boot where the
+    // overlay is merged — on subsequent boots the on-disk shape is the only
+    // signal that the profile was platform-supplied.
+    const existing = readObject(profiles[name]);
+    const existingProvider = readString(existing?.provider);
+    if (
+      existing !== null &&
+      existingProvider !== undefined &&
+      existingProvider !== "anthropic"
+    ) {
+      continue;
+    }
+    profiles[name] = materializeProfile(template, "anthropic");
   }
 
-  if (isAnthropicDefault) {
-    // Reset to the default managed profile when the current value is missing.
-    if (
-      typeof llm.activeProfile !== "string" ||
-      !(llm.activeProfile in profiles)
-    ) {
-      llm.activeProfile = "balanced";
+  if (!isAnthropicDefault) {
+    for (const [name, template] of Object.entries(CUSTOM_PROFILE_TEMPLATES)) {
+      if (preservedProfileNames.has(name)) continue;
+      profiles[name] = materializeProfile(template, resolvedProvider);
     }
-  } else if (
-    typeof llm.activeProfile !== "string" ||
-    !(llm.activeProfile in profiles) ||
-    MANAGED_PROFILE_NAMES.has(llm.activeProfile)
-  ) {
-    delete llm.activeProfile;
+  }
+
+  const requestedActiveProfile = readString(llm.activeProfile);
+  const requestedActiveEntry =
+    requestedActiveProfile !== undefined
+      ? readObject(profiles[requestedActiveProfile])
+      : null;
+  const requestedActiveExists = requestedActiveEntry !== null;
+  const shouldPreserveActiveProfile =
+    options.preserveActiveProfile === true && requestedActiveExists;
+
+  // Decide whether the existing active profile is still appropriate.
+  // Anthropic-managed names whose on-disk provider is still `anthropic` go
+  // stale when the resolved default flips to a non-Anthropic provider — a
+  // re-hatch should land the user on `custom-balanced` rather than leaving
+  // them on an Anthropic profile they didn't pick.
+  let keepActiveProfile = shouldPreserveActiveProfile;
+  if (!keepActiveProfile && requestedActiveExists) {
+    const isAnthropicManagedName =
+      requestedActiveProfile! in ANTHROPIC_PROFILE_TEMPLATES;
+    const activeProvider = readString(requestedActiveEntry?.provider);
+    const activeIsStaleAnthropic =
+      !isAnthropicDefault &&
+      isAnthropicManagedName &&
+      activeProvider === "anthropic";
+    keepActiveProfile = !activeIsStaleAnthropic;
+  }
+
+  let activeProfileName: string;
+  if (keepActiveProfile) {
+    activeProfileName = requestedActiveProfile!;
+  } else {
+    activeProfileName = isAnthropicDefault ? "balanced" : "custom-balanced";
+    llm.activeProfile = activeProfileName;
+  }
+
+  // Sync `llm.default.model` to the active profile's model so the providers
+  // registry sees a coherent provider/model pair. Only writes when the on-disk
+  // default model is missing or belongs to a different provider's catalog —
+  // a user-supplied model that's valid for the resolved provider is preserved.
+  // Skipped when the overlay owns the active profile (platform mode).
+  if (!shouldPreserveActiveProfile) {
+    const activeEntry = readObject(profiles[activeProfileName]);
+    const activeModel = readString(activeEntry?.model);
+    if (activeModel !== undefined) {
+      const defaultBlock = (readObject(llm.default) ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const currentModel = readString(defaultBlock.model);
+      const currentModelMatchesProvider =
+        currentModel !== undefined &&
+        isModelInCatalog(resolvedProvider, currentModel);
+      if (!currentModelMatchesProvider) {
+        defaultBlock.model = activeModel;
+        llm.default = defaultBlock;
+      }
+    }
   }
 
   const profileOrder = Array.isArray(llm.profileOrder)
     ? (llm.profileOrder as string[])
     : [];
   const orderSet = new Set(profileOrder);
-  for (const name of MANAGED_PROFILE_NAMES) {
+  const seededOrder = [
+    ...Object.keys(ANTHROPIC_PROFILE_TEMPLATES),
+    ...(isAnthropicDefault ? [] : Object.keys(CUSTOM_PROFILE_TEMPLATES)),
+  ];
+  for (const name of seededOrder) {
     if (!orderSet.has(name)) {
       profileOrder.push(name);
+      orderSet.add(name);
     }
   }
   llm.profileOrder = profileOrder;
@@ -129,26 +266,16 @@ export function seedInferenceProfiles(): void {
   saveRawConfig(config);
 }
 
-function resolveEffectiveDefaultProvider(llm: Record<string, unknown>): string {
-  return (
-    readDefaultProviderFromOverlay() ??
-    readString(readObject(llm.default)?.provider) ??
-    "anthropic"
-  );
-}
-
-function readDefaultProviderFromOverlay(): string | undefined {
-  const defaultConfigPath = process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
-  if (!defaultConfigPath) return undefined;
-
-  try {
-    const raw = JSON.parse(readFileSync(defaultConfigPath, "utf-8"));
-    const llm = readObject(raw)?.llm;
-    const defaultBlock = readObject(readObject(llm)?.default);
-    return readString(defaultBlock?.provider);
-  } catch {
-    return undefined;
-  }
+function materializeProfile(
+  template: ManagedProfileTemplate,
+  provider: NonNullable<ProfileEntry["provider"]>,
+): ProfileEntry {
+  const { intent, ...rest } = template;
+  return {
+    ...rest,
+    provider,
+    model: resolveModelIntent(provider, intent),
+  };
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -499,12 +499,22 @@ export async function runDaemon(): Promise<void> {
       }
     } // end if (dbReady)
 
+    // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
+    // into the workspace config file before profile seeding and the first
+    // loadConfig() call so onboarding/platform preferences are visible to the
+    // seeder and persisted alongside schema defaults.
+    const defaultConfigMerge = mergeDefaultWorkspaceConfig();
+
     // Seed managed inference profiles into the workspace config. Runs after
-    // workspace migrations and before mergeDefaultWorkspaceConfig / loadConfig
-    // so fresh hatches have profiles on disk before the first config load; the
-    // hatch overlay still merges afterward and can override seeded fields.
+    // workspace migrations and default-config merge, but before loadConfig() so
+    // fresh hatches have profiles on disk before the first config load. Any
+    // profile fields explicitly supplied by the default overlay stay
+    // authoritative for this startup.
     try {
-      seedInferenceProfiles();
+      seedInferenceProfiles({
+        preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
+        preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
+      });
       log.info("Inference profile seeding complete");
     } catch (err) {
       log.warn(
@@ -512,11 +522,6 @@ export async function runDaemon(): Promise<void> {
         "Inference profile seeding failed — continuing startup",
       );
     }
-
-    // Merge CLI-provided default config (from VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH)
-    // into the workspace config file before the first loadConfig() call so
-    // onboarding preferences are persisted alongside schema defaults.
-    mergeDefaultWorkspaceConfig();
 
     log.info("Daemon startup: loading config");
     const config = loadConfig();

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -11,31 +11,37 @@ const PROVIDER_DEFAULT_MODELS: Record<string, string> = Object.fromEntries(
 
 const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
+    balanced: "claude-sonnet-4-6",
     "latency-optimized": "claude-haiku-4-5-20251001",
     "quality-optimized": "claude-opus-4-7",
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {
+    balanced: "gpt-5.4-mini",
     "latency-optimized": "gpt-5.4-nano",
     "quality-optimized": "gpt-5.4",
     "vision-optimized": "gpt-5.4",
   },
   gemini: {
+    balanced: "gemini-3-flash-preview",
     "latency-optimized": "gemini-3.1-flash-lite-preview",
     "quality-optimized": "gemini-3.1-pro-preview",
     "vision-optimized": "gemini-3-flash-preview",
   },
   ollama: {
+    balanced: "llama3.2",
     "latency-optimized": "llama3.2",
     "quality-optimized": "llama3.2",
     "vision-optimized": "llama3.2",
   },
   fireworks: {
+    balanced: "accounts/fireworks/models/kimi-k2p5",
     "latency-optimized": "accounts/fireworks/models/kimi-k2p5",
     "quality-optimized": "accounts/fireworks/models/kimi-k2p5",
     "vision-optimized": "accounts/fireworks/models/kimi-k2p5",
   },
   openrouter: {
+    balanced: "anthropic/claude-sonnet-4.6",
     "latency-optimized": "anthropic/claude-haiku-4.5",
     "quality-optimized": "anthropic/claude-opus-4.7",
     "vision-optimized": "anthropic/claude-opus-4.6",
@@ -45,6 +51,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
 const FALLBACK_DEFAULT_MODEL = "claude-opus-4-7";
 
 const MODEL_INTENTS = new Set<ModelIntent>([
+  "balanced",
   "latency-optimized",
   "quality-optimized",
   "vision-optimized",

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -91,6 +91,7 @@ export interface Message {
 }
 
 export type ModelIntent =
+  | "balanced"
   | "latency-optimized"
   | "quality-optimized"
   | "vision-optimized";

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyEntryStepView.swift
@@ -117,9 +117,6 @@ struct APIKeyEntryStepView: View {
             }
         }
         .onChange(of: state.selectedProvider) { _, newProvider in
-            if let entry = providerCatalog.first(where: { $0.id == newProvider }) {
-                state.selectedModel = entry.defaultModel
-            }
             if let existingKey = APIKeyManager.getKey(for: newProvider) {
                 apiKey = existingKey
                 hasExistingKey = true

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -333,7 +333,6 @@ struct APIKeyStepView: View {
         if isAuthenticated {
             // Authenticated user: skip API key entry, advance to consent step
             state.selectedProvider = LLMProviderRegistry.defaultProvider?.id ?? "anthropic"
-            state.selectedModel = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
             state.skippedAPIKeyEntry = true
             state.advance(by: 2)
         } else {

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -580,14 +580,8 @@ struct HatchingStepView: View {
     /// Most config default values are determined by the daemon process and may
     /// depend on whether the assistant is hatched on the Vellum Platform or not.
     private func buildOnboardingConfigValues() -> [String: String] {
-        var configValues: [String: String] = [:]
-        if !state.selectedProvider.isEmpty {
-            configValues["llm.default.provider"] = state.selectedProvider
-        }
-        if !state.selectedModel.isEmpty {
-            configValues["llm.default.model"] = state.selectedModel
-        }
-        return configValues
+        let provider = state.selectedProvider.isEmpty ? "anthropic" : state.selectedProvider
+        return ["llm.default.provider": provider]
     }
 
     private func startRemoteHatch() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -82,7 +82,6 @@ final class OnboardingState {
     var sshHost: String = ""
     var sshUser: String = ""
     var sshPrivateKey: String = ""
-    var selectedModel: String = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
     var selectedProvider: String = LLMProviderRegistry.defaultProvider?.id ?? "anthropic"
     /// When true, the onboarding flow was launched from the developer tab's
     /// "Hatch New Assistant" button. This prevents auto-completing when the user
@@ -239,7 +238,6 @@ final class OnboardingState {
         }
 
         selectedProvider = LLMProviderRegistry.defaultProvider?.id ?? "anthropic"
-        selectedModel = LLMProviderRegistry.defaultProvider?.defaultModel ?? ""
 
         // Reset hosting selection and cloud credentials
         selectedHostingMode = .vellumCloud


### PR DESCRIPTION
## Summary
- Drop model collection from macOS onboarding; only the provider is sent to the daemon at hatch.
- Daemon always seeds the 3 Anthropic-managed profiles, and additionally seeds 3 `custom-*` profiles (with `custom-balanced` active) when the resolved default provider is non-Anthropic.
- `MANAGED_PROFILE_SEED_DATA` is now intent-driven: profile templates declare a `ModelIntent`, and models are resolved at seed time via `resolveModelIntent`/`PROVIDER_MODEL_INTENTS` (added a `balanced` intent across all providers) so the catalog is the single source of truth.
- Folds in PR #29726 (`mergeDefaultWorkspaceConfig` order/preservation/quarantine fixes) — close that PR with a pointer here.

## Original prompt
See `~/.claude/plans/gleaming-splashing-curry.md` (full plan also rendered into the description above).

## Test plan
- [x] `bun test assistant/src/__tests__/config-loader-backfill.test.ts` (27 pass)
- [x] `bun test assistant/src/__tests__/managed-profile-guard.test.ts` (18 pass)
- [x] Related profile suites (`config-loader-platform-defaults`, `conversation-inference-profile-list`, `conversation-inference-profile-route`, `workspace-migration-052-seed-default-inference-profiles`) pass individually.
- [ ] Manual: hatch a fresh assistant via macOS onboarding (Anthropic and OpenAI paths) and verify `~/.vellum/<assistant>/config.json` matches the plan's E2E expectations (3 profiles + balanced active for Anthropic; 6 profiles + custom-balanced active + `gpt-5.4-mini` for OpenAI).
- [ ] Manual: re-hatch with a different provider and confirm `activeProfile` flips to `custom-balanced`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->