### PR TITLE
fix(memory-v2): require both feature flag and config.memory.v2.enabled

### DIFF
--- a/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
+++ b/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
@@ -60,7 +60,7 @@ mock.module("../memory/v2/skill-store.js", () => ({
 
 const { registerMemoryV2Command } =
   await import("../cli/commands/memory-v2.js");
-const { ROUTES: memoryV2Routes } =
+const { ROUTES: memoryV2Routes, MEMORY_V2_DISABLED_CODE } =
   await import("../runtime/routes/memory-v2-routes.js");
 const { RouteError } = await import("../runtime/routes/errors.js");
 
@@ -205,4 +205,56 @@ describe("memory_v2_reembed_skills route", () => {
     ).rejects.toBeInstanceOf(RouteError);
     expect(seedCallCount).toBe(0);
   });
+});
+
+// ---------------------------------------------------------------------------
+// All v2 routes share the same gate
+// ---------------------------------------------------------------------------
+
+describe("all memory v2 routes — MEMORY_V2_DISABLED gate", () => {
+  // Minimal bodies that satisfy each route's schema. The gate runs before
+  // schema validation so any body would surface the gate error, but using
+  // valid shapes keeps the assertion precise: we're confirming the gate
+  // (not zod) is what blocks the call.
+  const MINIMAL_BODIES: Record<string, Record<string, unknown>> = {
+    memory_v2_backfill: { op: "migrate" },
+    memory_v2_validate: {},
+    memory_v2_get_concept_page: { slug: "any" },
+    memory_v2_list_concept_pages: {},
+    memory_v2_rebuild_corpus_stats: {},
+    memory_v2_explain_similarity: { userText: "hello" },
+    memory_v2_concept_frequency: {},
+    memory_v2_fit_anisotropy: {},
+  };
+
+  const GATE_OFF_CASES = [
+    {
+      label: "feature flag is off",
+      apply: () => _setOverridesForTesting({ "memory-v2-enabled": false }),
+    },
+    {
+      label: "config is off",
+      apply: () => writeWorkspaceConfig({ memory: { v2: { enabled: false } } }),
+    },
+  ];
+
+  for (const [operationId, body] of Object.entries(MINIMAL_BODIES)) {
+    for (const { label, apply } of GATE_OFF_CASES) {
+      test(`${operationId} throws MEMORY_V2_DISABLED when ${label}`, async () => {
+        apply();
+        const route = memoryV2Routes.find((r) => r.operationId === operationId);
+        expect(route).toBeDefined();
+
+        try {
+          await route!.handler({ body });
+          throw new Error("expected handler to throw");
+        } catch (err) {
+          expect(err).toBeInstanceOf(RouteError);
+          expect((err as InstanceType<typeof RouteError>).code).toBe(
+            MEMORY_V2_DISABLED_CODE,
+          );
+        }
+      });
+    }
+  }
 });

--- a/assistant/src/__tests__/filing-service.test.ts
+++ b/assistant/src/__tests__/filing-service.test.ts
@@ -342,20 +342,33 @@ describe("FilingService", () => {
       expect(service.nextCompactionAt).toBeNull();
     });
 
