### PR TITLE
Tombstone safe-storage release note migration

### DIFF
--- a/assistant/src/__tests__/workspace-migration-safe-storage-limits-release.test.ts
+++ b/assistant/src/__tests__/workspace-migration-safe-storage-limits-release.test.ts
@@ -12,7 +12,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { releaseNotesSafeStorageLimitsMigration } from "../workspace/migrations/067-release-notes-safe-storage-limits.js";
 
 const MIGRATION_ID = "067-release-notes-safe-storage-limits";
-const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
 
 let workspaceDir: string;
 
@@ -26,10 +25,6 @@ function freshWorkspace(): void {
 
 function updatesPath(): string {
   return join(workspaceDir, "UPDATES.md");
-}
-
-function markerCount(content: string): number {
-  return content.split(MARKER).length - 1;
 }
 
 beforeEach(() => {
@@ -47,44 +42,37 @@ describe("workspace migration 067-release-notes-safe-storage-limits", () => {
     expect(releaseNotesSafeStorageLimitsMigration.id).toBe(MIGRATION_ID);
   });
 
-  test("creates UPDATES.md with marker and key copy when file is absent", () => {
+  test("does not create UPDATES.md when file is absent", () => {
     expect(existsSync(updatesPath())).toBe(false);
 
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    const content = readFileSync(updatesPath(), "utf-8");
-    expect(content).toContain(MARKER);
-    expect(content).toContain("safe-storage-limits");
-    expect(content).toContain("critical 95% threshold");
-    expect(content).toContain("trusted-contact messages");
+    expect(existsSync(updatesPath())).toBe(false);
   });
 
-  test("is idempotent when run twice", () => {
-    releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
+  test("leaves existing UPDATES.md byte-identical", () => {
+    const existing = "## Prior\n\nExisting release note.\n";
+    writeFileSync(updatesPath(), existing, "utf-8");
+
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    const content = readFileSync(updatesPath(), "utf-8");
-    expect(markerCount(content)).toBe(1);
-    expect(content.match(/Safe storage limits/g)?.length).toBe(1);
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(existing);
   });
 
-  test("appends to existing UPDATES.md when marker is absent", () => {
-    const prior = "## Prior\n\nExisting release note.\n";
-    writeFileSync(updatesPath(), prior, "utf-8");
-
+  test("is idempotent when run twice in an empty workspace", () => {
+    releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    const content = readFileSync(updatesPath(), "utf-8");
-    expect(content.startsWith(prior)).toBe(true);
-    expect(content).toContain(MARKER);
+    expect(existsSync(updatesPath())).toBe(false);
   });
 
-  test("is a no-op when marker is already present", () => {
-    const seeded = `## Prior\n\n${MARKER}\nAlready announced.\n`;
-    writeFileSync(updatesPath(), seeded, "utf-8");
+  test("is idempotent when run twice with existing UPDATES.md", () => {
+    const existing = "## Prior\n\nExisting release note.\n";
+    writeFileSync(updatesPath(), existing, "utf-8");
 
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
+    releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    expect(readFileSync(updatesPath(), "utf-8")).toBe(seeded);
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(existing);
   });
 });

--- a/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
+++ b/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
@@ -1,72 +1,17 @@
-import {
-  appendFileSync,
-  existsSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
-import { join } from "node:path";
-
-import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
 
-const log = getLogger(
-  "workspace-migration-067-release-notes-safe-storage-limits",
-);
-
 const MIGRATION_ID = "067-release-notes-safe-storage-limits";
-const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
-
-const RELEASE_NOTE = `${MARKER}
-## Safe storage limits
-
-A new storage protection mode is available behind the safe-storage-limits
-rollout flag. When enabled, the assistant watches workspace disk usage and
-enters cleanup mode if the volume reaches the critical 95% threshold.
-
-In cleanup mode, background processes pause and remote messages, including
-trusted-contact messages, are blocked until the guardian frees enough space or
-explicitly overrides the lock. The macOS app now shows a storage cleanup banner
-that must be acknowledged before cleanup chat continues, then keeps a status
-banner visible while cleanup mode is active.
-`;
 
 export const releaseNotesSafeStorageLimitsMigration: WorkspaceMigration = {
   id: MIGRATION_ID,
-  description: "Append release notes for safe storage limits to UPDATES.md",
+  description: "Reserved migration slot for safe storage limits release notes",
 
-  run(workspaceDir: string): void {
-    const updatesPath = join(workspaceDir, "UPDATES.md");
-
-    try {
-      if (existsSync(updatesPath)) {
-        const existing = readFileSync(updatesPath, "utf-8");
-        if (existing.includes(MARKER)) {
-          return;
-        }
-        const needsLeadingNewline = !existing.endsWith("\n\n");
-        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
-        appendFileSync(
-          updatesPath,
-          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
-          "utf-8",
-        );
-      } else {
-        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
-      }
-      log.info(
-        { path: updatesPath },
-        "Appended safe storage limits release note",
-      );
-    } catch (err) {
-      log.warn(
-        { err, path: updatesPath },
-        "Failed to append safe storage limits release note to UPDATES.md",
-      );
-    }
+  run(_workspaceDir: string): void {
+    // Tombstoned: this migration id must remain registered for checkpoint
+    // compatibility, but it no longer writes a release bulletin.
   },
 
   down(_workspaceDir: string): void {
-    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
-    // processes and deletes on its own.
+    // No-op.
   },
 };


### PR DESCRIPTION
## Summary\n- Tombstones migration 067 so it no longer appends safe-storage release notes.\n- Updates the focused migration test to assert the no-op behavior.\n\nPart of plan: remove-disk-pressure-migration.md (PR 1 of 3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->