### PR TITLE
Remove Disk Pressure Protection Migration

### DIFF
--- a/assistant/src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
+++ b/assistant/src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
@@ -43,7 +43,7 @@ let testRoot: string;
 let workspaceDir: string;
 
 beforeAll(() => {
-  testRoot = mkdtempSync(join(tmpdir(), "migration-069-remove-safe-storage-"));
+  testRoot = mkdtempSync(join(tmpdir(), "migration-071-remove-safe-storage-"));
 });
 
 afterAll(() => {
@@ -159,6 +159,20 @@ This later note should stay.
     removeSafeStorageReleaseNoteMigration.run(workspaceDir);
 
     expect(readFileSync(updatesPath(), "utf-8")).toBe(original);
+  });
+
+  test("preserves CRLF in unrelated content when removing the safe-storage block", () => {
+    const prior =
+      "<!-- release-note-id:066-earlier-note -->\r\n## Earlier note\r\n\r\nThis note should keep CRLF.\r\n";
+    writeFileSync(
+      updatesPath(),
+      `${prior}\r\n${SAFE_STORAGE_RELEASE_NOTE}`,
+      "utf-8",
+    );
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(prior);
   });
 
   test("running twice is idempotent", () => {

--- a/assistant/src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
+++ b/assistant/src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
@@ -1,0 +1,192 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { removeSafeStorageReleaseNoteMigration } from "../workspace/migrations/071-remove-safe-storage-release-note.js";
+
+const MIGRATION_ID = "071-remove-safe-storage-release-note";
+const SAFE_STORAGE_MARKER =
+  "<!-- release-note-id:067-release-notes-safe-storage-limits -->";
+const LATER_MARKER =
+  "<!-- release-note-id:068-release-notes-local-timezone -->";
+
+const SAFE_STORAGE_RELEASE_NOTE = `${SAFE_STORAGE_MARKER}
+## Safe storage limits
+
+A new storage protection mode is available behind the safe-storage-limits
+rollout flag. When enabled, the assistant watches workspace disk usage and
+enters cleanup mode if the volume reaches the critical 95% threshold.
+
+In cleanup mode, background processes pause and remote messages, including
+trusted-contact messages, are blocked until the guardian frees enough space or
+explicitly overrides the lock. The macOS app now shows a storage cleanup banner
+that must be acknowledged before cleanup chat continues, then keeps a status
+banner visible while cleanup mode is active.
+`;
+
+let testRoot: string;
+let workspaceDir: string;
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "migration-069-remove-safe-storage-"));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(testRoot, "ws-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function updatesPath(): string {
+  return join(workspaceDir, "UPDATES.md");
+}
+
+describe("workspace migration 071-remove-safe-storage-release-note", () => {
+  test("has the correct id and description", () => {
+    expect(removeSafeStorageReleaseNoteMigration.id).toBe(MIGRATION_ID);
+    expect(removeSafeStorageReleaseNoteMigration.description).toContain(
+      "safe storage release note",
+    );
+  });
+
+  test("missing UPDATES.md is a no-op", () => {
+    expect(existsSync(updatesPath())).toBe(false);
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    expect(existsSync(updatesPath())).toBe(false);
+  });
+
+  test("removes UPDATES.md when it only contains the safe-storage bulletin", () => {
+    writeFileSync(updatesPath(), SAFE_STORAGE_RELEASE_NOTE, "utf-8");
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    expect(existsSync(updatesPath())).toBe(false);
+  });
+
+  test("preserves prior unrelated release notes when removing the safe-storage block", () => {
+    const prior = `<!-- release-note-id:066-earlier-note -->
+## Earlier note
+
+This note should stay.
+`;
+    writeFileSync(
+      updatesPath(),
+      `${prior}\n${SAFE_STORAGE_RELEASE_NOTE}`,
+      "utf-8",
+    );
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content).toContain("## Earlier note");
+    expect(content).toContain("This note should stay.");
+    expect(content).not.toContain(SAFE_STORAGE_MARKER);
+    expect(content).not.toContain("Safe storage limits");
+  });
+
+  test("preserves a later release-note block after safe storage", () => {
+    const later = `${LATER_MARKER}
+## Local timezone grounding
+
+This later note should stay.
+`;
+    writeFileSync(
+      updatesPath(),
+      `${SAFE_STORAGE_RELEASE_NOTE}\n${later}`,
+      "utf-8",
+    );
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(LATER_MARKER)).toBe(true);
+    expect(content).toContain("## Local timezone grounding");
+    expect(content).toContain("This later note should stay.");
+    expect(content).not.toContain(SAFE_STORAGE_MARKER);
+    expect(content).not.toContain("Safe storage limits");
+  });
+
+  test("fallback preserves a later release-note block after a partial safe-storage block", () => {
+    const partialSafeStorage = `${SAFE_STORAGE_MARKER}
+## Safe storage limits
+
+Partially written note.
+`;
+    const later = `${LATER_MARKER}
+## Local timezone grounding
+
+This later note should stay.
+`;
+    writeFileSync(updatesPath(), `${partialSafeStorage}\n${later}`, "utf-8");
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    const content = readFileSync(updatesPath(), "utf-8");
+    expect(content.startsWith(LATER_MARKER)).toBe(true);
+    expect(content).toContain("## Local timezone grounding");
+    expect(content).not.toContain(SAFE_STORAGE_MARKER);
+    expect(content).not.toContain("Partially written note.");
+  });
+
+  test("content without the safe-storage marker is byte-identical", () => {
+    const original =
+      "## Existing note\r\n\r\nNo safe storage marker appears here.\r\n";
+    writeFileSync(updatesPath(), original, "utf-8");
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(original);
+  });
+
+  test("running twice is idempotent", () => {
+    const prior = `<!-- release-note-id:066-earlier-note -->
+## Earlier note
+
+This note should stay.
+`;
+    const later = `${LATER_MARKER}
+## Local timezone grounding
+
+This later note should stay.
+`;
+    writeFileSync(
+      updatesPath(),
+      `${prior}\n${SAFE_STORAGE_RELEASE_NOTE}\n${later}`,
+      "utf-8",
+    );
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+    const afterFirst = readFileSync(updatesPath(), "utf-8");
+
+    removeSafeStorageReleaseNoteMigration.run(workspaceDir);
+    const afterSecond = readFileSync(updatesPath(), "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(afterSecond).toContain("## Earlier note");
+    expect(afterSecond).toContain("## Local timezone grounding");
+    expect(afterSecond).not.toContain(SAFE_STORAGE_MARKER);
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-safe-storage-limits-release.test.ts
+++ b/assistant/src/__tests__/workspace-migration-safe-storage-limits-release.test.ts
@@ -12,7 +12,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { releaseNotesSafeStorageLimitsMigration } from "../workspace/migrations/067-release-notes-safe-storage-limits.js";
 
 const MIGRATION_ID = "067-release-notes-safe-storage-limits";
-const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
 
 let workspaceDir: string;
 
@@ -26,10 +25,6 @@ function freshWorkspace(): void {
 
 function updatesPath(): string {
   return join(workspaceDir, "UPDATES.md");
-}
-
-function markerCount(content: string): number {
-  return content.split(MARKER).length - 1;
 }
 
 beforeEach(() => {
@@ -47,44 +42,37 @@ describe("workspace migration 067-release-notes-safe-storage-limits", () => {
     expect(releaseNotesSafeStorageLimitsMigration.id).toBe(MIGRATION_ID);
   });
 
-  test("creates UPDATES.md with marker and key copy when file is absent", () => {
+  test("does not create UPDATES.md when file is absent", () => {
     expect(existsSync(updatesPath())).toBe(false);
 
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    const content = readFileSync(updatesPath(), "utf-8");
-    expect(content).toContain(MARKER);
-    expect(content).toContain("safe-storage-limits");
-    expect(content).toContain("critical 95% threshold");
-    expect(content).toContain("trusted-contact messages");
+    expect(existsSync(updatesPath())).toBe(false);
   });
 
-  test("is idempotent when run twice", () => {
-    releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
+  test("leaves existing UPDATES.md byte-identical", () => {
+    const existing = "## Prior\n\nExisting release note.\n";
+    writeFileSync(updatesPath(), existing, "utf-8");
+
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    const content = readFileSync(updatesPath(), "utf-8");
-    expect(markerCount(content)).toBe(1);
-    expect(content.match(/Safe storage limits/g)?.length).toBe(1);
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(existing);
   });
 
-  test("appends to existing UPDATES.md when marker is absent", () => {
-    const prior = "## Prior\n\nExisting release note.\n";
-    writeFileSync(updatesPath(), prior, "utf-8");
-
+  test("is idempotent when run twice in an empty workspace", () => {
+    releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    const content = readFileSync(updatesPath(), "utf-8");
-    expect(content.startsWith(prior)).toBe(true);
-    expect(content).toContain(MARKER);
+    expect(existsSync(updatesPath())).toBe(false);
   });
 
-  test("is a no-op when marker is already present", () => {
-    const seeded = `## Prior\n\n${MARKER}\nAlready announced.\n`;
-    writeFileSync(updatesPath(), seeded, "utf-8");
+  test("is idempotent when run twice with existing UPDATES.md", () => {
+    const existing = "## Prior\n\nExisting release note.\n";
+    writeFileSync(updatesPath(), existing, "utf-8");
 
     releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
+    releaseNotesSafeStorageLimitsMigration.run(workspaceDir);
 
-    expect(readFileSync(updatesPath(), "utf-8")).toBe(seeded);
+    expect(readFileSync(updatesPath(), "utf-8")).toBe(existing);
   });
 });

--- a/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
+++ b/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
@@ -10,7 +10,5 @@ export const releaseNotesSafeStorageLimitsMigration: WorkspaceMigration = {
     // Registered no-op slot retained for workspace migration checkpoint compatibility.
   },
 
-  down(_workspaceDir: string): void {
-    // No-op.
-  },
+  down(_workspaceDir: string): void {},
 };

--- a/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
+++ b/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
@@ -7,8 +7,7 @@ export const releaseNotesSafeStorageLimitsMigration: WorkspaceMigration = {
   description: "Reserved migration slot for safe storage limits release notes",
 
   run(_workspaceDir: string): void {
-    // Tombstoned: this migration id must remain registered for checkpoint
-    // compatibility, but it no longer writes a release bulletin.
+    // Registered no-op slot retained for workspace migration checkpoint compatibility.
   },
 
   down(_workspaceDir: string): void {

--- a/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
+++ b/assistant/src/workspace/migrations/067-release-notes-safe-storage-limits.ts
@@ -1,72 +1,17 @@
-import {
-  appendFileSync,
-  existsSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
-import { join } from "node:path";
-
-import { getLogger } from "../../util/logger.js";
 import type { WorkspaceMigration } from "./types.js";
 
-const log = getLogger(
-  "workspace-migration-067-release-notes-safe-storage-limits",
-);
-
 const MIGRATION_ID = "067-release-notes-safe-storage-limits";
-const MARKER = `<!-- release-note-id:${MIGRATION_ID} -->`;
-
-const RELEASE_NOTE = `${MARKER}
-## Safe storage limits
-
-A new storage protection mode is available behind the safe-storage-limits
-rollout flag. When enabled, the assistant watches workspace disk usage and
-enters cleanup mode if the volume reaches the critical 95% threshold.
-
-In cleanup mode, background processes pause and remote messages, including
-trusted-contact messages, are blocked until the guardian frees enough space or
-explicitly overrides the lock. The macOS app now shows a storage cleanup banner
-that must be acknowledged before cleanup chat continues, then keeps a status
-banner visible while cleanup mode is active.
-`;
 
 export const releaseNotesSafeStorageLimitsMigration: WorkspaceMigration = {
   id: MIGRATION_ID,
-  description: "Append release notes for safe storage limits to UPDATES.md",
+  description: "Reserved migration slot for safe storage limits release notes",
 
-  run(workspaceDir: string): void {
-    const updatesPath = join(workspaceDir, "UPDATES.md");
-
-    try {
-      if (existsSync(updatesPath)) {
-        const existing = readFileSync(updatesPath, "utf-8");
-        if (existing.includes(MARKER)) {
-          return;
-        }
-        const needsLeadingNewline = !existing.endsWith("\n\n");
-        const prefix = existing.endsWith("\n") ? "\n" : "\n\n";
-        appendFileSync(
-          updatesPath,
-          needsLeadingNewline ? `${prefix}${RELEASE_NOTE}` : RELEASE_NOTE,
-          "utf-8",
-        );
-      } else {
-        writeFileSync(updatesPath, RELEASE_NOTE, "utf-8");
-      }
-      log.info(
-        { path: updatesPath },
-        "Appended safe storage limits release note",
-      );
-    } catch (err) {
-      log.warn(
-        { err, path: updatesPath },
-        "Failed to append safe storage limits release note to UPDATES.md",
-      );
-    }
+  run(_workspaceDir: string): void {
+    // Tombstoned: this migration id must remain registered for checkpoint
+    // compatibility, but it no longer writes a release bulletin.
   },
 
   down(_workspaceDir: string): void {
-    // Forward-only: UPDATES.md is a user-facing bulletin the assistant
-    // processes and deletes on its own.
+    // No-op.
   },
 };

--- a/assistant/src/workspace/migrations/071-remove-safe-storage-release-note.ts
+++ b/assistant/src/workspace/migrations/071-remove-safe-storage-release-note.ts
@@ -1,0 +1,101 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+const MIGRATION_ID = "071-remove-safe-storage-release-note";
+const SAFE_STORAGE_RELEASE_NOTE_ID = "067-release-notes-safe-storage-limits";
+const SAFE_STORAGE_MARKER = `<!-- release-note-id:${SAFE_STORAGE_RELEASE_NOTE_ID} -->`;
+const RELEASE_NOTE_MARKER_PREFIX = "<!-- release-note-id:";
+
+const SAFE_STORAGE_RELEASE_NOTE = `${SAFE_STORAGE_MARKER}
+## Safe storage limits
+
+A new storage protection mode is available behind the safe-storage-limits
+rollout flag. When enabled, the assistant watches workspace disk usage and
+enters cleanup mode if the volume reaches the critical 95% threshold.
+
+In cleanup mode, background processes pause and remote messages, including
+trusted-contact messages, are blocked until the guardian frees enough space or
+explicitly overrides the lock. The macOS app now shows a storage cleanup banner
+that must be acknowledged before cleanup chat continues, then keeps a status
+banner visible while cleanup mode is active.
+`;
+
+function normalizeNewlines(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function stitchAroundRemovedBlock(before: string, after: string): string {
+  if (before.trim() === "") {
+    return after.replace(/^\n+/, "");
+  }
+
+  if (after.trim() === "") {
+    return before.replace(/\n+$/, "\n");
+  }
+
+  return `${before.replace(/\n+$/, "\n\n")}${after.replace(/^\n+/, "")}`;
+}
+
+function removeRange(content: string, start: number, end: number): string {
+  return stitchAroundRemovedBlock(content.slice(0, start), content.slice(end));
+}
+
+function removeSafeStorageReleaseNote(content: string): string {
+  const normalized = normalizeNewlines(content);
+  const exactStart = normalized.indexOf(SAFE_STORAGE_RELEASE_NOTE);
+  if (exactStart >= 0) {
+    return removeRange(
+      normalized,
+      exactStart,
+      exactStart + SAFE_STORAGE_RELEASE_NOTE.length,
+    );
+  }
+
+  const markerStart = normalized.indexOf(SAFE_STORAGE_MARKER);
+  if (markerStart < 0) {
+    return content;
+  }
+
+  const nextMarkerStart = normalized.indexOf(
+    RELEASE_NOTE_MARKER_PREFIX,
+    markerStart + SAFE_STORAGE_MARKER.length,
+  );
+
+  return removeRange(
+    normalized,
+    markerStart,
+    nextMarkerStart >= 0 ? nextMarkerStart : normalized.length,
+  );
+}
+
+export const removeSafeStorageReleaseNoteMigration: WorkspaceMigration = {
+  id: MIGRATION_ID,
+  description: "Remove safe storage release note from UPDATES.md",
+
+  run(workspaceDir: string): void {
+    const updatesPath = join(workspaceDir, "UPDATES.md");
+    if (!existsSync(updatesPath)) {
+      return;
+    }
+
+    const existing = readFileSync(updatesPath, "utf-8");
+    if (!existing.includes(SAFE_STORAGE_MARKER)) {
+      return;
+    }
+
+    const cleaned = removeSafeStorageReleaseNote(existing);
+    if (cleaned.trim() === "") {
+      rmSync(updatesPath, { force: true });
+      return;
+    }
+
+    writeFileSync(updatesPath, cleaned, "utf-8");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: this removes a pending bulletin that should no longer be
+    // shown to users.
+  },
+};

--- a/assistant/src/workspace/migrations/071-remove-safe-storage-release-note.ts
+++ b/assistant/src/workspace/migrations/071-remove-safe-storage-release-note.ts
@@ -22,20 +22,31 @@ that must be acknowledged before cleanup chat continues, then keeps a status
 banner visible while cleanup mode is active.
 `;
 
-function normalizeNewlines(content: string): string {
-  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+const LEADING_NEWLINES = /^(?:(?:\r\n)|\n|\r)+/;
+const TRAILING_NEWLINES = /(?:(?:\r\n)|\n|\r)+$/;
+
+function findNewlineStyle(...samples: string[]): string {
+  for (const sample of samples) {
+    const match = sample.match(/\r\n|\n|\r/);
+    if (match) {
+      return match[0];
+    }
+  }
+
+  return "\n";
 }
 
 function stitchAroundRemovedBlock(before: string, after: string): string {
   if (before.trim() === "") {
-    return after.replace(/^\n+/, "");
+    return after.replace(LEADING_NEWLINES, "");
   }
 
   if (after.trim() === "") {
-    return before.replace(/\n+$/, "\n");
+    return `${before.replace(TRAILING_NEWLINES, "")}${findNewlineStyle(before)}`;
   }
 
-  return `${before.replace(/\n+$/, "\n\n")}${after.replace(/^\n+/, "")}`;
+  const newline = findNewlineStyle(before, after);
+  return `${before.replace(TRAILING_NEWLINES, "")}${newline}${newline}${after.replace(LEADING_NEWLINES, "")}`;
 }
 
 function removeRange(content: string, start: number, end: number): string {
@@ -43,30 +54,29 @@ function removeRange(content: string, start: number, end: number): string {
 }
 
 function removeSafeStorageReleaseNote(content: string): string {
-  const normalized = normalizeNewlines(content);
-  const exactStart = normalized.indexOf(SAFE_STORAGE_RELEASE_NOTE);
+  const exactStart = content.indexOf(SAFE_STORAGE_RELEASE_NOTE);
   if (exactStart >= 0) {
     return removeRange(
-      normalized,
+      content,
       exactStart,
       exactStart + SAFE_STORAGE_RELEASE_NOTE.length,
     );
   }
 
-  const markerStart = normalized.indexOf(SAFE_STORAGE_MARKER);
+  const markerStart = content.indexOf(SAFE_STORAGE_MARKER);
   if (markerStart < 0) {
     return content;
   }
 
-  const nextMarkerStart = normalized.indexOf(
+  const nextMarkerStart = content.indexOf(
     RELEASE_NOTE_MARKER_PREFIX,
     markerStart + SAFE_STORAGE_MARKER.length,
   );
 
   return removeRange(
-    normalized,
+    content,
     markerStart,
-    nextMarkerStart >= 0 ? nextMarkerStart : normalized.length,
+    nextMarkerStart >= 0 ? nextMarkerStart : content.length,
   );
 }
 

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -68,6 +68,7 @@ import { releaseNotesSafeStorageLimitsMigration } from "./067-release-notes-safe
 import { releaseNotesLocalTimezoneMigration } from "./068-release-notes-local-timezone.js";
 import { seedOnboardingThreadsMigration } from "./069-seed-onboarding-threads.js";
 import { memoryV2SummarySchemaRebuildMigration } from "./070-memory-v2-summary-schema-rebuild.js";
+import { removeSafeStorageReleaseNoteMigration } from "./071-remove-safe-storage-release-note.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -147,4 +148,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   releaseNotesLocalTimezoneMigration,
   seedOnboardingThreadsMigration,
   memoryV2SummarySchemaRebuildMigration,
+  removeSafeStorageReleaseNoteMigration,
 ];


### PR DESCRIPTION
## Summary
- Tombstone workspace migration 067 so it stays registered but no longer appends the safe-storage/disk-pressure release bulletin to UPDATES.md.
- Add migration 071 to scrub already-appended safe-storage bulletin content while preserving unrelated release notes and newline style.
- Keep the actual safe-storage-limits feature flag and guarded disk-pressure implementation untouched.

## Self-review result
PASS after 2 remediation PRs.

## PRs merged into feature branch
- #29839: Tombstone safe-storage release note migration
- #29838: Remove pending safe-storage bulletin from UPDATES.md
- #29841: Verify safe-storage bulletin removal

### Fix PRs
- #29842: Clarify safe-storage migration tombstone comment
- #29843: Clean up safe-storage release note migration

## Verification
- cd assistant && bun test src/__tests__/workspace-migration-safe-storage-limits-release.test.ts src/__tests__/workspace-migration-071-remove-safe-storage-release-note.test.ts
- cd assistant && bunx tsc --noEmit

Part of plan: remove-disk-pressure-migration.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->