### PR TITLE
test(macos): delete duplicate Pro compute upgrade tests

### DIFF
--- a/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
+++ b/clients/macos/vellum-assistantTests/ProComputeUpgradeSectionTests.swift
@@ -102,32 +102,4 @@ final class ProComputeUpgradeSectionTests: XCTestCase {
         )
         XCTAssertFalse(section.shouldShowCard)
     }
-
-    func testOptimisticMachineSizeAfterSuccessfulUpgrade() {
-        let section = ProComputeUpgradeSection(
-            assistantId: "asst-1",
-            subscription: makeProSubscription(),
-            initialMachineSize: "medium",
-            initialIsLoading: false
-        )
-        XCTAssertFalse(section.shouldShowCard)
-    }
-
-    func testTransitionFromBaseToProDoesNotShowStaleCardWhileLoading() {
-        let baseSection = ProComputeUpgradeSection(
-            assistantId: "asst-1",
-            subscription: makeBaseSubscription(),
-            initialMachineSize: nil,
-            initialIsLoading: false
-        )
-        XCTAssertFalse(baseSection.shouldShowCard)
-
-        let proLoadingSection = ProComputeUpgradeSection(
-            assistantId: "asst-1",
-            subscription: makeProSubscription(),
-            initialMachineSize: nil,
-            initialIsLoading: true
-        )
-        XCTAssertFalse(proLoadingSection.shouldShowCard)
-    }
 }


### PR DESCRIPTION
## Summary
Round-2 self-review remediation: drop two duplicate tests in `ProComputeUpgradeSectionTests.swift`.

Plan: pro-compute-upgrade-cta.md (round 2 cleanup)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->