### PR TITLE
feat(macos): add AdminAssistantClient for admin assistant detail and pro-upgrade-machine

### DIFF
--- a/clients/macos/vellum-assistantTests/AdminAssistantClientDecodingTests.swift
+++ b/clients/macos/vellum-assistantTests/AdminAssistantClientDecodingTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Wire-protocol decoding tests for `AdminAssistantDetailResponse`.
+///
+/// These lock in the byte-for-byte JSON shape produced by the Django admin
+/// assistant detail serializer. Any drift in the `machine_size` field name or
+/// type on the server side will fail decoding here.
+final class AdminAssistantClientDecodingTests: XCTestCase {
+    func testDecodesSmallMachineSize() throws {
+        let json = """
+        { "machine_size": "small" }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(AdminAssistantDetailResponse.self, from: json)
+
+        XCTAssertEqual(decoded.machine_size, "small")
+    }
+
+    func testDecodesNullMachineSize() throws {
+        let json = """
+        { "machine_size": null }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(AdminAssistantDetailResponse.self, from: json)
+
+        XCTAssertNil(decoded.machine_size)
+    }
+
+    func testIgnoresExtraFieldsInServerPayload() throws {
+        let json = """
+        {
+            "id": "asst_x",
+            "name": "x",
+            "machine_size": "medium"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(AdminAssistantDetailResponse.self, from: json)
+
+        XCTAssertEqual(decoded.machine_size, "medium")
+    }
+}

--- a/clients/shared/Network/AdminAssistantClient.swift
+++ b/clients/shared/Network/AdminAssistantClient.swift
@@ -1,0 +1,65 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AdminAssistantClient")
+
+/// Response payload from `GET /v1/admin/assistants/{id}/`.
+///
+/// Only the field consumed by the macOS client is declared. The Django
+/// serializer returns additional fields (id, name, etc.); `JSONDecoder`
+/// ignores undeclared keys so the lenient shape survives server additions.
+public struct AdminAssistantDetailResponse: Decodable, Sendable {
+    public let machine_size: String?
+}
+
+/// Focused client for admin-assistant operations routed through the platform.
+///
+/// Wraps the platform-scoped admin endpoints used by the Pro compute-upgrade
+/// CTA in Settings. Both methods target unprefixed routes (no
+/// `assistants/{assistantId}/` scope) because the path itself carries the
+/// assistant id.
+public enum AdminAssistantClient {
+    /// Fetches admin metadata for the given assistant.
+    ///
+    /// Returns `nil` on any error (network, non-2xx, decoding) so callers can
+    /// treat "unknown" as "show nothing" rather than surfacing transient
+    /// failures in the UI.
+    public static func fetchDetail(assistantId: String) async -> AdminAssistantDetailResponse? {
+        do {
+            let (decoded, response): (AdminAssistantDetailResponse?, GatewayHTTPClient.Response) =
+                try await GatewayHTTPClient.get(
+                    path: "admin/assistants/\(assistantId)/",
+                    timeout: 15,
+                    unprefixed: true
+                ) { $0.keyDecodingStrategy = .useDefaultKeys }
+            guard response.isSuccess else {
+                log.error("fetchDetail failed (HTTP \(response.statusCode))")
+                return nil
+            }
+            return decoded
+        } catch {
+            log.error("fetchDetail error: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    /// Triggers the platform's pro-upgrade-machine flow for the given assistant.
+    ///
+    /// The 60-second timeout is intentional — the platform performs two
+    /// sequential vembda calls which can be slow. Returns the success flag
+    /// alongside the server-provided `detail` string (when present) so the
+    /// caller can render either a confirmation or error message.
+    public static func proUpgradeMachine(assistantId: String) async throws -> (success: Bool, detail: String?) {
+        let response = try await GatewayHTTPClient.post(
+            path: "admin/assistants/\(assistantId)/pro-upgrade-machine/",
+            json: [:],
+            timeout: 60,
+            unprefixed: true
+        )
+        let detail = (try? JSONSerialization.jsonObject(with: response.data) as? [String: Any])?["detail"] as? String
+        if !response.isSuccess {
+            log.error("proUpgradeMachine failed (HTTP \(response.statusCode))")
+        }
+        return (response.isSuccess, detail)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AdminAssistantDetailResponse` model + `AdminAssistantClient` enum with `fetchDetail` and `proUpgradeMachine` static functions in clients/shared/Network/.
- Add wire-protocol decoding tests covering small/nil/extra-fields fixtures.

Part of plan: pro-compute-upgrade-cta.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->