### PR TITLE
[codex] Fix message_complete display id for tool turns

### DIFF
--- a/assistant/src/__tests__/message-complete-display-id.test.ts
+++ b/assistant/src/__tests__/message-complete-display-id.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    skills: {
+      entries: {},
+      load: { extraDirs: [], watch: true, watchDebounceMs: 250 },
+      install: { nodeManager: "npm" },
+      allowBundled: null,
+      remoteProviders: {
+        skillssh: { enabled: true },
+        clawhub: { enabled: true },
+      },
+      remotePolicy: {
+        blockSuspicious: true,
+        blockMalware: true,
+        maxSkillsShRisk: "medium",
+      },
+    },
+  }),
+  loadConfig: () => ({}),
+}));
+
+interface AddMessageCall {
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+const addMessageCalls: AddMessageCall[] = [];
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: (
+    conversationId: string,
+    role: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ) => {
+    addMessageCalls.push({ conversationId, role, content, metadata });
+    return { id: `mock-msg-${addMessageCalls.length}` };
+  },
+  getConversation: () => null,
+  getMessageById: () => null,
+  provenanceFromTrustContext: () => ({}),
+  updateMessageContent: () => {},
+}));
+
+mock.module("../memory/llm-request-log-store.js", () => ({
+  backfillMessageIdOnLogs: () => {},
+  recordRequestLog: () => {},
+}));
+
+mock.module("../memory/memory-recall-log-store.js", () => ({
+  backfillMemoryRecallLogMessageId: () => {},
+}));
+
+mock.module("../memory/memory-v2-activation-log-store.js", () => ({
+  backfillMemoryV2ActivationMessageId: () => {},
+}));
+
+mock.module("../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+}));
+
+import type { AgentEvent } from "../agent/loop.js";
+import type {
+  EventHandlerDeps,
+  EventHandlerState,
+} from "../daemon/conversation-agent-loop-handlers.js";
+import {
+  createEventHandlerState,
+  getClientDisplayMessageId,
+  handleMessageComplete,
+} from "../daemon/conversation-agent-loop-handlers.js";
+
+const CONVERSATION_ID = "conv-display-id";
+
+function makeDeps(): EventHandlerDeps {
+  return {
+    ctx: {
+      conversationId: CONVERSATION_ID,
+      currentTurnSurfaces: [],
+      provider: { name: "anthropic" },
+      traceEmitter: { emit: () => {} },
+      trustContext: {
+        sourceChannel: "vellum",
+        trustClass: "guardian",
+      },
+    } as unknown as EventHandlerDeps["ctx"],
+    onEvent: () => {},
+    reqId: "req-display-id",
+    isFirstMessage: false,
+    shouldGenerateTitle: false,
+    rlog: new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }) as unknown as EventHandlerDeps["rlog"],
+    turnChannelContext: {
+      userMessageChannel: "vellum",
+      assistantMessageChannel: "vellum",
+    } as EventHandlerDeps["turnChannelContext"],
+    turnInterfaceContext: {
+      userMessageInterface: "web",
+      assistantMessageInterface: "web",
+    } as EventHandlerDeps["turnInterfaceContext"],
+  };
+}
+
+function makeMessageCompleteEvent(
+  content: Extract<
+    AgentEvent,
+    { type: "message_complete" }
+  >["message"]["content"],
+): Extract<AgentEvent, { type: "message_complete" }> {
+  return {
+    type: "message_complete",
+    message: { role: "assistant", content },
+  };
+}
+
+describe("message_complete display identity", () => {
+  let state: EventHandlerState;
+
+  beforeEach(() => {
+    addMessageCalls.length = 0;
+    state = createEventHandlerState();
+    state.turnStartedAt = 1_700_000_000_000;
+  });
+
+  test("tracks the merged display id separately from the final row id", async () => {
+    await handleMessageComplete(
+      state,
+      makeDeps(),
+      makeMessageCompleteEvent([
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "bash",
+          input: { command: "true" },
+        },
+      ]),
+    );
+
+    expect(state.firstAssistantMessageId).toBe("mock-msg-1");
+    expect(state.lastAssistantMessageId).toBe("mock-msg-1");
+    expect(getClientDisplayMessageId(state)).toBe("mock-msg-1");
+
+    state.pendingToolResults.set("toolu_1", {
+      content: "ok",
+      isError: false,
+    });
+
+    await handleMessageComplete(
+      state,
+      makeDeps(),
+      makeMessageCompleteEvent([{ type: "text", text: "done" }]),
+    );
+
+    expect(addMessageCalls.map((call) => call.role)).toEqual([
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    expect(state.firstAssistantMessageId).toBe("mock-msg-1");
+    expect(state.lastAssistantMessageId).toBe("mock-msg-3");
+    expect(getClientDisplayMessageId(state)).toBe("mock-msg-1");
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -127,6 +127,11 @@ export interface EventHandlerState {
    */
   contextTooLargeError: unknown;
   providerErrorUserMessage: string | null;
+  /**
+   * First persisted assistant row in this run; history keeps this id when it
+   * merges tool-turn rows into one display bubble.
+   */
+  firstAssistantMessageId: string | undefined;
   lastAssistantMessageId: string | undefined;
   readonly pendingToolResults: Map<string, PendingToolResult>;
   readonly persistedToolUseIds: Set<string>;
@@ -222,6 +227,7 @@ export function createEventHandlerState(): EventHandlerState {
     contextTooLargeDetected: false,
     contextTooLargeError: null,
     providerErrorUserMessage: null,
+    firstAssistantMessageId: undefined,
     lastAssistantMessageId: undefined,
     pendingToolResults: new Map(),
     persistedToolUseIds: new Set(),
@@ -243,6 +249,12 @@ export function createEventHandlerState(): EventHandlerState {
     currentTurnToolUseIds: [],
     turnStartedAt: Date.now(),
   };
+}
+
+export function getClientDisplayMessageId(
+  state: EventHandlerState,
+): string | undefined {
+  return state.firstAssistantMessageId ?? state.lastAssistantMessageId;
 }
 
 // ── Shared Helper ────────────────────────────────────────────────────
@@ -1004,6 +1016,7 @@ export async function handleMessageComplete(
     DEFAULT_TIMEOUTS.persistence,
   )) as PersistAddResult;
   const assistantMsg = assistantPersistResult.message;
+  state.firstAssistantMessageId ??= assistantMsg.id;
   state.lastAssistantMessageId = assistantMsg.id;
 
   // Backfill message_id on all LLM request logs from this turn.

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -147,6 +147,7 @@ import {
   createEventHandlerState,
   dispatchAgentEvent,
   type EventHandlerDeps,
+  getClientDisplayMessageId,
 } from "./conversation-agent-loop-handlers.js";
 import {
   approveHostAttachmentRead,
@@ -2834,6 +2835,7 @@ export async function runAgentLoopImpl(
       ctx.lastAssistantAttachments = assistantAttachments;
       ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
       syncLastAssistantMessageToDisk();
+      const clientDisplayMessageId = getClientDisplayMessageId(state);
 
       // Re-check: the user may have cancelled during attachment resolution
       if (abortController.signal.aborted) {
@@ -2874,6 +2876,9 @@ export async function runAgentLoopImpl(
           ...(state.lastAssistantMessageId
             ? { messageId: state.lastAssistantMessageId }
             : {}),
+          ...(clientDisplayMessageId
+            ? { displayMessageId: clientDisplayMessageId }
+            : {}),
         });
       } else {
         ctx.emitActivityState("idle", "message_complete", "global", reqId);
@@ -2896,6 +2901,9 @@ export async function runAgentLoopImpl(
             : {}),
           ...(state.lastAssistantMessageId
             ? { messageId: state.lastAssistantMessageId }
+            : {}),
+          ...(clientDisplayMessageId
+            ? { displayMessageId: clientDisplayMessageId }
             : {}),
         });
 

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -310,8 +310,14 @@ export interface GenerationHandoff {
   queuedCount: number;
   attachments?: UserMessageAttachment[];
   attachmentWarnings?: string[];
-  /** Database ID of the persisted assistant message, if any. */
+  /** Database ID of the final persisted assistant row, if any. */
   messageId?: string;
+  /**
+   * Database ID used by clients for the rendered assistant bubble. Tool turns
+   * may persist multiple assistant rows; this matches the history row that
+   * survives query-time merging.
+   */
+  displayMessageId?: string;
 }
 
 export interface ModelInfo {
@@ -387,7 +393,10 @@ export interface HistoryResponse {
   type: "history_response";
   conversationId: string;
   messages: Array<{
-    id?: string; // Database message ID (for matching surfaces)
+    /** Database ID used by clients for the rendered message bubble. */
+    id?: string;
+    /** Concrete persisted row ID for row-scoped actions such as TTS/fork. */
+    daemonMessageId?: string;
     role: string;
     text: string;
     timestamp: number;

--- a/assistant/src/daemon/message-types/messages.ts
+++ b/assistant/src/daemon/message-types/messages.ts
@@ -240,8 +240,14 @@ export interface MessageComplete {
   conversationId?: string;
   attachments?: UserMessageAttachment[];
   attachmentWarnings?: string[];
-  /** Database ID of the persisted assistant message, if any. */
+  /** Database ID of the final persisted assistant row, if any. */
   messageId?: string;
+  /**
+   * Database ID used by clients for the rendered assistant bubble. Tool turns
+   * may persist multiple assistant rows; this matches the history row that
+   * survives query-time merging.
+   */
+  displayMessageId?: string;
   /**
    * Distinguishes a real main-turn completion from auxiliary events such as
    * call transcripts, call summaries, and watch notifier outputs. Clients

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -191,6 +191,8 @@ export interface RuntimeAttachmentMetadata {
 
 export interface RuntimeMessagePayload {
   id: string;
+  /** Concrete persisted assistant row id for row-scoped actions. */
+  daemonMessageId?: string;
   role: string;
   content: string;
   timestamp: string;

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -652,8 +652,14 @@ export function handleListMessages(
     // on createdAt. The mismatch is benign — it may return slightly extra
     // data on a page boundary but never loses messages.
     const displayTimestamp = m.sentAt ?? m.timestamp;
+    const mergedMessageIds = mergedIdMap.get(m.id) ?? [];
+    const daemonMessageId =
+      m.role === "assistant"
+        ? (mergedMessageIds[mergedMessageIds.length - 1] ?? m.id)
+        : undefined;
     return {
       id: m.id ?? "",
+      ...(daemonMessageId ? { daemonMessageId } : {}),
       role: m.role,
       content: m.text,
       timestamp: new Date(displayTimestamp).toISOString(),

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -253,6 +253,22 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.messages[0].isStreaming)
     }
 
+    func testMessageCompleteKeepsDisplayAndDaemonIdsSeparate() {
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response")))
+
+        viewModel.handleServerMessage(
+            .messageComplete(
+                MessageCompleteMessage(
+                    messageId: "row-a2",
+                    displayMessageId: "display-a1"
+                )
+            )
+        )
+
+        XCTAssertEqual(viewModel.messages[0].daemonMessageId, "row-a2")
+        XCTAssertEqual(viewModel.messages[0].displayMessageId, "display-a1")
+    }
+
     func testMessageCompleteWithoutStreamingMessage() {
         viewModel.isSending = true
         viewModel.isThinking = true
@@ -921,6 +937,26 @@ final class ChatViewModelTests: XCTestCase {
         } else {
             XCTFail("Expected dequeued message to remain in transcript")
         }
+    }
+
+    func testGenerationHandoffKeepsDisplayAndDaemonIdsSeparate() {
+        viewModel.conversationId = "sess-1"
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Response to A")))
+
+        viewModel.handleServerMessage(
+            .generationHandoff(
+                GenerationHandoffMessage(
+                    conversationId: "sess-1",
+                    requestId: nil,
+                    queuedCount: 1,
+                    messageId: "row-a2",
+                    displayMessageId: "display-a1"
+                )
+            )
+        )
+
+        XCTAssertEqual(viewModel.messages[0].daemonMessageId, "row-a2")
+        XCTAssertEqual(viewModel.messages[0].displayMessageId, "display-a1")
     }
 
     func testMessageDequeuedRestoresSendingAndThinkingState() {
@@ -2186,6 +2222,26 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.messages[1].attachments.count, 1)
         XCTAssertEqual(viewModel.messages[1].attachments[0].filename, "chart.png")
         XCTAssertEqual(viewModel.messages[1].attachments[0].id, "hist-att-1")
+    }
+
+    func testPopulateFromHistoryKeepsDisplayAndDaemonIdsSeparate() {
+        let displayId = UUID()
+        let historyItems: [HistoryResponseMessage] = [
+            HistoryResponseMessage(
+                id: displayId.uuidString,
+                daemonMessageId: "row-a2",
+                role: "assistant",
+                text: "Done",
+                timestamp: 1000
+            ),
+        ]
+
+        viewModel.populateFromHistory(historyItems, hasMore: false)
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        XCTAssertEqual(viewModel.messages[0].id, displayId)
+        XCTAssertEqual(viewModel.messages[0].displayMessageId, displayId.uuidString)
+        XCTAssertEqual(viewModel.messages[0].daemonMessageId, "row-a2")
     }
 
     func testPopulateFromHistoryIncludesAttachmentOnlyMessages() {

--- a/clients/shared/Features/Chat/ChatActionHandler.swift
+++ b/clients/shared/Features/Chat/ChatActionHandler.swift
@@ -504,12 +504,17 @@ final class ChatActionHandler {
         // Flush any buffered streaming text before finalizing the message.
         vm.flushStreamingBuffer()
         vm.flushPartialOutputBuffer()
-        // Backfill the daemon's persisted message ID so fork, inspect,
-        // TTS, and other daemon-anchored actions work without a history reload.
-        if let messageId = complete.messageId,
-           let msgId = vm.currentAssistantMessageId,
+        // Backfill both ids without a history reload: messageId is the
+        // concrete persisted row for row-scoped actions, while displayMessageId
+        // is the merged history/display id used for reconciliation.
+        if let msgId = vm.currentAssistantMessageId,
            let idx = vm.messages.firstIndex(where: { $0.id == msgId }) {
-            vm.messages[idx].daemonMessageId = messageId
+            if let messageId = complete.messageId {
+                vm.messages[idx].daemonMessageId = messageId
+            }
+            if let displayMessageId = complete.displayMessageId ?? complete.messageId {
+                vm.messages[idx].displayMessageId = displayMessageId
+            }
         }
         // Strip heavy binary data from old messages to cap memory growth.
         vm.trimOldMessagesIfNeeded()
@@ -958,11 +963,15 @@ final class ChatActionHandler {
         vm.ingestAssistantAttachments(handoff.attachments)
         // Keep isSending = true — daemon is handing off to next queued message
         if let existingId = vm.currentAssistantMessageId {
-            // Backfill the daemon's persisted message ID so fork, inspect,
-            // TTS, and other daemon-anchored actions work without a history reload.
-            if let messageId = handoff.messageId,
-               let index = vm.messages.firstIndex(where: { $0.id == existingId }) {
-                vm.messages[index].daemonMessageId = messageId
+            // Backfill both ids before the handoff clears currentAssistantMessageId.
+            // messageId remains row-scoped; displayMessageId is the merged bubble id.
+            if let index = vm.messages.firstIndex(where: { $0.id == existingId }) {
+                if let messageId = handoff.messageId {
+                    vm.messages[index].daemonMessageId = messageId
+                }
+                if let displayMessageId = handoff.displayMessageId ?? handoff.messageId {
+                    vm.messages[index].displayMessageId = displayMessageId
+                }
             }
             vm.messages.finalizeStreamingMessage(id: existingId, completeToolCalls: .none)
         }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1688,8 +1688,11 @@ public struct ChatMessage: Identifiable, Equatable {
     /// Typed error metadata for inline error display (category icon, recovery suggestion, etc.).
     /// Populated when the error originates from a `ConversationErrorMessage`.
     public var conversationError: ConversationError?
-    /// The daemon's persisted message ID, populated from history responses.
-    /// Nil for freshly streamed messages that haven't been loaded from history.
+    /// The daemon/history ID for the rendered bubble after history merges tool turns.
+    /// Used to reconcile a live streamed bubble with the same bubble loaded from history.
+    public var displayMessageId: String?
+    /// The daemon's concrete persisted message row ID.
+    /// Nil for freshly streamed messages until completion or history backfills it.
     /// Used for fork-from-message, inspect LLM context, TTS, and other daemon-anchored actions.
     public var daemonMessageId: String?
     /// Client-generated correlation nonce stamped on the optimistic row at

--- a/clients/shared/Features/Chat/HistoryReconstructionService.swift
+++ b/clients/shared/Features/Chat/HistoryReconstructionService.swift
@@ -134,7 +134,8 @@ public enum HistoryReconstructionService {
                 chatMsg = ChatMessage(role: role, text: item.text, timestamp: timestamp, attachments: attachments, toolCalls: toolCalls)
             }
 
-            chatMsg.daemonMessageId = item.id
+            chatMsg.displayMessageId = item.id
+            chatMsg.daemonMessageId = item.daemonMessageId ?? item.id
             chatMsg.wasTruncated = item.wasTruncated ?? false
             for i in chatMsg.attachments.indices {
                 chatMsg.attachments[i].data = ""

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -1706,8 +1706,9 @@ public struct GenerationHandoff: Codable, Sendable {
     public let attachments: [UserMessageAttachment]?
     public let attachmentWarnings: [String]?
     public let messageId: String?
+    public let displayMessageId: String?
 
-    public init(type: String, conversationId: String, requestId: String? = nil, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
+    public init(type: String, conversationId: String, requestId: String? = nil, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, displayMessageId: String? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.requestId = requestId
@@ -1715,6 +1716,7 @@ public struct GenerationHandoff: Codable, Sendable {
         self.attachments = attachments
         self.attachmentWarnings = attachmentWarnings
         self.messageId = messageId
+        self.displayMessageId = displayMessageId
     }
 }
 
@@ -2149,6 +2151,7 @@ public struct HistoryResponse: Codable, Sendable {
 
 public struct HistoryResponseMessage: Codable, Sendable {
     public let id: String?
+    public let daemonMessageId: String?
     public let role: String
     public let text: String
     public let timestamp: Double
@@ -2169,8 +2172,9 @@ public struct HistoryResponseMessage: Codable, Sendable {
     /// True when text or tool result content was truncated due to maxTextChars/maxToolResultChars.
     public let wasTruncated: Bool?
 
-    public init(id: String? = nil, role: String, text: String, timestamp: Double, toolCalls: [HistoryResponseToolCall]? = nil, toolCallsBeforeText: Bool? = nil, attachments: [UserMessageAttachment]? = nil, textSegments: [String]? = nil, thinkingSegments: [String]? = nil, contentOrder: [String]? = nil, surfaces: [HistoryResponseSurface]? = nil, subagentNotification: HistoryResponseMessageSubagentNotification? = nil, wasTruncated: Bool? = nil) {
+    public init(id: String? = nil, daemonMessageId: String? = nil, role: String, text: String, timestamp: Double, toolCalls: [HistoryResponseToolCall]? = nil, toolCallsBeforeText: Bool? = nil, attachments: [UserMessageAttachment]? = nil, textSegments: [String]? = nil, thinkingSegments: [String]? = nil, contentOrder: [String]? = nil, surfaces: [HistoryResponseSurface]? = nil, subagentNotification: HistoryResponseMessageSubagentNotification? = nil, wasTruncated: Bool? = nil) {
         self.id = id
+        self.daemonMessageId = daemonMessageId
         self.role = role
         self.text = text
         self.timestamp = timestamp
@@ -2690,14 +2694,16 @@ public struct MessageComplete: Codable, Sendable {
     public let attachments: [UserMessageAttachment]?
     public let attachmentWarnings: [String]?
     public let messageId: String?
+    public let displayMessageId: String?
     public let source: String?
 
-    public init(type: String, conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, source: String? = nil) {
+    public init(type: String, conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, displayMessageId: String? = nil, source: String? = nil) {
         self.type = type
         self.conversationId = conversationId
         self.attachments = attachments
         self.attachmentWarnings = attachmentWarnings
         self.messageId = messageId
+        self.displayMessageId = displayMessageId
         self.source = source
     }
 }

--- a/clients/shared/Network/MessageTypes.swift
+++ b/clients/shared/Network/MessageTypes.swift
@@ -701,8 +701,8 @@ extension AssistantThinkingDelta {
 public typealias MessageCompleteMessage = MessageComplete
 
 extension MessageComplete {
-    public init(conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, source: String? = nil) {
-        self.init(type: "message_complete", conversationId: conversationId, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId, source: source)
+    public init(conversationId: String? = nil, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, displayMessageId: String? = nil, source: String? = nil) {
+        self.init(type: "message_complete", conversationId: conversationId, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId, displayMessageId: displayMessageId, source: source)
     }
 }
 
@@ -887,8 +887,8 @@ public struct GenerationCancelledMessage: Decodable, Sendable {
 public typealias GenerationHandoffMessage = GenerationHandoff
 
 extension GenerationHandoff {
-    public init(conversationId: String, requestId: String?, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil) {
-        self.init(type: "generation_handoff", conversationId: conversationId, requestId: requestId, queuedCount: queuedCount, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId)
+    public init(conversationId: String, requestId: String?, queuedCount: Int, attachments: [UserMessageAttachment]? = nil, attachmentWarnings: [String]? = nil, messageId: String? = nil, displayMessageId: String? = nil) {
+        self.init(type: "generation_handoff", conversationId: conversationId, requestId: requestId, queuedCount: queuedCount, attachments: attachments, attachmentWarnings: attachmentWarnings, messageId: messageId, displayMessageId: displayMessageId)
     }
 }
 


### PR DESCRIPTION
## Summary
- keep `message_complete` / `generation_handoff` `messageId` as the final persisted assistant row id
- add `displayMessageId` for the rendered merged assistant bubble id used by history reconciliation
- include `daemonMessageId` in message history payloads for merged assistant rows
- update shared Swift decoding and chat state to keep display ids separate from row-scoped daemon ids

## Companion
- Web client consumption: vellum-ai/vellum-assistant-platform#6132

## Why
Tool turns can persist multiple assistant rows:

1. first assistant row with tool use
2. user row with tool result
3. final assistant row with text

History merges that into one rendered bubble keyed by the first assistant row. Row-scoped endpoints such as fork and message-content/TTS still need a concrete persisted row id, so the event payload now carries both ids explicitly.

## Tests
- `bun test src/__tests__/message-complete-display-id.test.ts`
- `bun run lint src/daemon/message-types/conversations.ts src/daemon/conversation-agent-loop.ts src/daemon/conversation-agent-loop-handlers.ts src/daemon/message-types/messages.ts src/runtime/http-types.ts src/runtime/routes/conversation-routes.ts src/__tests__/message-complete-display-id.test.ts`
- `bunx tsc --noEmit`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path clients --filter "ChatViewModelTests/testMessageCompleteKeepsDisplayAndDaemonIdsSeparate|ChatViewModelTests/testGenerationHandoffKeepsDisplayAndDaemonIdsSeparate|ChatViewModelTests/testPopulateFromHistoryKeepsDisplayAndDaemonIdsSeparate"`
