### PR TITLE
feat(macos): restore `pro-plan-adjust` flag and gate Plan card behind it

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -443,7 +443,8 @@ struct SettingsPanel: View {
             permissionsAndPrivacyContent
         case .billing:
             SettingsBillingTab(
-                authManager: authManager
+                authManager: authManager,
+                assistantFeatureFlagStore: assistantFeatureFlagStore
             )
         case .archivedConversations:
             SettingsArchivedConversationsTab(conversationManager: conversationManager)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsBillingTab.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 @MainActor
 struct SettingsBillingTab: View {
     var authManager: AuthManager
+    var assistantFeatureFlagStore: AssistantFeatureFlagStore
 
     @State private var summary: BillingSummaryResponse?
     @State private var subscription: SubscriptionResponse?
@@ -22,6 +23,10 @@ struct SettingsBillingTab: View {
         topUpAmounts.contains(selectedAmount) ? selectedAmount : topUpAmounts.first ?? ""
     }
 
+    var isProPlanAdjustEnabled: Bool {
+        assistantFeatureFlagStore.isEnabled("pro-plan-adjust")
+    }
+
     @State private var isProcessingTopUp: Bool = false
     @State private var topUpError: String?
     @State private var hostWindow: NSWindow?
@@ -29,7 +34,9 @@ struct SettingsBillingTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
-            planSection
+            if isProPlanAdjustEnabled {
+                planSection
+            }
             balanceCard
             if isLoading {
                 addFundsSkeleton
@@ -465,11 +472,13 @@ extension SettingsBillingTab {
     /// and `PlanCardTests` to exercise the rendered output against known fixtures.
     init(
         authManager: AuthManager,
+        assistantFeatureFlagStore: AssistantFeatureFlagStore,
         initialSummary: BillingSummaryResponse?,
         initialSubscription: SubscriptionResponse? = nil,
         initialPlans: [PlanCatalogEntry]? = nil
     ) {
         self.authManager = authManager
+        self.assistantFeatureFlagStore = assistantFeatureFlagStore
         self._summary = State(initialValue: initialSummary)
         self._subscription = State(initialValue: initialSubscription)
         self._plans = State(initialValue: initialPlans)

--- a/clients/macos/vellum-assistantTests/PlanCardTests.swift
+++ b/clients/macos/vellum-assistantTests/PlanCardTests.swift
@@ -165,6 +165,7 @@ final class PlanCardTests: XCTestCase {
         let cancelISO = "2026-09-15T00:00:00Z"
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(
                 cancelAtPeriodEnd: true,
@@ -189,6 +190,7 @@ final class PlanCardTests: XCTestCase {
     func testActiveProSubscriptionRendersRenewsLine() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(cancelAtPeriodEnd: false),
             initialPlans: makePlanCatalog()
@@ -207,6 +209,7 @@ final class PlanCardTests: XCTestCase {
     func testBaseSubscriptionRendersNoRenewalLine() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeBaseSubscription(),
             initialPlans: makePlanCatalog()
@@ -221,6 +224,7 @@ final class PlanCardTests: XCTestCase {
     func testCancellingSubscriptionWithoutExplicitCancelAtFallsBackToPeriodEnd() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(
                 cancelAtPeriodEnd: true,
@@ -245,6 +249,7 @@ final class PlanCardTests: XCTestCase {
     func testCanceledStatusHidesRenewalLine() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil,
             initialSubscription: makeProSubscription(
                 cancelAtPeriodEnd: false,

--- a/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsBillingTabSubtitleTests.swift
@@ -35,6 +35,7 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
     func testSubtitleNilWhenSummaryNotLoaded() {
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: nil
         )
         XCTAssertNil(view.addCreditsSubtitleAttributed)
@@ -44,6 +45,7 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
         let summary = makeSummary(maximumBalance: "1000")
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: summary
         )
 
@@ -70,6 +72,7 @@ final class SettingsBillingTabSubtitleTests: XCTestCase {
         let summary = makeSummary(maximumBalance: "1000")
         let view = SettingsBillingTab(
             authManager: AuthManager(),
+            assistantFeatureFlagStore: AssistantFeatureFlagStore(),
             initialSummary: summary
         )
 

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -280,6 +280,14 @@
       "label": "Analyze Conversation",
       "description": "Show the 'Analyze' / 'Analyze conversation' option in conversation context menus and the conversation title actions dropdown.",
       "defaultEnabled": false
+    },
+    {
+      "id": "pro-plan-adjust",
+      "scope": "assistant",
+      "key": "pro-plan-adjust",
+      "label": "Pro Plan Adjust",
+      "description": "Show the rich Plan card (current plan, features, Manage/Upgrade CTA) at the top of the macOS Settings → Billing tab.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Re-add the `pro-plan-adjust` feature flag definition to `meta/feature-flags/feature-flag-registry.json`.
- Gate the rich Plan card (`planSection`) on `Settings → Billing` behind `pro-plan-adjust` again so users on the legacy billing tab don't see it until the flag rolls out.
- Re-thread `AssistantFeatureFlagStore` through `SettingsBillingTab` (and its test convenience init) so the new gate has a flag store to consult.

## Original prompt
The `pro-plan-adjust` feature flag and its gating around the Plan management card was removed from the macOS client in #29783, but we still need that flag in place to control the rollout. Restore the flag definition and re-gate the Plan card so it stays hidden by default until enabled. Leave the separately-removed `auto-credit-topup` flag out of scope.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->