### PR TITLE
feat(macos-inspector): collapse memory v1/v2 tabs into single flag-gated tab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageInspectorView.swift
@@ -318,15 +318,9 @@ struct MessageInspectorView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var visibleTabs: [MessageInspectorDetailTab] {
-        MessageInspectorDetailTab.allCases.filter { tab in
-            tab != .memoryV2 || viewState.memoryV2Activation != nil
-        }
-    }
-
     private var detailTabBar: some View {
         VTabs(
-            items: visibleTabs.map { (label: $0.label, tag: $0) },
+            items: MessageInspectorDetailTab.allCases.map { (label: $0.label, tag: $0) },
             selection: Binding(
                 get: { viewState.selectedDetailTab },
                 set: { viewState.selectDetailTab($0) }
@@ -340,9 +334,11 @@ struct MessageInspectorView: View {
         case .overview:
             MessageInspectorOverviewTab(entry: entry)
         case .memory:
-            MessageInspectorMemoryTab(memoryRecall: viewState.memoryRecall)
-        case .memoryV2:
-            MessageInspectorMemoryV2Tab(activation: viewState.memoryV2Activation)
+            if let activation = viewState.memoryV2Activation {
+                MessageInspectorMemoryV2Tab(activation: activation)
+            } else {
+                MessageInspectorMemoryTab(memoryRecall: viewState.memoryRecall)
+            }
         case .prompt:
             MessageInspectorPromptTab(entry: entry)
         case .response:
@@ -638,7 +634,6 @@ enum RawPayloadPane: String, CaseIterable {
 enum MessageInspectorDetailTab: String, CaseIterable {
     case overview
     case memory
-    case memoryV2
     case prompt
     case response
     case raw
@@ -649,8 +644,6 @@ enum MessageInspectorDetailTab: String, CaseIterable {
             return "Overview"
         case .memory:
             return "Memory"
-        case .memoryV2:
-            return "Memory v2"
         case .prompt:
             return "Prompt"
         case .response:
@@ -711,7 +704,6 @@ struct MessageInspectorViewState {
             guard !orderedLogs.isEmpty else {
                 loadState = .empty
                 selectedLogID = nil
-                resetSelectedTabIfMemoryV2Unavailable()
                 return
             }
 
@@ -735,14 +727,6 @@ struct MessageInspectorViewState {
             conversationKind = nil
             loadState = .failed
             selectedLogID = nil
-        }
-
-        resetSelectedTabIfMemoryV2Unavailable()
-    }
-
-    private mutating func resetSelectedTabIfMemoryV2Unavailable() {
-        if selectedDetailTab == .memoryV2 && memoryV2Activation == nil {
-            selectedDetailTab = .overview
         }
     }
 


### PR DESCRIPTION
## Summary
- Collapse the Message Inspector's separate `.memory` and `.memoryV2` tabs into a single `.memory` tab whose contents swap on data presence — when `MemoryV2ActivationData` is present, render the v2 spreading-activation view; otherwise render the v1 hybrid-search view.
- Remove the now-unused `visibleTabs` filter, the `.memoryV2` enum case + label, and the `resetSelectedTabIfMemoryV2Unavailable` helper.
- Since `memory-v2-enabled` (default on) suppresses v1 logging when on and v2 logging when off, data presence is a reliable proxy for the flag — no new client-side flag plumbing required.

## Original prompt
The user asked: when the `memory-v2-enabled` flag is enabled, the contents of the memory tab in the Message Inspector should be replaced by an equivalent for memory v2 instead of showing the old memory v1 stuff. Today the inspector exposes two parallel tabs (`Memory` and `Memory v2`) which can both be visible at once; with v2 the dominant runtime mode, that misrepresents the memory subsystem and leaves dead UI for the typical user. The plan was to keep one "Memory" tab whose content swaps on the active subsystem, gated by data presence (the flag mutually excludes v1/v2 logging, so data presence is a reliable proxy).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->