### PR TITLE
fix: persist surface completion for all one-shot interactive types

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -3,16 +3,16 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ServerMessage } from "../daemon/message-protocol.js";
 
 let broadcastedMessages: ServerMessage[] = [];
+const realEventHub = await import("../runtime/assistant-event-hub.js");
 mock.module("../runtime/assistant-event-hub.js", () => ({
+  ...realEventHub,
   broadcastMessage: (msg: ServerMessage) => broadcastedMessages.push(msg),
 }));
 
-import {
-  createSurfaceMutex,
-  handleSurfaceAction,
-  type SurfaceConversationContext,
-  surfaceProxyResolver,
-} from "../daemon/conversation-surfaces.js";
+const { createSurfaceMutex, handleSurfaceAction, surfaceProxyResolver } =
+  await import("../daemon/conversation-surfaces.js");
+
+import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type {
   SurfaceData,
   SurfaceType,

--- a/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-action-delivery.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+let broadcastedMessages: ServerMessage[] = [];
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (msg: ServerMessage) => broadcastedMessages.push(msg),
+}));
 
 import {
   createSurfaceMutex,
@@ -7,7 +14,6 @@ import {
   surfaceProxyResolver,
 } from "../daemon/conversation-surfaces.js";
 import type {
-  ServerMessage,
   SurfaceData,
   SurfaceType,
   UiSurfaceShow,
@@ -81,6 +87,10 @@ function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext & {
 }
 
 describe("surface action delivery to assistant", () => {
+  beforeEach(() => {
+    broadcastedMessages = [];
+  });
+
   test("table action button click triggers processMessage with action content", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);
@@ -198,5 +208,156 @@ describe("surface action delivery to assistant", () => {
     expect(ctx.processMessageCalls[0].content).toContain(
       "[User action on app:",
     );
+  });
+
+  test("confirmation surface broadcasts ui_surface_complete on action", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const showResult = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "confirmation",
+      title: "Delete files?",
+      data: {
+        message: "This will permanently delete 3 files.",
+        confirmLabel: "Delete",
+        cancelLabel: "Keep",
+      },
+    });
+
+    expect(showResult.isError).toBe(false);
+    expect(showResult.yieldToUser).toBe(true);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+    await handleSurfaceAction(ctx, surfaceId, "confirm", {});
+
+    const completeMsg = broadcastedMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type ===
+          "ui_surface_complete" &&
+        (m as unknown as Record<string, unknown>).surfaceId === surfaceId,
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg?.conversationId).toBe("conv-1");
+    expect(completeMsg?.summary).toContain("Delete");
+  });
+
+  test("file_upload surface broadcasts ui_surface_complete on action", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const showResult = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "file_upload",
+      title: "Upload documents",
+      data: { accept: ".pdf,.docx", maxFiles: 5 },
+    });
+
+    expect(showResult.isError).toBe(false);
+    expect(showResult.yieldToUser).toBe(true);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+    expect(ctx.pendingSurfaceActions.has(surfaceId)).toBe(true);
+
+    await handleSurfaceAction(ctx, surfaceId, "submit", {
+      files: [
+        {
+          filename: "doc.pdf",
+          mimeType: "application/pdf",
+          data: "base64encodedcontent",
+        },
+      ],
+    });
+
+    const completeMsg = broadcastedMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type ===
+          "ui_surface_complete" &&
+        (m as unknown as Record<string, unknown>).surfaceId === surfaceId,
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(completeMsg).toBeDefined();
+    expect(completeMsg?.conversationId).toBe("conv-1");
+  });
+
+  test("file_upload completion event does not include base64 file blobs", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "file_upload",
+      title: "Upload",
+      data: { accept: "*" },
+    });
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+
+    const largeBase64 = "A".repeat(10_000);
+    await handleSurfaceAction(ctx, surfaceId, "submit", {
+      files: [
+        {
+          filename: "big.pdf",
+          mimeType: "application/pdf",
+          data: largeBase64,
+        },
+      ],
+    });
+
+    const completeMsg = broadcastedMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type ===
+          "ui_surface_complete" &&
+        (m as unknown as Record<string, unknown>).surfaceId === surfaceId,
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(completeMsg).toBeDefined();
+
+    const submittedData = completeMsg?.submittedData as
+      | Record<string, unknown>
+      | undefined;
+    // The files array with base64 blobs should be stripped from the
+    // completion event — only the sanitized payload (without files) is sent.
+    expect(submittedData?.files).toBeUndefined();
+    // The raw base64 content should not appear anywhere in the event
+    expect(JSON.stringify(completeMsg)).not.toContain(largeBase64);
+  });
+
+  test("table surface does NOT broadcast ui_surface_complete (not one-shot)", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "table",
+      title: "Items",
+      data: {
+        columns: [{ id: "name", label: "Name" }],
+        rows: [{ id: "r1", cells: { name: "Item 1" } }],
+      },
+      actions: [{ id: "select", label: "Select" }],
+    });
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    ) as UiSurfaceShow;
+    const surfaceId = showMessage.surfaceId;
+
+    broadcastedMessages = [];
+    await handleSurfaceAction(ctx, surfaceId, "select", {
+      selectedIds: ["r1"],
+    });
+
+    const completeMsg = broadcastedMessages.find(
+      (m) =>
+        (m as unknown as Record<string, unknown>).type ===
+        "ui_surface_complete",
+    );
+    expect(completeMsg).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ServerMessage } from "../daemon/message-protocol.js";
 
