### PR TITLE
[codex] Fix Gmail OAuth wake completion state

### DIFF
--- a/assistant/src/daemon/__tests__/wake-target-adapter.test.ts
+++ b/assistant/src/daemon/__tests__/wake-target-adapter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { AgentEvent } from "../../agent/loop.js";
+import type { ServerMessage } from "../message-protocol.js";
+
+const broadcastedMessages: ServerMessage[] = [];
+
+mock.module("../../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (message: ServerMessage) => {
+    broadcastedMessages.push(message);
+  },
+}));
+
+mock.module("../../memory/conversation-crud.js", () => ({
+  addMessage: async () => ({ id: "msg-1" }),
+  getConversation: () => null,
+  provenanceFromTrustContext: () => ({}),
+}));
+
+mock.module("../../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => ({
+    warn: () => {},
+  }),
+}));
+
+import { conversationToWakeTarget } from "../wake-target-adapter.js";
+
+describe("conversationToWakeTarget", () => {
+  test("marks wake message_complete frames as main-turn completions", () => {
+    broadcastedMessages.length = 0;
+
+    const target = conversationToWakeTarget({
+      conversationId: "conv-wake",
+      agentLoop: {},
+      getMessages: () => [],
+      messages: [],
+      isProcessing: () => false,
+      processing: false,
+      setTrustContext: () => {},
+      getTurnChannelContext: () => null,
+      getTurnInterfaceContext: () => null,
+      drainQueue: async () => {},
+    } as never);
+
+    target.emitAgentEvent({
+      type: "message_complete",
+      message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+    } as Extract<AgentEvent, { type: "message_complete" }>);
+
+    expect(broadcastedMessages).toEqual([
+      {
+        type: "message_complete",
+        conversationId: "conv-wake",
+        source: "main",
+      },
+    ]);
+  });
+});

--- a/assistant/src/daemon/wake-target-adapter.ts
+++ b/assistant/src/daemon/wake-target-adapter.ts
@@ -130,6 +130,7 @@ function translateAgentEventToServerMessage(
       return {
         type: "message_complete",
         conversationId,
+        source: "main",
       };
     case "input_json_delta":
     case "usage":

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -264,6 +264,82 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isThinking)
     }
 
+    func testExplicitMainMessageCompleteWithoutMessageIdClearsWakeToolTurn() {
+        viewModel.conversationId = "sess-wake"
+
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(
+            type: "tool_use_start",
+            toolName: "recall",
+            input: ["query": AnyCodable("Google account connection")],
+            conversationId: "sess-wake",
+            toolUseId: "tu-wake"
+        )))
+        XCTAssertTrue(viewModel.isAssistantBusy)
+
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(
+            type: "tool_result",
+            toolName: "recall",
+            result: "Found evidence",
+            isError: nil,
+            diff: nil,
+            status: nil,
+            conversationId: "sess-wake",
+            toolUseId: "tu-wake"
+        )))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(
+            text: "Google account is now connected.",
+            conversationId: "sess-wake"
+        )))
+
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(
+            conversationId: "sess-wake",
+            source: "main"
+        )))
+
+        XCTAssertNil(viewModel.currentAssistantMessageId)
+        XCTAssertFalse(viewModel.isAssistantBusy)
+    }
+
+    func testLegacyMessageCompleteWithoutMessageIdDoesNotClearActiveToolTurn() {
+        viewModel.conversationId = "sess-wake"
+
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(
+            type: "tool_use_start",
+            toolName: "recall",
+            input: ["query": AnyCodable("Google account connection")],
+            conversationId: "sess-wake",
+            toolUseId: "tu-wake"
+        )))
+
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(
+            conversationId: "sess-wake"
+        )))
+
+        XCTAssertNotNil(viewModel.currentAssistantMessageId)
+        XCTAssertTrue(viewModel.isAssistantBusy)
+    }
+
+    func testAuxMessageCompleteWithMessageIdDoesNotClearActiveToolTurn() {
+        viewModel.conversationId = "sess-wake"
+
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(
+            type: "tool_use_start",
+            toolName: "recall",
+            input: ["query": AnyCodable("Google account connection")],
+            conversationId: "sess-wake",
+            toolUseId: "tu-wake"
+        )))
+
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage(
+            conversationId: "sess-wake",
+            messageId: "aux-message",
+            source: "aux"
+        )))
+
+        XCTAssertNotNil(viewModel.currentAssistantMessageId)
+        XCTAssertTrue(viewModel.isAssistantBusy)
+    }
+
     // MARK: - Generation Cancelled
 
     func testGenerationCancelledClearsLoadingState() {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -493,7 +493,9 @@ final class ChatActionHandler {
         // is set) OR still in the thinking phase (isThinking is true but
         // currentAssistantMessageId hasn't been set yet by the first streaming flush).
         // This allows slash commands and other non-auxiliary completions to process normally.
-        if (complete.messageId == nil || complete.source == "aux") && (vm.currentAssistantMessageId != nil || vm.isThinking) {
+        let isActiveTurn = vm.currentAssistantMessageId != nil || vm.isThinking
+        let isLegacyNilMessageIdComplete = complete.messageId == nil && complete.source == nil
+        if (complete.source == "aux" || isLegacyNilMessageIdComplete) && isActiveTurn {
             return
         }
         vm.idleFallbackTask?.cancel()


### PR DESCRIPTION
## Summary

- mark background wake `message_complete` frames as explicit `source: "main"`
- allow macOS to clear an active turn for explicit main completions even when `messageId` is absent
- add daemon and macOS regression coverage for main, legacy nil-messageId, and aux completion behavior

## Root Cause

`google-email-management` completed Gmail OAuth successfully, but the background wake path emitted a `message_complete` without a `messageId`. The macOS client recently learned to ignore nil-`messageId` completions while a turn is active because those can be auxiliary notifier completions. Since the wake completion had no explicit `source`, the client ignored it, kept the conversation in "Working on it...", and the follow-up inbox prompt never reached the daemon.

This keeps the recent auxiliary-completion fix intact by making `source` the discriminator:

- `source: "aux"` still does not clear active turn state
- legacy nil-`messageId` completions with no source still do not clear active turn state
- explicit `source: "main"` completions clear active turn state even without a `messageId`

## Validation

- `bun test src/daemon/__tests__/wake-target-adapter.test.ts`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients --filter "ChatViewModelTests/test(ExplicitMainMessageCompleteWithoutMessageIdClearsWakeToolTurn|LegacyMessageCompleteWithoutMessageIdDoesNotClearActiveToolTurn|AuxMessageCompleteWithMessageIdDoesNotClearActiveToolTurn)"`
- pre-push hook: Swift build for `clients/`, assistant typecheck, assistant lint
