### PR TITLE
fix(macos): scope disable-library-validation to local builds only

### DIFF
--- a/clients/macos/app-entitlements.plist
+++ b/clients/macos/app-entitlements.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.virtualization</key>

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -2142,6 +2142,7 @@ else
     cp "$SCRIPT_DIR/app-entitlements.plist" "$APP_ENTITLEMENTS_PATH"
     cp "$SCRIPT_DIR/daemon-entitlements.plist" "$DAEMON_ENTITLEMENTS_PATH"
     /usr/libexec/PlistBuddy -c "Add :com.apple.security.get-task-allow bool true" "$APP_ENTITLEMENTS_PATH"
+    /usr/libexec/PlistBuddy -c "Add :com.apple.security.cs.disable-library-validation bool true" "$APP_ENTITLEMENTS_PATH"
     /usr/libexec/PlistBuddy -c "Add :com.apple.security.get-task-allow bool true" "$DAEMON_ENTITLEMENTS_PATH"
 fi
 


### PR DESCRIPTION
## Summary
- Remove `com.apple.security.cs.disable-library-validation` from `app-entitlements.plist` (was applying to all builds including release)
- Add it via PlistBuddy in the debug/local entitlements path in `build.sh`, alongside the existing `get-task-allow` injection
- Release builds retain full library validation; local ad-hoc builds get the exemption they need

## Original prompt
The previous fix (#29852) added `disable-library-validation` to the base entitlements plist, which applied it to both release and local builds. Release builds don't need it since the build script re-signs Sparkle with the same team identity. The user asked to scope the entitlement to local builds only to avoid unnecessarily weakening the security posture of release builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->