### PR TITLE
perf(qdrant): cap default_segment_number at 2 for memory collections

### DIFF
--- a/assistant/src/memory/qdrant-client.ts
+++ b/assistant/src/memory/qdrant-client.ts
@@ -248,6 +248,9 @@ export class VellumQdrantClient {
           m: 16,
           ef_construct: 100,
         },
+        optimizers_config: {
+          default_segment_number: 2,
+        },
         quantization_config:
           this.quantization === "scalar"
             ? {

--- a/assistant/src/memory/v2/qdrant.ts
+++ b/assistant/src/memory/v2/qdrant.ts
@@ -197,6 +197,9 @@ async function ensureConceptPageCollectionOnce(): Promise<{
         m: 16,
         ef_construct: 100,
       },
+      optimizers_config: {
+        default_segment_number: 2,
+      },
       on_disk_payload: onDisk,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Both memory collections (\`memory\`, \`memory_v2_concept_pages\`) were created with \`default_segment_number: 0\`, which Qdrant interprets as \"use CPU count.\" On the 8-core staging nodes that produced 8 segments per collection.
- Each segment pre-allocates fixed-size 32 MB mmap chunks per named vector + payload, so v1 (3 chunks) costs ~96 MB/segment and v2 (5 chunks: dense + summary_dense + sparse + summary_sparse + payload) costs ~160 MB/segment — regardless of how many points are stored.
- Setting \`default_segment_number: 2\` cuts the fixed mmap overhead 4x. A fresh empty pod should drop from ~2.3 GB to ~580 MB Qdrant footprint.

## Original prompt
Investigated a platform-hosted assistant pod (\`assistant-d332238d-c11f-4722-ad88-b333bc6d90e7-0\`) where \`vellum-qdrant\` was sitting at 2.7 GB RES with effectively no user data (711 points total across both collections). Traced the bloat to 16 nearly-empty segments × ~100-168 MB of pre-allocated mmap chunks. Capping \`default_segment_number\` at 2 in both \`createCollection\` calls reduces the per-pod baseline.

Note: only affects newly created collections. Existing pods will need to recreate the collections (or wait for natural segment merging) to reclaim the on-disk + RES space.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->