### PR TITLE
Reseed custom-* profiles on non-Anthropic provider switch

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -523,6 +523,37 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.default.model).toBe("claude-sonnet-4-6");
   });
 
+  test("re-hatch from openai to gemini reseeds custom-* profiles with new provider", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "openai", model: "gpt-5.4-mini" },
+        profiles: {
+          "custom-balanced": {
+            source: "user",
+            provider: "openai",
+            model: "gpt-5.4-mini",
+          },
+        },
+        activeProfile: "custom-balanced",
+      },
+    });
+
+    const overlayPath = join(WORKSPACE_DIR, "rehatch-gemini.json");
+    writeFileSync(
+      overlayPath,
+      JSON.stringify({ llm: { default: { provider: "gemini" } } }, null, 2) +
+        "\n",
+    );
+    process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH = overlayPath;
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("custom-balanced");
+    expect(raw.llm.profiles["custom-balanced"].provider).toBe("gemini");
+    expect(raw.llm.default.provider).toBe("gemini");
+  });
+
   test("unknown overlay provider falls back to Anthropic seeding", () => {
     const overlayPath = join(WORKSPACE_DIR, "hatch-overlay.json");
     writeFileSync(

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -189,7 +189,9 @@ export function seedInferenceProfiles(
   if (!isAnthropicDefault) {
     for (const [name, template] of Object.entries(CUSTOM_PROFILE_TEMPLATES)) {
       if (preservedProfileNames.has(name)) continue;
-      if (readObject(profiles[name]) !== null) continue;
+      const existing = readObject(profiles[name]);
+      const existingProvider = readString(existing?.provider);
+      if (existing !== null && existingProvider === resolvedProvider) continue;
       profiles[name] = materializeProfile(template, resolvedProvider);
     }
   }


### PR DESCRIPTION
## Summary
- When switching between non-Anthropic providers (e.g. openai→gemini), custom-* profiles are now re-seeded with the new provider's models instead of being preserved with stale data.
- Preserves custom-* profiles only when their provider already matches the resolved default (no change needed).
- Adds regression test for the openai→gemini re-hatch case.
- Follow-up to #29768 / #29755.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->