### PR TITLE
feat(macos): show Pro compute upgrade CTA on Settings → General for managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -129,15 +129,14 @@ struct SettingsGeneralTab: View {
                 await fetchHealthz()
                 await refreshAssistantSwitcherItems()
             }
-            Task {
-                if let sub = try? await BillingService.shared.getSubscription() {
-                    subscription = sub
-                }
-            }
+            Task { await refreshSubscription() }
             recordSystemResourcesDeepLinkIfNeeded(store.pendingSettingsGeneralSection)
         }
         .onChange(of: authManager.isAuthenticated) { _, _ in
-            Task { await refreshAssistantSwitcherItems() }
+            Task {
+                await refreshAssistantSwitcherItems()
+                await refreshSubscription()
+            }
         }
         .onChange(of: store.pendingSettingsGeneralSection) { _, section in
             recordSystemResourcesDeepLinkIfNeeded(section)
@@ -292,6 +291,10 @@ struct SettingsGeneralTab: View {
             settingsGeneralLog.warning("Failed to refresh assistant switcher: \(error.localizedDescription, privacy: .public)")
             assistantSwitcherError = "Could not load assistants."
         }
+    }
+
+    private func refreshSubscription() async {
+        subscription = (try? await BillingService.shared.getSubscription())
     }
 
     private func switchAssistantFromVersionCard(assistantId: String) async {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -156,6 +156,7 @@ struct SettingsGeneralTab: View {
                 await refreshLockfileAssistants()
                 await fetchHealthz()
                 await refreshAssistantSwitcherItems()
+                await refreshSubscription()
             }
         }
         .sheet(isPresented: $isDockerOperationInProgress) {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -38,6 +38,7 @@ struct SettingsGeneralTab: View {
     @State private var healthzLoaded = false
     @State private var isRefreshingHealthz = false
     @State private var systemResourcesDeepLinkRequested = false
+    @State private var subscription: SubscriptionResponse? = nil
 
 
     private var currentAssistant: LockfileAssistant? {
@@ -86,6 +87,15 @@ struct SettingsGeneralTab: View {
             if shouldShowSystemResourcesSection {
                 systemResourcesSection
             }
+            if topology == .managed, let assistant = currentAssistant {
+                ProComputeUpgradeSection(
+                    assistantId: assistant.assistantId,
+                    subscription: subscription,
+                    onUpgradeComplete: {
+                        Task { await fetchHealthz() }
+                    }
+                )
+            }
             if MacOSClientFeatureFlagManager.shared.isEnabled("teleport"),
                let assistant = currentAssistant,
                !assistant.isRemote || assistant.isDocker || assistant.isManaged {
@@ -118,6 +128,11 @@ struct SettingsGeneralTab: View {
                 await refreshLockfileAssistants()
                 await fetchHealthz()
                 await refreshAssistantSwitcherItems()
+            }
+            Task {
+                if let sub = try? await BillingService.shared.getSubscription() {
+                    subscription = sub
+                }
             }
             recordSystemResourcesDeepLinkIfNeeded(store.pendingSettingsGeneralSection)
         }


### PR DESCRIPTION
## Summary
- Adds a non-blocking subscription fetch on the Settings → General tab and instantiates `ProComputeUpgradeSection` between Storage & Resources and Teleport for managed assistants.
- The card self-gates on (Pro plan + managed topology + machine_size in {nil, small}); for any other combination the section renders nothing and no admin-detail API call is made.

Part of plan: pro-compute-upgrade-cta.md (PR 3 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->