### PR TITLE
feat(macos): add ProComputeUpgradeSection for Pro managed-assistant compute upgrade

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
@@ -139,8 +139,12 @@ struct ProComputeUpgradeSection: View {
         do {
             let (success, detail) = try await proUpgradeMachine(assistantId)
             if success {
-                let refreshed = await fetchDetail(assistantId)
-                machineSize = refreshed?.machine_size
+                // Server confirmed the upgrade — optimistically dismiss the CTA so a
+                // flaky re-fetch can't regress the card back into the visible state.
+                machineSize = "medium"
+                if let refreshed = await fetchDetail(assistantId), let actual = refreshed.machine_size {
+                    machineSize = actual
+                }
                 onUpgradeComplete()
             } else {
                 upgradeError = detail ?? "Failed to upgrade compute profile. Please try again."

--- a/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
@@ -42,7 +42,8 @@ struct ProComputeUpgradeSection: View {
                 upgradeCard
             }
         }
-        .task {
+        .task(id: "\(assistantId):\(subscription?.plan_id ?? "")") {
+            isLoadingMachineSize = true
             guard isPro else {
                 isLoadingMachineSize = false
                 return

--- a/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ProComputeUpgradeSection")
+
+/// Inline upgrade card prompting Pro subscribers to migrate their managed
+/// assistant to the larger compute profile that ships with the Pro plan.
+///
+/// The card only renders when:
+/// - the user holds an active Pro subscription (`subscription.plan_id == "pro"`),
+/// - the assistant's admin detail has loaded, and
+/// - the assistant is still on the default `small` machine size (or the field
+///   is `nil`, meaning the platform hasn't recorded one yet — treat as small).
+///
+/// The admin-detail fetch is intentionally gated on `isPro` so non-Pro users
+/// never trigger the network call.
+@MainActor
+struct ProComputeUpgradeSection: View {
+    let assistantId: String
+    let subscription: SubscriptionResponse?
+    let onUpgradeComplete: () -> Void
+
+    /// Closure-injected so tests can substitute fakes without touching the
+    /// network. Defaults wire through the production `AdminAssistantClient`.
+    var fetchDetail: (String) async -> AdminAssistantDetailResponse? = AdminAssistantClient.fetchDetail
+    var proUpgradeMachine: (String) async throws -> (Bool, String?) = AdminAssistantClient.proUpgradeMachine
+
+    @State var machineSize: String? = nil
+    @State var isLoadingMachineSize: Bool = true
+    @State var showConfirmation: Bool = false
+    @State var isUpgrading: Bool = false
+    @State var upgradeError: String? = nil
+
+    var isPro: Bool { subscription?.plan_id == "pro" }
+    var needsUpgrade: Bool { machineSize == nil || machineSize == "small" }
+    var shouldShowCard: Bool { isPro && !isLoadingMachineSize && needsUpgrade }
+
+    var body: some View {
+        Group {
+            if shouldShowCard {
+                upgradeCard
+            }
+        }
+        .task {
+            guard isPro else {
+                isLoadingMachineSize = false
+                return
+            }
+            let detail = await fetchDetail(assistantId)
+            machineSize = detail?.machine_size
+            isLoadingMachineSize = false
+        }
+    }
+
+    private var upgradeCard: some View {
+        SettingsCard(
+            title: "Compute Profile",
+            subtitle: "Your Pro plan includes a larger compute profile with more CPU and memory."
+        ) {
+            HStack(spacing: VSpacing.sm) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Current")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text("Small")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentDefault)
+                }
+
+                VIconView(.chevronRight, size: 14)
+                    .foregroundStyle(VColor.contentTertiary)
+
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Available")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.contentTertiary)
+                    Text("Medium (Pro)")
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(VColor.contentEmphasized)
+                }
+
+                Spacer()
+
+                if showConfirmation {
+                    VButton(
+                        label: "Cancel",
+                        style: .ghost,
+                        isDisabled: isUpgrading
+                    ) {
+                        showConfirmation = false
+                    }
+                }
+
+                VButton(
+                    label: showConfirmation ? "Confirm Upgrade" : "Upgrade Compute",
+                    style: showConfirmation ? .primary : .outlined,
+                    isDisabled: isUpgrading
+                ) {
+                    if showConfirmation {
+                        Task { await performUpgrade() }
+                    } else {
+                        showConfirmation = true
+                    }
+                }
+            }
+
+            if showConfirmation {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.triangleAlert, size: 13)
+                        .foregroundStyle(VColor.systemMidStrong)
+                    Text("Your assistant will be briefly unreachable while it restarts with the new compute profile.")
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemMidStrong)
+                }
+            }
+
+            if let upgradeError {
+                HStack(spacing: VSpacing.xs) {
+                    VIconView(.circleAlert, size: 13)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                    Text(upgradeError)
+                        .font(VFont.labelDefault)
+                        .foregroundStyle(VColor.systemNegativeStrong)
+                }
+            }
+        }
+    }
+
+    private func performUpgrade() async {
+        isUpgrading = true
+        upgradeError = nil
+        defer {
+            isUpgrading = false
+            showConfirmation = false
+        }
+
+        do {
+            let (success, detail) = try await proUpgradeMachine(assistantId)
+            if success {
+                let refreshed = await fetchDetail(assistantId)
+                machineSize = refreshed?.machine_size
+                onUpgradeComplete()
+            } else {
+                upgradeError = detail ?? "Failed to upgrade compute profile. Please try again."
+            }
+        } catch {
+            log.error("proUpgradeMachine threw: \(error.localizedDescription, privacy: .public)")
+            upgradeError = "Failed to upgrade compute profile. Please try again."
+        }
+    }
+}
+
+// MARK: - Test Support
+
+#if DEBUG
+extension ProComputeUpgradeSection {
+    /// Test-only initializer that pre-populates `@State` so tests can assert
+    /// on derived display properties without driving the `.task { ... }`
+    /// network fetch. Mirrors the pattern in `SettingsBillingTab.init(...)`.
+    init(
+        assistantId: String,
+        subscription: SubscriptionResponse?,
+        initialMachineSize: String?,
+        initialIsLoading: Bool,
+        onUpgradeComplete: @escaping () -> Void = {},
+        fetchDetail: @escaping (String) async -> AdminAssistantDetailResponse? = AdminAssistantClient.fetchDetail,
+        proUpgradeMachine: @escaping (String) async throws -> (Bool, String?) = AdminAssistantClient.proUpgradeMachine
+    ) {
+        self.assistantId = assistantId
+        self.subscription = subscription
+        self.onUpgradeComplete = onUpgradeComplete
+        self.fetchDetail = fetchDetail
+        self.proUpgradeMachine = proUpgradeMachine
+        self._machineSize = State(initialValue: initialMachineSize)
+        self._isLoadingMachineSize = State(initialValue: initialIsLoading)
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
@@ -49,6 +49,7 @@ struct ProComputeUpgradeSection: View {
                 return
             }
             let detail = await fetchDetail(assistantId)
+            guard !Task.isCancelled else { return }
             machineSize = detail?.machine_size
             isLoadingMachineSize = false
         }
@@ -101,6 +102,7 @@ struct ProComputeUpgradeSection: View {
                     if showConfirmation {
                         Task { await performUpgrade() }
                     } else {
+                        upgradeError = nil
                         showConfirmation = true
                     }
                 }

--- a/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
@@ -102,4 +102,30 @@ final class ProComputeUpgradeSectionTests: XCTestCase {
         )
         XCTAssertFalse(section.shouldShowCard)
     }
