### PR TITLE
refactor(memory): gate v1 maintenance paths when memory v2 is enabled

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -56,6 +56,16 @@ let autoAnalyzeEnabled = true;
 // `disposeConversation` must skip the `graph_extract` enqueue.
 const autoAnalysisConversations = new Set<string>();
 
+// Toggles the `memory.v2.enabled` flag the disposal code reads via
+// `getConfig()`. Defaults to false so the bulk of the suite — which asserts
+// v1 graph_extract still fires — keeps its semantics. The dedicated v2 cases
+// flip this to true.
+let v2Enabled = false;
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({ memory: { v2: { enabled: v2Enabled } } }),
+}));
+
 mock.module("../../memory/auto-analysis-guard.js", () => ({
   AUTO_ANALYSIS_SOURCE: "auto-analysis",
   isAutoAnalysisConversation: (conversationId: string) =>
@@ -160,6 +170,7 @@ describe("disposeConversation — auto-analysis enqueue", () => {
     autoAnalyzeCalls.length = 0;
     autoAnalyzeEnabled = true;
     autoAnalysisConversations.clear();
+    v2Enabled = false;
   });
 
   test("guardian conversation with auto-analyze ON — enqueues both graph_extract and conversation_analyze (via helper)", () => {
@@ -312,5 +323,26 @@ describe("disposeConversation — auto-analysis enqueue", () => {
       },
     }));
     autoAnalyzeEnabled = originalEnabled;
+  });
+
+  test("memory v2 enabled — graph_extract enqueue is suppressed (auto-analysis still runs)", () => {
+    // Under memory v2, the v1 graph has no readers (retrieval is bypassed at
+    // conversation-graph-memory.ts), so producing extraction jobs just fills
+    // the queue with stale work. Auto-analysis is orthogonal and must keep
+    // running.
+    v2Enabled = true;
+    const ctx = makeDisposeContext({
+      conversationId: "conv-v2-on",
+      trustClass: "guardian",
+    });
+
+    disposeConversation(ctx);
+
+    expect(memoryJobCalls).toHaveLength(0);
+    expect(autoAnalyzeCalls).toHaveLength(1);
+    expect(autoAnalyzeCalls[0]).toEqual({
+      conversationId: "conv-v2-on",
+      trigger: "lifecycle",
+    });
   });
 });

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -4,6 +4,7 @@
  * can delegate without exposing its full surface.
  */
 
