### PR TITLE
[LUM-1411] Fix incorrect skill counts by keeping category filtering client-side

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SkillsManager.swift
@@ -71,7 +71,7 @@ final class SkillsManager {
     }
 
     var selectedCategory: SkillCategory? {
-        didSet { fetchFilteredSkills() }
+        didSet { recomputeFilteredData() }
     }
 
     var skillFilter: SkillFilter = .all {
@@ -226,9 +226,7 @@ final class SkillsManager {
             }
         }()
         let queryParam = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        let categoryParam = selectedCategory?.rawValue
-
-        skillsStore.fetchSkills(force: true, origin: originParam, kind: kindParam, query: queryParam.isEmpty ? nil : queryParam, category: categoryParam)
+        skillsStore.fetchSkills(force: true, origin: originParam, kind: kindParam, query: queryParam.isEmpty ? nil : queryParam, category: nil)
     }
 
     // MARK: - Recomputation
@@ -264,10 +262,6 @@ final class SkillsManager {
             }
         }
 
-        // Compute category counts from the merged+filtered list so they
-        // include external search results and always match the displayed
-        // skills. Use server counts as a base, then layer on any external
-        // results the server didn't see.
         var counts: [SkillCategory: Int] = [:]
         for skill in kindFiltered {
             let cat = inferCategory(skill)


### PR DESCRIPTION
The skills sidebar showed incorrect category counts when a category was selected — only the active category had a non-zero count while all others showed 0. This happened because `fetchFilteredSkills()` sent the `category` param to the server, which returned only skills in that category, and then `recomputeFilteredData()` recomputed counts from that already-filtered list. The fix keeps category filtering purely client-side: `selectedCategory` changes trigger a local recompute instead of a server fetch, and `fetchFilteredSkills()` no longer sends the category param. The existing `recomputeFilteredData()` already applies the category filter after computing counts, so it works correctly once it receives the full list.

## Root cause analysis

1. **How did the code get into this state?** PR #25119 ("Server-side skill filtering with category counts") moved filtering server-side and added `categoryCounts`/`totalCount` to the response. The server correctly computes counts before applying the category filter, but the client-side `recomputeFilteredData()` was left recomputing counts from the (now category-filtered) server response instead of using the server-provided counts.
2. **What mistakes or decisions led to it?** The client duplicated the count computation locally rather than consuming the server's pre-computed counts. A stale comment even described the intended behavior ("Use server counts as a base") but the code didn't match.
3. **Were there warning signs we missed?** The comment/code mismatch at lines 267–270 was a signal that the implementation diverged from intent.
4. **What can we do to prevent this pattern from recurring?** When adding server-side filtering, verify that client-side derived state (like counts) uses the server's pre-computed values rather than recomputing from already-filtered data.
5. **Should we add a guideline to AGENTS.md?** Not needed — this is a standard data-flow bug, not a recurring architectural pattern.

## Prompt / plan

Fix LUM-1411: category sidebar counts are based on the filtered list rather than total. Two changes in `SkillsManager.swift`: (1) `selectedCategory.didSet` calls `recomputeFilteredData()` instead of `fetchFilteredSkills()`, (2) `fetchFilteredSkills()` passes `category: nil` to the server.

## Test plan

- CI checks (note: CI skips macOS builds — Swift compilation must be verified locally in Xcode)
- Manual verification: select a category in the skills sidebar → all category counts should remain stable, not drop to 0 for unselected categories

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/feea0f23cc5f48e9b28c039c5e9e958a
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->