### PR TITLE
JARVIS-713: Add New Profile shortcut to macOS chat dropdown

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatProfilePicker.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Bundle of the per-conversation inference-profile state and the persistence
-/// callback the composer threads through to ``ChatProfilePicker``. A single optional
-/// parameter on ``ComposerView`` / ``ComposerSection`` toggles the pill.
+/// Bundle of the per-conversation inference-profile state and callbacks the
+/// composer threads through to ``ChatProfilePicker``. A single optional parameter
+/// on ``ComposerView`` / ``ComposerSection`` toggles the pill.
 struct ChatProfilePickerConfiguration {
     /// The current per-conversation inference-profile override. `nil` means
     /// the conversation inherits `activeProfile`.
@@ -19,6 +19,28 @@ struct ChatProfilePickerConfiguration {
     /// Persists a selection. Passing `nil` clears the override so the
     /// conversation falls back to `activeProfile`.
     let onSelect: (String?) -> Void
+
+    /// Already feature-gated capability for surfacing a create-profile command.
+    let canCreateProfile: Bool
+
+    /// Opens the profile creation flow owned by the chat surface.
+    let onCreateProfile: (() -> Void)?
+
+    init(
+        current: String?,
+        profiles: [InferenceProfile],
+        activeProfile: String,
+        canCreateProfile: Bool = false,
+        onSelect: @escaping (String?) -> Void,
+        onCreateProfile: (() -> Void)? = nil
+    ) {
+        self.current = current
+        self.profiles = profiles
+        self.activeProfile = activeProfile
+        self.onSelect = onSelect
+        self.canCreateProfile = canCreateProfile
+        self.onCreateProfile = onCreateProfile
+    }
 }
 
 /// A compact pill button in the composer action bar that lets the user pick a

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 import UniformTypeIdentifiers
 
 private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatView")
+private let newModelProfileShortcutFeatureFlagKey = "new-model-profile-shortcut"
 
 // MARK: - Performance Baseline Success Criteria
 //
@@ -18,6 +19,8 @@ private let log = Logger(subsystem: Bundle.appBundleIdentifier, category: "ChatV
 //   3. ≥30% reduction in mean graph update duration during streaming
 
 struct ChatView: View {
+    @Environment(AssistantFeatureFlagStore.self) private var assistantFeatureFlagStore: AssistantFeatureFlagStore?
+
     // MARK: - ViewModel
 
     /// The chat view model. With @Observable + @Bindable, SwiftUI tracks only
@@ -49,6 +52,7 @@ struct ChatView: View {
     var onBootstrapSendLogs: (() -> Void)?
     var onOpenConversationApp: ((ConversationArtifact) -> Void)? = nil
     var onOpenConversationDocument: ((ConversationArtifact) -> Void)? = nil
+    var onCreateInferenceProfile: (() -> Void)? = nil
 
     // MARK: - Recovery Mode (managed assistants only)
 
@@ -523,6 +527,8 @@ struct ChatView: View {
             current: currentConversation?.inferenceProfile ?? viewModel.pendingInferenceProfile,
             profiles: inferenceProfiles,
             activeProfile: activeInferenceProfile,
+            canCreateProfile: assistantFeatureFlagStore?.isEnabled(newModelProfileShortcutFeatureFlagKey) == true
+                && onCreateInferenceProfile != nil,
             onSelect: { profile in
                 if conversationId == nil {
                     viewModel.pendingInferenceProfile = profile
@@ -535,7 +541,8 @@ struct ChatView: View {
                         profile: profile
                     )
                 }
-            }
+            },
+            onCreateProfile: onCreateInferenceProfile
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -49,6 +49,8 @@ struct ComposerSection: View, Equatable {
             && lhs.inferenceProfilePicker?.current == rhs.inferenceProfilePicker?.current
             && lhs.inferenceProfilePicker?.profiles == rhs.inferenceProfilePicker?.profiles
             && lhs.inferenceProfilePicker?.activeProfile == rhs.inferenceProfilePicker?.activeProfile
+            && lhs.inferenceProfilePicker?.canCreateProfile == rhs.inferenceProfilePicker?.canCreateProfile
+            && (lhs.inferenceProfilePicker?.onCreateProfile != nil) == (rhs.inferenceProfilePicker?.onCreateProfile != nil)
             && (lhs.inferenceProfilePicker == nil) == (rhs.inferenceProfilePicker == nil)
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
@@ -149,7 +149,7 @@ struct ComposerSettingsMenu: View {
                     }
                 }
 
-                if let config, !config.profiles.isEmpty {
+                if let config, Self.shouldRenderProfileSection(for: config) {
                     let effectiveProfile = config.current ?? config.activeProfile
 
                     sectionHeader("Model Profile")
@@ -169,12 +169,37 @@ struct ComposerSettingsMenu: View {
                             }
                         }
                     }
+
+                    if Self.shouldExposeCreateProfileCommand(for: config) {
+                        VMenuItem(
+                            icon: VIcon.plus.rawValue,
+                            label: "New Profile...",
+                            size: .regular
+                        ) {
+                            createProfile(using: config)
+                        }
+                    }
                 }
             }
         } onDismiss: {
             isMenuOpen = false
             activePanel = nil
         }
+    }
+
+    static func shouldRenderProfileSection(for config: ChatProfilePickerConfiguration) -> Bool {
+        !config.profiles.isEmpty || config.canCreateProfile
+    }
+
+    static func shouldExposeCreateProfileCommand(for config: ChatProfilePickerConfiguration) -> Bool {
+        config.canCreateProfile
+    }
+
+    private func createProfile(using config: ChatProfilePickerConfiguration) {
+        activePanel?.close()
+        activePanel = nil
+        isMenuOpen = false
+        config.onCreateProfile?()
     }
     #endif
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSettingsMenu.swift
@@ -188,11 +188,11 @@ struct ComposerSettingsMenu: View {
     }
 
     static func shouldRenderProfileSection(for config: ChatProfilePickerConfiguration) -> Bool {
-        !config.profiles.isEmpty || config.canCreateProfile
+        !config.profiles.isEmpty || shouldExposeCreateProfileCommand(for: config)
     }
 
     static func shouldExposeCreateProfileCommand(for config: ChatProfilePickerConfiguration) -> Bool {
-        config.canCreateProfile
+        config.canCreateProfile && config.onCreateProfile != nil
     }
 
     private func createProfile(using config: ChatProfilePickerConfiguration) {

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -51,6 +51,8 @@ struct ComposerView: View, Equatable {
             && lhs.inferenceProfilePicker?.current == rhs.inferenceProfilePicker?.current
             && lhs.inferenceProfilePicker?.profiles == rhs.inferenceProfilePicker?.profiles
             && lhs.inferenceProfilePicker?.activeProfile == rhs.inferenceProfilePicker?.activeProfile
+            && lhs.inferenceProfilePicker?.canCreateProfile == rhs.inferenceProfilePicker?.canCreateProfile
+            && (lhs.inferenceProfilePicker?.onCreateProfile != nil) == (rhs.inferenceProfilePicker?.onCreateProfile != nil)
             && (lhs.inferenceProfilePicker == nil) == (rhs.inferenceProfilePicker == nil)
     }
     private let composerMaxHeight: CGFloat = 300

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -999,6 +999,7 @@ struct ActiveChatViewWrapper: View {
     @Binding var anchorMessageId: UUID?
     @Binding var highlightedMessageId: UUID?
     var isInteractionEnabled: Bool = true
+    @State private var showCreateProfileSheet = false
 
     /// Reads the persisted bootstrap state so the chat view can suppress
     /// the empty state during first-launch bootstrap.
@@ -1049,6 +1050,9 @@ struct ActiveChatViewWrapper: View {
                 },
                 onOpenConversationApp: onOpenConversationApp,
                 onOpenConversationDocument: onOpenConversationDocument,
+                onCreateInferenceProfile: {
+                    showCreateProfileSheet = true
+                },
                 recoveryMode: settingsStore.managedAssistantRecoveryMode,
                 isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                 onResumeAssistant: {
@@ -1079,6 +1083,26 @@ struct ActiveChatViewWrapper: View {
             )
             .environment(\.cmdEnterToSend, settingsStore.cmdEnterToSend)
             .disabled(windowState.inspectorMessageId != nil || !isInteractionEnabled)
+            .sheet(isPresented: $showCreateProfileSheet) {
+                InferenceProfilesSheet(
+                    store: settingsStore,
+                    isPresented: $showCreateProfileSheet,
+                    startInCreateMode: true,
+                    onCreatedProfileSaved: { savedName in
+                        if conversationId == nil {
+                            viewModel.pendingInferenceProfile = savedName
+                            return
+                        }
+                        guard let conversationId else { return }
+                        Task { @MainActor in
+                            await conversationManager.setConversationInferenceProfile(
+                                id: conversationId,
+                                profile: savedName
+                            )
+                        }
+                    }
+                )
+            }
 
             if let messageId = windowState.inspectorMessageId {
                 MessageInspectorView(

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -1091,15 +1091,13 @@ struct ActiveChatViewWrapper: View {
                     onCreatedProfileSaved: { savedName in
                         if conversationId == nil {
                             viewModel.pendingInferenceProfile = savedName
-                            return
+                            return true
                         }
-                        guard let conversationId else { return }
-                        Task { @MainActor in
-                            await conversationManager.setConversationInferenceProfile(
-                                id: conversationId,
-                                profile: savedName
-                            )
-                        }
+                        guard let conversationId else { return false }
+                        return await conversationManager.setConversationInferenceProfile(
+                            id: conversationId,
+                            profile: savedName
+                        )
                     }
                 )
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -186,6 +186,7 @@ private struct ThreadWindowContentView: View {
     @State private var anchorMessageId: UUID?
     @State private var highlightedMessageId: UUID?
     @State private var windowSize: CGSize = CGSize(width: 700, height: 700)
+    @State private var showCreateProfileSheet = false
 
     /// Derived title from ConversationManager — updates reactively when
     /// the conversation is renamed, avoiding the stale-title bug.
@@ -209,6 +210,8 @@ private struct ThreadWindowContentView: View {
                         enabledSince: settingsStore.mediaEmbedsEnabledSince,
                         allowedDomains: settingsStore.mediaEmbedVideoAllowlistDomains
                     ),
+                    inferenceProfiles: settingsStore.profiles,
+                    activeInferenceProfile: settingsStore.activeProfile,
                     onMicrophoneToggle: {},
                     onForkFromMessage: (conversation?.isChannelConversation ?? false) ? nil : { daemonMessageId in onFork(daemonMessageId) },
                     onAddFunds: {
@@ -243,6 +246,9 @@ private struct ThreadWindowContentView: View {
                             userInfo: ["documentSurfaceId": surfaceId]
                         )
                     },
+                    onCreateInferenceProfile: {
+                        showCreateProfileSheet = true
+                    },
                     recoveryMode: settingsStore.managedAssistantRecoveryMode,
                     isRecoveryModeExiting: settingsStore.recoveryModeExiting,
                     onResumeAssistant: {
@@ -254,6 +260,7 @@ private struct ThreadWindowContentView: View {
                     },
                     anchorMessageId: $anchorMessageId,
                     highlightedMessageId: $highlightedMessageId,
+                    conversationId: conversationLocalId,
                     isInteractionEnabled: true,
                     isReadonly: conversation?.isChannelConversation ?? false,
                     watchSession: ambientAgent.activeWatchSession,
@@ -265,6 +272,21 @@ private struct ThreadWindowContentView: View {
                 // pop-out thread windows.
                 .environment(assistantFeatureFlagStore)
                 .padding(.bottom, VSpacing.md)
+                .sheet(isPresented: $showCreateProfileSheet) {
+                    InferenceProfilesSheet(
+                        store: settingsStore,
+                        isPresented: $showCreateProfileSheet,
+                        startInCreateMode: true,
+                        onCreatedProfileSaved: { savedName in
+                            Task { @MainActor in
+                                await conversationManager.setConversationInferenceProfile(
+                                    id: conversationLocalId,
+                                    profile: savedName
+                                )
+                            }
+                        }
+                    )
+                }
             }
 
             // Actions drawer rendered above all content

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadWindow.swift
@@ -278,12 +278,10 @@ private struct ThreadWindowContentView: View {
                         isPresented: $showCreateProfileSheet,
                         startInCreateMode: true,
                         onCreatedProfileSaved: { savedName in
-                            Task { @MainActor in
-                                await conversationManager.setConversationInferenceProfile(
-                                    id: conversationLocalId,
-                                    profile: savedName
-                                )
-                            }
+                            await conversationManager.setConversationInferenceProfile(
+                                id: conversationLocalId,
+                                profile: savedName
+                            )
                         }
                     )
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -567,6 +567,7 @@ struct InferenceProfilesSheet: View {
            let onCreatedProfileSaved {
             let didSelectCreatedProfile = await onCreatedProfileSaved(name)
             guard didSelectCreatedProfile else {
+                editorState = nil
                 actionError = "Saved \"\(name)\" but couldn't select it for this conversation. Try selecting it from the chat menu."
                 return
             }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -26,7 +26,7 @@ struct InferenceProfilesSheet: View {
     @ObservedObject var store: SettingsStore
     @Binding var isPresented: Bool
     let startInCreateMode: Bool
-    let onCreatedProfileSaved: ((String) -> Void)?
+    let onCreatedProfileSaved: ((String) async -> Bool)?
 
     @State private var didApplyInitialCreateMode = false
 
@@ -77,7 +77,7 @@ struct InferenceProfilesSheet: View {
         store: SettingsStore,
         isPresented: Binding<Bool>,
         startInCreateMode: Bool = false,
-        onCreatedProfileSaved: ((String) -> Void)? = nil
+        onCreatedProfileSaved: ((String) async -> Bool)? = nil
     ) {
         self._store = ObservedObject(wrappedValue: store)
         self._isPresented = isPresented
@@ -563,8 +563,13 @@ struct InferenceProfilesSheet: View {
             }
         }
 
-        if shouldNotifyCreatedProfile {
-            onCreatedProfileSaved?(name)
+        if shouldNotifyCreatedProfile,
+           let onCreatedProfileSaved {
+            let didSelectCreatedProfile = await onCreatedProfileSaved(name)
+            guard didSelectCreatedProfile else {
+                actionError = "Saved \"\(name)\" but couldn't select it for this conversation. Try selecting it from the chat menu."
+                return
+            }
         }
         editorState = nil
     }

--- a/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/InferenceProfilesSheet.swift
@@ -25,6 +25,10 @@ import VellumAssistantShared
 struct InferenceProfilesSheet: View {
     @ObservedObject var store: SettingsStore
     @Binding var isPresented: Bool
+    let startInCreateMode: Bool
+    let onCreatedProfileSaved: ((String) -> Void)?
+
+    @State private var didApplyInitialCreateMode = false
 
     @State private var editorState: EditorState?
 
@@ -69,6 +73,18 @@ struct InferenceProfilesSheet: View {
         case callSites(profileName: String, callSiteIds: [String])
     }
 
+    init(
+        store: SettingsStore,
+        isPresented: Binding<Bool>,
+        startInCreateMode: Bool = false,
+        onCreatedProfileSaved: ((String) -> Void)? = nil
+    ) {
+        self._store = ObservedObject(wrappedValue: store)
+        self._isPresented = isPresented
+        self.startInCreateMode = startInCreateMode
+        self.onCreatedProfileSaved = onCreatedProfileSaved
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -99,6 +115,13 @@ struct InferenceProfilesSheet: View {
             if newValue == nil {
                 replacementSelection = ""
             }
+        }
+        .onAppear {
+            guard startInCreateMode,
+                  !didApplyInitialCreateMode,
+                  editorState == nil else { return }
+            didApplyInitialCreateMode = true
+            beginCreate()
         }
         .animation(VAnimation.fast, value: editorState != nil)
     }
@@ -466,6 +489,7 @@ struct InferenceProfilesSheet: View {
     private func commitEditor() async {
         let draft = editorDraft
         let originalName = editorOriginalName
+        let shouldNotifyCreatedProfile = originalName == nil
         let name = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         // Refuse to commit empty or whitespace-only names — the daemon
         // would accept them but the row would render unusably.
@@ -539,6 +563,9 @@ struct InferenceProfilesSheet: View {
             }
         }
 
+        if shouldNotifyCreatedProfile {
+            onCreatedProfileSaved?(name)
+        }
         editorState = nil
     }
 

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -104,6 +104,19 @@ final class ChatProfilePickerTests: XCTestCase {
         XCTAssertFalse(ComposerSettingsMenu.shouldExposeCreateProfileCommand(for: config))
     }
 
+    func testCreateProfileCommandIsHiddenWhenCallbackIsMissing() {
+        let config = ChatProfilePickerConfiguration(
+            current: nil,
+            profiles: [],
+            activeProfile: "balanced",
+            canCreateProfile: true,
+            onSelect: { _ in }
+        )
+
+        XCTAssertFalse(ComposerSettingsMenu.shouldRenderProfileSection(for: config))
+        XCTAssertFalse(ComposerSettingsMenu.shouldExposeCreateProfileCommand(for: config))
+    }
+
     // MARK: - Selection callback wiring (covers ComposerView → ChatProfilePicker → ConversationManager)
 
     func testConversationManagerSetsOverrideOnSelection() async {
@@ -154,6 +167,50 @@ final class ChatProfilePickerTests: XCTestCase {
             [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: nil)]
         )
         XCTAssertNil(env.manager.conversations[0].inferenceProfile)
+    }
+
+    func testCreatedProfileSaveSelectsConversationOverrideWithoutChangingActiveProfile() async {
+        let fixture = SettingsTestFixture.make()
+        fixture.store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["provider": "anthropic", "model": "claude-sonnet-4-6"],
+                    "custom-profile": ["provider": "openai", "model": "gpt-5"],
+                ],
+            ]
+        ])
+        let env = makeManagerEnvironment(initialProfile: nil)
+        env.mockClient.setResponse = ConversationInferenceProfileResponse(
+            conversationId: "conv-1",
+            profile: "custom-profile"
+        )
+
+        let onCreatedProfileSaved: (String) -> Void = { savedName in
+            Task { @MainActor in
+                await env.manager.setConversationInferenceProfile(
+                    id: env.localId,
+                    profile: savedName
+                )
+            }
+        }
+
+        onCreatedProfileSaved("custom-profile")
+        await env.drainPendingTasks()
+
+        XCTAssertEqual(
+            env.mockClient.setCalls,
+            [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: "custom-profile")]
+        )
+        XCTAssertEqual(env.manager.conversations[0].inferenceProfile, "custom-profile")
+        XCTAssertEqual(fixture.store.activeProfile, "balanced")
+        XCTAssertFalse(
+            fixture.mockClient.patchConfigCalls.contains { payload in
+                guard let llm = payload["llm"] as? [String: Any] else { return false }
+                return llm.keys.contains("activeProfile")
+            },
+            "Chat-owned create-profile save must not patch llm.activeProfile"
+        )
     }
 
     // MARK: - Helpers

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -186,18 +186,16 @@ final class ChatProfilePickerTests: XCTestCase {
             profile: "custom-profile"
         )
 
-        let onCreatedProfileSaved: (String) -> Void = { savedName in
-            Task { @MainActor in
-                await env.manager.setConversationInferenceProfile(
-                    id: env.localId,
-                    profile: savedName
-                )
-            }
+        let onCreatedProfileSaved: (String) async -> Bool = { savedName in
+            await env.manager.setConversationInferenceProfile(
+                id: env.localId,
+                profile: savedName
+            )
         }
 
-        onCreatedProfileSaved("custom-profile")
-        await env.drainPendingTasks()
+        let didSelect = await onCreatedProfileSaved("custom-profile")
 
+        XCTAssertTrue(didSelect)
         XCTAssertEqual(
             env.mockClient.setCalls,
             [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: "custom-profile")]
@@ -210,6 +208,45 @@ final class ChatProfilePickerTests: XCTestCase {
                 return llm.keys.contains("activeProfile")
             },
             "Chat-owned create-profile save must not patch llm.activeProfile"
+        )
+    }
+
+    func testCreatedProfileSaveReportsConversationSelectionFailureWithoutChangingActiveProfile() async {
+        let fixture = SettingsTestFixture.make()
+        fixture.store.loadInferenceProfiles(config: [
+            "llm": [
+                "activeProfile": "balanced",
+                "profiles": [
+                    "balanced": ["provider": "anthropic", "model": "claude-sonnet-4-6"],
+                    "custom-profile": ["provider": "openai", "model": "gpt-5"],
+                ],
+            ]
+        ])
+        let env = makeManagerEnvironment(initialProfile: nil)
+        env.mockClient.setResponse = nil
+
+        let onCreatedProfileSaved: (String) async -> Bool = { savedName in
+            await env.manager.setConversationInferenceProfile(
+                id: env.localId,
+                profile: savedName
+            )
+        }
+
+        let didSelect = await onCreatedProfileSaved("custom-profile")
+
+        XCTAssertFalse(didSelect)
+        XCTAssertEqual(
+            env.mockClient.setCalls,
+            [MockChatProfilePickerClient.SetCall(conversationId: "conv-1", profile: "custom-profile")]
+        )
+        XCTAssertNil(env.manager.conversations[0].inferenceProfile)
+        XCTAssertEqual(fixture.store.activeProfile, "balanced")
+        XCTAssertFalse(
+            fixture.mockClient.patchConfigCalls.contains { payload in
+                guard let llm = payload["llm"] as? [String: Any] else { return false }
+                return llm.keys.contains("activeProfile")
+            },
+            "Failed chat-owned selection must not fall back to llm.activeProfile"
         )
     }
 

--- a/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ChatProfilePickerTests.swift
@@ -50,6 +50,60 @@ final class ChatProfilePickerTests: XCTestCase {
         )
     }
 
+    // MARK: - Create profile command
+
+    func testConfigurationDefaultsHideCreateProfileCommand() {
+        let config = ChatProfilePickerConfiguration(
+            current: nil,
+            profiles: [],
+            activeProfile: "balanced",
+            onSelect: { _ in }
+        )
+
+        XCTAssertFalse(config.canCreateProfile)
+        XCTAssertNil(config.onCreateProfile)
+        XCTAssertFalse(ComposerSettingsMenu.shouldRenderProfileSection(for: config))
+        XCTAssertFalse(ComposerSettingsMenu.shouldExposeCreateProfileCommand(for: config))
+    }
+
+    func testCreateProfileCommandIsExposedWhenEnabledWithoutProfiles() {
+        var didRequestCreateProfile = false
+        let config = ChatProfilePickerConfiguration(
+            current: nil,
+            profiles: [],
+            activeProfile: "balanced",
+            canCreateProfile: true,
+            onSelect: { _ in },
+            onCreateProfile: {
+                didRequestCreateProfile = true
+            }
+        )
+
+        XCTAssertTrue(config.canCreateProfile)
+        XCTAssertTrue(ComposerSettingsMenu.shouldRenderProfileSection(for: config))
+        XCTAssertTrue(ComposerSettingsMenu.shouldExposeCreateProfileCommand(for: config))
+
+        config.onCreateProfile?()
+
+        XCTAssertTrue(didRequestCreateProfile)
+    }
+
+    func testCreateProfileCommandIsHiddenWhenDisabledWithProfiles() {
+        let config = ChatProfilePickerConfiguration(
+            current: nil,
+            profiles: [InferenceProfile(name: "balanced")],
+            activeProfile: "balanced",
+            canCreateProfile: false,
+            onSelect: { _ in },
+            onCreateProfile: {
+                XCTFail("Disabled create-profile commands must not be exposed")
+            }
+        )
+
+        XCTAssertTrue(ComposerSettingsMenu.shouldRenderProfileSection(for: config))
+        XCTAssertFalse(ComposerSettingsMenu.shouldExposeCreateProfileCommand(for: config))
+    }
+
     // MARK: - Selection callback wiring (covers ComposerView → ChatProfilePicker → ConversationManager)
 
     func testConversationManagerSetsOverrideOnSelection() async {

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
@@ -73,6 +73,18 @@ final class InferenceProfilesSheetTests: XCTestCase {
         XCTAssertNotNil(sheet.body)
     }
 
+    func testSheetBuildsWhenConfiguredToStartInCreateMode() {
+        seedBuiltInsAndCustom(includeCustom: true)
+        let isPresented = Binding<Bool>(get: { true }, set: { _ in })
+        let sheet = InferenceProfilesSheet(
+            store: store,
+            isPresented: isPresented,
+            startInCreateMode: true,
+            onCreatedProfileSaved: { _ in }
+        )
+        XCTAssertNotNil(sheet.body)
+    }
+
     // MARK: - Managed detection
 
     /// Managed profiles (source == "managed") show a "Managed" badge;

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceProfilesSheetTests.swift
@@ -80,7 +80,7 @@ final class InferenceProfilesSheetTests: XCTestCase {
             store: store,
             isPresented: isPresented,
             startInCreateMode: true,
-            onCreatedProfileSaved: { _ in }
+            onCreatedProfileSaved: { _ in true }
         )
         XCTAssertNotNil(sheet.body)
     }

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
@@ -176,7 +176,7 @@ final class InferenceServiceCardTests: XCTestCase {
             store: store,
             isPresented: isPresented,
             startInCreateMode: true,
-            onCreatedProfileSaved: { _ in }
+            onCreatedProfileSaved: { _ in true }
         )
         XCTAssertNotNil(createSheet.body)
     }

--- a/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Settings/InferenceServiceCardTests.swift
@@ -171,6 +171,14 @@ final class InferenceServiceCardTests: XCTestCase {
         let isPresented = Binding<Bool>(get: { true }, set: { _ in })
         let sheet = InferenceProfilesSheet(store: store, isPresented: isPresented)
         XCTAssertNotNil(sheet.body)
+
+        let createSheet = InferenceProfilesSheet(
+            store: store,
+            isPresented: isPresented,
+            startInCreateMode: true,
+            onCreatedProfileSaved: { _ in }
+        )
+        XCTAssertNotNil(createSheet.body)
     }
 
     // MARK: - Save flow no longer writes llm.default.model

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -98,6 +98,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "new-model-profile-shortcut",
+      "scope": "assistant",
+      "key": "new-model-profile-shortcut",
+      "label": "New Model Profile Shortcut",
+      "description": "Show the New Profile... shortcut in the macOS chat composer model profile dropdown.",
+      "defaultEnabled": false
+    },
+    {
       "id": "multi-platform-assistant",
       "scope": "assistant",
       "key": "multi-platform-assistant",


### PR DESCRIPTION
## Summary
- Declares the default-off `new-model-profile-shortcut` assistant flag in the canonical registry.
- Adds a feature-gated `New Profile...` command to the macOS chat profile dropdown.
- Opens the existing Model Profiles sheet directly in create mode from main chat and pop-out chat, then selects the saved profile for the current conversation scope without changing the global active profile.
- Surfaces saved-but-not-selected failures so users do not silently think the profile was applied.

## Rollout
- Part of JARVIS-713.
- Depends on the platform Terraform flag PR being merged/applied before enabling the flag remotely.
- The web rollout PR should merge last and carries the Linear closing keyword.

## Plan / Review History
- Merged into the feature branch through milestone PRs #29792, #29793, #29796, #29805, plus remediation PRs #29809 and #29814.
- Self-review passes completed for assistant integration, platform integration, and external feedback sweep.

## Validation
- `git diff --check`
- `export PATH="$HOME/.bun/bin:$PATH"; bun run meta/feature-flags/sync-bundled-copies.ts`
- `cd assistant && export PATH="$HOME/.bun/bin:$PATH"; bun test src/config/__tests__/feature-flag-registry-guard.test.ts src/config/__tests__/feature-flag-registry-bundled.test.ts`
- `cd clients && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter ChatProfilePickerTests`
- `cd clients && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter InferenceProfilesSheetTests`
- `clients/scripts/check-design-tokens.sh --mode=strict`

## Notes
- The assistant pre-push Swift build hook hit a local SwiftPM scratch resolver issue for `SwiftMath` 1.7.3 even though the tag exists upstream and the targeted Swift test build passed. I pushed with `SKIP_SWIFT_BUILD=1` after running the targeted Swift suites and design-token guard manually.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->