### PR TITLE
[codex] Fix CES secret leakage in command and HTTP results

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import {
   AssistantEventHub,
+  assistantEventHub,
   broadcastMessage,
   capabilityForMessageType,
 } from "../runtime/assistant-event-hub.js";
@@ -503,5 +504,96 @@ describe("broadcastMessage — pending interaction registration", () => {
     } as never);
 
     expect(pendingInteractions.get("req-bash-1")).toBeUndefined();
+  });
+});
+
+describe("broadcastMessage — secret redaction", () => {
+  test("redacts known secret patterns from live assistant text events", async () => {
+    const conversationId = "conv-redact-text";
+    const secret = `sk-proj-${"A".repeat(40)}`;
+    let subscription: { dispose(): void } | undefined;
+    const eventPromise = new Promise<AssistantEvent>((resolve) => {
+      subscription = assistantEventHub.subscribe({
+        type: "process",
+        filter: { conversationId },
+        callback: (event) => {
+          subscription?.dispose();
+          resolve(event);
+        },
+      });
+    });
+
+    broadcastMessage({
+      type: "assistant_text_delta",
+      conversationId,
+      text: `provider rejected ${secret}`,
+    });
+
+    const event = await eventPromise;
+    expect(event.message.type).toBe("assistant_text_delta");
+    if (event.message.type === "assistant_text_delta") {
+      expect(event.message.text).not.toContain(secret);
+      expect(event.message.text).toContain(
+        '<redacted type="OpenAI Project Key" />',
+      );
+    }
+  });
+
+  test("redacts known secret patterns and sensitive input fields from live tool events", async () => {
+    const conversationId = "conv-redact-tool";
+    const secret = `sk-${"B".repeat(40)}`;
+    const events: AssistantEvent[] = [];
+    let subscription: { dispose(): void } | undefined;
+    const eventPromise = new Promise<void>((resolve) => {
+      subscription = assistantEventHub.subscribe({
+        type: "process",
+        filter: { conversationId },
+        callback: (event) => {
+          events.push(event);
+          if (events.length === 2) {
+            subscription?.dispose();
+            resolve();
+          }
+        },
+      });
+    });
+
+    broadcastMessage({
+      type: "tool_use_start",
+      conversationId,
+      toolName: "credential_test",
+      toolUseId: "toolu-redact",
+      input: {
+        query: `use ${secret}`,
+        token: "opaque-token-value",
+      },
+    });
+    broadcastMessage({
+      type: "tool_result",
+      conversationId,
+      toolName: "credential_test",
+      toolUseId: "toolu-redact",
+      isError: true,
+      result: `failed with ${secret}`,
+    });
+
+    await eventPromise;
+
+    const serialized = JSON.stringify(events.map((event) => event.message));
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain("opaque-token-value");
+    expect(serialized).toContain("<redacted />");
+    expect(events[0].message.type).toBe("tool_use_start");
+    if (events[0].message.type === "tool_use_start") {
+      expect(String(events[0].message.input.query)).toContain(
+        '<redacted type="OpenAI Secret Key" />',
+      );
+    }
+    expect(events[1].message.type).toBe("tool_result");
+    if (events[1].message.type === "tool_result") {
+      expect(events[1].message.result).toContain(
+        '<redacted type="OpenAI Secret Key" />',
+      );
+    }
   });
 });

--- a/assistant/src/__tests__/secret-scanner.test.ts
+++ b/assistant/src/__tests__/secret-scanner.test.ts
@@ -195,6 +195,10 @@ describe("OpenAI keys", () => {
       "OpenAI API Key",
     );
   });
