### PR TITLE
feat(macos): add search and sort controls to MemoriesV2Panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
@@ -1,6 +1,20 @@
 import SwiftUI
 import VellumAssistantShared
 
+// MARK: - Sort Options
+
+private enum MemoryV2SortOption: String, CaseIterable {
+    case recent = "Recent"
+    case alphabetical = "A-Z"
+
+    var icon: VIcon {
+        switch self {
+        case .recent: return .clock
+        case .alphabetical: return .arrowDown
+        }
+    }
+}
+
 // MARK: - Memories V2 Panel
 
 /// Browse-able list of memory v2 concept pages. Renders a sorted list of
@@ -18,6 +32,10 @@ struct MemoriesV2Panel: View {
     @State private var isLoading: Bool = true
     @State private var loadError: String?
     @State private var selectedSlug: String?
+    @State private var searchText: String = ""
+    @State private var debouncedSearchText: String = ""
+    @State private var sortOption: MemoryV2SortOption = .recent
+    @State private var searchDebounceTask: Task<Void, Never>?
 
     private let client: MemoryV2ClientProtocol
 
@@ -27,29 +45,75 @@ struct MemoriesV2Panel: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            listContent
-                .frame(maxWidth: .infinity)
+        VStack(alignment: .leading, spacing: 0) {
+            filterBar
 
-            if let slug = selectedSlug {
-                Divider()
-                ConceptPageContentView(
-                    slug: slug,
-                    onDismiss: { withAnimation(VAnimation.panel) { selectedSlug = nil } }
-                )
-                .id(slug)
-                .frame(width: 400)
-                .frame(maxHeight: .infinity)
-                .transition(.move(edge: .trailing).combined(with: .opacity))
-                .onKeyPress(.escape) {
-                    withAnimation(VAnimation.panel) { selectedSlug = nil }
-                    return .handled
+            HStack(spacing: 0) {
+                listContent
+                    .frame(maxWidth: .infinity)
+
+                if let slug = selectedSlug {
+                    Divider()
+                    ConceptPageContentView(
+                        slug: slug,
+                        onDismiss: { withAnimation(VAnimation.panel) { selectedSlug = nil } }
+                    )
+                    .id(slug)
+                    .frame(width: 400)
+                    .frame(maxHeight: .infinity)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                    .onKeyPress(.escape) {
+                        withAnimation(VAnimation.panel) { selectedSlug = nil }
+                        return .handled
+                    }
                 }
             }
+            .animation(VAnimation.panel, value: selectedSlug)
         }
-        .animation(VAnimation.panel, value: selectedSlug)
         .padding(.top, VSpacing.lg)
         .task { await loadPages() }
+        .onDisappear {
+            searchDebounceTask?.cancel()
+            searchDebounceTask = nil
+        }
+    }
+
+    // MARK: - Filter Bar
+
+    @ViewBuilder
+    private var filterBar: some View {
+        HStack(spacing: VSpacing.sm) {
+            VSearchBar(placeholder: "Search Concept Pages", text: $searchText)
+                .onChange(of: searchText) {
+                    searchDebounceTask?.cancel()
+                    searchDebounceTask = Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: 300_000_000)
+                        guard !Task.isCancelled else { return }
+                        debouncedSearchText = searchText
+                    }
+                }
+
+            VDropdown(
+                options: MemoryV2SortOption.allCases.map { VDropdownOption(label: $0.rawValue, value: $0, icon: $0.icon) },
+                selection: $sortOption,
+                maxWidth: 158
+            )
+        }
+        .padding(.bottom, VSpacing.sm)
+    }
+
+    // MARK: - Derived View Data
+
+    private var displayedPages: [MemoryV2ConceptPageSummary] {
+        let filtered = debouncedSearchText.isEmpty
+            ? pages
+            : pages.filter { $0.slug.localizedCaseInsensitiveContains(debouncedSearchText) }
+        switch sortOption {
+        case .recent:
+            return filtered.sorted { $0.updatedAtMs > $1.updatedAtMs }
+        case .alphabetical:
+            return filtered.sorted { $0.slug < $1.slug }
+        }
     }
 
     // MARK: - List Content
@@ -75,10 +139,16 @@ struct MemoriesV2Panel: View {
                 subtitle: "Memory v2 builds concept pages as the assistant reflects on your conversations. Check back after some chats.",
                 icon: VIcon.brain.rawValue
             )
+        } else if displayedPages.isEmpty {
+            VEmptyState(
+                title: "No matching concept pages",
+                subtitle: "Try a different search term.",
+                icon: VIcon.brain.rawValue
+            )
         } else {
             ScrollView {
                 LazyVStack(spacing: VSpacing.xs) {
-                    ForEach(pages) { page in
+                    ForEach(displayedPages) { page in
                         row(for: page)
                     }
                 }
@@ -123,7 +193,7 @@ struct MemoriesV2Panel: View {
         isLoading = true
         defer { isLoading = false }
         if let response = await client.listConceptPages() {
-            pages = response.pages.sorted { $0.slug < $1.slug }
+            pages = response.pages
             loadError = nil
         } else {
             loadError = "Failed to load concept pages."


### PR DESCRIPTION
## Summary
- Debounced search field (300ms) filters by slug substring.
- Sort dropdown: Recent (by updatedAtMs desc) / A-Z (by slug asc).
- All client-side filtering — no new server calls.

Part of plan: memories-v2-tab.md (PR 5 of 6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->