### PR TITLE
fix(macos-build): strip xattrs before codesigning the .app bundle

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -2023,6 +2023,12 @@ find "$MACOS_DIR" -maxdepth 1 \( -type f -o -type s \) \
     \( -name "*.pid" -o -name "*.sock" -o -name "*.log" \) \
     -delete
 
+# Strip extended attributes (com.apple.FinderInfo, com.apple.ResourceFork,
+# com.apple.provenance, etc.) that codesign rejects with "resource fork,
+# Finder information, or similar detritus not allowed". These can accumulate
+# from Finder interactions, file copies, or SPM package resolution.
+xattr -cr "$APP_DIR"
+
 # 6. Code sign
 echo "Signing with: $SIGN_IDENTITY"
 


### PR DESCRIPTION
## Summary
- Add `xattr -cr "$APP_DIR"` to `clients/macos/build.sh` immediately before the codesign block, so extended attributes that `codesign` rejects (`com.apple.FinderInfo`, `com.apple.ResourceFork`, `com.apple.provenance`, etc.) are stripped on every build.
- Prevents the cryptic `resource fork, Finder information, or similar detritus not allowed` failure during local `./build.sh run` invocations.

## Original prompt
Local `VELLUM_NO_WATCH=1 ./build.sh run` was failing with `codesign: ... resource fork, Finder information, or similar detritus not allowed` on `Velissa.app`. Investigation showed `com.apple.FinderInfo` (and `com.apple.provenance` on many nested files) had been set on the bundle root, likely from a Finder interaction or `cp` of a tagged source. Fix is to clear xattrs before signing so the build is robust against this regardless of where the attributes came from.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->