### PR TITLE
[ATL-478] Add sync invalidation message contract

### DIFF
--- a/assistant/src/__tests__/sync-message-contract.test.ts
+++ b/assistant/src/__tests__/sync-message-contract.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ServerMessage,
+  SyncChangedMessage,
+} from "../daemon/message-protocol.js";
+import {
+  buildSyncChangedMessage,
+  conversationMessagesSyncTag,
+  SYNC_TAGS,
+  SyncChangedMessageSchema,
+} from "../daemon/message-protocol.js";
+
+describe("sync message contract", () => {
+  test("sync_changed is assignable to ServerMessage", () => {
+    const msg: SyncChangedMessage = {
+      type: "sync_changed",
+      cursor: 2,
+      tags: [SYNC_TAGS.assistantAvatar],
+      changes: [
+        {
+          cursor: 2,
+          createdAt: 1_700_000_000_000,
+          resource: "assistant",
+          resourceId: "self",
+          op: "updated",
+          invalidatedTags: [SYNC_TAGS.assistantAvatar],
+        },
+      ],
+    };
+
+    const serverMessage: ServerMessage = msg;
+    expect(serverMessage.type).toBe("sync_changed");
+  });
+
+  test("buildSyncChangedMessage aggregates cursors and tags for batches", () => {
+    const msg = buildSyncChangedMessage([
+      {
+        cursor: 10,
+        createdAt: 1,
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantIdentity],
+      },
+      {
+        cursor: 11,
+        createdAt: 1,
+        resource: "conversation",
+        resourceId: "conv-1",
+        op: "invalidated",
+        invalidatedTags: [
+          SYNC_TAGS.conversationsList,
+          conversationMessagesSyncTag("conv-1"),
+        ],
+      },
+    ]);
+
+    expect(msg.cursor).toBe(11);
+    expect(msg.tags).toEqual([
+      SYNC_TAGS.assistantIdentity,
+      SYNC_TAGS.conversationsList,
+      "conversation:conv-1:messages",
+    ]);
+    expect(SyncChangedMessageSchema.safeParse(msg).success).toBe(true);
+  });
+
+  test("schema rejects malformed sync_changed payloads", () => {
+    expect(
+      SyncChangedMessageSchema.safeParse({
+        type: "sync_changed",
+        cursor: 1,
+        tags: [],
+        changes: [],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      SyncChangedMessageSchema.safeParse({
+        type: "sync_changed",
+        cursor: "1",
+        tags: [SYNC_TAGS.assistantAvatar],
+        changes: [
+          {
+            cursor: 1,
+            createdAt: 1,
+            resource: "assistant",
+            resourceId: "self",
+            op: "updated",
+            invalidatedTags: [SYNC_TAGS.assistantAvatar],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      SyncChangedMessageSchema.safeParse({
+        type: "sync_changed",
+        cursor: 1,
+        tags: [SYNC_TAGS.assistantAvatar],
+        changes: [
+          {
+            cursor: 1,
+            createdAt: 1,
+            resource: "assistant",
+            resourceId: "self",
+            op: "replaced",
+            invalidatedTags: [SYNC_TAGS.assistantAvatar],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -42,6 +42,7 @@ export * from "./message-types/shared.js";
 export * from "./message-types/skills.js";
 export * from "./message-types/subagents.js";
 export * from "./message-types/surfaces.js";
+export * from "./message-types/sync.js";
 export * from "./message-types/upgrades.js";
 export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
@@ -129,6 +130,7 @@ import type {
   _SurfacesClientMessages,
   _SurfacesServerMessages,
 } from "./message-types/surfaces.js";
+import type { _SyncInvalidationServerMessages } from "./message-types/sync.js";
 import type { _UpgradesServerMessages } from "./message-types/upgrades.js";
 import type {
   _WorkItemsClientMessages,
@@ -188,6 +190,7 @@ export type ServerMessage =
   | _SubagentsServerMessages
   | _DocumentsServerMessages
   | _GuardianActionsServerMessages
+  | _SyncInvalidationServerMessages
   | _HomeServerMessages
   | _HostAppControlServerMessages
   | _HostBashServerMessages

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+// Durable sync messages are resource invalidations, not realtime token/tool
+// stream events. Clients use the tags to decide which local cache/store entries
+// to refetch, and use the cursor to recover missed invalidations.
+
+export const SYNC_RESOURCES = [
+  "assistant",
+  "conversation",
+  "conversations",
+] as const;
+
+export type SyncResource = (typeof SYNC_RESOURCES)[number];
+
+export const SYNC_OPERATIONS = [
+  "created",
+  "updated",
+  "deleted",
+  "invalidated",
+] as const;
+
+export type SyncOperation = (typeof SYNC_OPERATIONS)[number];
+
+export const SYNC_TAGS = {
+  assistantAvatar: "assistant:self:avatar",
+  assistantIdentity: "assistant:self:identity",
+  assistantConfig: "assistant:self:config",
+  assistantSounds: "assistant:self:sounds",
+  conversationsList: "conversations:list",
+} as const;
+
+export type KnownSyncInvalidationTag =
+  (typeof SYNC_TAGS)[keyof typeof SYNC_TAGS];
+
+export type ConversationSyncInvalidationTag =
+  | `conversation:${string}:messages`
+  | `conversation:${string}:metadata`;
+
+export type SyncInvalidationTag =
+  | KnownSyncInvalidationTag
+  | ConversationSyncInvalidationTag
+  | (string & {});
+
+export function conversationMessagesSyncTag(
+  conversationId: string,
+): ConversationSyncInvalidationTag {
+  return `conversation:${conversationId}:messages`;
+}
+
+export function conversationMetadataSyncTag(
+  conversationId: string,
+): ConversationSyncInvalidationTag {
+  return `conversation:${conversationId}:metadata`;
+}
+
+export interface SyncChange {
+  cursor: number;
+  createdAt: number;
+  resource: SyncResource;
+  resourceId: string;
+  op: SyncOperation;
+  version?: number;
+  invalidatedTags: SyncInvalidationTag[];
+  originClientId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SyncChangedMessage {
+  type: "sync_changed";
+  cursor: number;
+  tags: SyncInvalidationTag[];
+  changes: SyncChange[];
+  originClientId?: string;
+}
+
+export const SyncResourceSchema = z.enum(SYNC_RESOURCES);
+export const SyncOperationSchema = z.enum(SYNC_OPERATIONS);
+export const SyncInvalidationTagSchema = z.string().min(1);
+
+export const SyncChangeSchema = z
+  .object({
+    cursor: z.number().int().nonnegative(),
+    createdAt: z.number().int().nonnegative(),
+    resource: SyncResourceSchema,
+    resourceId: z.string().min(1),
+    op: SyncOperationSchema,
+    version: z.number().int().nonnegative().optional(),
+    invalidatedTags: z.array(SyncInvalidationTagSchema).min(1),
+    originClientId: z.string().min(1).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export const SyncChangedMessageSchema = z
+  .object({
+    type: z.literal("sync_changed"),
+    cursor: z.number().int().nonnegative(),
+    tags: z.array(SyncInvalidationTagSchema).min(1),
+    changes: z.array(SyncChangeSchema).min(1),
+    originClientId: z.string().min(1).optional(),
+  })
+  .strict();
+
+export function buildSyncChangedMessage(
+  changes: SyncChange[],
+  originClientId?: string,
+): SyncChangedMessage {
+  if (changes.length === 0) {
+    throw new Error("sync_changed requires at least one persisted change");
+  }
+  const tags = Array.from(
+    new Set(changes.flatMap((change) => change.invalidatedTags)),
+  );
+  return {
+    type: "sync_changed",
+    cursor: Math.max(...changes.map((change) => change.cursor)),
+    tags,
+    changes,
+    ...(originClientId ? { originClientId } : {}),
+  };
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _SyncInvalidationServerMessages = SyncChangedMessage;


### PR DESCRIPTION
## Summary
- Add the durable `sync_changed` server message contract.
- Define sync resources, operations, invalidation tags, and conversation tag helpers.
- Add schema validation and protocol-union coverage tests.

## Stack
This is PR 1 of 3 for ATL-478.

## Validation
- `bun test --preload ./src/__tests__/test-preload.ts src/__tests__/sync-message-contract.test.ts`
- `bunx tsc --noEmit`
- Pre-push assistant typecheck and ESLint passed.