### PR TITLE
[LUM-1409] Refresh Contacts tab UI with Settings-card design (macOS)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/AssistantChannelsDetailView.swift
@@ -151,24 +151,14 @@ struct AssistantChannelsDetailView: View {
     }
 
     /// Contacts tab layout: compact row list with dividers, no ScrollView (container scrolls).
+    /// The parent SettingsCard provides the "Channels" title/subtitle header.
     private var flatLayout: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Channels")
-                    .font(VFont.titleSmall)
-                    .foregroundStyle(VColor.contentDefault)
-                Text("Manage where \(assistantName) can be reached.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-
-            VStack(alignment: .leading, spacing: 0) {
-                slackRow
-                SettingsDivider()
-                telegramRow
-                SettingsDivider()
-                voiceRow
-            }
+        VStack(alignment: .leading, spacing: 0) {
+            slackRow
+            SettingsDivider()
+            telegramRow
+            SettingsDivider()
+            voiceRow
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -32,24 +32,52 @@ struct ContactDetailView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                headerSection
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.bottom, VSpacing.lg)
+                // Header card: name, badge, interaction count, editable fields, actions
+                SettingsCard(
+                    title: displayContact.displayName,
+                    subtitle: "\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")"
+                ) {
+                    HStack(spacing: VSpacing.sm) {
+                        contactTypeBadge
+                        VButton(
+                            label: "Delete",
+                            iconOnly: VIcon.trash.rawValue,
+                            style: .dangerGhost,
+                            isDisabled: isDeleting,
+                            tooltip: "Delete Contact"
+                        ) {
+                            if displayContact.displayName == "New Contact" && displayContact.channels.isEmpty && displayContact.interactionCount == 0 {
+                                deleteContact()
+                            } else {
+                                showDeleteConfirmation = true
+                            }
+                        }
+                    }
+                } content: {
+                    headerFields
+                    headerActions
+                }
 
-                GuardianChannelsDetailView(
-                    contact: displayContact,
-                    connectionManager: connectionManager,
-                    store: store,
-                    conversationManager: conversationManager,
-                    onSelectAssistant: onSelectAssistant,
-                    showCardBorders: false
-                )
-                .padding(VSpacing.lg)
+                // Channels card
+                SettingsCard(
+                    title: "Channels",
+                    subtitle: "Once verified, your assistant will recognize this contact when they message from these channels."
+                ) {
+                    GuardianChannelsDetailView(
+                        contact: displayContact,
+                        connectionManager: connectionManager,
+                        store: store,
+                        conversationManager: conversationManager,
+                        onSelectAssistant: onSelectAssistant,
+                        showCardBorders: false
+                    )
+                }
 
                 if let errorMessage {
                     VNotification(errorMessage, tone: .negative)
                 }
             }
+            .padding(VSpacing.lg)
         }
         .scrollContentBackground(.hidden)
         .contentMargins(0)
@@ -85,19 +113,7 @@ struct ContactDetailView: View {
             focusTask?.cancel()
             focusTask = nil
         }
-    }
-
-    // MARK: - Header Section
-
-    private var headerSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.lg) {
-            headerTitle
-            headerFields
-            headerActions
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
-            // Leave name empty for placeholder contacts so the placeholder text shows
             let name = displayContact.displayName
             let isNewContact = name == "New Contact"
             editedName = isNewContact ? "" : name
@@ -113,36 +129,7 @@ struct ContactDetailView: View {
         }
     }
 
