### PR TITLE
feat(memory): seed memory/threads.md with onboarding tasks for new assistants

### DIFF
--- a/assistant/src/__tests__/workspace-migration-069-seed-onboarding-threads.test.ts
+++ b/assistant/src/__tests__/workspace-migration-069-seed-onboarding-threads.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for workspace migration `069-seed-onboarding-threads`.
+ *
+ * The migration writes onboarding bullet content to `memory/threads.md` only
+ * when the file exists and is empty (or whitespace-only). It must preserve
+ * any existing content and must be idempotent.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { memoryV2InitMigration } from "../workspace/migrations/060-memory-v2-init.js";
+import { seedOnboardingThreadsMigration } from "../workspace/migrations/069-seed-onboarding-threads.js";
+
+let workspaceDir: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-069-test-"));
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function readThreads(): string {
+  return readFileSync(join(workspaceDir, "memory", "threads.md"), "utf-8");
+}
+
+describe("069-seed-onboarding-threads migration", () => {
+  test("has correct id and description", () => {
+    expect(seedOnboardingThreadsMigration.id).toBe(
+      "069-seed-onboarding-threads",
+    );
+    expect(seedOnboardingThreadsMigration.description).toContain("threads.md");
+  });
+
+  test.each([
+    ["empty file", ""],
+    ["whitespace-only file", "   \n\n"],
+  ])("seeds onboarding bullets when memory/threads.md is %s", (_, initial) => {
+    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+    writeFileSync(join(workspaceDir, "memory", "threads.md"), initial, "utf-8");
+
+    seedOnboardingThreadsMigration.run(workspaceDir);
+
+    const content = readThreads();
+    expect(content).toContain("Figure out what kind of personality");
+    expect(content).toContain("data/avatar/avatar-image.png");
+    expect(content).toContain("ChatGPT, Claude");
+    expect(content).toContain("Slack or Telegram");
+  });
+
+  test("preserves existing content when memory/threads.md is non-empty", () => {
+    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+    const existing = "Follow up with Bob about the design review.\n";
+    writeFileSync(
+      join(workspaceDir, "memory", "threads.md"),
+      existing,
+      "utf-8",
+    );
+
+    seedOnboardingThreadsMigration.run(workspaceDir);
+
+    expect(readThreads()).toBe(existing);
+  });
+
+  test("no-op when memory/threads.md does not exist", () => {
+    seedOnboardingThreadsMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "memory", "threads.md"))).toBe(false);
+  });
+
+  test("idempotent — second run does not duplicate or rewrite content", () => {
+    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+    writeFileSync(join(workspaceDir, "memory", "threads.md"), "", "utf-8");
+
+    seedOnboardingThreadsMigration.run(workspaceDir);
+    const afterFirst = readThreads();
+
+    seedOnboardingThreadsMigration.run(workspaceDir);
+    const afterSecond = readThreads();
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  test("composes with 060: fresh workspace -> 060 -> 069 produces seeded threads.md", () => {
+    memoryV2InitMigration.run(workspaceDir);
+    seedOnboardingThreadsMigration.run(workspaceDir);
+
+    expect(readThreads()).toContain("Figure out what kind of personality");
+    // The other v2 prose files are untouched (still empty).
+    for (const filename of ["essentials.md", "recent.md", "buffer.md"]) {
+      expect(
+        readFileSync(join(workspaceDir, "memory", filename), "utf-8"),
+      ).toBe("");
+    }
+  });
+
+  test("down() is a no-op — seeded content remains", () => {
+    mkdirSync(join(workspaceDir, "memory"), { recursive: true });
+    writeFileSync(join(workspaceDir, "memory", "threads.md"), "", "utf-8");
+
+    seedOnboardingThreadsMigration.run(workspaceDir);
+    const seeded = readThreads();
+
+    seedOnboardingThreadsMigration.down(workspaceDir);
+
+    expect(readThreads()).toBe(seeded);
+  });
+});

--- a/assistant/src/workspace/migrations/069-seed-onboarding-threads.ts
+++ b/assistant/src/workspace/migrations/069-seed-onboarding-threads.ts
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const ONBOARDING_THREADS = `- Figure out what kind of personality would best mesh with your user. Figure out who you are and what your voice should be. Your choice should be DISTINCT and have CHARACTER. Once you've figured this out, rewrite SOUL.md and IDENTITY.md in your own voice to define who you are.
+- Work with your user to set a custom avatar for yourself. This task is done once data/avatar/avatar-image.png exists.
+- Ask your user if they use ChatGPT, Claude or another AI tool and offer to help them import memories from there.
+- Suggest connecting to available messaging services like Slack or Telegram
+`;
+
+export const seedOnboardingThreadsMigration: WorkspaceMigration = {
+  id: "069-seed-onboarding-threads",
+  description:
+    "Seed memory/threads.md with onboarding tasks for brand new assistants",
+
+  run(workspaceDir: string): void {
+    const filePath = join(workspaceDir, "memory", "threads.md");
+    if (!existsSync(filePath)) return;
+    const current = readFileSync(filePath, "utf-8");
+    if (current.trim().length > 0) return;
+    writeFileSync(filePath, ONBOARDING_THREADS, "utf-8");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: never delete user-visible memory content on rollback.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -66,6 +66,7 @@ import { bumpStaleHeartbeatIntervalMigration } from "./065-bump-stale-heartbeat-
 import { seedHeartbeatCallsiteCostDefaultMigration } from "./066-seed-heartbeat-callsite-cost-default.js";
 import { releaseNotesSafeStorageLimitsMigration } from "./067-release-notes-safe-storage-limits.js";
 import { releaseNotesLocalTimezoneMigration } from "./068-release-notes-local-timezone.js";
+import { seedOnboardingThreadsMigration } from "./069-seed-onboarding-threads.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -143,4 +144,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   seedHeartbeatCallsiteCostDefaultMigration,
   releaseNotesSafeStorageLimitsMigration,
   releaseNotesLocalTimezoneMigration,
+  seedOnboardingThreadsMigration,
 ];


### PR DESCRIPTION
## Summary
- Adds workspace migration `069-seed-onboarding-threads` that seeds `memory/threads.md` with four bullet onboarding tasks (pick personality + rewrite SOUL.md/IDENTITY.md, set avatar, offer to import ChatGPT/Claude memories, suggest Slack/Telegram) when the file is empty.
- Brand new assistants will see these tasks auto-injected under the `## Threads` heading on their first conversation via `readMemoryV2StaticContent` (`assistant/src/memory/v2/static-context.ts`).
- Preserves existing user content: the migration writes only when `memory/threads.md` is empty or whitespace-only, so existing assistants who have already populated the file are untouched.

## Original prompt
The user wanted brand new hatched assistants to boot with a default `memory/threads.md` containing onboarding bullet items: figure out a distinct personality and rewrite SOUL.md/IDENTITY.md, set up an avatar at `data/avatar/avatar-image.png`, ask the user about importing ChatGPT/Claude memories, and suggest connecting messaging services like Slack or Telegram. The file is auto-injected into the system context on first turn, so seeding it is enough to surface the tasks to the assistant without any prompt-plumbing changes. We chose memory v2's `threads.md` because `SOUL.md` already frames it as "active commitments / follow-ups," making onboarding-as-commitments a natural fit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->