### PR TITLE
chore(macos): drop graduated billing-flag mentions from doc comments

### DIFF
--- a/clients/macos/vellum-assistant/App/AppURLs.swift
+++ b/clients/macos/vellum-assistant/App/AppURLs.swift
@@ -76,9 +76,9 @@ public enum AppURLs {
     // MARK: - Web app URLs
 
     /// Web app billing settings page — opened from the Settings → Billing tab's
-    /// "Adjust Plan" and "Configure Auto Top Ups" buttons (both gated by the
-    /// `pro-plan-adjust` feature flag). Resolves to the Next.js web app at
-    /// `<webURL>/assistant/settings/billing` for the current build environment.
+    /// "Adjust Plan" and "Configure Auto Top Ups" buttons. Resolves to the
+    /// Next.js web app at `<webURL>/assistant/settings/billing` for the current
+    /// build environment.
     ///
     /// If `VELLUM_WEB_URL` is set but malformed (no scheme/host, non-http(s),
     /// or contains a query/fragment), falls back to the canonical environment

--- a/clients/macos/vellum-assistant/Features/Settings/PlanCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PlanCard.swift
@@ -33,8 +33,8 @@ struct PlanCard: View {
         case loaded(planName: String, subtitle: String, buttonLabel: String, isPro: Bool)
         /// Plan/subscription fetch failed. We still render a fallback CTA so
         /// users hitting a transient error retain a path to billing settings —
-        /// otherwise an `auto-credit-topup`-disabled user has no way to manage
-        /// or upgrade their plan when the API blips.
+        /// otherwise they have no way to manage or upgrade their plan when the
+        /// API blips.
         case error(message: String, buttonLabel: String)
     }
 

--- a/clients/macos/vellum-assistantTests/PlanCardTests.swift
+++ b/clients/macos/vellum-assistantTests/PlanCardTests.swift
@@ -135,9 +135,9 @@ final class PlanCardTests: XCTestCase {
         XCTAssertEqual(card.displayState, .error(message: "Boom", buttonLabel: "Manage Plan"))
     }
 
-    /// Without a fallback CTA in the error state, an `auto-credit-topup`-disabled
-    /// user hitting a transient `/billing/subscription` failure has no path to
-    /// billing settings — the prior simple "Adjust Plan" card always had a button.
+    /// Without a fallback CTA in the error state, a user hitting a transient
+    /// `/billing/subscription` failure has no path to billing settings — the
+    /// prior simple "Adjust Plan" card always had a button.
     func testErrorStateExposesManageButton() {
         var manageInvocations = 0
         let card = PlanCard(


### PR DESCRIPTION
## Summary
- Strip `pro-plan-adjust` and `auto-credit-topup` mentions from doc comments in `PlanCard.swift`, `AppURLs.swift`, and `PlanCardTests.swift` — these flags are graduating in PR 1 and disappearing from the registry in PR 3.
- Preserve each comment's rationale (why the error fallback CTA exists, what `billingSettings` opens, why the regression test guards the error CTA) — only the flag attribution is dropped.

Part of plan: remove-billing-feature-flags.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->