+
+    /// When `subscription` transitions from base/nil to Pro after the view
+    /// has mounted, the view's `.task(id:)` re-runs and resets
+    /// `isLoadingMachineSize = true` before fetching `machine_size`. While
+    /// that fetch is in flight, `shouldShowCard` must remain false so we
+    /// don't flash an upgrade CTA for an assistant that may already be on
+    /// medium/large. This documents the invariant enforced by keying the
+    /// task on `assistantId + subscription.plan_id` and resetting the
+    /// loading flag at the top of the task body.
+    func testTransitionFromBaseToProDoesNotShowStaleCardWhileLoading() {
+        let baseSection = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeBaseSubscription(),
+            initialMachineSize: nil,
+            initialIsLoading: false
+        )
+        XCTAssertFalse(baseSection.shouldShowCard)
+
+        let proLoadingSection = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeProSubscription(),
+            initialMachineSize: nil,
+            initialIsLoading: true
+        )
+        XCTAssertFalse(proLoadingSection.shouldShowCard)
+    }
 }

--- a/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
@@ -111,6 +111,25 @@ final class ProComputeUpgradeSectionTests: XCTestCase {
     /// medium/large. This documents the invariant enforced by keying the
     /// task on `assistantId + subscription.plan_id` and resetting the
     /// loading flag at the top of the task body.
+    /// Documents the optimistic-dismiss invariant in `performUpgrade()`: once
+    /// the server confirms the upgrade, the section sets `machineSize =
+    /// "medium"` *before* the best-effort re-fetch. Even if the re-fetch
+    /// returns nil (transient network error / vembda race), the CTA must stay
+    /// dismissed because `machineSize == "medium"` makes `needsUpgrade` false.
+    /// We can't drive `performUpgrade()` directly from a test (it's private and
+    /// the `@State` mutations require a live view), so we assert on the post-
+    /// condition: a Pro user on `"medium"` never shows the upgrade card,
+    /// regardless of whether a follow-up admin-detail fetch ever lands.
+    func testOptimisticMachineSizeAfterSuccessfulUpgrade() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeProSubscription(),
+            initialMachineSize: "medium",
+            initialIsLoading: false
+        )
+        XCTAssertFalse(section.shouldShowCard)
+    }
+
     func testTransitionFromBaseToProDoesNotShowStaleCardWhileLoading() {
         let baseSection = ProComputeUpgradeSection(
             assistantId: "asst-1",

--- a/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Behavioral tests for `ProComputeUpgradeSection`. Asserts on the derived
+/// `shouldShowCard` view-model property across the matrix of subscription /
+/// machine-size / loading combinations rather than inspecting the SwiftUI
+/// tree (the test target doesn't depend on ViewInspector).
+@MainActor
+final class ProComputeUpgradeSectionTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeProSubscription() -> SubscriptionResponse {
+        SubscriptionResponse(
+            plan_id: "pro",
+            status: "active",
+            current_period_end: "2026-06-01T00:00:00Z",
+            cancel_at_period_end: false,
+            cancel_at: nil
+        )
+    }
+
+    private func makeBaseSubscription() -> SubscriptionResponse {
+        SubscriptionResponse(
+            plan_id: "base",
+            status: nil,
+            current_period_end: nil,
+            cancel_at_period_end: false,
+            cancel_at: nil
+        )
+    }
+
+    // MARK: - shouldShowCard matrix
+
+    func testProUserWithNilMachineSizeShowsCard() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeProSubscription(),
+            initialMachineSize: nil,
+            initialIsLoading: false
+        )
+        XCTAssertTrue(section.shouldShowCard)
+    }
+
+    func testProUserWithSmallMachineSizeShowsCard() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeProSubscription(),
+            initialMachineSize: "small",
+            initialIsLoading: false
+        )
+        XCTAssertTrue(section.shouldShowCard)
+    }
+
+    func testBaseUserDoesNotShowCard() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeBaseSubscription(),
+            initialMachineSize: "small",
+            initialIsLoading: false
+        )
+        XCTAssertFalse(section.shouldShowCard)
+    }
+
+    func testProUserOnMediumDoesNotShowCard() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeProSubscription(),
+            initialMachineSize: "medium",
+            initialIsLoading: false
+        )
+        XCTAssertFalse(section.shouldShowCard)
+    }
+
+    func testProUserOnLargeDoesNotShowCard() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeProSubscription(),
+            initialMachineSize: "large",
+            initialIsLoading: false
+        )
+        XCTAssertFalse(section.shouldShowCard)
+    }
+
+    func testWhileLoadingDoesNotShowCard() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: makeProSubscription(),
+            initialMachineSize: nil,
+            initialIsLoading: true
+        )
+        XCTAssertFalse(section.shouldShowCard)
+    }
+
+    func testNilSubscriptionDoesNotShowCard() {
+        let section = ProComputeUpgradeSection(
+            assistantId: "asst-1",
+            subscription: nil,
+            initialMachineSize: "small",
+            initialIsLoading: false
+        )
+        XCTAssertFalse(section.shouldShowCard)
+    }
+}


### PR DESCRIPTION
## Summary
- New `ProComputeUpgradeSection` SwiftUI view rendering an inline Confirm/Cancel CTA when a Pro user's managed assistant is on the default (small) compute profile.
- Closure-injected network calls + DEBUG test-only init so tests can drive display state directly (mirrors the SettingsBillingTab test-only-init pattern).
- View-model tests covering all show/hide branches (pro+nil, pro+small, base, medium, large, loading, nil-subscription).

Part of plan: pro-compute-upgrade-cta.md (PR 2 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->