### PR TITLE
feat(macos): render MemoriesV2Panel when memory-v2-enabled is on

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -149,8 +149,19 @@ struct IntelligencePanel: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
         case .memories:
-            MemoriesPanel(connectionManager: connectionManager, assistantName: cachedAssistantName, onImportMemory: onImportMemory, focusedMemoryId: $pendingMemoryId)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            Group {
+                if assistantFeatureFlagStore?.isEnabled("memory-v2-enabled") == true {
+                    MemoriesV2Panel(connectionManager: connectionManager)
+                } else {
+                    MemoriesPanel(
+                        connectionManager: connectionManager,
+                        assistantName: cachedAssistantName,
+                        onImportMemory: onImportMemory,
+                        focusedMemoryId: $pendingMemoryId
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Flag-gated switch in IntelligencePanel.tabContent.
- Renders MemoriesV2Panel when memory-v2-enabled is on (default), MemoriesPanel otherwise.
- v1 deeplink (pendingMemoryId) stays wired to the v1 branch only.

Part of plan: memories-v2-tab.md (PR 6 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->