### PR TITLE
feat(memory-v2): inject page path + summary instead of full page

### DIFF
--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -86,6 +86,10 @@ const upsertCalls: Array<{
   slug: string;
   dense: number[];
   sparse: { indices: number[]; values: number[] };
+  summary?: {
+    dense: number[];
+    sparse: { indices: number[]; values: number[] };
+  };
   updatedAt: number;
 }> = [];
 
@@ -96,6 +100,10 @@ mock.module("../../v2/qdrant.js", () => ({
     slug: string;
     dense: number[];
     sparse: { indices: number[]; values: number[] };
+    summary?: {
+      dense: number[];
+      sparse: { indices: number[]; values: number[] };
+    };
     updatedAt: number;
   }) => {
     upsertCalls.push(params);
@@ -239,6 +247,114 @@ describe("embedConceptPageJob — happy path", () => {
     expect(row!.targetType).toBe("concept_page");
     expect(row!.dimensions).toBe(4);
     expect(row!.contentHash).toBeTruthy();
+  });
+});
+
+describe("embedConceptPageJob — summary embedding", () => {
+  test("embeds the summary when present and forwards summary vectors to upsert", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "summarized-page",
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        summary: "A short prose summary that retrieval indexes separately.",
+      },
+      body: "Long-form body content.\n",
+    });
+
+    await embedConceptPageJob(
+      makeJob({ slug: "summarized-page" }),
+      TEST_CONFIG,
+    );
+
+    // Body and summary are batched into one backend call (saves a round-trip).
+    expect(embedWithBackendCalls).toHaveLength(1);
+    expect(embedWithBackendCalls[0].inputs).toHaveLength(2);
+    expect(upsertCalls).toHaveLength(1);
+    const call = upsertCalls[0];
+    expect(call.slug).toBe("summarized-page");
+    expect(call.dense).toEqual([0.1, 0.2, 0.3, 0.4]);
+    expect(call.sparse).toBeDefined();
+    expect(call.summary?.dense).toEqual([0.1, 0.2, 0.3, 0.4]);
+    expect(call.summary?.sparse).toBeDefined();
+  });
+
+  test("skips summary embedding when the page has no summary in frontmatter", async () => {
+    await writePage(tmpWorkspace, {
+      slug: "legacy-page",
+      frontmatter: { edges: [], ref_files: [] },
+      body: "Body only — no summary in frontmatter.\n",
+    });
+
+    await embedConceptPageJob(makeJob({ slug: "legacy-page" }), TEST_CONFIG);
+
+    // Only the body was embedded.
+    expect(embedWithBackendCalls).toHaveLength(1);
+    expect(upsertCalls).toHaveLength(1);
+    const call = upsertCalls[0];
+    expect(call.summary).toBeUndefined();
+  });
+
+  test("skips summary embedding when the summary is whitespace-only", async () => {
+    // Whitespace-only summaries (` `, `\n`) are equivalent to absent — the
+    // embedding backend would reject the empty input downstream anyway.
+    await writePage(tmpWorkspace, {
+      slug: "whitespace-summary",
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        summary: "   ",
+      },
+      body: "Body content.\n",
+    });
+
+    await embedConceptPageJob(
+      makeJob({ slug: "whitespace-summary" }),
+      TEST_CONFIG,
+    );
+
+    expect(embedWithBackendCalls).toHaveLength(1);
+    expect(upsertCalls[0].summary).toBeUndefined();
+  });
+
+  test("body and summary cache rows are independent (summary edit doesn't invalidate body)", async () => {
+    // Write a page with a summary, run the job to prime caches.
+    await writePage(tmpWorkspace, {
+      slug: "cached-summary",
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        summary: "First version of the summary.",
+      },
+      body: "Stable body that never changes.\n",
+    });
+    await embedConceptPageJob(
+      makeJob({ slug: "cached-summary" }),
+      TEST_CONFIG,
+    );
+    // Body + summary batched into a single backend call on first run.
+    expect(embedWithBackendCalls).toHaveLength(1);
+    expect(embedWithBackendCalls[0].inputs).toHaveLength(2);
+
+    // Edit only the summary — body stays identical, only the summary text
+    // changes. Re-running the job should hit the body cache (no re-embed)
+    // but recompute the summary embedding.
+    await writePage(tmpWorkspace, {
+      slug: "cached-summary",
+      frontmatter: {
+        edges: [],
+        ref_files: [],
+        summary: "Second version of the summary, different wording.",
+      },
+      body: "Stable body that never changes.\n",
+    });
+    await embedConceptPageJob(
+      makeJob({ slug: "cached-summary" }),
+      TEST_CONFIG,
+    );
+    // One additional backend call with only the summary text — body hit the cache.
+    expect(embedWithBackendCalls).toHaveLength(2);
+    expect(embedWithBackendCalls[1].inputs).toHaveLength(1);
   });
 });
 

--- a/assistant/src/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/memory/jobs/embed-concept-page.ts
@@ -98,17 +98,184 @@ export async function embedConceptPageJob(
     );
   }
 
-  const contentHash = embeddingInputContentHash({ type: "text", text });
   const expectedDim = config.memory.qdrant.vectorSize;
-  let provider = status.provider;
-  let model = status.model!;
+  // The status provider is the cache lookup key for any prior row; the
+  // *actual* provider/model come back on the embedded result. They usually
+  // match, but a backend swap mid-run would surface here — body and summary
+  // are then re-embedded together so both rows write under the same identity.
+  const cacheProvider = status.provider;
+  const cacheModel = status.model!;
+
+  const db = getDb();
 
   // Cache lookup: same (targetType, targetId, provider, model) row gets
   // reused across runs as long as `contentHash` matches. The dim mismatch
   // check guards against a config change (vectorSize bumped) since the last
