### PR TITLE
[ATL-478] Expose sync catch-up runtime APIs

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -168,6 +168,8 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Events (SSE)
   { endpoint: "events", scopes: ["chat.read"] },
+  { endpoint: "sync/state", scopes: ["chat.read"] },
+  { endpoint: "sync/changes", scopes: ["chat.read"] },
 
   // Trace events
   { endpoint: "trace-events", scopes: ["chat.read"] },

--- a/assistant/src/runtime/routes/__tests__/sync-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/sync-routes.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { SYNC_TAGS } from "../../../daemon/message-types/sync.js";
+import { getSqlite } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { recordSyncChanges } from "../../../memory/sync-change-store.js";
+import { ROUTES } from "../sync-routes.js";
+
+initializeDb();
+
+function clearSyncChanges(): void {
+  getSqlite().run("DELETE FROM sync_changes");
+  getSqlite().run("DELETE FROM sqlite_sequence WHERE name = 'sync_changes'");
+}
+
+function routeHandler(endpoint: string) {
+  const route = ROUTES.find((item) => item.endpoint === endpoint);
+  if (!route) throw new Error(`Route not found: ${endpoint}`);
+  return route.handler;
+}
+
+beforeEach(() => {
+  clearSyncChanges();
+});
+
+describe("sync routes", () => {
+  test("GET /sync/state returns latest cursor", () => {
+    const handler = routeHandler("sync/state");
+    expect(handler({})).toEqual({
+      latestCursor: 0,
+      retentionFloorCursor: 0,
+    });
+
+    recordSyncChanges([
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantAvatar],
+      },
+    ]);
+
+    expect(handler({})).toEqual({
+      latestCursor: 1,
+      retentionFloorCursor: 0,
+    });
+  });
+
+  test("GET /sync/changes returns paginated changes since cursor", () => {
+    recordSyncChanges([
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantAvatar],
+      },
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantIdentity],
+      },
+    ]);
+
+    const handler = routeHandler("sync/changes");
+    const body = handler({
+      queryParams: { since: "0", limit: "1" },
+    }) as {
+      changes: Array<{ cursor: number }>;
+      latestCursor: number;
+      hasMore: boolean;
+      snapshotRequired: boolean;
+    };
+
+    expect(body.changes.map((change) => change.cursor)).toEqual([1]);
+    expect(body.latestCursor).toBe(2);
+    expect(body.hasMore).toBe(true);
+    expect(body.snapshotRequired).toBe(false);
+  });
+
+  test("GET /sync/changes marks malformed cursors as snapshot required", () => {
+    const handler = routeHandler("sync/changes");
+    const body = handler({
+      queryParams: { since: "not-a-number" },
+    }) as { changes: unknown[]; snapshotRequired: boolean };
+
+    expect(body.changes).toEqual([]);
+    expect(body.snapshotRequired).toBe(true);
+  });
+
+  test("GET /sync/changes marks cursors older than retention floor as snapshot required", () => {
+    recordSyncChanges([
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantAvatar],
+      },
+      {
+        resource: "assistant",
+        resourceId: "self",
+        op: "updated",
+        invalidatedTags: [SYNC_TAGS.assistantIdentity],
+      },
+    ]);
+    getSqlite().run("DELETE FROM sync_changes WHERE cursor = 1");
+
+    const handler = routeHandler("sync/changes");
+    const body = handler({
+      queryParams: { since: "0" },
+    }) as {
+      changes: unknown[];
+      latestCursor: number;
+      snapshotRequired: boolean;
+      retentionFloorCursor: number;
+    };
+
+    expect(body.changes).toEqual([]);
+    expect(body.latestCursor).toBe(2);
+    expect(body.retentionFloorCursor).toBe(1);
+    expect(body.snapshotRequired).toBe(true);
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -92,6 +92,7 @@ import { ROUTES as SUBAGENT_ROUTES } from "./subagents-routes.js";
 import { ROUTES as SUGGEST_TRUST_RULE_ROUTES } from "./suggest-trust-rule-routes.js";
 import { ROUTES as SURFACE_ACTION_ROUTES } from "./surface-action-routes.js";
 import { ROUTES as SURFACE_CONTENT_ROUTES } from "./surface-content-routes.js";
+import { ROUTES as SYNC_ROUTES } from "./sync-routes.js";
 import { ROUTES as TASK_ROUTES } from "./task-routes.js";
 import { ROUTES as TELEMETRY_ROUTES } from "./telemetry-routes.js";
 import { ROUTES as TRACE_EVENT_ROUTES } from "./trace-event-routes.js";
