### PR TITLE
fix: refresh skill memories after uninstall

### DIFF
--- a/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
+++ b/assistant/src/__tests__/handlers-skills-memory-v2-reseed.test.ts
@@ -182,7 +182,8 @@ mock.module("../daemon/config-watcher.js", () => ({
 }));
 
 // Import after mocking
-const { installSkill } = await import("../daemon/handlers/skills.js");
+const { installSkill, uninstallSkill } =
+  await import("../daemon/handlers/skills.js");
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -213,6 +214,16 @@ describe("v2 skill refresh delegation in skill handlers", () => {
     expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
     expect(mockRefreshSkillCapabilityMemories.mock.calls[0]?.[0]).toEqual({
       memory: { v2: { enabled: false } },
+    });
+  });
+
+  test("uninstall delegates to refresh helper", async () => {
+    const result = await uninstallSkill("managed-skill");
+
+    expect(result.success).toBe(true);
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
+    expect(mockRefreshSkillCapabilityMemories.mock.calls[0]?.[0]).toEqual({
+      memory: { v2: { enabled: true } },
     });
   });
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1183,6 +1183,8 @@ export async function uninstallSkill(
       state: "uninstalled",
     });
 
+    refreshSkillCapabilityMemories(getConfig());
+
     return { success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Refresh skill capability memories immediately after a successful skill uninstall so Memory V2 prunes removed skills without depending on filesystem watcher events.
- Add handler regression coverage for uninstall refresh delegation.

## Validation
- cd assistant && bun test src/__tests__/handlers-skills-memory-v2-reseed.test.ts
- cd assistant && bunx tsc --noEmit

Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->