### PR TITLE
fix(macos): drop FlexFrame from MemoriesV2Panel loading state

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
@@ -117,12 +117,10 @@ struct MemoriesV2Panel: View {
     @ViewBuilder
     private var listContent: some View {
         if isLoading {
-            VStack {
-                Spacer()
+            ZStack {
+                Color.clear
                 VLoadingIndicator()
-                Spacer()
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if pages.isEmpty {
             VEmptyState(
                 title: "No concept pages yet",

--- a/clients/scripts/flexframe-allowlist.txt
+++ b/clients/scripts/flexframe-allowlist.txt
@@ -177,7 +177,6 @@ clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift|.f
 clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesPanel.swift|.frame(maxWidth: .infinity, maxHeight: .infinity)
 clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift|.frame(maxHeight: .infinity)
 clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift|.frame(maxWidth: .infinity)
-clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift|.frame(maxWidth: .infinity, maxHeight: .infinity)
 clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryImportSheet.swift|.frame(maxWidth: .infinity, alignment: .leading)
 clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryImportSheet.swift|.frame(minHeight: 140)
 clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoryItemDetailSheet+Content.swift|.frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Replace `VStack { Spacer; VLoadingIndicator; Spacer }.frame(maxWidth: .infinity, maxHeight: .infinity)` with `ZStack { Color.clear; VLoadingIndicator() }` in `MemoriesV2Panel.listContent`'s loading branch — same fill-and-center behavior without `_FlexFrameLayout`.
- Remove the matching allowlist entry from `clients/scripts/flexframe-allowlist.txt`.

## Original prompt
The FlexFrame Lint job at https://github.com/vellum-ai/vellum-assistant/actions/runs/25413718847/job/74540694423 failed on commit `1c916d57` (PR #29801) flagging `.frame(maxWidth: .infinity, maxHeight: .infinity)` in `MemoriesV2Panel.swift`. PR #29802 silenced it via allowlist, but the lint script's docs explicitly call allowlisting "a last resort". This PR does the proper fix — refactor to a safe pattern and drop the allowlist entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->