### PR TITLE
fix(twilio): use registered public ingress for voice streams

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -23,7 +23,9 @@ mock.module("../channels/config.js", () => ({
   }),
 }));
 
-mock.module("../config/env.js", () => ({}));
+mock.module("../config/env.js", () => ({
+  getIngressPublicBaseUrl: () => undefined,
+}));
 
 mock.module("../config/loader.js", () => ({
   loadRawConfig: () => mockRawConfig ?? {},
@@ -305,7 +307,7 @@ describe("ChannelReadinessService", () => {
     });
   });
 
-  test("phone readiness accepts Twilio-specific ingress without generic public ingress", async () => {
+  test("phone readiness accepts configured public ingress", async () => {
     mockHasTwilioCredentials = true;
     mockTwilioPhoneNumber = "+15550123";
     mockRawConfig = {

--- a/assistant/src/__tests__/twilio-validation.test.ts
+++ b/assistant/src/__tests__/twilio-validation.test.ts
@@ -49,7 +49,7 @@ describe("Twilio validation middleware", () => {
     };
   });
 
-  test("validates signatures against Twilio-specific public ingress first", async () => {
+  test("validates signatures against configured public ingress", async () => {
     mockConfig = {
       ingress: {
         publicBaseUrl: "  https://twilio.example.com///  ",
@@ -77,7 +77,7 @@ describe("Twilio validation middleware", () => {
     ]);
   });
 
-  test("falls back to generic public ingress when Twilio-specific ingress is empty", async () => {
+  test("uses configured public ingress for status callbacks", async () => {
     const req = new Request("http://127.0.0.1:7821/v1/calls/twilio/status", {
       method: "POST",
       headers: { "x-twilio-signature": "valid" },

--- a/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
+++ b/assistant/src/config/bundled-skills/phone-calls/references/TROUBLESHOOTING.md
@@ -10,18 +10,24 @@ Run `assistant config set calls.enabled true`.
 
 ## "No public base URL configured"
 
-Run the **public-ingress** skill to set up ngrok or another custom tunnel and configure `ingress.publicBaseUrl`. Ngrok remains supported. Velay can also publish `ingress.twilioPublicBaseUrl` for Twilio calls when `VELAY_BASE_URL` is set on the gateway, but it does not replace `ingress.publicBaseUrl` for Telegram, OAuth, email, or other non-Twilio webhooks.
+First check whether this is a managed/platform assistant:
+
+```bash
+assistant platform status --json
+```
+
+If it reports an available platform assistant, do not install or start ngrok for Twilio. The gateway should use Velay, and `velayTunnel.connected` should become `true` after registration. If this is a local/self-hosted assistant without Velay, run the **public-ingress** skill to set up ngrok or another custom tunnel and configure `ingress.publicBaseUrl`.
 
 ## Call fails immediately after initiating
 
 - Check that the phone number is in E.164 format
 - Verify Twilio credentials are correct (wrong auth token causes API errors)
 - On trial accounts, ensure the destination number is verified
-- Check that the configured tunnel is still running. For ngrok, use `curl -s http://127.0.0.1:4040/api/tunnels`. For Velay, confirm the gateway logs show `Velay tunnel registered` and `ingress.twilioPublicBaseUrl` is populated.
+- Check that the configured tunnel is still running. For ngrok, use `curl -s http://127.0.0.1:4040/api/tunnels`. For Velay, run `assistant platform status --json` and confirm `velayTunnel.connected` is `true`, or check gateway logs for `Velay tunnel registered`.
 
 ## Call connects but no audio / one-way audio
 
-- The ConversationRelay WebSocket may not be connecting. If you are using ngrok or a custom tunnel, check that `ingress.publicBaseUrl` is correct and the tunnel is active. If you are using Velay, check that `ingress.twilioPublicBaseUrl` is present and points to the registered Velay URL.
+- The ConversationRelay WebSocket may not be connecting. If you are using ngrok or a custom tunnel, check that `ingress.publicBaseUrl` is correct and the tunnel is active. If you are using Velay, check `assistant platform status --json`; a 503 from `https://velay.../<assistant-id>/...` usually means the assistant tunnel is not connected or the gateway did not complete the WebSocket open, not that ngrok is required.
 - Verify the assistant is running
 
 ## "Number not eligible for caller identity"
@@ -50,20 +56,20 @@ assistant config set ingress.publicBaseUrl "<new-url>"
 
 Or re-run the public-ingress skill to auto-detect and save the new URL.
 
-Velay does not change this setting. When `VELAY_BASE_URL` is set on the gateway, Velay registration writes only `ingress.twilioPublicBaseUrl`; Twilio uses that URL first, and non-Twilio webhook ingress keeps using `ingress.publicBaseUrl`.
+Do not rotate ngrok to work around a managed Velay WebSocket failure. Fix the Velay tunnel state instead, or restart the assistant/gateway so it re-registers.
 
 ## Velay tunnel is not registering
 
-- Confirm vembda passes `VELAY_BASE_URL=http://host.docker.internal:8501` to the gateway container.
+- Confirm vembda passes the environment-appropriate `VELAY_BASE_URL` to the gateway container.
 - Re-hatch or restart the assistant after changing the environment.
 - Check gateway logs for `Velay tunnel connected` followed by `Velay tunnel registered`.
-- If `VELAY_BASE_URL` is not set, the gateway does not start the Velay client. Use ngrok or another custom tunnel in `ingress.publicBaseUrl`.
+- If `VELAY_BASE_URL` is not set on a local/self-hosted assistant, the gateway does not start the Velay client. Use ngrok or another custom tunnel in `ingress.publicBaseUrl`.
 
 ## Local Twilio Velay smoke tests
 
 - HTTP bridge: request `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/healthz` and `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/schema`. When testing a JSON webhook route under active development, POST a small JSON body through the same Velay public URL and confirm the gateway receives it.
 - Synthetic WebSocket: connect a local WebSocket client to `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/webhooks/twilio/relay?callSessionId=session-123&token=<edge-token>` and confirm the upgrade reaches the gateway.
-- Real Twilio call: back `VELAY_PUBLIC_BASE_URL` with a public HTTPS/WSS tunnel, wait for the gateway to re-register, then place a call and confirm Twilio fetches `/webhooks/twilio/voice` and opens the relay or media-stream WebSocket through the Velay URL.
+- Real Twilio call: wait for the gateway to register with Velay, then place a call and confirm Twilio fetches `/webhooks/twilio/voice` and opens the relay or media-stream WebSocket through the Velay URL.
 
 ## Call drops after 30 seconds of silence
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -280,10 +280,10 @@ Channel bindings follow a three-phase lifecycle:
 
 The public URL where the gateway is reachable is configured via:
 
-| Source                                           | Description                                                                                                                                                |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ingress.publicBaseUrl` (workspace config)       | Canonical public ingress URL for Telegram webhooks, OAuth callbacks, email callbacks, generic JSON webhooks, and custom/ngrok tunnel based Twilio fallback |
-| `ingress.twilioPublicBaseUrl` (workspace config) | Twilio-specific public ingress URL written by Velay registration; used only by Twilio URL builders when present                                            |
+| Source                                              | Description                                                                                                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ingress.publicBaseUrl` (workspace config)          | Canonical public ingress URL for Telegram webhooks, OAuth callbacks, email callbacks, generic JSON webhooks, Twilio webhooks, and Twilio WebSocket URLs |
+| `ingress.publicBaseUrlManagedBy` (workspace config) | Ownership marker used when Velay published `ingress.publicBaseUrl`; lets the gateway clear stale Velay-managed URLs without disturbing manual URLs      |
 
 ### Tunnel-Agnostic Setup
 
@@ -296,9 +296,9 @@ The assistant runtime reads this URL via the centralized `public-ingress-urls.ts
 
 ### Velay Twilio Ingress
 
-Velay is a platform-managed tunnel for assistant-hosted HTTP and WebSocket traffic. It is intentionally additive to the tunnel-agnostic setup above: Velay registration does not overwrite `ingress.publicBaseUrl`, and operators can continue using ngrok or custom tunnels for non-Twilio webhooks.
+Velay is a platform-managed tunnel for assistant-hosted HTTP and WebSocket traffic. When it is active, Velay publishes the registered public assistant URL to `ingress.publicBaseUrl` and marks it with `ingress.publicBaseUrlManagedBy: "velay"`.
 
-When `VELAY_BASE_URL` is present in the gateway environment, the gateway starts `VelayTunnelClient`. The client registers with Velay over `GET /v1/register` using the assistant API key, then receives a `registered` frame containing a public assistant URL such as `https://velay.vellum.ai/<assistant-id>`. The gateway writes that URL to `ingress.twilioPublicBaseUrl` only. When the tunnel disconnects, it clears that same value if it still matches the URL the tunnel published, leaving `ingress.publicBaseUrl` intact.
+When `VELAY_BASE_URL` is present in the gateway environment, the gateway starts `VelayTunnelClient`. The client registers with Velay over `GET /v1/register` using the assistant API key, then receives a `registered` frame containing a public assistant URL such as `https://velay.vellum.ai/<assistant-id>`. The gateway writes that URL to `ingress.publicBaseUrl`. When the tunnel disconnects, it clears that value only if the Velay ownership marker is still present and the URL still matches what the tunnel published, leaving manual URLs intact.
 
 Velay forwards both HTTP request frames and WebSocket frames into the local gateway loopback listener:
 
@@ -310,16 +310,16 @@ Public Velay HTTPS/WSS URL
   → Existing gateway route handlers
 ```
 
-The HTTP bridge can carry normal JSON requests and health checks, so it is useful for local bridge smoke tests. The advertised URL split is Twilio-scoped in this phase, though: only Twilio URL generation prefers `ingress.twilioPublicBaseUrl`; Telegram webhook registration, OAuth redirects, email callbacks, and generic public URL builders continue to use `ingress.publicBaseUrl`.
+The HTTP bridge can carry normal JSON requests and health checks, so it is useful for local bridge smoke tests. Velay-managed `ingress.publicBaseUrl` changes are tagged with `publicBaseUrlManagedBy` so gateway side effects can skip unrelated webhook reconciliation while still refreshing Twilio phone-number webhooks.
 
 Local platform smoke-test flow:
 
 1. In `vellum-assistant-platform`, run `vel up velay`.
-2. Ensure vembda passes `VELAY_BASE_URL=http://host.docker.internal:8501` into assistant gateway containers.
+2. Ensure vembda passes the environment-appropriate `VELAY_BASE_URL` into assistant gateway containers.
 3. Re-hatch or restart the assistant so the gateway receives the new environment.
 4. Confirm gateway logs show `Velay tunnel connected` and `Velay tunnel registered`.
 5. Verify HTTP forwarding by requesting `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/healthz` and `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/schema`. When validating a JSON webhook route under active development, POST a small JSON body through the same Velay public URL and confirm it reaches the loopback gateway.
-6. Verify Twilio WebSocket forwarding with a synthetic local WebSocket client against `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/webhooks/twilio/relay?callSessionId=...&token=...`, then with a real Twilio call after `VELAY_PUBLIC_BASE_URL` is backed by a public HTTPS/WSS tunnel.
+6. Verify Twilio WebSocket forwarding with a synthetic local WebSocket client against `${VELAY_PUBLIC_BASE_URL}/<assistant-id>/webhooks/twilio/relay?callSessionId=...&token=...`, then with a real Twilio call after the gateway has registered with Velay.
 
 ### URL Builders
 
@@ -328,10 +328,10 @@ All public-facing URLs are constructed by `assistant/src/inbound/public-ingress-
 | Function                       | URL Pattern                                                                                                                                                      |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `getPublicBaseUrl()`           | Resolves the canonical base URL from `ingress.publicBaseUrl` in workspace config or module-level state (assistant-side; the gateway reads via `ConfigFileCache`) |
-| `getTwilioVoiceWebhookUrl()`   | `${twilioBase}/webhooks/twilio/voice?callSessionId=...`, where `twilioBase` is `ingress.twilioPublicBaseUrl` when present, otherwise `ingress.publicBaseUrl`     |
-| `getTwilioStatusCallbackUrl()` | `${twilioBase}/webhooks/twilio/status`, with the same Twilio-specific base resolution                                                                            |
-| `getTwilioConnectActionUrl()`  | `${twilioBase}/webhooks/twilio/connect-action`, with the same Twilio-specific base resolution                                                                    |
-| `getTwilioRelayUrl()`          | `ws(s)://.../webhooks/twilio/relay`, with the same Twilio-specific base resolution                                                                               |
+| `getTwilioVoiceWebhookUrl()`   | `${base}/webhooks/twilio/voice?callSessionId=...`, using `ingress.publicBaseUrl`                                                                                 |
+| `getTwilioStatusCallbackUrl()` | `${base}/webhooks/twilio/status`, using `ingress.publicBaseUrl`                                                                                                  |
+| `getTwilioConnectActionUrl()`  | `${base}/webhooks/twilio/connect-action`, using `ingress.publicBaseUrl`                                                                                          |
+| `getTwilioRelayUrl()`          | `ws(s)://.../webhooks/twilio/relay`, using `ingress.publicBaseUrl`                                                                                               |
 | `getOAuthCallbackUrl()`        | `${base}/webhooks/oauth/callback`                                                                                                                                |
 | `getTelegramWebhookUrl()`      | `${base}/webhooks/telegram`                                                                                                                                      |
 
@@ -1077,21 +1077,20 @@ In gateway-fronted deployments, the TwiML WebSocket URL (returned by the voice w
 
 Signature validation is **fail-closed**: if the Twilio auth token is not configured, all webhook requests are rejected with `403`. Missing or invalid `X-Twilio-Signature` headers are also rejected with `403`. Payload size is capped by `maxWebhookPayloadBytes` (checked via both `Content-Length` header and actual body size).
 
-**Webhook base URL resolution:** Public ingress URL construction is centralized in `public-ingress-urls.ts`, with a Twilio-specific override for Velay:
+**Webhook base URL resolution:** Public ingress URL construction is centralized in `public-ingress-urls.ts`:
 
-- Twilio voice/status/connect-action/relay/media-stream URLs use `ingress.twilioPublicBaseUrl` when present. This is the value published by Velay registration.
-- If `ingress.twilioPublicBaseUrl` is absent, Twilio falls back to `ingress.publicBaseUrl`.
-- Telegram webhooks, OAuth callbacks, email callbacks, and normal JSON webhook URLs use `ingress.publicBaseUrl`; Velay does not replace those advertised URLs in this phase.
+- Twilio voice/status/connect-action/relay/media-stream URLs use `ingress.publicBaseUrl`.
+- Velay registration publishes its public assistant URL to `ingress.publicBaseUrl` with `ingress.publicBaseUrlManagedBy: "velay"`.
+- Telegram webhooks, OAuth callbacks, email callbacks, and normal JSON webhook URLs also use `ingress.publicBaseUrl`; Velay-managed URL changes are tagged so unrelated reconciliation can be skipped when appropriate.
 - Module-level assistant state remains a fallback for legacy tunnel start/stop flows.
 
 All webhook paths (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, `/webhooks/telegram`, `/webhooks/oauth/callback`, etc.) are appended automatically.
 
 For **inbound Twilio signature validation** at the gateway, URL reconstruction now supports multiple candidates in order:
 
-1. `ConfigFileCache.getString("ingress", "twilioPublicBaseUrl")` (if configured)
-2. `ConfigFileCache.getString("ingress", "publicBaseUrl")` (if configured)
-3. Forwarded public URL headers from the tunnel/proxy (`X-Forwarded-Proto` + `X-Forwarded-Host`/`X-Original-Host` fallbacks)
-4. Raw request URL (always included as the final fallback)
+1. `ConfigFileCache.getString("ingress", "publicBaseUrl")` (if configured)
+2. Forwarded public URL headers from the tunnel/proxy (`X-Forwarded-Proto` + `X-Forwarded-Host`/`X-Original-Host` fallbacks)
+3. Raw request URL (always included as the final fallback)
 
 This makes ingress URL updates smoother in local tunnel workflows because Twilio webhooks can continue validating immediately. For Telegram, the config file watcher detects ingress URL changes and triggers webhook reconciliation directly, so neither channel requires a gateway restart.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -210,9 +210,9 @@ In local tunnel setups, updating `ingress.publicBaseUrl` in Settings is typicall
 
 The assistant runtime uses this URL to construct all webhook and OAuth callback URLs automatically.
 
-### Velay for Twilio Local Testing
+### Velay for Twilio Testing
 
-Velay is an additional managed ingress transport for Twilio calls. It does not replace ngrok or `ingress.publicBaseUrl`. In this phase, Velay registration writes only `ingress.twilioPublicBaseUrl`; Twilio URL builders prefer that value when it is present, while Telegram webhooks, OAuth callbacks, email callbacks, and normal JSON webhook URLs continue to use `ingress.publicBaseUrl`.
+Velay is a managed ingress transport for assistant-hosted HTTP and WebSocket traffic. When Velay registration succeeds, the gateway writes the registered public assistant URL to `ingress.publicBaseUrl` and marks it with `ingress.publicBaseUrlManagedBy: "velay"`. Twilio URL builders use that public base URL for voice, status, relay, and media-stream endpoints.
 
 Use Velay when testing Twilio voice webhooks or Twilio WebSocket upgrades through the platform-managed tunnel:
 
@@ -222,16 +222,16 @@ Use Velay when testing Twilio voice webhooks or Twilio WebSocket upgrades throug
    vel up velay
    ```
 
-2. Ensure vembda injects the Velay endpoint into assistant gateway containers:
+2. Ensure vembda injects the Velay endpoint into assistant gateway containers. For local Docker-hosted assistants, the gateway container must dial the Velay service running on the host:
 
    ```bash
    VELAY_BASE_URL=http://host.docker.internal:8501
    ```
 
-   The `host.docker.internal` host is important for Docker-hosted assistants because the gateway container must dial the Velay service running on the host.
+   Hosted environments should use their environment's deployed Velay URL instead.
 
 3. Re-hatch or restart the assistant so the gateway process receives `VELAY_BASE_URL`.
-4. Confirm the gateway logs include `Velay tunnel connected` followed by `Velay tunnel registered`. Registration publishes the returned Velay URL to `ingress.twilioPublicBaseUrl` without changing `ingress.publicBaseUrl`.
+4. Confirm the gateway logs include `Velay tunnel connected` followed by `Velay tunnel registered`. Registration publishes the returned Velay URL to `ingress.publicBaseUrl`.
 
 For an HTTP bridge smoke test, send a request to the registered Velay public URL and confirm it reaches the loopback gateway, for example:
 
@@ -249,7 +249,7 @@ bun -e 'const ws = new WebSocket(process.argv[1]); ws.onopen = () => { console.l
   "wss://<velay-host>/<assistant-id>/webhooks/twilio/relay?callSessionId=session-123&token=<edge-token>"
 ```
 
-For a real Twilio call, expose local Velay with a public HTTPS/WSS tunnel and configure the platform Velay service with that origin as `VELAY_PUBLIC_BASE_URL`. After the assistant re-registers, Twilio should fetch `/webhooks/twilio/voice` and open `/webhooks/twilio/relay` or `/webhooks/twilio/media-stream/...` through the Velay URL. Keep using ngrok or another custom tunnel in `ingress.publicBaseUrl` when you need Telegram, OAuth, email, or non-Twilio webhook ingress.
+For a real Twilio call, expose local Velay with a public HTTPS/WSS tunnel and configure the platform Velay service with that origin as `VELAY_PUBLIC_BASE_URL`. After the assistant re-registers, Twilio should fetch `/webhooks/twilio/voice` and open `/webhooks/twilio/relay` or `/webhooks/twilio/media-stream/...` through the Velay URL. Use ngrok or another custom tunnel in `ingress.publicBaseUrl` only for local/self-hosted workflows that are not routed through Velay.
 
 ## Ingress Boundary Guarantees
 

--- a/gateway/src/__tests__/config-file-watcher.test.ts
+++ b/gateway/src/__tests__/config-file-watcher.test.ts
@@ -144,7 +144,7 @@ describe("Twilio webhook sync config-change triggers", () => {
     expect(shouldSyncTwilioPhoneWebhooksAfterConfigChange(event)).toBe(true);
   });
 
-  test("syncs when the Twilio-specific public ingress changes", () => {
+  test("syncs when Velay-managed public ingress changes", () => {
     const event = makeEvent(["ingress"], {
       ingress: ["publicBaseUrl", "publicBaseUrlManagedBy"],
     });

--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -150,11 +150,7 @@ function makeCaches(
     ingressUrl?: string;
   } = {},
 ) {
-  const {
-    authToken = AUTH_TOKEN,
-    ingressEnabled,
-    ingressUrl,
-  } = opts;
+  const { authToken = AUTH_TOKEN, ingressEnabled, ingressUrl } = opts;
   const credentials = {
     get: async (key: string, _opts?: { force?: boolean }) => {
       if (key === credentialKey("twilio", "auth_token")) return authToken;
@@ -876,7 +872,7 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
 });
 
 describe("Twilio webhook force retry", () => {
-  test("refreshes Twilio-specific ingress URL before retrying signature validation", async () => {
+  test("refreshes configured ingress URL before retrying signature validation", async () => {
     fetchMock = mock(
       async () =>
         new Response('<?xml version="1.0" encoding="UTF-8"?><Response/>', {

--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -314,7 +314,28 @@ describe("resolvePublicBaseWssUrl", () => {
     );
   });
 
-  test("falls back to configFile publicBaseUrl when velayBaseUrl is set but platformAssistantId is missing", () => {
+  test("uses configFile publicBaseUrl before velayBaseUrl fallback", () => {
+    const config = {
+      ...baseConfig,
+      velayBaseUrl: "http://host.docker.internal:8501",
+    };
+    const mockConfigFile = {
+      getString: (section: string, key: string) =>
+        section === "ingress" && key === "publicBaseUrl"
+          ? "https://velay-public.example.test/abc12345-0000-0000-0000-000000000000"
+          : undefined,
+    } as Parameters<typeof resolvePublicBaseWssUrl>[1];
+    const result = resolvePublicBaseWssUrl(
+      config,
+      mockConfigFile,
+      "abc12345-0000-0000-0000-000000000000",
+    );
+    expect(result).toBe(
+      "wss://velay-public.example.test/abc12345-0000-0000-0000-000000000000",
+    );
+  });
+
+  test("falls back to configFile publicBaseUrl when platformAssistantId is missing", () => {
     const config = {
       ...baseConfig,
       velayBaseUrl: "https://velay-dev.vellum.ai",

--- a/gateway/src/runtime/client.ts
+++ b/gateway/src/runtime/client.ts
@@ -514,11 +514,10 @@ const TWILIO_RELAY_TOKEN_PLACEHOLDER = "__VELLUM_RELAY_TOKEN__";
  * Resolve the public base URL as a WebSocket URL (`wss://…`).
  *
  * Sources (in priority order):
- * 1. `VELAY_BASE_URL` — present on platform-hosted gateway sidecars.
- *    When Velay is the tunnel provider, Twilio WebSocket connections
- *    are routed through the Velay service URL.
- * 2. `ingress.publicBaseUrl` from the config file — written by Velay
- *    on tunnel registration, or set manually for self-hosted.
+ * 1. `ingress.publicBaseUrl` from the config file — written by Velay
+ *    after tunnel registration, or set manually for self-hosted.
+ * 2. `VELAY_BASE_URL` + platform assistant ID — fallback for platform
+ *    sidecars before the config cache has observed the registered URL.
  *
  * Returns `undefined` when no source provides a value — the placeholder
  * will remain in TwiML and Twilio will fail to connect, which is the
@@ -529,16 +528,19 @@ export function resolvePublicBaseWssUrl(
   configFile?: ConfigFileCache,
   platformAssistantId?: string,
 ): string | undefined {
+  const raw = configFile?.getString("ingress", "publicBaseUrl");
+  const normalized = normalizePublicBaseUrl(raw);
+  if (normalized) return normalized.replace(/^http(s?)/, "ws$1");
+
   if (config.velayBaseUrl && platformAssistantId) {
     const withPath =
       config.velayBaseUrl.replace(/\/+$/, "") + "/" + platformAssistantId;
-    const normalized = normalizePublicBaseUrl(withPath);
-    if (normalized) return normalized.replace(/^http(s?)/, "ws$1");
+    const normalizedVelayUrl = normalizePublicBaseUrl(withPath);
+    if (normalizedVelayUrl) {
+      return normalizedVelayUrl.replace(/^http(s?)/, "ws$1");
+    }
   }
-  const raw = configFile?.getString("ingress", "publicBaseUrl");
-  const normalized = normalizePublicBaseUrl(raw);
-  if (!normalized) return undefined;
-  return normalized.replace(/^http(s?)/, "ws$1");
+  return undefined;
 }
 
 /**
@@ -608,7 +610,7 @@ export async function forwardTwilioVoiceWebhook(
     } else {
       log.error(
         "TwiML contains public URL placeholder but no public base URL is configured. " +
-          "Twilio will fail to connect. Set VELAY_BASE_URL or ingress.publicBaseUrl.",
+          "Twilio will fail to connect. Wait for Velay tunnel registration or set ingress.publicBaseUrl.",
       );
     }
   }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -683,7 +683,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-03-15T12:39:46-04:00"
+      "updatedAt": "2026-05-05T17:11:32-06:00"
     },
     {
       "id": "typescript-eval",

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -144,7 +144,15 @@ assistant config set twilio.phoneNumber "+14155551234"
 
 ### Verify Public Ingress is Set Up
 
-Twilio needs a publicly reachable URL for voice webhooks. Load the `public-ingress` skill to determine whether a public ingress has been configured and walk the user through setting one up if not.
+Twilio needs publicly reachable HTTP webhooks and, for live calls, a publicly reachable WebSocket path. First check managed/platform status:
+
+```bash
+assistant platform status --json
+```
+
+If this reports an available platform assistant and `velayTunnel.connected` is `true`, do not load `public-ingress` or install ngrok. Use the managed Velay route for the WebSocket leg. If `velayTunnel.connected` is `false`, restart or re-hatch the assistant/gateway and check gateway logs for `Velay tunnel registered`; do not treat that as an ngrok setup problem.
+
+For local/self-hosted assistants without Velay, load the `public-ingress` skill to determine whether `ingress.publicBaseUrl` is configured and walk the user through setting one up if not.
 
 ### Configure Twilio Webhooks
 


### PR DESCRIPTION
## Summary
- Use the registered `ingress.publicBaseUrl` before synthesizing a Velay URL for Twilio voice stream WebSocket replacement.
- Update Twilio/Velay troubleshooting and setup guidance so managed assistants check Velay tunnel state instead of installing ngrok.
- Remove stale Twilio-specific ingress wording and fix the assistant test mock isolation exposed by the focused tests.

## Test plan
- `node scripts/skills/check-catalog.mjs`
- `cd gateway && bun test src/http/routes/twilio-voice-webhook.test.ts`
- `cd gateway && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/twilio-validation.test.ts src/__tests__/channel-readiness-service.test.ts --grep "Twilio validation|phone readiness"`
- `cd assistant && bunx tsc --noEmit`

## Original prompt
Take over PR #29759 and finish the Twilio/Velay fix in place; do not open a new PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->