### PR TITLE
fix: refresh skill memories after skill management tools

### DIFF
--- a/assistant/src/__tests__/delete-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/delete-managed-skill-tool.test.ts
@@ -9,12 +9,17 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const mockRefreshSkillCapabilityMemories = mock(() => {});
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
+}));
+
+mock.module("../daemon/skill-memory-refresh.js", () => ({
+  refreshSkillCapabilityMemories: mockRefreshSkillCapabilityMemories,
 }));
 
 import { executeDeleteManagedSkill } from "../tools/skills/delete-managed.js";
@@ -39,6 +44,7 @@ function createSkill(id: string): void {
 
 beforeEach(() => {
   mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
+  mockRefreshSkillCapabilityMemories.mockClear();
 });
 
 afterEach(() => {
@@ -92,6 +98,7 @@ describe("delete_managed_skill tool", () => {
 
     expect(existsSync(indexPath)).toBe(true);
     expect(readFileSync(indexPath, "utf-8")).toBe(staleIndex);
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
   });
 
   test("accepts legacy remove_from_index input without returning index metadata", async () => {
@@ -110,6 +117,7 @@ describe("delete_managed_skill tool", () => {
     expect(parsed.deleted).toBe(true);
     expect(parsed).not.toHaveProperty("index_updated");
     expect(existsSync(join(TEST_DIR, "skills", "legacy-delete"))).toBe(false);
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
   });
 
   test("returns error for non-existent skill", async () => {
@@ -122,6 +130,7 @@ describe("delete_managed_skill tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("not found");
+    expect(mockRefreshSkillCapabilityMemories).not.toHaveBeenCalled();
   });
 
   test("rejects missing skill_id", async () => {

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -76,6 +76,10 @@ mock.module("../memory/v2/qdrant.js", () => ({
   pruneSlugsWithPrefixExcept: async () => {},
 }));
 
+mock.module("../daemon/skill-memory-refresh.js", () => ({
+  refreshSkillCapabilityMemories: mock(() => {}),
+}));
+
 import { loadSkillCatalog } from "../config/skills.js";
 import {
   _resetSkillStoreForTests,

--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -3,12 +3,17 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const mockRefreshSkillCapabilityMemories = mock(() => {});
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
+}));
+
+mock.module("../daemon/skill-memory-refresh.js", () => ({
+  refreshSkillCapabilityMemories: mockRefreshSkillCapabilityMemories,
 }));
 
 import { loadSkillCatalog } from "../config/skills.js";
@@ -25,6 +30,7 @@ function makeContext(): ToolContext {
 
 beforeEach(() => {
   mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
+  mockRefreshSkillCapabilityMemories.mockClear();
 });
 
 afterEach(() => {
@@ -82,6 +88,7 @@ describe("scaffold_managed_skill tool", () => {
     const skill = catalog.find((s) => s.id === "test-skill");
     expect(skill).toBeDefined();
     expect(skill!.name).toBe("Test Skill");
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
   });
 
   test("accepts legacy add_to_index input without returning index metadata", async () => {
@@ -101,6 +108,7 @@ describe("scaffold_managed_skill tool", () => {
     expect(parsed.created).toBe(true);
     expect(parsed).not.toHaveProperty("index_updated");
     expect(existsSync(join(TEST_DIR, "skills", "SKILLS.md"))).toBe(false);
+    expect(mockRefreshSkillCapabilityMemories).toHaveBeenCalledTimes(1);
   });
 
   test("rejects duplicate unless overwrite=true", async () => {

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -1,3 +1,4 @@
+import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
 import { deleteManagedSkill } from "../../skills/managed-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
@@ -22,6 +23,8 @@ export async function executeDeleteManagedSkill(
   if (!result.deleted) {
     return { content: `Error: ${result.error}`, isError: true };
   }
+
+  refreshSkillCapabilityMemories();
 
   return {
     content: JSON.stringify({

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -1,3 +1,4 @@
+import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
 import { createManagedSkill } from "../../skills/managed-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
@@ -99,6 +100,8 @@ export async function executeScaffoldManagedSkill(
   if (!result.created) {
     return { content: `Error: ${result.error}`, isError: true };
   }
+
+  refreshSkillCapabilityMemories();
 
   return {
     content: JSON.stringify({


### PR DESCRIPTION
## Summary
- Refresh skill capability memories after successful scaffold_managed_skill executions so new custom skills are immediately seeded.
- Refresh skill capability memories after successful delete_managed_skill executions so Memory V2 prunes removed custom skills without relying on watcher events.
- Add tool-level regression coverage for both refresh paths.

## Validation
- cd assistant && bun test src/__tests__/delete-managed-skill-tool.test.ts src/__tests__/scaffold-managed-skill-tool.test.ts
- cd assistant && bunx tsc --noEmit

Part of JARVIS-710
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->