### PR TITLE
fix(macos): stop clobbering dock-display-name during gateway cold start

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -945,6 +945,25 @@ KATA_KERNEL_BUNDLE_DIR="$RESOURCES_DIR/DeveloperVM"
 echo "BUNDLE_DISPLAY_NAME=$BUNDLE_DISPLAY_NAME"
 
 # ---------------------------------------------------------------------------
+# Defense in depth: remove sibling .app bundles in dist/ that share our
+# bundle ID. Different `BUNDLE_DISPLAY_NAME` values produce different bundle
+# paths but share `CFBundleIdentifier`, so a previous build under a different
+# display name (e.g. a persona name like "Jarvis.app") sits next to the new
+# one. Both can be launched and registered with Launch Services, producing
+# duplicate Dock entries with the same identity. AppBundleRenamer.swift has
+# the same cleanup but only runs on the sign-out / no-assistants path.
+# ---------------------------------------------------------------------------
+for stale in "$SCRIPT_DIR/dist"/*.app; do
+    [ -d "$stale" ] || continue
+    [ "$stale" = "$APP_DIR" ] && continue
+    stale_id=$(plutil -extract CFBundleIdentifier raw "$stale/Contents/Info.plist" 2>/dev/null || true)
+    if [ "$stale_id" = "$BUNDLE_ID" ]; then
+        echo "Removing stale bundle with matching ID: $stale"
+        rm -rf "$stale"
+    fi
+done
+
+# ---------------------------------------------------------------------------
 # Local Sparkle configuration
 #
 # For local builds, point the Sparkle appcast at a localhost route served by

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -481,7 +481,11 @@ final class AvatarAppearanceManager {
         assistantName = "V"
         AvatarCache.clearAll()
         updateDockIcon()
-        updateDockLabel()
+        // Explicit reset: drop the persisted dock label so the next build
+        // falls back to the env-default ("Vellum"/"Vellum Dev"). `updateDockLabel`
+        // intentionally no-ops on the "V" sentinel to avoid clobbering during
+        // the cold-start gateway race, so we delete here instead.
+        try? FileManager.default.removeItem(at: Self.dockDisplayNameURL)
     }
 
     // MARK: - Local Cache Hydration
@@ -651,9 +655,6 @@ final class AvatarAppearanceManager {
 
     // MARK: - Dock Label
 
-    /// Default app name used for the dock label when no assistant is connected.
-    private static let defaultDockLabel = "Vellum"
-
     /// Sentinel file that `build.sh` reads at build time to set
     /// `CFBundleDisplayName` so the Dock shows the assistant name from
     /// the very first launch after a rebuild.
@@ -675,11 +676,20 @@ final class AvatarAppearanceManager {
     /// TCC permissions (Accessibility, Screen Recording, Microphone) and
     /// Gatekeeper. The dock label only takes effect after a rebuild.
     private func updateDockLabel() {
-        let label = assistantName != "V" ? assistantName : Self.defaultDockLabel
+        // Only persist a resolved persona name. Writing a "Vellum" fallback
+        // here would clobber a previously-good value during the gateway
+        // cold-start race window — `IdentityInfo.loadAsync()` is a gateway
+        // HTTP call, and when the daemon/gateway aren't up yet it returns
+        // nil and `assistantName` collapses to "V". Overwriting at that
+        // point causes the next rebuild's `build.sh` to read "Vellum" and
+        // produce `Vellum.app` alongside the existing persona-named bundle.
+        // `cli/src/commands/retire.ts` deletes this file when the last
+        // assistant is retired, so no default write is needed either.
+        guard assistantName != "V" else { return }
 
         let dir = Self.dockDisplayNameURL.deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        try? label.write(to: Self.dockDisplayNameURL, atomically: true, encoding: .utf8)
+        try? assistantName.write(to: Self.dockDisplayNameURL, atomically: true, encoding: .utf8)
     }
 
     // MARK: - Image Utilities


### PR DESCRIPTION
## Summary
- Guard `AvatarAppearanceManager.updateDockLabel()` so it no-ops on the "V" sentinel, preventing the gateway-cold-start race from overwriting a previously-resolved persona name with "Vellum".
- Move the explicit reset-on-disconnect semantics into `resetForDisconnect()` by deleting the dock-display-name file directly, since `updateDockLabel()` no longer writes the default.
- Add a defense-in-depth loop in `clients/macos/build.sh` that removes sibling `dist/*.app` bundles sharing our `CFBundleIdentifier` before building, so a stale persona-named bundle can't survive a rebuild that produced a differently-named one.

## Original prompt
The user reported recurring duplicate Dock entries on macOS — one labeled with the brand name (responsive) and one labeled with the persona name (stuck on loading), both running under the same `CFBundleIdentifier`. After manual cleanup the bug returned within hours. The investigation traced it to `AvatarAppearanceManager.start()` calling `IdentityInfo.loadAsync()` (a gateway HTTP call) before the daemon/gateway were ready, returning nil, falling back to the "V" sentinel, and writing the brand-default to `dock-display-name` — so the next `/update` rebuilt under that name next to the existing persona-named bundle. The user asked to fix this for real so it stops recurring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->