### PR TITLE
fix(macos): add disable-library-validation entitlement for Sparkle

### DIFF
--- a/clients/macos/app-entitlements.plist
+++ b/clients/macos/app-entitlements.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.virtualization</key>


### PR DESCRIPTION
## Summary
- Add `com.apple.security.cs.disable-library-validation` entitlement to `app-entitlements.plist`
- Fixes immediate crash on launch (`SIGABRT` / `DYLD` Library missing) on macOS 26 when the hardened runtime rejects Sparkle.framework due to ad-hoc Team ID mismatch

## Original prompt
The macOS app built by `vel up` crashes immediately on launch with a DYLD "Library missing" error for Sparkle.framework. Investigation revealed that while Sparkle is correctly bundled in `Contents/Frameworks/`, macOS 26's hardened runtime library validation rejects it because the ad-hoc signed app and framework have "different Team IDs" (both are `not set`). The fix is the standard `disable-library-validation` entitlement that allows loading third-party frameworks under hardened runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->