### PR TITLE
[codex] Fix proactive artifact copy and heartbeat notifications

### DIFF
--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -95,6 +95,97 @@ describe("notification decision fallback copy", () => {
     );
   });
 
+  test("enforces guardian-facing popup copy for heartbeat alerts", async () => {
+    configuredProvider = { sendMessage: async () => ({}) };
+    extractedToolUse = {
+      input: {
+        shouldNotify: true,
+        selectedChannels: ["vellum"],
+        reasoningSummary: "Heartbeat found a useful follow-up.",
+        renderedCopy: {
+          vellum: {
+            title: "Heartbeat Follow-up",
+            body: "The daily tracker is ready; consider reminding the guardian to review it before the next check-in.",
+          },
+        },
+        dedupeKey: "heartbeat:test",
+        confidence: 0.9,
+      },
+    };
+
+    const decision = await evaluateSignal(
+      makeSignal({
+        sourceEventName: "heartbeat.alert",
+        sourceChannel: "watcher",
+        contextPayload: {
+          summary:
+            "The daily tracker is ready; consider reminding the guardian to review it before the next check-in.",
+          conversationTitle: "Running Habit Tracking",
+        },
+        attentionHints: {
+          requiresAction: true,
+          urgency: "medium",
+          isAsyncBackground: true,
+          visibleInSourceNow: false,
+        },
+      }),
+      ["vellum"] as NotificationChannel[],
+    );
+
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.renderedCopy.vellum?.title).toBe("Heartbeat Alert");
+    expect(decision.renderedCopy.vellum?.body).toBe(
+      "I found something worth your attention in a heartbeat check. Open the conversation for details.",
+    );
+    expect(decision.renderedCopy.vellum?.body).not.toContain(
+      "reminding the guardian",
+    );
+  });
+
+  test("keeps direct guardian-facing heartbeat copy", async () => {
+    configuredProvider = { sendMessage: async () => ({}) };
+    extractedToolUse = {
+      input: {
+        shouldNotify: true,
+        selectedChannels: ["vellum"],
+        reasoningSummary: "Heartbeat found a useful follow-up.",
+        renderedCopy: {
+          vellum: {
+            title: "Tracker Ready",
+            body: "Your daily tracker is ready. Review it before the next check-in.",
+          },
+        },
+        dedupeKey: "heartbeat:direct-copy-test",
+        confidence: 0.9,
+      },
+    };
+
+    const decision = await evaluateSignal(
+      makeSignal({
+        sourceEventName: "heartbeat.alert",
+        sourceChannel: "watcher",
+        contextPayload: {
+          summary:
+            "The daily tracker is ready; consider reminding the guardian to review it before the next check-in.",
+          conversationTitle: "Running Habit Tracking",
+        },
+        attentionHints: {
+          requiresAction: true,
+          urgency: "medium",
+          isAsyncBackground: true,
+          visibleInSourceNow: false,
+        },
+      }),
+      ["vellum"] as NotificationChannel[],
+    );
+
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.renderedCopy.vellum?.title).toBe("Tracker Ready");
+    expect(decision.renderedCopy.vellum?.body).toBe(
+      "Your daily tracker is ready. Review it before the next check-in.",
+    );
+  });
+
   test("enforces free-text answer instructions for guardian.question when requestCode exists", async () => {
     const signal = makeSignal({
       contextPayload: {

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -373,6 +373,28 @@ describe("notification decision strategy", () => {
         "A guardian question needs your attention",
       );
     });
+
+    test("heartbeat.alert fallback avoids intermediary-instruction popup copy", () => {
+      const signal = makeSignal({
+        sourceEventName: "heartbeat.alert",
+        contextPayload: {
+          summary:
+            "The daily tracker is ready; consider reminding the guardian to review it before the next check-in.",
+          conversationTitle: "Running Habit Tracking",
+        },
+      });
+
+      const copy = composeFallbackCopy(signal, channels);
+      expect(copy.vellum).toBeDefined();
+      expect(copy.vellum!.title).toBe("Heartbeat Alert");
+      expect(copy.vellum!.body).toBe(
+        "I found something worth your attention in a heartbeat check. Open the conversation for details.",
+      );
+      expect(copy.vellum!.conversationSeedMessage).toContain(
+        "consider reminding the guardian",
+      );
+      expect(copy.telegram!.deliveryText).toBe(copy.vellum!.body);
+    });
   });
 
   // -- NotificationChannel type correctness ----------------------------------

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -877,7 +877,7 @@ Do NOT attempt to use tools for these providers — they will fail. Skip any che
     prompt += `\n\n<heartbeat-disposition>
 This heartbeat runs frequently. Do not manufacture a report just because it ran.
 If there is nothing genuinely useful, actionable, or interesting to surface, keep the response brief and end with HEARTBEAT_OK.
-If there is something worth interrupting the guardian for, write a concise guardian-facing note first: what happened, why it matters, and the recommended next step. Then end with HEARTBEAT_ALERT. That note may be used as notification copy.
+If there is something worth interrupting the guardian for, write a concise guardian-facing note first: what happened, why it matters, and the recommended next step. Address the guardian directly as "you"; do not write instructions to yourself or another intermediary. Then end with HEARTBEAT_ALERT. That note may be used as notification copy.
 After completing your review, end your response with one of:
 - HEARTBEAT_OK — if everything looks good, no action needed
 - HEARTBEAT_ALERT — if you found issues that need attention (describe them before this marker)

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -32,6 +32,51 @@ export function nonEmpty(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+export function looksLikeIntermediaryInstruction(text: string): boolean {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const intermediaryAction =
+    "(?:tell|telling|ask|asking|remind|reminding|nudge|nudging|prompt|prompting|notify|notifying|encourage|encouraging|prime|priming|brief|briefing|coach|coaching)";
+  const target = "(?:the\\s+)?(?:guardian|recipient|user)";
+  return (
+    /\b(?:assistant|agent|system|model|watcher)\s+(?:should|needs?\s+to|must|can|could)\b/i.test(
+      normalized,
+    ) ||
+    new RegExp(
+      `\\b(?:consider|try|please)\\s+${intermediaryAction}\\s+${target}\\b`,
+      "i",
+    ).test(normalized) ||
+    new RegExp(
+      `\\b${intermediaryAction}\\s+${target}\\s+(?:to|that|about|with)\\b`,
+      "i",
+    ).test(normalized) ||
+    new RegExp(
+      `\\b${target}\\s+(?:should|needs?\\s+to|must|might\\s+want\\s+to)\\b`,
+      "i",
+    ).test(normalized) ||
+    new RegExp(`\\b(?:for|to)\\s+${target}\\s+to\\b`, "i").test(normalized)
+  );
+}
+
+function buildHeartbeatAlertCopy(
+  payload: Record<string, unknown>,
+): RenderedChannelCopy {
+  const summary = str(
+    payload.summary,
+    str(payload.body, "Your assistant found something worth your attention."),
+  ).trim();
+  const safePopupBody = looksLikeIntermediaryInstruction(summary)
+    ? "I found something worth your attention in a heartbeat check. Open the conversation for details."
+    : summary;
+
+  return {
+    title: str(payload.title, "Heartbeat Alert"),
+    body: safePopupBody,
+    deliveryText: safePopupBody,
+    conversationTitle: str(payload.conversationTitle, "Heartbeat"),
+    conversationSeedMessage: summary,
+  };
+}
+
 // ── Access-request copy contract ─────────────────────────────────────────────
 //
 // Deterministic helpers for building guardian-facing access-request copy.
@@ -505,18 +550,7 @@ const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
     body: str(payload.body, "A watcher event requires your attention"),
   }),
 
-  "heartbeat.alert": (payload) => {
-    const body = str(
-      payload.summary,
-      str(payload.body, "Your assistant found something worth your attention."),
-    );
-    return {
-      title: str(payload.title, "Heartbeat Alert"),
-      body,
-      conversationTitle: str(payload.conversationTitle, "Heartbeat"),
-      conversationSeedMessage: body,
-    };
-  },
+  "heartbeat.alert": buildHeartbeatAlertCopy,
 
   "tool_confirmation.required_action": (payload) => ({
     title: "Tool Confirmation",

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -35,6 +35,7 @@ import {
   composeFallbackCopy,
   hasAccessRequestInstructions,
   hasInviteFlowDirective,
+  looksLikeIntermediaryInstruction,
 } from "./copy-composer.js";
 import { createDecision } from "./decisions-store.js";
 import {
@@ -127,11 +128,13 @@ function buildSystemPrompt(
     ``,
     `Copy guidelines (three distinct outputs):`,
     `- \`title\` and \`body\` are for native notification popups (e.g. vellum desktop/mobile) — keep them short and glanceable (title ≤ 8 words, body ≤ 2 sentences).`,
+    `  - Write popup copy as final copy for the guardian or recipient. Do not write instructions for the assistant or another intermediary.`,
     `- \`deliveryText\` is the channel-native message for chat channels (e.g. telegram). It must read naturally as a standalone message.`,
     `  - Do not prepend mechanical labels like "Conversation:".`,
     `  - Do not mention channel or transport names (e.g. Telegram, Slack, email) unless the event context explicitly requires it.`,
     `  - Do not repeat title/body verbatim unless that repetition is truly necessary.`,
     `  - Avoid meta-send phrasing (e.g. "I'd like to send a notification", "May I go ahead with that?"). Write the recipient-facing message directly.`,
+    `  - Avoid intermediary-instruction phrasing like "consider telling the guardian", "ask the recipient to", or "the assistant should remind them". Rewrite it as final copy the recipient can act on directly.`,
     `  - For telegram: 1-2 concise sentences.`,
     `- \`conversationSeedMessage\` is the opening message in the internal notification conversation — it can be richer and more contextual.`,
     `  - For vellum (desktop): 2-4 short sentences with useful context and clear next step if action is required.`,
@@ -664,6 +667,47 @@ function enforceAccessRequestInstructions(
   };
 }
 
+function enforceHeartbeatAlertCopy(
+  decision: NotificationDecision,
+  signal: NotificationSignal,
+): NotificationDecision {
+  if (signal.sourceEventName !== "heartbeat.alert") return decision;
+  if (!decision.shouldNotify || decision.selectedChannels.length === 0)
+    return decision;
+
+  const fallbackCopy = composeFallbackCopy(signal, decision.selectedChannels);
+  const nextCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {
+    ...decision.renderedCopy,
+  };
+
+  for (const channel of decision.selectedChannels) {
+    const currentCopy = nextCopy[channel];
+    if (
+      currentCopy &&
+      !heartbeatCopyLooksLikeIntermediaryInstruction(currentCopy)
+    ) {
+      continue;
+    }
+    const safeCopy = fallbackCopy[channel];
+    if (!safeCopy) continue;
+    nextCopy[channel] = safeCopy;
+  }
+
+  return {
+    ...decision,
+    renderedCopy: nextCopy,
+  };
+}
+
+function heartbeatCopyLooksLikeIntermediaryInstruction(
+  copy: RenderedChannelCopy,
+): boolean {
+  return [copy.title, copy.body, copy.deliveryText].some(
+    (value) =>
+      typeof value === "string" && looksLikeIntermediaryInstruction(value),
+  );
+}
+
 function ensureAccessRequestInstructionsInCopy(
   copy: RenderedChannelCopy,
   requestCode: string,
@@ -754,6 +798,7 @@ export async function evaluateSignal(
     let decision = buildFallbackDecision(signal, availableChannels);
     decision = enforceGuardianRequestCode(decision, signal);
     decision = enforceAccessRequestInstructions(decision, signal);
+    decision = enforceHeartbeatAlertCopy(decision, signal);
     decision = enforceGuardianCallConversationAffinity(decision, signal);
     decision = enforceConversationAffinity(
       decision,
@@ -783,6 +828,7 @@ export async function evaluateSignal(
 
   decision = enforceGuardianRequestCode(decision, signal);
   decision = enforceAccessRequestInstructions(decision, signal);
+  decision = enforceHeartbeatAlertCopy(decision, signal);
   decision = enforceGuardianCallConversationAffinity(decision, signal);
   decision = enforceConversationAffinity(
     decision,

--- a/assistant/src/proactive-artifact/job.test.ts
+++ b/assistant/src/proactive-artifact/job.test.ts
@@ -231,8 +231,11 @@ mock.module("uuid", () => ({
 
 const { runProactiveArtifactJob } = await import("./job.js");
 const { injectAuxAssistantMessage } = await import("./aux-message-injector.js");
-const { buildMessageCopyPrompt, parseMessageCopy } =
-  await import("./message-copy.js");
+const {
+  buildMessageCopyPrompt,
+  ensureMessageMentionsLibraryLocation,
+  parseMessageCopy,
+} = await import("./message-copy.js");
 
 // ── Test helpers ────────────────────────────────────────────────────────
 
@@ -437,15 +440,23 @@ describe("runProactiveArtifactJob", () => {
       expect(bootstrapCalls[0].conversationType).toBe("background");
       expect(bootstrapCalls[0].source).toBe("proactive_artifact");
 
-      // App associated with user's conversation for Assets chip
+      // App associated with user's conversation for existing artifact linkage
       expect(addAppConvCalls).toHaveLength(1);
       expect(addAppConvCalls[0].appId).toBe("app-123");
       expect(addAppConvCalls[0].conversationId).toBe("conv-1");
+
+      expect(broadcastCalls).toContainEqual({
+        type: "app_files_changed",
+        appId: "app-123",
+      });
 
       // Message injection: addMessage called with skipIndexing
       expect(addMessageCalls).toHaveLength(1);
       expect(addMessageCalls[0].opts).toEqual({ skipIndexing: true });
       expect(addMessageCalls[0].conversationId).toBe("conv-1");
+      const injectedAppContent = JSON.parse(addMessageCalls[0].content);
+      expect(injectedAppContent[0].text).toContain("Library");
+      expect(injectedAppContent[0].text).not.toContain("Assets");
 
       // Notification emitted
       expect(emitSignalCalls).toHaveLength(1);
@@ -503,6 +514,9 @@ describe("runProactiveArtifactJob", () => {
 
       // Message injection and notification
       expect(addMessageCalls).toHaveLength(1);
+      const injectedDocumentContent = JSON.parse(addMessageCalls[0].content);
+      expect(injectedDocumentContent[0].text).toContain("Library");
+      expect(injectedDocumentContent[0].text).not.toContain("Assets");
       expect(emitSignalCalls).toHaveLength(1);
 
       // Claim NOT released on success
@@ -623,8 +637,10 @@ describe("runProactiveArtifactJob", () => {
       // Verify fallback message was used
       expect(addMessageCalls).toHaveLength(1);
       const content = JSON.parse(addMessageCalls[0].content);
-      expect(content[0].text).toContain("I made something for you");
+      expect(content[0].text).toContain("I made an app for you");
       expect(content[0].text).toContain("Budget Tracker");
+      expect(content[0].text).toContain("Library");
+      expect(content[0].text).not.toContain("Assets");
     });
   });
 
@@ -846,6 +862,8 @@ describe("message-copy", () => {
     expect(prompt).toContain("Budget Tracker");
     expect(prompt).toContain("app-123");
     expect(prompt).toContain("I need a budget tool");
+    expect(prompt).toContain("Library");
+    expect(prompt).not.toContain("Assets pill");
     expect(prompt).toContain("MESSAGE:");
   });
 
@@ -863,5 +881,34 @@ describe("message-copy", () => {
 
   test("parseMessageCopy returns null for empty MESSAGE", () => {
     expect(parseMessageCopy("MESSAGE:   ")).toBeNull();
+  });
+
+  test("ensureMessageMentionsLibraryLocation appends missing location", () => {
+    const message = ensureMessageMentionsLibraryLocation(
+      "I built a budget tracker for your rent and groceries.",
+      "app",
+    );
+    expect(message).toContain("Library");
+    expect(message).not.toContain("Assets");
+  });
+
+  test("ensureMessageMentionsLibraryLocation normalizes terminal punctuation once", () => {
+    const message = ensureMessageMentionsLibraryLocation(
+      "I built a budget tracker for you!",
+      "app",
+    );
+    expect(message).toBe(
+      "I built a budget tracker for you. You can find the app in Library.",
+    );
+  });
+
+  test("ensureMessageMentionsLibraryLocation replaces artifact panel wording", () => {
+    const message = ensureMessageMentionsLibraryLocation(
+      "You'll find it in the artifact panel.",
+      "document",
+    );
+    expect(message).toContain("Library");
+    expect(message).not.toContain("Assets");
+    expect(message).not.toContain("artifact panel");
   });
 });

--- a/assistant/src/proactive-artifact/job.ts
+++ b/assistant/src/proactive-artifact/job.ts
@@ -38,7 +38,11 @@ import {
   formatTranscript,
   parseDecisionOutput,
 } from "./decision.js";
-import { buildMessageCopyPrompt, parseMessageCopy } from "./message-copy.js";
+import {
+  buildMessageCopyPrompt,
+  ensureMessageMentionsLibraryLocation,
+  parseMessageCopy,
+} from "./message-copy.js";
 import { releaseProactiveArtifactClaim } from "./trigger-state.js";
 
 const log = getLogger("proactive-artifact-job");
@@ -150,9 +154,15 @@ export async function runProactiveArtifactJob(params: {
     }
     buildSucceeded = true;
 
+    if (artifactType === "app") {
+      params.broadcastMessage({ type: "app_files_changed", appId: artifactId });
+    }
+
     // ── Post-build message copy ─────────────────────────────────────
     let messageCopy: string;
-    const fallbackMessage = `I made something for you — ${artifactTitle}. Take a look when you get a chance.`;
+    const artifactNoun = artifactType === "app" ? "app" : "document";
+    const artifactArticle = artifactType === "app" ? "an" : "a";
+    const fallbackMessage = `I made ${artifactArticle} ${artifactNoun} for you — ${artifactTitle}. You can find it in Library.`;
 
     try {
       const copyProvider = await getConfiguredProvider(
@@ -184,6 +194,10 @@ export async function runProactiveArtifactJob(params: {
       log.warn({ err }, "Message copy generation failed; using fallback");
       messageCopy = fallbackMessage;
     }
+    messageCopy = ensureMessageMentionsLibraryLocation(
+      messageCopy,
+      artifactType,
+    );
 
     // ── Message injection ───────────────────────────────────────────
     await injectAuxAssistantMessage({

--- a/assistant/src/proactive-artifact/message-copy.ts
+++ b/assistant/src/proactive-artifact/message-copy.ts
@@ -24,9 +24,10 @@ ${params.transcript}
 Write a short message (2-3 sentences) to the user explaining:
 1. What you built
 2. Why you built it (reference something specific from the conversation)
-3. Where to find it
+3. Where to find it: say the ${params.artifactType} is available in Library.
 
 Keep it warm and natural — not robotic. This should feel like a thoughtful gift, not a system notification.
+Do not call it an artifact, artifact panel, or artifact drawer.
 
 Respond in EXACTLY this format (no extra text before or after):
 
@@ -38,4 +39,20 @@ export function parseMessageCopy(text: string): string | null {
   if (!match) return null;
   const value = match[1].trim();
   return value.length > 0 ? value : null;
+}
+
+export function ensureMessageMentionsLibraryLocation(
+  message: string,
+  artifactType: "app" | "document",
+): string {
+  const trimmed = message
+    .replace(/\bartifact\s+(?:panel|drawer)\b/gi, "Library")
+    .replace(/\bartifacts\s+(?:panel|drawer)\b/gi, "Library")
+    .trim();
+  const mentionsLibrary = /\blibrary\b/i.test(trimmed);
+  if (mentionsLibrary) return trimmed;
+
+  const noun = artifactType === "app" ? "app" : "document";
+  const suffix = `You can find the ${noun} in Library.`;
+  return `${trimmed.replace(/[ \t]+$/, "").replace(/[.!?]*$/, ".")} ${suffix}`;
 }


### PR DESCRIPTION
## Summary

- Point proactive app/document handoff copy to `Library` and scrub stale artifact-panel wording.
- Keep proactive app refresh on the existing `app_files_changed` event without adding a new client protocol event.
- Guard heartbeat alert copy against intermediary-instruction phrasing while preserving direct guardian-facing copy.

## Root Cause

Proactive build copy could still mention stale artifact-panel terminology. Separately, heartbeat alert copy could pass through text shaped like instructions to an intermediary, such as telling the assistant to remind or nudge the guardian, instead of final notification copy for the guardian.

## Impact

This remains intentionally launch-safe: the final diff is assistant-only and avoids server/client protocol or Swift refresh changes. Users should be directed to Library for proactive apps/documents, and heartbeat notifications should avoid intermediary-instruction prose without replacing already-good guardian-facing copy.

## Validation

- `cd assistant && bun test src/proactive-artifact/job.test.ts src/__tests__/notification-decision-strategy.test.ts src/__tests__/notification-decision-fallback.test.ts src/__tests__/heartbeat-service.test.ts`
- `cd assistant && bunx tsc --noEmit`
- Pre-push hook after amend: assistant typecheck, assistant lint

Note: the earlier broader protocol/client refresh approach was removed from this PR to reduce launch-day blast radius.