### PR TITLE
chore(gateway): run gateway under `bun --smol` to reduce idle memory

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -57,4 +57,4 @@ EXPOSE 7830
 
 ENV GATEWAY_PORT=7830
 
-CMD ["bun", "run", "src/index.ts"]
+CMD ["bun", "--smol", "run", "src/index.ts"]


### PR DESCRIPTION
## Prompt / plan
The managed gateway sidecar was running near its 384Mi memory limit in production (343Mi/384Mi observed) and OOM-crashing, which broke the IPC connection to the assistant and caused buggy streaming + tool-call re-approval prompts. Switching the gateway entrypoint to `bun --smol` lowers Bun's GC heap target so a request-driven proxy doesn't accumulate as much idle memory. This matches the pattern already used by the assistant daemon (`assistant/docker-entrypoint.sh:50`).

The companion change in `vellum-assistant-platform` doubles the sidecar's memory limit so already-deployed pods stop crashing while this rolls out.

## Test plan
- CI builds the gateway Docker image; this is a one-line `CMD` change so failure would surface as a build/runtime error.
- Once deployed, watch the gateway sidecar's memory usage on the admin K8s Resources panel — should sit well below the (newly-doubled) limit instead of pegging it.

---

- Requested by: @m-abboud
- Session: https://app.devin.ai/sessions/def99d9d6d0b4f8c96bf7248721f094c
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->