### PR TITLE
chore(feature-flags): drop pro-plan-adjust and auto-credit-topup definitions

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -280,22 +280,6 @@
       "label": "Analyze Conversation",
       "description": "Show the 'Analyze' / 'Analyze conversation' option in conversation context menus and the conversation title actions dropdown.",
       "defaultEnabled": false
-    },
-    {
-      "id": "pro-plan-adjust",
-      "scope": "assistant",
-      "key": "pro-plan-adjust",
-      "label": "Pro Plan Adjust",
-      "description": "Show the rich Plan card (current plan, features, Manage/Upgrade CTA) at the top of the macOS Settings → Billing tab. The 'Configure Auto Top Ups' CTA is gated separately on `auto-credit-topup`.",
-      "defaultEnabled": false
-    },
-    {
-      "id": "auto-credit-topup",
-      "scope": "assistant",
-      "key": "auto-credit-topup",
-      "label": "Auto Credit Top-Up",
-      "description": "Show the 'Configure Auto Top Ups' CTA in the macOS Settings → Billing tab. Mirrors the platform web flag of the same name that gates the auto-reload card and /v1/organizations/billing/auto-top-up/ API.",
-      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove the two graduated billing feature flags (`pro-plan-adjust`, `auto-credit-topup`) from the canonical `meta/feature-flags/feature-flag-registry.json`.
- Re-run `meta/feature-flags/sync-bundled-copies.ts` to regenerate the gateway and assistant bundled copies.
- Verify no remaining references to either flag id remain in the repo (PR 1 graduated the macOS UI; PR 2 cleaned the doc comments).

Part of plan: remove-billing-feature-flags.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->