### PR TITLE
fix(benchmarks): unstick CI Benchmark Regression Detection

### DIFF
--- a/assistant/src/__tests__/conversation-init.benchmark.test.ts
+++ b/assistant/src/__tests__/conversation-init.benchmark.test.ts
@@ -465,7 +465,7 @@ describe("End-to-end session creation benchmark", () => {
       timings.push(performance.now() - start);
 
       if (i === 0) {
-        expect(session.eventBus.listenerCount()).toBeGreaterThan(0);
+        expect(session.eventBus.anyListenerCount()).toBeGreaterThan(0);
       }
       session.dispose();
     }

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -30,16 +30,6 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Allow toggling between no-rule and matched-rule paths
-let mockRuleResponse: import("../permissions/types.js").TrustRule | null = null;
-
-mock.module("../permissions/trust-store.js", () => ({
-  addRule: () => {},
-  findHighestPriorityRule: () => mockRuleResponse,
-  onRulesChanged: () => {},
-  clearCache: () => {},
-}));
-
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
@@ -300,38 +290,6 @@ describe("Tool execution pipeline benchmark", () => {
     expect(p95).toBeLessThan(50);
     // git status is low risk, should auto-allow
     expect(results[0].decision).toBe("allow");
-  });
-
-  test("check: matched allow-rule path for medium-risk tool", async () => {
-    // Exercise the code path where findHighestPriorityRule returns a matching
-    // allow rule, rather than always falling through to the no-rule default.
-    mockRuleResponse = {
-      id: "bench:allow-file_write",
-      tool: "file_write",
-      pattern: "**",
-      scope: "/tmp",
-      decision: "allow",
-      priority: 90,
-      createdAt: Date.now(),
-    };
-
-    try {
-      const { timings, results } = await benchmarkAsync(
-        () => check("file_write", { path: "/tmp/out.txt" }, "/tmp"),
-        ITERATIONS,
-      );
-
-      const p50 = percentile(timings, 50);
-      const p95 = percentile(timings, 95);
-
-      expect(p50).toBeLessThan(10);
-      expect(p95).toBeLessThan(20);
-      // Medium-risk with a matching allow rule should auto-allow
-      expect(results[0].decision).toBe("allow");
-      expect(results[0].matchedRule?.id).toBe("bench:allow-file_write");
-    } finally {
-      mockRuleResponse = null;
-    }
   });
 
   test("check: permission cost is stable across different input paths", async () => {


### PR DESCRIPTION
## Summary
- `conversation-init`: switch to `anyListenerCount()` — the `Conversation` constructor registers all four telemetry listeners via `eventBus.onAny`, so `listenerCount()` (which counts direct listeners only) was always 0.
- `tool-execution-pipeline`: drop the dead "matched allow-rule path" test and its `mockRuleResponse` / `trust-store` stub. Trust rules moved to the gateway in #28376; the daemon's `check()` no longer pulls rules and never sets `matchedRule`, so the assertion `results[0].matchedRule?.id === "bench:allow-file_write"` could not pass. `approval-policy.test.ts` already covers the matched-rule branch directly.

## Original prompt
Fix the specific failing CI job at https://github.com/vellum-ai/vellum-assistant/actions/runs/25409797444/job/74528743274 (CI Benchmark Regression Detection → Run Benchmarks on `main`). Two benchmark assertions had drifted from the current architecture after trust rules moved to the gateway and the event bus listeners switched to `onAny`. Scope kept to unsticking that single job — no other refactors.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->