### PR TITLE
[codex] Infer provider for known call-site model overrides

### DIFF
--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -52,6 +52,50 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.maxTokens).toBe(64000);
   });
 
+  test("model-only call-site override infers provider from known model owner", () => {
+    const llm = LLMSchema.parse({
+      default: {
+        ...fullDefault,
+        provider: "openai",
+        model: "gpt-5.5",
+      },
+      profiles: {
+        active: { provider: "openai", model: "gpt-5.5" },
+      },
+      activeProfile: "active",
+      callSites: {
+        conversationStarters: {
+          model: "claude-haiku-4-5-20251001",
+          effort: "low",
+        },
+      },
+    });
+
+    const resolved = resolveCallSiteConfig("conversationStarters", llm);
+
+    expect(resolved.provider).toBe("anthropic");
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.effort).toBe("low");
+  });
+
+  test("unknown model-only override preserves inherited provider", () => {
+    const llm = LLMSchema.parse({
+      default: {
+        ...fullDefault,
+        provider: "openai",
+        model: "gpt-5.5",
+      },
+      callSites: {
+        memoryExtraction: { model: "local-custom-model" },
+      },
+    });
+
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.model).toBe("local-custom-model");
+  });
+
   test("profile field overrides default when call site references it", () => {
     const llm = LLMSchema.parse({
       default: fullDefault,

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { getCatalogProviderForModel } from "../providers/model-catalog.js";
 import {
   type LLMCallSite,
   LLMConfigBase,
@@ -67,7 +68,7 @@ export function resolveCallSiteConfig(
     appendCallSiteLayers(layers, callSite, llm, site);
   }
 
-  return finalize(deepMerge(...layers));
+  return finalize(deepMerge(...layers.map(withImpliedProviderForKnownModel)));
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +76,20 @@ export function resolveCallSiteConfig(
 // ---------------------------------------------------------------------------
 
 type Mergeable = Record<string, unknown>;
+
+function withImpliedProviderForKnownModel(source: Mergeable): Mergeable {
+  if (source.provider !== undefined) return source;
+  const model = source.model;
+  if (typeof model !== "string" || model.length === 0) return source;
+
+  const provider = getCatalogProviderForModel(model);
+  if (provider === undefined) return source;
+
+  return {
+    ...source,
+    provider,
+  };
+}
 
 function appendProfileLayer(
   layers: Mergeable[],

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -768,3 +768,13 @@ export function isModelInCatalog(provider: string, modelId: string): boolean {
   const entry = PROVIDER_CATALOG.find((p) => p.id === provider);
   return entry?.models.some((m) => m.id === modelId) ?? false;
 }
+
+/** Return the unique catalog provider that owns a model ID, if known. */
+export function getCatalogProviderForModel(
+  modelId: string,
+): string | undefined {
+  const matches = PROVIDER_CATALOG.filter((p) =>
+    p.models.some((m) => m.id === modelId),
+  );
+  return matches.length === 1 ? matches[0]?.id : undefined;
+}


### PR DESCRIPTION
## Summary
- infer the provider from catalog-owned model IDs when a call-site or profile layer sets `model` without `provider`
- preserve inherited provider behavior for unknown/custom model IDs
- add regression coverage for OpenAI active profile plus Claude call-site model overrides

## Root Cause
`resolveCallSiteConfig` merged `provider` and `model` independently. A model-only call-site override such as `claude-haiku-4-5-20251001` could inherit `provider: openai` from the active/default profile, causing invalid OpenAI requests for Claude models.

## Impact
Known model IDs now route through their owning provider when the override layer does not specify a provider. Custom or non-catalog model IDs continue to inherit the configured provider so local/custom providers are not broken.

## Validation
- `bun test src/__tests__/llm-resolver.test.ts`
- `bunx tsc --noEmit`
- `bun run lint src/config/llm-resolver.ts src/providers/model-catalog.ts src/__tests__/llm-resolver.test.ts`

Note: the pre-push hook also passed assistant type-check and lint, then printed a non-fatal shell-compat warning in its package-scan section before exiting 0.