### PR TITLE
Read `_isConnected` backing storage in deferred Task bodies in `GatewayConnectionManager`

### DIFF
--- a/clients/shared/Network/GatewayConnectionManager.swift
+++ b/clients/shared/Network/GatewayConnectionManager.swift
@@ -847,7 +847,7 @@ public final class GatewayConnectionManager {
             var attempt = 0
             while !Task.isCancelled {
                 // If another path (e.g. autoWakeIfAssistantDied) connected us, exit
-                guard !self.isConnected else {
+                guard !self._isConnected else {
                     log.info("reconnect-loop: already connected, exiting")
                     break
                 }
@@ -1041,7 +1041,7 @@ public final class GatewayConnectionManager {
     /// https://developer.apple.com/documentation/foundation/notificationcenter/post(name:object:)
     private func scheduleDaemonDidReconnect() {
         Task { @MainActor [weak self] in
-            guard let self, self.isConnected else { return }
+            guard let self, self._isConnected else { return }
             NotificationCenter.default.post(name: .daemonDidReconnect, object: self)
         }
     }


### PR DESCRIPTION
## Why

Follow-up to #29899. Two reads of `isConnected` inside `Task { @MainActor in }` bodies still went through the synthesised getter (`self.isConnected`) rather than the macro-synthesised backing storage (`self._isConnected`). Switching them makes every read of `isConnected` outside the public-API path a pure storage compare, which matches the pattern used everywhere else in the file.

Both Task bodies run on a fresh `@MainActor` turn outside any [`withObservationTracking`](https://developer.apple.com/documentation/observation/withobservationtracking(_:onchange:)) context, so [`_$observationRegistrar.access(_:keyPath:)`](https://developer.apple.com/documentation/observation/observationregistrar/access(_:keypath:)) is already a no-op there. **This is purely a visual-consistency change with no behavioral effect.**

## What changed

- `startReconnectionLoop`: `guard !self.isConnected` → `guard !self._isConnected`.
- `scheduleDaemonDidReconnect`: `guard let self, self.isConnected` → `guard let self, self._isConnected`.

## Safety

- Both call sites are inside `Task { @MainActor [weak self] in ... }` bodies on a fresh actor turn — no active `withObservationTracking` context — so `self.isConnected` and `self._isConnected` return the same value via the same load path at runtime.
- No control-flow change. No public API change. No test changes (existing #29899 coverage exercises both call sites).

## Notes for reviewers

- The AGENTS.md rule about backing-storage reads is scoped to "guarding a self-write." These two sites are *current-state checks*, not self-write guards, so the rule doesn't strictly apply — the change is justified by file-local consistency, not by the AGENTS.md rule.
- Suggested by a non-blocking nit from Devin Review on #29899; included here rather than expanded into the AGENTS.md rule because broadening the rule to cover non-self-write reads risks misleading future readers.

## Test plan

- Existing unit tests in `GatewayConnectionManagerTests` cover the connect/disconnect/reconnect-loop paths that exercise both call sites.
- CI on this repo skips macOS checks, so a local Xcode build / `swift test` on macOS is required to verify the build before merging.

Link to Devin session: https://app.devin.ai/sessions/2da0c092185640b284918ba17b129fa3
Requested by: @ashleeradka
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->