### PR TITLE
Make Twilio tool calls announce intent

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -3,6 +3,7 @@ import {
   beforeEach,
   describe,
   expect,
+  jest,
   type Mock,
   mock,
   test,
@@ -127,6 +128,7 @@ function createMockVoiceTurn(tokens: string[]) {
     assistantId?: string;
     onTextDelta: (text: string) => void;
     onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
+    onToolResult?: (toolName: string, toolUseId?: string) => void;
     onComplete: () => void;
     onError: (message: string) => void;
     signal?: AbortSignal;
@@ -530,6 +532,69 @@ describe("call-controller", () => {
     });
 
     controller.destroy();
+  });
+
+  test("handleCallerUtterance: reassures caller during long silent tool use", async () => {
+    jest.useFakeTimers();
+    let finishTurn = (): void => {
+      throw new Error("Voice turn has not started");
+    };
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        onToolUse?: (
+          toolName: string,
+          input: Record<string, unknown>,
+          toolUseId?: string,
+        ) => void;
+        onToolResult?: (toolName: string, toolUseId?: string) => void;
+        onComplete: () => void;
+        signal?: AbortSignal;
+      }) => {
+        if (opts.signal?.aborted) {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          throw err;
+        }
+        opts.onToolUse?.("web_search", { query: "store hours" }, "tool-1");
+        return new Promise((resolve) => {
+          finishTurn = () => {
+            opts.onToolResult?.("web_search", "tool-1");
+            opts.onComplete();
+            resolve({
+              turnId: "long-tool-run",
+              abort: () => {},
+            });
+          };
+        });
+      },
+    );
+    const { relay, controller } = setupController();
+
+    try {
+      const turnPromise = controller.handleCallerUtterance(
+        "Can you check their hours?",
+      );
+      await Promise.resolve();
+
+      expect(relay.sentTokens).not.toContainEqual({
+        token: "I'm still working on that.",
+        last: true,
+      });
+
+      jest.advanceTimersByTime(20_000);
+      await Promise.resolve();
+
+      expect(relay.sentTokens).toContainEqual({
+        token: "I'm still working on that.",
+        last: true,
+      });
+
+      finishTurn();
+      await turnPromise;
+    } finally {
+      controller.destroy();
+      jest.useRealTimers();
+    }
   });
 
   test("handleCallerUtterance: sends last=true at end of turn", async () => {

--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -126,6 +126,7 @@ function createMockVoiceTurn(tokens: string[]) {
     content: string;
     assistantId?: string;
     onTextDelta: (text: string) => void;
+    onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
     onComplete: () => void;
     onError: (message: string) => void;
     signal?: AbortSignal;
@@ -495,6 +496,38 @@ describe("call-controller", () => {
     // The last token should have last=true (empty string token signaling end)
     const lastToken = relay.sentTokens[relay.sentTokens.length - 1];
     expect(lastToken.last).toBe(true);
+
+    controller.destroy();
+  });
+
+  test("handleCallerUtterance: speaks fallback prelude before silent tool use", async () => {
+    mockStartVoiceTurn.mockImplementation(
+      async (opts: {
+        onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
+        onComplete: () => void;
+        signal?: AbortSignal;
+      }) => {
+        if (opts.signal?.aborted) {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          throw err;
+        }
+        opts.onToolUse?.("web_search", { query: "store hours" });
+        opts.onComplete();
+        return {
+          turnId: "silent-tool-run",
+          abort: () => {},
+        };
+      },
+    );
+    const { relay, controller } = setupController();
+
+    await controller.handleCallerUtterance("Can you check their hours?");
+
+    expect(relay.sentTokens).toContainEqual({
+      token: "I'm going to look that up now.",
+      last: true,
+    });
 
     controller.destroy();
   });

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -232,6 +232,43 @@ describe("voice-session-bridge", () => {
     expect(typeof handle.abort).toBe("function");
   });
 
+  test("startVoiceTurn forwards tool-use starts to onToolUse callback", async () => {
+    const conversation = createConversation("voice bridge tool-use test");
+    const events: ServerMessage[] = [
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "store hours" },
+        conversationId: conversation.id,
+        toolUseId: "tool-1",
+      },
+      { type: "message_complete", conversationId: conversation.id },
+    ];
+    const session = makeStreamingSession(events);
+    injectDeps(() => session);
+
+    const toolUses: Array<{
+      toolName: string;
+      input: Record<string, unknown>;
+    }> = [];
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: "Hello from caller",
+      isInbound: true,
+      onTextDelta: () => {},
+      onToolUse: (toolName, input) => toolUses.push({ toolName, input }),
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(toolUses).toEqual([
+      { toolName: "web_search", input: { query: "store hours" } },
+    ]);
+  });
+
   test("startVoiceTurn forwards error events to onError callback", async () => {
     const conversation = createConversation("voice bridge error test");
     const events: ServerMessage[] = [

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -269,6 +269,44 @@ describe("voice-session-bridge", () => {
     ]);
   });
 
+  test("startVoiceTurn forwards tool results to onToolResult callback", async () => {
+    const conversation = createConversation("voice bridge tool-result test");
+    const events: ServerMessage[] = [
+      {
+        type: "tool_result",
+        toolName: "web_search",
+        result: "Open until 6 PM",
+        conversationId: conversation.id,
+        toolUseId: "tool-1",
+      },
+      { type: "message_complete", conversationId: conversation.id },
+    ];
+    const session = makeStreamingSession(events);
+    injectDeps(() => session);
+
+    const toolResults: Array<{
+      toolName: string;
+      toolUseId?: string;
+    }> = [];
+
+    await startVoiceTurn({
+      conversationId: conversation.id,
+      content: "Hello from caller",
+      isInbound: true,
+      onTextDelta: () => {},
+      onToolResult: (toolName, toolUseId) =>
+        toolResults.push({ toolName, toolUseId }),
+      onComplete: () => {},
+      onError: () => {},
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(toolResults).toEqual([
+      { toolName: "web_search", toolUseId: "tool-1" },
+    ]);
+  });
+
   test("startVoiceTurn forwards error events to onError callback", async () => {
     const conversation = createConversation("voice bridge error test");
     const events: ServerMessage[] = [

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -73,6 +73,9 @@ const log = getLogger("call-controller");
 
 type ControllerState = "idle" | "processing" | "speaking";
 
+const VOICE_TOOL_STILL_WORKING_DELAY_MS = 20_000;
+const VOICE_TOOL_STILL_WORKING_MESSAGE = "I'm still working on that.";
+
 const VOICE_TOOL_PRELUDE_ACTIONS: Record<string, string> = {
   web_search: "look that up",
   web_fetch: "open that page",
@@ -623,6 +626,27 @@ export class CallController {
     let fullResponseText = "";
     let assistantSpeechQueued = false;
     let fallbackToolPreludeSpoken = false;
+    let activeToolCallCount = 0;
+    let stillWorkingTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearStillWorkingTimer = (): void => {
+      if (!stillWorkingTimer) return;
+      clearTimeout(stillWorkingTimer);
+      stillWorkingTimer = null;
+    };
+
+    const armStillWorkingTimer = (): void => {
+      clearStillWorkingTimer();
+      stillWorkingTimer = setTimeout(() => {
+        stillWorkingTimer = null;
+        if (!this.isCurrentRun(runVersion)) return;
+        if (runSignal.aborted || activeToolCallCount <= 0) return;
+        void speakSystemPrompt(
+          this.transport,
+          VOICE_TOOL_STILL_WORKING_MESSAGE,
+        );
+      }, VOICE_TOOL_STILL_WORKING_DELAY_MS);
+    };
 
     // When using the synthesized path, we accumulate all text and synthesize
     // the complete response at the end of the turn (better prosody).
@@ -696,12 +720,21 @@ export class CallController {
 
       const onToolUse = (toolName: string): void => {
         if (!this.isCurrentRun(runVersion)) return;
+        activeToolCallCount++;
+        armStillWorkingTimer();
         if (assistantSpeechQueued || fallbackToolPreludeSpoken) return;
         fallbackToolPreludeSpoken = true;
         void speakSystemPrompt(
           this.transport,
           formatVoiceToolPrelude(toolName),
         );
+      };
+
+      const onToolResult = (): void => {
+        activeToolCallCount = Math.max(0, activeToolCallCount - 1);
+        if (activeToolCallCount === 0) {
+          clearStillWorkingTimer();
+        }
       };
 
       // Start the voice turn through the session bridge
@@ -716,6 +749,7 @@ export class CallController {
         skipDisclosure: this.skipDisclosure,
         onTextDelta,
         onToolUse,
+        onToolResult,
         onComplete,
         onError,
         signal: runSignal,
@@ -749,7 +783,11 @@ export class CallController {
     // inside the Promise constructor before this await adds its handler.
     // The await below still re-throws, caught by the outer try-catch.
     turnComplete.catch(() => {});
-    await turnComplete;
+    try {
+      await turnComplete;
+    } finally {
+      clearStillWorkingTimer();
+    }
     if (!this.isCurrentRun(runVersion)) return fullResponseText;
 
     // Final sweep: strip any remaining control markers from the buffer

--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -32,6 +32,7 @@ import {
   getUserConsultationTimeoutMs,
 } from "./call-constants.js";
 import { addPointerMessage, formatDuration } from "./call-pointer-messages.js";
+import { speakSystemPrompt } from "./call-speech-output.js";
 import {
   fireCallQuestionNotifier,
   fireCallTranscriptNotifier,
@@ -71,6 +72,25 @@ import {
 const log = getLogger("call-controller");
 
 type ControllerState = "idle" | "processing" | "speaking";
+
+const VOICE_TOOL_PRELUDE_ACTIONS: Record<string, string> = {
+  web_search: "look that up",
+  web_fetch: "open that page",
+  file_read: "check the file",
+  skill_load: "load the relevant skill",
+  skill_execute: "run the skill",
+  recall: "check what I remember",
+  remember: "make a note of that",
+  call_status: "check the call status",
+  call_end: "end the call",
+};
+
+function formatVoiceToolPrelude(toolName: string): string {
+  const action =
+    VOICE_TOOL_PRELUDE_ACTIONS[toolName] ??
+    `use ${toolName.replace(/_/g, " ")}`;
+  return `I'm going to ${action} now.`;
+}
 
 /**
  * Tracks a pending guardian input request independently of the controller's
@@ -601,6 +621,8 @@ export class CallController {
     // could be the start of a control marker.
     let ttsBuffer = "";
     let fullResponseText = "";
+    let assistantSpeechQueued = false;
+    let fallbackToolPreludeSpoken = false;
 
     // When using the synthesized path, we accumulate all text and synthesize
     // the complete response at the end of the turn (better prosody).
@@ -610,6 +632,7 @@ export class CallController {
     const emitSafeChunk = (safeText: string): void => {
       const cleaned = sanitizeForTts(safeText);
       if (cleaned.length === 0) return;
+      assistantSpeechQueued = true;
       if (useSynthesizedPath) {
         synthesizedTextBuffer += cleaned;
       } else {
@@ -671,6 +694,16 @@ export class CallController {
         reject(new Error(message));
       };
 
+      const onToolUse = (toolName: string): void => {
+        if (!this.isCurrentRun(runVersion)) return;
+        if (assistantSpeechQueued || fallbackToolPreludeSpoken) return;
+        fallbackToolPreludeSpoken = true;
+        void speakSystemPrompt(
+          this.transport,
+          formatVoiceToolPrelude(toolName),
+        );
+      };
+
       // Start the voice turn through the session bridge
       startVoiceTurn({
         conversationId: this.conversationId,
@@ -682,6 +715,7 @@ export class CallController {
         task: this.task,
         skipDisclosure: this.skipDisclosure,
         onTextDelta,
+        onToolUse,
         onComplete,
         onError,
         signal: runSignal,

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -87,7 +87,12 @@ export interface VoiceRunEventSink {
     >,
   ): void;
   onError(message: string): void;
-  onToolUse(toolName: string, input: Record<string, unknown>): void;
+  onToolUse(
+    toolName: string,
+    input: Record<string, unknown>,
+    toolUseId?: string,
+  ): void;
+  onToolResult(toolName: string, toolUseId?: string): void;
 }
 
 export interface VoiceTurnCallbacks {
@@ -138,7 +143,13 @@ export interface VoiceTurnOptions {
   /** Called for each streaming text token from the agent loop. */
   onTextDelta?: (text: string) => void;
   /** Called when the agent loop is about to execute a tool. */
-  onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
+  onToolUse?: (
+    toolName: string,
+    input: Record<string, unknown>,
+    toolUseId?: string,
+  ) => void;
+  /** Called when the agent loop receives a tool result. */
+  onToolResult?: (toolName: string, toolUseId?: string) => void;
   /** Called when the agent loop completes a full response. */
   onComplete?: () => void;
   /** Called when the agent loop encounters an error. */
@@ -310,9 +321,13 @@ export async function startVoiceTurn(
     onError: (message) => {
       opts.onError?.(message);
     },
-    onToolUse: (toolName, input) => {
-      log.debug({ toolName, input }, "Voice turn tool_use event");
-      opts.onToolUse?.(toolName, input);
+    onToolUse: (toolName, input, toolUseId) => {
+      log.debug({ toolName, input, toolUseId }, "Voice turn tool_use event");
+      opts.onToolUse?.(toolName, input, toolUseId);
+    },
+    onToolResult: (toolName, toolUseId) => {
+      log.debug({ toolName, toolUseId }, "Voice turn tool_result event");
+      opts.onToolResult?.(toolName, toolUseId);
     },
   };
 
@@ -585,7 +600,9 @@ export async function startVoiceTurn(
           } else if (msg.type === "conversation_error") {
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
-            eventSink.onToolUse(msg.toolName, msg.input);
+            eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
+          } else if (msg.type === "tool_result") {
+            eventSink.onToolResult(msg.toolName, msg.toolUseId);
           }
           // Note: tool_use_preview_start is intentionally not handled here.
           // Voice only reacts to the definitive tool_use_start event.

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -137,6 +137,8 @@ export interface VoiceTurnOptions {
   skipDisclosure?: boolean;
   /** Called for each streaming text token from the agent loop. */
   onTextDelta?: (text: string) => void;
+  /** Called when the agent loop is about to execute a tool. */
+  onToolUse?: (toolName: string, input: Record<string, unknown>) => void;
   /** Called when the agent loop completes a full response. */
   onComplete?: () => void;
   /** Called when the agent loop encounters an error. */
@@ -255,6 +257,7 @@ function buildVoiceCallControlPrompt(opts: {
     "9. After the opening greeting turn, treat the Task field as background context only — do not re-execute its instructions on subsequent turns.",
     '10. Do not make up information. If you are unsure, use [ASK_GUARDIAN: your question] to consult your guardian. For tool permission requests, use [ASK_GUARDIAN_APPROVAL: {"question":"...","toolName":"...","input":{...}}].',
     `11. Your text is sent directly to a text-to-speech engine. Never use markdown formatting (asterisks, headers, backticks, links) or emojis in your spoken responses. Write plain conversational text only. Protocol markers like ${opts.isCallerGuardian ? "[END_CALL]" : "[ASK_GUARDIAN: ...] and [END_CALL]"} are not spoken text and should still be used normally.`,
+    '12. Before using any tool during the call, first say one short plain-language sentence telling the caller what you are about to do, such as "I\'ll check that now." Then make the tool call. Do not leave the caller in silence while a tool runs.',
     "</voice_call_control>",
   );
 
@@ -309,6 +312,7 @@ export async function startVoiceTurn(
     },
     onToolUse: (toolName, input) => {
       log.debug({ toolName, input }, "Voice turn tool_use event");
+      opts.onToolUse?.(toolName, input);
     },
   };
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -601,7 +601,11 @@ export async function startVoiceTurn(
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
-          } else if (msg.type === "tool_result") {
+          } else if (
+            // guard:allow-tool-result-only — web_search_tool_result is a persisted
+            // content block, not a ServerMessage emitted by the live voice turn.
+            msg.type === "tool_result"
+          ) {
             eventSink.onToolResult(msg.toolName, msg.toolUseId);
           }
           // Note: tool_use_preview_start is intentionally not handled here.

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -19,6 +19,10 @@ metadata:
 
 You are helping the user set up and manage phone calls via Twilio. This skill covers enabling the calls feature, placing outbound calls, receiving inbound calls, and interacting with live calls. Twilio credential storage, phone number provisioning, and public ingress are handled by the **twilio-setup** skill.
 
+## Tool Call Narration
+
+Before using any phone-call tool (`call_start`, `call_status`, or `call_end`), send a brief user-visible sentence saying what you are about to do. Keep it concrete and short: "I'm going to start the test call now" or "I'll check the call status now." Do not silently start a call, poll status, or end a call.
+
 ## External Identity
 
 When speaking on behalf of your user during calls, refer to yourself as an "assistant" (not "AI assistant"). Use your user's name and pronouns from their user persona file (`users/<slug>.md`). Don't volunteer that you are an AI unless directly asked.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -683,7 +683,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-05-05T17:11:32-06:00"
+      "updatedAt": "2026-05-05T21:43:58-06:00"
     },
     {
       "id": "typescript-eval",

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -11,6 +11,10 @@ metadata:
 
 You are helping your user configure Twilio for voice calls. Walk through each step below.
 
+## Tool Call Narration
+
+Before any tool call or command, send a brief user-visible sentence saying what you are about to do. Keep it concrete and short: "I'm going to check your current Twilio configuration now" or "I'll open the secure credential prompt for your Auth Token." Do not silently check config, open credential prompts, or call the Twilio API.
+
 ## Value Classification
 
 Before you begin, understand how each Twilio value is stored:


### PR DESCRIPTION
Context: I talk to the assistant on call and its just doing stuff and not talking to me so im like did it die or what

## Summary
- Tell the Twilio setup and phone-calls skills to briefly narrate before tool calls.
- Add a phone-call fallback that speaks a short prelude if a voice turn starts a tool without prior spoken text.
- Cover the voice tool-start callback and fallback prelude with focused tests.

## Original prompt
Before starting a tool call the twilio skill assistant should tell the user what they are about to do