### PR TITLE
docs(macos): document ASWebAuthenticationSession auth-flag pitfall

### DIFF
--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -429,6 +429,12 @@ All `vellum.ai` and external links the app navigates to (docs pages, terms of se
 - The docs base URL honors a `VELLUM_DOCS_BASE_URL` env var (validated as an absolute http(s) URL with no query/fragment, falls back to `https://www.vellum.ai/docs` on failure).
 - If you introduce a new env-var-overridable URL, also: (1) embed the var into `Info.plist`'s `LSEnvironment` in `clients/macos/build.sh` — LaunchServices doesn't inherit shell env, so `./build.sh run` requires the embedding (XML-escape values; see the existing `VELLUM_DOCS_BASE_URL` block for the pattern); (2) register the var in `assistant/src/tools/terminal/safe-env.ts` and `assistant/src/config/env-registry.ts` per `assistant/CLAUDE.md` § "Adding new environment variables".
 
+### Authentication
+
+The WorkOS sign-in flow uses [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (`AuthManager.startWorkOSLogin`). Apple's defaults assume the sheet shares cookies with the user's existing Safari session — flipping [`prefersEphemeralWebBrowserSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession) to `true` silently breaks SSO, because the user's existing IdP cookies (Google etc.) become invisible to the sheet and every login asks for credentials from scratch.
+
+Before mirroring an auth-session flag from iOS to macOS (or vice versa), reproduce the bug being fixed on the *target* platform. The two platforms use the same `ASWebAuthenticationSession` API but have different IdP-cookie expectations and different historical bug surfaces, so a setting that is right on one platform can be wrong on the other.
+
 ---
 
 ## Data Storage


### PR DESCRIPTION
## Prompt / plan

Add a short subsection under macOS-Specific Guidance in `clients/macos/AGENTS.md` documenting the [`prefersEphemeralWebBrowserSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession) pitfall and the broader principle that auth-session flags must be reproduced on the target platform before being mirrored from iOS to macOS or vice versa.

This was the root-cause-prevention follow-up flagged in the LUM-1410 fix PR (this repo) and the companion platform PR. The original regression — Google forcing credential re-entry on every login — happened because [`ASWebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession)'s ephemeral flag was mirrored from iOS to macOS without a macOS-side reproduction of the bug it was meant to fix on iOS, and the SSO regression slipped through review with the "native auth login is infrequent" assumption.

The note follows this repo's documentation style:

- **Lightweight + link-heavy** — links to Apple's authoritative docs rather than embedding implementation detail that will go stale (per established `clients/AGENTS.md` and `clients/macos/AGENTS.md` patterns).
- **Generic enough to outlive the specific incident** — the rule is "reproduce the bug on the target platform before mirroring an auth-session flag," which applies to any future flag (`prefersEphemeralWebBrowserSession`, `additionalHeaderFields`, presentation context choices, etc.), not just the one that triggered LUM-1410.
- **No PR numbers or transient context** — per documentation guidelines, AGENTS.md should not reference specific PRs.

### Alternatives considered

1. **Put the note in `clients/AGENTS.md` (cross-cutting client guidance).** Rejected — the cross-cutting file covers SwiftUI / accessibility / performance practices that apply across all clients, but auth-session flags are specifically a macOS surface in this repo. The companion iOS plugin lives in `vellum-assistant-platform/web/ios/App/App/NativeAuthPlugin.swift` and is governed by that repo's own conventions; there's no `web/ios/App/AGENTS.md` to mirror this note into.
2. **Add a stand-alone "Authentication" top-level section.** Rejected — the existing macOS-Specific Guidance section already groups system-services concerns (Accessibility APIs, Screen Capture, Entitlements, External URLs). Adding a new subsection there fits the existing structure; a top-level section would over-index for what's a few sentences of guidance.
3. **Reference the specific PR that introduced the regression.** Rejected — per knowledge-base documentation guidelines, AGENTS.md should not reference specific PR numbers. The rule must stand on its own merits, not depend on git archaeology.

## Test plan

- Documentation-only change in `clients/macos/AGENTS.md`. No code changes; CI lint/typecheck/build is unaffected.
- Verified the new section renders with markdown links and uses the existing subsection structure (`### Authentication` under `## macOS-Specific Guidance`, between `### External URLs` and `## Data Storage`).

Link to Devin session: https://app.devin.ai/sessions/987da8b3f8464f078bfb0d1549232bf3
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->