### PR TITLE
[codex] Add assistant switcher to General settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantUpgradeSection.swift
@@ -43,6 +43,16 @@ struct AssistantUpgradeSection: View {
     /// The update manager to observe for reactive Sparkle status updates.
     var updateManager: UpdateManager
 
+    /// Assistant choices shown above version controls. Uses the same
+    /// presentation model as the platform-login picker.
+    var assistantSwitcherItems: [AssistantPickerItem] = []
+    var selectedAssistantId: String?
+    var switchingAssistantId: String?
+    var isAssistantSwitcherLoading: Bool = false
+    var assistantSwitcherError: String?
+    var onSwitchAssistant: (String) -> Void = { _ in }
+    var onRefreshAssistants: () -> Void = {}
+
     @State private var availableReleases: [AssistantRelease] = []
     @State private var selectedVersion: String?
     @State private var isLoadingReleases = false
@@ -151,6 +161,20 @@ struct AssistantUpgradeSection: View {
 
     var body: some View {
         SettingsCard(title: "Assistant Version", subtitle: topologySubtitle) {
+            if shouldShowAssistantSwitcher {
+                AssistantVersionSwitcher(
+                    items: assistantSwitcherItems,
+                    selectedAssistantId: selectedAssistantId,
+                    switchingAssistantId: switchingAssistantId,
+                    isLoading: isAssistantSwitcherLoading,
+                    errorMessage: assistantSwitcherError,
+                    onSwitch: onSwitchAssistant,
+                    onRefresh: onRefreshAssistants
+                )
+
+                SettingsDivider()
+            }
+
             // Version info — always visible
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 if topology == .local {
@@ -426,6 +450,10 @@ struct AssistantUpgradeSection: View {
         }
     }
 
+    private var shouldShowAssistantSwitcher: Bool {
+        assistantSwitcherItems.count > 1 || assistantSwitcherError != nil
+    }
+
     // MARK: - Actions
 
     private func loadReleases() async {
@@ -693,5 +721,4 @@ struct AssistantRelease: Decodable, Identifiable {
 
     var id: String { version }
 }
-
 

--- a/clients/macos/vellum-assistant/Features/Settings/AssistantVersionSwitcher.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/AssistantVersionSwitcher.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Compact assistant chooser embedded in Settings > General > Assistant Version.
+/// Rows intentionally use the same `AssistantPickerItem` model as onboarding
+/// so labels stay consistent between first login and later switching.
+struct AssistantVersionSwitcher: View {
+    let items: [AssistantPickerItem]
+    let selectedAssistantId: String?
+    let switchingAssistantId: String?
+    let isLoading: Bool
+    let errorMessage: String?
+    let onSwitch: (String) -> Void
+    let onRefresh: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                Text("Assistant")
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.contentTertiary)
+                    .accessibilityAddTraits(.isHeader)
+
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .progressViewStyle(.circular)
+                }
+
+                Spacer()
+
+                VButton(
+                    label: "Refresh assistants",
+                    iconOnly: VIcon.refreshCw.rawValue,
+                    style: .ghost,
+                    size: .compact,
+                    tooltip: "Refresh assistants"
+                ) {
+                    onRefresh()
+                }
+            }
+
+            VStack(spacing: VSpacing.sm) {
+                ForEach(items) { item in
+                    assistantRow(item)
+                }
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(VFont.labelDefault)
+                    .foregroundStyle(VColor.systemNegativeStrong)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func assistantRow(_ item: AssistantPickerItem) -> some View {
+        let isSelected = item.id == selectedAssistantId
+        let isSwitching = item.id == switchingAssistantId
+        HStack(spacing: VSpacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.displayName)
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if let subtitle = item.subtitle {
+                    Text(subtitle)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentSecondary)
+                }
+            }
+
+            Spacer(minLength: VSpacing.md)
+
+            if isSwitching {
+                ProgressView()
+                    .controlSize(.small)
+                    .progressViewStyle(.circular)
+            } else if isSelected {
+                VBadge(label: "Current", tone: .positive, emphasis: .subtle)
+            } else {
+                VButton(label: "Switch", style: .outlined, size: .compact) {
+                    onSwitch(item.id)
+                }
+                .accessibilityLabel("Switch to \(item.displayName)")
+                .disabled(switchingAssistantId != nil)
+            }
+        }
+        .padding(VSpacing.md)
+        .background(isSelected ? VColor.surfaceActive : VColor.surfaceOverlay)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.md)
+                .stroke(isSelected ? VColor.borderActive : VColor.borderBase, lineWidth: 1)
+        )
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import VellumAssistantShared
+import os
+
+private let settingsGeneralLog = Logger(subsystem: Bundle.appBundleIdentifier, category: "SettingsGeneralTab")
 
 /// General settings tab — account/platform login card followed by appearance settings.
 @MainActor
