### PR TITLE
fix(macos): keep per-sound preview buttons enabled when global toggle is off

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSoundsTab.swift
@@ -7,6 +7,10 @@ struct SettingsSoundsTab: View {
     /// The sound manager singleton provides config, playback, and available sounds.
     private var soundManager: SoundManager { SoundManager.shared }
 
+    /// True when the global toggle is off. Disables editing/triggering controls but
+    /// not preview buttons — `SoundManager.previewSound` bypasses the global toggle.
+    private var isGlobalDisabled: Bool { !soundManager.config.globalEnabled }
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             globalSoundSection
@@ -52,7 +56,7 @@ struct SettingsSoundsTab: View {
                 )
                 .frame(maxWidth: 200)
             }
-            .disabled(!soundManager.config.globalEnabled)
+            .disabled(isGlobalDisabled)
 
             SettingsDivider()
 
@@ -78,7 +82,6 @@ struct SettingsSoundsTab: View {
                 soundEventRow(for: event)
             }
         }
-        .disabled(!soundManager.config.globalEnabled)
     }
 
     @ViewBuilder
@@ -106,6 +109,7 @@ struct SettingsSoundsTab: View {
                         }
                     )
                 )
+                .disabled(isGlobalDisabled)
             }
 
             soundPoolEditor(for: event, eventConfig: eventConfig, sounds: sounds)
@@ -163,6 +167,7 @@ struct SettingsSoundsTab: View {
                         ) {
                             removeSound(at: index, for: event)
                         }
+                        .disabled(isGlobalDisabled)
                     }
                     .frame(maxWidth: 220, alignment: .leading)
                 }
@@ -206,6 +211,7 @@ struct SettingsSoundsTab: View {
                     menuWidth: 260,
                     menuMaxHeight: 360
                 )
+                .disabled(isGlobalDisabled)
             }
         }
         .frame(maxWidth: 220, alignment: .leading)


### PR DESCRIPTION
## Summary

- The play (▷) buttons next to each configured sound in Settings → Sounds were disabled by a section-wide `.disabled(!globalEnabled)` modifier whenever the global "Enable sound effects" toggle was off, even though `SoundManager.previewSound()` deliberately bypasses `globalEnabled` so previews can play in any state.
- Move the disabled modifier off the section container and onto each non-preview control individually (per-event toggle, remove button, "Add sound…" dropdown). The preview button stays unconditionally clickable.
- Extract the repeated `!soundManager.config.globalEnabled` condition into an `isGlobalDisabled` computed property (used 4× in this file).

## Original prompt

The user reported, with a screenshot of the Sound Effects settings tab, that the per-sound play buttons used to sample/audition each configured sound should still work when the global "Enable sound effects" toggle is off. Sampling a sound is a preview action — it's about hearing what a sound sounds like to decide whether to keep it in the pool — and is independent of whether the assistant should automatically play sounds in response to events. The `Preview` button next to the volume slider already worked in both states; per-sound preview should match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->