-    test("start() does not schedule timers when only the flag is on", () => {
+    test("start() schedules timers when flag is on but config is off (v2 inactive → v1 filing runs)", () => {
       _setOverridesForTesting({ "memory-v2-enabled": true });
       mockConfig.memory.v2.enabled = false;
 
       const service = createService();
       service.start();
 
-      expect(service.nextRunAt).toBeNull();
-      expect(service.nextCompactionAt).toBeNull();
+      expect(service.nextRunAt).not.toBeNull();
+      expect(service.nextCompactionAt).not.toBeNull();
+      service.stop();
     });
 
     test("start() schedules timers when only the config is on", () => {
       _setOverridesForTesting({ "memory-v2-enabled": false });
       mockConfig.memory.v2.enabled = true;
+
+      const service = createService();
+      service.start();
+
+      expect(service.nextRunAt).not.toBeNull();
+      expect(service.nextCompactionAt).not.toBeNull();
+      service.stop();
+    });
+
+    test("start() schedules timers when both flag and config are off", () => {
+      _setOverridesForTesting({ "memory-v2-enabled": false });
+      mockConfig.memory.v2.enabled = false;
 
       const service = createService();
       service.start();

--- a/assistant/src/filing/filing-service.ts
+++ b/assistant/src/filing/filing-service.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import {
@@ -10,6 +9,7 @@ import {
   shouldLogDiskPressureBackgroundSkip,
 } from "../daemon/disk-pressure-background-gate.js";
 import { processMessage } from "../daemon/process-message.js";
+import { isMemoryV2ReadActive } from "../memory/context-search/sources/memory-v2.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -115,8 +115,8 @@ export class FilingService {
 
   start(): void {
     const fullConfig = getConfig();
-    if (isAssistantFeatureFlagEnabled("memory-v2-enabled", fullConfig)) {
-      log.info("Filing service disabled — memory v2 flag is set");
+    if (isMemoryV2ReadActive(fullConfig)) {
+      log.info("Filing service disabled — memory v2 is active");
       this._nextRunAt = null;
       this._nextCompactionAt = null;
       return;

--- a/assistant/src/memory/graph/__tests__/handle-remember-v2.test.ts
+++ b/assistant/src/memory/graph/__tests__/handle-remember-v2.test.ts
@@ -1,12 +1,9 @@
 /**
- * Tests for `handleRemember` flag-routing between v1 (PKB) and v2 (memory/).
+ * Tests for `handleRemember` routing between v1 (PKB) and v2 (memory/).
  *
- * Verifies:
- *   - Flag on  → writes go to `memory/buffer.md` + `memory/archive/<today>.md`
- *                and NO PKB re-index job is enqueued.
- *   - Flag off → existing PKB path is unchanged (writes to `pkb/buffer.md`
- *                + `pkb/archive/<today>.md`, both files are re-indexed).
- *   - Archive filename uses today's local date.
+ * Routing follows `isMemoryV2ReadActive(config)` — both the
+ * `memory-v2-enabled` flag AND `config.memory.v2.enabled` must be true for
+ * writes to go to v2. Any other combination falls back to v1 PKB.
  */
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -221,5 +218,35 @@ describe("handleRemember — memory-v2 flag off (v1 PKB path)", () => {
     for (const call of enqueueCalls) {
       expect(call.pkbRoot).toBe(pkbDir);
     }
+  });
+});
+
+describe("handleRemember — flag on but config off (v1 PKB path)", () => {
+  beforeEach(() => {
+    _setOverridesForTesting({ "memory-v2-enabled": true });
+  });
+
+  test("falls back to v1 when memory.v2.enabled is false", () => {
+    const configWithV2Off = {
+      ...CONFIG,
+      memory: { ...CONFIG.memory, v2: { ...CONFIG.memory.v2, enabled: false } },
+    };
+
+    const result = handleRemember(
+      { content: "config kill switch is on" },
+      "conv-asymmetric-1",
+      "default",
+      configWithV2Off,
+    );
+
+    expect(result.success).toBe(true);
+
+    const pkbDir = join(tmpWorkspace, "pkb");
+    expect(readFileSync(join(pkbDir, "buffer.md"), "utf-8")).toContain(
+      "config kill switch is on",
+    );
+    expect(existsSync(join(tmpWorkspace, "memory"))).toBe(false);
+    // v1 path enqueues both buffer and archive re-index jobs.
+    expect(enqueueCalls).toHaveLength(2);
   });
 });

--- a/assistant/src/memory/graph/tool-handlers.ts
+++ b/assistant/src/memory/graph/tool-handlers.ts
@@ -2,17 +2,17 @@
 // Memory Tool handlers
 //
 // remember: save facts to the PKB (buffer.md + daily archive) under the v1
-// path, or to memory/buffer.md + memory/archive/<today>.md when the
-// `memory-v2-enabled` feature flag is on.
+// path, or to memory/buffer.md + memory/archive/<today>.md when memory v2 is
+// active.
 // ---------------------------------------------------------------------------
 
 import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { isMemoryV2ReadActive } from "../context-search/sources/memory-v2.js";
 import { enqueuePkbIndexJob } from "../jobs/embed-pkb-file.js";
 import { PKB_WORKSPACE_SCOPE } from "../pkb/types.js";
 
@@ -46,7 +46,7 @@ export function handleRemember(
   const now = new Date();
   const entry = formatRememberEntry(input.content.trim(), now);
 
-  if (isAssistantFeatureFlagEnabled("memory-v2-enabled", config)) {
+  if (isMemoryV2ReadActive(config)) {
     appendBufferAndArchive({
       rootDir: join(workspaceDir, "memory"),
       entry,

--- a/assistant/src/runtime/routes/memory-v2-routes.ts
+++ b/assistant/src/runtime/routes/memory-v2-routes.ts
@@ -9,7 +9,6 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { loadConfig } from "../../config/loader.js";
 import {
   applyCorrectionIfCalibrated,
@@ -17,6 +16,7 @@ import {
   fitAnisotropyCalibration,
   saveCalibration,
 } from "../../memory/anisotropy.js";
+import { isMemoryV2ReadActive } from "../../memory/context-search/sources/memory-v2.js";
 import {
   embedWithBackend,
   selectEmbeddingBackend,
@@ -59,6 +59,31 @@ import type { RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("memory-v2-routes");
 
+/**
+ * Wire-format error code emitted when v2 routes reject a request because
+ * the dual gate (`isMemoryV2ReadActive`) is off. Exported so tests and the
+ * macOS client can reference the same string without drift.
+ */
+export const MEMORY_V2_DISABLED_CODE = "MEMORY_V2_DISABLED";
+
+/**
+ * Reject the request when memory v2 is not active. The route surface mirrors
+ * the runtime gate (`isMemoryV2ReadActive`): both the `memory-v2-enabled`
+ * feature flag and the per-workspace `memory.v2.enabled` config must be on.
+ * Returning 409 (rather than serving a partial response) keeps clients honest
+ * — the desktop Memories panel reads this code to render an explicit
+ * "disabled in config" empty state.
+ */
+function requireMemoryV2Enabled(): void {
+  if (!isMemoryV2ReadActive(loadConfig())) {
+    throw new RouteError(
+      "Memory v2 is not enabled — flip both the memory-v2-enabled feature flag and memory.v2.enabled to use this command.",
+      MEMORY_V2_DISABLED_CODE,
+      409,
+    );
+  }
+}
+
 // ── Backfill ────────────────────────────────────────────────────────────
 
 const MemoryV2BackfillParams = z
@@ -83,6 +108,7 @@ const OP_TO_JOB_TYPE: Record<MemoryV2BackfillOp, MemoryJobType> = {
 async function handleBackfill({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2BackfillResult> {
+  requireMemoryV2Enabled();
   const { op, force } = MemoryV2BackfillParams.parse(body);
   const payload: Record<string, unknown> =
     op === "migrate" && force === true ? { force: true } : {};
@@ -109,6 +135,7 @@ export type MemoryV2ValidateResult = {
 async function handleValidate({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2ValidateResult> {
+  requireMemoryV2Enabled();
   MemoryV2ValidateParams.parse(body);
 
   const workspaceDir = getWorkspaceDir();
@@ -165,6 +192,7 @@ export type MemoryV2GetConceptPageResult = {
 async function handleGetConceptPage({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2GetConceptPageResult> {
+  requireMemoryV2Enabled();
   const { slug } = MemoryV2GetConceptPageParams.parse(body);
   const workspaceDir = getWorkspaceDir();
   let page;
@@ -203,6 +231,7 @@ export type MemoryV2ListConceptPagesResult = {
 async function handleListConceptPages({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2ListConceptPagesResult> {
+  requireMemoryV2Enabled();
   MemoryV2ListConceptPagesParams.parse(body);
 
   const workspaceDir = getWorkspaceDir();
@@ -253,6 +282,7 @@ export interface MemoryV2RebuildCorpusStatsResult {
 async function handleRebuildCorpusStats({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2RebuildCorpusStatsResult> {
+  requireMemoryV2Enabled();
   MemoryV2RebuildCorpusStatsParams.parse(body);
   const workspaceDir = getWorkspaceDir();
   await rebuildConceptPageCorpusStats(workspaceDir);
@@ -284,22 +314,8 @@ export type MemoryV2ReembedSkillsResult = {
 async function handleReembedSkills({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2ReembedSkillsResult> {
+  requireMemoryV2Enabled();
   MemoryV2ReembedSkillsParams.parse(body);
-
-  // Gate the route on both the feature flag and the per-workspace config
-  // toggle so the v2 skill collection never gets re-seeded against a
-  // workspace whose v2 subsystem is intentionally off.
-  const config = loadConfig();
-  if (
-    !isAssistantFeatureFlagEnabled("memory-v2-enabled", config) ||
-    !config.memory.v2.enabled
-  ) {
-    throw new RouteError(
-      "Memory v2 is not enabled — flip both the memory-v2-enabled feature flag and memory.v2.enabled to use this command.",
-      "MEMORY_V2_DISABLED",
-      409,
-    );
-  }
 
   // Unlike the queued backfill jobs above, this is a CLI-driven sync
   // request: the operator wants the cache replaced before the next prompt
@@ -475,6 +491,7 @@ async function scoreChannel(
 async function handleExplainSimilarity({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2ExplainSimilarityResult> {
+  requireMemoryV2Enabled();
   const params = MemoryV2ExplainSimilarityParams.parse(body);
   const config = loadConfig();
   const { dense_weight: denseWeight, sparse_weight: sparseWeight } =
@@ -534,6 +551,7 @@ const MemoryV2ConceptFrequencyParams = z
 async function handleConceptFrequency({
   body = {},
 }: RouteHandlerArgs): Promise<ConceptFrequencyResponse> {
+  requireMemoryV2Enabled();
   const { conversationId, sinceMs } =
     MemoryV2ConceptFrequencyParams.parse(body);
   const workspaceDir = getWorkspaceDir();
@@ -576,6 +594,7 @@ export interface MemoryV2FitAnisotropyResult {
 async function handleFitAnisotropy({
   body = {},
 }: RouteHandlerArgs): Promise<MemoryV2FitAnisotropyResult> {
+  requireMemoryV2Enabled();
   const { k, sample } = MemoryV2FitAnisotropyParams.parse(body);
   const config = loadConfig();
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/MemoriesV2Panel.swift
@@ -28,6 +28,7 @@ private enum MemoryV2SortOption: String, CaseIterable {
 struct MemoriesV2Panel: View {
     @State private var pages: [MemoryV2ConceptPageSummary] = []
     @State private var isLoading: Bool = true
+    @State private var v2Disabled: Bool = false
     @State private var selectedSlug: String?
     @State private var searchText: String = ""
     @State private var debouncedSearchText: String = ""
@@ -121,6 +122,12 @@ struct MemoriesV2Panel: View {
                 Color.clear
                 VLoadingIndicator()
             }
+        } else if v2Disabled {
+            VEmptyState(
+                title: "Memory v2 is disabled",
+                subtitle: "Set memory.v2.enabled to true in your workspace config to use the Memories tab.",
+                icon: VIcon.brain.rawValue
+            )
         } else if pages.isEmpty {
             VEmptyState(
                 title: "No concept pages yet",
@@ -180,8 +187,15 @@ struct MemoriesV2Panel: View {
     private func loadPages() async {
         isLoading = true
         defer { isLoading = false }
-        if let response = await client.listConceptPages() {
+        switch await client.listConceptPages() {
+        case .success(let response):
+            v2Disabled = false
             pages = response.pages
+        case .disabled:
+            v2Disabled = true
+            pages = []
+        case .error:
+            v2Disabled = false
         }
     }
 }

--- a/clients/shared/Network/MemoryV2Client.swift
+++ b/clients/shared/Network/MemoryV2Client.swift
@@ -28,33 +28,63 @@ public struct MemoryV2ListConceptPagesResponse: Codable, Sendable, Equatable {
     }
 }
 
+/// Outcome of `listConceptPages()`.
+///
+/// The `disabled` case lets the UI distinguish "memory v2 is intentionally
+/// off in this workspace" (flag-on/config-off, surfaced as HTTP 409
+/// `MEMORY_V2_DISABLED`) from a generic transport failure. The Memories
+/// panel renders an explicit empty state for `disabled` rather than silently
+/// showing zero pages.
+public enum MemoryV2ListConceptPagesResult: Sendable, Equatable {
+    case success(MemoryV2ListConceptPagesResponse)
+    case disabled
+    case error
+}
+
 /// Focused client for memory v2 concept-page operations routed through the gateway.
 ///
 /// Single-page fetches reuse `LLMContextClient.fetchConceptPage(slug:)` rather
 /// than duplicating the endpoint here.
 public protocol MemoryV2ClientProtocol: Sendable {
-    func listConceptPages() async -> MemoryV2ListConceptPagesResponse?
+    func listConceptPages() async -> MemoryV2ListConceptPagesResult
 }
 
 /// Gateway-backed implementation of ``MemoryV2ClientProtocol``.
 public struct MemoryV2Client: MemoryV2ClientProtocol {
     nonisolated public init() {}
 
-    public func listConceptPages() async -> MemoryV2ListConceptPagesResponse? {
+    public func listConceptPages() async -> MemoryV2ListConceptPagesResult {
         do {
             let response = try await GatewayHTTPClient.post(
                 path: "memory/v2/list-concept-pages",
                 json: [:],
                 timeout: 15
             )
-            guard response.isSuccess else {
-                log.error("listConceptPages failed (HTTP \(response.statusCode))")
-                return nil
+            if response.isSuccess {
+                if let decoded = try? JSONDecoder().decode(MemoryV2ListConceptPagesResponse.self, from: response.data) {
+                    return .success(decoded)
+                }
+                log.error("listConceptPages succeeded but body did not decode")
+                return .error
             }
-            return try? JSONDecoder().decode(MemoryV2ListConceptPagesResponse.self, from: response.data)
+            if response.statusCode == 409, isMemoryV2DisabledError(response.data) {
+                return .disabled
+            }
+            log.error("listConceptPages failed (HTTP \(response.statusCode))")
+            return .error
         } catch {
             log.error("listConceptPages failed: \(error.localizedDescription)")
-            return nil
+            return .error
         }
     }
+}
+
+/// Decode the standard `{ error: { code, message } }` envelope and return
+/// `true` when the server signaled that memory v2 is disabled in config.
+private func isMemoryV2DisabledError(_ data: Data) -> Bool {
+    struct Envelope: Decodable {
+        struct Body: Decodable { let code: String? }
+        let error: Body?
+    }
+    return (try? JSONDecoder().decode(Envelope.self, from: data))?.error?.code == "MEMORY_V2_DISABLED"
 }


### PR DESCRIPTION
## Summary
- Route the four asymmetric gate sites through the canonical `isMemoryV2ReadActive(config)` helper so v2 only activates when both the `memory-v2-enabled` feature flag AND `config.memory.v2.enabled` are true.
- Gate every `memory/v2/*` HTTP route with a shared `requireMemoryV2Enabled()` helper that returns 409 `MEMORY_V2_DISABLED`; the macOS Memories panel now renders an explicit "Memory v2 is disabled" empty state when the config is off.
- Update `FilingService` and `handleRemember` so flag-on/config-off cleanly falls back to v1 filing + v1 PKB writes instead of leaving the workspace in a half-on state.

## Original prompt
The schema documents that the `memory-v2-enabled` feature flag and the `memory.v2.enabled` workspace config must both be true for v2 to run, but four call sites only checked the flag — producing a confusing flag-on/config-off state where v2 reads were off, v1 fallback was also off, and the UI silently showed v2 surfaces with stale data. The ask was to route all four sites through the existing `isMemoryV2ReadActive(config)` helper so v2 is on if and only if both gates are true, and to surface a clear disabled state in the macOS Memories tab.

## Test plan
- [x] `bunx tsc --noEmit` (clean)
- [x] `bun test src/memory/graph/__tests__/handle-remember-v2.test.ts` (8 pass)
- [x] `bun test src/__tests__/filing-service.test.ts` (21 pass)
- [x] `bun test src/__tests__/cli-memory-v2-reembed-skills.test.ts` (33 pass — covers all 9 routes × {flag-off, config-off})
- [x] `bun test src/memory/graph/__tests__/conversation-graph-memory-v2-routing.test.ts` (8 pass)
- [ ] Manual macOS verification: set `memory.v2.enabled: false`, restart, open Memories tab, see "Memory v2 is disabled" empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->