### PR TITLE
[LUM-1418] Fix ACTIVITY_COMPLETE notification deep-link using wrong conversation ID

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ConversationManager.swift
@@ -491,6 +491,7 @@ final class ConversationManager: ConversationRestorerDelegate {
         guard !NSApp.isActive else { return }
         guard let conversation = listStore.conversations.first(where: { $0.id == conversationId }) else { return }
         if conversation.shouldSuppressUnreadIndicator { return }
+        guard let daemonConversationId = conversation.conversationId else { return }
         guard let vm = selectionStore.chatViewModels[conversationId] else { return }
         // Voice path posts its own VOICE_RESPONSE_COMPLETE notification; skip to avoid duplicates.
         if vm.isVoiceModeActive { return }
@@ -504,8 +505,8 @@ final class ConversationManager: ConversationRestorerDelegate {
         content.body = bodyText
         content.sound = .default
         content.categoryIdentifier = "ACTIVITY_COMPLETE"
-        content.threadIdentifier = conversationId.uuidString
-        content.userInfo = ["conversationId": conversationId.uuidString]
+        content.threadIdentifier = daemonConversationId
+        content.userInfo = ["conversationId": daemonConversationId]
 
         let request = UNNotificationRequest(
             identifier: "turn-complete-\(conversationId.uuidString)-\(UUID().uuidString)",


### PR DESCRIPTION
The turn-complete notification (`ACTIVITY_COMPLETE`) stored the **local UUID** in `userInfo["conversationId"]` instead of the daemon conversation ID. When the user clicked the notification, `openConversation` → `selectConversationByConversationIdAsync` looked up conversations by daemon ID — so the local UUID never matched, and the user saw whatever conversation was last active instead of the notification's conversation.

This was introduced in #29093 (May 1) which added `postTurnCompleteNotificationIfNeeded` using the local UUID, then broken by #29400 (May 3) which refactored `openConversation` to use daemon-ID-based lookup via `selectConversationByConversationIdAsync`. The other notification types (`NOTIFICATION_INTENT`, `TOOL_CONFIRMATION`) already use daemon conversation IDs and were unaffected.

The fix uses `conversation.conversationId` (daemon ID) for both `userInfo` and `threadIdentifier`, matching the pattern used by all other notification types. A guard on `conversation.conversationId` is added — by the time a turn completes the daemon will have assigned an ID, and if it somehow hasn't, skipping the notification is safer than posting one that can't deep-link.

Apple refs checked (2026-05-06): [UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:)](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/1649501-usernotificationcenter), [UNMutableNotificationContent.userInfo](https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/userinfo)

### Root cause analysis

1. **How did the code get into this state?** Two PRs landed days apart — #29093 added notification posting with local UUIDs, #29400 refactored the click handler to daemon-ID lookup. Neither was aware of the other's assumption about ID format.
2. **What mistakes or decisions led to it?** The `postTurnCompleteNotificationIfNeeded` function parameter is `conversationId: UUID` (the local ID), making it natural to reach for `.uuidString` — the daemon ID required a separate lookup through the `conversation` model.
3. **Were there warning signs we missed?** The function already had `conversation` in scope (fetched on line 492), so the daemon ID was available but not used.
4. **What can we do to prevent this pattern from recurring?** Consider naming the function parameter `localConversationId` to make it unambiguous that it is NOT the daemon conversation ID.
5. **Should we add a guideline to AGENTS.md?** Not needed — this was a one-off interaction between two PRs, not a systemic pattern.

## Prompt / plan
Investigating LUM-1418: clicking macOS system notification doesn't bring you to the correct conversation.

## Test plan
CI checks. Manual verification requires building the macOS app in Xcode (CI skips macOS builds).

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/fc75c972bcc44b9c82e33870b6a1e501
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->