### PR TITLE
Clean up safe-storage release note migration

### DIFF
--- a/assistant/src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
+++ b/assistant/src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
@@ -43,7 +43,7 @@ let testRoot: string;
 let workspaceDir: string;
 
 beforeAll(() => {
-  testRoot = mkdtempSync(join(tmpdir(), "migration-069-remove-safe-storage-"));
+  testRoot = mkdtempSync(join(tmpdir(), "migration-071-remove-safe-storage-"));
 });
 
 afterAll(() => {
@@ -159,6 +159,20 @@ This later note should stay.
     removeSafeStorageReleaseNoteMigration.run(workspaceDir);
 
     expect(readFileSync(updatesPath(), "utf-8")).toBe(original);
+  });
+
+  test("preserves CRLF in unrelated content when removing the safe-storage block", () => {
+    const prior =
+      "<!-- release-note-id:066-earlier-note -->\r\n## Earlier note\r\n\r\nThis note should keep CRLF.\r\n";
+    writeFileSync(
+      updatesPath(),
+      `${prior}\r\n${SAFE_STORAGE_RELEASE_NOTE}`,
+      "utf-8",
+    );
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(prior);
   });
 
   test("running twice is idempotent", () => {

--- a/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
+++ b/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
@@ -10,7 +10,5 @@ export const releaseNotesSafeStorageLimitsMigration: WorkspaceMigration = {
     // Registered no-op slot retained for workspace migration checkpoint compatibility.
   },
 
-  down(_workspaceDir: string): void {
-    // No-op.
-  },
+  down(_workspaceDir: string): void {},
 };

--- a/assistant/src/workspace/migrations/071-remove-safe-storage-release-note.ts
+++ b/assistant/src/workspace/migrations/071-remove-safe-storage-release-note.ts
@@ -22,20 +22,31 @@ that must be acknowledged before cleanup chat continues, then keeps a status
 banner visible while cleanup mode is active.
 `;
 
-function normalizeNewlines(content: string): string {
-  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+const LEADING_NEWLINES = /^(?:(?:\r\n)|\n|\r)+/;
+const TRAILING_NEWLINES = /(?:(?:\r\n)|\n|\r)+$/;
+
+function findNewlineStyle(...samples: string[]): string {
+  for (const sample of samples) {
+    const match = sample.match(/\r\n|\n|\r/);
+    if (match) {
+      return match[0];
+    }
+  }
+
+  return "\n";
 }
 
 function stitchAroundRemovedBlock(before: string, after: string): string {
   if (before.trim() === "") {
-    return after.replace(/^\n+/, "");
+    return after.replace(LEADING_NEWLINES, "");
   }
 
   if (after.trim() === "") {
-    return before.replace(/\n+$/, "\n");
+    return `${before.replace(TRAILING_NEWLINES, "")}${findNewlineStyle(before)}`;
   }
 
-  return `${before.replace(/\n+$/, "\n\n")}${after.replace(/^\n+/, "")}`;
+  const newline = findNewlineStyle(before, after);
+  return `${before.replace(TRAILING_NEWLINES, "")}${newline}${newline}${after.replace(LEADING_NEWLINES, "")}`;
 }
 
 function removeRange(content: string, start: number, end: number): string {
@@ -43,30 +54,29 @@ function removeRange(content: string, start: number, end: number): string {
 }
 
 function removeSafeStorageReleaseNote(content: string): string {
-  const normalized = normalizeNewlines(content);
-  const exactStart = normalized.indexOf(SAFE_STORAGE_RELEASE_NOTE);
+  const exactStart = content.indexOf(SAFE_STORAGE_RELEASE_NOTE);
   if (exactStart >= 0) {
     return removeRange(
-      normalized,
+      content,
       exactStart,
       exactStart + SAFE_STORAGE_RELEASE_NOTE.length,
     );
   }
 
-  const markerStart = normalized.indexOf(SAFE_STORAGE_MARKER);
+  const markerStart = content.indexOf(SAFE_STORAGE_MARKER);
   if (markerStart < 0) {
     return content;
   }
 
-  const nextMarkerStart = normalized.indexOf(
+  const nextMarkerStart = content.indexOf(
     RELEASE_NOTE_MARKER_PREFIX,
     markerStart + SAFE_STORAGE_MARKER.length,
   );
 
   return removeRange(
-    normalized,
+    content,
     markerStart,
-    nextMarkerStart >= 0 ? nextMarkerStart : normalized.length,
+    nextMarkerStart >= 0 ? nextMarkerStart : content.length,
   );
 }
 


### PR DESCRIPTION
## Summary
- Preserve original newline style when removing the safe-storage bulletin from UPDATES.md.
- Fix the migration 071 test temp-directory prefix.
- Remove empty narration from the migration 067 down hook.

## Verification
- cd assistant && bun test src/__tests__/workspace-migration-safe-storage-limits-release.test.ts src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
- cd assistant && bunx tsc --noEmit

Fixes slop gaps identified during re-review for remove-disk-pressure-migration.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->