### PR TITLE
fix(memory-v2): register list-concept-pages route policy and regenerate openapi

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7635,6 +7635,26 @@ paths:
                 - k
                 - sample
               additionalProperties: false
+  /v1/memory/v2/list-concept-pages:
+    post:
+      operationId: memory_v2_listconceptpages_post
+      summary: List all memory v2 concept pages with metadata
+      description:
+        Returns slugs, body sizes, edge counts, and last-modified timestamps for every concept page on disk.
+        Read-only; used by the desktop About → Memories surface to render a browse-able list.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+              additionalProperties: false
   /v1/memory/v2/rebuild-corpus-stats:
     post:
       operationId: memory_v2_rebuildcorpusstats_post

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -432,6 +432,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "memory/v2/backfill:POST", scopes: ["settings.write"] },
   { endpoint: "memory/v2/validate:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/concept-page:POST", scopes: ["settings.read"] },
+  { endpoint: "memory/v2/list-concept-pages:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/reembed-skills:POST", scopes: ["settings.write"] },
   { endpoint: "memory/v2/explain-similarity:POST", scopes: ["settings.read"] },
   { endpoint: "memory/v2/fit-anisotropy:POST", scopes: ["settings.write"] },


### PR DESCRIPTION
## Summary
- Adds settings.read policy entry for memory/v2/list-concept-pages.
- Regenerates openapi.yaml.

Restores green CI on main after #29798.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->