### PR TITLE
Pass staging environment to release Playwright runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2579,6 +2579,7 @@ jobs:
         id: trigger
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PLAYWRIGHT_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'auto' }}
         run: |
           SOURCE="run:${{ github.run_id }}"
           BEFORE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -2589,9 +2590,9 @@ jobs:
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/vellum-ai/vellum-assistant-platform/actions/workflows/playwright.yaml/dispatches" \
-            -d "{\"ref\":\"main\",\"inputs\":{\"source\":\"$SOURCE\",\"shards\":\"4\",\"test_filter\":\"critical\"}}"
+            -d "{\"ref\":\"main\",\"inputs\":{\"source\":\"$SOURCE\",\"environment\":\"$PLAYWRIGHT_ENVIRONMENT\",\"shards\":\"4\",\"test_filter\":\"critical\"}}"
 
-          echo "Triggered playwright workflow with source $SOURCE"
+          echo "Triggered playwright workflow with source $SOURCE and environment $PLAYWRIGHT_ENVIRONMENT"
           sleep 15
 
       - name: Wait for Playwright workflow result


### PR DESCRIPTION
## Summary
- include the Playwright environment input when the release workflow dispatches platform QA
- send staging for staging releases and keep auto for non-staging releases
- log the resolved environment alongside the run source

## Verification
- git diff --check -- .github/workflows/release.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->