### PR TITLE
Fix command palette (⌘K) panel not resizing after clearing a no-results query

### DIFF
--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -7,6 +7,7 @@ struct CommandPaletteView: View {
     var onDismiss: () -> Void
     var onSelectRecent: ((UUID) -> Void)?
     var onSelectConversation: ((String) -> Void)?
+    var onResizeNeeded: (() -> Void)?
 
     @FocusState private var isSearchFocused: Bool
 
@@ -126,6 +127,12 @@ struct CommandPaletteView: View {
         .onChange(of: viewModel.query) {
             viewModel.clampSelection()
             viewModel.triggerSearch()
+        }
+        .onChange(of: viewModel.allItems.count) {
+            onResizeNeeded?()
+        }
+        .onChange(of: viewModel.isSearching) {
+            onResizeNeeded?()
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -15,6 +15,7 @@ private class CommandPalettePanel: NSPanel {
 @MainActor
 final class CommandPaletteWindow {
     private var panel: NSPanel?
+    private var hostingController: NSHostingController<CommandPaletteView>?
     private var resignObserver: Any?
     private var isDismissing = false
     private let viewModel = CommandPaletteViewModel()
@@ -59,11 +60,17 @@ final class CommandPaletteWindow {
             },
             onSelectConversation: { [weak self] convId in
                 self?.onSelectSearchConversation?(convId)
+            },
+            onResizeNeeded: { [weak self] in
+                DispatchQueue.main.async {
+                    self?.updatePanelSize(animated: true)
+                }
             }
         )
 
         let hostingController = NSHostingController(rootView: view)
-        hostingController.sizingOptions = [.intrinsicContentSize]
+        hostingController.sizingOptions = []
+        self.hostingController = hostingController
         hostingController.view.wantsLayer = true
         hostingController.view.layer?.cornerRadius = VRadius.lg
         hostingController.view.layer?.masksToBounds = true
@@ -135,6 +142,7 @@ final class CommandPaletteWindow {
             MainActor.assumeIsolated {
                 panel.close()
                 self?.panel = nil
+                self?.hostingController = nil
                 self?.isDismissing = false
             }
         })
@@ -142,6 +150,34 @@ final class CommandPaletteWindow {
 
     var isVisible: Bool {
         panel?.isVisible ?? false
+    }
+
+    // MARK: - Sizing
+
+    private func updatePanelSize(animated: Bool) {
+        guard let panel, let hostingController else { return }
+        let idealSize = hostingController.sizeThatFits(
+            in: CGSize(width: 600, height: CGFloat.greatestFiniteMagnitude)
+        )
+        let width = max(idealSize.width, 600)
+        let height = idealSize.height
+
+        let currentFrame = panel.frame
+        guard abs(currentFrame.height - height) > 1 else { return }
+
+        // Anchor the top edge so the panel grows/shrinks downward.
+        let newY = currentFrame.maxY - height
+        let newFrame = NSRect(x: currentFrame.origin.x, y: newY, width: width, height: height)
+
+        if animated {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = VAnimation.durationFast
+                context.timingFunction = CAMediaTimingFunction(name: .easeInOut)
+                panel.animator().setFrame(newFrame, display: true)
+            }
+        } else {
+            panel.setFrame(newFrame, display: true)
+        }
     }
 
     // MARK: - Positioning
@@ -153,17 +189,17 @@ final class CommandPaletteWindow {
             ?? NSScreen.screens.first
         guard let screenFrame = screen?.visibleFrame else { return }
 
-        if let fittingSize = panel.contentView?.fittingSize {
-            let width = max(fittingSize.width, 600)
-            let height = fittingSize.height
-            let x = screenFrame.midX - width / 2
-            let y = screenFrame.midY - height / 2
-            panel.setFrame(
-                NSRect(x: x, y: y, width: width, height: height),
-                display: true
-            )
-        } else {
-            panel.center()
-        }
+        guard let hostingController else { panel.center(); return }
+        let idealSize = hostingController.sizeThatFits(
+            in: CGSize(width: 600, height: CGFloat.greatestFiniteMagnitude)
+        )
+        let width = max(idealSize.width, 600)
+        let height = idealSize.height
+        let x = screenFrame.midX - width / 2
+        let y = screenFrame.midY - height / 2
+        panel.setFrame(
+            NSRect(x: x, y: y, width: width, height: height),
+            display: true
+        )
     }
 }

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteWindow.swift
@@ -172,7 +172,7 @@ final class CommandPaletteWindow {
         if animated {
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = VAnimation.durationFast
-                context.timingFunction = CAMediaTimingFunction(name: .easeInOut)
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
                 panel.animator().setFrame(newFrame, display: true)
             }
         } else {


### PR DESCRIPTION
Fixes the ⌘K command palette panel getting stuck at a smaller height after showing "No results found" and then clearing the query. The panel now explicitly measures and animates to the correct size whenever content changes, using Apple's recommended `sizeThatFits(in:)` API.

---

## Root Cause Analysis

1. **How did the code get into this state?** `sizingOptions = [.intrinsicContentSize]` was the original approach — it works for initial sizing and shrinking, creating the illusion of correct behavior until the "grow back" case is hit.

2. **What mistakes or decisions led to it?** The asymmetric behavior of Auto Layout constraints in borderless NSPanels isn't obvious. The window frame acts as a priority-1000 constraint that overrides content hugging/compression resistance (~750), so shrinking works but growing does not.

3. **Were there warning signs we missed?** The panel was only ever sized in `centerOnScreen()` during `show()` — there was no mechanism to re-measure after content changed. This worked fine when content was static, but broke once search results/empty states introduced dynamic content height.

4. **What can we do to prevent this pattern from recurring?** Any future NSPanel-hosted SwiftUI content that changes size dynamically should use explicit `sizeThatFits(in:)` measurement rather than relying on `sizingOptions`.

5. **Should we add a guideline to AGENTS.md?** Consider adding: "For borderless NSPanels with dynamic SwiftUI content, use `sizingOptions = []` + explicit `sizeThatFits(in:)` measurement. Do not rely on `.intrinsicContentSize` for bidirectional auto-sizing."

---

- Requested by: @Jasonnnz
- Session: https://app.devin.ai/sessions/d92ce3d8721b4df2ae7c37b7df9d1f8e
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
