### PR TITLE
fix: add draggingUpdated override to ComposerTextView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -145,6 +145,10 @@ final class ComposerTextView: NSTextView {
         return []
     }
 
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        return []
+    }
+
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         return false
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for drag-drop-attach.md.

**Gap:** Missing draggingUpdated override allows NSTextView to re-accept rejected drags
**What was expected:** Comprehensive NSDraggingDestination rejection matching ForbiddenDropTargetView pattern
**What was found:** Only draggingEntered was overridden; base draggingUpdated could re-accept
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->