-  // write — in that case we treat the row as stale and re-embed.
-  const db = getDb();
-  let cachedRow = db
+  // write — in that case we treat the row as stale and re-embed. The body
+  // and (optional) summary share the same provider/model — but each gets
+  // its own cache row keyed by a distinct targetId so summary edits don't
+  // invalidate the body cache and vice versa.
+  const bodyContentHash = embeddingInputContentHash({ type: "text", text });
+  const bodyCache = readEmbeddingCache(
+    db,
+    slug,
+    cacheProvider,
+    cacheModel,
+    expectedDim,
+  );
+  const bodyCacheHit = bodyCache?.contentHash === bodyContentHash;
+
+  // Optional summary embedding — only when the page has a `summary` in its
+  // frontmatter. Pages without one fall back to body-only retrieval at
+  // query time (the activation pipeline reads the summary score as
+  // undefined and uses the body score directly).
+  const summaryText = page.frontmatter.summary?.trim() ?? "";
+  const hasSummary = summaryText.length > 0;
+  const summaryCacheId = `${slug}#summary`;
+  const summaryContentHash = hasSummary
+    ? embeddingInputContentHash({ type: "text", text: summaryText })
+    : undefined;
+  const summaryCache = hasSummary
+    ? readEmbeddingCache(
+        db,
+        summaryCacheId,
+        cacheProvider,
+        cacheModel,
+        expectedDim,
+      )
+    : null;
+  const summaryCacheHit =
+    hasSummary && summaryCache?.contentHash === summaryContentHash;
+
+  // Batch all cache misses into one `embedWithBackend` call. Each backend
+  // round-trip is the dominant cost — fresh body + fresh summary in a
+  // single batch saves a round-trip vs serial calls and gives both vectors
+  // the same provider/model regardless of any backend rotation mid-run.
+  type Slot = "body" | "summary";
+  const toEmbed: Array<{ type: "text"; text: string }> = [];
+  const slots: Slot[] = [];
+  if (!bodyCacheHit) {
+    toEmbed.push({ type: "text", text });
+    slots.push("body");
+  }
+  if (hasSummary && !summaryCacheHit) {
+    toEmbed.push({ type: "text", text: summaryText });
+    slots.push("summary");
+  }
+
+  let bodyDense: number[] | undefined = bodyCacheHit ? bodyCache!.dense : undefined;
+  let summaryDense: number[] | undefined = summaryCacheHit
+    ? summaryCache!.dense
+    : undefined;
+  let writeProvider = cacheProvider;
+  let writeModel = cacheModel;
+  if (toEmbed.length > 0) {
+    const embedded = await embedWithBackend(config, toEmbed);
+    writeProvider = embedded.provider;
+    writeModel = embedded.model;
+    for (let i = 0; i < slots.length; i++) {
+      const vector = embedded.vectors[i];
+      if (!vector) continue;
+      if (slots[i] === "body") bodyDense = vector;
+      else summaryDense = vector;
+    }
+  }
+  // Body embedding is the ground truth — without it the page can't surface.
+  // (Cache hit paths populate `bodyDense` above; a fresh embed that returned
+  // no vectors short-circuits here too.)
+  if (!bodyDense) return;
+
+  // Sparse is cheap (in-process tokenization) and changes any time the body
+  // changes, so we always recompute it rather than caching alongside dense.
+  // BM25 weights live on the doc side; queries embed binary occurrence in
+  // sim.ts. When corpus stats aren't built yet (cold daemon, walking the
+  // corpus for the first time), fall back to the legacy TF-only encoding —
+  // the next reembed pass overwrites the page once stats are available.
+  const corpusStats = getConceptPageCorpusStats();
+  const encodeSparse = (input: string) =>
+    corpusStats
+      ? generateBm25DocEmbedding(input, corpusStats, {
+          k1: config.memory.v2.bm25_k1,
+          b: config.memory.v2.bm25_b,
+        })
+      : generateSparseEmbedding(input);
+  const sparse = encodeSparse(text);
+  const summarySparse = hasSummary ? encodeSparse(summaryText) : undefined;
+
+  const now = Date.now();
+  // Persist freshly embedded vectors for cross-restart reuse. On cache hit
+  // the existing row already has identical content + hash, so the write
+  // would be a no-op — skip it. Best-effort: write failure is not fatal,
+  // we still want the Qdrant upsert below to fire.
+  if (!bodyCacheHit) {
+    writeEmbeddingCache(db, {
+      slug,
+      cacheId: slug,
+      dense: bodyDense,
+      contentHash: bodyContentHash,
+      provider: writeProvider,
+      model: writeModel,
+      now,
+    });
+  }
+  if (hasSummary && !summaryCacheHit && summaryDense && summaryContentHash) {
+    writeEmbeddingCache(db, {
+      slug,
+      cacheId: summaryCacheId,
+      dense: summaryDense,
+      contentHash: summaryContentHash,
+      provider: writeProvider,
+      model: writeModel,
+      now,
+    });
+  }
+
+  // Apply anisotropy correction at the boundary between the (raw) cached
+  // dense vector and the Qdrant collection. Storing raw in SQLite and
+  // corrected in Qdrant means a recalibration just needs a reembed pass —
+  // the cache survives and the (cheap) correction math reruns over each
+  // cached vector. Pass-through when no calibration is fit yet.
+  const correctedDense = await applyCorrectionIfCalibrated(
+    bodyDense,
+    writeProvider,
+    writeModel,
+  );
+  const correctedSummaryDense = summaryDense
+    ? await applyCorrectionIfCalibrated(summaryDense, writeProvider, writeModel)
+    : undefined;
+
+  await upsertConceptPageEmbedding({
+    slug,
+    dense: correctedDense,
+    sparse,
+    summary:
+      correctedSummaryDense && summarySparse
+        ? { dense: correctedSummaryDense, sparse: summarySparse }
+        : undefined,
+    updatedAt: now,
+  });
+}
+
+/** SQLite cache row shape returned by `readEmbeddingCache`. */
+interface EmbeddingCacheEntry {
+  dense: number[];
+  contentHash: string;
+}
+
+/**
+ * Look up a cached dense vector keyed on `(targetType, targetId, provider,
+ * model)`. Returns the row only when the persisted dimensions match the
+ * configured expectation — a stale row from a previous `vectorSize` is
+ * treated as a cache miss so the caller re-embeds.
+ */
+function readEmbeddingCache(
+  db: ReturnType<typeof getDb>,
+  cacheId: string,
+  provider: string,
+  model: string,
+  expectedDim: number,
+): EmbeddingCacheEntry | null {
+  const row = db
     .select({
       vectorBlob: memoryEmbeddings.vectorBlob,
       vectorJson: memoryEmbeddings.vectorJson,
@@ -119,108 +286,77 @@ export async function embedConceptPageJob(
     .where(
       and(
         eq(memoryEmbeddings.targetType, CONCEPT_PAGE_TARGET_TYPE),
-        eq(memoryEmbeddings.targetId, slug),
+        eq(memoryEmbeddings.targetId, cacheId),
         eq(memoryEmbeddings.provider, provider),
         eq(memoryEmbeddings.model, model),
       ),
     )
     .get();
-  if (cachedRow && cachedRow.dimensions !== expectedDim) cachedRow = undefined;
-  if (cachedRow && cachedRow.contentHash !== contentHash) cachedRow = undefined;
+  if (!row || row.dimensions !== expectedDim) return null;
+  // A row without a contentHash is a legacy/corrupt entry — treat as a miss
+  // and force a re-embed rather than misalign the cache key.
+  if (row.contentHash === null) return null;
+  const dense = row.vectorBlob
+    ? blobToVector(row.vectorBlob as Buffer)
+    : (JSON.parse(row.vectorJson!) as number[]);
+  return { dense, contentHash: row.contentHash };
+}
 
-  let dense: number[];
-  let cacheHit = false;
-  if (cachedRow) {
-    dense = cachedRow.vectorBlob
-      ? blobToVector(cachedRow.vectorBlob as Buffer)
-      : (JSON.parse(cachedRow.vectorJson!) as number[]);
-    cacheHit = true;
-  } else {
-    const embedded = await embedWithBackend(config, [{ type: "text", text }]);
-    const vector = embedded.vectors[0];
-    if (!vector) return;
-    dense = vector;
-    provider = embedded.provider;
-    model = embedded.model;
-  }
-
-  // Sparse is cheap (in-process tokenization) and changes any time the body
-  // changes, so we always recompute it rather than caching alongside dense.
-  // BM25 weights live on the doc side; queries embed binary occurrence in
-  // sim.ts. When corpus stats aren't built yet (cold daemon, walking the
-  // corpus for the first time), fall back to the legacy TF-only encoding —
-  // the next reembed pass overwrites the page once stats are available.
-  const corpusStats = getConceptPageCorpusStats();
-  const sparse = corpusStats
-    ? generateBm25DocEmbedding(text, corpusStats, {
-        k1: config.memory.v2.bm25_k1,
-        b: config.memory.v2.bm25_b,
+/**
+ * Persist a freshly embedded dense vector in the SQLite cache. Best-effort:
+ * a write failure is logged and swallowed so the Qdrant upsert still runs.
+ */
+function writeEmbeddingCache(
+  db: ReturnType<typeof getDb>,
+  params: {
+    slug: string;
+    cacheId: string;
+    dense: number[];
+    contentHash: string;
+    provider: string;
+    model: string;
+    now: number;
+  },
+): void {
+  const { slug, cacheId, dense, contentHash, provider, model, now } = params;
+  try {
+    const blobValue = vectorToBlob(dense);
+    db.insert(memoryEmbeddings)
+      .values({
+        id: randomUUID(),
+        targetType: CONCEPT_PAGE_TARGET_TYPE,
+        targetId: cacheId,
+        provider,
+        model,
+        dimensions: dense.length,
+        vectorBlob: blobValue,
+        vectorJson: null,
+        contentHash,
+        createdAt: now,
+        updatedAt: now,
       })
-    : generateSparseEmbedding(text);
-
-  const now = Date.now();
-  // Persist freshly embedded vectors for cross-restart reuse. On cache hit
-  // the existing row already has identical content + hash, so the write
-  // would be a no-op — skip it. Best-effort: write failure is not fatal,
-  // we still want the Qdrant upsert below to fire.
-  if (!cacheHit) {
-    try {
-      const blobValue = vectorToBlob(dense);
-      db.insert(memoryEmbeddings)
-        .values({
-          id: randomUUID(),
-          targetType: CONCEPT_PAGE_TARGET_TYPE,
-          targetId: slug,
-          provider,
-          model,
-          dimensions: dense.length,
+      .onConflictDoUpdate({
+        target: [
+          memoryEmbeddings.targetType,
+          memoryEmbeddings.targetId,
+          memoryEmbeddings.provider,
+          memoryEmbeddings.model,
+        ],
+        set: {
           vectorBlob: blobValue,
           vectorJson: null,
+          dimensions: dense.length,
           contentHash,
-          createdAt: now,
           updatedAt: now,
-        })
-        .onConflictDoUpdate({
-          target: [
-            memoryEmbeddings.targetType,
-            memoryEmbeddings.targetId,
-            memoryEmbeddings.provider,
-            memoryEmbeddings.model,
-          ],
-          set: {
-            vectorBlob: blobValue,
-            vectorJson: null,
-            dimensions: dense.length,
-            contentHash,
-            updatedAt: now,
-          },
-        })
-        .run();
-    } catch (err) {
-      log.warn(
-        { err, slug },
-        "Failed to write concept-page embedding cache row",
-      );
-    }
+        },
+      })
+      .run();
+  } catch (err) {
+    log.warn(
+      { err, slug, cacheId },
+      "Failed to write concept-page embedding cache row",
+    );
   }
-
-  // Apply anisotropy correction at the boundary between the (raw) cached
-  // dense vector and the Qdrant collection. Storing raw in SQLite and
-  // corrected in Qdrant means a recalibration just needs a reembed pass —
-  // the cache survives and the (cheap) correction math reruns over each
-  // cached vector. Pass-through when no calibration is fit yet.
-  const correctedDense = await applyCorrectionIfCalibrated(
-    dense,
-    provider,
-    model,
-  );
-
-  await upsertConceptPageEmbedding({
-    slug,
-    dense: correctedDense,
-    sparse,
-    updatedAt: now,
-  });
 }
 
 /**

--- a/assistant/src/memory/v2/__tests__/activation.test.ts
+++ b/assistant/src/memory/v2/__tests__/activation.test.ts
@@ -114,7 +114,10 @@ class MockQdrantClient {
       limit: params.limit,
       filter: params.filter,
     });
-    const channel = params.using as "dense" | "sparse";
+    // The four-channel hybrid query fires body-dense, body-sparse,
+    // summary-dense, summary-sparse in order; both dense channels share
+    // the dense queue and both sparse channels share the sparse queue.
+    const channel = params.using.endsWith("sparse") ? "sparse" : "dense";
     return state.queryResponses[channel].shift() ?? { points: [] };
   }
 }
@@ -223,9 +226,20 @@ function makeConfig(
   } as unknown as AssistantConfig;
 }
 
-/** Stage a single dense + sparse pair on the response queues. */
+/**
+ * Stage a single hybrid-query response — body channels first, then summary
+ * channels (which default to empty). The four-channel hybrid query fires
+ * body-dense, body-sparse, summary-dense, summary-sparse in that order, so
+ * each logical call consumes 2 dense + 2 sparse queue entries.
+ */
 function stageHybridResponse(
-  hits: Array<{ slug: string; denseScore?: number; sparseScore?: number }>,
+  hits: Array<{
+    slug: string;
+    denseScore?: number;
+    sparseScore?: number;
+    summaryDenseScore?: number;
+    summarySparseScore?: number;
+  }>,
 ): void {
   state.queryResponses.dense.push({
     points: hits
@@ -236,6 +250,22 @@ function stageHybridResponse(
     points: hits
       .filter((h) => h.sparseScore !== undefined)
       .map((h) => ({ score: h.sparseScore, payload: { slug: h.slug } })),
+  });
+  state.queryResponses.dense.push({
+    points: hits
+      .filter((h) => h.summaryDenseScore !== undefined)
+      .map((h) => ({
+        score: h.summaryDenseScore,
+        payload: { slug: h.slug },
+      })),
+  });
+  state.queryResponses.sparse.push({
+    points: hits
+      .filter((h) => h.summarySparseScore !== undefined)
+      .map((h) => ({
+        score: h.summarySparseScore,
+        payload: { slug: h.slug },
+      })),
   });
 }
 
@@ -369,7 +399,7 @@ describe("selectCandidates", () => {
       nowText: "",
       config: makeConfig(),
     });
-    expect(state.queryCalls).toHaveLength(2);
+    expect(state.queryCalls).toHaveLength(4);
     for (const call of state.queryCalls) {
       expect(call.limit).toBe(1_000_000);
       expect(call.filter).toBeUndefined();
@@ -385,7 +415,7 @@ describe("selectCandidates", () => {
       nowText: "",
       config: makeConfig({ ann_candidate_limit: 25 }),
     });
-    expect(state.queryCalls).toHaveLength(2);
+    expect(state.queryCalls).toHaveLength(4);
     for (const call of state.queryCalls) {
       expect(call.limit).toBe(25);
       expect(call.filter).toBeUndefined();

--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -114,8 +114,11 @@ class MockQdrantClient {
     _name: string,
     params: { using: string; limit: number; filter?: unknown },
   ) {
-    const queue = state.queryResponses[params.using as "dense" | "sparse"];
-    return queue.shift() ?? { points: [] };
+    // The four-channel hybrid query fires body-dense, body-sparse,
+    // summary-dense, summary-sparse in order; both dense channels share
+    // the dense queue and both sparse channels share the sparse queue.
+    const channel = params.using.endsWith("sparse") ? "sparse" : "dense";
+    return state.queryResponses[channel].shift() ?? { points: [] };
   }
 }
 
@@ -229,6 +232,18 @@ ref_files:
 ---
 Demo body content.`,
   );
+  // A page WITH a `summary` in its frontmatter — exercises the summary-only
+  // injection path. Body is intentionally longer than the summary so tests
+  // can assert that the body is *not* injected when the summary is present.
+  writeFileSync(
+    join(tmpWorkspace, "memory", "concepts", "summarized-page.md"),
+    `---
+edges: []
+ref_files: []
+summary: A short prose description of the summarized page that retrieval injects in place of the full body.
+---
+Long-form body content that should NOT appear in the injection block when the page has a summary in frontmatter — the agent reads the file on demand instead.`,
+  );
 });
 
 afterAll(() => {
@@ -308,14 +323,26 @@ function makeConfig(
 /**
  * Stage one set of dense/sparse hits, used uniformly by every `simBatch`
  * channel call (user/assistant/now) AND by the un-restricted ANN candidate
- * query. The candidate query runs first, then three simBatch calls, so we
- * push 4 dense + 4 sparse responses per turn.
+ * query. The candidate query runs first, then three simBatch calls — that's
+ * `channels` (= 4) logical hybrid queries. Each logical hybrid query now
+ * fires a four-channel fan-out (body dense, body sparse, summary dense,
+ * summary sparse), so we push 2 dense + 2 sparse responses per logical
+ * call to match the post-summary-vector wire pattern.
  *
  * Each entry is mapped to a hit per channel; pass `denseScore`/`sparseScore`
- * undefined to omit a slug from that channel.
+ * undefined to omit a slug from that channel. `summaryDenseScore` /
+ * `summarySparseScore` route to the summary-side channels — tests that
+ * don't care about summary scoring leave them undefined and the summary
+ * channel falls back to body-only behavior.
  */
 function stageTurn(
-  hits: Array<{ slug: string; denseScore?: number; sparseScore?: number }>,
+  hits: Array<{
+    slug: string;
+    denseScore?: number;
+    sparseScore?: number;
+    summaryDenseScore?: number;
+    summarySparseScore?: number;
+  }>,
   channels = 4,
 ): void {
   // Clear any leftovers from a prior turn before staging this one so unused
@@ -335,6 +362,22 @@ function stageTurn(
       points: hits
         .filter((h) => h.sparseScore !== undefined)
         .map((h) => ({ score: h.sparseScore, payload: { slug: h.slug } })),
+    });
+    state.queryResponses.dense.push({
+      points: hits
+        .filter((h) => h.summaryDenseScore !== undefined)
+        .map((h) => ({
+          score: h.summaryDenseScore,
+          payload: { slug: h.slug },
+        })),
+    });
+    state.queryResponses.sparse.push({
+      points: hits
+        .filter((h) => h.summarySparseScore !== undefined)
+        .map((h) => ({
+          score: h.summarySparseScore,
+          payload: { slug: h.slug },
+        })),
     });
   }
 }
@@ -395,7 +438,7 @@ describe("injectMemoryV2Block", () => {
     expect(result.block).not.toContain("<memory>");
     expect(result.block).not.toContain("</memory>");
     expect(result.block).not.toContain("## What I Remember Right Now");
-    expect(result.block).toContain("### alice-vscode");
+    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
     expect(result.block).toContain("VS Code");
 
     // State persisted: alice's activation is above epsilon and recorded;
@@ -484,10 +527,10 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.toInject).toEqual(["carol-jazz"]);
-    expect(result.block).toContain("### carol-jazz");
+    expect(result.block).toContain("# memory/concepts/carol-jazz.md");
     // The block only shows the new slug — alice's attachment lives on the
     // previous turn's user message.
-    expect(result.block).not.toContain("### alice-vscode");
+    expect(result.block).not.toContain("# memory/concepts/alice-vscode.md");
 
     const persisted = await hydrate(db, "conv-1");
     expect(persisted!.everInjected).toEqual([
@@ -532,12 +575,80 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.toInject).toEqual(["alice-vscode"]);
-    expect(result.block).toContain("### alice-vscode");
+    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
 
     const persisted = await hydrate(db, "conv-1");
     expect(persisted!.everInjected).toEqual([
       { slug: "alice-vscode", turn: 2 },
     ]);
+  });
+
+  test("page with summary renders as path + summary, no body, with the CRITICAL header", async () => {
+    // Pages whose frontmatter carries a `summary` should inject only the
+    // summary text behind the path header — the agent reads the full file
+    // on demand. The leading `**CRITICAL:**` line tells the agent how to
+    // read the block.
+    stageTurn([{ slug: "summarized-page", denseScore: 0.9 }]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "tell me about the summarized page",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.block).not.toBeNull();
+    expect(result.block).toContain(
+      "**CRITICAL:** These are page summaries. Read the page file if it looks relevant.",
+    );
+    expect(result.block).toContain(
+      "# memory/concepts/summarized-page.md\nA short prose description",
+    );
+    // Body is NOT in the block — the agent must follow up with a read tool.
+    expect(result.block).not.toContain("Long-form body content");
+    // Frontmatter is also omitted; the path header carries the identifying
+    // information by itself, and edges flow through the activation graph.
+    expect(result.block).not.toContain("---\nedges:");
+  });
+
+  test("mixed batch — summary page renders short, fallback page renders full", async () => {
+    // Both pages rank into top-K. summarized-page has a summary → short
+    // form. frontmatter-demo has no summary → full-page fallback. The
+    // single CRITICAL header sits at the top regardless.
+    stageTurn([
+      { slug: "summarized-page", denseScore: 0.95 },
+      { slug: "frontmatter-demo", denseScore: 0.85 },
+    ]);
+
+    const result = await injectMemoryV2Block({
+      database: db,
+      conversationId: "conv-1",
+      currentTurn: 1,
+      userMessage: "show me everything",
+      assistantMessage: "",
+      nowText: "Now",
+      messageId: "msg-1",
+      config: makeConfig(),
+    });
+
+    expect(result.block).not.toBeNull();
+    // CRITICAL header appears exactly once.
+    const criticalCount = (
+      result.block!.match(/\*\*CRITICAL:\*\* These are page summaries\./g) ?? []
+    ).length;
+    expect(criticalCount).toBe(1);
+    // summarized-page → short form (path + summary, no body, no frontmatter).
+    expect(result.block).toContain("# memory/concepts/summarized-page.md\nA");
+    expect(result.block).not.toContain("Long-form body content");
+    // frontmatter-demo → full-page fallback (path + frontmatter + body).
+    expect(result.block).toContain(
+      "# memory/concepts/frontmatter-demo.md\n---\n",
+    );
+    expect(result.block).toContain("Demo body content.");
   });
 
   test("includes the page frontmatter (edges, ref_files) in each rendered section", async () => {
@@ -560,8 +671,12 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.block).not.toBeNull();
-    // Slug header is immediately followed by the frontmatter open delimiter.
-    expect(result.block).toContain("### frontmatter-demo\n---\n");
+    // Path header is immediately followed by the frontmatter open delimiter.
+    // The fallback path renders the full page (frontmatter + body) when the
+    // page has no `summary` field — `frontmatter-demo` predates the field.
+    expect(result.block).toContain(
+      "# memory/concepts/frontmatter-demo.md\n---\n",
+    );
     // Both fields render in YAML block style with their populated values.
     expect(result.block).toContain("edges:\n  - alice-vscode");
     expect(result.block).toContain("ref_files:\n  - images/demo.jpg");
@@ -589,8 +704,8 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.toInject).toEqual(["carol-jazz", "alice-vscode"]);
-    const carolIdx = result.block!.indexOf("### carol-jazz");
-    const aliceIdx = result.block!.indexOf("### alice-vscode");
+    const carolIdx = result.block!.indexOf("# memory/concepts/carol-jazz.md");
+    const aliceIdx = result.block!.indexOf("# memory/concepts/alice-vscode.md");
     expect(carolIdx).toBeGreaterThan(-1);
     expect(aliceIdx).toBeGreaterThan(-1);
     expect(carolIdx).toBeLessThan(aliceIdx);
@@ -692,7 +807,7 @@ describe("injectMemoryV2Block", () => {
     expect(result.block).not.toContain("<memory>");
     expect(result.block).not.toContain("</memory>");
     expect(result.block).not.toContain("## What I Remember Right Now");
-    expect(result.block).not.toContain("### alice-vscode");
+    expect(result.block).not.toContain("# memory/concepts/alice-vscode.md");
     expect(result.block).toContain("### Skills You Can Use");
     expect(result.block).toContain(
       '- The "Example Skill A" skill (example-skill-a) is available. Helps with examples. → use skill_load to activate',
@@ -731,11 +846,13 @@ describe("injectMemoryV2Block", () => {
     );
     expect(result.block).not.toBeNull();
 
-    const aliceIdx = result.block!.indexOf("### alice-vscode");
+    const aliceHeaderIdx = result.block!.indexOf(
+      "# memory/concepts/alice-vscode.md",
+    );
     const skillsIdx = result.block!.indexOf("### Skills You Can Use");
-    expect(aliceIdx).toBeGreaterThan(-1);
+    expect(aliceHeaderIdx).toBeGreaterThan(-1);
     expect(skillsIdx).toBeGreaterThan(-1);
-    expect(aliceIdx).toBeLessThan(skillsIdx);
+    expect(aliceHeaderIdx).toBeLessThan(skillsIdx);
 
     expect(result.block).toContain(
       '- The "Example Skill A" skill (example-skill-a) is available. Helps with examples. → use skill_load to activate',
@@ -864,7 +981,7 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.block).not.toBeNull();
-    expect(result.block).toContain("### alice-vscode");
+    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
     // No newly-injected slug — alice was already in everInjected.
     expect(result.toInject).toEqual([]);
 
@@ -900,9 +1017,9 @@ describe("injectMemoryV2Block", () => {
     });
 
     expect(result.block).not.toBeNull();
-    expect(result.block).toContain("### alice-vscode");
-    expect(result.block).toContain("### bob-coffee");
-    expect(result.block).toContain("### carol-jazz");
+    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
+    expect(result.block).toContain("# memory/concepts/bob-coffee.md");
+    expect(result.block).toContain("# memory/concepts/carol-jazz.md");
     // The seeded directed edges (alice→bob, bob→alice, frontmatter-demo→alice)
     // mean alice has two incoming predecessors and bob has one, so directed
     // spread normalizes alice's activation more aggressively than bob's. The
@@ -1163,7 +1280,7 @@ describe("injectMemoryV2Block", () => {
     expect(telemetryState.recordCalls.length).toBe(0);
     expect(result.toInject).toEqual(["alice-vscode"]);
     expect(result.block).not.toBeNull();
-    expect(result.block).toContain("### alice-vscode");
+    expect(result.block).toContain("# memory/concepts/alice-vscode.md");
 
     const persisted = await hydrate(db, "conv-1");
     expect(persisted!.everInjected).toEqual([

--- a/assistant/src/memory/v2/__tests__/qdrant.test.ts
+++ b/assistant/src/memory/v2/__tests__/qdrant.test.ts
@@ -27,7 +27,12 @@ mock.module("../../qdrant-client.js", () => ({
 // records every call and lets each test program the next response.
 type MockPoint = {
   id: string;
-  vector: { dense: number[]; sparse: { indices: number[]; values: number[] } };
+  vector: {
+    dense: number[];
+    sparse: { indices: number[]; values: number[] };
+    summary_dense?: number[];
+    summary_sparse?: { indices: number[]; values: number[] };
+  };
   payload: { slug: string; updated_at: number };
 };
 
@@ -102,7 +107,14 @@ class MockQdrantClient {
     },
   ) {
     state.queryCalls.push(params);
-    const queue = state.queryResponses[params.using as "dense" | "sparse"];
+    // Both `dense` and `summary_dense` consume from the dense queue (and
+    // similarly for sparse). The four-channel hybrid query fires them in
+    // order: body-dense, body-sparse, summary-dense, summary-sparse — so
+    // queue order matches call order.
+    const queue =
+      state.queryResponses[
+        params.using.endsWith("sparse") ? "sparse" : "dense"
+      ];
     return queue.shift() ?? { points: [] };
   }
 }
@@ -140,7 +152,7 @@ describe("memory v2 qdrant — collection lifecycle", () => {
   beforeEach(resetState);
   afterEach(resetState);
 
-  test("creates the collection with named dense + sparse vectors", async () => {
+  test("creates the collection with named dense + sparse vectors (body and summary)", async () => {
     state.collectionExistsBeforeCreate = false;
 
     await ensureConceptPageCollection();
@@ -149,8 +161,12 @@ describe("memory v2 qdrant — collection lifecycle", () => {
     const params = state.createCollectionParams as {
       vectors: {
         dense: { size: number; distance: string; on_disk: boolean };
+        summary_dense: { size: number; distance: string; on_disk: boolean };
       };
-      sparse_vectors: { sparse: Record<string, unknown> };
+      sparse_vectors: {
+        sparse: Record<string, unknown>;
+        summary_sparse: Record<string, unknown>;
+      };
       hnsw_config: { on_disk: boolean; m: number; ef_construct: number };
       on_disk_payload: boolean;
     };
@@ -159,7 +175,14 @@ describe("memory v2 qdrant — collection lifecycle", () => {
       distance: "Cosine",
       on_disk: true,
     });
+    // Summary side mirrors body so the activation pipeline can fuse symmetrically.
+    expect(params.vectors.summary_dense).toEqual({
+      size: 384,
+      distance: "Cosine",
+      on_disk: true,
+    });
     expect(params.sparse_vectors.sparse).toEqual({});
+    expect(params.sparse_vectors.summary_sparse).toEqual({});
     expect(params.hnsw_config).toEqual({
       on_disk: true,
       m: 16,
@@ -249,10 +272,65 @@ describe("memory v2 qdrant — upsert", () => {
       indices: [1, 2],
       values: [0.5, 0.5],
     });
+    // No summary vectors when caller didn't pass them — Qdrant accepts a
+    // partial named-vector subset, and pages without a frontmatter summary
+    // legitimately have nothing to embed on the summary side.
+    const vectorRecord = point.vector as unknown as Record<string, unknown>;
+    expect(vectorRecord.summary_dense).toBeUndefined();
+    expect(vectorRecord.summary_sparse).toBeUndefined();
     // Point ID is a UUID-shaped string derived from the slug.
     expect(point.id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
+  });
+
+  test("upserts summary vectors alongside body vectors when both are provided", async () => {
+    state.collectionExistsBeforeCreate = true;
+
+    await upsertConceptPageEmbedding({
+      slug: "summarized-page",
+      dense: [0.1, 0.2, 0.3],
+      sparse: { indices: [1, 2], values: [0.5, 0.5] },
+      summary: {
+        dense: [0.4, 0.5, 0.6],
+        sparse: { indices: [3, 4], values: [0.7, 0.7] },
+      },
+      updatedAt: 1714000000000,
+    });
+
+    expect(state.upsertCalls).toHaveLength(1);
+    const [point] = state.upsertCalls[0].points;
+    const vectorRecord = point.vector as unknown as Record<string, unknown>;
+    expect(vectorRecord.dense).toEqual([0.1, 0.2, 0.3]);
+    expect(vectorRecord.sparse).toEqual({
+      indices: [1, 2],
+      values: [0.5, 0.5],
+    });
+    expect(vectorRecord.summary_dense).toEqual([0.4, 0.5, 0.6]);
+    expect(vectorRecord.summary_sparse).toEqual({
+      indices: [3, 4],
+      values: [0.7, 0.7],
+    });
+  });
+
+  test("omits summary vectors when the summary block is undefined", async () => {
+    // The grouped-shape signature enforces summary as a paired { dense, sparse }
+    // block; passing `undefined` (or omitting it) leaves the summary vectors off
+    // the point entirely so query-time fusion stays symmetric.
+    state.collectionExistsBeforeCreate = true;
+
+    await upsertConceptPageEmbedding({
+      slug: "no-summary",
+      dense: [0.1],
+      sparse: { indices: [1], values: [1] },
+      // summary intentionally omitted
+      updatedAt: 1,
+    });
+
+    const [point] = state.upsertCalls[0].points;
+    const vectorRecord = point.vector as unknown as Record<string, unknown>;
+    expect(vectorRecord.summary_dense).toBeUndefined();
+    expect(vectorRecord.summary_sparse).toBeUndefined();
   });
 
   test("two upserts for the same slug share the same point id (overwrites in place)", async () => {
@@ -357,8 +435,9 @@ describe("memory v2 qdrant — hybrid query", () => {
   beforeEach(resetState);
   afterEach(resetState);
 
-  test("runs both dense and sparse queries and returns per-channel scores", async () => {
+  test("runs all four channels (body dense/sparse + summary dense/sparse) and returns per-channel scores", async () => {
     state.collectionExistsBeforeCreate = true;
+    // Body channel hits.
     state.queryResponses.dense.push({
       points: [
         { score: 0.91, payload: { slug: "alice-prefers-vs-code" } },
@@ -371,6 +450,14 @@ describe("memory v2 qdrant — hybrid query", () => {
         { score: 3, payload: { slug: "bob-uses-zsh" } },
       ],
     });
+    // Summary channel hits — queue order is body-dense, body-sparse,
+    // summary-dense, summary-sparse, so push summaries after bodies.
+    state.queryResponses.dense.push({
+      points: [{ score: 0.81, payload: { slug: "alice-prefers-vs-code" } }],
+    });
+    state.queryResponses.sparse.push({
+      points: [{ score: 9, payload: { slug: "alice-prefers-vs-code" } }],
+    });
 
     const results = await hybridQueryConceptPages(
       [0.1, 0.2, 0.3],
@@ -378,14 +465,19 @@ describe("memory v2 qdrant — hybrid query", () => {
       5,
     );
 
-    // Both queries fired, with the same limit and the right `using`.
-    expect(state.queryCalls).toHaveLength(2);
+    // All four queries fired with the same limit and distinct `using`.
+    expect(state.queryCalls).toHaveLength(4);
     const usings = state.queryCalls.map((c) => c.using).sort();
-    expect(usings).toEqual(["dense", "sparse"]);
+    expect(usings).toEqual([
+      "dense",
+      "sparse",
+      "summary_dense",
+      "summary_sparse",
+    ]);
     expect(state.queryCalls.every((c) => c.limit === 5)).toBe(true);
     expect(state.queryCalls.every((c) => c.with_payload === true)).toBe(true);
 
-    // Each slug exposes both channel scores.
+    // Alice has hits on all four channels; bob is body-only.
     expect(results).toHaveLength(2);
     const alice = results.find((r) => r.slug === "alice-prefers-vs-code");
     const bob = results.find((r) => r.slug === "bob-uses-zsh");
@@ -393,6 +485,8 @@ describe("memory v2 qdrant — hybrid query", () => {
       slug: "alice-prefers-vs-code",
       denseScore: 0.91,
       sparseScore: 12,
+      summaryDenseScore: 0.81,
+      summarySparseScore: 9,
     });
     expect(bob).toEqual({
       slug: "bob-uses-zsh",
@@ -403,6 +497,8 @@ describe("memory v2 qdrant — hybrid query", () => {
 
   test("dense-only hits leave sparseScore undefined (and vice versa)", async () => {
     state.collectionExistsBeforeCreate = true;
+    // Body dense + sparse hits. Summary channels stay empty (no push) →
+    // they fall through to `{ points: [] }` and produce no summary scores.
     state.queryResponses.dense.push({
       points: [{ score: 0.7, payload: { slug: "dense-only" } }],
     });
@@ -420,8 +516,41 @@ describe("memory v2 qdrant — hybrid query", () => {
     const sparseOnly = results.find((r) => r.slug === "sparse-only");
     expect(denseOnly).toEqual({ slug: "dense-only", denseScore: 0.7 });
     expect(denseOnly?.sparseScore).toBeUndefined();
+    expect(denseOnly?.summaryDenseScore).toBeUndefined();
     expect(sparseOnly).toEqual({ slug: "sparse-only", sparseScore: 2 });
     expect(sparseOnly?.denseScore).toBeUndefined();
+    expect(sparseOnly?.summarySparseScore).toBeUndefined();
+  });
+
+  test("returns summary-channel scores when only the summary side hits", async () => {
+    // Page has no body hits but matches via the summary embedding —
+    // exercises the path where `simBatch` falls back to summary-only.
+    state.collectionExistsBeforeCreate = true;
+    // Body channels empty.
+    state.queryResponses.dense.push({ points: [] });
+    state.queryResponses.sparse.push({ points: [] });
+    // Summary channels hit.
+    state.queryResponses.dense.push({
+      points: [{ score: 0.6, payload: { slug: "summary-only" } }],
+    });
+    state.queryResponses.sparse.push({
+      points: [{ score: 4, payload: { slug: "summary-only" } }],
+    });
+
+    const results = await hybridQueryConceptPages(
+      [0.1],
+      { indices: [1], values: [1] },
+      5,
+    );
+
+    const summaryOnly = results.find((r) => r.slug === "summary-only");
+    expect(summaryOnly).toEqual({
+      slug: "summary-only",
+      summaryDenseScore: 0.6,
+      summarySparseScore: 4,
+    });
+    expect(summaryOnly?.denseScore).toBeUndefined();
+    expect(summaryOnly?.sparseScore).toBeUndefined();
   });
 
   test("does not use Qdrant-side RRF fusion (separate per-channel queries)", async () => {

--- a/assistant/src/memory/v2/__tests__/sim.test.ts
+++ b/assistant/src/memory/v2/__tests__/sim.test.ts
@@ -136,7 +136,11 @@ class MockQdrantClient {
       limit: params.limit,
       filter: params.filter,
     });
-    const channel = params.using as "dense" | "sparse";
+    // Both `dense` and `summary_dense` consume from the dense queue (and
+    // similarly for sparse). The four-channel hybrid query fires them in
+    // order: body-dense, body-sparse, summary-dense, summary-sparse — so
+    // the queue order matches the call order.
+    const channel = params.using.endsWith("sparse") ? "sparse" : "dense";
     return state.queryResponses[channel].shift() ?? { points: [] };
   }
 }
@@ -185,10 +189,18 @@ function configWithWeights(
 /**
  * Stage a single Qdrant response that maps each (slug, denseScore?, sparseScore?)
  * tuple onto the dense or sparse channel, mirroring how `hybridQueryConceptPages`
- * merges per-channel hits.
+ * merges per-channel hits. Optional `summaryDenseScore` / `summarySparseScore`
+ * stage the summary-side channels — pages without those entries fall through
+ * to body-only scoring at fusion time.
  */
 function stageHybridResponse(
-  hits: Array<{ slug: string; denseScore?: number; sparseScore?: number }>,
+  hits: Array<{
+    slug: string;
+    denseScore?: number;
+    sparseScore?: number;
+    summaryDenseScore?: number;
+    summarySparseScore?: number;
+  }>,
 ): void {
   state.queryResponses.dense.push({
     points: hits
@@ -199,6 +211,20 @@ function stageHybridResponse(
     points: hits
       .filter((h) => h.sparseScore !== undefined)
       .map((h) => ({ score: h.sparseScore, payload: { slug: h.slug } })),
+  });
+  // The four-channel hybrid query also fires `summary_dense` and
+  // `summary_sparse` queries against the same collection. Tests that don't
+  // care about summary scores leave those channels empty so the fallback
+  // (body-only) path runs.
+  state.queryResponses.dense.push({
+    points: hits
+      .filter((h) => h.summaryDenseScore !== undefined)
+      .map((h) => ({ score: h.summaryDenseScore, payload: { slug: h.slug } })),
+  });
+  state.queryResponses.sparse.push({
+    points: hits
+      .filter((h) => h.summarySparseScore !== undefined)
+      .map((h) => ({ score: h.summarySparseScore, payload: { slug: h.slug } })),
   });
 }
 
@@ -468,15 +494,16 @@ describe("simBatch", () => {
     expect(out.get("loud-page")).toBe(1);
   });
 
-  test("forwards the candidate slugs as a Qdrant slug-IN filter", async () => {
+  test("forwards the candidate slugs as a Qdrant slug-IN filter on every channel", async () => {
     const config = configWithWeights(0.7, 0.3);
     stageHybridResponse([]);
 
     await simBatch("query", ["alice", "bob", "carol"], config);
 
-    // Both channels (dense + sparse) ran with the same slug-restriction
-    // filter and the same per-channel limit equal to the candidate count.
-    expect(state.queryCalls).toHaveLength(2);
+    // All four channels (body dense + sparse, summary dense + sparse) ran
+    // with the same slug-restriction filter and the same per-channel limit
+    // equal to the candidate count.
+    expect(state.queryCalls).toHaveLength(4);
     for (const call of state.queryCalls) {
       expect(call.limit).toBe(3);
       expect(call.filter).toEqual({
@@ -494,6 +521,90 @@ describe("simBatch", () => {
     expect(state.embedCalls).toHaveLength(1);
     expect(state.embedCalls[0].inputs).toEqual(["hello world"]);
     expect(state.sparseCalls).toEqual(["hello world"]);
+  });
+
+  test("takes max(body, summary) per slug — summary higher than body wins", async () => {
+    // Body channels return a modest score; summary channels return a much
+    // higher score. The max collapses to the summary score.
+    const config = configWithWeights(1.0, 0.0);
+    stageHybridResponse([
+      {
+        slug: "alice",
+        denseScore: 0.3,
+        summaryDenseScore: 0.7,
+      },
+    ]);
+
+    const out = await simBatch("query", ["alice"], config);
+
+    expect(out.get("alice")).toBeCloseTo(0.7, 6);
+  });
+
+  test("takes max(body, summary) per slug — body higher than summary wins", async () => {
+    // Inverse case: body dominates, max stays at body.
+    const config = configWithWeights(1.0, 0.0);
+    stageHybridResponse([
+      {
+        slug: "alice",
+        denseScore: 0.9,
+        summaryDenseScore: 0.4,
+      },
+    ]);
+
+    const out = await simBatch("query", ["alice"], config);
+
+    expect(out.get("alice")).toBeCloseTo(0.9, 6);
+  });
+
+  test("falls back to body-only when the page has no summary embedding", async () => {
+    // Pages predating the summary field have no summary_dense/sparse vectors.
+    // Their summary channels return no hits — the max collapses to body.
+    const config = configWithWeights(1.0, 0.0);
+    stageHybridResponse([
+      {
+        slug: "legacy-page",
+        denseScore: 0.6,
+        // summaryDenseScore / summarySparseScore omitted
+      },
+    ]);
+
+    const out = await simBatch("query", ["legacy-page"], config);
+
+    expect(out.get("legacy-page")).toBeCloseTo(0.6, 6);
+  });
+
+  test("normalizes body and summary sparse channels independently", async () => {
+    // Summary sparse scores live on a different scale than body sparse —
+    // a small absolute summary-sparse value (1.5) on the only page that
+    // has summary signal still normalizes to 1.0 within the summary
+    // channel, so the summary-only fused score should win out.
+    const config = configWithWeights(0.0, 1.0);
+    stageHybridResponse([
+      {
+        slug: "alice",
+        denseScore: 0.0,
+        sparseScore: 100, // body sparse max in this batch
+      },
+      {
+        slug: "bob",
+        denseScore: 0.0,
+        sparseScore: 0.5, // body sparse normalized = 0.005
+        summaryDenseScore: 0.0,
+        summarySparseScore: 1.5, // summary sparse max in this batch
+      },
+    ]);
+
+    const out = await simBatch("query", ["alice", "bob"], config);
+
+    // Alice has only body. Body sparse normalized to 1.0; sparse_weight=1.0 → 1.0.
+    expect(out.get("alice")).toBeCloseTo(1.0, 6);
+    // Bob's summary side normalizes its 1.5 (only sparse-bearing summary
+    // hit) — a single sparse-bearing hit is below the adaptive-spread
+    // floor, so the channel collapses to base weights and the lone
+    // sparseNormalized=1.0 hit yields a fused summary score of 1.0.
+    // Body side has only bob's tiny sparse=0.5 against the body batch max
+    // of 100 → ~0.005. The max picks the summary side.
+    expect(out.get("bob")).toBeCloseTo(1.0, 6);
   });
 
   test("returned scores are always in [0, 1] for arbitrary inputs", async () => {

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -361,6 +361,16 @@ interface RenderInjectionBlockResult {
 }
 
 /**
+ * Leading instruction line emitted at the top of every non-empty injection
+ * block. Tells the agent that what follows are page summaries and that it
+ * should read the underlying file when a summary looks relevant. Pages
+ * without a `summary` field render in full instead — the agent treats
+ * those as inline content and doesn't need to follow up.
+ */
+const INJECTION_HEADER =
+  "**CRITICAL:** These are page summaries. Read the page file if it looks relevant.";
+
+/**
  * Render the inner content of the `<memory>` block for a list of slugs.
  * The caller wraps the result in `<memory>...</memory>` exactly once at
  * injection time.
@@ -383,22 +393,23 @@ interface RenderInjectionBlockResult {
  * skill is an expected catalog-level outcome rather than a stale-index
  * bug.
  *
- * The block shape mirrors the §5 layout — concept-page sections first,
- * skills subsection last — preserving the prompt format the agent sees:
+ * Each concept-page section is rendered as a path header followed by either
+ * the page's `summary` (when present in frontmatter) or the full page (the
+ * fallback for pages predating the summary field). Skills sit at the end
+ * under `### Skills You Can Use`, unchanged. The leading `**CRITICAL:**`
+ * line tells the agent how to read the block.
  *
- *   ### <concept-slug-1>
+ *   **CRITICAL:** These are page summaries. Read the page file if it looks relevant.
+ *
+ *   # memory/concepts/<concept-slug-1>.md
+ *   <summary-1>
+ *
+ *   # memory/concepts/<concept-slug-2>.md
  *   ---
  *   edges:
  *     - <neighbor-slug>
  *   ref_files:
  *     - <path/to/asset>
- *   ---
- *   <body-1>
- *
- *   ### <concept-slug-2>
- *   ---
- *   edges: []
- *   ref_files: []
  *   ---
  *   <body-2>
  *
@@ -427,9 +438,18 @@ async function renderInjectionBlock(
       missingSlugs.push(slug);
       continue;
     }
+    const summary = page.frontmatter.summary?.trim();
+    const path = `memory/concepts/${slug}.md`;
+    if (summary && summary.length > 0) {
+      sections.push(`# ${path}\n${summary}`);
+      continue;
+    }
+    // Fallback: page predates the `summary` field (or the field was set to
+    // empty). Render the full page — frontmatter + body — so retrieval
+    // still surfaces the same content the agent saw before this change.
     const content = renderPageContent(page).trim();
     if (content.length === 0) continue;
-    sections.push(`### ${slug}\n${content}`);
+    sections.push(`# ${path}\n${content}`);
   }
 
   const skillLines: string[] = [];
@@ -445,7 +465,7 @@ async function renderInjectionBlock(
   if (sections.length === 0) return { block: null, missingSlugs };
 
   return {
-    block: sections.join("\n\n"),
+    block: `${INJECTION_HEADER}\n\n${sections.join("\n\n")}`,
     missingSlugs,
   };
 }

--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -131,6 +131,7 @@ edges:
   - path/to/sister
   - path/to/parent
 ref_files: []
+summary: 1-4 sentences describing what this article is. Plain prose only — no bullets, no newlines, no markdown lists. Lead with the most identifying detail.
 ---
 # title
 
@@ -139,6 +140,8 @@ ref_files: []
 - **bullet 1.** fact + implication folded in. inline pointer when bullet references another article → \`path/to/article.md\`.
 - **bullet 2.** ...
 \`\`\`
+
+The \`summary\` field is required on every new or updated article. Retrieval injects \`path + summary\` into context — the agent reads the full file only when the summary looks relevant — so make the summary specific and terse. Keep it on a single YAML line (no \`|\` block scalars, no embedded newlines).
 
 **Caps:** ~5-8 bullets per topic/concept article. ~10-12 per arc-node (which can use bold inline labels: \`**the open**: ...\`).
 
@@ -285,6 +288,7 @@ edges:
   - some-named-phrase
   - objects/some-artifact
 ref_files: []
+summary: A short prose description of the article — 1-4 sentences, single line.
 ---
 \`\`\`
 
@@ -416,6 +420,7 @@ For each article you touched:
 9. **Spawn check.** Did you ask "what's recognizable here?" not "what have I earned?" Did you catch any hedging — and spawn anyway? Any fold-into-parent / defer stealth-skips you almost did?
 10. **Split-not-compress.** If anything went over cap, did you split? If you compressed, can you name the rationale in one sentence?
 11. **Edges.** Outgoing within tiered caps (atomic ≤10, arc ≤15, gravity well ≤25, hard limit 20 on non-hubs)? No noise-edges to gravity wells from non-arc pages?
+11a. **Summary present.** Every new or updated article has a \`summary:\` line — 1-4 sentences, single YAML line, lead with the identifying detail.
 12. **Topic coherence.** Does each article answer ONE question? Gravity wells acting as hubs (pointing at topic articles), not absorbing body?
 13. **\`recent.md\`** under 2000 chars, today=full / older=one-liners?
 14. **\`[SOURCE NEEDED]\`** tags surfaced for human review?

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -48,16 +48,30 @@ export interface ConceptPagePayload {
 export interface ConceptPageQueryResult {
   slug: string;
   /**
-   * Dense cosine similarity, when the slug appeared in the dense top-`limit`.
-   * `undefined` if the slug only appeared in the sparse channel.
+   * Dense cosine similarity against the page body, when the slug appeared in
+   * the body dense top-`limit`. `undefined` if the slug only appeared in the
+   * sparse channel — or in a summary-side channel.
    */
   denseScore?: number;
   /**
-   * Sparse score, when the slug appeared in the sparse top-`limit`.
-   * `undefined` if the slug only appeared in the dense channel. Lives on a
-   * different scale than `denseScore` — callers must normalize before fusing.
+   * Sparse score against the page body, when the slug appeared in the body
+   * sparse top-`limit`. `undefined` if the slug only appeared in the dense
+   * channel. Lives on a different scale than `denseScore` — callers must
+   * normalize before fusing.
    */
   sparseScore?: number;
+  /**
+   * Dense cosine similarity against the page's frontmatter `summary`, when
+   * the page has a summary embedded and the slug appeared in the summary
+   * dense top-`limit`. `undefined` for pages without a summary embedding —
+   * those fall back to body-only scoring.
+   */
+  summaryDenseScore?: number;
+  /**
+   * Sparse score against the page's frontmatter `summary`, paired with
+   * `summaryDenseScore`. `undefined` for pages without a summary embedding.
+   */
+  summarySparseScore?: number;
 }
 
 let _client: QdrantRestClient | null = null;
@@ -124,9 +138,19 @@ async function ensureConceptPageCollectionOnce(): Promise<void> {
           distance: "Cosine",
           on_disk: onDisk,
         },
+        // Optional second dense vector covering the page's frontmatter
+        // `summary`. Pages without a summary store nothing under this name —
+        // Qdrant supports per-point named-vector subsets — so the named-vector
+        // index stays cheap until summaries are populated.
+        summary_dense: {
+          size: vectorSize,
+          distance: "Cosine",
+          on_disk: onDisk,
+        },
       },
       sparse_vectors: {
         sparse: {}, // Qdrant auto-infers sparse vector params
+        summary_sparse: {}, // BM25 sparse vector for the summary
       },
       hnsw_config: {
         on_disk: onDisk,
@@ -162,18 +186,35 @@ async function ensureConceptPageCollectionOnce(): Promise<void> {
  * Upsert a concept page's dense + sparse embedding. The point ID is derived
  * deterministically from the slug so subsequent calls for the same slug
  * replace the prior point in place rather than accumulating duplicates.
+ *
+ * `summary` is optional — supplied when the page's frontmatter carries a
+ * `summary`, omitted otherwise. Pages without a summary store only the body
+ * vectors and fall back to body-only scoring at query time. The grouped
+ * shape enforces at the type level that summary dense and sparse are
+ * always written together.
  */
 export async function upsertConceptPageEmbedding(params: {
   slug: string;
   dense: number[];
   sparse: SparseEmbedding;
+  summary?: { dense: number[]; sparse: SparseEmbedding };
   updatedAt: number;
 }): Promise<void> {
   await ensureConceptPageCollection();
 
-  const { slug, dense, sparse, updatedAt } = params;
+  const { slug, dense, sparse, summary, updatedAt } = params;
   const client = getClient();
   const pointId = pointIdForSlug(slug);
+
+  // Qdrant lets us upsert any subset of named vectors per point. The summary
+  // entries appear only when the caller passed a `summary` block — pairing
+  // them at the type level keeps query-time fusion symmetric with the body
+  // channels.
+  const vector: Record<string, number[] | SparseEmbedding> = { dense, sparse };
+  if (summary) {
+    vector.summary_dense = summary.dense;
+    vector.summary_sparse = summary.sparse;
+  }
 
   const upsertOnce = () =>
     client.upsert(MEMORY_V2_COLLECTION, {
@@ -181,7 +222,7 @@ export async function upsertConceptPageEmbedding(params: {
       points: [
         {
           id: pointId,
-          vector: { dense, sparse },
+          vector,
           payload: { slug, updated_at: updatedAt },
         },
       ],
@@ -319,9 +360,15 @@ export async function dropLegacySkillsCollection(): Promise<void> {
  * a normalized weighted-sum — because RRF would discard the score magnitudes
  * the activation formula needs.
  *
+ * Four channels are queried concurrently: body dense, body sparse, summary
+ * dense, summary sparse. The summary channels only return hits for pages whose
+ * frontmatter carries a `summary` (and therefore stored `summary_dense` /
+ * `summary_sparse` named vectors at upsert time). Pages without a summary
+ * surface body-only scores; callers fall back to body-only fusion for those.
+ *
  * Each channel returns up to `limit` hits. A slug is included in the result
- * if it appears in either channel; the missing channel's score is left
- * `undefined` so callers can detect single-channel matches.
+ * if it appears in any channel; missing channel scores stay `undefined` so
+ * callers can distinguish "no match in this channel" from "match with score 0".
  *
  * `restrictToSlugs`, when provided, filters the search server-side to only
  * those slugs (Qdrant `slug IN [...]` filter). Used by `simBatch` when the
@@ -355,42 +402,51 @@ export async function hybridQueryConceptPages(
   // Qdrant 1.13.x sparse-index crash that we've reproduced in the wild.
   const skipSparse = options?.skipSparse ?? false;
 
-  const denseQuery = () =>
+  const queryDense = (using: string) =>
     client.query(MEMORY_V2_COLLECTION, {
       query: dense,
-      using: "dense",
+      using,
       limit,
       with_payload: true,
       filter,
     });
-  const sparseQuery = () =>
+  const querySparse = (using: string) =>
     client.query(MEMORY_V2_COLLECTION, {
       query: sparse,
-      using: "sparse",
+      using,
       limit,
       with_payload: true,
       filter,
     });
 
-  // Run both queries concurrently — they hit independent named vectors.
-  // When sparse is gated off we still resolve a Promise so the destructuring
-  // below stays uniform; the empty `points: []` matches the shape of a
-  // no-hit Qdrant response.
+  // Run all four channels concurrently — they hit independent named vectors.
+  // When sparse is gated off the sparse channels still resolve a Promise so
+  // the destructuring below stays uniform; the empty `points: []` matches
+  // the shape of a no-hit Qdrant response.
   const emptyResult = {
     points: [] as Array<{ payload?: unknown; score?: number }>,
   };
   const runQueries = async () =>
-    Promise.all([denseQuery(), skipSparse ? emptyResult : sparseQuery()]);
+    Promise.all([
+      queryDense("dense"),
+      skipSparse ? emptyResult : querySparse("sparse"),
+      queryDense("summary_dense"),
+      skipSparse ? emptyResult : querySparse("summary_sparse"),
+    ]);
 
   let denseResults;
   let sparseResults;
+  let summaryDenseResults;
+  let summarySparseResults;
   try {
-    [denseResults, sparseResults] = await runQueries();
+    [denseResults, sparseResults, summaryDenseResults, summarySparseResults] =
+      await runQueries();
   } catch (err) {
     if (isCollectionMissing(err)) {
       _collectionReady = false;
       await ensureConceptPageCollection();
-      [denseResults, sparseResults] = await runQueries();
+      [denseResults, sparseResults, summaryDenseResults, summarySparseResults] =
+        await runQueries();
     } else {
       throw err;
     }
@@ -399,21 +455,22 @@ export async function hybridQueryConceptPages(
   // Merge by slug. Missing-side scores stay undefined so the fuser can tell
   // "no match in this channel" apart from "match with score 0".
   const merged = new Map<string, ConceptPageQueryResult>();
-  for (const point of denseResults.points ?? []) {
-    const slug = (point.payload as { slug?: unknown } | null)?.slug;
-    if (typeof slug !== "string") continue;
-    merged.set(slug, { slug, denseScore: point.score ?? 0 });
-  }
-  for (const point of sparseResults.points ?? []) {
-    const slug = (point.payload as { slug?: unknown } | null)?.slug;
-    if (typeof slug !== "string") continue;
-    const existing = merged.get(slug);
-    if (existing) {
-      existing.sparseScore = point.score ?? 0;
-    } else {
-      merged.set(slug, { slug, sparseScore: point.score ?? 0 });
+  const recordHit = (
+    points: Array<{ payload?: unknown; score?: number }> | undefined,
+    set: (entry: ConceptPageQueryResult, score: number) => void,
+  ): void => {
+    for (const point of points ?? []) {
+      const slug = (point.payload as { slug?: unknown } | null)?.slug;
+      if (typeof slug !== "string") continue;
+      const existing = merged.get(slug) ?? { slug };
+      set(existing, point.score ?? 0);
+      merged.set(slug, existing);
     }
-  }
+  };
+  recordHit(denseResults.points, (e, s) => (e.denseScore = s));
+  recordHit(sparseResults.points, (e, s) => (e.sparseScore = s));
+  recordHit(summaryDenseResults.points, (e, s) => (e.summaryDenseScore = s));
+  recordHit(summarySparseResults.points, (e, s) => (e.summarySparseScore = s));
 
   return Array.from(merged.values());
 }

--- a/assistant/src/memory/v2/sim.ts
+++ b/assistant/src/memory/v2/sim.ts
@@ -120,14 +120,18 @@ export function effectiveWeights(
  *      sparse via the in-process TF-IDF encoder).
  *   2. Run server-side dense + sparse queries against the v2 concept-page
  *      Qdrant collection, restricted to `candidateSlugs` so we don't waste
- *      query bandwidth on unrelated pages.
- *   3. Fuse: per slug, `score = clamp01(dense_weight · denseCosine +
- *      sparse_weight · normalizedSparse)`. Sparse scores are normalized by
- *      the per-batch maximum (so the largest is 1.0); slugs missing from a
- *      channel contribute 0 from that channel.
+ *      query bandwidth on unrelated pages. The query hits four channels per
+ *      page: body dense + body sparse, and (for pages that have a summary
+ *      embedded) summary dense + summary sparse.
+ *   3. Fuse: per slug, score = `max(fused(body), fused(summary))`. Each
+ *      half is `clamp01(dense_weight · denseCosine + sparse_weight ·
+ *      normalizedSparse)` with sparse normalized by the per-batch maximum.
+ *      Pages without a summary embedding fall back to body-only fusion —
+ *      the summary half is undefined and the max collapses to the body
+ *      score.
  *
  * Returns a `Map<slug, score>` containing only the candidate slugs that hit
- * in at least one channel. Slugs in `candidateSlugs` that miss both channels
+ * in at least one channel. Slugs in `candidateSlugs` that miss every channel
  * are absent from the map; callers should treat absence as score = 0 (the
  * activation pipeline does this implicitly when reading back A_o).
  *
@@ -181,20 +185,52 @@ export async function simBatch(
     return new Map();
   }
 
-  const maxSparse = computeMaxSparse(hits);
+  // Compute per-batch sparse maxima independently for the body and summary
+  // channels so each side normalizes against its own scale. Mixing the two
+  // — e.g. dividing every sparse score by the larger of the two maxima —
+  // would punish whichever channel happened to have lower-magnitude scores
+  // even when its hits were the best matches available.
+  const maxBodySparse = computeMaxSparse(hits, (h) => h.sparseScore);
+  const maxSummarySparse = computeMaxSparse(hits, (h) => h.summarySparseScore);
   const { dense_weight: baseDense, sparse_weight: baseSparse } =
     config.memory.v2;
-  const { dense: denseWeight, sparse: sparseWeight } = effectiveWeights(
-    hits,
-    maxSparse,
+  const { dense: bodyDenseWeight, sparse: bodySparseWeight } = effectiveWeights(
+    hits.map((h) => ({ sparseScore: h.sparseScore })),
+    maxBodySparse,
     baseDense,
     baseSparse,
     config,
   );
+  const { dense: summaryDenseWeight, sparse: summarySparseWeight } =
+    effectiveWeights(
+      hits.map((h) => ({ sparseScore: h.summarySparseScore })),
+      maxSummarySparse,
+      baseDense,
+      baseSparse,
+      config,
+    );
 
   const scores = new Map<string, number>();
   for (const hit of hits) {
-    scores.set(hit.slug, fuseHit(hit, maxSparse, denseWeight, sparseWeight));
+    const bodyScore = fuseHalf(
+      hit.denseScore,
+      hit.sparseScore,
+      maxBodySparse,
+      bodyDenseWeight,
+      bodySparseWeight,
+    );
+    const summaryScore = fuseHalf(
+      hit.summaryDenseScore,
+      hit.summarySparseScore,
+      maxSummarySparse,
+      summaryDenseWeight,
+      summarySparseWeight,
+    );
+    // Pages without a summary embedding return undefined for both summary
+    // channels; their `summaryScore` falls back to the body score so the
+    // max collapses cleanly to body-only behavior.
+    const score = Math.max(bodyScore ?? 0, summaryScore ?? bodyScore ?? 0);
+    scores.set(hit.slug, score);
   }
 
   return scores;
@@ -207,36 +243,41 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
 }
 
 /**
- * Per-batch sparse-score maximum used for normalization. Hits missing from
- * the sparse channel contribute 0 (handled by the `undefined` guard).
+ * Per-batch sparse-score maximum used for normalization. The accessor picks
+ * which sparse channel to scan — `sparseScore` for the body channel,
+ * `summarySparseScore` for the summary channel. Hits missing from the
+ * channel contribute 0 (handled by the `undefined` guard).
  */
-function computeMaxSparse(
-  hits: ReadonlyArray<{ sparseScore?: number }>,
+function computeMaxSparse<T>(
+  hits: ReadonlyArray<T>,
+  accessor: (hit: T) => number | undefined,
 ): number {
   let max = 0;
   for (const hit of hits) {
-    if (hit.sparseScore !== undefined && hit.sparseScore > max) {
-      max = hit.sparseScore;
+    const value = accessor(hit);
+    if (value !== undefined && value > max) {
+      max = value;
     }
   }
   return max;
 }
 
 /**
- * Fuse a single hit's dense + sparse scores into a normalized [0, 1] score
+ * Fuse one half of a hit (body or summary) into a normalized [0, 1] score
  * via `clamp01(dense_weight · dense + sparse_weight · sparse/maxSparse)`.
- * Missing-channel scores contribute 0.
+ * Returns `undefined` when neither channel hit — a signal the half had no
+ * match at all, so the caller can fall back to the other half cleanly.
  */
-function fuseHit(
-  hit: { denseScore?: number; sparseScore?: number },
+function fuseHalf(
+  denseScore: number | undefined,
+  sparseScore: number | undefined,
   maxSparse: number,
   denseWeight: number,
   sparseWeight: number,
-): number {
-  const dense = hit.denseScore ?? 0;
+): number | undefined {
+  if (denseScore === undefined && sparseScore === undefined) return undefined;
+  const dense = denseScore ?? 0;
   const sparseNormalized =
-    hit.sparseScore !== undefined && maxSparse > 0
-      ? hit.sparseScore / maxSparse
-      : 0;
+    sparseScore !== undefined && maxSparse > 0 ? sparseScore / maxSparse : 0;
   return clamp01(denseWeight * dense + sparseWeight * sparseNormalized);
 }

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -26,10 +26,17 @@ import { z } from "zod";
  * B → A. The full graph is the union of every page's `edges:` list — there
  * is no separate edges-index file. `ref_files` lists paths to attached media
  * (images, audio, etc.).
+ *
+ * `summary` is a 1-4 sentence prose description of the page. When present,
+ * retrieval injects the path + summary instead of the full page so the agent
+ * can decide whether to read the file. Optional because legacy pages predating
+ * the summary field still parse — those fall back to full-page injection and
+ * full-page-only similarity.
  */
 export const ConceptPageFrontmatterSchema = z.object({
   edges: z.array(z.string()).default([]),
   ref_files: z.array(z.string()).default([]),
+  summary: z.string().optional(),
 });
 
 export type ConceptPageFrontmatter = z.infer<


### PR DESCRIPTION
## Summary

- Add optional `summary` field to concept-page frontmatter; consolidation prompt now requires it on every new or updated page.
- Inject `# memory/concepts/<slug>.md\n<summary>` into the `<memory>` block when a summary is present; fall back to the full page (frontmatter + body) when it isn't, so legacy pages keep working without a migration.
- Embed the summary alongside the body via paired `summary_dense` / `summary_sparse` named vectors on the v2 Qdrant collection; ranking takes `max(body, summary)` per similarity component so a summary-relevant page surfaces even when the body alone wouldn't.

## Original prompt

Memory V2 just GA'd. Today, every retrieved concept page is injected in full into the system memory block — expensive when `top_k` is 25 and pages are arbitrarily long. Switch to injecting just the path + a 1-4 sentence `summary` from the page's frontmatter, with a leading `**CRITICAL:**` line telling the agent to read the file when a summary looks relevant. Pages without a summary fall back to today's full-page injection (and use only the body for similarity). Ranking embeds the summary separately and takes `max(body, summary)` per similarity component (user message, assistant message, `now.md`). No migration needed — Memory V2 went GA last night and nobody is on it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->