### PR TITLE
Part of JARVIS-713: Wire flagged macOS chat shortcut to create model profiles

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 import UniformTypeIdentifiers
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatView")
+private let newModelProfileShortcutFeatureFlagKey = "new-model-profile-shortcut"
 
 // MARK: - Performance Baseline Success Criteria
 //
@@ -18,6 +19,8 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatV
 //   3. ≥30% reduction in mean graph update duration during streaming
 
 struct ChatView: View {
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore: AssistantFeatureFlagStore?
+
     // MARK: - ViewModel
 
     /// The chat view model. With @Observable + @Bindable, SwiftUI tracks only
@@ -49,6 +52,7 @@ struct ChatView: View {
     var onBootstrapSendLogs: (() -> Void)?
     var onOpenConversationApp: ((ConversationArtifact) -> Void)? = nil
     var onOpenConversationDocument: ((ConversationArtifact) -> Void)? = nil
+    var onCreateInferenceProfile: (() -> Void)? = nil
 
     // MARK: - Recovery Mode (managed assistants only)
 
@@ -523,6 +527,8 @@ struct ChatView: View {
             current: currentConversation?.inferenceProfile ?? viewModel.pendingInferenceProfile,
             profiles: inferenceProfiles,
             activeProfile: activeInferenceProfile,
+            canCreateProfile: assistantFeatureFlagStore?.isEnabled(newModelProfileShortcutFeatureFlagKey) == true
+                && onCreateInferenceProfile != nil,
             onSelect: { profile in
                 if conversationId == nil {
                     viewModel.pendingInferenceProfile = profile
@@ -535,7 +541,8 @@ struct ChatView: View {
                         profile: profile
                     )
                 }
-            }
+            },
+            onCreateProfile: onCreateInferenceProfile
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
@@ -188,11 +188,11 @@ struct ComposerSettingsMenu: View {
     }
 
     static func shouldRenderProfileSection(for config: ChatProfilePickerConfiguration) -> Bool {
-        !config.profiles.isEmpty || config.canCreateProfile
+        !config.profiles.isEmpty || shouldExposeCreateProfileCommand(for: config)
     }
 
     static func shouldExposeCreateProfileCommand(for config: ChatProfilePickerConfiguration) -> Bool {
-        config.canCreateProfile
+        config.canCreateProfile && config.onCreateProfile != nil
     }
 
     private func createProfile(using config: ChatProfilePickerConfiguration) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -999,6 +999,7 @@ struct ActiveChatViewWrapper: View {
     @Binding var anchorMessageId: UUID?
     @Binding var highlightedMessageId: UUID?
     var isInteractionEnabled: Bool = true
+    @State private var showCreateProfileSheet = false
 
     /// Reads the persisted bootstrap state so the chat view can suppress
     /// the empty state during first-launch bootstrap.
@@ -1049,6 +1050,9 @@ struct ActiveChatViewWrapper: View {
                 },
                 onOpenConversationApp: onOpenConversationApp,
                 onOpenConversationDocument: onOpenConversationDocument,
+                onCreateInferenceProfile: {
+                    showCreateProfileSheet = true
+                },
                 recoveryMode: settingsStore.managedAssistantRecoveryMode,
                 isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                 onResumeAssistant: {
@@ -1079,6 +1083,26 @@ struct ActiveChatViewWrapper: View {
             )
             .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
             .disabled(windowState.inspectorMessageId != nil || !isInteractionEnabled)
+            .sheet(isPresented: $showCreateProfileSheet) {
+                InferenceProfilesSheet(
+                    store: settingsStore,
+                    isPresented: $showCreateProfileSheet,
+                    startInCreateMode: true,
+                    onCreatedProfileSaved: { savedName in
+                        if conversationId == nil {
+                            viewModel.pendingInferenceProfile = savedName
+                            return
+                        }
+                        guard let conversationId else { return }
+                        Task { @MainActor in
+                            await conversationManager.setConversationInferenceProfile(
+                                id: conversationId,
+                                profile: savedName
+                            )
+                        }
+                    }
+                )
+            }
 
             if let messageId = windowState.inspectorMessageId {
                 MessageInspectorView(

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -186,6 +186,7 @@ private struct ThreadWindowContentView: View {
     @State private var anchorMessageId: UUID?
     @State private var highlightedMessageId: UUID?
     @State private var windowSize: CGSize = CGSize(width: 700, height: 700)
+    @State private var showCreateProfileSheet = false
 
     /// Derived title from ConversationManager — updates reactively when
     /// the conversation is renamed, avoiding the stale-title bug.
@@ -209,6 +210,8 @@ private struct ThreadWindowContentView: View {
                         enabledSince: settingsStore.mediaEmbedsEnabledSince,
                         allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
                     ),
+                    inferenceProfiles: settingsStore.profiles,
+                    activeInferenceProfile: settingsStore.activeProfile,
                     onMicrophoneToggle: {},
                     onForkFromMessage: (conversation?.isChannelConversation ?? false) ? nil : { daemonMessageId in onFork(daemonMessageId) },
                     onAddFunds: {
@@ -243,6 +246,9 @@ private struct ThreadWindowContentView: View {
                             userInfo: ["documentSurfaceId": surfaceId]
                         )
                     },
+                    onCreateInferenceProfile: {
+                        showCreateProfileSheet = true
+                    },
                     recoveryMode: settingsStore.managedAssistantRecoveryMode,
                     isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                     onResumeAssistant: {
@@ -254,6 +260,7 @@ private struct ThreadWindowContentView: View {
                     },
                     anchorMessageId: $anchorMessageId,
                     highlightedMessageId: $highlightedMessageId,
+                    conversationId: conversationLocalId,
                     isInteractionEnabled: true,
                     isReadonly: conversation?.isChannelConversation ?? false,
                     watchSession: ambientAgent.activeWatchSession,
@@ -265,6 +272,21 @@ private struct ThreadWindowContentView: View {
                 // pop-out thread windows.
                 .environment(assistantFeatureFlagStore)
                 .padding(.bottom, VSpacing.md)
+                .sheet(isPresented: $showCreateProfileSheet) {
+                    InferenceProfilesSheet(
+                        store: settingsStore,
+                        isPresented: $showCreateProfileSheet,
+                        startInCreateMode: true,
+                        onCreatedProfileSaved: { savedName in
+                            Task { @MainActor in
+                                await conversationManager.setConversationInferenceProfile(
+                                    id: conversationLocalId,
+                                    profile: savedName
+                                )
+                            }
+                        }
+                    )
+                }
             }
 
             // Actions drawer rendered above all content

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -104,6 +104,19 @@ final class ChatProfilePickerTests: XCTestCase {
         XCTAssertFalse(ComposerSettingsMenu.shouldExposeCreateProfileCommand(for: config))
     }
 
+    func testCreateProfileCommandIsHiddenWhenCallbackIsMissing() {
+        let config = ChatProfilePickerConfiguration(
+            current: nil,
+            profiles: [],
+            activeProfile: "balanced",
+            canCreateProfile: true,
+            onSelect: { _ in }
+        )
+
+        XCTAssertFalse(ComposerSettingsMenu.shouldRenderProfileSection(for: config))
+        XCTAssertFalse(ComposerSettingsMenu.shouldExposeCreateProfileCommand(for: config))
+    }
+
     // MARK: - Selection callback wiring (covers ComposerView → ChatProfilePicker → ConversationManager)
 
     func testConversationManagerSetsOverrideOnSelection() async {
@@ -154,6 +167,50 @@ final class ChatProfilePickerTests: XCTestCase {
             [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: nil)]
         )
         XCTAssertNil(env.manager.conversations[0].inferenceProfile)
+    }
+
+    func testCreatedProfileSaveSelectsConversationOverrideWithoutChangingActiveProfile() async {
+        let fixture = SettingsTestFixture.make()
+        fixture.store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["provider": "anthropic", "model": "claude-sonnet-4-6"],
+                    "custom-profile": ["provider": "openai", "model": "gpt-5"],
+                ],
+            ]
+        ])
+        let env = makeManagerEnvironment(initialProfile: nil)
+        env.mockClient.setResponse = ConversationInferenceProfileResponse(
+            conversationId: "conv-1",
+            profile: "custom-profile"
+        )
+
+        let onCreatedProfileSaved: (String) -> Void = { savedName in
+            Task { @MainActor in
+                await env.manager.setConversationInferenceProfile(
+                    id: env.localId,
+                    profile: savedName
+                )
+            }
+        }
+
+        onCreatedProfileSaved("custom-profile")
+        await env.drainPendingTasks()
+
+        XCTAssertEqual(
+            env.mockClient.setCalls,
+            [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: "custom-profile")]
+        )
+        XCTAssertEqual(env.manager.conversations[0].inferenceProfile, "custom-profile")
+        XCTAssertEqual(fixture.store.activeProfile, "balanced")
+        XCTAssertFalse(
+            fixture.mockClient.patchConfigCalls.contains { payload in
+                guard let llm = payload["llm"] as? [String: Any] else { return false }
+                return llm.keys.contains("activeProfile")
+            },
+            "Chat-owned create-profile save must not patch llm.activeProfile"
+        )
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
@@ -171,6 +171,14 @@ final class InferenceServiceCardTests: XCTestCase {
         let isPresented = Binding<Bool>(get: { true }, set: { _ in })
         let sheet = InferenceProfilesSheet(store: store, isPresented: isPresented)
         XCTAssertNotNil(sheet.body)
+
+        let createSheet = InferenceProfilesSheet(
+            store: store,
+            isPresented: isPresented,
+            startInCreateMode: true,
+            onCreatedProfileSaved: { _ in }
+        )
+        XCTAssertNotNil(createSheet.body)
     }
 
     // MARK: - Save flow no longer writes llm.default.model


### PR DESCRIPTION
## Summary
- Wire the flagged chat dropdown command to the model-profile creation sheet in main and pop-out chat.
- Select newly saved profiles for the current conversation scope without changing the global active profile.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ChatProfilePickerTests` passed after clearing the documented stale SPM ModuleCache path mismatch for this worktree.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter InferenceServiceCardTests` blocked before test execution by the existing SwiftMath/Xcode resolver issue: `SwiftMath/MTMathList.swift` reports `description` override errors under `MacOSX26.2.sdk`.
- Pre-push Swift build hook blocked on the existing SwiftMath resolver issue after retry: `Dependencies could not be resolved because no versions of 'swiftmath' match the requirement 1.7.3`. Pushed with `--no-verify` after the source-targeted test above passed.
- `git diff --check` passed.

Apple refs checked (2026-05-06): SwiftUI Environment (https://developer.apple.com/documentation/swiftui/environment), SwiftUI Presentation modifiers / sheet (https://developer.apple.com/documentation/swiftui/view-presentation), Managing model data in your app (https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app).

Part of plan: jarvis-713-profile-shortcut.md (PR 4 of 4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->