### PR TITLE
Clarify safe-storage migration tombstone comment

### DIFF
--- a/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
+++ b/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
@@ -7,8 +7,7 @@ export const releaseNotesSafeStorageLimitsMigration: WorkspaceMigration = {
   description: "Reserved migration slot for safe storage limits release notes",
 
   run(_workspaceDir: string): void {
-    // Tombstoned: this migration id must remain registered for checkpoint
-    // compatibility, but it no longer writes a release bulletin.
+    // Registered no-op slot retained for workspace migration checkpoint compatibility.
   },
 
   down(_workspaceDir: string): void {


### PR DESCRIPTION
## Summary
- Rephrase migration 067's no-op comment to describe the retained migration checkpoint invariant.

## Verification
- cd assistant && bun test src/__tests__/workspace-migration-safe-storage-limits-release.test.ts src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
- cd assistant && bunx tsc --noEmit

Part of remove-disk-pressure-migration plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->