### PR TITLE
fix(memory-v2): floor mtimeMs so Swift Int64 decode succeeds in Memories tab

### DIFF
--- a/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-routes.test.ts
@@ -99,18 +99,24 @@ describe("memory_v2_list_concept_pages handler", () => {
     expect(alice!.bodyBytes).toBe(Buffer.byteLength(pages[0]!.body, "utf8"));
     expect(alice!.edgeCount).toBe(2);
     expect(alice!.updatedAtMs).toBeGreaterThanOrEqual(before);
+    // updatedAtMs must be an integer on the wire — Swift clients decode it as
+    // Int64 and a sub-millisecond float (which fs.Stats.mtimeMs returns by
+    // default) breaks JSONDecoder strict number parsing.
+    expect(Number.isInteger(alice!.updatedAtMs)).toBe(true);
 
     const bob = bySlug.get("bob");
     expect(bob).toBeDefined();
     expect(bob!.bodyBytes).toBe(Buffer.byteLength(pages[1]!.body, "utf8"));
     expect(bob!.edgeCount).toBe(0);
     expect(bob!.updatedAtMs).toBeGreaterThanOrEqual(before);
+    expect(Number.isInteger(bob!.updatedAtMs)).toBe(true);
 
     const carol = bySlug.get("people/carol");
     expect(carol).toBeDefined();
     expect(carol!.bodyBytes).toBe(Buffer.byteLength(pages[2]!.body, "utf8"));
     expect(carol!.edgeCount).toBe(1);
     expect(carol!.updatedAtMs).toBeGreaterThanOrEqual(before);
+    expect(Number.isInteger(carol!.updatedAtMs)).toBe(true);
   });
 
   test("tolerates a single corrupt page — returns valid pages and skips the broken one", async () => {

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -219,7 +219,7 @@ async function handleListConceptPages({
           slug,
           bodyBytes: Buffer.byteLength(page.body, "utf8"),
           edgeCount: page.frontmatter.edges.length,
-          updatedAtMs: stats.mtimeMs,
+          updatedAtMs: Math.floor(stats.mtimeMs),
         };
       } catch (err) {
         // A single corrupt page (bad YAML, schema mismatch, etc.) shouldn't


### PR DESCRIPTION
## Summary

- The Memories tab in the assistant detail view was rendering its empty state ('No concept pages yet') even for users with 1000+ concept pages on disk.
- Root cause: `fs.statSync().mtimeMs` returns a float with sub-millisecond precision; the Swift client decodes `updatedAtMs` as `Int64`, and Swift's default `JSONDecoder` strict-rejects float→Int64. The `try?` in `MemoryV2Client.listConceptPages` swallows the decode error, the panel keeps its initial empty array, and the empty-state branch fires.
- Fix is a one-line `Math.floor(stats.mtimeMs)` at the wire boundary in `assistant/src/runtime/routes/memory-v2-routes.ts`, plus three `Number.isInteger` regression assertions in the existing route test so this can't regress silently.

## Original prompt

User asked why concept pages weren't showing up in the Memories tab even though many conversations had been had. Investigation against their workspace confirmed 1116 `.md` files exist under `~/.vellum/workspace/memory/concepts/`, and daemon logs showed the API returning 200 in 50ms with only 2 invalid-slug skips — so the missing data wasn't a backend or migration issue. Tracing into the Swift client revealed the float→Int64 decode mismatch; ship the minimal server-side fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->