### PR TITLE
feat(composer): hold Shift during drop to insert file paths as text

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -102,6 +102,8 @@ struct ChatView: View {
     @State private var isDraggingInternalImage = false
     @State private var dragEndLocalMonitor: Any?
     @State private var dragEndGlobalMonitor: Any?
+    @State private var isShiftHeld = false
+    @State private var shiftMonitor: Any?
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
@@ -199,8 +201,18 @@ struct ChatView: View {
                 showSkeleton = false
             }
         }
+        .onAppear {
+            shiftMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+                isShiftHeld = event.modifierFlags.contains(.shift)
+                return event
+            }
+        }
         .onDisappear {
             removeDragEndMonitors()
+            if let monitor = shiftMonitor {
+                NSEvent.removeMonitor(monitor)
+                shiftMonitor = nil
+            }
         }
     }
 
@@ -572,9 +584,9 @@ struct ChatView: View {
                 )
                 .overlay {
                     VStack(spacing: VSpacing.sm) {
-                        VIconView(.arrowDownToLine, size: 28)
+                        VIconView(isShiftHeld ? .fileText : .arrowDownToLine, size: 28)
                             .foregroundStyle(VColor.primaryBase)
-                        Text("Drop files here")
+                        Text(isShiftHeld ? "Drop to insert path" : "Drop files here")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.primaryBase)
                     }
@@ -646,7 +658,15 @@ struct ChatView: View {
             onDropEnded: { viewModel.attachmentManager.endExternalLoad() },
             isDropTargeted: $isDropTargeted,
             isDraggingInternalImage: $isDraggingInternalImage,
-            onInternalDragRejected: { self.removeDragEndMonitors() }
+            onInternalDragRejected: { self.removeDragEndMonitors() },
+            onDropPathsAsText: { urls in
+                let paths = urls.map(\.path).joined(separator: " ")
+                if viewModel.inputText.isEmpty {
+                    viewModel.inputText = paths
+                } else {
+                    viewModel.inputText += " " + paths
+                }
+            }
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerDropHandler.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerDropHandler.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import AppKit
 import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
@@ -24,6 +25,9 @@ struct DropActions {
     /// cleanup (e.g. removing drag-end monitors) that would otherwise be skipped
     /// by the early return.
     var onInternalDragRejected: (() -> Void)?
+    /// Called with resolved file URLs when the user holds Shift during drop,
+    /// inserting the file paths as text instead of attaching them.
+    var onDropPathsAsText: (([URL]) -> Void)?
 
     /// A no-op default suitable for use as an EnvironmentKey default value.
     static let noop = DropActions(
@@ -33,7 +37,8 @@ struct DropActions {
         onDropEnded: nil,
         isDropTargeted: .constant(false),
         isDraggingInternalImage: .constant(false),
-        onInternalDragRejected: nil
+        onInternalDragRejected: nil,
+        onDropPathsAsText: nil
     )
 }
 
@@ -71,6 +76,31 @@ enum ComposerDropHandler {
             actions.isDraggingInternalImage.wrappedValue = false
             actions.onInternalDragRejected?()
             return false
+        }
+
+        // When Shift is held, resolve file URLs and insert their paths as text
+        // instead of going through the attachment flow.
+        let isShiftHeld = NSEvent.modifierFlags.contains(.shift)
+        if isShiftHeld, let onDropPathsAsText = actions.onDropPathsAsText {
+            var resolvedURLs: [URL] = []
+            let group = DispatchGroup()
+            for provider in providers {
+                if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                    group.enter()
+                    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                        DispatchQueue.main.async {
+                            if let url { resolvedURLs.append(url) }
+                            group.leave()
+                        }
+                    }
+                }
+            }
+            group.notify(queue: .main) {
+                if !resolvedURLs.isEmpty {
+                    onDropPathsAsText(resolvedURLs)
+                }
+            }
+            return true
         }
 
         // Signal loading immediately so the "Processing…" chip appears without


### PR DESCRIPTION
## Summary
- Add `onDropPathsAsText` callback to DropActions for shift+drop path insertion
- Check `NSEvent.modifierFlags.contains(.shift)` in ComposerDropHandler to route drops to path-as-text flow
- Wire up path insertion in ChatView's currentDropActions to append paths to composer input
- Update drop overlay to show "Drop to insert path" hint when Shift is held

Part of plan: drag-drop-attach.md (PR 2 of 2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->