### PR TITLE
fix(memory): evict v2 everInjected on compaction

### DIFF
--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -476,7 +476,7 @@ function makeCtx(
     }),
 
     graphMemory: {
-      onCompacted: () => {},
+      onCompacted: async () => {},
       prepareMemory: async () => ({
         runMessages: [],
         injectedTokens: 0,

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -531,7 +531,7 @@ function makeCtx(
     }),
 
     graphMemory: {
-      onCompacted: () => {},
+      onCompacted: async () => {},
       prepareMemory: async () => ({
         runMessages: [],
         injectedTokens: 0,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -626,7 +626,7 @@ function makeCtx(
     }),
 
     graphMemory: {
-      onCompacted: () => {},
+      onCompacted: async () => {},
       prepareMemory: async () => ({
         runMessages: [],
         injectedTokens: 0,
@@ -3652,11 +3652,11 @@ describe("session-agent-loop", () => {
       expect(rendered).not.toContain("original root");
     });
 
-    test("applyCompactionResult records Slack timestamp watermark when provided", () => {
+    test("applyCompactionResult records Slack timestamp watermark when provided", async () => {
       const ctx = makeCtx();
       const events: ServerMessage[] = [];
 
-      applyCompactionResult(
+      await applyCompactionResult(
         ctx,
         {
           messages: [

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -986,7 +986,7 @@ export async function runAgentLoopImpl(
         compactableStartIndex: 1,
       };
     };
-    const applySuccessfulCompaction = (
+    const applySuccessfulCompaction = async (
       result: Awaited<ReturnType<typeof ctx.contextWindowManager.maybeCompact>>,
       compactedBasis?: Message[],
     ) => {
@@ -1000,7 +1000,7 @@ export async function runAgentLoopImpl(
         provenanceContext,
         result.compactedMessages,
       );
-      applyCompactionResult(ctx, result, onEvent, reqId, {
+      await applyCompactionResult(ctx, result, onEvent, reqId, {
         slackContextCompactionWatermarkTs: slackWatermarkTs,
       });
       currentSlackContextSummary = result.summaryText;
@@ -1087,7 +1087,10 @@ export async function runAgentLoopImpl(
       await trackCompactionOutcome(ctx, compacted.summaryFailed, onEvent);
     }
     if (compacted?.compacted) {
-      applySuccessfulCompaction(compacted, messagesForStartOfTurnCompaction);
+      await applySuccessfulCompaction(
+        compacted,
+        messagesForStartOfTurnCompaction,
+      );
       shouldInjectWorkspace = true;
       if (compacted.compactedPersistedMessages > 0) {
         compactedThisTurn = true;
@@ -1790,7 +1793,7 @@ export async function runAgentLoopImpl(
             await trackCompactionOutcome(ctx, result.summaryFailed, onEvent);
           }
           if (result.compacted) {
-            applySuccessfulCompaction(result, compactedBasis);
+            await applySuccessfulCompaction(result, compactedBasis);
             shouldInjectWorkspace = true;
           }
         },
@@ -2119,7 +2122,7 @@ export async function runAgentLoopImpl(
         );
       }
       if (midLoopCompact.compacted) {
-        applySuccessfulCompaction(midLoopCompact, rawHistory);
+        await applySuccessfulCompaction(midLoopCompact, rawHistory);
         reducerCompacted = true;
         shouldInjectWorkspace = true;
       }
@@ -2371,7 +2374,7 @@ export async function runAgentLoopImpl(
         }
 
         if (step.compactionResult?.compacted) {
-          applySuccessfulCompaction(
+          await applySuccessfulCompaction(
             step.compactionResult,
             convergenceCompactionBasis,
           );
@@ -2537,7 +2540,7 @@ export async function runAgentLoopImpl(
             );
           }
           if (emergencyCompact?.compacted) {
-            applySuccessfulCompaction(emergencyCompact, ctx.messages);
+            await applySuccessfulCompaction(emergencyCompact, ctx.messages);
             reducerCompacted = true;
             shouldInjectWorkspace = true;
           }
@@ -3223,7 +3226,7 @@ export interface CompactionApplyContext {
  * truth for the UI indicator after compaction. Emitting both caused a
  * redundant SwiftUI invalidation on every compaction.
  */
-export function applyCompactionResult(
+export async function applyCompactionResult(
   ctx: CompactionApplyContext,
   result: {
     messages: Message[];
@@ -3249,12 +3252,12 @@ export function applyCompactionResult(
   options: {
     slackContextCompactionWatermarkTs?: string | null;
   } = {},
-): void {
+): Promise<void> {
   ctx.messages = result.messages;
   ctx.contextCompactedMessageCount += result.compactedPersistedMessages;
   const compactedAt = Date.now();
   ctx.contextCompactedAt = compactedAt;
-  ctx.graphMemory.onCompacted(result.compactedPersistedMessages);
+  await ctx.graphMemory.onCompacted(result.compactedPersistedMessages);
   updateConversationContextWindow(
     ctx.conversationId,
     result.summaryText,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1052,7 +1052,7 @@ export class Conversation {
       );
     }
     if (result.compacted) {
-      applyCompactionResult(this, result, this.sendToClient, null, {
+      await applyCompactionResult(this, result, this.sendToClient, null, {
         slackContextCompactionWatermarkTs: getSlackCompactionWatermarkForPrefix(
           slackChronologicalContext,
           result.compactedMessages,

--- a/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
+++ b/assistant/src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts
@@ -178,6 +178,8 @@ const { migrateActivationState } =
   await import("../../migrations/232-activation-state.js");
 const schema = await import("../../schema.js");
 const { _resetMemoryV2QdrantForTests } = await import("../../v2/qdrant.js");
+const { hydrate: hydrateActivationState } =
+  await import("../../v2/activation-store.js");
 
 // The wiring layer calls `getDb()` to fetch the SQLite handle. We mock
 // only that one export and spread the real module so unrelated callers
@@ -460,5 +462,48 @@ describe("ConversationGraphMemory.prepareMemory — v2 routing (context-load pat
 
     expect(result.mode).toBe("context-load");
     expect(result.injectedBlockText).toBeNull();
+  });
+});
+
+describe("ConversationGraphMemory.onCompacted — v2 activation eviction", () => {
+  test("clears everInjected so a previously-injected slug can re-attach", async () => {
+    // Without this wiring, `selectInjections` keeps subtracting the slug from
+    // every per-turn delta even though compaction discarded the cached
+    // `<memory>` attachment that previously made it visible.
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+
+    const conversationId = "conv-test-evict";
+    const memory = new ConversationGraphMemory(conversationId);
+    const config = makeConfig(true);
+
+    // Turn 1 — context-load fires (initialized=false), injecting alice-vscode.
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    const initial = await memory.prepareMemory(
+      makeMessages("Tell me about Alice's editor preferences"),
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+    expect(initial.injectedBlockText).toContain("### alice-vscode");
+
+    const before = await hydrateActivationState(testDbHandle!, conversationId);
+    expect(before?.everInjected.map((e) => e.slug)).toContain("alice-vscode");
+
+    await memory.onCompacted(1);
+
+    const after = await hydrateActivationState(testDbHandle!, conversationId);
+    expect(after?.everInjected).toEqual([]);
+
+    // Turn 2 — same Qdrant relevance. With everInjected cleared the slug
+    // should appear again in the injection block (re-attached on the new
+    // user message after compaction).
+    stageTurn([{ slug: "alice-vscode", denseScore: 0.9 }]);
+    const next = await memory.prepareMemory(
+      makeMessages("And what about Alice's editor again?"),
+      config,
+      new AbortController().signal,
+      noopEvent,
+    );
+    expect(next.injectedBlockText).toContain("### alice-vscode");
   });
 });

--- a/assistant/src/memory/graph/conversation-graph-memory.ts
+++ b/assistant/src/memory/graph/conversation-graph-memory.ts
@@ -24,6 +24,11 @@ import type { QdrantSparseVector } from "../qdrant-client.js";
 import { memorySummaries } from "../schema.js";
 import { conversations } from "../schema/conversations.js";
 import {
+  evictCompactedTurns as evictCompactedTurnsV2,
+  hydrate as hydrateV2State,
+  save as saveV2State,
+} from "../v2/activation-store.js";
+import {
   injectMemoryV2Block,
   type InjectMemoryV2Mode,
 } from "../v2/injection.js";
@@ -206,11 +211,33 @@ export class ConversationGraphMemory {
    * Notify that context compaction just happened.
    * On the next turn, we'll re-run full context load.
    */
-  onCompacted(compactedMessageCount: number): void {
+  async onCompacted(compactedMessageCount: number): Promise<void> {
     // Evict everything — compaction summarized all prior turns.
     // The tracker can't know exactly which turns were compacted,
     // so we conservatively clear everything and reload.
-    this.tracker.evictCompactedTurns(this.tracker.getTurn());
+    const upToTurn = this.tracker.getTurn();
+    this.tracker.evictCompactedTurns(upToTurn);
+
+    // Mirror the eviction on the v2 activation row: the cached `<memory>`
+    // attachments those slugs lived on are gone, but `everInjected` would
+    // otherwise keep them deduped from per-turn deltas forever.
+    try {
+      const db = getDb();
+      const state = await hydrateV2State(db, this.conversationId);
+      if (state) {
+        await saveV2State(
+          db,
+          this.conversationId,
+          evictCompactedTurnsV2(state, upToTurn),
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Failed to evict v2 activation state on compaction (non-fatal)",
+      );
+    }
+
     this.needsReload = true;
     log.info(
       { compactedMessageCount },


### PR DESCRIPTION
## Summary
- `ConversationGraphMemory.onCompacted` now also evicts `everInjected` on the v2 activation row, matching the v1 tracker behavior. Previously the v2 helper existed but was only called from tests, leaving slugs deduped forever after their cached `<memory>` attachments were thrown away.
- `applyCompactionResult` becomes async; five call sites in `conversation-agent-loop.ts` and one in `conversation.ts` await it.
- Adds an end-to-end test in `conversation-graph-memory-v2-routing.test.ts` that drives `prepareMemory → onCompacted → prepareMemory` and asserts the slug re-attaches.

## Original prompt
We dug into the v2 memory injection path and confirmed the bug: `everInjected` was append-only and `evictCompactedTurns` (in `assistant/src/memory/v2/activation-store.ts`) was wired to nothing in production — so per-turn delta injection after compaction would skip any slug seen before compaction even though its cached attachment was gone. The fix is mechanical: hook the existing helper into `onCompacted` and propagate the `await`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->