@@ -191,6 +192,7 @@ export const ROUTES: RouteDefinition[] = [
   ...SUBAGENT_ROUTES,
   ...SURFACE_ACTION_ROUTES,
   ...SURFACE_CONTENT_ROUTES,
+  ...SYNC_ROUTES,
   ...TELEGRAM_ROUTES,
   ...TWILIO_ROUTES,
   ...TASK_ROUTES,

--- a/assistant/src/runtime/routes/sync-routes.ts
+++ b/assistant/src/runtime/routes/sync-routes.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+
+import {
+  getSyncCursorState,
+  listSyncChangesSince,
+} from "../../memory/sync-change-store.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const DEFAULT_SYNC_CHANGES_LIMIT = 100;
+const MAX_SYNC_CHANGES_LIMIT = 500;
+
+const SyncChangeResponseSchema = z.object({
+  cursor: z.number().int().nonnegative(),
+  createdAt: z.number().int().nonnegative(),
+  resource: z.string(),
+  resourceId: z.string(),
+  op: z.string(),
+  version: z.number().int().nonnegative().optional(),
+  invalidatedTags: z.array(z.string()),
+  originClientId: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+function parseCursor(raw: string | undefined): number | null {
+  if (raw == null || raw.trim() === "") return null;
+  const cursor = Number(raw);
+  if (!Number.isSafeInteger(cursor) || cursor < 0) return null;
+  return cursor;
+}
+
+function parseLimit(raw: string | undefined): number {
+  if (raw == null || raw.trim() === "") return DEFAULT_SYNC_CHANGES_LIMIT;
+  const limit = Number(raw);
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    return DEFAULT_SYNC_CHANGES_LIMIT;
+  }
+  return Math.min(limit, MAX_SYNC_CHANGES_LIMIT);
+}
+
+function handleGetSyncState() {
+  const state = getSyncCursorState();
+  return {
+    latestCursor: state.latestCursor,
+    retentionFloorCursor: state.retentionFloorCursor,
+  };
+}
+
+function handleListSyncChanges({ queryParams = {} }: RouteHandlerArgs) {
+  const state = getSyncCursorState();
+  const since = parseCursor(queryParams.since);
+  const limit = parseLimit(queryParams.limit);
+
+  if (since == null || since < state.retentionFloorCursor) {
+    return {
+      changes: [],
+      latestCursor: state.latestCursor,
+      hasMore: false,
+      snapshotRequired: true,
+      retentionFloorCursor: state.retentionFloorCursor,
+    };
+  }
+
+  const changes = listSyncChangesSince(since, limit + 1);
+  const page = changes.slice(0, limit);
+  return {
+    changes: page,
+    latestCursor: state.latestCursor,
+    hasMore: changes.length > limit,
+    snapshotRequired: false,
+    retentionFloorCursor: state.retentionFloorCursor,
+  };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "getSyncState",
+    endpoint: "sync/state",
+    method: "GET",
+    policyKey: "sync/state",
+    summary: "Get sync cursor state",
+    description:
+      "Return the latest durable sync cursor so clients can initialize catch-up state.",
+    tags: ["sync"],
+    handler: handleGetSyncState,
+    responseBody: z.object({
+      latestCursor: z.number().int().nonnegative(),
+      retentionFloorCursor: z.number().int().nonnegative(),
+    }),
+  },
+  {
+    operationId: "listSyncChanges",
+    endpoint: "sync/changes",
+    method: "GET",
+    policyKey: "sync/changes",
+    summary: "List sync changes since cursor",
+    description:
+      "Return durable sync invalidations newer than the provided cursor.",
+    tags: ["sync"],
+    queryParams: [
+      {
+        name: "since",
+        type: "integer",
+        required: true,
+        description: "Last sync cursor observed by the client.",
+      },
+      {
+        name: "limit",
+        type: "integer",
+        description: "Maximum number of changes to return.",
+      },
+    ],
+    handler: handleListSyncChanges,
+    responseBody: z.object({
+      changes: z.array(SyncChangeResponseSchema),
+      latestCursor: z.number().int().nonnegative(),
+      hasMore: z.boolean(),
+      snapshotRequired: z.boolean(),
+      retentionFloorCursor: z.number().int().nonnegative(),
+    }),
+  },
+];

--- a/assistant/src/runtime/sync/sync-publisher.test.ts
+++ b/assistant/src/runtime/sync/sync-publisher.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { SYNC_TAGS } from "../../daemon/message-types/sync.js";
+import { getSqlite } from "../../memory/db-connection.js";
+import { initializeDb } from "../../memory/db-init.js";
+import { listSyncChangesSince } from "../../memory/sync-change-store.js";
+import type { AssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import { publishSyncChanges } from "./sync-publisher.js";
+
+initializeDb();
+
+function clearSyncChanges(): void {
+  getSqlite().run("DELETE FROM sync_changes");
+  getSqlite().run("DELETE FROM sqlite_sequence WHERE name = 'sync_changes'");
+}
+
+beforeEach(() => {
+  clearSyncChanges();
+});
+
+describe("sync publisher", () => {
+  test("records changes before broadcasting sync_changed", async () => {
+    const received: AssistantEvent[] = [];
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: (event) => {
+        received.push(event);
+      },
+    });
+
+    try {
+      const persisted = await publishSyncChanges(
+        [
+          {
+            resource: "assistant",
+            resourceId: "self",
+            op: "updated",
+            invalidatedTags: [SYNC_TAGS.assistantAvatar],
+          },
+        ],
+        { originClientId: "client-1", createdAt: 1234 },
+      );
+
+      expect(persisted).toHaveLength(1);
+      expect(listSyncChangesSince(0)).toHaveLength(1);
+      expect(received).toHaveLength(1);
+      expect(received[0].message).toMatchObject({
+        type: "sync_changed",
+        cursor: 1,
+        tags: [SYNC_TAGS.assistantAvatar],
+        originClientId: "client-1",
+      });
+    } finally {
+      subscription.dispose();
+    }
+  });
+
+  test("keeps durable storage when live publish fails", async () => {
+    const subscription = assistantEventHub.subscribe({
+      type: "process",
+      callback: () => {
+        throw new Error("subscriber failed");
+      },
+    });
+
+    try {
+      const persisted = await publishSyncChanges([
+        {
+          resource: "assistant",
+          resourceId: "self",
+          op: "updated",
+          invalidatedTags: [SYNC_TAGS.assistantIdentity],
+        },
+      ]);
+
+      expect(persisted).toHaveLength(1);
+      expect(listSyncChangesSince(0)).toHaveLength(1);
+    } finally {
+      subscription.dispose();
+    }
+  });
+});

