### PR TITLE
Make custom-* inference profiles user-owned

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -125,31 +125,14 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     ).toThrow(BadRequestError);
   });
 
-  test("rejects edits to custom-balanced", () => {
-    expect(() =>
-      replaceRoute.handler({
-        pathParams: { name: "custom-balanced" },
-        body: { provider: "openai", model: "gpt-4o" },
-      }),
-    ).toThrow(BadRequestError);
-  });
-
-  test("rejects edits to custom-quality-optimized", () => {
-    expect(() =>
-      replaceRoute.handler({
-        pathParams: { name: "custom-quality-optimized" },
-        body: { provider: "openai", model: "gpt-4o" },
-      }),
-    ).toThrow(BadRequestError);
-  });
-
-  test("rejects edits to custom-cost-optimized", () => {
-    expect(() =>
-      replaceRoute.handler({
-        pathParams: { name: "custom-cost-optimized" },
-        body: { provider: "openai", model: "gpt-4o" },
-      }),
-    ).toThrow(BadRequestError);
+  test("allows edits to custom-balanced (user-owned)", () => {
+    savedRaw = null;
+    const result = replaceRoute.handler({
+      pathParams: { name: "custom-balanced" },
+      body: { provider: "openai", model: "gpt-4o" },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(savedRaw).not.toBeNull();
   });
 
   test("allows edits to a user-defined profile", () => {
@@ -192,28 +175,12 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
     ).rejects.toThrow(BadRequestError);
   });
 
-  test("rejects deletion of custom-balanced via null", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { "custom-balanced": null } } },
-      }),
-    ).rejects.toThrow(BadRequestError);
-  });
-
-  test("rejects deletion of custom-quality-optimized via null", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { "custom-quality-optimized": null } } },
-      }),
-    ).rejects.toThrow(BadRequestError);
-  });
-
-  test("rejects deletion of custom-cost-optimized via null", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { "custom-cost-optimized": null } } },
-      }),
-    ).rejects.toThrow(BadRequestError);
+  test("allows deletion of custom-balanced via null (user-owned)", async () => {
+    savedRaw = null;
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { "custom-balanced": null } } },
+    });
+    expect(result).toEqual({ ok: true });
   });
 
   test("allows deletion of a user-defined profile via null", async () => {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -61,7 +61,7 @@ const ANTHROPIC_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
 const CUSTOM_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   "custom-balanced": {
     intent: "balanced",
-    source: "managed",
+    source: "user",
     label: "Balanced (Custom Provider)",
     description: "Good balance of quality, cost, and speed",
     maxTokens: 16000,
@@ -71,7 +71,7 @@ const CUSTOM_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
   "custom-quality-optimized": {
     intent: "quality-optimized",
-    source: "managed",
+    source: "user",
     label: "Quality (Custom Provider)",
     description: "Best results with the most capable model",
     maxTokens: 32000,
@@ -81,7 +81,7 @@ const CUSTOM_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
   "custom-cost-optimized": {
     intent: "latency-optimized",
-    source: "managed",
+    source: "user",
     label: "Speed (Custom Provider)",
     description: "Fastest responses at lower cost",
     maxTokens: 8192,
@@ -91,7 +91,11 @@ const CUSTOM_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
   },
 };
 
-export const MANAGED_PROFILE_NAMES = new Set([
+export const MANAGED_PROFILE_NAMES = new Set(
+  Object.keys(ANTHROPIC_PROFILE_TEMPLATES),
+);
+
+const SEEDED_PROFILE_NAMES = new Set([
   ...Object.keys(ANTHROPIC_PROFILE_TEMPLATES),
   ...Object.keys(CUSTOM_PROFILE_TEMPLATES),
 ]);
@@ -185,8 +189,7 @@ export function seedInferenceProfiles(
   if (!isAnthropicDefault) {
     for (const [name, template] of Object.entries(CUSTOM_PROFILE_TEMPLATES)) {
       if (preservedProfileNames.has(name)) continue;
-      const existing = readObject(profiles[name]);
-      if (existing !== null && readString(existing.source) === "user") continue;
+      if (readObject(profiles[name]) !== null) continue;
       profiles[name] = materializeProfile(template, resolvedProvider);
     }
   }
@@ -209,10 +212,10 @@ export function seedInferenceProfiles(
   // User-created profiles are left alone — those are the user's choice.
   let keepActiveProfile = shouldPreserveActiveProfile;
   if (!keepActiveProfile && requestedActiveExists) {
-    const isManagedName = MANAGED_PROFILE_NAMES.has(requestedActiveProfile!);
+    const isSeededName = SEEDED_PROFILE_NAMES.has(requestedActiveProfile!);
     const activeProvider = readString(requestedActiveEntry?.provider);
     const managedActiveProviderMismatch =
-      isManagedName && activeProvider !== resolvedProvider;
+      isSeededName && activeProvider !== resolvedProvider;
     keepActiveProfile = !managedActiveProviderMismatch;
   }
 


### PR DESCRIPTION
## Summary
- Custom-provider profiles (`custom-balanced`, `custom-quality-optimized`, `custom-cost-optimized`) are now seeded with `source: "user"` and only written on first hatch — never overwritten on restart.
- Users can freely edit and delete them via the settings UI.
- Only the 3 Anthropic profiles remain daemon-managed (overwritten on restart, edit/delete-guarded).
- Follow-up to #29755 — that PR was merged before this change landed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->