### PR TITLE
fix(memory): route v2 alone and remove foreground retrieval budget

### DIFF
--- a/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
+++ b/assistant/src/__tests__/memory-retrieval-pipeline.test.ts
@@ -158,38 +158,25 @@ describe("runDefaultMemoryRetrieval", () => {
     expect(result.nowContent).toBe("now-default");
   });
 
-  test("soft-times out graph retrieval and keeps PKB/NOW", async () => {
-    let capturedSignal: AbortSignal | undefined;
-    const hangingPrepare = mock(
+  test("propagates errors from prepareMemory rather than swallowing them", async () => {
+    // Memory is critical — failures must surface to the caller (the agent
+    // loop) rather than silently degrading to an empty memory block.
+    const failingPrepare = mock(
       (
         _msgs: Message[],
         _cfg: AssistantConfig,
-        signal: AbortSignal,
+        _signal: AbortSignal,
         _onEvent: (msg: ServerMessage) => void,
-      ) => {
-        capturedSignal = signal;
-        return new Promise((_resolve, reject) => {
-          signal.addEventListener("abort", () =>
-            reject(new DOMException("Aborted", "AbortError")),
-          );
-        });
-      },
+      ) => Promise.reject(new Error("retrieval failed")),
     );
     const graphMemory = {
-      prepareMemory: hangingPrepare,
+      prepareMemory: failingPrepare,
     } as unknown as ConversationGraphMemory;
-    const deps = makeDeps({
-      graphMemory,
-      isTrustedActor: true,
-      graphRetrievalBudgetMs: 20,
-    });
+    const deps = makeDeps({ graphMemory, isTrustedActor: true });
 
-    const result = await runDefaultMemoryRetrieval(makeMemoryArgs(), deps);
-
-    expect(result.pkbContent).toBe("pkb-default");
-    expect(result.nowContent).toBe("now-default");
-    expect(result.memoryGraphBlocks).toEqual([]);
-    expect(capturedSignal?.aborted).toBe(true);
+    await expect(
+      runDefaultMemoryRetrieval(makeMemoryArgs(), deps),
+    ).rejects.toThrow("retrieval failed");
   });
 
   test("passes through null PKB and NOW when the files are absent", async () => {

--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -45,25 +45,28 @@ mock.module("../../../util/logger.js", () => ({
 
 // Stub the v1 retriever so we don't reach Qdrant. Both modes return zero
 // nodes — the v1 injection branch becomes a no-op, isolating the assertion
-// to "did the v2 routing fire?".
+// to "did the v2 routing fire?". Tracked via `mock()` so tests can also
+// assert that v1 retrieval is *not* called when v2 is enabled.
+const loadContextMemoryMock = mock(async () => ({
+  nodes: [],
+  serendipityNodes: [],
+  latencyMs: 1,
+  metrics: null,
+  queryVector: undefined,
+  sparseVector: undefined,
+  userQueryVector: undefined,
+  userQuerySparseVector: undefined,
+}));
+const retrieveForTurnMock = mock(async () => ({
+  nodes: [],
+  latencyMs: 1,
+  metrics: null,
+  queryVector: undefined,
+  sparseVector: undefined,
+}));
 mock.module("../retriever.js", () => ({
-  loadContextMemory: async () => ({
-    nodes: [],
-    serendipityNodes: [],
-    latencyMs: 1,
-    metrics: null,
-    queryVector: undefined,
-    sparseVector: undefined,
-    userQueryVector: undefined,
-    userQuerySparseVector: undefined,
-  }),
-  retrieveForTurn: async () => ({
-    nodes: [],
-    latencyMs: 1,
-    metrics: null,
-    queryVector: undefined,
-    sparseVector: undefined,
-  }),
+  loadContextMemory: loadContextMemoryMock,
+  retrieveForTurn: retrieveForTurnMock,
 }));
 
 // Programmable embedding + Qdrant state. Mirrors the pattern in
@@ -262,6 +265,8 @@ beforeEach(() => {
   testDbHandle = createTestDb();
   qdrantState.queryResponses.dense.length = 0;
   qdrantState.queryResponses.sparse.length = 0;
+  loadContextMemoryMock.mockClear();
+  retrieveForTurnMock.mockClear();
   _resetMemoryV2QdrantForTests();
 });
 
@@ -347,6 +352,9 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (per-turn path)",
     expect(firstBlock.text.endsWith("\n</memory>")).toBe(true);
     // No nested wrapper.
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
+
+    // v1 retrieval is fully bypassed when v2 is enabled.
+    expect(retrieveForTurnMock).not.toHaveBeenCalled();
   });
 
   test("reinjectCachedMemory after v2 injection wraps exactly once (no double-wrap)", async () => {
@@ -430,6 +438,9 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (context-load pat
     const firstBlock = lastMsg?.content[0];
     if (firstBlock?.type !== "text") throw new Error("unexpected block type");
     expect(firstBlock.text.match(/<memory>/g)?.length).toBe(1);
+
+    // v1 retrieval is fully bypassed when v2 is enabled.
+    expect(loadContextMemoryMock).not.toHaveBeenCalled();
   });
 
   test("flag off → v2 not run on first turn either", async () => {

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -382,29 +382,11 @@ export class ConversationGraphMemory {
     signal: AbortSignal,
     onEvent: (msg: ServerMessage) => void,
   ) {
-    const result = await loadContextMemory({
-      scopeId: "default",
-      recentSummaries,
-      userQuery,
-      config,
-      signal,
-    });
-
-    this.initialized = true;
-    this.needsReload = false;
-
-    // v2 routing: when the feature flag and workspace config are both on,
-    // replace v1's injection with the activation-pipeline output. v1
-    // retrieval still runs above so its tracker stays warm — keeps the
-    // off→on→off flag flip cheap and avoids invalidating cached metrics.
-    // assistantMessage is empty: context-load fires on turn 1 / post-
-    // compaction, so there is no immediately-prior assistant turn to
-    // weight the activation against.
-    //
     // Use the raw user text (no >10-char filter) so even short greetings
     // ("hi") get a fresh top-K activation dump on the first user message.
-    // The activation pipeline is robust to weak ANN signal — it still falls
-    // back to spreading + nowText to surface candidates.
+    // The activation pipeline is robust to weak ANN signal — it falls back
+    // to spreading + nowText to surface candidates.
+    const startedAt = Date.now();
     const rawUserText = readRawUserText(messages[messages.length - 1]);
     const v2 = await this.maybeRouteV2Injection(
       messages,
@@ -414,6 +396,9 @@ export class ConversationGraphMemory {
       "",
       signal,
     );
+    this.initialized = true;
+    this.needsReload = false;
+
     if (v2.routed) {
       this.lastInjectedBlock = v2.injectedBlockText;
       this.lastInjectedNodeIds = [];
@@ -423,16 +408,21 @@ export class ConversationGraphMemory {
         injectedTokens: v2.injectedBlockText
           ? estimateTextTokens(v2.injectedBlockText)
           : 0,
-        latencyMs: result.latencyMs,
+        latencyMs: Date.now() - startedAt,
         mode: "context-load" as const,
         injectedBlockText: v2.injectedBlockText,
-        metrics: result.metrics,
-        queryVector: result.queryVector,
-        sparseVector: result.sparseVector,
-        userQueryVector: result.userQueryVector,
-        userQuerySparseVector: result.userQuerySparseVector,
+        metrics: null,
       };
     }
+
+    // v1 fallback — only reached when the v2 flag or workspace config is off.
+    const result = await loadContextMemory({
+      scopeId: "default",
+      recentSummaries,
+      userQuery,
+      config,
+      signal,
+    });
 
     if (result.nodes.length === 0) {
       this.lastInjectedBlock = null;
@@ -541,21 +531,9 @@ export class ConversationGraphMemory {
       if (userLastBlocks.length > 0 && assistantLast) break;
     }
 
-    const result = await retrieveForTurn({
-      assistantLastMessage: assistantLast,
-      userLastMessage: userLast,
-      userLastMessageBlocks: userLastBlocks,
-      scopeId: "default",
-      config,
-      tracker: this.tracker,
-      signal,
-    });
-
-    // v2 routing: same gating as `runContextLoad` — when the flag and config
-    // are both on, the v2 activation pipeline produces the injection block
-    // (or `null` for the cache-stable empty path). v1 retrieval above runs
-    // unconditionally so the tracker stays in sync with the v1 nodes —
-    // cheap insurance for an off→on→off flag flip mid-conversation.
+    // v2 path — skip v1 retrieval entirely when v2 is enabled. See the
+    // matching comment in `runContextLoad` for rationale.
+    const startedAt = Date.now();
     const v2 = await this.maybeRouteV2Injection(
       messages,
       config,
@@ -573,14 +551,23 @@ export class ConversationGraphMemory {
         injectedTokens: v2.injectedBlockText
           ? estimateTextTokens(v2.injectedBlockText)
           : 0,
-        latencyMs: result.latencyMs,
+        latencyMs: Date.now() - startedAt,
         mode: "per-turn" as const,
         injectedBlockText: v2.injectedBlockText,
-        metrics: result.metrics,
-        queryVector: result.queryVector,
-        sparseVector: result.sparseVector,
+        metrics: null,
       };
     }
+
+    // v1 path (only reached when the v2 flag or workspace config is off).
+    const result = await retrieveForTurn({
+      assistantLastMessage: assistantLast,
+      userLastMessage: userLast,
+      userLastMessageBlocks: userLastBlocks,
+      scopeId: "default",
+      config,
+      tracker: this.tracker,
+      signal,
+    });
 
     if (result.nodes.length === 0) {
       this.lastInjectedBlock = null;
@@ -640,12 +627,12 @@ export class ConversationGraphMemory {
   }
 
   /**
-   * Route the v1 retrieval's injection step through the v2 activation
-   * pipeline when the `memory-v2-enabled` feature flag *and* the workspace
-   * config (`memory.v2.enabled`) are both on.
+   * Run the v2 activation pipeline when the `memory-v2-enabled` feature flag
+   * *and* the workspace config (`memory.v2.enabled`) are both on.
    *
    * The two outcomes the caller distinguishes via `routed`:
-   *   - `routed: false` — v2 disabled; caller runs the existing v1 injection.
+   *   - `routed: false` — v2 disabled; caller falls through to the legacy v1
+   *                        retrieval path.
    *   - `routed: true`  — v2 ran. `runMessages` is either the v2-prepended
    *                        message list (block was non-null) or the input
    *                        messages unchanged (cache-stable empty path).

--- a/assistant/src/plugins/defaults/memory-retrieval.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval.ts
@@ -32,7 +32,6 @@ import {
 import type { ServerMessage } from "../../daemon/message-protocol.js";
 import type { ConversationGraphMemory } from "../../memory/graph/conversation-graph-memory.js";
 import type { Message } from "../../providers/types.js";
-import { getLogger } from "../../util/logger.js";
 import { registerPlugin } from "../registry.js";
 import {
   type MemoryArgs,
@@ -50,15 +49,6 @@ import {
  * hatch for custom retrievers.
  */
 export const DEFAULT_MEMORY_GRAPH_KIND = "default.graph" as const;
-
-const log = getLogger("default-memory-retrieval");
-
-/**
- * Foreground turns should not wait on cold embedding/model/Qdrant startup.
- * Warm memory retrieval is normally well under this budget; cold-start work
- * continues through background jobs and the next turn can pick it up.
- */
-const DEFAULT_MEMORY_GRAPH_RETRIEVAL_BUDGET_MS = 2_000;
 
 /**
  * Shape of the single block the default memory-graph retriever emits.
@@ -82,12 +72,6 @@ export interface GraphMemoryPayload {
  * Passed as a second argument to {@link runDefaultMemoryRetrieval} rather
  * than threaded through {@link MemoryArgs} to keep the plugin-facing
  * pipeline surface minimal.
- *
- * The per-turn abort signal lives on {@link MemoryArgs.signal} instead of
- * here so the pipeline runner's `linkAbortSignal` can swap it for an
- * internally-linked signal — that way a plugin timeout actually cancels
- * the underlying `prepareMemory` work instead of letting it run after
- * `Promise.race` has already rejected.
  */
 export interface DefaultMemoryRetrievalDeps {
   /** Live message list for this turn (pre-injection). */
@@ -100,8 +84,6 @@ export interface DefaultMemoryRetrievalDeps {
   readonly onEvent: (msg: ServerMessage) => void;
   /** True when the actor for this turn is trusted (guardian-class). */
   readonly isTrustedActor: boolean;
-  /** Override for tests; `null` disables the foreground soft budget. */
-  readonly graphRetrievalBudgetMs?: number | null;
 }
 
 /**
@@ -113,6 +95,11 @@ export interface DefaultMemoryRetrievalDeps {
  * trusted) or a single {@link GraphMemoryPayload} wrapping the graph
  * retriever's full output. The agent loop narrows via
  * {@link DEFAULT_MEMORY_GRAPH_KIND} to consume it.
+ *
+ * Memory retrieval blocks the turn — there is no soft timeout here. Memory
+ * is critical context, and silently dropping it produces a worse outcome
+ * than a slower turn. Cancellation still works via `args.signal`, which is
+ * threaded into `prepareMemory`.
  */
 export async function runDefaultMemoryRetrieval(
   args: MemoryArgs,
@@ -133,14 +120,12 @@ export async function runDefaultMemoryRetrieval(
     };
   }
 
-  const graphResult = await prepareGraphMemoryWithBudget(args, deps);
-  if (!graphResult) {
-    return {
-      pkbContent,
-      nowContent,
-      memoryGraphBlocks: [],
-    };
-  }
+  const graphResult = await deps.graphMemory.prepareMemory(
+    deps.messages,
+    deps.config,
+    args.signal,
+    deps.onEvent,
+  );
 
   const payload: GraphMemoryPayload = {
     kind: DEFAULT_MEMORY_GRAPH_KIND,
@@ -152,69 +137,6 @@ export async function runDefaultMemoryRetrieval(
     nowContent,
     memoryGraphBlocks: [payload],
   };
-}
-
-async function prepareGraphMemoryWithBudget(
-  args: MemoryArgs,
-  deps: DefaultMemoryRetrievalDeps,
-): Promise<Awaited<
-  ReturnType<ConversationGraphMemory["prepareMemory"]>
-> | null> {
-  const budgetMs =
-    deps.graphRetrievalBudgetMs === undefined
-      ? DEFAULT_MEMORY_GRAPH_RETRIEVAL_BUDGET_MS
-      : deps.graphRetrievalBudgetMs;
-
-  if (budgetMs === null) {
-    return deps.graphMemory.prepareMemory(
-      deps.messages,
-      deps.config,
-      args.signal,
-      deps.onEvent,
-    );
-  }
-
-  if (args.signal.aborted) return null;
-
-  const controller = new AbortController();
-  const abortFromParent = () => controller.abort();
-  args.signal.addEventListener("abort", abortFromParent, { once: true });
-
-  let timedOut = false;
-  let timeout: ReturnType<typeof setTimeout> | null = null;
-
-  const graphPromise = deps.graphMemory
-    .prepareMemory(deps.messages, deps.config, controller.signal, deps.onEvent)
-    .then(
-      (result) => ({ status: "ok" as const, result }),
-      (err) => ({ status: "error" as const, err }),
-    );
-
-  const timeoutPromise = new Promise<{ status: "timeout" }>((resolve) => {
-    timeout = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-      resolve({ status: "timeout" });
-    }, budgetMs);
-  });
-
-  try {
-    const winner = await Promise.race([graphPromise, timeoutPromise]);
-    if (winner.status === "ok") return winner.result;
-    if (winner.status === "timeout") {
-      log.warn(
-        { budgetMs },
-        "Memory graph retrieval exceeded foreground budget; continuing without graph memory",
-      );
-      return null;
-    }
-
-    if (timedOut || controller.signal.aborted) return null;
-    throw winner.err;
-  } finally {
-    if (timeout) clearTimeout(timeout);
-    args.signal.removeEventListener("abort", abortFromParent);
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Memory v2 per-turn injection has been silently failing on this workspace for ~28 hours: `retrieveForTurn` was busting the 2s `prepareGraphMemoryWithBudget` race, the timeout aborted the shared signal, and v2's `throwIfAborted` checks tore the activation pipeline down before any block could be emitted. The catch in `prepareMemory` swallowed it into one warn.
- When v2 is enabled, route the v2 activation pipeline as the sole retriever — skip `loadContextMemory` / `retrieveForTurn` entirely. The "v1 keeps the tracker warm in case the flag flips back" justification didn't pay for itself; it just coupled v2 to v1's latency and outcome.
- Remove the foreground retrieval budget. Memory is critical context — silently degrading to no memory is worse than blocking the turn. Cancellation still flows through the parent `args.signal`. Errors now propagate to the agent loop instead of being swallowed.

## Original prompt

User noticed Velissa wasn't injecting memories into user messages despite Memory V2 being enabled. Investigation found feature flag + workspace config both ON and v2 firing reliably for `context-load` (background conversations every 5–15 min) but `per-turn` injection had not produced a `memory_v2_activation_logs` row in 28 hours. Root cause was that v2 routing lives downstream of v1 retrieval and shares its 2s budget/abort signal — so any v1 slowdown silently disables v2. User explicitly asked to skip v1 when v2 is on AND remove the budget, since memory is critical and we should block on it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->