### PR TITLE
fix(memory-v2): clean up wire types and panel state after PR review

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7635,6 +7635,26 @@ paths:
                 - k
                 - sample
               additionalProperties: false
+  /v1/memory/v2/list-concept-pages:
+    post:
+      operationId: memory_v2_listconceptpages_post
+      summary: List all memory v2 concept pages with metadata
+      description:
+        Returns slugs, body sizes, edge counts, and last-modified timestamps for every concept page on disk.
+        Read-only; used by the desktop About → Memories surface to render a browse-able list.
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+              additionalProperties: false
   /v1/memory/v2/rebuild-corpus-stats:
     post:
       operationId: memory_v2_rebuildcorpusstats_post

--- a/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
@@ -3,7 +3,7 @@
  *
  * Currently focused on `memory_v2_list_concept_pages`:
  *   - empty workspace → returns no pages
- *   - populated workspace → surfaces slug, bodyChars, edgeCount, updatedAtMs
+ *   - populated workspace → surfaces slug, bodyBytes, edgeCount, updatedAtMs
  *   - corrupt page on disk → logged-and-skipped, does not poison listing
  */
 
@@ -58,10 +58,10 @@ describe("memory_v2_list_concept_pages handler", () => {
       body: {},
     })) as MemoryV2ListConceptPagesResult;
 
-    expect(result).toEqual({ pages: [], total: 0 });
+    expect(result).toEqual({ pages: [] });
   });
 
