### PR TITLE
[ATL-478] Add durable sync change ledger

### DIFF
--- a/assistant/src/memory/__tests__/sync-change-store.test.ts
+++ b/assistant/src/memory/__tests__/sync-change-store.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  conversationMessagesSyncTag,
+  SYNC_TAGS,
+} from "../../daemon/message-types/sync.js";
+import { getSqlite } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import {
+  getSyncCursorState,
+  listSyncChangesSince,
+  pruneSyncChangesToRetention,
+  recordSyncChanges,
+} from "../sync-change-store.js";
+
+initializeDb();
+
+function clearSyncChanges(): void {
+  getSqlite().run("DELETE FROM sync_changes");
+  getSqlite().run("DELETE FROM sqlite_sequence WHERE name = 'sync_changes'");
+}
+
+beforeEach(() => {
+  clearSyncChanges();
+});
+
+describe("sync change store", () => {
+  test("records a batch with monotonic cursors", () => {
+    const changes = recordSyncChanges(
+      [
+        {
+          resource: "assistant",
+          resourceId: "self",
+          op: "updated",
+          invalidatedTags: [SYNC_TAGS.assistantAvatar],
+        },
+        {
+          resource: "conversation",
+          resourceId: "conv-1",
+          op: "invalidated",
+          invalidatedTags: [conversationMessagesSyncTag("conv-1")],
+        },
+      ],
+      { createdAt: 1234 },
+    );
+
+    expect(changes).toHaveLength(2);
+    expect(changes[0].cursor).toBe(1);
+    expect(changes[1].cursor).toBe(2);
+    expect(changes.map((change) => change.createdAt)).toEqual([1234, 1234]);
+
+    const listed = listSyncChangesSince(0);
+    expect(listed.map((change) => change.cursor)).toEqual([1, 2]);
+  });
+
+  test("round trips optional version, origin client, tags, and metadata", () => {
+    const [change] = recordSyncChanges(
+      [
+        {
+          resource: "assistant",
+          resourceId: "self",
+          op: "updated",
+          version: 7,
+          invalidatedTags: [
+            SYNC_TAGS.assistantIdentity,
+            SYNC_TAGS.assistantConfig,
+          ],
+          metadata: { reason: "settings-save" },
+        },
+      ],
+      { originClientId: "client-1", createdAt: 5678 },
+    );
+
+    expect(change).toMatchObject({
+      cursor: 1,
+      createdAt: 5678,
+      resource: "assistant",
+      resourceId: "self",
+      op: "updated",
+      version: 7,
+      originClientId: "client-1",
+      metadata: { reason: "settings-save" },
+    });
+    expect(change.invalidatedTags).toEqual([
+      SYNC_TAGS.assistantIdentity,
+      SYNC_TAGS.assistantConfig,
+    ]);
+  });
+
+  test("lists changes after a cursor with a bounded limit", () => {
+    recordSyncChanges([
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantAvatar],
+      },
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantIdentity],
+      },
+      {
+        resource: "conversations",
+        resourceId: "list",
+        op: "invalidated",
+        invalidatedTags: [SYNC_TAGS.conversationsList],
+      },
+    ]);
+
+    const page = listSyncChangesSince(1, 1);
+    expect(page).toHaveLength(1);
+    expect(page[0].cursor).toBe(2);
+  });
+
+  test("reports latest cursor and retention floor", () => {
+    recordSyncChanges([
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantAvatar],
+      },
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantIdentity],
+      },
+    ]);
+
+    expect(getSyncCursorState()).toEqual({
+      latestCursor: 2,
+      oldestCursor: 1,
+      retentionFloorCursor: 0,
+    });
+
+    getSqlite().run("DELETE FROM sync_changes WHERE cursor = 1");
+    expect(getSyncCursorState()).toEqual({
+      latestCursor: 2,
+      oldestCursor: 2,
+      retentionFloorCursor: 1,
+    });
+  });
+
+  test("prunes to retained row count", () => {
+    recordSyncChanges([
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantAvatar],
+      },
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantIdentity],
+      },
+      {
+        resource: "conversations",
+        resourceId: "list",
+        op: "invalidated",
+        invalidatedTags: [SYNC_TAGS.conversationsList],
+      },
+    ]);
+
+    expect(pruneSyncChangesToRetention(2)).toBe(1);
+    expect(listSyncChangesSince(0).map((change) => change.cursor)).toEqual([
+      2, 3,
+    ]);
+  });
+
+  test("applies retention after recording changes", () => {
+    recordSyncChanges(
+      [
+        {
+          resource: "assistant",
+          resourceId: "self",
+          op: "updated",
+          invalidatedTags: [SYNC_TAGS.assistantAvatar],
+        },
+        {
+          resource: "assistant",
+          resourceId: "self",
+          op: "updated",
+          invalidatedTags: [SYNC_TAGS.assistantIdentity],
+        },
+        {
+          resource: "conversations",
+          resourceId: "list",
+          op: "invalidated",
+          invalidatedTags: [SYNC_TAGS.conversationsList],
+        },
+      ],
+      { retentionRows: 2 },
+    );
+
+    expect(listSyncChangesSince(0).map((change) => change.cursor)).toEqual([
+      2, 3,
+    ]);
+    expect(getSyncCursorState().retentionFloorCursor).toBe(1);
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -164,6 +164,7 @@ import {
   migrateStripIntegrationPrefixFromProviderKeys,
   migrateStripPlaceholderSentinelsFromMessages,
   migrateStripThinkingFromConsolidated,
+  migrateSyncChanges,
   migrateToolInvocationsMatchedRuleId,
   migrateTraceEventsCreatedAtIndex,
   migrateUsageDashboardIndexes,
@@ -410,6 +411,7 @@ export function initializeDb(): void {
     },
     migrateScheduleRetryPolicy,
     migrateTraceEventsCreatedAtIndex,
+    migrateSyncChanges,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/240-sync-changes.ts
+++ b/assistant/src/memory/migrations/240-sync-changes.ts
@@ -1,0 +1,37 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const CHECKPOINT_KEY = "migration_sync_changes_v1";
+
+export function migrateSyncChanges(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+    raw.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS sync_changes (
+        cursor INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at INTEGER NOT NULL,
+        resource TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        op TEXT NOT NULL,
+        version INTEGER,
+        invalidated_tags_json TEXT NOT NULL,
+        origin_client_id TEXT,
+        metadata_json TEXT
+      )
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_sync_changes_created_at
+        ON sync_changes (created_at)
+    `);
+    raw.exec(/*sql*/ `
+      CREATE INDEX IF NOT EXISTS idx_sync_changes_resource
+        ON sync_changes (resource, resource_id)
+    `);
+  });
+}
+
+export function downSyncChanges(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  raw.exec(/*sql*/ `DROP TABLE IF EXISTS sync_changes`);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -201,6 +201,7 @@ export {
 } from "./237-heartbeat-runs.js";
 export { migrateScheduleRetryPolicy } from "./238-schedule-retry-policy.js";
 export { migrateTraceEventsCreatedAtIndex } from "./239-trace-events-created-at-index.js";
+export { downSyncChanges, migrateSyncChanges } from "./240-sync-changes.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -48,6 +48,7 @@ import { downMemoryV2ActivationLogs } from "./234-memory-v2-activation-logs.js";
 import { downSlackCompactionWatermark } from "./235-slack-compaction-watermark.js";
 import { downToolInvocationsMatchedRuleId } from "./236-tool-invocations-matched-rule-id.js";
 import { downHeartbeatRuns } from "./237-heartbeat-runs.js";
+import { downSyncChanges } from "./240-sync-changes.js";
 
 export interface MigrationRegistryEntry {
   /** The checkpoint key written to memory_checkpoints on completion. */
@@ -411,6 +412,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Create heartbeat_runs table for tracking heartbeat execution lifecycle with CAS state transitions",
     down: downHeartbeatRuns,
+  },
+  {
+    key: "migration_sync_changes_v1",
+    version: 48,
+    description:
+      "Create durable sync_changes table for multi-client cache invalidation cursors",
+    down: downSyncChanges,
   },
 ];
 

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -254,3 +254,22 @@ export const traceEvents = sqliteTable(
     ),
   ],
 );
+
+export const syncChanges = sqliteTable(
+  "sync_changes",
+  {
+    cursor: integer("cursor").primaryKey({ autoIncrement: true }),
+    createdAt: integer("created_at").notNull(),
+    resource: text("resource").notNull(),
+    resourceId: text("resource_id").notNull(),
+    op: text("op").notNull(),
+    version: integer("version"),
+    invalidatedTagsJson: text("invalidated_tags_json").notNull(),
+    originClientId: text("origin_client_id"),
+    metadataJson: text("metadata_json"),
+  },
+  (table) => [
+    index("idx_sync_changes_created_at").on(table.createdAt),
+    index("idx_sync_changes_resource").on(table.resource, table.resourceId),
+  ],
+);

--- a/assistant/src/memory/sync-change-store.ts
+++ b/assistant/src/memory/sync-change-store.ts
@@ -1,0 +1,216 @@
+import type {
+  SyncChange,
+  SyncInvalidationTag,
+  SyncOperation,
+  SyncResource,
+} from "../daemon/message-types/sync.js";
+import { getSqlite } from "./db-connection.js";
+
+export const DEFAULT_SYNC_CHANGE_RETENTION_ROWS = 10_000;
+
+export interface SyncChangeInput {
+  resource: SyncResource;
+  resourceId: string;
+  op: SyncOperation;
+  invalidatedTags: SyncInvalidationTag[];
+  version?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecordSyncChangesOptions {
+  originClientId?: string;
+  createdAt?: number;
+  retentionRows?: number;
+}
+
+interface SyncChangeRow {
+  cursor: number;
+  created_at: number;
+  resource: string;
+  resource_id: string;
+  op: string;
+  version: number | null;
+  invalidated_tags_json: string;
+  origin_client_id: string | null;
+  metadata_json: string | null;
+}
+
+export interface SyncCursorState {
+  latestCursor: number;
+  oldestCursor: number | null;
+  retentionFloorCursor: number;
+}
+
+function parseJsonArray(value: string): SyncInvalidationTag[] {
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.filter((item): item is string => typeof item === "string");
+}
+
+function parseMetadata(
+  value: string | null,
+): Record<string, unknown> | undefined {
+  if (!value) return undefined;
+  const parsed = JSON.parse(value) as unknown;
+  if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function rowToSyncChange(row: SyncChangeRow): SyncChange {
+  return {
+    cursor: row.cursor,
+    createdAt: row.created_at,
+    resource: row.resource as SyncResource,
+    resourceId: row.resource_id,
+    op: row.op as SyncOperation,
+    ...(row.version == null ? {} : { version: row.version }),
+    invalidatedTags: parseJsonArray(row.invalidated_tags_json),
+    ...(row.origin_client_id ? { originClientId: row.origin_client_id } : {}),
+    ...(row.metadata_json
+      ? { metadata: parseMetadata(row.metadata_json) }
+      : {}),
+  };
+}
+
+function assertValidChange(change: SyncChangeInput): void {
+  if (change.resourceId.trim() === "") {
+    throw new Error("Sync change resourceId must be non-empty");
+  }
+  if (change.invalidatedTags.length === 0) {
+    throw new Error("Sync change must include at least one invalidated tag");
+  }
+  for (const tag of change.invalidatedTags) {
+    if (tag.trim() === "") {
+      throw new Error("Sync invalidation tags must be non-empty");
+    }
+  }
+}
+
+export function recordSyncChanges(
+  changes: SyncChangeInput[],
+  options: RecordSyncChangesOptions = {},
+): SyncChange[] {
+  if (changes.length === 0) return [];
+  for (const change of changes) {
+    assertValidChange(change);
+  }
+
+  const sqlite = getSqlite();
+  const createdAt = options.createdAt ?? Date.now();
+  const inserted: SyncChange[] = [];
+  const insert = sqlite.prepare(/*sql*/ `
+    INSERT INTO sync_changes (
+      created_at,
+      resource,
+      resource_id,
+      op,
+      version,
+      invalidated_tags_json,
+      origin_client_id,
+      metadata_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const selectInserted = sqlite.prepare(
+    /*sql*/ `SELECT * FROM sync_changes WHERE cursor = ?`,
+  );
+
+  sqlite.exec("BEGIN IMMEDIATE");
+  try {
+    for (const change of changes) {
+      insert.run(
+        createdAt,
+        change.resource,
+        change.resourceId,
+        change.op,
+        change.version ?? null,
+        JSON.stringify(change.invalidatedTags),
+        options.originClientId ?? null,
+        change.metadata ? JSON.stringify(change.metadata) : null,
+      );
+      const cursor = (
+        sqlite.query("SELECT last_insert_rowid() AS cursor").get() as {
+          cursor: number;
+        }
+      ).cursor;
+      const row = selectInserted.get(cursor) as SyncChangeRow | null;
+      if (!row) {
+        throw new Error(`Failed to load inserted sync change ${cursor}`);
+      }
+      inserted.push(rowToSyncChange(row));
+    }
+    pruneSyncChangesToRetention(
+      options.retentionRows ?? DEFAULT_SYNC_CHANGE_RETENTION_ROWS,
+    );
+    sqlite.exec("COMMIT");
+  } catch (err) {
+    sqlite.exec("ROLLBACK");
+    throw err;
+  }
+
+  return inserted;
+}
+
+export function listSyncChangesSince(
+  cursor: number,
+  limit = 100,
+): SyncChange[] {
+  const boundedLimit = Math.max(1, Math.floor(limit));
+  const rows = getSqlite()
+    .query(
+      /*sql*/ `
+        SELECT * FROM sync_changes
+        WHERE cursor > ?
+        ORDER BY cursor ASC
+        LIMIT ?
+      `,
+    )
+    .all(Math.max(0, Math.floor(cursor)), boundedLimit) as SyncChangeRow[];
+  return rows.map(rowToSyncChange);
+}
+
+export function getSyncCursorState(): SyncCursorState {
+  const row = getSqlite()
+    .query(
+      /*sql*/ `
+        SELECT
+          MAX(cursor) AS latest_cursor,
+          MIN(cursor) AS oldest_cursor
+        FROM sync_changes
+      `,
+    )
+    .get() as { latest_cursor: number | null; oldest_cursor: number | null };
+  const latestCursor = row.latest_cursor ?? 0;
+  const oldestCursor = row.oldest_cursor;
+  return {
+    latestCursor,
+    oldestCursor,
+    retentionFloorCursor:
+      oldestCursor == null ? 0 : Math.max(0, oldestCursor - 1),
+  };
+}
+
+export function pruneSyncChangesToRetention(
+  retentionRows = DEFAULT_SYNC_CHANGE_RETENTION_ROWS,
+): number {
+  if (retentionRows <= 0) {
+    return 0;
+  }
+  const sqlite = getSqlite();
+  sqlite
+    .query(
+      /*sql*/ `
+        DELETE FROM sync_changes
+        WHERE cursor NOT IN (
+          SELECT cursor FROM sync_changes
+          ORDER BY cursor DESC
+          LIMIT ?
+        )
+      `,
+    )
+    .run(Math.floor(retentionRows));
+  return (sqlite.query("SELECT changes() AS c").get() as { c: number }).c;
+}


### PR DESCRIPTION
## Summary
- Add the `sync_changes` SQLite table, schema registration, and migration.
- Add a durable sync change store with monotonic cursors, cursor state, retention, and JSON field round-tripping.
- Cover insert, pagination, retention floor, and pruning behavior with focused tests.

## Stack
This is PR 2 of 3 for ATL-478.
Base PR: #29874

## Validation
- `bun test --preload ./src/__tests__/test-preload.ts src/memory/__tests__/sync-change-store.test.ts`
- `bunx tsc --noEmit`
- Pre-push assistant typecheck and ESLint passed.