### PR TITLE
feat(/compact): accept optional <tokens> arg to override target budget

### DIFF
--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -128,6 +128,55 @@ describe("resolveSlash command contract", () => {
   });
 });
 
+describe("resolveSlash /compact target override", () => {
+  test("plain /compact returns no override", async () => {
+    const result = await resolveSlash("/compact");
+    expect(result).toEqual({ kind: "compact" });
+  });
+
+  test("/compact <integer> sets explicit token target", async () => {
+    const result = await resolveSlash("/compact 30000");
+    expect(result).toEqual({
+      kind: "compact",
+      targetInputTokensOverride: 30000,
+    });
+  });
+
+  test("/compact <n>k expands to thousands", async () => {
+    const result = await resolveSlash("/compact 30k");
+    expect(result).toEqual({
+      kind: "compact",
+      targetInputTokensOverride: 30_000,
+    });
+  });
+
+  test("/compact <n>m expands to millions", async () => {
+    const result = await resolveSlash("/compact 1.5M");
+    expect(result).toEqual({
+      kind: "compact",
+      targetInputTokensOverride: 1_500_000,
+    });
+  });
+
+  test("/compact rejects malformed args with usage hint", async () => {
+    const result = await resolveSlash("/compact bogus");
+    expect(result.kind).toBe("unknown");
+    if (result.kind !== "unknown") throw new Error("expected unknown");
+    expect(result.message).toContain("`bogus`");
+    expect(result.message).toContain("/compact");
+  });
+
+  test("/compact rejects zero", async () => {
+    const result = await resolveSlash("/compact 0");
+    expect(result.kind).toBe("unknown");
+  });
+
+  test("/compact rejects negative numbers", async () => {
+    const result = await resolveSlash("/compact -50");
+    expect(result.kind).toBe("unknown");
+  });
+});
+
 describe("classifySlash is a pure classifier matching resolveSlash kinds", () => {
   // Lookahead in `buildPassthroughBatch` must not run `resolveSlash`'s side
   // effects. The pure classifier is synchronous, takes no side-effecting
@@ -141,11 +190,16 @@ describe("classifySlash is a pure classifier matching resolveSlash kinds", () =>
     { input: "/status", kind: "unknown" },
     { input: "/commands", kind: "unknown" },
     { input: "/compact", kind: "compact" },
+    { input: "/compact 30000", kind: "compact" },
+    { input: "/compact 30k", kind: "compact" },
+    { input: "/compact 1.5M", kind: "compact" },
+    { input: "/compact bogus", kind: "unknown" },
     { input: "/model", kind: "unknown" },
     { input: "/model foo", kind: "unknown" },
     { input: "/opus", kind: "unknown" },
     { input: "hello", kind: "passthrough" },
     { input: "  /compact  ", kind: "compact" },
+    { input: "  /compact 50k  ", kind: "compact" },
     { input: "/models foo", kind: "passthrough" },
   ];
 

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -179,7 +179,9 @@ export interface ProcessConversationContext {
     statusText?: string,
   ): void;
   /** Force context compaction regardless of threshold/cooldown. */
-  forceCompact(): Promise<ContextWindowResult>;
+  forceCompact(options?: {
+    targetInputTokensOverride?: number;
+  }): Promise<ContextWindowResult>;
   /** Set transport-derived hints for the conversation. */
   setTransportHints(hints: string[] | undefined): void;
   /** IANA timezone reported by the active client for the current turn. */
@@ -628,7 +630,9 @@ async function drainSingleMessage(
         "assistant_turn",
         next.requestId,
       );
-      const result = await conversation.forceCompact();
+      const result = await conversation.forceCompact({
+        targetInputTokensOverride: slashResult.targetInputTokensOverride,
+      });
       const responseText = formatCompactResult(result);
 
       const assistantMsg = createAssistantMessage(responseText);
@@ -1474,7 +1478,9 @@ export async function processMessage(
         "assistant_turn",
         requestId,
       );
-      const result = await conversation.forceCompact();
+      const result = await conversation.forceCompact({
+        targetInputTokensOverride: slashResult.targetInputTokensOverride,
+      });
       const responseText = formatCompactResult(result);
 
       const assistantMsg = createAssistantMessage(responseText);

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -8,7 +8,43 @@ import { getConfiguredProviders } from "../providers/provider-availability.js";
 export type SlashResolution =
   | { kind: "passthrough"; content: string }
   | { kind: "unknown"; message: string }
-  | { kind: "compact" };
+  | { kind: "compact"; targetInputTokensOverride?: number };
+
+const COMPACT_USAGE_HINT =
+  "Usage: `/compact [<tokens>]` (e.g. `/compact 30000`, `/compact 30k`, `/compact 1m`).";
+
+type CompactParse =
+  | { kind: "compact"; targetInputTokensOverride?: number }
+  | { kind: "unknown"; message: string };
+
+const TOKEN_COUNT_PATTERN = /^(\d+(?:\.\d+)?)([km])?$/i;
+const COMPACT_COMMAND_PATTERN = /^\/compact(?:\s+(.+?))?\s*$/i;
+
+function parseTokenCount(input: string): number | null {
+  const match = input.match(TOKEN_COUNT_PATTERN);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  const suffix = match[2]?.toLowerCase();
+  const multiplier = suffix === "m" ? 1_000_000 : suffix === "k" ? 1_000 : 1;
+  const tokens = Math.floor(value * multiplier);
+  return tokens > 0 ? tokens : null;
+}
+
+function parseCompactCommand(trimmed: string): CompactParse | null {
+  const match = trimmed.match(COMPACT_COMMAND_PATTERN);
+  if (!match) return null;
+  const rest = match[1]?.trim();
+  if (!rest) return { kind: "compact" };
+  const tokens = parseTokenCount(rest);
+  if (tokens == null) {
+    return {
+      kind: "unknown",
+      message: `Unrecognized argument to \`/compact\`: \`${rest}\`. ${COMPACT_USAGE_HINT}`,
+    };
+  }
+  return { kind: "compact", targetInputTokensOverride: tokens };
+}
 
 // ── /context and /status commands ────────────────────────────────────
 
@@ -214,7 +250,8 @@ export function classifySlash(
     return "unknown";
   }
   if (trimmed === "/models") return "unknown";
-  if (trimmed === "/compact") return "compact";
+  const compactParse = parseCompactCommand(trimmed);
+  if (compactParse) return compactParse.kind;
   if (trimmed === "/context") return "unknown";
   if (trimmed === "/status") return "unknown";
   if (trimmed === "/commands") return "unknown";
@@ -260,10 +297,9 @@ export async function resolveSlash(
     return await resolveModelList();
   }
 
-  // Handle /compact command
-  if (trimmed === "/compact") {
-    return { kind: "compact" };
-  }
+  // Handle /compact command (with optional `<tokens>` override).
+  const compactParse = parseCompactCommand(trimmed);
+  if (compactParse) return compactParse;
 
   // Handle /context and legacy /status commands
   if (trimmed === "/context" || trimmed === "/status") {

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -991,7 +991,9 @@ export class Conversation {
     }
   }
 
-  async forceCompact(): Promise<ContextWindowResult> {
+  async forceCompact(options?: {
+    targetInputTokensOverride?: number;
+  }): Promise<ContextWindowResult> {
     const conversationRow = getConversation(this.conversationId);
     const overrideProfile =
       getConversationOverrideProfileFromRow(conversationRow) ?? null;
@@ -1037,6 +1039,7 @@ export class Conversation {
         conversationOriginChannel:
           getConversationOriginChannel(this.conversationId) ?? undefined,
         overrideProfile,
+        targetInputTokensOverride: options?.targetInputTokensOverride,
       },
     );
     // Track circuit-breaker state for user-initiated `/compact` and other

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -375,7 +375,9 @@ export async function processMessage(
       "context_compacting",
       "assistant_turn",
     );
-    const result = await conversation.forceCompact();
+    const result = await conversation.forceCompact({
+      targetInputTokensOverride: slashResult.targetInputTokensOverride,
+    });
     const responseText = formatCompactResult(result);
     const assistantMsg = createAssistantMessage(responseText);
     await addMessage(

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1869,7 +1869,9 @@ export async function handleSendMessage(
           "context_compacting",
           "assistant_turn",
         );
-        const result = await conversation.forceCompact();
+        const result = await conversation.forceCompact({
+          targetInputTokensOverride: slashResult.targetInputTokensOverride,
+        });
         const responseText = formatCompactResult(result);
 
         const assistantMsg = createAssistantMessage(responseText);


### PR DESCRIPTION
## Summary
- `/compact [<tokens>]` (e.g. `/compact 30k`, `/compact 1.5M`) lets users tighten the post-compaction target below the configured `targetBudgetRatio × maxInputTokens` budget.
- Wires the parsed override through `forceCompact()` → `maybeCompact()` via the existing `targetInputTokensOverride` plumbing — the override only tightens (`Math.min(override, configured)`), matching overflow-recovery semantics.
- Malformed args (`/compact bogus`, `/compact -50`) produce a usage hint instead of passthrough to the LLM.

## Original prompt
While debugging why `/compact` only saved ~3k tokens out of 267k on a conversation with a permissive `compactThreshold`/`targetBudgetRatio` config, we traced it to the projection-vs-actual gap in `pickKeepBoundary`: the per-keep-turns projection truncates tool results before estimating tokens, so the fast path in `maybeCompact` declares the conversation "already fits" and skips summarization. The user wanted a way to force a tighter target without lowering `compactThreshold` (which doesn't help once `force: true` is in play) or running `/clear`. The plumbing for `targetInputTokensOverride` already existed in `maybeCompact`; this PR exposes it as an optional argument to the slash command.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/29916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->