+const realEventHub = await import("../runtime/assistant-event-hub.js");
+
 mock.module("../runtime/assistant-event-hub.js", () => ({
+  ...realEventHub,
   broadcastMessage: (_msg: ServerMessage) => {},
 }));
 

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { ServerMessage } from "../daemon/message-protocol.js";
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: (_msg: ServerMessage) => {},
+}));
+
 // Mock the persistence layer the surface helpers reach into so we can
 // observe writes without touching SQLite. We swap this out per test by
 // re-assigning the spies recorded on the closure below.
@@ -29,8 +35,10 @@ const {
   flushPendingSurfaceDataPersists,
   createSurfaceMutex,
   flushSurfaceDataPersist,
+  handleSurfaceAction,
   markSurfaceCompleted,
   scheduleSurfaceDataPersist,
+  showStandaloneSurface,
   surfaceProxyResolver,
 } = await import("../daemon/conversation-surfaces.js");
 
@@ -60,6 +68,8 @@ function makeContext(sent: ServerMessage[] = []): SurfaceConversationContext {
     accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
     surfaceActionRequestIds: new Set<string>(),
     currentTurnSurfaces: [],
+    pendingStandaloneSurfaces: new Map(),
+    recentlyCompletedStandaloneSurfaces: new Map(),
     isProcessing: () => false,
     enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
     getQueueDepth: () => 0,
@@ -400,5 +410,65 @@ describe("ui_surface_update persistence", () => {
 
     // Cleanup the other conversation's timer.
     cancelPendingSurfaceDataPersists("conv-other");
+  });
+});
+
+describe("standalone surface DB persistence", () => {
+  let writes: Array<{ id: string; content: unknown }> = [];
+
+  beforeEach(() => {
+    writes = [];
+    updateMessageContentSpy = (id: string, content: string) => {
+      writes.push({ id, content: JSON.parse(content) });
+    };
+    getMessagesImpl = () => [];
+    cancelPendingSurfaceDataPersists();
+  });
+
+  afterEach(() => {
+    cancelPendingSurfaceDataPersists();
+  });
+
+  test("standalone surface action persists completed state to DB", async () => {
+    const ctx = makeContext();
+    const surfaceId = "standalone-persist-1";
+
+    seedRows([
+      {
+        id: "msg-standalone",
+        content: [
+          { type: "text", text: "confirm this" },
+          {
+            type: "ui_surface",
+            surfaceId,
+            surfaceType: "confirmation",
+            data: { message: "Proceed?" },
+          },
+        ],
+      },
+    ]);
+
+    const resultPromise = showStandaloneSurface(
+      ctx,
+      {
+        conversationId: "conv-persist-1",
+        surfaceType: "confirmation",
+        data: { message: "Proceed?" },
+        timeoutMs: 60_000,
+      },
+      surfaceId,
+    );
+
+    await handleSurfaceAction(ctx, surfaceId, "confirm", {});
+    const result = await resultPromise;
+    expect(result.status).toBe("submitted");
+
+    expect(writes.length).toBeGreaterThanOrEqual(1);
+    const finalBlocks = writes[writes.length - 1].content as Array<
+      Record<string, unknown>
+    >;
+    const surfaceBlock = finalBlocks.find((b) => b.type === "ui_surface")!;
+    expect(surfaceBlock.completed).toBe(true);
+    expect(surfaceBlock.completionSummary).toBe("Confirmed");
   });
 });

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -45,7 +45,6 @@ const {
 import type { SurfaceConversationContext } from "../daemon/conversation-surfaces.js";
 import type {
   CardSurfaceData,
-  ServerMessage,
   SurfaceData,
   SurfaceType,
 } from "../daemon/message-protocol.js";

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1159,6 +1159,7 @@ export async function handleSurfaceAction(
       summary,
       submittedData: data,
     });
