### PR TITLE
Drag-and-drop attachment fix + shift-key path insertion

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -202,6 +202,9 @@ struct ChatView: View {
             }
         }
         .onAppear {
+            if let existing = shiftMonitor {
+                NSEvent.removeMonitor(existing)
+            }
             shiftMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
                 isShiftHeld = event.modifierFlags.contains(.shift)
                 return event
@@ -660,11 +663,11 @@ struct ChatView: View {
             isDraggingInternalImage: $isDraggingInternalImage,
             onInternalDragRejected: { self.removeDragEndMonitors() },
             onDropPathsAsText: { urls in
-                let paths = urls.map(\.path).joined(separator: " ")
+                let paths = urls.map(\.path).joined(separator: "\n")
                 if viewModel.inputText.isEmpty {
                     viewModel.inputText = paths
                 } else {
-                    viewModel.inputText += " " + paths
+                    viewModel.inputText += "\n" + paths
                 }
             }
         )

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -102,6 +102,8 @@ struct ChatView: View {
     @State private var isDraggingInternalImage = false
     @State private var dragEndLocalMonitor: Any?
     @State private var dragEndGlobalMonitor: Any?
+    @State private var isShiftHeld = false
+    @State private var shiftMonitor: Any?
 
     // MARK: - In-Chat Search (Cmd+F)
     @State private var isSearchActive = false
@@ -199,8 +201,18 @@ struct ChatView: View {
                 showSkeleton = false
             }
         }
+        .onAppear {
+            shiftMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+                isShiftHeld = event.modifierFlags.contains(.shift)
+                return event
+            }
+        }
         .onDisappear {
             removeDragEndMonitors()
+            if let monitor = shiftMonitor {
+                NSEvent.removeMonitor(monitor)
+                shiftMonitor = nil
+            }
         }
     }
 
@@ -572,9 +584,9 @@ struct ChatView: View {
                 )
                 .overlay {
                     VStack(spacing: VSpacing.sm) {
-                        VIconView(.arrowDownToLine, size: 28)
+                        VIconView(isShiftHeld ? .fileText : .arrowDownToLine, size: 28)
                             .foregroundStyle(VColor.primaryBase)
-                        Text("Drop files here")
+                        Text(isShiftHeld ? "Drop to insert path" : "Drop files here")
                             .font(VFont.bodyMediumDefault)
                             .foregroundStyle(VColor.primaryBase)
                     }
@@ -646,7 +658,15 @@ struct ChatView: View {
             onDropEnded: { viewModel.attachmentManager.endExternalLoad() },
             isDropTargeted: $isDropTargeted,
             isDraggingInternalImage: $isDraggingInternalImage,
-            onInternalDragRejected: { self.removeDragEndMonitors() }
+            onInternalDragRejected: { self.removeDragEndMonitors() },
+            onDropPathsAsText: { urls in
+                let paths = urls.map(\.path).joined(separator: " ")
+                if viewModel.inputText.isEmpty {
+                    viewModel.inputText = paths
+                } else {
+                    viewModel.inputText += " " + paths
+                }
+            }
         )
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerDropHandler.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerDropHandler.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import AppKit
 import Foundation
 import SwiftUI
 import UniformTypeIdentifiers
@@ -24,6 +25,9 @@ struct DropActions {
     /// cleanup (e.g. removing drag-end monitors) that would otherwise be skipped
     /// by the early return.
     var onInternalDragRejected: (() -> Void)?
+    /// Called with resolved file URLs when the user holds Shift during drop,
+    /// inserting the file paths as text instead of attaching them.
+    var onDropPathsAsText: (([URL]) -> Void)?
 
     /// A no-op default suitable for use as an EnvironmentKey default value.
     static let noop = DropActions(
@@ -33,7 +37,8 @@ struct DropActions {
         onDropEnded: nil,
         isDropTargeted: .constant(false),
         isDraggingInternalImage: .constant(false),
-        onInternalDragRejected: nil
+        onInternalDragRejected: nil,
+        onDropPathsAsText: nil
     )
 }
 
@@ -71,6 +76,31 @@ enum ComposerDropHandler {
             actions.isDraggingInternalImage.wrappedValue = false
             actions.onInternalDragRejected?()
             return false
+        }
+
+        // When Shift is held, resolve file URLs and insert their paths as text
+        // instead of going through the attachment flow.
+        let isShiftHeld = NSEvent.modifierFlags.contains(.shift)
+        if isShiftHeld, let onDropPathsAsText = actions.onDropPathsAsText {
+            var resolvedURLs: [URL] = []
+            let group = DispatchGroup()
+            for provider in providers {
+                if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                    group.enter()
+                    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                        DispatchQueue.main.async {
+                            if let url { resolvedURLs.append(url) }
+                            group.leave()
+                        }
+                    }
+                }
+            }
+            group.notify(queue: .main) {
+                if !resolvedURLs.isEmpty {
+                    onDropPathsAsText(resolvedURLs)
+                }
+            }
+            return true
         }
 
         // Signal loading immediately so the "Processing…" chip appears without

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextEditor.swift
@@ -149,11 +149,6 @@ struct ComposerTextEditor: NSViewRepresentable {
 
         textView.postsFrameChangedNotifications = true
 
-        // Strip all drag types so the NSTextView doesn't intercept file drops
-        // (which would insert file paths as text). File drops are handled by
-        // SwiftUI's .onDrop modifier on the composer container.
-        textView.unregisterDraggedTypes()
-
         scrollView.contentHeight = minHeight
         scrollView.documentView = textView
         textView.delegate = coordinator
@@ -285,14 +280,6 @@ struct ComposerTextEditor: NSViewRepresentable {
             proxy.replaceText = { [weak textView] range, replacement in
                 textView?.insertText(replacement, replacementRange: range)
             }
-        }
-
-        // Re-strip drag types after any attribute change that may cause
-        // TextKit to re-register them. Also strip after external text
-        // replacement since NSTextStorage manipulation can trigger
-        // re-registration.
-        if fontChanged || colorChanged || textWasExternallyReplaced {
-            textView.unregisterDraggedTypes()
         }
 
         // --- Focus (guarded — only schedules work when intent changed) ---

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -138,5 +138,15 @@ final class ComposerTextView: NSTextView {
         let hasImageData = pasteboard.data(forType: .png) != nil || pasteboard.data(forType: .tiff) != nil
         return hasImageFile || hasImageData
     }
+
+    // MARK: - Drag Rejection
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        return []
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        return false
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerTextView.swift
@@ -145,6 +145,10 @@ final class ComposerTextView: NSTextView {
         return []
     }
 
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        return []
+    }
+
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         return false
     }


### PR DESCRIPTION
## Summary
- Fix bug where dropping files/folders directly onto the chat composer inserts their filesystem path as text instead of attaching them
- Add shift+drop modifier that intentionally inserts file paths as text (power-user workflow for referencing local directories)
- Drop overlay dynamically shows "Drop to insert path" hint when Shift is held

## Self-review result
PASS — 3 integration gaps found and fixed across 2 fix PRs

## PRs merged into feature branch
- #29832: fix(composer): prevent NSTextView from intercepting file drops
- #29836: feat(composer): hold Shift during drop to insert file paths as text

### Fix PRs
- #29850: fix: add draggingUpdated override to ComposerTextView
- #29851: fix: shift monitor leak guard + newline-separated drop paths

Part of plan: drag-drop-attach.md