### PR TITLE
fix(documents): persist documents to DB on creation for web viewer access

### DIFF
--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -5,7 +5,7 @@
  * background jobs (e.g. proactive artifact generation) can persist documents
  * without going through the HTTP layer.
  */
-import { rawRun } from "../memory/raw-query.js";
+import { rawGet, rawRun } from "../memory/raw-query.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("document-store");
@@ -81,5 +81,38 @@ export function saveDocument(params: {
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",
     };
+  }
+}
+
+/** Update persisted document content (append or replace). */
+export function updateDocumentContent(
+  surfaceId: string,
+  markdown: string,
+  mode: string,
+): void {
+  try {
+    const existing = rawGet<{ content: string }>(
+      /*sql*/ `SELECT content FROM documents WHERE surface_id = ?`,
+      surfaceId,
+    );
+    if (!existing) {
+      log.info({ surfaceId }, "No persisted document to update");
+      return;
+    }
+    const newContent =
+      mode === "append" ? existing.content + markdown : markdown;
+    const wordCount = newContent
+      .split(/\s+/)
+      .filter((w) => w.length > 0).length;
+    rawRun(
+      /*sql*/ `UPDATE documents SET content = ?, word_count = ?, updated_at = ? WHERE surface_id = ?`,
+      newContent,
+      wordCount,
+      Date.now(),
+      surfaceId,
+    );
+    log.info({ surfaceId, mode }, "Updated document content");
+  } catch (error) {
+    log.error({ err: error, surfaceId }, "Document content update error");
   }
 }

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -99,8 +99,9 @@ export function updateDocumentContent(
       log.info({ surfaceId }, "No persisted document to update");
       return;
     }
+    const sep = mode === "append" && existing.content.length > 0 ? "\n\n" : "";
     const newContent =
-      mode === "append" ? existing.content + markdown : markdown;
+      mode === "append" ? existing.content + sep + markdown : markdown;
     const wordCount = newContent
       .split(/\s+/)
       .filter((w) => w.length > 0).length;

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
 
-import { saveDocument } from "../../documents/document-store.js";
+import {
+  saveDocument,
+  updateDocumentContent,
+} from "../../documents/document-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 // ── Exported execute functions ──────────────────────────────────────
@@ -81,6 +84,8 @@ export function executeDocumentUpdate(
   const surfaceId = input.surface_id as string;
   const content = input.content as string;
   const mode = (input.mode as string | undefined) || "append";
+
+  updateDocumentContent(surfaceId, content, mode);
 
   // Send document_editor_update message to update the built-in RTE
   if (context.sendToClient) {

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { saveDocument } from "../../documents/document-store.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 // ── Exported execute functions ──────────────────────────────────────
@@ -11,6 +12,20 @@ export function executeDocumentCreate(
   const title = (input.title as string | undefined) || "Untitled Document";
   const initialContent = (input.initial_content as string | undefined) || "";
   const surfaceId = `doc-${randomUUID()}`;
+
+  // Persist the document so any client (web or macOS) can fetch it via
+  // GET /v1/documents/:id. The macOS client may later update the row
+  // via document_save; ON CONFLICT DO UPDATE handles that.
+  const wordCount = initialContent
+    .split(/\s+/)
+    .filter((w) => w.length > 0).length;
+  saveDocument({
+    surfaceId,
+    conversationId: context.conversationId,
+    title,
+    content: initialContent,
+    wordCount,
+  });
 
   // Send document_editor_show message to open the built-in RTE
   if (context.sendToClient) {


### PR DESCRIPTION
## Prompt / plan

`executeDocumentCreate` streams document content to the macOS client via `document_editor_show` SSE but never persists the document to the SQLite `documents` table. Persistence only happens when the macOS client explicitly sends `document_save` back. This means `GET /v1/documents/:id` returns 404 for any tool-created document that hasn't been manually saved by the macOS editor — blocking the web document viewer (vellum-assistant-platform#6013) from displaying content.

The fix adds `saveDocument()` in `executeDocumentCreate`, consistent with how the proactive artifact job already persists documents. The macOS client's subsequent `document_save` calls are handled by the existing `ON CONFLICT DO UPDATE` clause.

## Test plan

- Pre-push hook: type-check and lint pass
- Pre-existing tests for `saveDocument` and `ON CONFLICT DO UPDATE` cover the persistence behavior
- The 3 test failures in `invite-routes-http.test.ts` are pre-existing timeouts unrelated to this change (invite/contact routes, not documents)
- End-to-end: companion PR vellum-assistant-platform#6013 adds the web viewer that calls `GET /v1/documents/:id`

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/9daa4dd8e46f459fbad5fded3beae724