+    markSurfaceCompleted(ctx, surfaceId, summary);
 
     // Cleanup and resolve — order matters: cleanup clears the timer
     // before resolve() unblocks the caller.
@@ -1505,10 +1506,12 @@ export async function handleSurfaceAction(
     surfaceData,
   );
 
-  // Forms are one-shot surfaces — auto-complete immediately so the client
-  // transitions from the "Submitting…" spinner to a completion chip without
-  // requiring the LLM to call ui_dismiss.
-  if (pending.surfaceType === "form") {
+  // One-shot interactive surfaces — auto-complete immediately so the client
+  // transitions to a completion chip without requiring the LLM to call
+  // ui_dismiss. Forms, confirmations, and file uploads are all terminal
+  // after a single user action.
+  const ONE_SHOT_SURFACE_TYPES = ["form", "confirmation", "file_upload"];
+  if (ONE_SHOT_SURFACE_TYPES.includes(pending.surfaceType)) {
     broadcastMessage({
       type: "ui_surface_complete",
       conversationId: ctx.conversationId,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1506,22 +1506,6 @@ export async function handleSurfaceAction(
     surfaceData,
   );
 
-  // One-shot interactive surfaces — auto-complete immediately so the client
-  // transitions to a completion chip without requiring the LLM to call
-  // ui_dismiss. Forms, confirmations, and file uploads are all terminal
-  // after a single user action.
-  const ONE_SHOT_SURFACE_TYPES = ["form", "confirmation", "file_upload"];
-  if (ONE_SHOT_SURFACE_TYPES.includes(pending.surfaceType)) {
-    broadcastMessage({
-      type: "ui_surface_complete",
-      conversationId: ctx.conversationId,
-      surfaceId,
-      summary,
-      submittedData: mergedData,
-    });
-    markSurfaceCompleted(ctx, surfaceId, summary);
-  }
-
   // Extract file attachments from action data so they are sent as proper
   // image/file content blocks instead of dumping base64 into the text.
   let pendingAttachments: UserMessageAttachment[] = [];
@@ -1649,6 +1633,21 @@ export async function handleSurfaceAction(
   if (result.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
     return;
+  }
+
+  // One-shot interactive surfaces — auto-complete now that the message has
+  // been accepted. Deferred until after rejection check so the surface stays
+  // active and retryable if the queue was full.
+  const ONE_SHOT_SURFACE_TYPES = ["form", "confirmation", "file_upload"];
+  if (ONE_SHOT_SURFACE_TYPES.includes(pending.surfaceType)) {
+    broadcastMessage({
+      type: "ui_surface_complete",
+      conversationId: ctx.conversationId,
+      surfaceId,
+      summary,
+      submittedData: mergedData,
+    });
+    markSurfaceCompleted(ctx, surfaceId, summary);
   }
 
   // One-shot: clear accumulated state now that the message has been accepted.

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1645,7 +1645,7 @@ export async function handleSurfaceAction(
       conversationId: ctx.conversationId,
       surfaceId,
       summary,
-      submittedData: mergedData,
+      submittedData: mergedDataForText,
     });
     markSurfaceCompleted(ctx, surfaceId, summary);
   }


### PR DESCRIPTION
## Summary
- Expand `markSurfaceCompleted` DB persistence from form-only to all one-shot interactive surface types (form, confirmation, file_upload)
- Add `markSurfaceCompleted` to the standalone surface resolution path, which was broadcasting `ui_surface_complete` via SSE but never persisting to DB

Previously, confirmation and file_upload surfaces lost their completion state on conversation reload — the `completed: true` flag was only set in-memory via the SSE broadcast but never written to the message content block in the DB. On reload from history, these surfaces reappeared with active buttons instead of showing the completion chip.

No behavior change for macOS — `InlineSurfaceRouter` already handles `completionState` and renders `CompletedSurfaceChip` when present. This just ensures the data is there on reload.

## Test plan
- [x] All 32 existing surface tests pass (`conversation-surfaces-standalone`, `conversation-surfaces-action-delivery`, `conversation-surfaces-data-persist`)
- [x] Type check passes
- [x] Lint passes
- [ ] Manual: act on a confirmation surface → switch conversations → return → verify completed chip persists
- [ ] Manual: act on a file_upload surface → reload page → verify completed chip persists
- [ ] Manual: verify form surfaces still work as before (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->