### PR TITLE
fix: shift monitor leak guard + newline-separated drop paths

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -202,6 +202,9 @@ struct ChatView: View {
             }
         }
         .onAppear {
+            if let existing = shiftMonitor {
+                NSEvent.removeMonitor(existing)
+            }
             shiftMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
                 isShiftHeld = event.modifierFlags.contains(.shift)
                 return event
@@ -660,11 +663,11 @@ struct ChatView: View {
             isDraggingInternalImage: $isDraggingInternalImage,
             onInternalDragRejected: { self.removeDragEndMonitors() },
             onDropPathsAsText: { urls in
-                let paths = urls.map(\.path).joined(separator: " ")
+                let paths = urls.map(\.path).joined(separator: "\n")
                 if viewModel.inputText.isEmpty {
                     viewModel.inputText = paths
                 } else {
-                    viewModel.inputText += " " + paths
+                    viewModel.inputText += "\n" + paths
                 }
             }
         )


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for drag-drop-attach.md.

**Gap 1:** Shift monitor leak — .onAppear didn't clean up existing monitor before installing
**Gap 2:** Space-separated paths ambiguous — changed to newline separation for paths with spaces
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->