### PR TITLE
fix(macos): scope speculative SSE remap to user_message_echo

### DIFF
--- a/clients/shared/Network/EventStreamClient.swift
+++ b/clients/shared/Network/EventStreamClient.swift
@@ -507,18 +507,18 @@ public final class EventStreamClient {
         var jsonString = data
 
         // Remap server conversation IDs to client-local conversation IDs.
-        // When a mapping exists (HTTP response already processed), use it directly.
-        // Otherwise, if there's exactly one pending send, speculatively remap to
-        // that local ID — the server likely assigned a new ID that we haven't
-        // mapped yet.  Pre-register the mapping so subsequent events in the same
-        // window are handled by the fast path above.
-        // Track the final (remapped) conversation ID for broadcast filtering.
+        // Speculative remap is gated on user_message_echo so background and
+        // scheduled conversations — which never emit user_message_echo —
+        // can't pollute the map with their conversationId during the window
+        // between sendUserMessage and the HTTP 202 response.
         var broadcastConversationId: String?
         if let conversationId = extractJsonStringValue(from: jsonString, key: "conversationId") {
+            let eventType = extractJsonStringValue(from: jsonString, key: "type")
             let localId: String?
             if let mapped = serverToLocalConversationMap[conversationId] {
                 localId = mapped
-            } else if !locallyOwnedConversationIds.contains(conversationId),
+            } else if eventType == "user_message_echo",
+                      !locallyOwnedConversationIds.contains(conversationId),
                       pendingMappingLocalIds.count == 1,
                       let pendingLocalId = pendingMappingLocalIds.first {
                 localId = pendingLocalId


### PR DESCRIPTION
## Summary
- Background or scheduled conversations whose SSE events arrived during the pending window of an active sendUserMessage were being mis-mapped onto the user's active conversation, interleaving the two streams in the chat view until the app was restarted.
- Gate the speculative remap in EventStreamClient.parseSSEData on the event type being user_message_echo. Background/scheduled wakes inject system hints, not user messages, so they never emit user_message_echo and can no longer pollute serverToLocalConversationMap.

## Original prompt
it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->