### PR TITLE
fix(ci): anchor migration ID regex in dev-release workflow

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -664,11 +664,11 @@ jobs:
             const filePath = path.join('assistant/src/workspace/migrations', relPath.replace(/\.js$/, '.ts'));
             const src = fs.readFileSync(filePath, 'utf-8');
             let id;
-            const litMatch = src.match(/id:\s*['\x22]([^'\x22]+)['\x22]/);
+            const litMatch = src.match(/^\s*id:\s*['\x22]([^'\x22]+)['\x22]/m);
             if (litMatch) {
               id = litMatch[1];
             } else {
-              const refMatch = src.match(/id:\s*(\w+)/);
+              const refMatch = src.match(/^\s*id:\s*(\w+)/m);
               const constLine = src.split('\n').find(l => l.includes('const ' + refMatch[1] + ' ='));
               id = constLine.match(/['\x22]([^'\x22]+)['\x22]/)[1];
             }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ When adding a new dependency:
 
 All `uses:` steps in `.github/workflows/**` and `.github/actions/**` must pin to a 40-character commit SHA with a trailing `# vX.Y.Z` comment (e.g. `actions/checkout@a1b2c3... # v6.0.2`). Never use a bare major tag (`@v6`) or a floating version tag (`@v6.0.2`) on its own — SHAs are immutable while tags can be force-moved, so SHA pinning is the GitHub security-hardening recommendation. To upgrade: look up the new tag's commit SHA with `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha`, then replace both the SHA and the trailing comment. For actions that don't publish `vX.Y.Z` tags (e.g. `dawidd6/action-download-artifact`, which tags only bare majors), pin to the SHA with a `# vN` trailing comment instead.
 
+### Workflow duplication
+
+`dev-release.yaml` and `release.yml` share duplicated logic (e.g. the "Compute migration ceilings" inline Node script). When fixing or changing logic that appears in both workflows, apply the change to both files in the same PR. Search for the same code block in the other workflow before marking the fix complete.
+
 ### iOS release dispatch
 
 The release workflows (`dev-release.yaml`, `release.yml`) include `dispatch-ios-release` jobs that fire a [`repository_dispatch`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch) event to [`vellum-assistant-platform`](https://github.com/vellum-ai/vellum-assistant-platform) to trigger iOS Capacitor builds. The dispatch carries `environment` (dev/staging/production) and `version` in the payload. The receiving workflow [`release-ios.yaml`](https://github.com/vellum-ai/vellum-assistant-platform/blob/main/.github/workflows/release-ios.yaml) handles those events. Full environment mapping is documented in [`web/ios/README.md`](https://github.com/vellum-ai/vellum-assistant-platform/blob/main/web/ios/README.md#ci--release-pipeline) in the platform repo.


### PR DESCRIPTION
## Summary

Anchor the workspace migration ID regexes in `dev-release.yaml` to match the already-fixed `release.yml`, unblocking hourly dev releases.

## What changed

Two regexes in the "Compute migration ceilings" step of `dev-release.yaml` are anchored to line-start with `/m` (multiline flag):

```diff
- src.match(/id:\s*['"](...)['"]/)
+ src.match(/^\s*id:\s*['"](...)['"]/ m)

- src.match(/id:\s*(\w+)/)
+ src.match(/^\s*id:\s*(\w+)/m)
```

An `AGENTS.md` guideline is added reminding contributors that `dev-release.yaml` and `release.yml` share duplicated logic and fixes must be applied to both.

## Why this is needed

Since migration `071-remove-safe-storage-release-note` landed, the `register-release` job in `dev-release.yaml` fails every hourly run. The unanchored regex `/id:\s*['"]/` matches `release-note-id:"` inside a string constant in that migration file, causing the inline Node script to extract a multiline blob instead of the migration ID. This corrupts `$GITHUB_OUTPUT`, producing:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '## Safe storage limits'
```

## Why this is safe

- The identical anchored regexes have been running successfully in `release.yml` since [7cc10a357a](https://github.com/vellum-ai/vellum-assistant/commit/7cc10a357a) (merged May 6).
- The `/^\s*id:/m` anchor only matches `id:` at the start of a line (after optional whitespace), which is exclusively the object-property `id:` field in migration files. It correctly excludes substrings like `release-note-id:` that appear mid-line inside string constants.
- No other workflow logic is touched.

## Alternatives considered

**Extract migration-ceiling logic into a shared script** — Both `dev-release.yaml` and `release.yml` contain the same ~30-line inline Node script. Extracting it to a single file (e.g. `scripts/compute-migration-ceilings.js`) would eliminate the duplication entirely and prevent future drift. This was rejected for this PR because the immediate priority is unblocking dev releases with a minimal, proven fix. The AGENTS.md guideline added here serves as a lighter-weight guard against future drift. A follow-up to deduplicate could be pursued separately.

**Add `[^\n]` to the character class instead of anchoring** — The `apollo/fix-migration-ceiling-regex` branch took this approach (`/id:\s*['\x22]([^'\x22\n]+)['\x22]/`), preventing newline characters in the capture group. This addresses the symptom (multiline capture) but not the root cause (matching `release-note-id:` at all). The line-start anchor is more precise and is what was merged to `release.yml`.

## Root cause analysis

**How did the code get into this state?**
The migration-ceiling extraction logic was written as an inline Node script and copy-pasted into both `dev-release.yaml` and `release.yml`. When migration `071-remove-safe-storage-release-note` introduced a file containing `release-note-id:"`, the unanchored `/id:\s*/` regex began false-matching in both workflows.

**What mistakes or decisions led to it?**
1. The inline Node script was duplicated across two workflow files with no mechanism to keep them in sync.
2. When the fix ([7cc10a357a](https://github.com/vellum-ai/vellum-assistant/commit/7cc10a357a)) was applied to `release.yml`, the contributor did not search for the same code in `dev-release.yaml`. The PR only modified one file.

**Were there warning signs we missed?**
The dev-release workflow runs hourly and has been failing since the migration landed. The failure was visible in GitHub Actions but wasn't caught until it was manually investigated.

**What can we do to prevent this pattern from recurring?**
- Added an `AGENTS.md` guideline under "Workflow duplication" reminding contributors to apply fixes to both workflow files.
- Longer-term, extracting shared workflow logic into reusable scripts would eliminate the duplication entirely.

## Validation

- Confirmed the two regex changes produce byte-identical patterns to `release.yml` lines 1116/1120.
- The fix will be validated end-to-end by the next hourly dev-release run after merge.
Link to Devin session: https://app.devin.ai/sessions/18500858635e4c139ced0e48b343181c
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
