### PR TITLE
fix(macos): address self-review findings on Pro compute upgrade flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ProComputeUpgradeSection.swift
@@ -1,30 +1,11 @@
 import SwiftUI
 import VellumAssistantShared
-import os
 
-private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ProComputeUpgradeSection")
-
-/// Inline upgrade card prompting Pro subscribers to migrate their managed
-/// assistant to the larger compute profile that ships with the Pro plan.
-///
-/// The card only renders when:
-/// - the user holds an active Pro subscription (`subscription.plan_id == "pro"`),
-/// - the assistant's admin detail has loaded, and
-/// - the assistant is still on the default `small` machine size (or the field
-///   is `nil`, meaning the platform hasn't recorded one yet — treat as small).
-///
-/// The admin-detail fetch is intentionally gated on `isPro` so non-Pro users
-/// never trigger the network call.
 @MainActor
 struct ProComputeUpgradeSection: View {
     let assistantId: String
     let subscription: SubscriptionResponse?
     let onUpgradeComplete: () -> Void
-
-    /// Closure-injected so tests can substitute fakes without touching the
-    /// network. Defaults wire through the production `AdminAssistantClient`.
-    var fetchDetail: (String) async -> AdminAssistantDetailResponse? = AdminAssistantClient.fetchDetail
-    var proUpgradeMachine: (String) async throws -> (Bool, String?) = AdminAssistantClient.proUpgradeMachine
 
     @State var machineSize: String? = nil
     @State var isLoadingMachineSize: Bool = true
@@ -48,7 +29,7 @@ struct ProComputeUpgradeSection: View {
                 isLoadingMachineSize = false
                 return
             }
-            let detail = await fetchDetail(assistantId)
+            let detail = await AdminAssistantClient.fetchDetail(assistantId: assistantId)
             guard !Task.isCancelled else { return }
             machineSize = detail?.machine_size
             isLoadingMachineSize = false
@@ -133,27 +114,22 @@ struct ProComputeUpgradeSection: View {
     private func performUpgrade() async {
         isUpgrading = true
         upgradeError = nil
-        defer {
-            isUpgrading = false
-            showConfirmation = false
-        }
+        defer { isUpgrading = false }
 
-        do {
-            let (success, detail) = try await proUpgradeMachine(assistantId)
-            if success {
-                // Server confirmed the upgrade — optimistically dismiss the CTA so a
-                // flaky re-fetch can't regress the card back into the visible state.
-                machineSize = "medium"
-                if let refreshed = await fetchDetail(assistantId), let actual = refreshed.machine_size {
-                    machineSize = actual
-                }
-                onUpgradeComplete()
-            } else {
-                upgradeError = detail ?? "Failed to upgrade compute profile. Please try again."
+        let (success, detail) = await AdminAssistantClient.proUpgradeMachine(assistantId: assistantId)
+        if success {
+            // Optimistically dismiss before the re-fetch — a stale GET that still
+            // returns "small" must not regress the card back into view.
+            machineSize = "medium"
+            if let refreshed = await AdminAssistantClient.fetchDetail(assistantId: assistantId),
+               let actual = refreshed.machine_size,
+               actual != "small" {
+                machineSize = actual
             }
-        } catch {
-            log.error("proUpgradeMachine threw: \(error.localizedDescription, privacy: .public)")
-            upgradeError = "Failed to upgrade compute profile. Please try again."
+            showConfirmation = false
+            onUpgradeComplete()
+        } else {
+            upgradeError = detail ?? "Failed to upgrade compute profile. Please try again."
         }
     }
 }
@@ -162,23 +138,16 @@ struct ProComputeUpgradeSection: View {
 
 #if DEBUG
 extension ProComputeUpgradeSection {
-    /// Test-only initializer that pre-populates `@State` so tests can assert
-    /// on derived display properties without driving the `.task { ... }`
-    /// network fetch. Mirrors the pattern in `SettingsBillingTab.init(...)`.
     init(
         assistantId: String,
         subscription: SubscriptionResponse?,
         initialMachineSize: String?,
         initialIsLoading: Bool,
-        onUpgradeComplete: @escaping () -> Void = {},
-        fetchDetail: @escaping (String) async -> AdminAssistantDetailResponse? = AdminAssistantClient.fetchDetail,
-        proUpgradeMachine: @escaping (String) async throws -> (Bool, String?) = AdminAssistantClient.proUpgradeMachine
+        onUpgradeComplete: @escaping () -> Void = {}
     ) {
         self.assistantId = assistantId
         self.subscription = subscription
         self.onUpgradeComplete = onUpgradeComplete
-        self.fetchDetail = fetchDetail
-        self.proUpgradeMachine = proUpgradeMachine
         self._machineSize = State(initialValue: initialMachineSize)
         self._isLoadingMachineSize = State(initialValue: initialIsLoading)
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsGeneralTab.swift
@@ -132,10 +132,14 @@ struct SettingsGeneralTab: View {
             Task { await refreshSubscription() }
             recordSystemResourcesDeepLinkIfNeeded(store.pendingSettingsGeneralSection)
         }
-        .onChange(of: authManager.isAuthenticated) { _, _ in
+        .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             Task {
                 await refreshAssistantSwitcherItems()
-                await refreshSubscription()
+                if !isAuthenticated {
+                    subscription = nil
+                } else {
+                    await refreshSubscription()
+                }
             }
         }
         .onChange(of: store.pendingSettingsGeneralSection) { _, section in
@@ -295,7 +299,9 @@ struct SettingsGeneralTab: View {
     }
 
     private func refreshSubscription() async {
-        subscription = (try? await BillingService.shared.getSubscription())
+        if let sub = try? await BillingService.shared.getSubscription() {
+            subscription = sub
+        }
     }
 
     private func switchAssistantFromVersionCard(assistantId: String) async {

--- a/clients/macos/vellum-assistantTests/AdminAssistantClientDecodingTests.swift
+++ b/clients/macos/vellum-assistantTests/AdminAssistantClientDecodingTests.swift
@@ -1,13 +1,8 @@
 import XCTest
 @testable import VellumAssistantShared
 
-/// Wire-protocol decoding tests for `AdminAssistantDetailResponse`.
-///
-/// These lock in the byte-for-byte JSON shape produced by the Django admin
-/// assistant detail serializer. Any drift in the `machine_size` field name or
-/// type on the server side will fail decoding here.
 final class AdminAssistantClientDecodingTests: XCTestCase {
-    func testDecodesSmallMachineSize() throws {
+    func testDecodesMachineSizeField() throws {
         let json = """
         { "machine_size": "small" }
         """.data(using: .utf8)!
@@ -15,29 +10,5 @@ final class AdminAssistantClientDecodingTests: XCTestCase {
         let decoded = try JSONDecoder().decode(AdminAssistantDetailResponse.self, from: json)
 
         XCTAssertEqual(decoded.machine_size, "small")
-    }
-
-    func testDecodesNullMachineSize() throws {
-        let json = """
-        { "machine_size": null }
-        """.data(using: .utf8)!
-
-        let decoded = try JSONDecoder().decode(AdminAssistantDetailResponse.self, from: json)
-
-        XCTAssertNil(decoded.machine_size)
-    }
-
-    func testIgnoresExtraFieldsInServerPayload() throws {
-        let json = """
-        {
-            "id": "asst_x",
-            "name": "x",
-            "machine_size": "medium"
-        }
-        """.data(using: .utf8)!
-
-        let decoded = try JSONDecoder().decode(AdminAssistantDetailResponse.self, from: json)
-
-        XCTAssertEqual(decoded.machine_size, "medium")
     }
 }

--- a/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
@@ -103,23 +103,6 @@ final class ProComputeUpgradeSectionTests: XCTestCase {
         XCTAssertFalse(section.shouldShowCard)
     }
 
-    /// When `subscription` transitions from base/nil to Pro after the view
-    /// has mounted, the view's `.task(id:)` re-runs and resets
-    /// `isLoadingMachineSize = true` before fetching `machine_size`. While
-    /// that fetch is in flight, `shouldShowCard` must remain false so we
-    /// don't flash an upgrade CTA for an assistant that may already be on
-    /// medium/large. This documents the invariant enforced by keying the
-    /// task on `assistantId + subscription.plan_id` and resetting the
-    /// loading flag at the top of the task body.
-    /// Documents the optimistic-dismiss invariant in `performUpgrade()`: once
-    /// the server confirms the upgrade, the section sets `machineSize =
-    /// "medium"` *before* the best-effort re-fetch. Even if the re-fetch
-    /// returns nil (transient network error / vembda race), the CTA must stay
-    /// dismissed because `machineSize == "medium"` makes `needsUpgrade` false.
-    /// We can't drive `performUpgrade()` directly from a test (it's private and
-    /// the `@State` mutations require a live view), so we assert on the post-
-    /// condition: a Pro user on `"medium"` never shows the upgrade card,
-    /// regardless of whether a follow-up admin-detail fetch ever lands.
     func testOptimisticMachineSizeAfterSuccessfulUpgrade() {
         let section = ProComputeUpgradeSection(
             assistantId: "asst-1",

--- a/clients/shared/Network/AdminAssistantClient.swift
+++ b/clients/shared/Network/AdminAssistantClient.swift
@@ -3,27 +3,11 @@ import os
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "AdminAssistantClient")
 
-/// Response payload from `GET /v1/admin/assistants/{id}/`.
-///
-/// Only the field consumed by the macOS client is declared. The Django
-/// serializer returns additional fields (id, name, etc.); `JSONDecoder`
-/// ignores undeclared keys so the lenient shape survives server additions.
 public struct AdminAssistantDetailResponse: Decodable, Sendable {
     public let machine_size: String?
 }
 
-/// Focused client for admin-assistant operations routed through the platform.
-///
-/// Wraps the platform-scoped admin endpoints used by the Pro compute-upgrade
-/// CTA in Settings. Both methods target unprefixed routes (no
-/// `assistants/{assistantId}/` scope) because the path itself carries the
-/// assistant id.
 public enum AdminAssistantClient {
-    /// Fetches admin metadata for the given assistant.
-    ///
-    /// Returns `nil` on any error (network, non-2xx, decoding) so callers can
-    /// treat "unknown" as "show nothing" rather than surfacing transient
-    /// failures in the UI.
     public static func fetchDetail(assistantId: String) async -> AdminAssistantDetailResponse? {
         do {
             let (decoded, response): (AdminAssistantDetailResponse?, GatewayHTTPClient.Response) =
@@ -43,23 +27,23 @@ public enum AdminAssistantClient {
         }
     }
 
-    /// Triggers the platform's pro-upgrade-machine flow for the given assistant.
-    ///
-    /// The 60-second timeout is intentional — the platform performs two
-    /// sequential vembda calls which can be slow. Returns the success flag
-    /// alongside the server-provided `detail` string (when present) so the
-    /// caller can render either a confirmation or error message.
-    public static func proUpgradeMachine(assistantId: String) async throws -> (success: Bool, detail: String?) {
-        let response = try await GatewayHTTPClient.post(
-            path: "admin/assistants/\(assistantId)/pro-upgrade-machine/",
-            json: [:],
-            timeout: 60,
-            unprefixed: true
-        )
-        let detail = (try? JSONSerialization.jsonObject(with: response.data) as? [String: Any])?["detail"] as? String
-        if !response.isSuccess {
-            log.error("proUpgradeMachine failed (HTTP \(response.statusCode))")
+    /// Two sequential vembda calls — give the platform a full minute.
+    public static func proUpgradeMachine(assistantId: String) async -> (success: Bool, detail: String?) {
+        do {
+            let response = try await GatewayHTTPClient.post(
+                path: "admin/assistants/\(assistantId)/pro-upgrade-machine/",
+                json: [:],
+                timeout: 60,
+                unprefixed: true
+            )
+            let detail = (try? JSONSerialization.jsonObject(with: response.data) as? [String: Any])?["detail"] as? String
+            if !response.isSuccess {
+                log.error("proUpgradeMachine failed (HTTP \(response.statusCode))")
+            }
+            return (response.isSuccess, detail)
+        } catch {
+            log.error("proUpgradeMachine error: \(error.localizedDescription, privacy: .public)")
+            return (false, nil)
         }
-        return (response.isSuccess, detail)
     }
 }


### PR DESCRIPTION
## Summary
Bundled remediation of 8 self-review findings on the Pro compute upgrade plan. Targets the feature branch directly.

- Eventual-consistency `actual != \"small\"` guard in `performUpgrade`
- `refreshSubscription` preserves state on transient errors; auth handler clears on logout
- `performUpgrade` keeps Confirm/Cancel state visible on failure
- Removed unused closure-injection seam (`fetchDetail`/`proUpgradeMachine` vars + DEBUG init params)
- Dropped `throws` on `AdminAssistantClient.proUpgradeMachine` — both error branches collapsed to the same UX
- Trimmed oversized doc comments; deleted misplaced test docs
- Simplified `AdminAssistantClientDecodingTests` to one happy-path test

Plan: pro-compute-upgrade-cta.md (self-review remediation round 1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->