### PR TITLE
fix(composer): prevent NSTextView from intercepting file drops

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -149,11 +149,6 @@ struct ComposerTextEditor: NSViewRepresentable {
 
         textView.postsFrameChangedNotifications = true
 
-        // Strip all drag types so the NSTextView doesn't intercept file drops
-        // (which would insert file paths as text). File drops are handled by
-        // SwiftUI's .onDrop modifier on the composer container.
-        textView.unregisterDraggedTypes()
-
         scrollView.contentHeight = minHeight
         scrollView.documentView = textView
         textView.delegate = coordinator
@@ -285,14 +280,6 @@ struct ComposerTextEditor: NSViewRepresentable {
             proxy.replaceText = { [weak textView] range, replacement in
                 textView?.insertText(replacement, replacementRange: range)
             }
-        }
-
-        // Re-strip drag types after any attribute change that may cause
-        // TextKit to re-register them. Also strip after external text
-        // replacement since NSTextStorage manipulation can trigger
-        // re-registration.
-        if fontChanged || colorChanged || textWasExternallyReplaced {
-            textView.unregisterDraggedTypes()
         }
 
         // --- Focus (guarded — only schedules work when intent changed) ---

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -138,5 +138,15 @@ final class ComposerTextView: NSTextView {
         let hasImageData = pasteboard.data(forType: .png) != nil || pasteboard.data(forType: .tiff) != nil
         return hasImageFile || hasImageData
     }
+
+    // MARK: - Drag Rejection
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        return []
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        return false
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- Override `draggingEntered` and `performDragOperation` on ComposerTextView to unconditionally reject drops
- Remove fragile `unregisterDraggedTypes()` calls from ComposerTextEditor that could be undone by TextKit re-registration
- All file drops now consistently route through SwiftUI's .onDrop handler for proper attachment handling

Part of plan: drag-drop-attach.md (PR 1 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->