### PR TITLE
fix(auth): restore non-ephemeral ASWebAuthenticationSession on macOS (LUM-1410)

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -309,11 +309,15 @@ public final class AuthManager {
                     continuation.resume(throwing: AuthServiceError.authCallbackFailed("No callback URL received."))
                 }
             }
-            // Use an ephemeral (private) session so each auth attempt starts
-            // with a clean cookie jar. Without this, stale WorkOS cookies
-            // from a failed attempt (e.g. signup_closed) persist and cause
-            // an infinite error loop on retry.
-            session.prefersEphemeralWebBrowserSession = true
+            // Rely on Apple's default (non-ephemeral) browser session so the
+            // user's existing IdP cookies in Safari are visible during auth —
+            // otherwise Google re-prompts for credentials on every login,
+            // defeating SSO inside ASWebAuthenticationSession. (The iOS
+            // counterpart in vellum-assistant-platform opts into ephemeral
+            // mode separately for a platform-specific signup_closed loop
+            // that this client does not have.)
+            //
+            // https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession
             session.presentationContextProvider = WebAuthPresentationContext.shared
             self.webAuthSession = session
             session.start()


### PR DESCRIPTION
## Prompt / plan

LUM-1410 reports two regressions on dev/staging macOS builds after the recent native-auth refactor:

1. Every login via Google requires full Google credential re-entry (username + password), even immediately after logging out from the same app.
2. The Safari authentication sheet does not always auto-close after auth completes.

This PR addresses Symptom 1 on macOS. Symptom 2 and the related WorkOS `prompt=login` strip are fixed in the companion platform PR linked below.

### Root cause

[`prefersEphemeralWebBrowserSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession) was flipped from `false` (the Apple default) to `true` on macOS to match the iOS `NativeAuthPlugin` behavior. Per Apple's docs:

> Set `prefersEphemeralWebBrowserSession` to `true` to request that the browser doesn't share cookies or other browsing data between the authentication session and the user's normal browser session.

On macOS that means the Safari sheet starts with an empty cookie jar on every auth attempt, so the user's existing Google (or other IdP) session in Safari is never visible. WorkOS forwards the user to Google, Google sees no session cookie, and asks for credentials from scratch — defeating SSO.

### Why ephemeral mode was added in the first place

The iOS counterpart was added to escape an `signup_closed` infinite error loop where a stale WorkOS AuthKit session cookie would replay the same error indefinitely on retry. On iOS, that loop has been further mitigated by the `provider_hint=GoogleOAuth` plumbing in `vellum-assistant-platform`, which routes around AuthKit entirely. The macOS client never had this loop bug history, so the trade-off (lose SSO convenience to guard against a loop that doesn't manifest here) doesn't apply.

### Why fix only macOS, not iOS

iOS keeps `prefersEphemeralWebBrowserSession = true` as a defensive measure against the original iOS-only loop until we can verify at runtime that the AuthKit-bypass via `provider_hint` is sufficient on its own. Per [`AGENTS.md`](AGENTS.md) (Native client backwards compatibility), this is a **server-side** guarantee that has to keep working with already-shipped clients; we don't want to remove it on iOS yet.

### Alternatives considered

1. **Persist refresh tokens / scoped non-ephemeral mode after first login.** Rejected — `ASWebAuthenticationSession` doesn't expose hooks for this and the cookie-jar lifetime is determined entirely by `prefersEphemeralWebBrowserSession`. There's no documented way to "warm up" a private session.
2. **Add `login_hint=<email>` for macOS.** Rejected — `login_hint` only pre-fills the email field at the IdP, it does not skip the password prompt. Without an existing IdP cookie, Google will still ask for a password.
3. **Keep ephemeral and rely on a refresh-token flow at the WorkOS layer.** Rejected — WorkOS's auth sheet is what reaches Google; refresh tokens issued to our backend after `code` exchange don't help with the *next* sheet open because that sheet talks to Google fresh.

The simplest correct fix is to revert the macOS-side flag to Apple's documented default and let SSO work as designed.

## Test plan

- Local Xcode build verification required (CI skips macOS checks per `clients/macos/AGENTS.md`).
- On a dev or staging macOS build:
  1. Log in with a Google account that has an active Safari session.
  2. Log out via the preferences menu.
  3. Log in again with the same Google account — expect account-aware redirect (no password prompt) and the Safari sheet to auto-close.
- Regression check: trigger a `signup_closed` error path (e.g. a non-allowlisted email) and confirm we get a clean error toast instead of an infinite loop. The companion platform PR's "always-redirect-via-scheme on errors" change is what closes the sheet on the failure path.

## References

- [Apple — `ASWebAuthenticationSession.prefersEphemeralWebBrowserSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession)
- [Apple — `ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession)
- Companion PR: vellum-ai/vellum-assistant-platform — drops `prompt=login` for native flows and always closes the Safari sheet on error paths.

## Root cause analysis

1. **How did the code get into this state?** ATL-461 mirrored the iOS ephemeral-session setting onto macOS to match platform behavior, treating it as a low-risk parity fix. The PR description called out the SSO-loss trade-off but only on the assumption that "native auth login is infrequent" — in practice, log out → log in is a common dev/staging flow and the symptom shows up immediately.
2. **What mistakes or decisions led to it?** We backported a fix targeted at an iOS-only failure mode (`signup_closed` loop replayed by AuthKit cookies) to macOS without a corresponding macOS reproduction. Platform parity isn't always the right goal — both platforms use the same Safari sheet, but they have different bug histories.
3. **Were there warning signs we missed?** Yes — the PR description for #29663 explicitly listed losing Safari SSO continuity as a trade-off but underweighted how visible that would be when re-logins happen back-to-back.
4. **What can we do to prevent this pattern from recurring?** When mirroring a platform-specific fix to another platform, require a reproducible test case on the target platform first. If the target platform doesn't reproduce the bug being fixed, the trade-off math is different.
5. **Should we add a guideline to AGENTS.md?** A short note under the auth section is worth it: "Cross-platform auth-flag changes (e.g. `prefersEphemeralWebBrowserSession`, `prompt`, etc.) require a per-platform reproduction of the bug being fixed before applying — same setting can have different consequences on iOS vs macOS because of different IdP-cookie expectations." Will land in a follow-up if the reviewer agrees.

Link to Devin session: https://app.devin.ai/sessions/987da8b3f8464f078bfb0d1549232bf3
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->