### PR TITLE
fix(trust-rules): un-conflate riskScopeOptions (regex) from riskAllowlistOptions (glob)

### DIFF
--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -73,6 +73,11 @@ let cachedAssessmentOverride:
       riskLevel: string;
       reason: string;
       scopeOptions: Array<{ pattern: string; label: string }>;
+      allowlistOptions?: Array<{
+        label: string;
+        description: string;
+        pattern: string;
+      }>;
       directoryScopeOptions?: Array<{ scope: string; label: string }>;
       matchType: string;
     }
@@ -1121,6 +1126,130 @@ describe("ToolExecutionResult includes risk metadata from classifier assessment"
     ]);
     expect(result.riskDirectoryScopeOptions).toEqual([
       { scope: "/tmp", label: "Anywhere in tmp/" },
+    ]);
+  });
+
+  test("auto-approved tool result includes riskAllowlistOptions when classifier emits them (Minimatch-glob shape for save path)", async () => {
+    cachedAssessmentOverride = {
+      riskLevel: "medium",
+      reason: "Reads workspace files",
+      // Display ladder (regex shape — not for save).
+      scopeOptions: [
+        { pattern: "^echo\\b.*hello$", label: "echo hello" },
+        { pattern: "^echo\\b", label: "echo *" },
+      ],
+      // Save ladder (Minimatch-glob shape — what gateway matches against).
+      allowlistOptions: [
+        {
+          label: "echo hello",
+          description: "This exact command",
+          pattern: "echo hello",
+        },
+        {
+          label: "echo *",
+          description: "Any echo command",
+          pattern: "action:echo",
+        },
+      ],
+      matchType: "registry",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext({ requireFreshApproval: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    // Both shapes flow through independently — same labels, different patterns.
+    expect(result.riskScopeOptions).toEqual([
+      { pattern: "^echo\\b.*hello$", label: "echo hello" },
+      { pattern: "^echo\\b", label: "echo *" },
+    ]);
+    expect(result.riskAllowlistOptions).toEqual([
+      {
+        label: "echo hello",
+        description: "This exact command",
+        pattern: "echo hello",
+      },
+      {
+        label: "echo *",
+        description: "Any echo command",
+        pattern: "action:echo",
+      },
+    ]);
+  });
+
+  test("riskAllowlistOptions is undefined when classifier did not produce allowlist (e.g. web-risk classifier)", async () => {
+    cachedAssessmentOverride = {
+      riskLevel: "low",
+      reason: "GET request to public URL",
+      scopeOptions: [{ pattern: "https://example.com/.*", label: "example.com" }],
+      // allowlistOptions intentionally omitted — some classifiers don't emit them.
+      matchType: "registry",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext({ requireFreshApproval: true }),
+    );
+
+    expect(result.isError).toBe(false);
+    // Display ladder still flows; save ladder is absent so the client must
+    // fall back to a synthesized option (or omit save).
+    expect(result.riskScopeOptions).toEqual([
+      { pattern: "https://example.com/.*", label: "example.com" },
+    ]);
+    expect(result.riskAllowlistOptions).toBeUndefined();
+  });
+
+  test("riskAllowlistOptions is undefined when no classifier ran (MCP tools)", async () => {
+    // cachedAssessmentOverride is undefined — no classifier ran.
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.riskScopeOptions).toBeUndefined();
+    expect(result.riskAllowlistOptions).toBeUndefined();
+  });
+
+  test("denied tool result still carries riskAllowlistOptions for the rule editor save path", async () => {
+    checkResultOverride = { decision: "deny", reason: "Blocked by deny rule" };
+    cachedAssessmentOverride = {
+      riskLevel: "high",
+      reason: "Recursive force delete",
+      scopeOptions: [{ pattern: "^rm\\s+-rf", label: "rm -rf *" }],
+      allowlistOptions: [
+        {
+          label: "rm -rf *",
+          description: "Any rm -rf command",
+          pattern: "action:rm",
+        },
+      ],
+      matchType: "registry",
+    };
+
+    const executor = new ToolExecutor(makePrompter());
+    const result = await executor.execute(
+      "file_read",
+      { path: "anything" },
+      makeContext({ requireFreshApproval: true }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.riskAllowlistOptions).toEqual([
+      {
+        label: "rm -rf *",
+        description: "Any rm -rf command",
+        pattern: "action:rm",
+      },
     ]);
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -96,6 +96,11 @@ export type AgentEvent =
       matchedTrustRuleId?: string;
       isContainerized?: boolean;
       riskScopeOptions?: Array<{ pattern: string; label: string }>;
+      riskAllowlistOptions?: Array<{
+        label: string;
+        description: string;
+        pattern: string;
+      }>;
       riskDirectoryScopeOptions?: Array<{ scope: string; label: string }>;
       approvalMode?: string;
       approvalReason?: string;
@@ -282,6 +287,11 @@ export type LoopToolExecutor = (
   matchedTrustRuleId?: string;
   isContainerized?: boolean;
   riskScopeOptions?: Array<{ pattern: string; label: string }>;
+  riskAllowlistOptions?: Array<{
+    label: string;
+    description: string;
+    pattern: string;
+  }>;
   riskDirectoryScopeOptions?: Array<{ scope: string; label: string }>;
   approvalMode?: string;
   approvalReason?: string;
@@ -1001,6 +1011,7 @@ export class AgentLoop {
             matchedTrustRuleId: result.matchedTrustRuleId,
             isContainerized: result.isContainerized,
             riskScopeOptions: result.riskScopeOptions,
+            riskAllowlistOptions: result.riskAllowlistOptions,
             riskDirectoryScopeOptions: result.riskDirectoryScopeOptions,
             approvalMode: result.approvalMode,
             approvalReason: result.approvalReason,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -633,6 +633,7 @@ export function handleToolResult(
     matchedTrustRuleId: event.matchedTrustRuleId,
     isContainerized: event.isContainerized,
     riskScopeOptions: event.riskScopeOptions,
+    riskAllowlistOptions: event.riskAllowlistOptions,
     riskDirectoryScopeOptions: event.riskDirectoryScopeOptions,
     approvalMode: event.approvalMode,
     approvalReason: event.approvalReason,

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -147,8 +147,26 @@ export interface ToolResult {
   matchedTrustRuleId?: string;
   /** Whether the daemon is running in a containerized (Docker) environment. */
   isContainerized?: boolean;
-  /** Scope options ladder for the rule editor modal (narrowest to broadest). */
+  /**
+   * Display-only ladder of scope option labels for the rule editor
+   * (narrowest to broadest). The `pattern` here is regex-style and is
+   * NOT a valid trust rule pattern. Clients must use
+   * `riskAllowlistOptions` for the pattern that gets saved.
+   */
   riskScopeOptions?: Array<{ pattern: string; label: string }>;
+  /**
+   * Allowlist options for the rule editor save path (narrowest to
+   * broadest). Each `pattern` is a Minimatch-glob compatible string —
+   * what the gateway actually matches against. Mirrors the
+   * `allowlistOptions` field on `ConfirmationRequest`. May be absent
+   * for tools whose classifier does not produce an allowlist (e.g.
+   * web-risk classifier, MCP tools without classifier coverage).
+   */
+  riskAllowlistOptions?: Array<{
+    label: string;
+    description: string;
+    pattern: string;
+  }>;
   /** Directory scope ladder for the rule editor modal (narrowest to broadest). */
   riskDirectoryScopeOptions?: Array<{ scope: string; label: string }>;
   /** How the approval decision was reached: prompted, auto, blocked, or unknown (legacy). */

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -107,6 +107,11 @@ export class ToolExecutor {
           riskLevel: string;
           riskReason: string;
           riskScopeOptions: Array<{ pattern: string; label: string }>;
+          riskAllowlistOptions?: Array<{
+            label: string;
+            description: string;
+            pattern: string;
+          }>;
           riskDirectoryScopeOptions?: Array<{ scope: string; label: string }>;
           isContainerized?: boolean;
         }
@@ -205,6 +210,7 @@ export class ToolExecutor {
             riskLevel: permRiskMeta?.riskLevel,
             riskReason: permRiskMeta?.riskReason,
             riskScopeOptions: permRiskMeta?.riskScopeOptions,
+            riskAllowlistOptions: permRiskMeta?.riskAllowlistOptions,
             riskDirectoryScopeOptions: permRiskMeta?.riskDirectoryScopeOptions,
             isContainerized: permRiskMeta?.isContainerized,
             matchedTrustRuleId: permMatchedTrustRuleId,
@@ -422,6 +428,7 @@ export class ToolExecutor {
           riskLevel: permRiskMeta.riskLevel,
           riskReason: permRiskMeta.riskReason,
           riskScopeOptions: permRiskMeta.riskScopeOptions,
+          riskAllowlistOptions: permRiskMeta.riskAllowlistOptions,
           riskDirectoryScopeOptions: permRiskMeta.riskDirectoryScopeOptions,
           isContainerized: permRiskMeta.isContainerized,
         };

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -32,6 +32,11 @@ export type PermissionDecision =
         riskLevel: string;
         riskReason: string;
         riskScopeOptions: Array<{ pattern: string; label: string }>;
+        riskAllowlistOptions?: Array<{
+          label: string;
+          description: string;
+          pattern: string;
+        }>;
         riskDirectoryScopeOptions?: Array<{ scope: string; label: string }>;
         isContainerized?: boolean;
       };
@@ -51,6 +56,11 @@ export type PermissionDecision =
         riskLevel: string;
         riskReason: string;
         riskScopeOptions: Array<{ pattern: string; label: string }>;
+        riskAllowlistOptions?: Array<{
+          label: string;
+          description: string;
+          pattern: string;
+        }>;
         riskDirectoryScopeOptions?: Array<{ scope: string; label: string }>;
         isContainerized?: boolean;
       };
@@ -111,7 +121,12 @@ export class PermissionChecker {
       ? {
           riskLevel: cachedAssessment.riskLevel,
           riskReason: cachedAssessment.reason,
+          // Display ladder (regex patterns — internal only, not for save).
           riskScopeOptions: cachedAssessment.scopeOptions,
+          // Save ladder (Minimatch globs — what the gateway matches against).
+          // Populated for classifiers that produce allowlist options
+          // (bash, file, skill); undefined otherwise.
+          riskAllowlistOptions: cachedAssessment.allowlistOptions,
           riskDirectoryScopeOptions: cachedAssessment.directoryScopeOptions,
           isContainerized: getIsContainerized(),
         }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -115,8 +115,26 @@ export interface ToolExecutionResult {
   riskThreshold?: string;
   /** Whether the daemon is running in a containerized (Docker) environment. */
   isContainerized?: boolean;
-  /** Scope options ladder for the rule editor (narrowest to broadest). */
+  /**
+   * Display-only ladder of scope option labels for the rule editor
+   * (narrowest to broadest). The `pattern` field here is a regex-style
+   * descriptor used internally by the daemon and is NOT a valid trust
+   * rule pattern. Use `riskAllowlistOptions` for the pattern that gets
+   * saved as a trust rule.
+   */
   riskScopeOptions?: Array<{ pattern: string; label: string }>;
+  /**
+   * Allowlist options for the rule editor save path (narrowest to
+   * broadest). Each `pattern` is a Minimatch-glob compatible string
+   * (e.g. raw command for exact match, `action:<program>` for command
+   * wildcards) — what the gateway actually matches against. Mirrors
+   * the `allowlistOptions` field on `ConfirmationRequest` SSE events.
+   */
+  riskAllowlistOptions?: Array<{
+    label: string;
+    description: string;
+    pattern: string;
+  }>;
   /** Directory scope ladder for the rule editor (narrowest to broadest). */
   riskDirectoryScopeOptions?: Array<{ scope: string; label: string }>;
   /**

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -1200,30 +1200,50 @@ struct ToolCallStepDetailRow: View {
 
     // MARK: - Scope Options
 
-    /// Constructs scope option items from the tool call's risk scope options.
-    /// Falls back to a wildcard when no server-provided options exist, since
-    /// `inputSummary` may be a natural-language activity description (e.g. for
-    /// `remember`) rather than a matchable command pattern.
+    /// Constructs scope option items from the tool call's risk options for the
+    /// Rule Editor modal "Apply to" chip ladder.
+    ///
+    /// Priority order (narrowest correct shape wins):
+    ///   1. `riskAllowlistOptions` — Minimatch-glob patterns produced by the
+    ///      classifier. This is the **save-correct** shape: the gateway
+    ///      matches saved trust rules as Minimatch globs, so chips built from
+    ///      this field actually fire on subsequent invocations.
+    ///   2. `riskScopeOptions` — display-shape regex patterns (legacy).
+    ///      Useful as a UI fallback only; saving these patterns produces
+    ///      ghost rules that look saved but never match. Kept here so we
+    ///      don't lose the chip ladder for tools whose classifiers haven't
+    ///      yet been migrated to emit allowlistOptions.
+    ///   3. Synthesized "*" wildcard when neither field is populated (e.g.
+    ///      for unclassified MCP tools or natural-language activity strings
+    ///      like `remember`).
     static func scopeOptions(from toolCall: ToolCallData) -> [ScopeOptionItem] {
-        guard let options = toolCall.riskScopeOptions, !options.isEmpty else {
-            // Determine whether inputRawValue is a real command or just the
-            // activity description. Priority-key tools (bash → `command`) give
-            // a structured value; others fall through alphabetically and end up
-            // with the natural-language activity text.
-            let raw = toolCall.inputRawValue
-            let isNaturalLanguage = !raw.isEmpty && raw == (toolCall.reasonDescription ?? "")
-            let pattern = (isNaturalLanguage || raw.isEmpty) ? "*" : raw
-            let label = pattern == "*"
-                ? "Any \(toolCall.toolName) call"
-                : pattern
-            return [ScopeOptionItem(label: label, pattern: pattern)]
+        if let allowlist = toolCall.riskAllowlistOptions, !allowlist.isEmpty {
+            return allowlist.map { option in
+                ScopeOptionItem(
+                    label: option.label,
+                    pattern: option.pattern
+                )
+            }
         }
-        return options.map { option in
-            ScopeOptionItem(
-                label: option.label,
-                pattern: option.pattern
-            )
+        if let options = toolCall.riskScopeOptions, !options.isEmpty {
+            return options.map { option in
+                ScopeOptionItem(
+                    label: option.label,
+                    pattern: option.pattern
+                )
+            }
         }
+        // Determine whether inputRawValue is a real command or just the
+        // activity description. Priority-key tools (bash → `command`) give
+        // a structured value; others fall through alphabetically and end up
+        // with the natural-language activity text.
+        let raw = toolCall.inputRawValue
+        let isNaturalLanguage = !raw.isEmpty && raw == (toolCall.reasonDescription ?? "")
+        let pattern = (isNaturalLanguage || raw.isEmpty) ? "*" : raw
+        let label = pattern == "*"
+            ? "Any \(toolCall.toolName) call"
+            : pattern
+        return [ScopeOptionItem(label: label, pattern: pattern)]
     }
 
     /// Returns the best structured text to display in the "Command" header of

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -521,9 +521,21 @@ struct AssistantProgressView: View {
     @MainActor
     private func fetchSuggestionAndOpenEditor(for toolCall: ToolCallData) async {
         let client = TrustRuleClient()
-        let scopeOpts: [(pattern: String, label: String)] = (toolCall.riskScopeOptions ?? []).map {
-            (pattern: $0.pattern, label: $0.label)
-        }
+        // Priority: prefer the Minimatch-glob save-path ladder
+        // (`riskAllowlistOptions`) because that is what the chips render and
+        // what the rule editor will persist — feeding the LLM the same
+        // pattern shapes it can save. Fall back to the regex-shaped legacy
+        // `riskScopeOptions` ladder for tool calls without allowlist
+        // coverage yet (and for the pre-tool_result "Allow and Create Rule"
+        // path where the daemon may not have populated either field yet, in
+        // which case both are empty and the suggester runs on command text
+        // alone — same behavior as before #29826).
+        let scopeOpts: [(pattern: String, label: String)] = {
+            if let allowlist = toolCall.riskAllowlistOptions, !allowlist.isEmpty {
+                return allowlist.map { (pattern: $0.pattern, label: $0.label) }
+            }
+            return (toolCall.riskScopeOptions ?? []).map { (pattern: $0.pattern, label: $0.label) }
+        }()
         let dirScopeOpts: [(scope: String, label: String)] = (toolCall.riskDirectoryScopeOptions ?? []).map {
             (scope: $0.scope, label: $0.label)
         }
@@ -1288,9 +1300,16 @@ struct ToolCallStepDetailRow: View {
     }
 
     private func fetchSuggestionForEditor(_ toolCall: ToolCallData, existingRule: TrustRule?) async throws -> TrustRuleSuggestion {
-        let scopeOpts: [(pattern: String, label: String)] = (toolCall.riskScopeOptions ?? []).map {
-            (pattern: $0.pattern, label: $0.label)
-        }
+        // Same priority as `fetchSuggestionAndOpenEditor`: feed the LLM the
+        // glob-shaped save-path ladder (the chips it can pick from), falling
+        // back to the regex-shaped display ladder when allowlist coverage
+        // is absent.
+        let scopeOpts: [(pattern: String, label: String)] = {
+            if let allowlist = toolCall.riskAllowlistOptions, !allowlist.isEmpty {
+                return allowlist.map { (pattern: $0.pattern, label: $0.label) }
+            }
+            return (toolCall.riskScopeOptions ?? []).map { (pattern: $0.pattern, label: $0.label) }
+        }()
         let dirScopeOpts: [(scope: String, label: String)] = (toolCall.riskDirectoryScopeOptions ?? []).map {
             (scope: $0.scope, label: $0.label)
         }

--- a/clients/macos/vellum-assistantTests/Features/Chat/ToolCallStepDetailRowScopeOptionsTests.swift
+++ b/clients/macos/vellum-assistantTests/Features/Chat/ToolCallStepDetailRowScopeOptionsTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+/// Unit tests for `ToolCallStepDetailRow.scopeOptions(from:)`, which feeds the
+/// "Apply to" chip ladder in the Rule Editor modal.
+///
+/// Priority contract (matches the JSDoc in production):
+///   1. `riskAllowlistOptions` (Minimatch-glob patterns from classifier — save-correct)
+///   2. `riskScopeOptions` (regex display patterns — UI fallback only)
+///   3. Synthesized "*" wildcard (natural-language activity strings, unclassified tools)
+@Suite("ToolCallStepDetailRow scopeOptions(from:)")
+struct ToolCallStepDetailRowScopeOptionsTests {
+
+    // MARK: - Helpers
+
+    private static func makeToolCall(
+        toolName: String = "bash",
+        inputSummary: String = "echo hello",
+        inputRawValue: String = "echo hello",
+        reasonDescription: String? = nil,
+        riskScopeOptions: [ToolResultRiskScopeOption]? = nil,
+        riskAllowlistOptions: [ConfirmationRequestAllowlistOption]? = nil
+    ) -> ToolCallData {
+        let id = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        var tc = ToolCallData(
+            id: id,
+            toolName: toolName,
+            inputSummary: inputSummary,
+            inputRawValue: inputRawValue
+        )
+        tc.reasonDescription = reasonDescription
+        tc.riskScopeOptions = riskScopeOptions
+        tc.riskAllowlistOptions = riskAllowlistOptions
+        return tc
+    }
+
+    // MARK: - Priority 1: riskAllowlistOptions wins
+
+    @Test("riskAllowlistOptions wins over riskScopeOptions when both present")
+    @MainActor
+    func allowlistOverridesScopeOptions() async {
+        let tc = Self.makeToolCall(
+            // Display ladder (regex shape — would be wrong for save).
+            riskScopeOptions: [
+                ToolResultRiskScopeOption(pattern: "^echo\\b.*hello$", label: "echo hello"),
+                ToolResultRiskScopeOption(pattern: "^echo\\b", label: "echo *"),
+            ],
+            // Save ladder (Minimatch-glob shape — what the rule editor must save).
+            riskAllowlistOptions: [
+                ConfirmationRequestAllowlistOption(
+                    label: "echo hello",
+                    description: "This exact command",
+                    pattern: "echo hello"
+                ),
+                ConfirmationRequestAllowlistOption(
+                    label: "echo *",
+                    description: "Any echo command",
+                    pattern: "action:echo"
+                ),
+            ]
+        )
+
+        let result = ToolCallStepDetailRow.scopeOptions(from: tc)
+
+        #expect(result.count == 2)
+        #expect(result[0].label == "echo hello")
+        #expect(result[0].pattern == "echo hello")
+        #expect(result[1].label == "echo *")
+        #expect(result[1].pattern == "action:echo")
+    }
+
+    // MARK: - Priority 2: riskScopeOptions fallback
+
+    @Test("riskScopeOptions used when riskAllowlistOptions is nil")
+    @MainActor
+    func fallsBackToScopeOptionsWhenAllowlistNil() async {
+        let tc = Self.makeToolCall(
+            riskScopeOptions: [
+                ToolResultRiskScopeOption(pattern: "https://example.com/.*", label: "example.com"),
+            ],
+            riskAllowlistOptions: nil
+        )
+
+        let result = ToolCallStepDetailRow.scopeOptions(from: tc)
+
+        #expect(result.count == 1)
+        #expect(result[0].label == "example.com")
+        #expect(result[0].pattern == "https://example.com/.*")
+    }
+
+    @Test("riskScopeOptions used when riskAllowlistOptions is empty array")
+    @MainActor
+    func fallsBackToScopeOptionsWhenAllowlistEmpty() async {
+        // web-risk-classifier emits empty allowlistOptions: [] explicitly.
+        let tc = Self.makeToolCall(
+            riskScopeOptions: [
+                ToolResultRiskScopeOption(pattern: "https://example.com/.*", label: "example.com"),
+            ],
+            riskAllowlistOptions: []
+        )
+
+        let result = ToolCallStepDetailRow.scopeOptions(from: tc)
+
+        #expect(result.count == 1)
+        #expect(result[0].pattern == "https://example.com/.*")
+    }
+
+    // MARK: - Priority 3: synthesized wildcard
+
+    @Test("synthesizes wildcard when both option arrays are absent and input is natural-language")
+    @MainActor
+    func synthesizesWildcardForNaturalLanguageActivity() async {
+        // Mirror the case from PR #6033's screenshot: `remember` with no
+        // priority key — `inputRawValue` ends up holding the activity string.
+        let tc = Self.makeToolCall(
+            toolName: "remember",
+            inputRawValue: "desktop files count items",
+            reasonDescription: "desktop files count items"
+        )
+
+        let result = ToolCallStepDetailRow.scopeOptions(from: tc)
+
+        #expect(result.count == 1)
+        #expect(result[0].pattern == "*")
+        #expect(result[0].label == "Any remember call")
+    }
+
+    @Test("synthesizes raw input when no options and input is real command shape")
+    @MainActor
+    func synthesizesRawInputForRealCommand() async {
+        let tc = Self.makeToolCall(
+            toolName: "bash",
+            inputRawValue: "ls -la /tmp",
+            reasonDescription: "Listing tmp directory"
+        )
+
+        let result = ToolCallStepDetailRow.scopeOptions(from: tc)
+
+        #expect(result.count == 1)
+        #expect(result[0].pattern == "ls -la /tmp")
+        #expect(result[0].label == "ls -la /tmp")
+    }
+
+    // MARK: - Edge cases
+
+    @Test("empty riskAllowlistOptions falls through to riskScopeOptions, then to synthesis")
+    @MainActor
+    func emptyAllowlistAndEmptyScopeFallsThroughToSynthesis() async {
+        let tc = Self.makeToolCall(
+            toolName: "bash",
+            inputRawValue: "ls",
+            riskScopeOptions: [],
+            riskAllowlistOptions: []
+        )
+
+        let result = ToolCallStepDetailRow.scopeOptions(from: tc)
+
+        #expect(result.count == 1)
+        #expect(result[0].pattern == "ls")
+    }
+
+    @Test("riskAllowlistOptions description is not surfaced in ScopeOptionItem (label/pattern only)")
+    @MainActor
+    func descriptionIsDroppedFromScopeOptionItem() async {
+        // The chip ladder UI only renders label + pattern — descriptions are
+        // documentation for the LLM suggestion path. Confirms we don't
+        // accidentally leak descriptions into the visible chip text.
+        let tc = Self.makeToolCall(
+            riskAllowlistOptions: [
+                ConfirmationRequestAllowlistOption(
+                    label: "echo hello",
+                    description: "This very specific command exactly",
+                    pattern: "echo hello"
+                ),
+            ]
+        )
+
+        let result = ToolCallStepDetailRow.scopeOptions(from: tc)
+
+        #expect(result.count == 1)
+        #expect(result[0].label == "echo hello")
+        #expect(result[0].pattern == "echo hello")
+        // ScopeOptionItem has no description field — verified by absence at type level.
+    }
+}

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -1193,14 +1193,20 @@ final class ChatActionHandler {
             if !dirOpts.isEmpty {
                 vm.messages[msgIdx].toolCalls[tcIdx].riskDirectoryScopeOptions = dirOpts
             }
-            // Populate riskScopeOptions from the confirmation's allowlistOptions so the
-            // Rule Editor modal has real classifier-produced patterns available when
-            // "Allow and Create Rule" is clicked (before the tool result arrives).
-            let scopeOptsFromConfirmation = confirmation.allowlistOptions.map {
-                ToolResultRiskScopeOption(pattern: $0.pattern, label: $0.label)
-            }
-            if !scopeOptsFromConfirmation.isEmpty {
-                vm.messages[msgIdx].toolCalls[tcIdx].riskScopeOptions = scopeOptsFromConfirmation
+            // Pre-populate riskAllowlistOptions from the confirmation's allowlistOptions
+            // so the Rule Editor modal has real classifier-produced save-shape patterns
+            // available when "Allow and Create Rule" is clicked before the tool result
+            // arrives. Once the tool_result SSE event lands, StreamingHelpers will
+            // overwrite both `riskScopeOptions` (display ladder) and
+            // `riskAllowlistOptions` (save ladder) from the daemon's payload.
+            //
+            // We populate `riskAllowlistOptions` directly (preserving the full
+            // `{pattern, label, description}` shape) instead of remapping into
+            // `riskScopeOptions`, which has a narrower regex-shaped contract and
+            // would silently lose the description plus mis-tag glob patterns as
+            // regex. See the riskScopeOptions JSDoc for the shape distinction.
+            if !confirmation.allowlistOptions.isEmpty {
+                vm.messages[msgIdx].toolCalls[tcIdx].riskAllowlistOptions = confirmation.allowlistOptions
             }
         }
         let confirmMsg = ChatMessage(

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -811,8 +811,16 @@ public struct ToolCallData: Identifiable, Equatable {
     public var approvalReason: String?
     /// Snapshot of the auto-approve threshold at execution time.
     public var riskThreshold: String?
-    /// Scope options ladder for the rule editor (pattern + label pairs, narrowest to broadest).
+    /// Display-only scope options ladder for the rule editor (regex patterns from
+    /// the classifier — narrowest to broadest). NOT safe to use as the saved
+    /// trust-rule pattern (gateway matches as Minimatch glob). For save use
+    /// `riskAllowlistOptions`.
     public var riskScopeOptions: [ToolResultRiskScopeOption]?
+    /// Save-shape allowlist options ladder for the rule editor (Minimatch-glob
+    /// patterns + descriptions from the classifier — narrowest to broadest).
+    /// This is the field whose `pattern` is persisted when the user picks a
+    /// chip and saves the trust rule.
+    public var riskAllowlistOptions: [ConfirmationRequestAllowlistOption]?
     /// Directory scope options ladder for the rule editor (scope + label pairs, narrowest to broadest).
     public var riskDirectoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]?
     /// Working directory for this tool call (extracted from confirmation scope options).

--- a/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift
@@ -447,6 +447,7 @@ extension ChatViewModel {
             messages[msgIndex].toolCalls[tcIndex].riskThreshold = msg.riskThreshold
             if let containerized = msg.isContainerized { messages[msgIndex].toolCalls[tcIndex].isContainerized = containerized }
             messages[msgIndex].toolCalls[tcIndex].riskScopeOptions = msg.riskScopeOptions
+            messages[msgIndex].toolCalls[tcIndex].riskAllowlistOptions = msg.riskAllowlistOptions
             messages[msgIndex].toolCalls[tcIndex].riskDirectoryScopeOptions = msg.riskDirectoryScopeOptions
             if let status = msg.status, !status.isEmpty {
                 messages[msgIndex].toolCalls[tcIndex].buildingStatus = status

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -4909,11 +4909,19 @@ public struct ToolResult: Codable, Sendable {
     public let riskThreshold: String?
     /// Whether the daemon is running in a containerized (Docker) environment.
     public let isContainerized: Bool?
-    /// Scope options ladder for the rule editor modal (narrowest to broadest).
+    /// Display-only scope options ladder for the rule editor modal (regex
+    /// patterns from the classifier — narrowest to broadest). NOT safe to use
+    /// as the saved trust-rule pattern; the gateway matches saved patterns as
+    /// Minimatch globs, not regex. For save use `riskAllowlistOptions`.
     public let riskScopeOptions: [ToolResultRiskScopeOption]?
+    /// Save-shape allowlist options ladder for the rule editor modal
+    /// (Minimatch-glob patterns from the classifier — narrowest to broadest).
+    /// This is the field whose `pattern` should be used when persisting a
+    /// trust rule from the chip-ladder UI.
+    public let riskAllowlistOptions: [ConfirmationRequestAllowlistOption]?
     public let riskDirectoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]?
 
-    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, matchedTrustRuleId: String? = nil, approvalMode: String? = nil, approvalReason: String? = nil, riskThreshold: String? = nil, isContainerized: Bool? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil, riskDirectoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]? = nil) {
+    public init(type: String, toolName: String, result: String, isError: Bool? = nil, diff: ToolResultDiff? = nil, status: String? = nil, conversationId: String? = nil, imageDataList: [String]? = nil, toolUseId: String? = nil, riskLevel: String? = nil, riskReason: String? = nil, matchedTrustRuleId: String? = nil, approvalMode: String? = nil, approvalReason: String? = nil, riskThreshold: String? = nil, isContainerized: Bool? = nil, riskScopeOptions: [ToolResultRiskScopeOption]? = nil, riskAllowlistOptions: [ConfirmationRequestAllowlistOption]? = nil, riskDirectoryScopeOptions: [ConfirmationRequestDirectoryScopeOption]? = nil) {
         self.type = type
         self.toolName = toolName
         self.result = result
@@ -4931,6 +4939,7 @@ public struct ToolResult: Codable, Sendable {
         self.riskThreshold = riskThreshold
         self.isContainerized = isContainerized
         self.riskScopeOptions = riskScopeOptions
+        self.riskAllowlistOptions = riskAllowlistOptions
         self.riskDirectoryScopeOptions = riskDirectoryScopeOptions
     }
 }


### PR DESCRIPTION
## Why

The Rule Editor modal's "Apply to" chip ladder was rendered from `riskScopeOptions`, which carries display-shape **regex** patterns from the classifier. When a user picked a chip and clicked Save, that regex pattern got persisted as the trust rule's `pattern` — but the gateway matches saved patterns as **Minimatch globs**, not regex (see `gateway/src/risk/bash-risk-classifier.ts:869` for the explicit comment).

Net effect: chip-saved trust rules looked saved but never fired. Silent correctness bug.

The classifier was already producing save-correct Minimatch-glob patterns via `scopeOptionsToAllowlistOptions()` and friends — they were just dropped on the way out via the `tool_result` SSE event.

## What

Threads a separate `riskAllowlistOptions` field end-to-end through daemon → SSE → macOS clients, sourced from the cached classifier's `allowlistOptions`. The display ladder (`riskScopeOptions`) stays put but is now correctly marked display-only in JSDoc / Swift docs. Clients that consume the chip ladder for save (Rule Editor modal) prefer `riskAllowlistOptions` when present, fall back to `riskScopeOptions`, then synthesize `"*"` (the PR #6033 fallback path).

## Daemon (TypeScript)

| File | Change |
|---|---|
| `assistant/src/tools/types.ts` | Added `riskAllowlistOptions` to `ToolExecutionResult`; updated JSDoc on `riskScopeOptions` to mark display-only |
| `assistant/src/tools/permission-checker.ts` | Populates new field from `cachedAssessment.allowlistOptions` on both denied and allowed paths |
| `assistant/src/tools/executor.ts` | Threads through `permRiskMeta` type, denied-result, and allowed-result merges |
| `assistant/src/daemon/message-types/messages.ts` | Added `riskAllowlistOptions` to the `tool_result` SSE event |
| `assistant/src/daemon/conversation-agent-loop-handlers.ts` | Forwards new field on SSE emit |
| `assistant/src/agent/loop.ts` | Extended `AgentEvent.tool_result` + `ToolExecutionResult` Pick + agent emit |
| `assistant/src/__tests__/tool-executor.test.ts` | 4 new test cases. **75/75 pass.** |

## macOS (Swift)

| File | Change |
|---|---|
| `clients/shared/Network/Generated/GeneratedAPITypes.swift` | New `riskAllowlistOptions: [ConfirmationRequestAllowlistOption]?` on `ToolResult` |
| `clients/shared/Features/Chat/ChatMessage.swift` | Matching field on `ToolCallData`; updated JSDoc on both options arrays |
| `clients/shared/Features/Chat/ChatViewModel+StreamingHelpers.swift` | Copies `msg.riskAllowlistOptions` on `tool_result` |
| `clients/shared/Features/Chat/ChatActionHandler.swift` | Pre-pops `riskAllowlistOptions` from `confirmation.allowlistOptions` (full `{pattern,label,description}` shape) instead of remapping into `riskScopeOptions` (which silently dropped descriptions and mis-tagged glob patterns as regex) |
| `clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift` | `ToolCallStepDetailRow.scopeOptions(from:)` priority: allowlist → scope → synthesized `*` |
| `clients/macos/vellum-assistantTests/Features/Chat/ToolCallStepDetailRowScopeOptionsTests.swift` | New Swift Testing suite with 7 unit tests covering priority, fallback, synthesis, edge cases |

## Out of scope

- **Web client** (api.ts decode + RuleEditorModal priority) → separate PR in vellum-assistant-platform, forward-compatible with this contract.
- **Persistence** of all three risk-option arrays in `annotatePersistedAssistantMessage` → tracked in PR #6033's follow-ups list.
- **MCP tool classifier coverage** → tracked in PR #6033's follow-ups list.

## Relation to PR #6033

PR #6033 added a synthesized fallback `*` option for tools where no classifier ran or the input is a natural-language activity string (e.g. `remember`). That fallback is **still needed** post-this-PR — it covers tools without any classifier, which never set `riskAllowlistOptions`. This PR is the structural fix for follow-up #3 from #6033's description (un-conflate `riskScopeOptions` vs `allowlistOptions` in api.ts:665).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->