### PR TITLE
Fix inbound voice assistant name fallback

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -2334,16 +2334,57 @@ describe("relay-server", () => {
 
       expect(relay.getConnectionState()).toBe("awaiting_name");
 
-      // Fallback prompt should not include assistant name or internal assistant id.
+      // Fallback prompt should use the existing guardian-label wording.
       const textMessages = ws.sentMessages
         .map((raw) => JSON.parse(raw) as { type: string; token?: string })
         .filter((m) => m.type === "text");
       const promptText = textMessages.map((m) => m.token ?? "").join("");
-      expect(promptText).toContain("Hi, this is the assistant.");
+      expect(promptText).toContain("Hi, this is my human's assistant.");
       expect(promptText).not.toContain("Vellum");
-      expect(promptText).not.toContain("self");
       expect(promptText).toContain("don't recognize this number");
       expect(promptText).toContain("Can I get your name");
+
+      relay.destroy();
+    } finally {
+      mockAssistantName = prevName;
+    }
+  });
+
+  test("inbound voice: unknown caller name capture does not speak a UUID assistant name", async () => {
+    const prevName = mockAssistantName;
+    mockAssistantName = "11111111-2222-4333-8444-555555555555";
+    const db = getDb();
+    db.run("DELETE FROM contact_channels");
+    db.run("DELETE FROM contacts");
+    try {
+      ensureConversation("conv-invite-uuid-name");
+      const session = createCallSession({
+        conversationId: "conv-invite-uuid-name",
+        provider: "twilio",
+        fromNumber: "+12125550157",
+        toNumber: "+12125550111",
+      });
+
+      const { ws, relay } = createMockWs(session.id);
+
+      await relay.handleMessage(
+        JSON.stringify({
+          type: "setup",
+          callSid: "CA_invite_uuid_name",
+          from: "+12125550157",
+          to: "+12125550111",
+        }),
+      );
+
+      expect(relay.getConnectionState()).toBe("awaiting_name");
+
+      const promptText = ws.sentMessages
+        .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+        .filter((m) => m.type === "text")
+        .map((m) => m.token ?? "")
+        .join("");
+      expect(promptText).toContain("Hi, this is my human's assistant.");
+      expect(promptText).not.toContain("11111111-2222-4333-8444-555555555555");
 
       relay.destroy();
     } finally {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -362,7 +362,9 @@ function getLatestAssistantText(conversationId: string): string | null {
     if (Array.isArray(parsed)) {
       return parsed
         .filter(
-          (block): block is {
+          (
+            block,
+          ): block is {
             type: string;
             text?: string;
             surfaceType?: string;
@@ -2332,13 +2334,14 @@ describe("relay-server", () => {
 
       expect(relay.getConnectionState()).toBe("awaiting_name");
 
-      // Fallback prompt should NOT include assistant name but should include guardian label
+      // Fallback prompt should not include assistant name or internal assistant id.
       const textMessages = ws.sentMessages
         .map((raw) => JSON.parse(raw) as { type: string; token?: string })
         .filter((m) => m.type === "text");
       const promptText = textMessages.map((m) => m.token ?? "").join("");
-      expect(promptText).toContain("Hi, this is my human's assistant.");
+      expect(promptText).toContain("Hi, this is the assistant.");
       expect(promptText).not.toContain("Vellum");
+      expect(promptText).not.toContain("self");
       expect(promptText).toContain("don't recognize this number");
       expect(promptText).toContain("Can I get your name");
 

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -650,10 +650,10 @@ describe("voice-session-bridge", () => {
       "Introduce yourself once at the start using your assistant name if you know it",
     );
     expect(prompt).toContain(
-      'If your assistant name is not known, call yourself "the assistant" instead.',
+      "If your assistant name is not known, skip the name and just identify yourself as the guardian's assistant.",
     );
     expect(prompt).toContain(
-      'Never use an internal assistant ID such as "self" as your spoken name.',
+      "Never use a UUID-shaped internal assistant ID as your spoken name.",
     );
     expect(prompt).toContain(
       'Do NOT say "I\'m calling" or "I\'m calling on behalf of".',

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -650,7 +650,10 @@ describe("voice-session-bridge", () => {
       "Introduce yourself once at the start using your assistant name if you know it",
     );
     expect(prompt).toContain(
-      "If your assistant name is not known, skip the name and just identify yourself as the guardian's assistant.",
+      'If your assistant name is not known, call yourself "the assistant" instead.',
+    );
+    expect(prompt).toContain(
+      'Never use an internal assistant ID such as "self" as your spoken name.',
     );
     expect(prompt).toContain(
       'Do NOT say "I\'m calling" or "I\'m calling on behalf of".',

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -66,7 +66,8 @@ import {
 } from "./speaker-identification.js";
 
 const log = getLogger("relay-server");
-const DEFAULT_ASSISTANT_VOICE_LABEL = "the assistant";
+const UUID_SHAPED_NAME =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 // ── ConversationRelay message types ──────────────────────────────────
 
@@ -1160,7 +1161,7 @@ export class RelayConnection {
 
     const greeting = assistantName
       ? `Hi, this is ${assistantName}, ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`
-      : `Hi, this is ${DEFAULT_ASSISTANT_VOICE_LABEL}. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
+      : `Hi, this is ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
 
     void speakSystemPrompt(this, greeting);
 
@@ -1616,7 +1617,11 @@ export class RelayConnection {
   private resolveAssistantLabel(): string | null {
     try {
       const name = getAssistantName();
-      return name?.trim() || null;
+      const trimmedName = name?.trim();
+      if (!trimmedName || UUID_SHAPED_NAME.test(trimmedName)) {
+        return null;
+      }
+      return trimmedName;
     } catch {
       return null;
     }

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -66,6 +66,7 @@ import {
 } from "./speaker-identification.js";
 
 const log = getLogger("relay-server");
+const DEFAULT_ASSISTANT_VOICE_LABEL = "the assistant";
 
 // ── ConversationRelay message types ──────────────────────────────────
 
@@ -1159,7 +1160,7 @@ export class RelayConnection {
 
     const greeting = assistantName
       ? `Hi, this is ${assistantName}, ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`
-      : `Hi, this is ${guardianLabel}'s assistant. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
+      : `Hi, this is ${DEFAULT_ASSISTANT_VOICE_LABEL}. Sorry, I don't recognize this number. I'll let ${guardianLabel} know you called and see if I have permission to speak with you. Can I get your name?`;
 
     void speakSystemPrompt(this, greeting);
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -233,7 +233,7 @@ function buildVoiceCallControlPrompt(opts: {
       );
     } else {
       lines.push(
-        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Introduce yourself once at the start using your assistant name if you know it (for example: "Hey there, this is Ava, Sam\'s assistant. How can I help?"). If your assistant name is not known, skip the name and just identify yourself as the guardian\'s assistant. Do NOT say "I\'m calling" or "I\'m calling on behalf of". Vary the wording; do not use a fixed template.',
+        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Introduce yourself once at the start using your assistant name if you know it (for example: "Hey there, this is Ava, Sam\'s assistant. How can I help?"). If your assistant name is not known, call yourself "the assistant" instead. Never use an internal assistant ID such as "self" as your spoken name. Do NOT say "I\'m calling" or "I\'m calling on behalf of". Vary the wording; do not use a fixed template.',
       );
     }
     lines.push(

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -233,7 +233,7 @@ function buildVoiceCallControlPrompt(opts: {
       );
     } else {
       lines.push(
-        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Introduce yourself once at the start using your assistant name if you know it (for example: "Hey there, this is Ava, Sam\'s assistant. How can I help?"). If your assistant name is not known, call yourself "the assistant" instead. Never use an internal assistant ID such as "self" as your spoken name. Do NOT say "I\'m calling" or "I\'m calling on behalf of". Vary the wording; do not use a fixed template.',
+        '7. If the latest user turn is "(call connected — deliver opening greeting)", this is an inbound call you are answering (not a call you initiated). Greet the caller warmly and ask how you can help. Introduce yourself once at the start using your assistant name if you know it (for example: "Hey there, this is Ava, Sam\'s assistant. How can I help?"). If your assistant name is not known, skip the name and just identify yourself as the guardian\'s assistant. Never use a UUID-shaped internal assistant ID as your spoken name. Do NOT say "I\'m calling" or "I\'m calling on behalf of". Vary the wording; do not use a fixed template.',
       );
     }
     lines.push(


### PR DESCRIPTION
## Summary
- Use the configured assistant name for inbound voice self-introductions, and fall back to "the assistant" when no name is available.
- Guard inbound voice opener instructions against speaking internal assistant IDs such as "self".
- Update regression coverage for the no-name inbound fallback and voice opener prompt.

## Original prompt
when the twilio skill has an inbound call it refferedd to itself by the assistant id, it should instead refer to itself by its name and if doesn't have a name it should just call itself assistant