### PR TITLE
Part of JARVIS-713: Declare the model profile shortcut feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -98,6 +98,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "new-model-profile-shortcut",
+      "scope": "assistant",
+      "key": "new-model-profile-shortcut",
+      "label": "New Model Profile Shortcut",
+      "description": "Show the New Profile... shortcut in the macOS chat composer model profile dropdown.",
+      "defaultEnabled": false
+    },
+    {
       "id": "multi-platform-assistant",
       "scope": "assistant",
       "key": "multi-platform-assistant",


### PR DESCRIPTION
## Summary
- Declare the default-off assistant feature flag for the model profile shortcut.
- Sync bundled feature-flag registries for assistant and gateway.
- Companion platform Terraform flag PR must merge/apply before rollout.

Part of plan: jarvis-713-profile-shortcut.md (PR 1 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->