+
+  test("detects generic OpenAI secret key format", () => {
+    expectMatch(`sk-${"A".repeat(40)}`, "OpenAI Secret Key");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -41,6 +41,7 @@ export function capabilityForMessageType(
 }
 import { emitFeedEvent } from "../home/emit-feed-event.js";
 import { rewriteCommandPreview } from "../home/rewrite-command-preview.js";
+import { redactSensitiveFields } from "../security/redaction.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { appendEventToStream } from "../signals/event-stream.js";
 import { summarizeToolInput } from "../tools/tool-input-summary.js";
@@ -554,23 +555,25 @@ export function broadcastMessage(
   conversationId?: string,
   options?: { targetClientId?: string },
 ): void {
-  const resolvedConversationId = conversationId ?? extractConversationId(msg);
+  const safeMsg = redactServerMessage(msg);
+  const resolvedConversationId =
+    conversationId ?? extractConversationId(safeMsg);
   const targetClientId = options?.targetClientId;
 
   // Confirmation-request side effects: feed event + canonical guardian request.
-  if (msg.type === "confirmation_request" && resolvedConversationId) {
-    void emitConfirmationFeedEvent(msg, resolvedConversationId);
-    void createCanonicalRequestForConfirmation(msg, resolvedConversationId);
+  if (safeMsg.type === "confirmation_request" && resolvedConversationId) {
+    void emitConfirmationFeedEvent(safeMsg, resolvedConversationId);
+    void createCanonicalRequestForConfirmation(safeMsg, resolvedConversationId);
   }
 
   // `conversation_list_invalidated` is a list-level system event — publish
   // it unscoped so every subscriber refreshes its sidebar.
   const scopedConversationId =
-    msg.type === "conversation_list_invalidated"
+    safeMsg.type === "conversation_list_invalidated"
       ? undefined
       : resolvedConversationId;
-  const event = buildAssistantEvent(msg, scopedConversationId);
-  const targetCapability = capabilityForMessageType(msg.type);
+  const event = buildAssistantEvent(safeMsg, scopedConversationId);
+  const targetCapability = capabilityForMessageType(safeMsg.type);
   const publishOptions =
     targetCapability != null || targetClientId != null
       ? { targetCapability, targetClientId }
@@ -581,7 +584,7 @@ export function broadcastMessage(
       // When a conversation title changes, also broadcast an unscoped
       // `conversation_list_invalidated` so every connected client's sidebar
       // refreshes — not just the client viewing this conversation.
-      if (msg.type === "conversation_title_updated") {
+      if (safeMsg.type === "conversation_title_updated") {
         return assistantEventHub
           .publish(
             buildAssistantEvent({
@@ -610,6 +613,127 @@ function extractConversationId(msg: ServerMessage): string | undefined {
   return undefined;
 }
 
+function redactStructuredValue(value: unknown): unknown {
+  if (typeof value === "string") return redactSecrets(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => redactStructuredValue(item));
+  }
+  if (value == null || typeof value !== "object") return value;
+
+  const fieldRedacted = redactSensitiveFields(value as Record<string, unknown>);
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(fieldRedacted)) {
+    result[key] = redactStructuredValue(val);
+  }
+  return result;
+}
+
+function redactServerMessage(msg: ServerMessage): ServerMessage {
+  switch (msg.type) {
+    case "assistant_text_delta":
+      return { ...msg, text: redactSecrets(msg.text) };
+    case "assistant_thinking_delta":
+      return { ...msg, thinking: redactSecrets(msg.thinking) };
+    case "tool_result":
+      return {
+        ...msg,
+        result: redactSecrets(msg.result),
+        ...(msg.status ? { status: redactSecrets(msg.status) } : {}),
+        ...(msg.riskReason
+          ? { riskReason: redactSecrets(msg.riskReason) }
+          : {}),
+        ...(msg.diff
+          ? {
+              diff: {
+                ...msg.diff,
+                oldContent: redactSecrets(msg.diff.oldContent),
+                newContent: redactSecrets(msg.diff.newContent),
+              },
+            }
+          : {}),
+      };
+    case "tool_output_chunk":
+      return {
+        ...msg,
+        chunk: redactSecrets(msg.chunk),
+        ...(msg.subToolInput
+          ? { subToolInput: redactSecrets(msg.subToolInput) }
+          : {}),
+      };
+    case "tool_input_delta":
+      return { ...msg, content: redactSecrets(msg.content) };
+    case "tool_use_start":
+      return {
+        ...msg,
+        input: redactStructuredValue(msg.input) as Record<string, unknown>,
+      } as ServerMessage;
+    case "confirmation_request":
+      return {
+        ...msg,
+        input: redactStructuredValue(msg.input) as Record<string, unknown>,
+        ...(msg.riskReason
+          ? { riskReason: redactSecrets(msg.riskReason) }
+          : {}),
+        ...(msg.diff
+          ? {
+              diff: {
+                ...msg.diff,
+                oldContent: redactSecrets(msg.diff.oldContent),
+                newContent: redactSecrets(msg.diff.newContent),
+              },
+            }
+          : {}),
+      };
+    case "conversation_error":
+      return {
+        ...msg,
+        userMessage: redactSecrets(msg.userMessage),
+        ...(msg.debugDetails
+          ? { debugDetails: redactSecrets(msg.debugDetails) }
+          : {}),
+      };
+    case "error":
+      return {
+        ...msg,
+        message: redactSecrets(msg.message),
+      };
+    case "trace_event":
+      return {
+        ...msg,
+        summary: redactSecrets(msg.summary),
+        ...(msg.attributes
+          ? {
+              attributes: redactStructuredValue(msg.attributes) as Record<
+                string,
+                string | number | boolean | null
+              >,
+            }
+          : {}),
+      };
+    case "assistant_activity_state":
+      return {
+        ...msg,
+        ...(msg.statusText
+          ? { statusText: redactSecrets(msg.statusText) }
+          : {}),
+      };
+    case "suggestion_response":
+      return {
+        ...msg,
+        suggestion: msg.suggestion ? redactSecrets(msg.suggestion) : null,
+      };
+    case "user_message_echo":
+      return { ...msg, text: redactSecrets(msg.text) };
+    case "subagent_event":
+      return {
+        ...msg,
+        event: redactServerMessage(msg.event),
+      };
+    default:
+      return msg;
+  }
+}
+
 // ── Canonical guardian request ────────────────────────────────────────────────
 
 function resolveCanonicalRequestSourceType(
@@ -619,7 +743,6 @@ function resolveCanonicalRequestSourceType(
   if (sourceChannel === "vellum") return "desktop";
   return "channel";
 }
-
 
 /**
  * Lazily load heavy dependencies and create a canonical guardian request +

--- a/assistant/src/security/secret-patterns.ts
+++ b/assistant/src/security/secret-patterns.ts
@@ -83,6 +83,10 @@ export const PREFIX_PATTERNS: SecretPrefixPattern[] = [
     regex: /sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}/,
   },
   { label: "OpenAI Project Key", regex: /sk-proj-[A-Za-z0-9\-_]{40,}/ },
+  {
+    label: "OpenAI Secret Key",
+    regex: /sk-(?!ant-|or-v1-)[A-Za-z0-9][A-Za-z0-9\-_]{39,}/,
+  },
 
   // -- Google --
   { label: "Google API Key", regex: /AIza[A-Za-z0-9\-_]{35}/ },

--- a/credential-executor/src/__tests__/command-executor.test.ts
+++ b/credential-executor/src/__tests__/command-executor.test.ts
@@ -679,7 +679,8 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
         },
       },
     });
-    // Script that prints the env var
+    // Script that prints the env var. CES should redact the value before
+    // returning stdout to the assistant.
     const { digest } = publishTestBundle(
       manifest,
       "local",
@@ -707,9 +708,9 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
 
     const result = await executeAuthenticatedCommand(request, deps);
 
-    // The script should output the injected token
     if (result.exitCode === 0) {
-      expect(result.stdout?.trim()).toBe("secret-token-123");
+      expect(result.stdout).not.toContain("secret-token-123");
+      expect(result.stdout?.trim()).toBe("[CES:REDACTED]");
     }
     // If the script can't execute (path issues in test), verify we got past
     // the adapter phase
@@ -765,7 +766,8 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
     const result = await executeAuthenticatedCommand(request, deps);
 
     if (result.exitCode === 0) {
-      expect(result.stdout?.trim()).toBe("Bearer my-oauth-token");
+      expect(result.stdout).not.toContain("my-oauth-token");
+      expect(result.stdout?.trim()).toBe("Bearer [CES:REDACTED]");
     }
     expect(result.error ?? "").not.toContain("Auth adapter");
   });
@@ -820,7 +822,8 @@ describe("executeAuthenticatedCommand — auth adapters", () => {
     const result = await executeAuthenticatedCommand(request, deps);
 
     if (result.exitCode === 0) {
-      expect(result.stdout?.trim()).toBe('{"key":"test-secret"}');
+      expect(result.stdout).not.toContain("test-secret");
+      expect(result.stdout?.trim()).toBe("[CES:REDACTED]");
     }
     // Verify we got past the adapter phase
     expect(result.error ?? "").not.toContain("Auth adapter");
@@ -985,10 +988,12 @@ describe("executeAuthenticatedCommand — command execution", () => {
     const { digest } = publishTestBundle(
       manifest,
       "local",
-      '#!/bin/sh\necho "error" >&2\nexit 42\n',
+      '#!/bin/sh\necho "error $TEST_API_KEY" >&2\nexit 42\n',
     );
 
-    const deps = buildDeps();
+    const deps = buildDeps({
+      materializeCredential: successMaterializer("stderr-secret-value"),
+    });
     addCommandGrant(
       deps.persistentStore,
       "local_static:test/api_key",
@@ -1010,6 +1015,61 @@ describe("executeAuthenticatedCommand — command execution", () => {
     expect(result.exitCode).toBe(42);
     expect(result.success).toBe(false);
     expect(result.stderr).toContain("error");
+    expect(result.stderr).not.toContain("stderr-secret-value");
+    expect(result.stderr).toContain("[CES:REDACTED]");
+  });
+
+  test("scrubs command stderr before truncating boundary-crossing secrets", async () => {
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      commandProfiles: {
+        list: {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\ni=0\nwhile [ "$i" -lt 95 ]; do printf a >&2; i=$((i + 1)); done\nprintf "$TEST_API_KEY" >&2\nexit 42\n',
+    );
+
+    const secret = "boundary-secret-value";
+    const deps = buildDeps({
+      materializeCredential: successMaterializer(secret),
+      maxOutputBytes: 100,
+    });
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      digest,
+      "list",
+    );
+
+    const result = await executeAuthenticatedCommand(
+      {
+        bundleDigest: digest,
+        profileName: "list",
+        credentialHandle: "local_static:test/api_key",
+        argv: ["list", "--format", "json"],
+        workspaceDir: testWorkspaceDir,
+        purpose: "Test boundary redaction",
+      },
+      deps,
+    );
+
+    expect(result.exitCode).toBe(42);
+    expect(result.success).toBe(false);
+    expect(result.stderr).not.toContain(secret);
+    expect(result.stderr).not.toContain(secret.slice(0, 5));
+    expect(result.stderr).toContain("[CES:");
   });
 
   test("does not leak CES process environment to subprocess", async () => {
@@ -1328,7 +1388,72 @@ describe("executeAuthenticatedCommand — credential_process stdin", () => {
     // cat should have echoed the credential value via stdin, which then
     // gets injected into TRANSFORMED_CRED for the command to use
     expect(result.exitCode).toBe(0);
-    expect(result.stdout?.trim()).toBe("my-raw-credential");
+    expect(result.stdout).not.toContain("my-raw-credential");
+    expect(result.stdout?.trim()).toBe("[CES:REDACTED]");
+  });
+
+  test("redacts credential_process transformed credential from command output", async () => {
+    const helperDir = makeTempDir("ces-helper");
+    const helperPath = join(helperDir, "transform-helper");
+    writeFileSync(
+      helperPath,
+      '#!/bin/sh\ncat >/dev/null\nprintf "derived-helper-token"\n',
+      { mode: 0o755 },
+    );
+
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      authAdapter: {
+        type: AuthAdapterType.CredentialProcess,
+        helperCommand: helperPath,
+        envVarName: "TRANSFORMED_CRED",
+      },
+      commandProfiles: {
+        list: {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "$TRANSFORMED_CRED"\n',
+    );
+
+    const deps = buildDeps({
+      materializeCredential: successMaterializer("source-secret-value"),
+    });
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      digest,
+      "list",
+    );
+
+    const result = await executeAuthenticatedCommand(
+      {
+        bundleDigest: digest,
+        profileName: "list",
+        credentialHandle: "local_static:test/api_key",
+        argv: ["list", "--format", "json"],
+        workspaceDir: testWorkspaceDir,
+        purpose: "Test transformed credential redaction",
+      },
+      deps,
+    );
+
+    rmSync(helperDir, { recursive: true, force: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("derived-helper-token");
+    expect(result.stdout?.trim()).toBe("[CES:REDACTED]");
   });
 });
 
@@ -1520,7 +1645,8 @@ describe("executeAuthenticatedCommand — integration: local OAuth", () => {
 
     expect(result.success).toBe(true);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout?.trim()).toBe("Bearer ya29.test-oauth-token");
+    expect(result.stdout).not.toContain("ya29.test-oauth-token");
+    expect(result.stdout?.trim()).toBe("Bearer [CES:REDACTED]");
   });
 });
 
@@ -1578,7 +1704,8 @@ describe("executeAuthenticatedCommand — integration: managed OAuth", () => {
 
     expect(result.success).toBe(true);
     expect(result.exitCode).toBe(0);
-    expect(result.stdout?.trim()).toBe("platform-managed-token-xyz");
+    expect(result.stdout).not.toContain("platform-managed-token-xyz");
+    expect(result.stdout?.trim()).toBe("[CES:REDACTED]");
   });
 });
 
@@ -1717,6 +1844,70 @@ describe("executeAuthenticatedCommand — credential_process defense-in-depth", 
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("shell metacharacters");
+  });
+
+  test("redacts credential value from helper failure errors", async () => {
+    const helperDir = makeTempDir("ces-helper");
+    const helperPath = join(helperDir, "failing-helper");
+    writeFileSync(
+      helperPath,
+      '#!/bin/sh\nsecret="$(cat)"\necho "helper failed with $secret" >&2\nexit 7\n',
+      { mode: 0o755 },
+    );
+
+    const manifest = buildManifest({
+      egressMode: EgressMode.NoNetwork,
+      authAdapter: {
+        type: AuthAdapterType.CredentialProcess,
+        helperCommand: helperPath,
+        envVarName: "TRANSFORMED_CRED",
+      },
+      commandProfiles: {
+        list: {
+          description: "List resources",
+          allowedArgvPatterns: [
+            {
+              name: "list-all",
+              tokens: ["list", "--format", "<format>"],
+            },
+          ],
+          deniedSubcommands: [],
+        },
+      },
+    });
+    const { digest } = publishTestBundle(
+      manifest,
+      "local",
+      '#!/bin/sh\necho "should not run"\n',
+    );
+
+    const deps = buildDeps({
+      materializeCredential: successMaterializer("helper-secret-value"),
+    });
+    addCommandGrant(
+      deps.persistentStore,
+      "local_static:test/api_key",
+      digest,
+      "list",
+    );
+
+    const result = await executeAuthenticatedCommand(
+      {
+        bundleDigest: digest,
+        profileName: "list",
+        credentialHandle: "local_static:test/api_key",
+        argv: ["list", "--format", "json"],
+        workspaceDir: testWorkspaceDir,
+        purpose: "Test helper error redaction",
+      },
+      deps,
+    );
+
+    rmSync(helperDir, { recursive: true, force: true });
+
+    expect(result.success).toBe(false);
+    expect(result.error).not.toContain("helper-secret-value");
+    expect(result.error).toContain("[CES:REDACTED]");
   });
 });
 

--- a/credential-executor/src/__tests__/http-executor.test.ts
+++ b/credential-executor/src/__tests__/http-executor.test.ts
@@ -385,6 +385,38 @@ describe("HTTP executor: local static secrets", () => {
     expect(result.responseBody).toContain("octocat");
   });
 
+  test("response body is scrubbed before clamping so boundary-crossing secrets do not leak", async () => {
+    const handle = localStaticHandle("github", "api_key");
+
+    fixture.persistentStore.add({
+      id: "grant-github-boundary",
+      tool: "http",
+      pattern: "GET https://api.github.com/boundary",
+      scope: handle,
+      createdAt: Date.now(),
+      sessionId: "test-session",
+    });
+
+    const secret = "ghp_testtoken_12345678";
+    const maxBodyBytes = 256 * 1024;
+    const body = `${"a".repeat(maxBodyBytes - 5)}${secret}`;
+    const deps = buildDeps(fixture, [], { fetch: mockFetch(200, body) });
+
+    const result = await executeAuthenticatedHttpRequest(
+      {
+        credentialHandle: handle,
+        method: "GET",
+        url: "https://api.github.com/boundary",
+        purpose: "Boundary scrub test",
+      },
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.responseBody).not.toContain(secret.slice(0, 5));
+    expect(result.responseBody).not.toContain(secret);
+  });
+
   test("response headers are filtered (set-cookie stripped)", async () => {
     const handle = localStaticHandle("github", "api_key");
 

--- a/credential-executor/src/commands/executor.ts
+++ b/credential-executor/src/commands/executor.ts
@@ -79,6 +79,7 @@ import { hashProposal, type AuditRecordSummary, type CommandGrantProposal } from
 import type { AuditStore } from "../audit/store.js";
 import type { PersistentGrantStore } from "../grants/persistent-store.js";
 import type { TemporaryGrantStore } from "../grants/temporary-store.js";
+import { scrubSecrets } from "../http/response-filter.js";
 import type { SessionIdRef } from "../server.js";
 
 // ---------------------------------------------------------------------------
@@ -384,7 +385,17 @@ export async function executeAuthenticatedCommand(
     );
     adapterEnv = adapterResult.env;
     tempFilePath = adapterResult.tempFilePath;
+    for (const injectedSecret of authAdapterInjectedSecrets(
+      manifest.authAdapter,
+      adapterEnv,
+    )) {
+      secretSet.add(injectedSecret);
+    }
   } catch (err) {
+    const safeMessage = scrubSecrets(
+      err instanceof Error ? err.message : String(err),
+      [matResult.value],
+    );
     // Stop the proxy session before returning — it may already be running
     if (proxySessionId) {
       try {
@@ -396,7 +407,7 @@ export async function executeAuthenticatedCommand(
     cleanupScratchDir(scratchDir);
     return {
       success: false,
-      error: `Auth adapter materialization failed: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Auth adapter materialization failed: ${safeMessage}`,
       auditId,
     };
   }
@@ -510,11 +521,16 @@ export async function executeAuthenticatedCommand(
       commandEnv,
       maxOutput,
       auditId,
+      secretSet,
     );
   } catch (err) {
+    const safeMessage = scrubSecrets(
+      err instanceof Error ? err.message : String(err),
+      Array.from(secretSet),
+    );
     execResult = {
       success: false,
-      error: `Command execution failed: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Command execution failed: ${safeMessage}`,
       auditId,
     };
   }
@@ -537,14 +553,19 @@ export async function executeAuthenticatedCommand(
           .filter((o) => !o.success)
           .map((o) => `${o.scratchPath}: ${o.reason}`)
           .join("; ");
+        const safeFailures = scrubSecrets(failures, Array.from(secretSet));
         execResult.error = execResult.error
-          ? `${execResult.error}; Output copyback failures: ${failures}`
-          : `Output copyback failures: ${failures}`;
+          ? `${execResult.error}; Output copyback failures: ${safeFailures}`
+          : `Output copyback failures: ${safeFailures}`;
       }
     } catch (err) {
+      const safeMessage = scrubSecrets(
+        err instanceof Error ? err.message : String(err),
+        Array.from(secretSet),
+      );
       execResult.error = execResult.error
-        ? `${execResult.error}; Output copyback error: ${err instanceof Error ? err.message : String(err)}`
-        : `Output copyback error: ${err instanceof Error ? err.message : String(err)}`;
+        ? `${execResult.error}; Output copyback error: ${safeMessage}`
+        : `Output copyback error: ${safeMessage}`;
     }
   }
 
@@ -558,6 +579,8 @@ export async function executeAuthenticatedCommand(
   }
 
   cleanupAll(scratchDir, tempFilePath, generatedHomeDir);
+
+  execResult = scrubCommandResult(execResult, secretSet);
 
   // -- 12. Persist audit record -----------------------------------------------
   if (deps.auditStore) {
@@ -859,9 +882,8 @@ async function buildAuthAdapterEnv(
         noNetworkEnv,
       );
       if (!helperResult.ok) {
-        throw new Error(
-          `Credential process helper failed: ${helperResult.error}`,
-        );
+        const safeError = scrubSecrets(helperResult.error, [credentialValue]);
+        throw new Error(`Credential process helper failed: ${safeError}`);
       }
       return {
         env: { [adapter.envVarName]: helperResult.stdout },
@@ -962,9 +984,10 @@ async function runCredentialProcess(
     ]);
 
     if (exitCode !== 0) {
+      const safeStderr = scrubSecrets(stderr.trim(), [credentialValue]);
       return {
         ok: false,
-        error: `Helper exited with code ${exitCode}: ${stderr.trim()}`,
+        error: `Helper exited with code ${exitCode}: ${safeStderr}`,
       };
     }
 
@@ -972,7 +995,9 @@ async function runCredentialProcess(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: scrubSecrets(err instanceof Error ? err.message : String(err), [
+        credentialValue,
+      ]),
     };
   }
 }
@@ -1085,6 +1110,7 @@ async function runCommand(
   env: Record<string, string>,
   maxOutputBytes: number,
   auditId: string,
+  secrets: ReadonlySet<string>,
 ): Promise<ExecuteCommandResult> {
   // Ensure the HOME directory exists (for clean config dirs isolation)
   if (env["HOME"]) {
@@ -1108,21 +1134,68 @@ async function runCommand(
     new Response(proc.stderr).text(),
   ]);
 
-  const stdout = stdoutRaw.length > maxOutputBytes
-    ? stdoutRaw.slice(0, maxOutputBytes) + "\n[output truncated]"
-    : stdoutRaw;
+  const secretList = Array.from(secrets);
+  const stdout = clampCommandOutput(
+    scrubSecrets(stdoutRaw, secretList),
+    maxOutputBytes,
+  );
+  const stderr = clampCommandOutput(
+    scrubSecrets(stderrRaw, secretList),
+    maxOutputBytes,
+  );
 
-  const stderr = stderrRaw.length > maxOutputBytes
-    ? stderrRaw.slice(0, maxOutputBytes) + "\n[output truncated]"
-    : stderrRaw;
+  return scrubCommandResult(
+    {
+      success: exitCode === 0,
+      exitCode,
+      stdout,
+      stderr,
+      auditId,
+      ...(exitCode !== 0
+        ? { error: `Command exited with code ${exitCode}` }
+        : {}),
+    },
+    secrets,
+  );
+}
 
+function authAdapterInjectedSecrets(
+  adapter: AuthAdapterConfig,
+  env: Record<string, string>,
+): string[] {
+  switch (adapter.type) {
+    case AuthAdapterType.EnvVar:
+    case AuthAdapterType.CredentialProcess:
+      return Object.values(env);
+    case AuthAdapterType.TempFile:
+      return [];
+    default:
+      return [];
+  }
+}
+
+function clampCommandOutput(output: string, maxOutputBytes: number): string {
+  return output.length > maxOutputBytes
+    ? output.slice(0, maxOutputBytes) + "\n[output truncated]"
+    : output;
+}
+
+function scrubCommandResult(
+  result: ExecuteCommandResult,
+  secrets: ReadonlySet<string>,
+): ExecuteCommandResult {
+  const secretList = Array.from(secrets);
   return {
-    success: exitCode === 0,
-    exitCode,
-    stdout,
-    stderr,
-    auditId,
-    ...(exitCode !== 0 ? { error: `Command exited with code ${exitCode}` } : {}),
+    ...result,
+    ...(result.stdout !== undefined
+      ? { stdout: scrubSecrets(result.stdout, secretList) }
+      : {}),
+    ...(result.stderr !== undefined
+      ? { stderr: scrubSecrets(result.stderr, secretList) }
+      : {}),
+    ...(result.error !== undefined
+      ? { error: scrubSecrets(result.error, secretList) }
+      : {}),
   };
 }
 

--- a/credential-executor/src/http/response-filter.ts
+++ b/credential-executor/src/http/response-filter.ts
@@ -208,8 +208,8 @@ function replaceAll(str: string, search: string, replacement: string): string {
  *
  * Pipeline:
  * 1. Filter response headers to the whitelist.
- * 2. Clamp the body to MAX_BODY_BYTES.
- * 3. Scrub known secrets from the (already clamped) body.
+ * 2. Scrub known secrets from the body.
+ * 3. Clamp the scrubbed body to MAX_BODY_BYTES.
  *
  * @param raw - The raw HTTP response from the outbound call.
  * @param secrets - Known secret values to scrub from the body.
@@ -220,13 +220,14 @@ export function filterHttpResponse(
   secrets: string[] = [],
 ): SanitisedHttpResponse {
   const filteredHeaders = filterResponseHeaders(raw.headers);
-  const { clampedBody, truncated, originalBytes } = clampBody(raw.body);
-  const scrubbedBody = scrubSecrets(clampedBody, secrets);
+  const originalBytes = Buffer.byteLength(raw.body, "utf-8");
+  const scrubbedBody = scrubSecrets(raw.body, secrets);
+  const { clampedBody, truncated } = clampBody(scrubbedBody);
 
   return {
     statusCode: raw.statusCode,
     headers: filteredHeaders,
-    body: scrubbedBody,
+    body: clampedBody,
     truncated,
     originalBodyBytes: originalBytes,
   };


### PR DESCRIPTION
## Summary

Closes JARVIS-692

This fixes the credential leak path where CES-backed command or HTTP execution could return materialized credential values to the assistant/chat stream when a tool failed or echoed credentials.

## Changes

- Scrub materialized CES credential values from authenticated command stdout, stderr, errors, copyback failures, and credential_process helper failures before returning results to the assistant.
- Track credential_process transformed outputs as derived secrets so helper-produced tokens are also redacted.
- Scrub command and HTTP output before truncation/clamping to avoid boundary-crossing partial leaks.
- Add live assistant event redaction for known secret patterns and sensitive structured fields as defense in depth.
- Add generic OpenAI `sk-...` secret detection.

## Validation

- `cd assistant && PATH="$HOME/.bun/bin:$PATH" bun test src/__tests__/assistant-event-hub.test.ts src/__tests__/secret-scanner.test.ts`
- `cd assistant && PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- `cd credential-executor && PATH="$HOME/.bun/bin:$PATH" CREDENTIAL_SECURITY_DIR=/private/tmp/vellum-ces-test-security bun test src/__tests__/command-executor.test.ts src/__tests__/http-executor.test.ts`
- `cd credential-executor && PATH="$HOME/.bun/bin:$PATH" bun run typecheck`
- Commit hook: assistant formatting, lint, and typecheck passed
- Pre-push hook: assistant typecheck and lint passed; the hook emitted an existing shell compatibility warning in package scan but exited 0

## Notes

The assistant still only receives credential references from CES. Exact-value scrubbing is performed inside CES where credentials are materialized; the assistant event redaction is pattern/field-based defense in depth, not an assistant-side secret registry.