### PR TITLE
fix(ci): anchor migration ID regex to prevent false matches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1113,11 +1113,11 @@ jobs:
             const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
             const src = fs.readFileSync(filePath, 'utf-8');
             let id;
-            const litMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
+            const litMatch = src.match(/^\s*id:\s*['\x22]([^'\x22]+)['\x22]/m);
             if (litMatch) {
               id = litMatch[1];
             } else {
-              const refMatch = src.match(/id:\s*(\w+)/);
+              const refMatch = src.match(/^\s*id:\s*(\w+)/m);
               const constLine = src.split('\n').find(l => l.includes('const ' + refMatch[1] + ' ='));
               id = constLine.match(/['\x22]([^'\x22]+)['\x22]/)[1];
             }


### PR DESCRIPTION
## Summary
- Anchored the workspace-migration ID extraction regexes in `release.yml` to `^\s*id:` with the multiline flag, preventing false matches on substrings like `release-note-id:` inside string constants
- Fixes the `register-release` / `Compute migration ceilings` step that broke after PR #29844 introduced migration `071-remove-safe-storage-release-note`

## Original prompt
The CI `register-release` job started failing after PR #29844 was merged. The "Compute migration ceilings" step uses a regex `/id:\s*['"]([^'"]+)['"]/` to extract the workspace migration ID from the last migration file. Migration 071 contains a `RELEASE_NOTE_MARKER_PREFIX = "<!-- release-note-id:"` constant where the `id:` substring followed by a closing `"` caused the regex to false-match, capturing a multiline blob that broke `$GITHUB_OUTPUT` parsing. The fix anchors both regexes to the start of a line so they only match actual `id:` object properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->