@@ -25,6 +28,11 @@ struct SettingsGeneralTab: View {
     @State private var updateStatusMessage: String?
     @State private var lockfileAssistants: [LockfileAssistant] = []
     @State private var selectedAssistantId: String = ""
+    @State private var assistantSwitcherItems: [AssistantPickerItem] = []
+    @State private var platformAssistantsById: [String: PlatformAssistant] = [:]
+    @State private var isLoadingAssistantSwitcher = false
+    @State private var switchingAssistantId: String?
+    @State private var assistantSwitcherError: String?
     @State private var dockerOperationTimedOut = false
     @State private var dockerOperationTimeoutTask: Task<Void, Never>?
     @State private var healthzLoaded = false
@@ -61,7 +69,18 @@ struct SettingsGeneralTab: View {
                     isServiceGroupUpdateInProgress: isServiceGroupUpdateInProgress,
                     updateStatusMessage: updateStatusMessage,
                     healthzLoaded: healthzLoaded,
-                    updateManager: updateManager
+                    updateManager: updateManager,
+                    assistantSwitcherItems: assistantSwitcherItems,
+                    selectedAssistantId: selectedAssistantId.isEmpty ? nil : selectedAssistantId,
+                    switchingAssistantId: switchingAssistantId,
+                    isAssistantSwitcherLoading: isLoadingAssistantSwitcher,
+                    assistantSwitcherError: assistantSwitcherError,
+                    onSwitchAssistant: { assistantId in
+                        Task { await switchAssistantFromVersionCard(assistantId: assistantId) }
+                    },
+                    onRefreshAssistants: {
+                        Task { await refreshAssistantSwitcherItems() }
+                    }
                 )
             }
             if shouldShowSystemResourcesSection {
@@ -82,7 +101,10 @@ struct SettingsGeneralTab: View {
             }
         }
         .onAppear {
-            Task { await authManager.checkSession() }
+            Task {
+                await authManager.checkSession()
+                await refreshAssistantSwitcherItems()
+            }
             selectedAssistantId = LockfileAssistant.loadActiveAssistantId() ?? ""
             sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
             sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
@@ -93,11 +115,14 @@ struct SettingsGeneralTab: View {
             Task {
                 // Load lockfile on a background thread — the underlying
                 // Data(contentsOf:) file I/O can block the main thread.
-                let assistants = await Task.detached { LockfileAssistant.loadAll() }.value
-                lockfileAssistants = assistants
+                await refreshLockfileAssistants()
                 await fetchHealthz()
+                await refreshAssistantSwitcherItems()
             }
             recordSystemResourcesDeepLinkIfNeeded(store.pendingSettingsGeneralSection)
+        }
+        .onChange(of: authManager.isAuthenticated) { _, _ in
+            Task { await refreshAssistantSwitcherItems() }
         }
         .onChange(of: store.pendingSettingsGeneralSection) { _, section in
             recordSystemResourcesDeepLinkIfNeeded(section)
@@ -111,6 +136,13 @@ struct SettingsGeneralTab: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             sparkleUpdateAvailable = AppDelegate.shared?.updateManager.isUpdateAvailable ?? false
             sparkleUpdateVersion = AppDelegate.shared?.updateManager.availableUpdateVersion
+        }
+        .task {
+            for await _ in NotificationCenter.default.notifications(named: LockfileAssistant.activeAssistantDidChange) {
+                await refreshLockfileAssistants()
+                await fetchHealthz()
+                await refreshAssistantSwitcherItems()
+            }
         }
         .sheet(isPresented: $isDockerOperationInProgress) {
             VStack(spacing: VSpacing.lg) {
@@ -209,6 +241,86 @@ struct SettingsGeneralTab: View {
     }
 
     // MARK: - Software Update
+
+    private func refreshLockfileAssistants() async {
+        let assistants = await Task.detached { LockfileAssistant.loadAll() }.value
+        lockfileAssistants = assistants
+        selectedAssistantId = LockfileAssistant.loadActiveAssistantId() ?? ""
+
+        if assistantSwitcherItems.isEmpty {
+            let landscape = ReturningUserRouter.AssistantLandscape(
+                lockfileAssistants: assistants,
+                platformAssistants: [],
+                platformWasConsulted: false
+            )
+            assistantSwitcherItems = AssistantPickerItem.from(landscape: landscape)
+        }
+    }
+
+    private func refreshAssistantSwitcherItems() async {
+        isLoadingAssistantSwitcher = true
+        assistantSwitcherError = nil
+        defer { isLoadingAssistantSwitcher = false }
+
+        do {
+            let landscape = try await ReturningUserRouter().fetchLandscape()
+            lockfileAssistants = landscape.lockfileAssistants
+            selectedAssistantId = LockfileAssistant.loadActiveAssistantId() ?? ""
+            platformAssistantsById = Dictionary(
+                landscape.platformAssistants.map { ($0.id, $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            assistantSwitcherItems = AssistantPickerItem.from(landscape: landscape)
+        } catch is CancellationError {
+            return
+        } catch {
+            settingsGeneralLog.warning("Failed to refresh assistant switcher: \(error.localizedDescription, privacy: .public)")
+            assistantSwitcherError = "Could not load assistants."
+        }
+    }
+
+    private func switchAssistantFromVersionCard(assistantId: String) async {
+        guard switchingAssistantId == nil else { return }
+        guard assistantId != selectedAssistantId else { return }
+
+        switchingAssistantId = assistantId
+        assistantSwitcherError = nil
+        defer {
+            if switchingAssistantId == assistantId {
+                switchingAssistantId = nil
+            }
+        }
+
+        guard let target = AssistantPickerSelectionResolver.resolveLockfileAssistant(
+            assistantId: assistantId,
+            platformAssistants: platformAssistantsById
+        ) else {
+            assistantSwitcherError = "Could not switch assistants."
+            return
+        }
+
+        if target.isManaged,
+           let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+            do {
+                try await AuthService.shared.activateAssistant(
+                    id: target.assistantId,
+                    organizationId: orgId
+                )
+            } catch {
+                settingsGeneralLog.warning("Failed to activate assistant on platform: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        selectedAssistantId = target.assistantId
+        if !lockfileAssistants.contains(where: { $0.assistantId == target.assistantId }) {
+            lockfileAssistants.append(target)
+        }
+
+        AppDelegate.shared?.performSwitchAssistant(
+            to: target,
+            managedAuthenticationAlreadyVerified: target.isManaged && authManager.isAuthenticated
+        )
+    }
 
     private func fetchHealthz() async {
         guard !selectedAssistantId.isEmpty else { return }


### PR DESCRIPTION
## Summary
- add an assistant switcher inside Settings > General > Assistant Version
- reuse the platform-login `AssistantPickerItem` presentation model so managed/local labels match onboarding
- resolve platform-only managed assistants into the lockfile and switch through the existing `performSwitchAssistant` path

## Why
Users who can choose between a platform-managed assistant and a locally hosted assistant during login had no way to correct that choice later. This gives them the same choice from Settings without adding a separate switching flow.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients --filter AssistantPickerSelectionResolverTests`
- pre-push Swift build for `clients/`
- pre-push design-token guard

Apple refs checked (2026-05-05): SwiftUI accessibility modifiers, SwiftUI `View.task`.