--- a/assistant/src/runtime/sync/sync-publisher.ts
+++ b/assistant/src/runtime/sync/sync-publisher.ts
@@ -1,0 +1,33 @@
+import type { SyncChange } from "../../daemon/message-types/sync.js";
+import { buildSyncChangedMessage } from "../../daemon/message-types/sync.js";
+import type { SyncChangeInput } from "../../memory/sync-change-store.js";
+import { recordSyncChanges } from "../../memory/sync-change-store.js";
+import { getLogger } from "../../util/logger.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+
+const log = getLogger("sync-publisher");
+
+export interface PublishSyncChangesOptions {
+  originClientId?: string;
+  createdAt?: number;
+  retentionRows?: number;
+}
+
+export async function publishSyncChanges(
+  changes: SyncChangeInput[],
+  options: PublishSyncChangesOptions = {},
+): Promise<SyncChange[]> {
+  const persisted = recordSyncChanges(changes, options);
+  if (persisted.length === 0) {
+    return persisted;
+  }
+
+  const message = buildSyncChangedMessage(persisted, options.originClientId);
+  try {
+    await assistantEventHub.publish(buildAssistantEvent(message));
+  } catch (err) {
+    log.warn({ err }, "Failed to publish sync_changed event");
+  }
+  return persisted;
+}


### PR DESCRIPTION
## Summary
- Add `GET /v1/sync/state` and `GET /v1/sync/changes` for durable cursor catch-up.
- Register sync route policies under `chat.read`.
- Add `publishSyncChanges`, which records durable changes before broadcasting `sync_changed`.

## Stack
This is PR 3 of 3 for ATL-478.
Base PRs: #29874, #29875

## Validation
- `bun test --preload ./src/__tests__/test-preload.ts src/runtime/routes/__tests__/sync-routes.test.ts`
- `bun test --preload ./src/__tests__/test-preload.ts src/runtime/sync/sync-publisher.test.ts`
- `bunx tsc --noEmit`
- Pre-push assistant typecheck and ESLint passed.