### PR TITLE
feat(memory-v2): add list-concept-pages route

### DIFF
--- a/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the memory v2 route handlers in `memory-v2-routes.ts`.
+ *
+ * Currently focused on `memory_v2_list_concept_pages`:
+ *   - empty workspace → returns no pages
+ *   - populated workspace → surfaces slug, bodyChars, edgeCount, updatedAtMs
+ *   - corrupt page on disk → logged-and-skipped, does not poison listing
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { writePage } from "../../../memory/v2/page-store.js";
+import type { ConceptPage } from "../../../memory/v2/types.js";
+import type { MemoryV2ListConceptPagesResult } from "../memory-v2-routes.js";
+import { ROUTES } from "../memory-v2-routes.js";
+import type { RouteDefinition } from "../types.js";
+
+// ─── Setup ─────────────────────────────────────────────────────────────────
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-memv2-list-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  try {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe("memory_v2_list_concept_pages handler", () => {
+  test("returns empty list for an empty workspace", async () => {
+    const handler = findHandler("memory_v2_list_concept_pages");
+    const result = (await handler({
+      body: {},
+    })) as MemoryV2ListConceptPagesResult;
+
+    expect(result).toEqual({ pages: [], total: 0 });
+  });
+
+  test("returns slugs, body chars, edge counts, and mtimes for populated workspace", async () => {
+    const before = Date.now();
+
+    const pages: ConceptPage[] = [
+      {
+        slug: "alice",
+        frontmatter: { edges: ["bob", "carol"], ref_files: [] },
+        body: "Alice prefers VS Code.\n",
+      },
+      {
+        slug: "bob",
+        frontmatter: { edges: [], ref_files: [] },
+        body: "Bob ships at end of day.\nLikes async standups.\n",
+      },
+      {
+        slug: "people/carol",
+        frontmatter: { edges: ["alice"], ref_files: [] },
+        body: "Carol leads the platform team.\n",
+      },
+    ];
+    for (const page of pages) {
+      await writePage(workspaceDir, page);
+    }
+
+    const handler = findHandler("memory_v2_list_concept_pages");
+    const result = (await handler({
+      body: {},
+    })) as MemoryV2ListConceptPagesResult;
+
+    expect(result.total).toBe(3);
+    expect(result.pages).toHaveLength(3);
+
+    const bySlug = new Map(result.pages.map((p) => [p.slug, p]));
+
+    const alice = bySlug.get("alice");
+    expect(alice).toBeDefined();
+    expect(alice!.bodyChars).toBe(Buffer.byteLength(pages[0]!.body, "utf8"));
+    expect(alice!.edgeCount).toBe(2);
+    expect(alice!.updatedAtMs).toBeGreaterThanOrEqual(before);
+
+    const bob = bySlug.get("bob");
+    expect(bob).toBeDefined();
+    expect(bob!.bodyChars).toBe(Buffer.byteLength(pages[1]!.body, "utf8"));
+    expect(bob!.edgeCount).toBe(0);
+    expect(bob!.updatedAtMs).toBeGreaterThanOrEqual(before);
+
+    const carol = bySlug.get("people/carol");
+    expect(carol).toBeDefined();
+    expect(carol!.bodyChars).toBe(Buffer.byteLength(pages[2]!.body, "utf8"));
+    expect(carol!.edgeCount).toBe(1);
+    expect(carol!.updatedAtMs).toBeGreaterThanOrEqual(before);
+  });
+
+  test("tolerates a single corrupt page — returns valid pages and skips the broken one", async () => {
+    await writePage(workspaceDir, {
+      slug: "valid-page",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Body of the valid page.\n",
+    });
+
+    // A `.md` file with frontmatter that fails schema validation — `edges`
+    // must be a list of strings, not a single number — so `readPage` throws.
+    const conceptsDir = join(workspaceDir, "memory", "concepts");
+    await mkdir(conceptsDir, { recursive: true });
+    await writeFile(
+      join(conceptsDir, "broken.md"),
+      "---\nedges: 42\n---\nbroken body\n",
+      "utf-8",
+    );
+
+    const handler = findHandler("memory_v2_list_concept_pages");
+    const result = (await handler({
+      body: {},
+    })) as MemoryV2ListConceptPagesResult;
+
+    expect(result.total).toBe(1);
+    expect(result.pages.map((p) => p.slug)).toEqual(["valid-page"]);
+  });
+});

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -4,6 +4,9 @@
  * Migrated from `ipc/routes/memory-v2-backfill.ts` and
  * `ipc/routes/memory-v2-validate.ts` into the shared ROUTES array.
  */
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+
 import { z } from "zod";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
@@ -32,6 +35,7 @@ import {
   validateEdgeTargets,
 } from "../../memory/v2/edge-index.js";
 import {
+  getConceptsDir,
   listPages,
   readPage,
   renderPageContent,
@@ -47,10 +51,13 @@ import {
   getConceptPageCorpusStats,
   rebuildConceptPageCorpusStats,
 } from "../../memory/v2/sparse-bm25.js";
+import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import { RouteError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 import type { RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("memory-v2-routes");
 
 // ── Backfill ────────────────────────────────────────────────────────────
 
@@ -178,6 +185,59 @@ async function handleGetConceptPage({
     );
   }
   return { slug, rendered: renderPageContent(page) };
+}
+
+// ── List concept pages ──────────────────────────────────────────────────
+
+const MemoryV2ListConceptPagesParams = z.object({}).strict();
+
+export type MemoryV2ListConceptPagesResult = {
+  pages: Array<{
+    slug: string;
+    bodyChars: number;
+    edgeCount: number;
+    updatedAtMs: number;
+  }>;
+  total: number;
+};
+
+async function handleListConceptPages({
+  body = {},
+}: RouteHandlerArgs): Promise<MemoryV2ListConceptPagesResult> {
+  MemoryV2ListConceptPagesParams.parse(body);
+
+  const workspaceDir = getWorkspaceDir();
+  const conceptsDir = getConceptsDir(workspaceDir);
+  const slugs = await listPages(workspaceDir);
+
+  const settled = await Promise.all(
+    slugs.map(async (slug) => {
+      try {
+        const page = await readPage(workspaceDir, slug);
+        if (!page) return null;
+        const stats = await stat(join(conceptsDir, `${slug}.md`));
+        return {
+          slug,
+          bodyChars: Buffer.byteLength(page.body, "utf8"),
+          edgeCount: page.frontmatter.edges.length,
+          updatedAtMs: stats.mtimeMs,
+        };
+      } catch (err) {
+        // A single corrupt page (bad YAML, schema mismatch, etc.) shouldn't
+        // poison the whole listing — the validate route is the place to
+        // surface those; this one is read-only and best-effort.
+        log.warn(
+          `Skipping concept page '${slug}' in list-concept-pages: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return null;
+      }
+    }),
+  );
+  const pages = settled.filter(
+    (p): p is MemoryV2ListConceptPagesResult["pages"][number] => p !== null,
+  );
+
+  return { pages, total: pages.length };
 }
 
 // ── Rebuild BM25 corpus stats ───────────────────────────────────────────
@@ -602,6 +662,17 @@ export const ROUTES: RouteDefinition[] = [
       "Returns the rendered (frontmatter + body) markdown for a slug. 404 when the slug has no on-disk page — the activation log inspector uses this to show what got injected.",
     tags: ["memory"],
     requestBody: MemoryV2GetConceptPageParams,
+  },
+  {
+    operationId: "memory_v2_list_concept_pages",
+    method: "POST",
+    endpoint: "memory/v2/list-concept-pages",
+    handler: handleListConceptPages,
+    summary: "List all memory v2 concept pages with metadata",
+    description:
+      "Returns slugs, body sizes, edge counts, and last-modified timestamps for every concept page on disk. Read-only; used by the desktop About → Memories surface to render a browse-able list.",
+    tags: ["memory"],
+    requestBody: MemoryV2ListConceptPagesParams,
   },
   {
     operationId: "memory_v2_reembed_skills",


### PR DESCRIPTION
## Summary
- New POST memory/v2/list-concept-pages route returning slug, body chars, edge count, and updatedAtMs per page.
- Tolerant of per-page parse failures (logs and skips).
- Tests cover empty workspace, populated workspace, and corrupt-page tolerance.

Part of plan: memories-v2-tab.md (PR 1 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->