### PR TITLE
Guard release notes for flagged features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,10 @@ The assistant's container root (`/`) stores per-container ephemeral and persiste
 
 Release notes for user/assistant-facing changes ship via **workspace migrations**. There is no bundled template to edit and no checkpoint state to clear — the notes are just a migration that writes to `<workspace>/UPDATES.md`.
 
+**Do not ship release notes for feature-flagged or rollout-only features.** `UPDATES.md` is processed by the assistant without checking the feature flag that may guard the underlying feature, so release-note copy for disabled features can still leak into user-facing prompts. If a feature is still controlled by a default-disabled assistant flag or rollout flag, skip the release-note migration. When the feature actually GAs, add a new append-only release-note migration with a new marker; never change an already-shipped migration id from no-op back to writing release notes.
+
+The guard test `assistant/src/__tests__/workspace-release-notes-feature-flag-guard.test.ts` blocks new release-note migrations that mention flag/rollout launch language or default-disabled assistant feature flag keys. Prefer removing that copy and waiting for GA. Only extend the legacy allowlist for a bulletin that already shipped before the guard existed.
+
 **To ship release notes:**
 
 1. Add a new migration file at `assistant/src/workspace/migrations/0XX-release-notes-<slug>.ts`. Use the next available sequence number (migrations are append-only). Put the release-note text inline as a string literal inside the migration and append it to `UPDATES.md` in the migration's `run()`.

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7681,8 +7681,7 @@ paths:
     post:
       operationId: memory_v2_reembedskills_post
       summary: Re-seed v2 skill entries from the current skill catalog
-      description:
-        Synchronously re-runs seedV2SkillEntries against the current skill catalog. Gated on config.memory.v2.enabled.
+      description: Synchronously re-runs seedV2SkillEntries against the current skill catalog. Gated on config.memory.v2.enabled.
       tags:
         - memory
       responses:

--- a/assistant/src/__tests__/workspace-release-notes-feature-flag-guard.test.ts
+++ b/assistant/src/__tests__/workspace-release-notes-feature-flag-guard.test.ts
@@ -1,0 +1,115 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+type Registry = {
+  flags: Array<{
+    key: string;
+    scope: string;
+    defaultEnabled: boolean;
+  }>;
+};
+
+const LEGACY_FLAGGED_RELEASE_NOTE_ALLOWLIST = new Map<string, string>([
+  [
+    "045-release-notes-meet-avatar.ts",
+    "Historical bulletin that already shipped before this guard existed.",
+  ],
+]);
+
+const FLAGGED_FEATURE_LANGUAGE_PATTERNS: Array<{
+  label: string;
+  pattern: RegExp;
+}> = [
+  { label: "feature flag", pattern: /\bfeature[- ]flag(?:ged)?\b/i },
+  { label: "rollout flag", pattern: /\brollout flag\b/i },
+  { label: "behind ... flag", pattern: /\bbehind\b[^\n.]{0,120}\bflag\b/i },
+  { label: "gated on", pattern: /\bgated on\b/i },
+  { label: "when enabled", pattern: /\bwhen enabled\b/i },
+];
+
+function getRepoRoot(): string {
+  return join(process.cwd(), "..");
+}
+
+function getReleaseNoteMigrationFiles(): string[] {
+  const migrationsDir = join(process.cwd(), "src", "workspace", "migrations");
+  return readdirSync(migrationsDir)
+    .filter((fileName) => /^\d+-release-notes-[a-z0-9-]+\.ts$/.test(fileName))
+    .sort();
+}
+
+function loadDefaultDisabledAssistantFlagKeys(): string[] {
+  const registryPath = join(
+    getRepoRoot(),
+    "meta",
+    "feature-flags",
+    "feature-flag-registry.json",
+  );
+  const registry = JSON.parse(readFileSync(registryPath, "utf-8")) as Registry;
+  return registry.flags
+    .filter((flag) => flag.scope === "assistant" && !flag.defaultEnabled)
+    .map((flag) => flag.key)
+    .sort();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function featureFlagKeyPattern(key: string): RegExp {
+  const escaped = escapeRegExp(key);
+  if (key.includes("-")) {
+    return new RegExp(`(?:^|[^a-z0-9-])${escaped}(?:$|[^a-z0-9-])`, "i");
+  }
+
+  return new RegExp("[`'\"]" + escaped + "[`'\"]", "i");
+}
+
+describe("workspace release-note migrations feature flag guard", () => {
+  test("new release-note migrations do not announce default-disabled feature-flagged work", () => {
+    const migrationsDir = join(process.cwd(), "src", "workspace", "migrations");
+    const defaultDisabledFlagKeys = loadDefaultDisabledAssistantFlagKeys();
+    const violations: string[] = [];
+
+    for (const fileName of getReleaseNoteMigrationFiles()) {
+      if (LEGACY_FLAGGED_RELEASE_NOTE_ALLOWLIST.has(fileName)) {
+        continue;
+      }
+
+      const content = readFileSync(join(migrationsDir, fileName), "utf-8");
+
+      for (const { label, pattern } of FLAGGED_FEATURE_LANGUAGE_PATTERNS) {
+        if (pattern.test(content)) {
+          violations.push(
+            `${fileName}: contains flagged-feature language "${label}"`,
+          );
+        }
+      }
+
+      for (const key of defaultDisabledFlagKeys) {
+        if (featureFlagKeyPattern(key).test(content)) {
+          violations.push(
+            `${fileName}: references default-disabled assistant feature flag "${key}"`,
+          );
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const message = [
+        "Release-note migrations write to UPDATES.md, which is processed without checking feature flags.",
+        "Do not announce features that are still behind default-disabled assistant flags or rollout flags.",
+        "Wait until GA and add a new append-only release-note migration with a new marker.",
+        "",
+        "Violations:",
+        ...violations.map((violation) => `  - ${violation}`),
+        "",
+        "If this is an already-shipped historical bulletin, add a narrow entry to",
+        "LEGACY_FLAGGED_RELEASE_NOTE_ALLOWLIST in workspace-release-notes-feature-flag-guard.test.ts.",
+      ].join("\n");
+
+      expect(violations, message).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a static guard test that blocks new release-note migrations from announcing default-disabled assistant feature-flagged work.
- Detect explicit flag/rollout language and references to default-disabled assistant feature flag keys in release-note migration files.
- Document the release-note rule in AGENTS.md, including the GA/new-marker requirement.
- Refresh OpenAPI YAML formatting generated by `bun run generate:openapi` so the existing spec check passes.

## Verification
- cd assistant && bun test src/__tests__/workspace-release-notes-feature-flag-guard.test.ts
- cd assistant && bunx eslint src/__tests__/workspace-release-notes-feature-flag-guard.test.ts
- cd assistant && bunx tsc --noEmit
- cd assistant && bun run generate:openapi -- --check