### PR TITLE
Delay phone-call hangup after task completion

### DIFF
--- a/assistant/src/__tests__/call-constants.test.ts
+++ b/assistant/src/__tests__/call-constants.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { isDeniedNumber } from "../calls/call-constants.js";
+import {
+  getEndCallListenWindowMs,
+  isDeniedNumber,
+} from "../calls/call-constants.js";
 
 describe("isDeniedNumber", () => {
   // Numbers that MUST be blocked
@@ -38,4 +41,10 @@ describe("isDeniedNumber", () => {
       expect(isDeniedNumber(num)).toBe(false);
     });
   }
+});
+
+describe("getEndCallListenWindowMs", () => {
+  test("leaves a brief response window before task-complete hangup", () => {
+    expect(getEndCallListenWindowMs()).toBe(8_000);
+  });
 });

--- a/assistant/src/__tests__/call-constants.test.ts
+++ b/assistant/src/__tests__/call-constants.test.ts
@@ -45,6 +45,6 @@ describe("isDeniedNumber", () => {
 
 describe("getEndCallListenWindowMs", () => {
   test("leaves a brief response window before task-complete hangup", () => {
-    expect(getEndCallListenWindowMs()).toBe(8_000);
+    expect(getEndCallListenWindowMs()).toBe(15_000);
   });
 });

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -780,6 +780,31 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("delayed END_CALL completion skips side effects when session is already terminal", async () => {
+    mockEndCallListenWindowMs = 25;
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Thank you for calling, goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("That is all, thanks");
+
+    const externalEndedAt = Date.now();
+    updateCallSession(session.id, {
+      status: "completed",
+      endedAt: externalEndedAt,
+    });
+
+    await new Promise((r) => setTimeout(r, 35));
+
+    expect(relay.endCalled).toBe(false);
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe("completed");
+    expect(updatedSession!.endedAt).toBe(externalEndedAt);
+
+    controller.destroy();
+  });
+
   test("callee speech during END_CALL listen window cancels pending completion", async () => {
     mockEndCallListenWindowMs = 30;
     const turnContents: string[] = [];

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -841,6 +841,47 @@ describe("call-controller", () => {
     controller.destroy();
   });
 
+  test("END_CALL listen window restores in_progress after clearing pending guardian input", async () => {
+    mockEndCallListenWindowMs = 30;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        if (turnContents.length === 1) {
+          opts.onTextDelta("Let me check. [ASK_GUARDIAN: Is this okay?]");
+        } else if (turnContents.length === 2) {
+          opts.onTextDelta("Never mind, goodbye. [END_CALL]");
+        } else {
+          opts.onTextDelta("I'm still here.");
+        }
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    const { session, relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Can you ask?");
+    expect(controller.getPendingConsultationQuestionId()).not.toBeNull();
+    expect(getCallSession(session.id)!.status).toBe("waiting_on_user");
+
+    await controller.handleCallerUtterance("Actually never mind");
+    expect(controller.getPendingConsultationQuestionId()).toBeNull();
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+    expect(relay.endCalled).toBe(false);
+
+    await controller.handleCallerUtterance("Wait, one more thing");
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+
+    controller.destroy();
+  });
+
   // ── handleUserAnswer ──────────────────────────────────────────────
 
   test("handleUserAnswer: returns true immediately and fires LLM asynchronously", async () => {

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -105,11 +105,13 @@ mock.module("../security/credential-key.js", () => ({
 
 let mockConsultationTimeoutMs = 90_000;
 let mockSilenceTimeoutMs = 30_000;
+let mockEndCallListenWindowMs = 0;
 
 mock.module("../calls/call-constants.js", () => ({
   getMaxCallDurationMs: () => 12 * 60 * 1000,
   getUserConsultationTimeoutMs: () => mockConsultationTimeoutMs,
   getSilenceTimeoutMs: () => mockSilenceTimeoutMs,
+  getEndCallListenWindowMs: () => mockEndCallListenWindowMs,
 }));
 
 // ── Voice session bridge mock ────────────────────────────────────────
@@ -467,6 +469,7 @@ describe("call-controller", () => {
     // Reset consultation timeout to the default (long) value
     mockConsultationTimeoutMs = 90_000;
     mockSilenceTimeoutMs = 30_000;
+    mockEndCallListenWindowMs = 0;
     // Reset TTS config to defaults so per-test mutations don't leak.
     const cfg = loadConfig();
     cfg.services.tts.provider = "elevenlabs";
@@ -751,6 +754,64 @@ describe("call-controller", () => {
     // The END_CALL marker text should NOT appear in the relay tokens
     const allText = relay.sentTokens.map((t) => t.token).join("");
     expect(allText).not.toContain("[END_CALL]");
+
+    controller.destroy();
+  });
+
+  test("END_CALL waits through the listen window before completing", async () => {
+    mockEndCallListenWindowMs = 25;
+    mockStartVoiceTurn.mockImplementation(
+      createMockVoiceTurn(["Thank you for calling, goodbye! ", "[END_CALL]"]),
+    );
+    const { session, relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("That is all, thanks");
+
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+
+    await new Promise((r) => setTimeout(r, 35));
+
+    expect(relay.endCalled).toBe(true);
+    const updatedSession = getCallSession(session.id);
+    expect(updatedSession!.status).toBe("completed");
+    expect(updatedSession!.endedAt).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  test("callee speech during END_CALL listen window cancels pending completion", async () => {
+    mockEndCallListenWindowMs = 30;
+    const turnContents: string[] = [];
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        content: string;
+        onTextDelta: (t: string) => void;
+        onComplete: () => void;
+      }) => {
+        turnContents.push(opts.content);
+        if (turnContents.length === 1) {
+          opts.onTextDelta("Goodbye! [END_CALL]");
+        } else {
+          opts.onTextDelta("Of course. I'm still here.");
+        }
+        opts.onComplete();
+        return { turnId: `run-${turnContents.length}`, abort: () => {} };
+      },
+    );
+    const { session, relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("That is all, thanks");
+    expect(relay.endCalled).toBe(false);
+
+    await controller.handleCallerUtterance("Wait, one more thing");
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(relay.endCalled).toBe(false);
+    expect(getCallSession(session.id)!.status).toBe("in_progress");
+    expect(turnContents).toContain("Wait, one more thing");
+    const allText = relay.sentTokens.map((t) => t.token).join("");
+    expect(allText).toContain("I'm still here.");
 
     controller.destroy();
   });

--- a/assistant/src/calls/call-constants.ts
+++ b/assistant/src/calls/call-constants.ts
@@ -70,5 +70,5 @@ export function getSilenceTimeoutMs(): number {
 }
 
 export function getEndCallListenWindowMs(): number {
-  return 8 * 1000;
+  return 15 * 1000;
 }

--- a/assistant/src/calls/call-constants.ts
+++ b/assistant/src/calls/call-constants.ts
@@ -1,14 +1,7 @@
 import { getConfig } from "../config/loader.js";
 
 // Emergency/high-risk numbers that should never be called
-const DENIED_NUMBERS = new Set([
-  "911",
-  "112",
-  "999",
-  "000",
-  "110",
-  "119",
-]);
+const DENIED_NUMBERS = new Set(["911", "112", "999", "000", "110", "119"]);
 
 /**
  * Check whether a phone number is a denied emergency number.
@@ -74,4 +67,8 @@ export function getGuardianWaitUpdateSteadyMaxIntervalMs(): number {
 
 export function getSilenceTimeoutMs(): number {
   return 30 * 1000; // 30 seconds
+}
+
+export function getEndCallListenWindowMs(): number {
+  return 8 * 1000;
 }

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -38,6 +38,7 @@ import {
   registerCallController,
   unregisterCallController,
 } from "./call-state.js";
+import { isTerminalState } from "./call-state-machine.js";
 import {
   createPendingQuestion,
   expirePendingQuestions,
@@ -1154,11 +1155,12 @@ export class CallController {
     if (this.destroyed) return;
 
     const currentSession = getCallSession(this.callSessionId);
-    const shouldNotifyCompletion = currentSession
-      ? currentSession.status !== "completed" &&
-        currentSession.status !== "failed" &&
-        currentSession.status !== "cancelled"
-      : false;
+    if (currentSession && isTerminalState(currentSession.status)) {
+      this.state = "idle";
+      return;
+    }
+
+    const shouldNotifyCompletion = !!currentSession;
 
     this.transport.endSession("Call completed");
     updateCallSession(this.callSessionId, {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -1099,14 +1099,17 @@ export class CallController {
   }
 
   private scheduleEndCallAfterListenWindow(): void {
-    this.clearPendingGuardianInputForCallEnd();
-    this.state = "idle";
-    this.currentTurnHandle = null;
-
-    if (this.pendingInstructions.length > 0) {
-      this.flushPendingInstructions();
+    const currentSession = getCallSession(this.callSessionId);
+    if (currentSession && isTerminalState(currentSession.status)) {
+      this.state = "idle";
+      this.currentTurnHandle = null;
       return;
     }
+
+    const clearedPendingGuardianInput =
+      this.clearPendingGuardianInputForCallEnd();
+    this.state = "idle";
+    this.currentTurnHandle = null;
 
     if (this.endCallListenTimer) {
       clearTimeout(this.endCallListenTimer);
@@ -1114,6 +1117,17 @@ export class CallController {
     }
 
     const listenWindowMs = getEndCallListenWindowMs();
+    const callContinues =
+      this.pendingInstructions.length > 0 || listenWindowMs > 0;
+    if (clearedPendingGuardianInput && callContinues) {
+      updateCallSession(this.callSessionId, { status: "in_progress" });
+    }
+
+    if (this.pendingInstructions.length > 0) {
+      this.flushPendingInstructions();
+      return;
+    }
+
     if (listenWindowMs <= 0) {
       this.completeCallFromEndMarker();
       return;
@@ -1132,8 +1146,8 @@ export class CallController {
     this.endCallListenTimer = null;
   }
 
-  private clearPendingGuardianInputForCallEnd(): void {
-    if (!this.pendingGuardianInput) return;
+  private clearPendingGuardianInputForCallEnd(): boolean {
+    if (!this.pendingGuardianInput) return false;
 
     clearTimeout(this.pendingGuardianInput.timer);
 
@@ -1149,6 +1163,7 @@ export class CallController {
     }
 
     this.pendingGuardianInput = null;
+    return true;
   }
 
   private completeCallFromEndMarker(): void {

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -26,6 +26,7 @@ import type { TtsProvider, TtsProviderId } from "../tts/types.js";
 import { getLogger } from "../util/logger.js";
 import { createStreamingEntry } from "./audio-store.js";
 import {
+  getEndCallListenWindowMs,
   getMaxCallDurationMs,
   getSilenceTimeoutMs,
   getUserConsultationTimeoutMs,
@@ -93,6 +94,7 @@ export class CallController {
   private currentTurnPromise: Promise<void> | null = null;
   private destroyed = false;
   private silenceTimer: ReturnType<typeof setTimeout> | null = null;
+  private endCallListenTimer: ReturnType<typeof setTimeout> | null = null;
   private durationTimer: ReturnType<typeof setTimeout> | null = null;
   private durationWarningTimer: ReturnType<typeof setTimeout> | null = null;
   /**
@@ -244,6 +246,8 @@ export class CallController {
     transcript: string,
     speaker?: PromptSpeakerContext,
   ): Promise<void> {
+    this.cancelPendingEndCall();
+
     const interruptedInFlight =
       this.state === "processing" || this.state === "speaking";
     // If we're already processing or speaking, abort the in-flight generation
@@ -295,6 +299,8 @@ export class CallController {
       return false;
     }
 
+    this.cancelPendingEndCall();
+
     // Clear the consultation timeout and record
     clearTimeout(this.pendingGuardianInput.timer);
     this.pendingGuardianInput = null;
@@ -326,6 +332,8 @@ export class CallController {
    * position once the current turn completes.
    */
   async handleUserInstruction(instructionText: string): Promise<void> {
+    this.cancelPendingEndCall();
+
     recordCallEvent(this.callSessionId, "user_instruction_relayed", {
       instruction: instructionText,
     });
@@ -408,6 +416,7 @@ export class CallController {
   destroy(): void {
     this.destroyed = true;
     if (this.silenceTimer) clearTimeout(this.silenceTimer);
+    if (this.endCallListenTimer) clearTimeout(this.endCallListenTimer);
     if (this.durationTimer) clearTimeout(this.durationTimer);
     if (this.durationWarningTimer) clearTimeout(this.durationWarningTimer);
     if (this.pendingGuardianInput) {
@@ -419,6 +428,7 @@ export class CallController {
       this.durationEndTimer = null;
     }
     this.pendingInstructions = [];
+    this.endCallListenTimer = null;
     this.llmRunVersion++;
     this.abortCurrentTurn();
     if (this.activeSynthesisAbort) {
@@ -1075,73 +1085,7 @@ export class CallController {
 
     // Check for END_CALL marker
     if (responseText.includes(END_CALL_MARKER)) {
-      // Clear any pending consultation before completing the call.
-      // Without this, the consultation timeout can fire on an already-ended
-      // call, overwriting 'completed' status back to 'in_progress' and
-      // starting a new LLM turn on a dead conversation. Similarly, a late
-      // handleUserAnswer could be accepted since pendingGuardianInput is
-      // still non-null.
-      if (this.pendingGuardianInput) {
-        clearTimeout(this.pendingGuardianInput.timer);
-
-        // Expire store-side consultation records so clients don't observe
-        // a completed call with a dangling pendingQuestion, and guardian
-        // replies are cleanly rejected instead of hitting answerCall failures.
-        expirePendingQuestions(this.callSessionId);
-        const previousRequest = getPendingCanonicalRequestByCallSessionId(
-          this.callSessionId,
-        );
-        if (previousRequest) {
-          expireCanonicalGuardianRequest(previousRequest.id);
-        }
-
-        this.pendingGuardianInput = null;
-      }
-
-      const currentSession = getCallSession(this.callSessionId);
-      const shouldNotifyCompletion = currentSession
-        ? currentSession.status !== "completed" &&
-          currentSession.status !== "failed" &&
-          currentSession.status !== "cancelled"
-        : false;
-
-      this.transport.endSession("Call completed");
-      updateCallSession(this.callSessionId, {
-        status: "completed",
-        endedAt: Date.now(),
-      });
-      recordCallEvent(this.callSessionId, "call_ended", {
-        reason: "completed",
-      });
-
-      // Notify the voice conversation
-      if (shouldNotifyCompletion && currentSession) {
-        finalizeCall(this.callSessionId, currentSession.conversationId);
-      }
-
-      // Post a pointer message in the initiating conversation
-      if (currentSession?.initiatedFromConversationId) {
-        const durationMs = currentSession.startedAt
-          ? Date.now() - currentSession.startedAt
-          : 0;
-        addPointerMessage(
-          currentSession.initiatedFromConversationId,
-          "completed",
-          currentSession.toNumber,
-          {
-            duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
-          },
-        ).catch((err) => {
-          log.warn(
-            {
-              conversationId: currentSession.initiatedFromConversationId,
-              err,
-            },
-            "Skipping pointer write — origin conversation may no longer exist",
-          );
-        });
-      }
-      this.state = "idle";
+      this.scheduleEndCallAfterListenWindow();
       return;
     }
 
@@ -1151,6 +1095,108 @@ export class CallController {
     this.currentTurnHandle = null;
     this.resetSilenceTimer();
     this.flushPendingInstructions();
+  }
+
+  private scheduleEndCallAfterListenWindow(): void {
+    this.clearPendingGuardianInputForCallEnd();
+    this.state = "idle";
+    this.currentTurnHandle = null;
+
+    if (this.pendingInstructions.length > 0) {
+      this.flushPendingInstructions();
+      return;
+    }
+
+    if (this.endCallListenTimer) {
+      clearTimeout(this.endCallListenTimer);
+      this.endCallListenTimer = null;
+    }
+
+    const listenWindowMs = getEndCallListenWindowMs();
+    if (listenWindowMs <= 0) {
+      this.completeCallFromEndMarker();
+      return;
+    }
+
+    this.resetSilenceTimer();
+    this.endCallListenTimer = setTimeout(() => {
+      this.endCallListenTimer = null;
+      this.completeCallFromEndMarker();
+    }, listenWindowMs);
+  }
+
+  private cancelPendingEndCall(): void {
+    if (!this.endCallListenTimer) return;
+    clearTimeout(this.endCallListenTimer);
+    this.endCallListenTimer = null;
+  }
+
+  private clearPendingGuardianInputForCallEnd(): void {
+    if (!this.pendingGuardianInput) return;
+
+    clearTimeout(this.pendingGuardianInput.timer);
+
+    // Expire store-side consultation records so clients don't observe
+    // a completed call with a dangling pendingQuestion, and guardian
+    // replies are cleanly rejected instead of hitting answerCall failures.
+    expirePendingQuestions(this.callSessionId);
+    const previousRequest = getPendingCanonicalRequestByCallSessionId(
+      this.callSessionId,
+    );
+    if (previousRequest) {
+      expireCanonicalGuardianRequest(previousRequest.id);
+    }
+
+    this.pendingGuardianInput = null;
+  }
+
+  private completeCallFromEndMarker(): void {
+    if (this.destroyed) return;
+
+    const currentSession = getCallSession(this.callSessionId);
+    const shouldNotifyCompletion = currentSession
+      ? currentSession.status !== "completed" &&
+        currentSession.status !== "failed" &&
+        currentSession.status !== "cancelled"
+      : false;
+
+    this.transport.endSession("Call completed");
+    updateCallSession(this.callSessionId, {
+      status: "completed",
+      endedAt: Date.now(),
+    });
+    recordCallEvent(this.callSessionId, "call_ended", {
+      reason: "completed",
+    });
+
+    // Notify the voice conversation
+    if (shouldNotifyCompletion && currentSession) {
+      finalizeCall(this.callSessionId, currentSession.conversationId);
+    }
+
+    // Post a pointer message in the initiating conversation
+    if (currentSession?.initiatedFromConversationId) {
+      const durationMs = currentSession.startedAt
+        ? Date.now() - currentSession.startedAt
+        : 0;
+      addPointerMessage(
+        currentSession.initiatedFromConversationId,
+        "completed",
+        currentSession.toNumber,
+        {
+          duration: durationMs > 0 ? formatDuration(durationMs) : undefined,
+        },
+      ).catch((err) => {
+        log.warn(
+          {
+            conversationId: currentSession.initiatedFromConversationId,
+            err,
+          },
+          "Skipping pointer write — origin conversation may no longer exist",
+        );
+      });
+    }
+    this.state = "idle";
   }
 
   private isExpectedAbortError(err: unknown): boolean {


### PR DESCRIPTION
## Summary
- Add an 8-second listen window after the voice agent emits [END_CALL] before Twilio teardown.
- Cancel the pending hangup if the callee speaks or the user sends a live instruction during that window.
- Add regression coverage for delayed completion and callee speech canceling the pending hangup.

## Original prompt
When i told the assistant to call a number and tell them "i love you baby" it immedaditly hung up afterward. I think maybe it should update the twilio skill to like wait a little before hanging up no matter what incase the called person wants to say something back right?

also use the [$do](/Users/maddieabboud/projects/claude-skills/skills/do/SKILL.md) skill to implement this
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->