-  test("returns slugs, body chars, edge counts, and mtimes for populated workspace", async () => {
+  test("returns slugs, body bytes, edge counts, and mtimes for populated workspace", async () => {
     const before = Date.now();
 
     const pages: ConceptPage[] = [
@@ -90,26 +90,25 @@ describe("memory_v2_list_concept_pages handler", () => {
       body: {},
     })) as MemoryV2ListConceptPagesResult;
 
-    expect(result.total).toBe(3);
     expect(result.pages).toHaveLength(3);
 
     const bySlug = new Map(result.pages.map((p) => [p.slug, p]));
 
     const alice = bySlug.get("alice");
     expect(alice).toBeDefined();
-    expect(alice!.bodyChars).toBe(Buffer.byteLength(pages[0]!.body, "utf8"));
+    expect(alice!.bodyBytes).toBe(Buffer.byteLength(pages[0]!.body, "utf8"));
     expect(alice!.edgeCount).toBe(2);
     expect(alice!.updatedAtMs).toBeGreaterThanOrEqual(before);
 
     const bob = bySlug.get("bob");
     expect(bob).toBeDefined();
-    expect(bob!.bodyChars).toBe(Buffer.byteLength(pages[1]!.body, "utf8"));
+    expect(bob!.bodyBytes).toBe(Buffer.byteLength(pages[1]!.body, "utf8"));
     expect(bob!.edgeCount).toBe(0);
     expect(bob!.updatedAtMs).toBeGreaterThanOrEqual(before);
 
     const carol = bySlug.get("people/carol");
     expect(carol).toBeDefined();
-    expect(carol!.bodyChars).toBe(Buffer.byteLength(pages[2]!.body, "utf8"));
+    expect(carol!.bodyBytes).toBe(Buffer.byteLength(pages[2]!.body, "utf8"));
     expect(carol!.edgeCount).toBe(1);
     expect(carol!.updatedAtMs).toBeGreaterThanOrEqual(before);
   });
@@ -136,7 +135,7 @@ describe("memory_v2_list_concept_pages handler", () => {
       body: {},
     })) as MemoryV2ListConceptPagesResult;
 
-    expect(result.total).toBe(1);
+    expect(result.pages).toHaveLength(1);
     expect(result.pages.map((p) => p.slug)).toEqual(["valid-page"]);
   });
 });

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -194,11 +194,10 @@ const MemoryV2ListConceptPagesParams = z.object({}).strict();
 export type MemoryV2ListConceptPagesResult = {
   pages: Array<{
     slug: string;
-    bodyChars: number;
+    bodyBytes: number;
     edgeCount: number;
     updatedAtMs: number;
   }>;
-  total: number;
 };
 
 async function handleListConceptPages({
@@ -218,7 +217,7 @@ async function handleListConceptPages({
         const stats = await stat(join(conceptsDir, `${slug}.md`));
         return {
           slug,
-          bodyChars: Buffer.byteLength(page.body, "utf8"),
+          bodyBytes: Buffer.byteLength(page.body, "utf8"),
           edgeCount: page.frontmatter.edges.length,
           updatedAtMs: stats.mtimeMs,
         };
@@ -237,7 +236,7 @@ async function handleListConceptPages({
     (p): p is MemoryV2ListConceptPagesResult["pages"][number] => p !== null,
   );
 
-  return { pages, total: pages.length };
+  return { pages };
 }
 
 // ── Rebuild BM25 corpus stats ───────────────────────────────────────────

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IntelligencePanel.swift
@@ -150,8 +150,8 @@ struct IntelligencePanel: View {
 
         case .memories:
             Group {
-                if assistantFeatureFlagStore?.isEnabled("memory-v2-enabled") == true {
-                    MemoriesV2Panel(connectionManager: connectionManager)
+                if assistantFeatureFlagStore?.isEnabled("memory-v2-enabled") ?? true {
+                    MemoriesV2Panel()
                 } else {
                     MemoriesPanel(
                         connectionManager: connectionManager,

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
@@ -26,11 +26,8 @@ private enum MemoryV2SortOption: String, CaseIterable {
 /// `memory-v2-enabled` is on — wired in by the IntelligencePanel flag-gate
 /// (PR 6 of the plan).
 struct MemoriesV2Panel: View {
-    let connectionManager: GatewayConnectionManager
-
     @State private var pages: [MemoryV2ConceptPageSummary] = []
     @State private var isLoading: Bool = true
-    @State private var loadError: String?
     @State private var selectedSlug: String?
     @State private var searchText: String = ""
     @State private var debouncedSearchText: String = ""
@@ -39,8 +36,7 @@ struct MemoriesV2Panel: View {
 
     private let client: MemoryV2ClientProtocol
 
-    init(connectionManager: GatewayConnectionManager, client: MemoryV2ClientProtocol = MemoryV2Client()) {
-        self.connectionManager = connectionManager
+    init(client: MemoryV2ClientProtocol = MemoryV2Client()) {
         self.client = client
     }
 
@@ -127,12 +123,6 @@ struct MemoriesV2Panel: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let loadError {
-            VEmptyState(
-                title: "Couldn't load concept pages",
-                subtitle: loadError,
-                icon: VIcon.brain.rawValue
-            )
         } else if pages.isEmpty {
             VEmptyState(
                 title: "No concept pages yet",
@@ -172,7 +162,7 @@ struct MemoriesV2Panel: View {
 
                 Spacer(minLength: VSpacing.sm)
 
-                Text("\(page.bodyChars) chars · \(page.edgeCount) edges")
+                Text("\(page.bodyBytes) bytes · \(page.edgeCount) edges")
                     .font(VFont.labelDefault)
                     .foregroundStyle(VColor.contentTertiary)
             }
@@ -194,9 +184,6 @@ struct MemoriesV2Panel: View {
         defer { isLoading = false }
         if let response = await client.listConceptPages() {
             pages = response.pages
-            loadError = nil
-        } else {
-            loadError = "Failed to load concept pages."
         }
     }
 }

--- a/clients/shared/Network/MemoryV2Client.swift
+++ b/clients/shared/Network/MemoryV2Client.swift
@@ -7,13 +7,13 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "Memor
 public struct MemoryV2ConceptPageSummary: Codable, Sendable, Equatable, Identifiable {
     public var id: String { slug }
     public let slug: String
-    public let bodyChars: Int
+    public let bodyBytes: Int
     public let edgeCount: Int
     public let updatedAtMs: Int64
 
-    public init(slug: String, bodyChars: Int, edgeCount: Int, updatedAtMs: Int64) {
+    public init(slug: String, bodyBytes: Int, edgeCount: Int, updatedAtMs: Int64) {
         self.slug = slug
-        self.bodyChars = bodyChars
+        self.bodyBytes = bodyBytes
         self.edgeCount = edgeCount
         self.updatedAtMs = updatedAtMs
     }
@@ -22,11 +22,9 @@ public struct MemoryV2ConceptPageSummary: Codable, Sendable, Equatable, Identifi
 /// Response wrapper for the memory v2 concept-page list endpoint.
 public struct MemoryV2ListConceptPagesResponse: Codable, Sendable, Equatable {
     public let pages: [MemoryV2ConceptPageSummary]
-    public let total: Int
 
-    public init(pages: [MemoryV2ConceptPageSummary], total: Int) {
+    public init(pages: [MemoryV2ConceptPageSummary]) {
         self.pages = pages
-        self.total = total
     }
 }
 


### PR DESCRIPTION
## Summary
- Rename bodyChars → bodyBytes (matches actual semantics).
- Drop unused 'total' wire field.
- Drop unused connectionManager param on MemoriesV2Panel.
- Simplify loadError state.
- Fix flag-gate nil-fallback to match registry default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->