+import { getConfig } from "../config/loader.js";
 import { createContextSummaryMessage } from "../context/window-manager.js";
 import type { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
@@ -373,16 +374,29 @@ export function disposeConversation(ctx: DisposeContext): void {
       // Best-effort — don't block conversation disposal
     }
     if (!isAutoAnalysis) {
+      // Suppress v1 graph extraction when memory v2 is active — v2 reads
+      // from buffer.md and concept pages, so the v1 graph would be stale
+      // data nobody consumes. Mirrors the gate applied in `indexer.ts`
+      // for the per-message indexing path. Fail open to v1 if config
+      // can't load, since the worker handler also short-circuits.
+      let v2Enabled = false;
       try {
-        enqueueMemoryJob("graph_extract", {
-          conversationId: ctx.conversationId,
-          scopeId: "default",
-          ...(ctx.activeContextNodeIds?.length
-            ? { activeContextNodeIds: ctx.activeContextNodeIds }
-            : {}),
-        });
+        v2Enabled = getConfig().memory.v2.enabled;
       } catch {
-        // Best-effort — don't block conversation disposal
+        // Best-effort — fall through to legacy v1 enqueue
+      }
+      if (!v2Enabled) {
+        try {
+          enqueueMemoryJob("graph_extract", {
+            conversationId: ctx.conversationId,
+            scopeId: "default",
+            ...(ctx.activeContextNodeIds?.length
+              ? { activeContextNodeIds: ctx.activeContextNodeIds }
+              : {}),
+          });
+        } catch {
+          // Best-effort — don't block conversation disposal
+        }
       }
     }
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -736,41 +736,48 @@ export async function runDaemon(): Promise<void> {
       }
 
       if (qdrantStarted) {
-        try {
-          const embeddingSelection = await selectEmbeddingBackend(config);
-          // Sentinel only encodes the dense provider+model identity; sparse
-          // encoder changes never require collection recreation, so they
-          // intentionally do not contribute to the v1 collection identity.
-          const embeddingModel = embeddingSelection.backend
-            ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
-            : undefined;
-          const qdrantClient = initQdrantClient({
-            url: qdrantUrl,
-            collection: config.memory.qdrant.collection,
-            vectorSize: config.memory.qdrant.vectorSize,
-            onDisk: config.memory.qdrant.onDisk,
-            quantization: config.memory.qdrant.quantization,
-            embeddingModel,
-          });
+        // Skip the v1 Qdrant collection lifecycle when memory v2 is active —
+        // the v1 collection has no writers (handleRemember returns early) or
+        // readers (graph search is bypassed) under v2, so ensuring/migrating
+        // it just maintains a dead-on-arrival collection. Existing on-disk
+        // collections are left intact so flipping v2 off restores v1 cleanly.
+        if (!config.memory.v2.enabled) {
+          try {
+            const embeddingSelection = await selectEmbeddingBackend(config);
+            // Sentinel only encodes the dense provider+model identity; sparse
+            // encoder changes never require collection recreation, so they
+            // intentionally do not contribute to the v1 collection identity.
+            const embeddingModel = embeddingSelection.backend
+              ? `${embeddingSelection.backend.provider}:${embeddingSelection.backend.model}`
+              : undefined;
+            const qdrantClient = initQdrantClient({
+              url: qdrantUrl,
+              collection: config.memory.qdrant.collection,
+              vectorSize: config.memory.qdrant.vectorSize,
+              onDisk: config.memory.qdrant.onDisk,
+              quantization: config.memory.qdrant.quantization,
+              embeddingModel,
+            });
 
-          // Eagerly ensure the collection exists so we detect migrations
-          // (unnamed→named vectors, dimension/model changes) at startup.
-          // If a destructive migration occurred, enqueue a rebuild_index job
-          // to re-embed all memory items from the SQLite cache.
-          const { migrated } = await qdrantClient.ensureCollection();
-          if (migrated) {
-            enqueueMemoryJob("rebuild_index", {});
-            log.info(
-              "Qdrant collection was migrated — enqueued rebuild_index job",
+            // Eagerly ensure the collection exists so we detect migrations
+            // (unnamed→named vectors, dimension/model changes) at startup.
+            // If a destructive migration occurred, enqueue a rebuild_index job
+            // to re-embed all memory items from the SQLite cache.
+            const { migrated } = await qdrantClient.ensureCollection();
+            if (migrated) {
+              enqueueMemoryJob("rebuild_index", {});
+              log.info(
+                "Qdrant collection was migrated — enqueued rebuild_index job",
+              );
+            }
+
+            log.info("Qdrant vector store initialized");
+          } catch (err) {
+            log.warn(
+              { err },
+              "Qdrant client initialization failed — memory features will be degraded",
             );
           }
-
-          log.info("Qdrant vector store initialized");
-        } catch (err) {
-          log.warn(
-            { err },
-            "Qdrant client initialization failed — memory features will be degraded",
-          );
         }
 
         // Detect schema drift on the v2 concept-page collection (e.g.
@@ -788,27 +795,28 @@ export async function runDaemon(): Promise<void> {
           );
         }
 
-        // Reconcile the PKB Qdrant index against the on-disk tree. Kept
-        // inside the `qdrantStarted` guard so we don't call
-        // `getQdrantClient()` (which throws "not initialized") on every
-        // startup when Qdrant is unavailable. Fire-and-forget so enqueued
-        // re-index jobs drain in the background and first-turn latency
-        // stays unaffected.
-        void (async () => {
-          try {
-            const { reconcilePkbIndex } =
-              await import("../memory/pkb/pkb-reconcile.js");
-            const { PKB_WORKSPACE_SCOPE } =
-              await import("../memory/pkb/types.js");
-            const pkbRoot = join(getWorkspaceDir(), "pkb");
-            await reconcilePkbIndex(pkbRoot, PKB_WORKSPACE_SCOPE);
-          } catch (err) {
-            log.warn(
-              { err },
-              "PKB index reconciliation failed — continuing startup",
-            );
-          }
-        })();
+        // Reconcile the PKB Qdrant index against the on-disk tree. Gated on
+        // !v2 because PKB is the v1 storage layer; under v2 the v1 collection
+        // is not initialized, so calling `getQdrantClient()` here would throw.
+        // Fire-and-forget so enqueued re-index jobs drain in the background
+        // and first-turn latency stays unaffected.
+        if (!config.memory.v2.enabled) {
+          void (async () => {
+            try {
+              const { reconcilePkbIndex } =
+                await import("../memory/pkb/pkb-reconcile.js");
+              const { PKB_WORKSPACE_SCOPE } =
+                await import("../memory/pkb/types.js");
+              const pkbRoot = join(getWorkspaceDir(), "pkb");
+              await reconcilePkbIndex(pkbRoot, PKB_WORKSPACE_SCOPE);
+            } catch (err) {
+              log.warn(
+                { err },
+                "PKB index reconciliation failed — continuing startup",
+              );
+            }
+          })();
+        }
 
         // Build the BM25 corpus stats (per-token document frequencies and
         // average document length) used by the v2 sparse channel. Without

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -509,6 +509,11 @@ async function processJob(
       await embedGraphTriggerJob(job, config);
       return;
     case "graph_extract":
+      // Stale rows enqueued before v2 was enabled (or by any unguarded v1
+      // path) must not consume embedding/extraction budget when v2 is on.
+      if (config.memory.v2.enabled) {
+        return;
+      }
       await graphExtractJob(job, config);
       return;
     case "conversation_analyze":


### PR DESCRIPTION
## Summary

- Stop allocating/maintaining the v1 `\"memory\"` Qdrant collection at startup when `memory.v2.enabled` is true (default) — fresh assistants no longer get a dead-on-arrival collection
- Stop enqueueing `graph_extract` on conversation end when v2 is on; defensive short-circuit in the handler catches any stale rows
- Skip the PKB reconcile fire-and-forget when v2 is on (it would throw without the v1 client initialized)
- v1 collections on disk are left intact so toggling `memory.v2.enabled: false` still restores v1 cleanly

## Original prompt

Investigation in chat surfaced that even with `memory.v2.enabled: true`, several v1 maintenance paths still ran on every daemon startup and conversation end — wasting CPU/disk/embedding budget on data nothing reads. The ask was to add gating so a fresh assistant with v2 on doesn't allocate the v1 `\"memory\"` Qdrant collection or accrue stale `graph_extract` jobs, while keeping toggle-back to v1 working. Audited the other `getQdrantClient()` callers and confirmed they're either already v2-gated or handle \"not initialized\" gracefully.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->