-    private var headerTitle: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                HStack(spacing: VSpacing.sm) {
-                    Text(displayContact.displayName)
-                        .font(VFont.titleSmall)
-                        .foregroundStyle(VColor.contentDefault)
-                    contactTypeBadge
-                }
-                Text("\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-            Spacer()
-            VButton(
-                label: "Delete",
-                iconOnly: VIcon.trash.rawValue,
-                style: .dangerGhost,
-                isDisabled: isDeleting,
-                tooltip: "Delete Contact"
-            ) {
-                // Skip confirmation for empty/placeholder contacts
-                if displayContact.displayName == "New Contact" && displayContact.channels.isEmpty && displayContact.interactionCount == 0 {
-                    deleteContact()
-                } else {
-                    showDeleteConfirmation = true
-                }
-            }
-        }
-    }
+    // MARK: - Header Fields & Actions
 
     private var headerFields: some View {
         VStack(alignment: .leading, spacing: VSpacing.md) {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -37,22 +37,7 @@ struct ContactDetailView: View {
                     title: displayContact.displayName,
                     subtitle: "\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")"
                 ) {
-                    HStack(spacing: VSpacing.sm) {
-                        contactTypeBadge
-                        VButton(
-                            label: "Delete",
-                            iconOnly: VIcon.trash.rawValue,
-                            style: .dangerGhost,
-                            isDisabled: isDeleting,
-                            tooltip: "Delete Contact"
-                        ) {
-                            if displayContact.displayName == "New Contact" && displayContact.channels.isEmpty && displayContact.interactionCount == 0 {
-                                deleteContact()
-                            } else {
-                                showDeleteConfirmation = true
-                            }
-                        }
-                    }
+                    contactTypeBadge
                 } content: {
                     headerFields
                     headerActions
@@ -69,7 +54,8 @@ struct ContactDetailView: View {
                         store: store,
                         conversationManager: conversationManager,
                         onSelectAssistant: onSelectAssistant,
-                        showCardBorders: false
+                        showCardBorders: false,
+                        setupButtonLabel: "Invite"
                     )
                 }
 
@@ -159,6 +145,14 @@ struct ContactDetailView: View {
             VButton(label: "Save", style: .primary, isDisabled: isSaving || editedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                 Task { await saveCardEdits() }
             }
+            VButton(label: "Delete Contact", style: .danger, isDisabled: isDeleting) {
+                if displayContact.displayName == "New Contact" && displayContact.channels.isEmpty && displayContact.interactionCount == 0 {
+                    deleteContact()
+                } else {
+                    showDeleteConfirmation = true
+                }
+            }
+            .accessibilityLabel("Delete Contact")
             if isSaving {
                 ProgressView()
                     .controlSize(.small)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
@@ -31,7 +31,7 @@ struct ContactTypeBadge: View {
     }
 
     var body: some View {
-        VTag(label, color: VColor.primaryBase, icon: icon)
+        VTag(label, color: color, icon: icon)
     }
 
     private var label: String {
@@ -39,6 +39,14 @@ struct ContactTypeBadge: View {
         case .guardian: return "Guardian"
         case .assistant: return "Assistant"
         case .human: return "Human"
+        }
+    }
+
+    private var color: Color {
+        switch kind {
+        case .guardian: return VColor.primaryBase
+        case .assistant: return VColor.systemNegativeStrong
+        case .human: return VColor.systemPositiveStrong
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
@@ -44,9 +44,9 @@ struct ContactTypeBadge: View {
 
     private var color: Color {
         switch kind {
-        case .guardian: return VColor.primaryBase
+        case .guardian: return VColor.systemPositiveStrong
         case .assistant: return VColor.systemNegativeStrong
-        case .human: return VColor.systemPositiveStrong
+        case .human: return VColor.systemMidStrong
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactTypeBadge.swift
@@ -31,7 +31,7 @@ struct ContactTypeBadge: View {
     }
 
     var body: some View {
-        VTag(label, color: color, icon: icon)
+        VTag(label, color: color)
     }
 
     private var label: String {
@@ -47,14 +47,6 @@ struct ContactTypeBadge: View {
         case .guardian: return VColor.systemPositiveStrong
         case .assistant: return VColor.systemNegativeStrong
         case .human: return VColor.systemMidStrong
-        }
-    }
-
-    private var icon: VIcon {
-        switch kind {
-        case .guardian: return .shieldCheck
-        case .assistant: return .sparkles
-        case .human: return .user
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -45,6 +45,7 @@ struct ContactsContainerView: View {
                     VNotification(createContactError, tone: .negative)
                 }
             }
+            .padding(VSpacing.lg)
             .frame(width: 320)
             .frame(maxHeight: .infinity, alignment: .top)
 
@@ -175,21 +176,13 @@ struct ContactsContainerView: View {
     private func guardianDetailView(contact: ContactPayload) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    // Title row: display name + badge + interaction count
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        HStack(spacing: VSpacing.sm) {
-                            Text(contact.displayName.hasPrefix("vellum-principal-") ? "You" : "\(contact.displayName) (You)")
-                                .font(VFont.titleSmall)
-                                .foregroundStyle(VColor.contentDefault)
-                            ContactTypeBadge(kind: .guardian)
-                        }
-                        Text("\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")")
-                            .font(VFont.labelDefault)
-                            .foregroundStyle(VColor.contentTertiary)
-                    }
-
-                    // Editable fields
+                // Header card: name, badge, interaction count, editable fields, save
+                SettingsCard(
+                    title: contact.displayName.hasPrefix("vellum-principal-") ? "You" : "\(contact.displayName) (You)",
+                    subtitle: "\(contact.interactionCount) interaction\(contact.interactionCount == 1 ? "" : "s")"
+                ) {
+                    ContactTypeBadge(kind: .guardian)
+                } content: {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {
                             Text("Name")
@@ -213,7 +206,6 @@ struct ContactsContainerView: View {
                         }
                     }
 
-                    // Save button
                     HStack(spacing: VSpacing.sm) {
                         VButton(
                             label: "Save",
@@ -232,20 +224,23 @@ struct ContactsContainerView: View {
                         VNotification(guardianErrorMessage, tone: .negative)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, VSpacing.lg)
-                .padding(.bottom, VSpacing.lg)
 
-                GuardianChannelsDetailView(
-                    contact: contact,
-                    connectionManager: connectionManager,
-                    store: store,
-                    conversationManager: conversationManager,
-                    onSelectAssistant: { selection = .assistant },
-                    showCardBorders: false
-                )
-                .padding(VSpacing.lg)
+                // Channels card
+                SettingsCard(
+                    title: "Channels",
+                    subtitle: "Once verified, your assistant will recognize you when you message from these channels."
+                ) {
+                    GuardianChannelsDetailView(
+                        contact: contact,
+                        connectionManager: connectionManager,
+                        store: store,
+                        conversationManager: conversationManager,
+                        onSelectAssistant: { selection = .assistant },
+                        showCardBorders: false
+                    )
+                }
             }
+            .padding(VSpacing.lg)
         }
         .scrollContentBackground(.hidden)
         .contentMargins(0)
@@ -302,26 +297,31 @@ struct ContactsContainerView: View {
 
     @State private var cachedAssistantName: String = AssistantDisplayName.resolve(IdentityInfo.loadFromDiskCache()?.name)
 
-    /// Assistant detail — header + channels.
+    /// Assistant detail — header card + channels card.
     @ViewBuilder
     private var assistantDetailView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
-                // Header matching contact/guardian detail pattern
-                HStack(spacing: VSpacing.sm) {
-                    Text("\(cachedAssistantName) (Your Assistant)")
-                        .font(VFont.titleSmall)
-                        .foregroundStyle(VColor.contentDefault)
+                // Header card
+                SettingsCard(
+                    title: "\(cachedAssistantName) (Your Assistant)"
+                ) {
                     ContactTypeBadge(kind: .assistant)
+                } content: {
+                    EmptyView()
                 }
-                .padding(.horizontal, VSpacing.lg)
 
+                // Channels card
                 if let store {
-                    AssistantChannelsDetailView(store: store, connectionManager: connectionManager, conversationManager: conversationManager, assistantName: cachedAssistantName, showCardBorders: false)
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.bottom, VSpacing.lg)
+                    SettingsCard(
+                        title: "Channels",
+                        subtitle: "Channels your assistant is available on."
+                    ) {
+                        AssistantChannelsDetailView(store: store, connectionManager: connectionManager, conversationManager: conversationManager, assistantName: cachedAssistantName, showCardBorders: false)
+                    }
                 }
             }
+            .padding(VSpacing.lg)
         }
         .scrollContentBackground(.hidden)
         .contentMargins(0)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -46,7 +46,7 @@ struct ContactsContainerView: View {
                 }
             }
             .padding(VSpacing.lg)
-            .frame(width: 320)
+            .frame(width: 360)
             .frame(maxHeight: .infinity, alignment: .top)
 
             // Thin vertical separator with shadow
@@ -55,7 +55,7 @@ struct ContactsContainerView: View {
                 .frame(maxHeight: .infinity)
                 .shadow(color: VColor.auxBlack.opacity(0.08), radius: 2, x: 1, y: 0)
 
-            // Right pane: detail, loading, or placeholder (max 700pt, left-aligned)
+            // Right pane: detail, loading, or placeholder
             VStack(alignment: .leading, spacing: 0) {
             if viewModel.isLoading && viewModel.contacts.isEmpty {
                 // Skeleton loading state for detail pane
@@ -154,7 +154,6 @@ struct ContactsContainerView: View {
                 }
             }
             }
-            .frame(maxWidth: 700, maxHeight: .infinity, alignment: .leading)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
         .onChange(of: viewModel.contacts, initial: true) { _, newContacts in

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -40,10 +40,23 @@ struct ContactsListView: View {
 
     private var contactsCard: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
+            // Header: "Entries" title + add button
+            HStack {
+                Text("Entries")
+                    .font(VFont.titleSmall)
+                    .foregroundStyle(VColor.contentDefault)
+                Spacer()
+                VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .ghost, size: .compact) {
+                    viewModel.isCreatingContact = true
+                }
+                .accessibilityLabel("Add contact")
+            }
+
             // System contacts (always visible, not affected by search)
             VStack(alignment: .leading, spacing: VSpacing.sm) {
                 contactListRow(
                     name: "Your Assistant",
+                    subtitle: nil,
                     badgeKind: .assistant,
                     isSelected: selection == .assistant,
                     isHovered: isAssistantHovered,
@@ -54,6 +67,7 @@ struct ContactsListView: View {
                 if let guardian = viewModel.guardianContact {
                     contactListRow(
                         name: "You",
+                        subtitle: channelTypesLabel(for: guardian.channels),
                         badgeKind: ContactTypeBadge.Kind(role: guardian.role, contactType: guardian.contactType),
                         isSelected: selection == .contact(guardian.id),
                         isHovered: hoveredContactId == guardian.id,
@@ -63,19 +77,13 @@ struct ContactsListView: View {
                 }
             }
 
-            Divider()
+            SettingsDivider()
 
-            if viewModel.regularContacts.isEmpty {
-                // No contacts yet — full-width add button matching contact row height
+            if viewModel.regularContacts.isEmpty && viewModel.searchQuery.isEmpty {
                 addContactButton
             } else {
-                // Search + Add button
-                HStack(spacing: VSpacing.sm) {
+                if !viewModel.regularContacts.isEmpty {
                     searchBar
-                    VButton(label: "Add", iconOnly: VIcon.plus.rawValue, style: .ghost, size: .compact) {
-                        viewModel.isCreatingContact = true
-                    }
-                    .accessibilityLabel("Add contact")
                 }
 
                 ScrollView {
@@ -83,6 +91,7 @@ struct ContactsListView: View {
                         ForEach(viewModel.filteredRegularContacts, id: \.id) { contact in
                             contactListRow(
                                 name: contact.displayName,
+                                subtitle: channelTypesLabel(for: contact.channels),
                                 badgeKind: ContactTypeBadge.Kind(role: contact.role, contactType: contact.contactType),
                                 isSelected: selection == .contact(contact.id),
                                 isHovered: hoveredContactId == contact.id,
@@ -107,8 +116,8 @@ struct ContactsListView: View {
                 }
             }
         }
-        .padding(.trailing, VSpacing.lg)
-        .padding(.bottom, VSpacing.lg)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceLift)
         .frame(maxHeight: .infinity, alignment: .top)
     }
 
@@ -151,6 +160,7 @@ struct ContactsListView: View {
 
     private func contactListRow(
         name: String,
+        subtitle: String?,
         badgeKind: ContactTypeBadge.Kind,
         isSelected: Bool,
         isHovered: Bool,
@@ -159,10 +169,19 @@ struct ContactsListView: View {
     ) -> some View {
         Button(action: onTap) {
             HStack(spacing: VSpacing.xs) {
-                Text(name)
-                    .font(VFont.bodyMediumDefault)
-                    .foregroundStyle(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(name)
+                        .font(VFont.bodyMediumDefault)
+                        .foregroundStyle(isSelected ? VColor.contentEmphasized : VColor.contentSecondary)
+                        .lineLimit(1)
+
+                    if let subtitle, !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(VFont.labelDefault)
+                            .foregroundStyle(VColor.contentTertiary)
+                            .lineLimit(1)
+                    }
+                }
 
                 Spacer()
 
@@ -215,6 +234,23 @@ struct ContactsListView: View {
     }
 
     // MARK: - Helpers
+
+    private func channelTypesLabel(for channels: [ContactChannelPayload]) -> String? {
+        let types = Set(channels.filter { $0.status != "revoked" }.map { $0.type })
+        guard !types.isEmpty else { return nil }
+        let labels: [String: String] = [
+            "slack": "Slack",
+            "telegram": "Telegram",
+            "phone": "Phone",
+            "email": "Email",
+            "whatsapp": "WhatsApp",
+        ]
+        let ordered = ["email", "slack", "telegram", "phone", "whatsapp"]
+        let result = ordered.compactMap { type in
+            types.contains(type) ? labels[type] : nil
+        }
+        return result.isEmpty ? nil : result.joined(separator: " | ")
+    }
 
     private func rowBackground(isSelected: Bool, isHovered: Bool) -> some View {
         RoundedRectangle(cornerRadius: VRadius.md)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -82,7 +82,7 @@ struct ContactsListView: View {
             if viewModel.regularContacts.isEmpty && viewModel.searchQuery.isEmpty {
                 addContactButton
             } else {
-                if !viewModel.regularContacts.isEmpty {
+                if !viewModel.regularContacts.isEmpty || !viewModel.searchQuery.isEmpty {
                     searchBar
                 }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -54,16 +54,6 @@ struct ContactsListView: View {
 
             // System contacts (always visible, not affected by search)
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                contactListRow(
-                    name: "Your Assistant",
-                    subtitle: nil,
-                    badgeKind: .assistant,
-                    isSelected: selection == .assistant,
-                    isHovered: isAssistantHovered,
-                    onTap: { selection = .assistant },
-                    onHover: { isAssistantHovered = $0 }
-                )
-
                 if let guardian = viewModel.guardianContact {
                     contactListRow(
                         name: "You",
@@ -75,6 +65,16 @@ struct ContactsListView: View {
                         onHover: { hoveredContactId = $0 ? guardian.id : nil }
                     )
                 }
+
+                contactListRow(
+                    name: cachedAssistantDisplayName,
+                    subtitle: nil,
+                    badgeKind: .assistant,
+                    isSelected: selection == .assistant,
+                    isHovered: isAssistantHovered,
+                    onTap: { selection = .assistant },
+                    onHover: { isAssistantHovered = $0 }
+                )
             }
 
             SettingsDivider()

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -90,7 +90,17 @@ struct GuardianChannelsDetailView: View {
     }
 
     private var visibleTypes: [String] {
-        Self.allChannelTypes
+        let isGuardian = displayContact.role == "guardian"
+        if isGuardian {
+            return Self.allChannelTypes
+        }
+        // For contacts, only show channels the assistant has configured.
+        return Self.allChannelTypes.filter { type in
+            let hasExisting = displayContact.channels.contains { $0.type == type && $0.status != "revoked" }
+            guard !hasExisting else { return true }
+            guard let info = channelReadiness[type] else { return false }
+            return info.ready || info.setupStatus == "ready" || info.setupStatus == "incomplete"
+        }
     }
 
     /// Channel content rows. The parent SettingsCard provides the "Channels" title/subtitle header.

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -90,14 +90,7 @@ struct GuardianChannelsDetailView: View {
     }
 
     private var visibleTypes: [String] {
-        Self.allChannelTypes.filter { type in
-            let hasExisting = displayContact.channels.contains { $0.type == type && $0.status != "revoked" }
-            let readiness = channelReadiness[type]
-            let isAvailable = readiness?.ready == true
-                || readiness?.setupStatus == "ready"
-                || readiness?.setupStatus == "incomplete"
-            return hasExisting || isAvailable
-        }
+        Self.allChannelTypes
     }
 
     /// Channel content rows. The parent SettingsCard provides the "Channels" title/subtitle header.
@@ -161,8 +154,9 @@ struct GuardianChannelsDetailView: View {
         let existingChannels = displayContact.channels.filter { $0.type == type && $0.status != "revoked" }
         let activeChannel = existingChannels.first(where: { $0.status == "active" && $0.verifiedAt != nil })
             ?? existingChannels.first
+        let isGuardian = displayContact.role == "guardian"
         let isVerified = (activeChannel?.status == "active" && activeChannel?.verifiedAt != nil)
-            || store?.channelVerificationState(for: type).verified == true
+            || (isGuardian && store?.channelVerificationState(for: type).verified == true)
 
         if showCardBorders {
             SettingsCard(title: channelLabel(for: type), subtitle: channelSubtitle(for: type), showBorder: true) {
@@ -170,11 +164,12 @@ struct GuardianChannelsDetailView: View {
                     VBadge(label: "Verified", tone: .positive)
                 }
             } content: {
-                channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified)
+                channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified, isGuardian: isGuardian)
             }
         } else {
+            let storeVerified = isGuardian && (store?.channelVerificationState(for: type).verified == true)
             let needsSetup = !isVerified
-                && store?.channelVerificationState(for: type).verified != true
+                && !storeVerified
                 && (existingChannels.isEmpty || dismissedChannels.contains(type))
                 && !setupExpanded.contains(type)
 
@@ -219,17 +214,17 @@ struct GuardianChannelsDetailView: View {
                 .frame(minHeight: 36)
 
                 if !needsSetup && !isVerified {
-                    channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified)
+                    channelCardContent(type: type, existingChannels: existingChannels, activeChannel: activeChannel, isVerified: isVerified, isGuardian: isGuardian)
                 }
             }
         }
     }
 
     @ViewBuilder
-    private func channelCardContent(type: String, existingChannels: [ContactChannelPayload], activeChannel: ContactChannelPayload?, isVerified: Bool) -> some View {
+    private func channelCardContent(type: String, existingChannels: [ContactChannelPayload], activeChannel: ContactChannelPayload?, isVerified: Bool, isGuardian: Bool = true) -> some View {
         if let channel = activeChannel, isVerified {
             verifiedChannelContent(channel: channel, type: type)
-        } else if store?.channelVerificationState(for: type).verified == true
+        } else if (isGuardian && store?.channelVerificationState(for: type).verified == true)
             || (!existingChannels.isEmpty && !dismissedChannels.contains(type))
             || setupExpanded.contains(type) {
             verificationFlowContent(for: type)

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -201,7 +201,7 @@ struct GuardianChannelsDetailView: View {
                         VButton(label: setupButtonLabel, style: .outlined) {
                             if let conversationManager {
                                 conversationManager.openConversation(
-                                    message: channelSetupMessage(for: type),
+                                    message: channelSetupMessage(for: type, isGuardian: isGuardian),
                                     forceNew: true
                                 )
                             } else {
@@ -232,7 +232,7 @@ struct GuardianChannelsDetailView: View {
             VButton(label: setupButtonLabel, style: .outlined) {
                 if let conversationManager {
                     conversationManager.openConversation(
-                        message: channelSetupMessage(for: type),
+                        message: channelSetupMessage(for: type, isGuardian: isGuardian),
                         forceNew: true
                     )
                 } else {
@@ -490,12 +490,21 @@ struct GuardianChannelsDetailView: View {
         }
     }
 
-    private func channelSetupMessage(for type: String) -> String {
-        switch type {
-        case "telegram": return "I'd like to verify my identity as your guardian on Telegram. Can you help me set that up?"
-        case "slack": return "I'd like to verify my identity as your guardian on Slack. Can you help me set that up?"
-        case "phone": return "I'd like to verify my identity as your guardian for phone calls. Can you help me set that up?"
-        default: return "I'd like to verify my identity as your guardian on \(type.capitalized). Can you help me set that up?"
+    private func channelSetupMessage(for type: String, isGuardian: Bool) -> String {
+        if isGuardian {
+            switch type {
+            case "telegram": return "I'd like to verify my identity as your guardian on Telegram. Can you help me set that up?"
+            case "slack": return "I'd like to verify my identity as your guardian on Slack. Can you help me set that up?"
+            case "phone": return "I'd like to verify my identity as your guardian for phone calls. Can you help me set that up?"
+            default: return "I'd like to verify my identity as your guardian on \(type.capitalized). Can you help me set that up?"
+            }
+        } else {
+            switch type {
+            case "telegram": return "I'd like to verify a contact's Telegram identity. Can you walk me through it?"
+            case "slack": return "I'd like to verify a contact's Slack identity. Can you walk me through it?"
+            case "phone": return "I'd like to verify a contact's phone number. Can you help me set that up?"
+            default: return "I'd like to verify a contact's \(type.capitalized) identity. Can you walk me through it?"
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -99,17 +99,9 @@ struct GuardianChannelsDetailView: View {
         }
     }
 
+    /// Channel content rows. The parent SettingsCard provides the "Channels" title/subtitle header.
     private var content: some View {
         VStack(alignment: .leading, spacing: VSpacing.xl) {
-            VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Channels")
-                    .font(VFont.titleSmall)
-                    .foregroundStyle(VColor.contentDefault)
-                Text("Once verified, your assistant will recognize you when you message from these channels.")
-                    .font(VFont.labelDefault)
-                    .foregroundStyle(VColor.contentTertiary)
-            }
-
             if isLoadingReadiness && visibleTypes.isEmpty {
                 channelSkeletonRows()
             } else if visibleTypes.isEmpty {

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -18,6 +18,7 @@ struct GuardianChannelsDetailView: View {
     var conversationManager: ConversationManager?
     var onSelectAssistant: (() -> Void)?
     var showCardBorders: Bool = true
+    var setupButtonLabel: String = "Enable"
 
     @State var currentContact: ContactPayload?
     @State private var isLoadingReadiness: Bool = true
@@ -202,7 +203,7 @@ struct GuardianChannelsDetailView: View {
                             }
                         }
                     } else if needsSetup {
-                        VButton(label: "Set up", style: .outlined) {
+                        VButton(label: setupButtonLabel, style: .outlined) {
                             if let conversationManager {
                                 conversationManager.openConversation(
                                     message: channelSetupMessage(for: type),
@@ -233,7 +234,7 @@ struct GuardianChannelsDetailView: View {
             || setupExpanded.contains(type) {
             verificationFlowContent(for: type)
         } else {
-            VButton(label: "Set up", style: .outlined) {
+            VButton(label: setupButtonLabel, style: .outlined) {
                 if let conversationManager {
                     conversationManager.openConversation(
                         message: channelSetupMessage(for: type),

--- a/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/GuardianChannelsDetailView.swift
@@ -90,11 +90,7 @@ struct GuardianChannelsDetailView: View {
     }
 
     private var visibleTypes: [String] {
-        let isGuardian = displayContact.role == "guardian"
-        if isGuardian {
-            return Self.allChannelTypes
-        }
-        // For contacts, only show channels the assistant has configured.
+        // Show only channels the assistant has configured (ready/incomplete).
         return Self.allChannelTypes.filter { type in
             let hasExisting = displayContact.channels.contains { $0.type == type && $0.status != "revoked" }
             guard !hasExisting else { return true }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -677,7 +677,7 @@ async function main() {
     {
       // Keep DELETE on the invite collection unsupported; only /invites/:id
       // should revoke an invite.
-      path: /^\/v1\/contacts\/(?!invites$)([^/]+)\/?$/,
+      path: /^\/v1\/contacts\/(?!invites\/?$)([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge",
       handler: (_req, params) =>
@@ -685,7 +685,7 @@ async function main() {
     },
     {
       // Assistant-scoped variant for clients using the auto-prefix.
-      path: /^\/v1\/assistants\/[^/]+\/contacts\/(?!invites$)([^/]+)\/?$/,
+      path: /^\/v1\/assistants\/[^/]+\/contacts\/(?!invites\/?$)([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge",
       handler: (_req, params) =>

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -421,7 +421,9 @@ async function main() {
 
   const audioProxy = createAudioProxyHandler(config);
 
-  const backupDeps = { assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl };
+  const backupDeps = {
+    assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl,
+  };
   const handleListBackups = createListBackupsHandler(backupDeps);
   const handleCreateBackup = createBackupSnapshotHandler(backupDeps);
 
@@ -675,7 +677,15 @@ async function main() {
     {
       // Keep DELETE on the invite collection unsupported; only /invites/:id
       // should revoke an invite.
-      path: /^\/v1\/contacts\/(?!invites$)([^/]+)$/,
+      path: /^\/v1\/contacts\/(?!invites$)([^/]+)\/?$/,
+      method: "DELETE",
+      auth: "edge",
+      handler: (_req, params) =>
+        contactsControlPlaneProxy.handleDeleteContact(params[0]),
+    },
+    {
+      // Assistant-scoped variant for clients using the auto-prefix.
+      path: /^\/v1\/assistants\/[^/]+\/contacts\/(?!invites$)([^/]+)\/?$/,
       method: "DELETE",
       auth: "edge",
       handler: (_req, params) =>
@@ -1548,7 +1558,8 @@ async function main() {
             headers: { "Retry-After": String(err.retryAfterSecs) },
           },
         );
-        if (extensionOrigin) return withExtensionCorsHeaders(body, extensionOrigin);
+        if (extensionOrigin)
+          return withExtensionCorsHeaders(body, extensionOrigin);
         return withCorsHeaders(body, webviewOrigin!);
       }
       log.error({ err }, "Unhandled gateway error");
@@ -1556,7 +1567,8 @@ async function main() {
         { error: "Internal server error" },
         { status: 500 },
       );
-      if (extensionOrigin) return withExtensionCorsHeaders(errBody, extensionOrigin);
+      if (extensionOrigin)
+        return withExtensionCorsHeaders(errBody, extensionOrigin);
       return withCorsHeaders(errBody, webviewOrigin!);
     }
 
@@ -1564,7 +1576,8 @@ async function main() {
       { error: "Not found", source: "gateway" },
       { status: 404 },
     );
-    if (extensionOrigin) return withExtensionCorsHeaders(notFound, extensionOrigin);
+    if (extensionOrigin)
+      return withExtensionCorsHeaders(notFound, extensionOrigin);
     if (webviewOrigin) return withCorsHeaders(notFound, webviewOrigin);
     return notFound;
   }
@@ -1713,7 +1726,10 @@ async function main() {
               sourceChannel: "slack",
               externalUserId: normalized.event.actor.actorExternalId,
               ...(normalized.event.source.chatType === "im"
-                ? { externalChatId: normalized.event.message.conversationExternalId }
+                ? {
+                    externalChatId:
+                      normalized.event.message.conversationExternalId,
+                  }
                 : {}),
               displayName: normalized.event.actor.displayName,
               username: normalized.event.actor.username,


### PR DESCRIPTION
Refreshes the macOS Contacts tab UI to use the Settings-card design language (aligning with web PR vellum-ai/vellum-assistant-platform#6090) and fixes the "Invite" button for human contacts to send a contact-appropriate setup message instead of the guardian-specific one.

## Prompt / plan

LUM-1409: Refresh the Contacts tab UI with Settings-based design cues. Additionally, align macOS "Invite" button behavior with web — when inviting a new human contact, send a contact verification prompt rather than the guardian identity verification message.

## Test plan

- CI (FlexFrame Lint, Socket Security, Type Check, Lint) passes
- macOS Build/Tests are skipped (no macOS runner in CI) — requires local Xcode verification
- Web contacts tab tested via Playwright with comprehensive API mocking (5 test cases passing)

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/4f9b38f009324295a340aa9a5c8af7b9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->